### PR TITLE
freelist: batch free and region allocations

### DIFF
--- a/TreeDB/db/vacuum_online.go
+++ b/TreeDB/db/vacuum_online.go
@@ -45,6 +45,26 @@ type vacuumRecorder struct {
 	ranges []batch.DeleteRange
 }
 
+type vacuumRetiredPageFreer interface {
+	FreeMany([]uint64) error
+	Free(uint64) error
+}
+
+func freeVacuumRetired(freer vacuumRetiredPageFreer, retired []uint64) {
+	err := freer.FreeMany(retired)
+	if err == nil {
+		return
+	}
+	processed := 0
+	var batchErr *freelist.FreeManyError
+	if errors.As(err, &batchErr) && batchErr.Processed >= 0 && batchErr.Processed <= len(retired) {
+		processed = batchErr.Processed
+	}
+	for _, id := range retired[processed:] {
+		_ = freer.Free(id)
+	}
+}
+
 func (r *vacuumRecorder) Active() bool {
 	return r.active.Load()
 }
@@ -336,7 +356,7 @@ func (db *DB) vacuumIndexOnline(ctx context.Context, lockMaintenance bool) error
 	}
 
 	freeRetired := func(retired []uint64) {
-		_ = newAlloc.FreeMany(retired)
+		freeVacuumRetired(newAlloc, retired)
 	}
 
 	// Online catch-up: replay recorded keys in bounded passes.

--- a/TreeDB/db/vacuum_online.go
+++ b/TreeDB/db/vacuum_online.go
@@ -24,6 +24,10 @@ import (
 var ErrVacuumInProgress = errors.New("online vacuum already in progress")
 var ErrVacuumUnsupported = errors.New("online vacuum unsupported on this platform")
 
+// testHookVacuumAfterBaseSnapshot coordinates writes that must be replayed by
+// online vacuum tests. It remains nil in production.
+var testHookVacuumAfterBaseSnapshot func()
+
 const (
 	vacuumDeltaBatchSize     = 4096
 	vacuumCatchupPassesMax   = 3
@@ -269,6 +273,9 @@ func (db *DB) vacuumIndexOnline(ctx context.Context, lockMaintenance bool) error
 
 	// Build a fresh user tree from a stable snapshot.
 	baseSnap := db.AcquireSnapshot()
+	if testHookVacuumAfterBaseSnapshot != nil {
+		testHookVacuumAfterBaseSnapshot()
+	}
 	var newRoot uint64
 	if db.indexOuterLeavesInValueLog {
 		if db.leafPageLog == nil {

--- a/TreeDB/db/vacuum_online.go
+++ b/TreeDB/db/vacuum_online.go
@@ -329,9 +329,7 @@ func (db *DB) vacuumIndexOnline(ctx context.Context, lockMaintenance bool) error
 	}
 
 	freeRetired := func(retired []uint64) {
-		for _, id := range retired {
-			_ = newAlloc.Free(id)
-		}
+		_ = newAlloc.FreeMany(retired)
 	}
 
 	// Online catch-up: replay recorded keys in bounded passes.

--- a/TreeDB/db/vacuum_online_free_retired_instrument_test.go
+++ b/TreeDB/db/vacuum_online_free_retired_instrument_test.go
@@ -1,0 +1,52 @@
+//go:build treedb_freelist_instrument
+
+package db
+
+import (
+	"errors"
+	"path/filepath"
+	"slices"
+	"testing"
+
+	"github.com/snissn/gomap/TreeDB/freelist"
+	"github.com/snissn/gomap/TreeDB/page"
+	"github.com/snissn/gomap/TreeDB/pager"
+)
+
+func TestVacuumFreeRetired_GetForWriteFailurePreservesSuffix(t *testing.T) {
+	const suffixIDs = 7
+	pageCount := page.MaxFreeIDs + suffixIDs + 2
+	p, err := pager.Open(filepath.Join(t.TempDir(), "index.db"), 64*1024)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	t.Cleanup(func() { _ = p.Close() })
+	if _, err := p.Alloc(pageCount); err != nil {
+		t.Fatalf("Alloc(%d): %v", pageCount, err)
+	}
+	a := freelist.New(p, 0)
+	retired := make([]uint64, page.MaxFreeIDs+1+suffixIDs)
+	for i := range retired {
+		retired[i] = uint64(i + 1)
+	}
+	injectedErr := errors.New("injected second get-for-write failure")
+	a.TestInjectGetForWriteFailureAfter(1, injectedErr)
+
+	freeVacuumRetired(a, retired)
+
+	if got := a.TestInjectedGetForWriteFailures(); got != 1 {
+		t.Fatalf("injected GetForWrite failures = %d, want 1", got)
+	}
+	stats := a.Counters()
+	if got, want := stats.ReclaimablePages(), uint64(len(retired)); got != want {
+		t.Fatalf("reclaimable pages = %d, want all retired pages %d", got, want)
+	}
+	got, err := a.AllocMany(len(retired), 0)
+	if err != nil {
+		t.Fatalf("AllocMany: %v", err)
+	}
+	slices.Sort(got)
+	if !slices.Equal(got, retired) {
+		t.Fatalf("recovered retired IDs differ: got %v want %v", got, retired)
+	}
+}

--- a/TreeDB/db/vacuum_online_free_retired_test.go
+++ b/TreeDB/db/vacuum_online_free_retired_test.go
@@ -1,0 +1,42 @@
+package db
+
+import (
+	"errors"
+	"slices"
+	"testing"
+
+	"github.com/snissn/gomap/TreeDB/freelist"
+)
+
+type partialRetiredPageFreer struct {
+	batchCalls [][]uint64
+	freeCalls  []uint64
+	err        error
+}
+
+func (f *partialRetiredPageFreer) FreeMany(ids []uint64) error {
+	f.batchCalls = append(f.batchCalls, append([]uint64(nil), ids...))
+	return f.err
+}
+
+func (f *partialRetiredPageFreer) Free(id uint64) error {
+	f.freeCalls = append(f.freeCalls, id)
+	return nil
+}
+
+func TestVacuumFreeRetired_RetriesOnlyUnprocessedSuffix(t *testing.T) {
+	retired := []uint64{11, 12, 13, 14}
+	ioErr := errors.New("injected get-for-write failure")
+	freer := &partialRetiredPageFreer{
+		err: &freelist.FreeManyError{Processed: 2, Err: ioErr},
+	}
+
+	freeVacuumRetired(freer, retired)
+
+	if len(freer.batchCalls) != 1 || !slices.Equal(freer.batchCalls[0], retired) {
+		t.Fatalf("FreeMany calls = %v, want one call with %v", freer.batchCalls, retired)
+	}
+	if want := retired[2:]; !slices.Equal(freer.freeCalls, want) {
+		t.Fatalf("Free calls = %v, want suffix %v", freer.freeCalls, want)
+	}
+}

--- a/TreeDB/db/vacuum_online_swap_test.go
+++ b/TreeDB/db/vacuum_online_swap_test.go
@@ -196,7 +196,42 @@ func TestVacuumIndexOnline_ShrinksAndPreservesData(t *testing.T) {
 	var freeManyChecksumUpdates atomic.Int64
 	freelist.TestHookFreeManyBeforeChecksum = func() { freeManyChecksumUpdates.Add(1) }
 	defer func() { freelist.TestHookFreeManyBeforeChecksum = nil }()
-	if err := d.VacuumIndexOnline(ctx); err != nil {
+	snapshotReady := make(chan struct{})
+	continueVacuum := make(chan struct{})
+	released := false
+	defer func() {
+		if !released {
+			close(continueVacuum)
+		}
+	}()
+	testHookVacuumAfterBaseSnapshot = func() {
+		close(snapshotReady)
+		<-continueVacuum
+	}
+	defer func() { testHookVacuumAfterBaseSnapshot = nil }()
+	vacuumDone := make(chan error, 1)
+	go func() { vacuumDone <- d.VacuumIndexOnline(ctx) }()
+	select {
+	case <-snapshotReady:
+	case err := <-vacuumDone:
+		t.Fatalf("vacuum finished before base snapshot hook: %v", err)
+	case <-ctx.Done():
+		t.Fatalf("waiting for vacuum base snapshot: %v", ctx.Err())
+	}
+
+	deltaValue := bytes.Repeat([]byte("w"), 200)
+	delta := d.NewBatch()
+	if err := delta.Set([]byte("k000010"), deltaValue); err != nil {
+		t.Fatalf("delta set: %v", err)
+	}
+	deltaErr := delta.Write()
+	_ = delta.Close()
+	close(continueVacuum)
+	released = true
+	if deltaErr != nil {
+		t.Fatalf("delta write: %v", deltaErr)
+	}
+	if err := <-vacuumDone; err != nil {
 		t.Fatalf("vacuum: %v", err)
 	}
 	if got := freeManyChecksumUpdates.Load(); got == 0 {
@@ -215,7 +250,7 @@ func TestVacuumIndexOnline_ShrinksAndPreservesData(t *testing.T) {
 	if err != nil {
 		t.Fatalf("get: %v", err)
 	}
-	if !bytes.Equal(got, value) {
+	if !bytes.Equal(got, deltaValue) {
 		t.Fatalf("value mismatch")
 	}
 }

--- a/TreeDB/db/vacuum_online_swap_test.go
+++ b/TreeDB/db/vacuum_online_swap_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/snissn/gomap/TreeDB/freelist"
 	"github.com/snissn/gomap/TreeDB/internal/leafrefscan"
 	"github.com/snissn/gomap/TreeDB/node"
 	"github.com/snissn/gomap/TreeDB/page"
@@ -192,8 +193,14 @@ func TestVacuumIndexOnline_ShrinksAndPreservesData(t *testing.T) {
 
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
+	var freeManyChecksumUpdates atomic.Int64
+	freelist.TestHookFreeManyBeforeChecksum = func() { freeManyChecksumUpdates.Add(1) }
+	defer func() { freelist.TestHookFreeManyBeforeChecksum = nil }()
 	if err := d.VacuumIndexOnline(ctx); err != nil {
 		t.Fatalf("vacuum: %v", err)
+	}
+	if got := freeManyChecksumUpdates.Load(); got == 0 {
+		t.Fatal("online vacuum did not batch retired pages through FreeMany")
 	}
 
 	afterInfo, err := os.Stat(indexPath)

--- a/TreeDB/freelist/allocator.go
+++ b/TreeDB/freelist/allocator.go
@@ -30,24 +30,33 @@ type Allocator struct {
 	preferAppend bool
 }
 
-type allocatorPageEvent uint8
+type allocatorPageOperations interface {
+	getForWrite(*pager.Pager, uint64) ([]byte, error)
+	verifyChecksum(uint64, []byte) bool
+	updateChecksum(uint64, []byte)
+}
 
-const (
-	allocatorPageGetForWrite allocatorPageEvent = iota
-	allocatorPageVerifyChecksum
-	allocatorPageUpdateChecksum
-)
+type directAllocatorPageOperations struct{}
 
-var testAllocatorPageEvent func(allocatorPageEvent, uint64)
+func (directAllocatorPageOperations) getForWrite(p *pager.Pager, pageID uint64) ([]byte, error) {
+	return p.GetForWrite(pageID)
+}
 
-func observeAllocatorPage(hook func(allocatorPageEvent, uint64), pageID uint64, verified, updated bool) {
-	hook(allocatorPageGetForWrite, pageID)
-	if verified {
-		hook(allocatorPageVerifyChecksum, pageID)
+func (directAllocatorPageOperations) verifyChecksum(_ uint64, data []byte) bool {
+	return node.NewNode(data).VerifyChecksum()
+}
+
+func (directAllocatorPageOperations) updateChecksum(_ uint64, data []byte) {
+	node.NewNode(data).UpdateChecksum()
+}
+
+var testAllocatorPageOperations allocatorPageOperations
+
+func activeAllocatorPageOperations() allocatorPageOperations {
+	if testAllocatorPageOperations != nil {
+		return testAllocatorPageOperations
 	}
-	if updated {
-		hook(allocatorPageUpdateChecksum, pageID)
-	}
+	return directAllocatorPageOperations{}
 }
 
 var errCannotFreePageZero = errors.New("cannot free page 0")
@@ -270,9 +279,10 @@ func (a *Allocator) AllocMany(count int, hint uint64) ([]uint64, error) {
 
 	a.mu.Lock()
 	defer a.mu.Unlock()
+	pageOps := activeAllocatorPageOperations()
 
 	if a.regionPages > 0 && a.regionRadius > 0 {
-		return a.allocManyRegionLocked(count, hint)
+		return a.allocManyRegionLocked(count, hint, pageOps)
 	}
 
 	ids := make([]uint64, 0, count)
@@ -293,12 +303,12 @@ func (a *Allocator) AllocMany(count int, hint uint64) ([]uint64, error) {
 		}
 
 		headID := a.head
-		data, err := a.pager.GetForWrite(headID)
+		data, err := pageOps.getForWrite(a.pager, headID)
 		if err != nil {
 			return ids, err
 		}
 		n := node.NewNode(data)
-		if !n.VerifyChecksum() {
+		if !pageOps.verifyChecksum(headID, data) {
 			return ids, errors.New("freelist head corrupted (AllocMany)")
 		}
 		if n.Type() != page.PageTypeFreelist {
@@ -308,6 +318,7 @@ func (a *Allocator) AllocMany(count int, hint uint64) ([]uint64, error) {
 		countFree := int(n.Count())
 		if countFree == 0 {
 			next := freelistNextPageID(data)
+			pageOps.updateChecksum(headID, data)
 
 			recycled := a.head
 			a.head = next
@@ -319,9 +330,6 @@ func (a *Allocator) AllocMany(count int, hint uint64) ([]uint64, error) {
 				a.stats.Pages--
 			}
 			ids = append(ids, recycled)
-			if hook := testAllocatorPageEvent; hook != nil {
-				observeAllocatorPage(hook, headID, true, false)
-			}
 			continue
 		}
 
@@ -341,10 +349,7 @@ func (a *Allocator) AllocMany(count int, hint uint64) ([]uint64, error) {
 		}
 
 		n.SetCount(uint16(countFree))
-		n.UpdateChecksum()
-		if hook := testAllocatorPageEvent; hook != nil {
-			observeAllocatorPage(hook, headID, true, true)
-		}
+		pageOps.updateChecksum(headID, data)
 	}
 	return ids, nil
 }
@@ -370,17 +375,17 @@ func findRegionSlot(data []byte, count int, target, regionPages uint64, radius i
 // semantics while verifying and checksumming each mutated head once. Small
 // selections scan directly; larger selections reuse one transient range-max
 // index across head pages.
-func (a *Allocator) allocManyRegionLocked(count int, hint uint64) ([]uint64, error) {
+func (a *Allocator) allocManyRegionLocked(count int, hint uint64, pageOps allocatorPageOperations) ([]uint64, error) {
 	if count == 2 {
-		return a.allocTwoRegionLocked(hint)
+		return a.allocTwoRegionLocked(hint, pageOps)
 	}
 	if count < regionIndexMinSelections {
-		return a.allocManyRegionScanLocked(count, hint)
+		return a.allocManyRegionScanLocked(count, hint, pageOps)
 	}
-	return a.allocManyRegionIndexedLocked(count, hint)
+	return a.allocManyRegionIndexedLocked(count, hint, pageOps)
 }
 
-func (a *Allocator) allocTwoRegionLocked(hint uint64) ([]uint64, error) {
+func (a *Allocator) allocTwoRegionLocked(hint uint64, pageOps allocatorPageOperations) ([]uint64, error) {
 	ids := make([]uint64, 0, 2)
 	if a.preferAppend || a.head == 0 {
 		id, err := a.pager.Alloc(2)
@@ -395,12 +400,12 @@ func (a *Allocator) allocTwoRegionLocked(hint uint64) ([]uint64, error) {
 	}
 
 	headID := a.head
-	data, err := a.pager.GetForWrite(headID)
+	data, err := pageOps.getForWrite(a.pager, headID)
 	if err != nil {
 		return ids, err
 	}
 	n := node.NewNode(data)
-	if !n.VerifyChecksum() {
+	if !pageOps.verifyChecksum(headID, data) {
 		return ids, errors.New("freelist head corrupted (AllocMany)")
 	}
 	if n.Type() != page.PageTypeFreelist {
@@ -410,6 +415,7 @@ func (a *Allocator) allocTwoRegionLocked(hint uint64) ([]uint64, error) {
 	countFree := int(n.Count())
 	if countFree == 0 {
 		next := freelistNextPageID(data)
+		pageOps.updateChecksum(headID, data)
 		a.head = next
 		a.pager.MarkUnverified(headID)
 		a.lastAlloc = headID
@@ -419,10 +425,7 @@ func (a *Allocator) allocTwoRegionLocked(hint uint64) ([]uint64, error) {
 			a.stats.Pages--
 		}
 		ids = append(ids, headID)
-		if hook := testAllocatorPageEvent; hook != nil {
-			observeAllocatorPage(hook, headID, true, false)
-		}
-		tail, tailErr := a.allocManyRegionScanLocked(1, headID)
+		tail, tailErr := a.allocManyRegionScanLocked(1, headID, pageOps)
 		ids = append(ids, tail...)
 		return ids, tailErr
 	}
@@ -457,10 +460,7 @@ func (a *Allocator) allocTwoRegionLocked(hint uint64) ([]uint64, error) {
 	}
 
 	n.SetCount(uint16(countFree))
-	n.UpdateChecksum()
-	if hook := testAllocatorPageEvent; hook != nil {
-		observeAllocatorPage(hook, headID, true, true)
-	}
+	pageOps.updateChecksum(headID, data)
 	if countFree == 0 && len(ids) < 2 {
 		next := freelistNextPageID(data)
 		a.head = next
@@ -476,7 +476,7 @@ func (a *Allocator) allocTwoRegionLocked(hint uint64) ([]uint64, error) {
 	return ids, nil
 }
 
-func (a *Allocator) allocManyRegionScanLocked(count int, hint uint64) ([]uint64, error) {
+func (a *Allocator) allocManyRegionScanLocked(count int, hint uint64, pageOps allocatorPageOperations) ([]uint64, error) {
 	ids := make([]uint64, 0, count)
 	target := hint
 	for len(ids) < count {
@@ -496,12 +496,12 @@ func (a *Allocator) allocManyRegionScanLocked(count int, hint uint64) ([]uint64,
 		}
 
 		headID := a.head
-		data, err := a.pager.GetForWrite(headID)
+		data, err := pageOps.getForWrite(a.pager, headID)
 		if err != nil {
 			return ids, err
 		}
 		n := node.NewNode(data)
-		if !n.VerifyChecksum() {
+		if !pageOps.verifyChecksum(headID, data) {
 			return ids, errors.New("freelist head corrupted (AllocMany)")
 		}
 		if n.Type() != page.PageTypeFreelist {
@@ -511,6 +511,7 @@ func (a *Allocator) allocManyRegionScanLocked(count int, hint uint64) ([]uint64,
 		countFree := int(n.Count())
 		if countFree == 0 {
 			next := freelistNextPageID(data)
+			pageOps.updateChecksum(headID, data)
 			a.head = next
 			a.pager.MarkUnverified(headID)
 			a.lastAlloc = headID
@@ -521,9 +522,6 @@ func (a *Allocator) allocManyRegionScanLocked(count int, hint uint64) ([]uint64,
 			}
 			ids = append(ids, headID)
 			target = headID
-			if hook := testAllocatorPageEvent; hook != nil {
-				observeAllocatorPage(hook, headID, true, false)
-			}
 			continue
 		}
 
@@ -550,10 +548,7 @@ func (a *Allocator) allocManyRegionScanLocked(count int, hint uint64) ([]uint64,
 		}
 
 		n.SetCount(uint16(countFree))
-		n.UpdateChecksum()
-		if hook := testAllocatorPageEvent; hook != nil {
-			observeAllocatorPage(hook, headID, true, true)
-		}
+		pageOps.updateChecksum(headID, data)
 		for _, id := range ids[start:] {
 			a.recordReuseAllocation(id)
 		}
@@ -574,12 +569,12 @@ func (a *Allocator) allocManyRegionScanLocked(count int, hint uint64) ([]uint64,
 	return ids, nil
 }
 
-func (a *Allocator) allocManyRegionIndexedLocked(count int, hint uint64) ([]uint64, error) {
+func (a *Allocator) allocManyRegionIndexedLocked(count int, hint uint64, pageOps allocatorPageOperations) ([]uint64, error) {
 	var regionSlots regionSlotIndex
-	return a.allocManyRegionWithIndexLocked(count, hint, &regionSlots)
+	return a.allocManyRegionWithIndexLocked(count, hint, &regionSlots, pageOps)
 }
 
-func (a *Allocator) allocManyRegionWithIndexLocked(count int, hint uint64, regionSlots *regionSlotIndex) ([]uint64, error) {
+func (a *Allocator) allocManyRegionWithIndexLocked(count int, hint uint64, regionSlots *regionSlotIndex, pageOps allocatorPageOperations) ([]uint64, error) {
 	ids := make([]uint64, 0, count)
 	target := hint
 	for len(ids) < count {
@@ -599,12 +594,12 @@ func (a *Allocator) allocManyRegionWithIndexLocked(count int, hint uint64, regio
 		}
 
 		headID := a.head
-		data, err := a.pager.GetForWrite(headID)
+		data, err := pageOps.getForWrite(a.pager, headID)
 		if err != nil {
 			return ids, err
 		}
 		n := node.NewNode(data)
-		if !n.VerifyChecksum() {
+		if !pageOps.verifyChecksum(headID, data) {
 			return ids, errors.New("freelist head corrupted (AllocMany)")
 		}
 		if n.Type() != page.PageTypeFreelist {
@@ -614,6 +609,7 @@ func (a *Allocator) allocManyRegionWithIndexLocked(count int, hint uint64, regio
 		countFree := int(n.Count())
 		if countFree == 0 {
 			next := freelistNextPageID(data)
+			pageOps.updateChecksum(headID, data)
 			recycled := headID
 			a.head = next
 			a.pager.MarkUnverified(recycled)
@@ -625,9 +621,6 @@ func (a *Allocator) allocManyRegionWithIndexLocked(count int, hint uint64, regio
 			}
 			ids = append(ids, recycled)
 			target = recycled
-			if hook := testAllocatorPageEvent; hook != nil {
-				observeAllocatorPage(hook, headID, true, false)
-			}
 			continue
 		}
 
@@ -668,10 +661,7 @@ func (a *Allocator) allocManyRegionWithIndexLocked(count int, hint uint64, regio
 		}
 
 		n.SetCount(uint16(countFree))
-		n.UpdateChecksum()
-		if hook := testAllocatorPageEvent; hook != nil {
-			observeAllocatorPage(hook, headID, true, true)
-		}
+		pageOps.updateChecksum(headID, data)
 		for _, id := range ids[start:] {
 			a.recordReuseAllocation(id)
 		}
@@ -899,15 +889,16 @@ func (a *Allocator) FreeMany(ids []uint64) error {
 
 	a.mu.Lock()
 	defer a.mu.Unlock()
+	pageOps := activeAllocatorPageOperations()
 
 	if a.head != 0 {
 		headID := a.head
-		data, err := a.pager.GetForWrite(headID)
+		data, err := pageOps.getForWrite(a.pager, headID)
 		if err != nil {
 			return err
 		}
 		n := node.NewNode(data)
-		if !n.VerifyChecksum() {
+		if !pageOps.verifyChecksum(headID, data) {
 			return errors.New("freelist head corrupted (FreeMany)")
 		}
 		if n.Type() != page.PageTypeFreelist {
@@ -915,9 +906,9 @@ func (a *Allocator) FreeMany(ids []uint64) error {
 		}
 
 		count := int(n.Count())
-		updated := false
+		take := 0
 		if count < page.MaxFreeIDs {
-			take := page.MaxFreeIDs - count
+			take = page.MaxFreeIDs - count
 			if take > len(ids) {
 				take = len(ids)
 			}
@@ -928,21 +919,19 @@ func (a *Allocator) FreeMany(ids []uint64) error {
 					TestHookFreeBeforeChecksum()
 				}
 			}
-			if TestHookFreeManyBeforeChecksum != nil {
-				TestHookFreeManyBeforeChecksum()
-			}
-			n.UpdateChecksum()
-			updated = true
+		}
+		if TestHookFreeManyBeforeChecksum != nil {
+			TestHookFreeManyBeforeChecksum()
+		}
+		pageOps.updateChecksum(headID, data)
+		if take > 0 {
 			a.recordFreedPages(take, false)
 			ids = ids[take:]
-		}
-		if hook := testAllocatorPageEvent; hook != nil {
-			observeAllocatorPage(hook, headID, true, updated)
 		}
 	}
 
 	for len(ids) > 0 {
-		consumed, err := a.initHeadWithFreeIDs(ids[0], a.head, ids[1:], true)
+		consumed, err := a.initHeadWithFreeIDs(ids[0], a.head, ids[1:], pageOps)
 		if err != nil {
 			return err
 		}
@@ -952,15 +941,17 @@ func (a *Allocator) FreeMany(ids []uint64) error {
 	return nil
 }
 
-func (a *Allocator) initHeadWithFreeIDs(id, next uint64, ids []uint64, batchHook bool) (int, error) {
+func (a *Allocator) initHeadWithFreeIDs(id, next uint64, ids []uint64, pageOps allocatorPageOperations) (int, error) {
 	take := len(ids)
 	if take > page.MaxFreeIDs {
 		take = page.MaxFreeIDs
 	}
-	var data []byte
-	var err error
-	if batchHook {
-		data, err = a.pager.GetForWrite(id)
+	var (
+		data []byte
+		err  error
+	)
+	if pageOps != nil {
+		data, err = pageOps.getForWrite(a.pager, id)
 	} else {
 		data, err = a.pager.GetForWrite(id)
 	}
@@ -980,14 +971,11 @@ func (a *Allocator) initHeadWithFreeIDs(id, next uint64, ids []uint64, batchHook
 			TestHookFreeBeforeChecksum()
 		}
 	}
-	if batchHook && TestHookFreeManyBeforeChecksum != nil {
+	if pageOps != nil && TestHookFreeManyBeforeChecksum != nil {
 		TestHookFreeManyBeforeChecksum()
 	}
-	if batchHook {
-		n.UpdateChecksum()
-		if hook := testAllocatorPageEvent; hook != nil {
-			observeAllocatorPage(hook, id, false, true)
-		}
+	if pageOps != nil {
+		pageOps.updateChecksum(id, data)
 	} else {
 		n.UpdateChecksum()
 	}
@@ -1005,7 +993,7 @@ func (a *Allocator) recordFreedPages(count int, newHead bool) {
 }
 
 func (a *Allocator) initHead(id, next uint64) error {
-	_, err := a.initHeadWithFreeIDs(id, next, nil, false)
+	_, err := a.initHeadWithFreeIDs(id, next, nil, nil)
 	return err
 }
 

--- a/TreeDB/freelist/allocator.go
+++ b/TreeDB/freelist/allocator.go
@@ -4,6 +4,7 @@ import (
 	"encoding/binary"
 	"errors"
 	"fmt"
+	"sort"
 	"sync"
 
 	"github.com/snissn/gomap/TreeDB/node"
@@ -47,6 +48,182 @@ func setFreelistIDAt(data []byte, idx int, id uint64) {
 func clearFreelistIDAt(data []byte, idx int) {
 	off := page.PageHeaderSize + 8 + idx*8
 	clear(data[off : off+8])
+}
+
+type regionSlotHeap []int
+
+func (h *regionSlotHeap) init() {
+	for parent := len(*h)/2 - 1; parent >= 0; parent-- {
+		h.down(parent)
+	}
+}
+
+func (h *regionSlotHeap) push(slot int) {
+	*h = append(*h, slot)
+	child := len(*h) - 1
+	for child > 0 {
+		parent := (child - 1) / 2
+		if (*h)[parent] >= (*h)[child] {
+			break
+		}
+		(*h)[parent], (*h)[child] = (*h)[child], (*h)[parent]
+		child = parent
+	}
+}
+
+func (h *regionSlotHeap) pop() int {
+	last := len(*h) - 1
+	maximum := (*h)[0]
+	(*h)[0] = (*h)[last]
+	*h = (*h)[:last]
+	if len(*h) > 0 {
+		h.down(0)
+	}
+	return maximum
+}
+
+func (h *regionSlotHeap) down(parent int) {
+	for {
+		left := parent*2 + 1
+		if left >= len(*h) {
+			return
+		}
+		child := left
+		right := left + 1
+		if right < len(*h) && (*h)[right] > (*h)[left] {
+			child = right
+		}
+		if (*h)[parent] >= (*h)[child] {
+			return
+		}
+		(*h)[parent], (*h)[child] = (*h)[child], (*h)[parent]
+		parent = child
+	}
+}
+
+// regionSlotIndex finds the highest current freelist slot in a region range.
+// Per-region heaps use lazy deletion while the segment tree indexes their
+// current maxima.
+type regionSlotIndex struct {
+	regions     []uint64
+	buckets     []regionSlotHeap
+	slotBuckets []int
+	tree        []int
+	treeBase    int
+}
+
+func newRegionSlotIndex(data []byte, count int, regionPages uint64) *regionSlotIndex {
+	slotRegions := make([]uint64, count)
+	regions := make([]uint64, count)
+	for slot := 0; slot < count; slot++ {
+		region := freelistIDAt(data, slot) / regionPages
+		slotRegions[slot] = region
+		regions[slot] = region
+	}
+	sort.Slice(regions, func(i, j int) bool { return regions[i] < regions[j] })
+	unique := regions[:0]
+	for _, region := range regions {
+		if len(unique) == 0 || unique[len(unique)-1] != region {
+			unique = append(unique, region)
+		}
+	}
+	regions = unique
+
+	bucketByRegion := make(map[uint64]int, len(regions))
+	for bucket, region := range regions {
+		bucketByRegion[region] = bucket
+	}
+	idx := &regionSlotIndex{
+		regions:     regions,
+		buckets:     make([]regionSlotHeap, len(regions)),
+		slotBuckets: make([]int, count),
+		treeBase:    1,
+	}
+	for idx.treeBase < len(regions) {
+		idx.treeBase *= 2
+	}
+	idx.tree = make([]int, idx.treeBase*2)
+	for i := range idx.tree {
+		idx.tree[i] = -1
+	}
+	for slot, region := range slotRegions {
+		bucket := bucketByRegion[region]
+		idx.slotBuckets[slot] = bucket
+		idx.buckets[bucket] = append(idx.buckets[bucket], slot)
+	}
+	for bucket := range idx.buckets {
+		idx.buckets[bucket].init()
+		idx.tree[idx.treeBase+bucket] = idx.buckets[bucket][0]
+	}
+	for treeIdx := idx.treeBase - 1; treeIdx > 0; treeIdx-- {
+		idx.tree[treeIdx] = max(idx.tree[treeIdx*2], idx.tree[treeIdx*2+1])
+	}
+	return idx
+}
+
+func (idx *regionSlotIndex) highestInRange(targetRegion uint64, radius int) int {
+	distance := uint64(radius)
+	low := uint64(0)
+	if targetRegion > distance {
+		low = targetRegion - distance
+	}
+	high := targetRegion + distance
+	if high < targetRegion {
+		high = ^uint64(0)
+	}
+	left := sort.Search(len(idx.regions), func(i int) bool { return idx.regions[i] >= low })
+	right := sort.Search(len(idx.regions), func(i int) bool { return idx.regions[i] > high })
+	if left == right {
+		return -1
+	}
+	return idx.rangeMax(left, right)
+}
+
+func (idx *regionSlotIndex) rangeMax(left, right int) int {
+	best := -1
+	for left, right = left+idx.treeBase, right+idx.treeBase; left < right; left, right = left/2, right/2 {
+		if left%2 == 1 {
+			best = max(best, idx.tree[left])
+			left++
+		}
+		if right%2 == 1 {
+			right--
+			best = max(best, idx.tree[right])
+		}
+	}
+	return best
+}
+
+func (idx *regionSlotIndex) remove(slot, lastSlot int) {
+	removedBucket := idx.slotBuckets[slot]
+	lastBucket := idx.slotBuckets[lastSlot]
+	idx.slotBuckets[lastSlot] = -1
+	if slot != lastSlot {
+		idx.slotBuckets[slot] = lastBucket
+		if lastBucket != removedBucket {
+			idx.buckets[lastBucket].push(slot)
+		}
+	}
+	idx.refreshBucket(removedBucket)
+	if lastBucket != removedBucket {
+		idx.refreshBucket(lastBucket)
+	}
+}
+
+func (idx *regionSlotIndex) refreshBucket(bucket int) {
+	h := &idx.buckets[bucket]
+	for len(*h) > 0 && idx.slotBuckets[(*h)[0]] != bucket {
+		h.pop()
+	}
+	maximum := -1
+	if len(*h) > 0 {
+		maximum = (*h)[0]
+	}
+	treeIdx := idx.treeBase + bucket
+	idx.tree[treeIdx] = maximum
+	for treeIdx /= 2; treeIdx > 0; treeIdx /= 2 {
+		idx.tree[treeIdx] = max(idx.tree[treeIdx*2], idx.tree[treeIdx*2+1])
+	}
 }
 
 // TestHookFreeBeforeChecksum is a test-only hook that fires after a freelist
@@ -250,7 +427,10 @@ func (a *Allocator) allocManyRegionLocked(count int, hint uint64) ([]uint64, err
 			next := freelistNextPageID(data)
 			recycled := a.head
 			a.head = next
-			a.recordReuseAllocation(recycled)
+			a.pager.MarkUnverified(recycled)
+			a.lastAlloc = recycled
+			a.stats.AllocPages++
+			a.stats.ReuseAllocPages++
 			if a.stats.Pages > 0 {
 				a.stats.Pages--
 			}
@@ -260,47 +440,28 @@ func (a *Allocator) allocManyRegionLocked(count int, hint uint64) ([]uint64, err
 		}
 
 		start := len(ids)
-		need := count - start
-		selected := 0
 		if target == 0 {
 			target = a.lastAlloc
 		}
-		selectionTarget := target
-		var selectedSlots [page.MaxFreeIDs]bool
-		if selectionTarget != 0 {
-			for i := countFree - 1; i >= 0 && selected < need; i-- {
-				candidate := freelistIDAt(data, i)
-				if a.inRegion(candidate, selectionTarget/a.regionPages) {
-					ids = append(ids, candidate)
-					selectedSlots[i] = true
-					selected++
-					selectionTarget = candidate
-				}
-			}
-		}
-
-		if selected > 0 {
-			// Compact selected entries without re-verifying the page or updating
-			// its checksum for every ID.
-			write := 0
-			for i := 0; i < countFree; i++ {
-				if selectedSlots[i] {
-					continue
-				}
-				setFreelistIDAt(data, write, freelistIDAt(data, i))
-				write++
-			}
-			for i := write; i < countFree; i++ {
-				clearFreelistIDAt(data, i)
-			}
-			countFree = write
-		}
-
+		regionSlots := newRegionSlotIndex(data, countFree, a.regionPages)
 		for countFree > 0 && len(ids) < count {
-			idx := countFree - 1
-			ids = append(ids, freelistIDAt(data, idx))
-			clearFreelistIDAt(data, idx)
+			slot := -1
+			if target != 0 {
+				slot = regionSlots.highestInRange(target/a.regionPages, a.regionRadius)
+			}
+			lastSlot := countFree - 1
+			if slot < 0 {
+				slot = lastSlot
+			}
+			id := freelistIDAt(data, slot)
+			if slot != lastSlot {
+				setFreelistIDAt(data, slot, freelistIDAt(data, lastSlot))
+			}
+			clearFreelistIDAt(data, lastSlot)
+			regionSlots.remove(slot, lastSlot)
+			ids = append(ids, id)
 			countFree--
+			target = id
 		}
 
 		n.SetCount(uint16(countFree))
@@ -308,19 +469,8 @@ func (a *Allocator) allocManyRegionLocked(count int, hint uint64) ([]uint64, err
 		for _, id := range ids[start:] {
 			a.recordReuseAllocation(id)
 		}
-		if len(ids) > 0 {
-			target = ids[len(ids)-1]
-		}
 	}
 	return ids, nil
-}
-
-func (a *Allocator) inRegion(id, targetRegion uint64) bool {
-	region := id / a.regionPages
-	if region >= targetRegion {
-		return region-targetRegion <= uint64(a.regionRadius)
-	}
-	return targetRegion-region <= uint64(a.regionRadius)
 }
 
 func (a *Allocator) recordReuseAllocation(id uint64) {

--- a/TreeDB/freelist/allocator.go
+++ b/TreeDB/freelist/allocator.go
@@ -27,6 +27,37 @@ type Allocator struct {
 	// extending the file. This improves locality at the cost of reclaiming space
 	// later via vacuum.
 	preferAppend bool
+
+	testPageEvent func(allocatorPageEvent, uint64)
+}
+
+type allocatorPageEvent uint8
+
+const (
+	allocatorPageGetForWrite allocatorPageEvent = iota
+	allocatorPageVerifyChecksum
+	allocatorPageUpdateChecksum
+)
+
+func (a *Allocator) getPageForWrite(pageID uint64) ([]byte, error) {
+	if a.testPageEvent != nil {
+		a.testPageEvent(allocatorPageGetForWrite, pageID)
+	}
+	return a.pager.GetForWrite(pageID)
+}
+
+func (a *Allocator) verifyChecksum(pageID uint64, n *node.Node) bool {
+	if a.testPageEvent != nil {
+		a.testPageEvent(allocatorPageVerifyChecksum, pageID)
+	}
+	return n.VerifyChecksum()
+}
+
+func (a *Allocator) updateChecksum(pageID uint64, n *node.Node) {
+	if a.testPageEvent != nil {
+		a.testPageEvent(allocatorPageUpdateChecksum, pageID)
+	}
+	n.UpdateChecksum()
 }
 
 var errCannotFreePageZero = errors.New("cannot free page 0")
@@ -50,115 +81,76 @@ func clearFreelistIDAt(data []byte, idx int) {
 	clear(data[off : off+8])
 }
 
-type regionSlotHeap []int
+const regionIndexMinSelections = 8
 
-func (h *regionSlotHeap) init() {
-	for parent := len(*h)/2 - 1; parent >= 0; parent-- {
-		h.down(parent)
-	}
+type regionSlotEntry struct {
+	region uint64
+	slot   int
 }
 
-func (h *regionSlotHeap) push(slot int) {
-	*h = append(*h, slot)
-	child := len(*h) - 1
-	for child > 0 {
-		parent := (child - 1) / 2
-		if (*h)[parent] >= (*h)[child] {
-			break
-		}
-		(*h)[parent], (*h)[child] = (*h)[child], (*h)[parent]
-		child = parent
-	}
-}
+type regionSlotEntries []regionSlotEntry
 
-func (h *regionSlotHeap) pop() int {
-	last := len(*h) - 1
-	maximum := (*h)[0]
-	(*h)[0] = (*h)[last]
-	*h = (*h)[:last]
-	if len(*h) > 0 {
-		h.down(0)
+func (entries regionSlotEntries) Len() int      { return len(entries) }
+func (entries regionSlotEntries) Swap(i, j int) { entries[i], entries[j] = entries[j], entries[i] }
+func (entries regionSlotEntries) Less(i, j int) bool {
+	if entries[i].region != entries[j].region {
+		return entries[i].region < entries[j].region
 	}
-	return maximum
-}
-
-func (h *regionSlotHeap) down(parent int) {
-	for {
-		left := parent*2 + 1
-		if left >= len(*h) {
-			return
-		}
-		child := left
-		right := left + 1
-		if right < len(*h) && (*h)[right] > (*h)[left] {
-			child = right
-		}
-		if (*h)[parent] >= (*h)[child] {
-			return
-		}
-		(*h)[parent], (*h)[child] = (*h)[child], (*h)[parent]
-		parent = child
-	}
+	return entries[i].slot < entries[j].slot
 }
 
 // regionSlotIndex finds the highest current freelist slot in a region range.
-// Per-region heaps use lazy deletion while the segment tree indexes their
-// current maxima.
+// Entries remain ordered by candidate region while the segment tree tracks the
+// slot each candidate currently occupies after swap-with-last removals.
 type regionSlotIndex struct {
-	regions     []uint64
-	buckets     []regionSlotHeap
-	slotBuckets []int
+	entries     []regionSlotEntry
+	slotEntries []int
 	tree        []int
 	treeBase    int
 }
 
-func newRegionSlotIndex(data []byte, count int, regionPages uint64) *regionSlotIndex {
-	slotRegions := make([]uint64, count)
-	regions := make([]uint64, count)
-	for slot := 0; slot < count; slot++ {
-		region := freelistIDAt(data, slot) / regionPages
-		slotRegions[slot] = region
-		regions[slot] = region
+func (idx *regionSlotIndex) reset(data []byte, count int, regionPages uint64) {
+	if cap(idx.entries) < count {
+		idx.entries = make([]regionSlotEntry, count)
+	} else {
+		idx.entries = idx.entries[:count]
 	}
-	sort.Slice(regions, func(i, j int) bool { return regions[i] < regions[j] })
-	unique := regions[:0]
-	for _, region := range regions {
-		if len(unique) == 0 || unique[len(unique)-1] != region {
-			unique = append(unique, region)
+	for slot := 0; slot < count; slot++ {
+		idx.entries[slot] = regionSlotEntry{
+			region: freelistIDAt(data, slot) / regionPages,
+			slot:   slot,
 		}
 	}
-	regions = unique
+	sort.Sort(regionSlotEntries(idx.entries))
 
-	bucketByRegion := make(map[uint64]int, len(regions))
-	for bucket, region := range regions {
-		bucketByRegion[region] = bucket
+	if cap(idx.slotEntries) < count {
+		idx.slotEntries = make([]int, count)
+	} else {
+		idx.slotEntries = idx.slotEntries[:count]
 	}
-	idx := &regionSlotIndex{
-		regions:     regions,
-		buckets:     make([]regionSlotHeap, len(regions)),
-		slotBuckets: make([]int, count),
-		treeBase:    1,
+	for entry, candidate := range idx.entries {
+		idx.slotEntries[candidate.slot] = entry
 	}
-	for idx.treeBase < len(regions) {
+
+	idx.treeBase = 1
+	for idx.treeBase < count {
 		idx.treeBase *= 2
 	}
-	idx.tree = make([]int, idx.treeBase*2)
+	treeLen := idx.treeBase * 2
+	if cap(idx.tree) < treeLen {
+		idx.tree = make([]int, treeLen)
+	} else {
+		idx.tree = idx.tree[:treeLen]
+	}
 	for i := range idx.tree {
 		idx.tree[i] = -1
 	}
-	for slot, region := range slotRegions {
-		bucket := bucketByRegion[region]
-		idx.slotBuckets[slot] = bucket
-		idx.buckets[bucket] = append(idx.buckets[bucket], slot)
-	}
-	for bucket := range idx.buckets {
-		idx.buckets[bucket].init()
-		idx.tree[idx.treeBase+bucket] = idx.buckets[bucket][0]
+	for entry, candidate := range idx.entries {
+		idx.tree[idx.treeBase+entry] = candidate.slot
 	}
 	for treeIdx := idx.treeBase - 1; treeIdx > 0; treeIdx-- {
 		idx.tree[treeIdx] = max(idx.tree[treeIdx*2], idx.tree[treeIdx*2+1])
 	}
-	return idx
 }
 
 func (idx *regionSlotIndex) highestInRange(targetRegion uint64, radius int) int {
@@ -171,8 +163,8 @@ func (idx *regionSlotIndex) highestInRange(targetRegion uint64, radius int) int 
 	if high < targetRegion {
 		high = ^uint64(0)
 	}
-	left := sort.Search(len(idx.regions), func(i int) bool { return idx.regions[i] >= low })
-	right := sort.Search(len(idx.regions), func(i int) bool { return idx.regions[i] > high })
+	left := sort.Search(len(idx.entries), func(i int) bool { return idx.entries[i].region >= low })
+	right := sort.Search(len(idx.entries), func(i int) bool { return idx.entries[i].region > high })
 	if left == right {
 		return -1
 	}
@@ -195,32 +187,19 @@ func (idx *regionSlotIndex) rangeMax(left, right int) int {
 }
 
 func (idx *regionSlotIndex) remove(slot, lastSlot int) {
-	removedBucket := idx.slotBuckets[slot]
-	lastBucket := idx.slotBuckets[lastSlot]
-	idx.slotBuckets[lastSlot] = -1
+	removedEntry := idx.slotEntries[slot]
+	lastEntry := idx.slotEntries[lastSlot]
+	idx.slotEntries[lastSlot] = -1
+	idx.update(removedEntry, -1)
 	if slot != lastSlot {
-		idx.slotBuckets[slot] = lastBucket
-		if lastBucket != removedBucket {
-			idx.buckets[lastBucket].push(slot)
-		}
-	}
-	idx.refreshBucket(removedBucket)
-	if lastBucket != removedBucket {
-		idx.refreshBucket(lastBucket)
+		idx.slotEntries[slot] = lastEntry
+		idx.update(lastEntry, slot)
 	}
 }
 
-func (idx *regionSlotIndex) refreshBucket(bucket int) {
-	h := &idx.buckets[bucket]
-	for len(*h) > 0 && idx.slotBuckets[(*h)[0]] != bucket {
-		h.pop()
-	}
-	maximum := -1
-	if len(*h) > 0 {
-		maximum = (*h)[0]
-	}
-	treeIdx := idx.treeBase + bucket
-	idx.tree[treeIdx] = maximum
+func (idx *regionSlotIndex) update(entry, slot int) {
+	treeIdx := idx.treeBase + entry
+	idx.tree[treeIdx] = slot
 	for treeIdx /= 2; treeIdx > 0; treeIdx /= 2 {
 		idx.tree[treeIdx] = max(idx.tree[treeIdx*2], idx.tree[treeIdx*2+1])
 	}
@@ -337,12 +316,12 @@ func (a *Allocator) AllocMany(count int, hint uint64) ([]uint64, error) {
 			return ids, nil
 		}
 
-		data, err := a.pager.GetForWrite(a.head)
+		data, err := a.getPageForWrite(a.head)
 		if err != nil {
 			return ids, err
 		}
 		n := node.NewNode(data)
-		if !n.VerifyChecksum() {
+		if !a.verifyChecksum(a.head, n) {
 			return ids, errors.New("freelist head corrupted (AllocMany)")
 		}
 		if n.Type() != page.PageTypeFreelist {
@@ -382,18 +361,36 @@ func (a *Allocator) AllocMany(count int, hint uint64) ([]uint64, error) {
 		}
 
 		n.SetCount(uint16(countFree))
-		n.UpdateChecksum()
+		a.updateChecksum(a.head, n)
 	}
 	return ids, nil
 }
 
-// allocManyRegionLocked consumes all region-preferred entries from a verified
-// head page before falling back to LIFO entries from that same page. Region
-// preference is evaluated from the incoming hint (or last allocation); each
-// returned ID still advances lastAlloc for the next head-page selection.
+func findRegionSlot(data []byte, count int, target, regionPages uint64, radius int) int {
+	targetRegion := target / regionPages
+	for slot := count - 1; slot >= 0; slot-- {
+		candidateRegion := freelistIDAt(data, slot) / regionPages
+		var distance uint64
+		if candidateRegion >= targetRegion {
+			distance = candidateRegion - targetRegion
+		} else {
+			distance = targetRegion - candidateRegion
+		}
+		if distance <= uint64(radius) {
+			return slot
+		}
+	}
+	return -1
+}
+
+// allocManyRegionLocked applies repeated Alloc selection and swap-with-last
+// semantics while verifying and checksumming each mutated head once. Small
+// selections scan directly; larger selections reuse one transient range-max
+// index across head pages.
 func (a *Allocator) allocManyRegionLocked(count int, hint uint64) ([]uint64, error) {
 	ids := make([]uint64, 0, count)
 	target := hint
+	var regionSlots regionSlotIndex
 	for len(ids) < count {
 		if a.preferAppend || a.head == 0 {
 			allocCount := count - len(ids)
@@ -410,12 +407,13 @@ func (a *Allocator) allocManyRegionLocked(count int, hint uint64) ([]uint64, err
 			return ids, nil
 		}
 
-		data, err := a.pager.GetForWrite(a.head)
+		headID := a.head
+		data, err := a.getPageForWrite(headID)
 		if err != nil {
 			return ids, err
 		}
 		n := node.NewNode(data)
-		if !n.VerifyChecksum() {
+		if !a.verifyChecksum(headID, n) {
 			return ids, errors.New("freelist head corrupted (AllocMany)")
 		}
 		if n.Type() != page.PageTypeFreelist {
@@ -425,7 +423,7 @@ func (a *Allocator) allocManyRegionLocked(count int, hint uint64) ([]uint64, err
 		countFree := int(n.Count())
 		if countFree == 0 {
 			next := freelistNextPageID(data)
-			recycled := a.head
+			recycled := headID
 			a.head = next
 			a.pager.MarkUnverified(recycled)
 			a.lastAlloc = recycled
@@ -443,11 +441,20 @@ func (a *Allocator) allocManyRegionLocked(count int, hint uint64) ([]uint64, err
 		if target == 0 {
 			target = a.lastAlloc
 		}
-		regionSlots := newRegionSlotIndex(data, countFree, a.regionPages)
+		indexed := false
 		for countFree > 0 && len(ids) < count {
 			slot := -1
 			if target != 0 {
-				slot = regionSlots.highestInRange(target/a.regionPages, a.regionRadius)
+				selections := min(countFree, count-len(ids))
+				if !indexed && selections >= regionIndexMinSelections {
+					regionSlots.reset(data, countFree, a.regionPages)
+					indexed = true
+				}
+				if indexed {
+					slot = regionSlots.highestInRange(target/a.regionPages, a.regionRadius)
+				} else {
+					slot = findRegionSlot(data, countFree, target, a.regionPages, a.regionRadius)
+				}
 			}
 			lastSlot := countFree - 1
 			if slot < 0 {
@@ -458,16 +465,31 @@ func (a *Allocator) allocManyRegionLocked(count int, hint uint64) ([]uint64, err
 				setFreelistIDAt(data, slot, freelistIDAt(data, lastSlot))
 			}
 			clearFreelistIDAt(data, lastSlot)
-			regionSlots.remove(slot, lastSlot)
+			if indexed {
+				regionSlots.remove(slot, lastSlot)
+			}
 			ids = append(ids, id)
 			countFree--
 			target = id
 		}
 
 		n.SetCount(uint16(countFree))
-		n.UpdateChecksum()
+		a.updateChecksum(headID, n)
 		for _, id := range ids[start:] {
 			a.recordReuseAllocation(id)
+		}
+		if countFree == 0 && len(ids) < count {
+			next := freelistNextPageID(data)
+			a.head = next
+			a.pager.MarkUnverified(headID)
+			a.lastAlloc = headID
+			a.stats.AllocPages++
+			a.stats.ReuseAllocPages++
+			if a.stats.Pages > 0 {
+				a.stats.Pages--
+			}
+			ids = append(ids, headID)
+			target = headID
 		}
 	}
 	return ids, nil
@@ -504,12 +526,12 @@ func (a *Allocator) allocLocked(hint uint64) (uint64, error) {
 		return id, err
 	}
 
-	data, err := a.pager.GetForWrite(a.head)
+	data, err := a.getPageForWrite(a.head)
 	if err != nil {
 		return 0, err
 	}
 	n := node.NewNode(data)
-	if !n.VerifyChecksum() {
+	if !a.verifyChecksum(a.head, n) {
 		return 0, errors.New("freelist head corrupted (Alloc)")
 	}
 	if n.Type() != page.PageTypeFreelist {
@@ -550,7 +572,7 @@ func (a *Allocator) allocLocked(hint uint64) (uint64, error) {
 				}
 				clearFreelistIDAt(data, lastIdx)
 				n.SetCount(uint16(lastIdx))
-				n.UpdateChecksum()
+				a.updateChecksum(a.head, n)
 
 				a.pager.MarkUnverified(id)
 				a.lastAlloc = id
@@ -566,7 +588,7 @@ func (a *Allocator) allocLocked(hint uint64) (uint64, error) {
 		lastIdx := count - 1
 		clearFreelistIDAt(data, lastIdx)
 		n.SetCount(uint16(lastIdx))
-		n.UpdateChecksum()
+		a.updateChecksum(a.head, n)
 
 		a.pager.MarkUnverified(id)
 		a.lastAlloc = id
@@ -623,12 +645,12 @@ func (a *Allocator) Free(id uint64) error {
 	}
 
 	// Load Head
-	data, err := a.pager.GetForWrite(a.head)
+	data, err := a.getPageForWrite(a.head)
 	if err != nil {
 		return err
 	}
 	n := node.NewNode(data)
-	if !n.VerifyChecksum() {
+	if !a.verifyChecksum(a.head, n) {
 		return errors.New("freelist head corrupted (Free)")
 	}
 	if n.Type() != page.PageTypeFreelist {
@@ -644,7 +666,7 @@ func (a *Allocator) Free(id uint64) error {
 		if TestHookFreeBeforeChecksum != nil {
 			TestHookFreeBeforeChecksum()
 		}
-		n.UpdateChecksum()
+		a.updateChecksum(a.head, n)
 		a.stats.FreePages++
 		a.stats.FreeIDs++
 		return nil
@@ -681,23 +703,14 @@ func (a *Allocator) FreeMany(ids []uint64) error {
 	a.mu.Lock()
 	defer a.mu.Unlock()
 
-	for len(ids) > 0 {
-		if a.head == 0 {
-			consumed, err := a.initHeadWithFreeIDs(ids[0], 0, ids[1:], true)
-			if err != nil {
-				return err
-			}
-			a.recordFreedPages(consumed, true)
-			ids = ids[consumed:]
-			continue
-		}
-
-		data, err := a.pager.GetForWrite(a.head)
+	if a.head != 0 {
+		headID := a.head
+		data, err := a.getPageForWrite(headID)
 		if err != nil {
 			return err
 		}
 		n := node.NewNode(data)
-		if !n.VerifyChecksum() {
+		if !a.verifyChecksum(headID, n) {
 			return errors.New("freelist head corrupted (FreeMany)")
 		}
 		if n.Type() != page.PageTypeFreelist {
@@ -705,33 +718,34 @@ func (a *Allocator) FreeMany(ids []uint64) error {
 		}
 
 		count := int(n.Count())
-		if count >= page.MaxFreeIDs {
-			consumed, err := a.initHeadWithFreeIDs(ids[0], a.head, ids[1:], true)
-			if err != nil {
-				return err
+		if count < page.MaxFreeIDs {
+			take := page.MaxFreeIDs - count
+			if take > len(ids) {
+				take = len(ids)
 			}
-			a.recordFreedPages(consumed, true)
-			ids = ids[consumed:]
-			continue
+			for i := 0; i < take; i++ {
+				setFreelistIDAt(data, count+i, ids[i])
+				n.SetCount(uint16(count + i + 1))
+				if TestHookFreeBeforeChecksum != nil {
+					TestHookFreeBeforeChecksum()
+				}
+			}
+			if TestHookFreeManyBeforeChecksum != nil {
+				TestHookFreeManyBeforeChecksum()
+			}
+			a.updateChecksum(headID, n)
+			a.recordFreedPages(take, false)
+			ids = ids[take:]
 		}
+	}
 
-		take := page.MaxFreeIDs - count
-		if take > len(ids) {
-			take = len(ids)
+	for len(ids) > 0 {
+		consumed, err := a.initHeadWithFreeIDs(ids[0], a.head, ids[1:], true)
+		if err != nil {
+			return err
 		}
-		for i := 0; i < take; i++ {
-			setFreelistIDAt(data, count+i, ids[i])
-			n.SetCount(uint16(count + i + 1))
-			if TestHookFreeBeforeChecksum != nil {
-				TestHookFreeBeforeChecksum()
-			}
-		}
-		if TestHookFreeManyBeforeChecksum != nil {
-			TestHookFreeManyBeforeChecksum()
-		}
-		n.UpdateChecksum()
-		a.recordFreedPages(take, false)
-		ids = ids[take:]
+		a.recordFreedPages(consumed, true)
+		ids = ids[consumed:]
 	}
 	return nil
 }
@@ -741,7 +755,7 @@ func (a *Allocator) initHeadWithFreeIDs(id, next uint64, ids []uint64, batchHook
 	if take > page.MaxFreeIDs {
 		take = page.MaxFreeIDs
 	}
-	data, err := a.pager.GetForWrite(id)
+	data, err := a.getPageForWrite(id)
 	if err != nil {
 		return 0, err
 	}
@@ -761,7 +775,7 @@ func (a *Allocator) initHeadWithFreeIDs(id, next uint64, ids []uint64, batchHook
 	if batchHook && TestHookFreeManyBeforeChecksum != nil {
 		TestHookFreeManyBeforeChecksum()
 	}
-	n.UpdateChecksum()
+	a.updateChecksum(id, n)
 	a.head = id
 	return take + 1, nil
 }

--- a/TreeDB/freelist/allocator.go
+++ b/TreeDB/freelist/allocator.go
@@ -4,6 +4,7 @@ import (
 	"encoding/binary"
 	"errors"
 	"fmt"
+	"slices"
 	"sort"
 	"sync"
 
@@ -88,47 +89,37 @@ type regionSlotEntry struct {
 	slot   int
 }
 
-type regionSlotEntries []regionSlotEntry
-
-func (entries regionSlotEntries) Len() int      { return len(entries) }
-func (entries regionSlotEntries) Swap(i, j int) { entries[i], entries[j] = entries[j], entries[i] }
-func (entries regionSlotEntries) Less(i, j int) bool {
-	if entries[i].region != entries[j].region {
-		return entries[i].region < entries[j].region
-	}
-	return entries[i].slot < entries[j].slot
-}
-
 // regionSlotIndex finds the highest current freelist slot in a region range.
 // Entries remain ordered by candidate region while the segment tree tracks the
 // slot each candidate currently occupies after swap-with-last removals.
 type regionSlotIndex struct {
-	entries     []regionSlotEntry
-	slotEntries []int
-	tree        []int
+	entries     [page.MaxFreeIDs]regionSlotEntry
+	slotEntries [page.MaxFreeIDs]int
+	tree        [page.MaxFreeIDs * 4]int
+	count       int
 	treeBase    int
 }
 
 func (idx *regionSlotIndex) reset(data []byte, count int, regionPages uint64) {
-	if cap(idx.entries) < count {
-		idx.entries = make([]regionSlotEntry, count)
-	} else {
-		idx.entries = idx.entries[:count]
-	}
+	idx.count = count
+	entries := idx.entries[:count]
 	for slot := 0; slot < count; slot++ {
-		idx.entries[slot] = regionSlotEntry{
+		entries[slot] = regionSlotEntry{
 			region: freelistIDAt(data, slot) / regionPages,
 			slot:   slot,
 		}
 	}
-	sort.Sort(regionSlotEntries(idx.entries))
+	slices.SortFunc(entries, func(a, b regionSlotEntry) int {
+		if a.region < b.region {
+			return -1
+		}
+		if a.region > b.region {
+			return 1
+		}
+		return a.slot - b.slot
+	})
 
-	if cap(idx.slotEntries) < count {
-		idx.slotEntries = make([]int, count)
-	} else {
-		idx.slotEntries = idx.slotEntries[:count]
-	}
-	for entry, candidate := range idx.entries {
+	for entry, candidate := range entries {
 		idx.slotEntries[candidate.slot] = entry
 	}
 
@@ -137,15 +128,10 @@ func (idx *regionSlotIndex) reset(data []byte, count int, regionPages uint64) {
 		idx.treeBase *= 2
 	}
 	treeLen := idx.treeBase * 2
-	if cap(idx.tree) < treeLen {
-		idx.tree = make([]int, treeLen)
-	} else {
-		idx.tree = idx.tree[:treeLen]
-	}
-	for i := range idx.tree {
+	for i := range idx.tree[:treeLen] {
 		idx.tree[i] = -1
 	}
-	for entry, candidate := range idx.entries {
+	for entry, candidate := range entries {
 		idx.tree[idx.treeBase+entry] = candidate.slot
 	}
 	for treeIdx := idx.treeBase - 1; treeIdx > 0; treeIdx-- {
@@ -163,8 +149,9 @@ func (idx *regionSlotIndex) highestInRange(targetRegion uint64, radius int) int 
 	if high < targetRegion {
 		high = ^uint64(0)
 	}
-	left := sort.Search(len(idx.entries), func(i int) bool { return idx.entries[i].region >= low })
-	right := sort.Search(len(idx.entries), func(i int) bool { return idx.entries[i].region > high })
+	entries := idx.entries[:idx.count]
+	left := sort.Search(len(entries), func(i int) bool { return entries[i].region >= low })
+	right := sort.Search(len(entries), func(i int) bool { return entries[i].region > high })
 	if left == right {
 		return -1
 	}
@@ -388,9 +375,201 @@ func findRegionSlot(data []byte, count int, target, regionPages uint64, radius i
 // selections scan directly; larger selections reuse one transient range-max
 // index across head pages.
 func (a *Allocator) allocManyRegionLocked(count int, hint uint64) ([]uint64, error) {
+	if count == 2 {
+		return a.allocTwoRegionLocked(hint)
+	}
+	if count < regionIndexMinSelections {
+		return a.allocManyRegionScanLocked(count, hint)
+	}
+	return a.allocManyRegionIndexedLocked(count, hint)
+}
+
+func (a *Allocator) allocTwoRegionLocked(hint uint64) ([]uint64, error) {
+	ids := make([]uint64, 0, 2)
+	if a.preferAppend || a.head == 0 {
+		id, err := a.pager.Alloc(2)
+		if err != nil {
+			return ids, err
+		}
+		ids = append(ids, id, id+1)
+		a.stats.AllocPages += 2
+		a.stats.AppendAllocPages += 2
+		a.lastAlloc = id + 1
+		return ids, nil
+	}
+
+	headID := a.head
+	data, err := a.getPageForWrite(headID)
+	if err != nil {
+		return ids, err
+	}
+	n := node.NewNode(data)
+	if !a.verifyChecksum(headID, n) {
+		return ids, errors.New("freelist head corrupted (AllocMany)")
+	}
+	if n.Type() != page.PageTypeFreelist {
+		return ids, errors.New("invalid freelist page type")
+	}
+
+	countFree := int(n.Count())
+	if countFree == 0 {
+		next := freelistNextPageID(data)
+		a.head = next
+		a.pager.MarkUnverified(headID)
+		a.lastAlloc = headID
+		a.stats.AllocPages++
+		a.stats.ReuseAllocPages++
+		if a.stats.Pages > 0 {
+			a.stats.Pages--
+		}
+		ids = append(ids, headID)
+		tail, tailErr := a.allocManyRegionScanLocked(1, headID)
+		ids = append(ids, tail...)
+		return ids, tailErr
+	}
+
+	target := hint
+	if target == 0 {
+		target = a.lastAlloc
+	}
+	for countFree > 0 && len(ids) < 2 {
+		slot := countFree - 1
+		if target != 0 {
+			if regionSlot := findRegionSlot(data, countFree, target, a.regionPages, a.regionRadius); regionSlot >= 0 {
+				slot = regionSlot
+			}
+		}
+		lastSlot := countFree - 1
+		id := freelistIDAt(data, slot)
+		if slot != lastSlot {
+			setFreelistIDAt(data, slot, freelistIDAt(data, lastSlot))
+		}
+		clearFreelistIDAt(data, lastSlot)
+		ids = append(ids, id)
+		countFree--
+		target = id
+	}
+
+	n.SetCount(uint16(countFree))
+	a.updateChecksum(headID, n)
+	for _, id := range ids {
+		a.recordReuseAllocation(id)
+	}
+	if countFree == 0 && len(ids) < 2 {
+		next := freelistNextPageID(data)
+		a.head = next
+		a.pager.MarkUnverified(headID)
+		a.lastAlloc = headID
+		a.stats.AllocPages++
+		a.stats.ReuseAllocPages++
+		if a.stats.Pages > 0 {
+			a.stats.Pages--
+		}
+		ids = append(ids, headID)
+	}
+	return ids, nil
+}
+
+func (a *Allocator) allocManyRegionScanLocked(count int, hint uint64) ([]uint64, error) {
 	ids := make([]uint64, 0, count)
 	target := hint
+	for len(ids) < count {
+		if a.preferAppend || a.head == 0 {
+			allocCount := count - len(ids)
+			id, err := a.pager.Alloc(allocCount)
+			if err != nil {
+				return ids, err
+			}
+			a.stats.AllocPages += uint64(allocCount)
+			a.stats.AppendAllocPages += uint64(allocCount)
+			for i := 0; i < allocCount; i++ {
+				ids = append(ids, id+uint64(i))
+			}
+			a.lastAlloc = ids[len(ids)-1]
+			return ids, nil
+		}
+
+		headID := a.head
+		data, err := a.getPageForWrite(headID)
+		if err != nil {
+			return ids, err
+		}
+		n := node.NewNode(data)
+		if !a.verifyChecksum(headID, n) {
+			return ids, errors.New("freelist head corrupted (AllocMany)")
+		}
+		if n.Type() != page.PageTypeFreelist {
+			return ids, errors.New("invalid freelist page type")
+		}
+
+		countFree := int(n.Count())
+		if countFree == 0 {
+			next := freelistNextPageID(data)
+			a.head = next
+			a.pager.MarkUnverified(headID)
+			a.lastAlloc = headID
+			a.stats.AllocPages++
+			a.stats.ReuseAllocPages++
+			if a.stats.Pages > 0 {
+				a.stats.Pages--
+			}
+			ids = append(ids, headID)
+			target = headID
+			continue
+		}
+
+		start := len(ids)
+		if target == 0 {
+			target = a.lastAlloc
+		}
+		for countFree > 0 && len(ids) < count {
+			slot := countFree - 1
+			if target != 0 {
+				if regionSlot := findRegionSlot(data, countFree, target, a.regionPages, a.regionRadius); regionSlot >= 0 {
+					slot = regionSlot
+				}
+			}
+			lastSlot := countFree - 1
+			id := freelistIDAt(data, slot)
+			if slot != lastSlot {
+				setFreelistIDAt(data, slot, freelistIDAt(data, lastSlot))
+			}
+			clearFreelistIDAt(data, lastSlot)
+			ids = append(ids, id)
+			countFree--
+			target = id
+		}
+
+		n.SetCount(uint16(countFree))
+		a.updateChecksum(headID, n)
+		for _, id := range ids[start:] {
+			a.recordReuseAllocation(id)
+		}
+		if countFree == 0 && len(ids) < count {
+			next := freelistNextPageID(data)
+			a.head = next
+			a.pager.MarkUnverified(headID)
+			a.lastAlloc = headID
+			a.stats.AllocPages++
+			a.stats.ReuseAllocPages++
+			if a.stats.Pages > 0 {
+				a.stats.Pages--
+			}
+			ids = append(ids, headID)
+			target = headID
+		}
+	}
+	return ids, nil
+}
+
+func (a *Allocator) allocManyRegionIndexedLocked(count int, hint uint64) ([]uint64, error) {
 	var regionSlots regionSlotIndex
+	return a.allocManyRegionWithIndexLocked(count, hint, &regionSlots)
+}
+
+func (a *Allocator) allocManyRegionWithIndexLocked(count int, hint uint64, regionSlots *regionSlotIndex) ([]uint64, error) {
+	ids := make([]uint64, 0, count)
+	target := hint
 	for len(ids) < count {
 		if a.preferAppend || a.head == 0 {
 			allocCount := count - len(ids)
@@ -446,7 +625,7 @@ func (a *Allocator) allocManyRegionLocked(count int, hint uint64) ([]uint64, err
 			slot := -1
 			if target != 0 {
 				selections := min(countFree, count-len(ids))
-				if !indexed && selections >= regionIndexMinSelections {
+				if !indexed && regionSlots != nil && selections >= regionIndexMinSelections {
 					regionSlots.reset(data, countFree, a.regionPages)
 					indexed = true
 				}

--- a/TreeDB/freelist/allocator.go
+++ b/TreeDB/freelist/allocator.go
@@ -705,12 +705,12 @@ func (a *Allocator) allocLocked(hint uint64) (uint64, error) {
 		return id, err
 	}
 
-	data, err := a.getPageForWrite(a.head)
+	data, err := a.pager.GetForWrite(a.head)
 	if err != nil {
 		return 0, err
 	}
 	n := node.NewNode(data)
-	if !a.verifyChecksum(a.head, n) {
+	if !n.VerifyChecksum() {
 		return 0, errors.New("freelist head corrupted (Alloc)")
 	}
 	if n.Type() != page.PageTypeFreelist {
@@ -751,7 +751,7 @@ func (a *Allocator) allocLocked(hint uint64) (uint64, error) {
 				}
 				clearFreelistIDAt(data, lastIdx)
 				n.SetCount(uint16(lastIdx))
-				a.updateChecksum(a.head, n)
+				n.UpdateChecksum()
 
 				a.pager.MarkUnverified(id)
 				a.lastAlloc = id
@@ -767,7 +767,7 @@ func (a *Allocator) allocLocked(hint uint64) (uint64, error) {
 		lastIdx := count - 1
 		clearFreelistIDAt(data, lastIdx)
 		n.SetCount(uint16(lastIdx))
-		a.updateChecksum(a.head, n)
+		n.UpdateChecksum()
 
 		a.pager.MarkUnverified(id)
 		a.lastAlloc = id
@@ -824,12 +824,12 @@ func (a *Allocator) Free(id uint64) error {
 	}
 
 	// Load Head
-	data, err := a.getPageForWrite(a.head)
+	data, err := a.pager.GetForWrite(a.head)
 	if err != nil {
 		return err
 	}
 	n := node.NewNode(data)
-	if !a.verifyChecksum(a.head, n) {
+	if !n.VerifyChecksum() {
 		return errors.New("freelist head corrupted (Free)")
 	}
 	if n.Type() != page.PageTypeFreelist {
@@ -845,7 +845,7 @@ func (a *Allocator) Free(id uint64) error {
 		if TestHookFreeBeforeChecksum != nil {
 			TestHookFreeBeforeChecksum()
 		}
-		a.updateChecksum(a.head, n)
+		n.UpdateChecksum()
 		a.stats.FreePages++
 		a.stats.FreeIDs++
 		return nil
@@ -934,7 +934,13 @@ func (a *Allocator) initHeadWithFreeIDs(id, next uint64, ids []uint64, batchHook
 	if take > page.MaxFreeIDs {
 		take = page.MaxFreeIDs
 	}
-	data, err := a.getPageForWrite(id)
+	var data []byte
+	var err error
+	if batchHook {
+		data, err = a.getPageForWrite(id)
+	} else {
+		data, err = a.pager.GetForWrite(id)
+	}
 	if err != nil {
 		return 0, err
 	}
@@ -954,7 +960,11 @@ func (a *Allocator) initHeadWithFreeIDs(id, next uint64, ids []uint64, batchHook
 	if batchHook && TestHookFreeManyBeforeChecksum != nil {
 		TestHookFreeManyBeforeChecksum()
 	}
-	a.updateChecksum(id, n)
+	if batchHook {
+		a.updateChecksum(id, n)
+	} else {
+		n.UpdateChecksum()
+	}
 	a.head = id
 	return take + 1, nil
 }

--- a/TreeDB/freelist/allocator.go
+++ b/TreeDB/freelist/allocator.go
@@ -40,25 +40,17 @@ const (
 
 var testAllocatorPageEvent func(allocatorPageEvent, uint64)
 
-func (a *Allocator) getPageForWrite(pageID uint64) ([]byte, error) {
-	if testAllocatorPageEvent != nil {
-		testAllocatorPageEvent(allocatorPageGetForWrite, pageID)
+func observeAllocatorPage(pageID uint64, verified, updated bool) {
+	if testAllocatorPageEvent == nil {
+		return
 	}
-	return a.pager.GetForWrite(pageID)
-}
-
-func (a *Allocator) verifyChecksum(pageID uint64, n *node.Node) bool {
-	if testAllocatorPageEvent != nil {
+	testAllocatorPageEvent(allocatorPageGetForWrite, pageID)
+	if verified {
 		testAllocatorPageEvent(allocatorPageVerifyChecksum, pageID)
 	}
-	return n.VerifyChecksum()
-}
-
-func (a *Allocator) updateChecksum(pageID uint64, n *node.Node) {
-	if testAllocatorPageEvent != nil {
+	if updated {
 		testAllocatorPageEvent(allocatorPageUpdateChecksum, pageID)
 	}
-	n.UpdateChecksum()
 }
 
 var errCannotFreePageZero = errors.New("cannot free page 0")
@@ -303,12 +295,13 @@ func (a *Allocator) AllocMany(count int, hint uint64) ([]uint64, error) {
 			return ids, nil
 		}
 
-		data, err := a.getPageForWrite(a.head)
+		headID := a.head
+		data, err := a.pager.GetForWrite(headID)
 		if err != nil {
 			return ids, err
 		}
 		n := node.NewNode(data)
-		if !a.verifyChecksum(a.head, n) {
+		if !n.VerifyChecksum() {
 			return ids, errors.New("freelist head corrupted (AllocMany)")
 		}
 		if n.Type() != page.PageTypeFreelist {
@@ -329,6 +322,7 @@ func (a *Allocator) AllocMany(count int, hint uint64) ([]uint64, error) {
 				a.stats.Pages--
 			}
 			ids = append(ids, recycled)
+			observeAllocatorPage(headID, true, false)
 			continue
 		}
 
@@ -348,7 +342,8 @@ func (a *Allocator) AllocMany(count int, hint uint64) ([]uint64, error) {
 		}
 
 		n.SetCount(uint16(countFree))
-		a.updateChecksum(a.head, n)
+		n.UpdateChecksum()
+		observeAllocatorPage(headID, true, true)
 	}
 	return ids, nil
 }
@@ -399,12 +394,12 @@ func (a *Allocator) allocTwoRegionLocked(hint uint64) ([]uint64, error) {
 	}
 
 	headID := a.head
-	data, err := a.getPageForWrite(headID)
+	data, err := a.pager.GetForWrite(headID)
 	if err != nil {
 		return ids, err
 	}
 	n := node.NewNode(data)
-	if !a.verifyChecksum(headID, n) {
+	if !n.VerifyChecksum() {
 		return ids, errors.New("freelist head corrupted (AllocMany)")
 	}
 	if n.Type() != page.PageTypeFreelist {
@@ -423,6 +418,7 @@ func (a *Allocator) allocTwoRegionLocked(hint uint64) ([]uint64, error) {
 			a.stats.Pages--
 		}
 		ids = append(ids, headID)
+		observeAllocatorPage(headID, true, false)
 		tail, tailErr := a.allocManyRegionScanLocked(1, headID)
 		ids = append(ids, tail...)
 		return ids, tailErr
@@ -451,7 +447,8 @@ func (a *Allocator) allocTwoRegionLocked(hint uint64) ([]uint64, error) {
 	}
 
 	n.SetCount(uint16(countFree))
-	a.updateChecksum(headID, n)
+	n.UpdateChecksum()
+	observeAllocatorPage(headID, true, true)
 	for _, id := range ids {
 		a.recordReuseAllocation(id)
 	}
@@ -490,12 +487,12 @@ func (a *Allocator) allocManyRegionScanLocked(count int, hint uint64) ([]uint64,
 		}
 
 		headID := a.head
-		data, err := a.getPageForWrite(headID)
+		data, err := a.pager.GetForWrite(headID)
 		if err != nil {
 			return ids, err
 		}
 		n := node.NewNode(data)
-		if !a.verifyChecksum(headID, n) {
+		if !n.VerifyChecksum() {
 			return ids, errors.New("freelist head corrupted (AllocMany)")
 		}
 		if n.Type() != page.PageTypeFreelist {
@@ -515,6 +512,7 @@ func (a *Allocator) allocManyRegionScanLocked(count int, hint uint64) ([]uint64,
 			}
 			ids = append(ids, headID)
 			target = headID
+			observeAllocatorPage(headID, true, false)
 			continue
 		}
 
@@ -541,7 +539,8 @@ func (a *Allocator) allocManyRegionScanLocked(count int, hint uint64) ([]uint64,
 		}
 
 		n.SetCount(uint16(countFree))
-		a.updateChecksum(headID, n)
+		n.UpdateChecksum()
+		observeAllocatorPage(headID, true, true)
 		for _, id := range ids[start:] {
 			a.recordReuseAllocation(id)
 		}
@@ -587,12 +586,12 @@ func (a *Allocator) allocManyRegionWithIndexLocked(count int, hint uint64, regio
 		}
 
 		headID := a.head
-		data, err := a.getPageForWrite(headID)
+		data, err := a.pager.GetForWrite(headID)
 		if err != nil {
 			return ids, err
 		}
 		n := node.NewNode(data)
-		if !a.verifyChecksum(headID, n) {
+		if !n.VerifyChecksum() {
 			return ids, errors.New("freelist head corrupted (AllocMany)")
 		}
 		if n.Type() != page.PageTypeFreelist {
@@ -613,6 +612,7 @@ func (a *Allocator) allocManyRegionWithIndexLocked(count int, hint uint64, regio
 			}
 			ids = append(ids, recycled)
 			target = recycled
+			observeAllocatorPage(headID, true, false)
 			continue
 		}
 
@@ -653,7 +653,8 @@ func (a *Allocator) allocManyRegionWithIndexLocked(count int, hint uint64, regio
 		}
 
 		n.SetCount(uint16(countFree))
-		a.updateChecksum(headID, n)
+		n.UpdateChecksum()
+		observeAllocatorPage(headID, true, true)
 		for _, id := range ids[start:] {
 			a.recordReuseAllocation(id)
 		}
@@ -884,12 +885,12 @@ func (a *Allocator) FreeMany(ids []uint64) error {
 
 	if a.head != 0 {
 		headID := a.head
-		data, err := a.getPageForWrite(headID)
+		data, err := a.pager.GetForWrite(headID)
 		if err != nil {
 			return err
 		}
 		n := node.NewNode(data)
-		if !a.verifyChecksum(headID, n) {
+		if !n.VerifyChecksum() {
 			return errors.New("freelist head corrupted (FreeMany)")
 		}
 		if n.Type() != page.PageTypeFreelist {
@@ -897,6 +898,7 @@ func (a *Allocator) FreeMany(ids []uint64) error {
 		}
 
 		count := int(n.Count())
+		updated := false
 		if count < page.MaxFreeIDs {
 			take := page.MaxFreeIDs - count
 			if take > len(ids) {
@@ -912,10 +914,12 @@ func (a *Allocator) FreeMany(ids []uint64) error {
 			if TestHookFreeManyBeforeChecksum != nil {
 				TestHookFreeManyBeforeChecksum()
 			}
-			a.updateChecksum(headID, n)
+			n.UpdateChecksum()
+			updated = true
 			a.recordFreedPages(take, false)
 			ids = ids[take:]
 		}
+		observeAllocatorPage(headID, true, updated)
 	}
 
 	for len(ids) > 0 {
@@ -937,7 +941,7 @@ func (a *Allocator) initHeadWithFreeIDs(id, next uint64, ids []uint64, batchHook
 	var data []byte
 	var err error
 	if batchHook {
-		data, err = a.getPageForWrite(id)
+		data, err = a.pager.GetForWrite(id)
 	} else {
 		data, err = a.pager.GetForWrite(id)
 	}
@@ -961,7 +965,8 @@ func (a *Allocator) initHeadWithFreeIDs(id, next uint64, ids []uint64, batchHook
 		TestHookFreeManyBeforeChecksum()
 	}
 	if batchHook {
-		a.updateChecksum(id, n)
+		n.UpdateChecksum()
+		observeAllocatorPage(id, false, true)
 	} else {
 		n.UpdateChecksum()
 	}

--- a/TreeDB/freelist/allocator.go
+++ b/TreeDB/freelist/allocator.go
@@ -6,61 +6,38 @@ import (
 	"fmt"
 	"slices"
 	"sort"
-	"sync"
 
 	"github.com/snissn/gomap/TreeDB/node"
 	"github.com/snissn/gomap/TreeDB/page"
 	"github.com/snissn/gomap/TreeDB/pager"
 )
 
-type Allocator struct {
-	pager *pager.Pager
-	head  uint64
-	mu    sync.Mutex
+type allocatorPageOperation uint8
 
-	lastAlloc    uint64
-	regionPages  uint64
-	regionRadius int
-
-	stats Stats
-
-	// preferAppend makes Alloc ignore the freelist and allocate new pages by
-	// extending the file. This improves locality at the cost of reclaiming space
-	// later via vacuum.
-	preferAppend bool
-}
-
-type allocatorPageOperations struct {
-	getForWriteFunc    func(*pager.Pager, uint64) ([]byte, error)
-	verifyChecksumFunc func(uint64, []byte) bool
-	updateChecksumFunc func(uint64, []byte)
-}
-
-func (ops *allocatorPageOperations) getForWrite(p *pager.Pager, pageID uint64) ([]byte, error) {
-	if ops == nil {
-		return p.GetForWrite(pageID)
-	}
-	return ops.getForWriteFunc(p, pageID)
-}
-
-func (ops *allocatorPageOperations) verifyChecksum(pageID uint64, data []byte) bool {
-	if ops == nil {
-		return node.NewNode(data).VerifyChecksum()
-	}
-	return ops.verifyChecksumFunc(pageID, data)
-}
-
-func (ops *allocatorPageOperations) updateChecksum(pageID uint64, data []byte) {
-	if ops == nil {
-		node.NewNode(data).UpdateChecksum()
-		return
-	}
-	ops.updateChecksumFunc(pageID, data)
-}
-
-var testAllocatorPageOperations *allocatorPageOperations
+const (
+	allocatorPageGetForWrite allocatorPageOperation = iota
+	allocatorPageVerifyChecksum
+	allocatorPageUpdateChecksum
+)
 
 var errCannotFreePageZero = errors.New("cannot free page 0")
+
+// FreeManyError reports an error after FreeMany committed a prefix of its
+// input. Processed is the number of leading IDs that were added to the
+// freelist; callers may retry ids[Processed:] without double-freeing the
+// committed prefix.
+type FreeManyError struct {
+	Processed int
+	Err       error
+}
+
+func (e *FreeManyError) Error() string {
+	return fmt.Sprintf("free many after %d IDs: %v", e.Processed, e.Err)
+}
+
+func (e *FreeManyError) Unwrap() error {
+	return e.Err
+}
 
 func freelistNextPageID(data []byte) uint64 {
 	return binary.LittleEndian.Uint64(data[page.PageHeaderSize : page.PageHeaderSize+8])
@@ -280,10 +257,9 @@ func (a *Allocator) AllocMany(count int, hint uint64) ([]uint64, error) {
 
 	a.mu.Lock()
 	defer a.mu.Unlock()
-	pageOps := testAllocatorPageOperations
 
 	if a.regionPages > 0 && a.regionRadius > 0 {
-		return a.allocManyRegionLocked(count, hint, pageOps)
+		return a.allocManyRegionLocked(count, hint)
 	}
 
 	ids := make([]uint64, 0, count)
@@ -304,12 +280,25 @@ func (a *Allocator) AllocMany(count int, hint uint64) ([]uint64, error) {
 		}
 
 		headID := a.head
-		data, err := pageOps.getForWrite(a.pager, headID)
+		if allocatorInstrumentationEnabled {
+			if err := a.injectedGetForWriteError(headID); err != nil {
+				a.observePageOperation(allocatorPageGetForWrite, headID)
+				return ids, err
+			}
+		}
+		data, err := a.pager.GetForWrite(headID)
+		if allocatorInstrumentationEnabled {
+			a.observePageOperation(allocatorPageGetForWrite, headID)
+		}
 		if err != nil {
 			return ids, err
 		}
 		n := node.NewNode(data)
-		if !pageOps.verifyChecksum(headID, data) {
+		checksumOK := n.VerifyChecksum()
+		if allocatorInstrumentationEnabled {
+			a.observePageOperation(allocatorPageVerifyChecksum, headID)
+		}
+		if !checksumOK {
 			return ids, errors.New("freelist head corrupted (AllocMany)")
 		}
 		if n.Type() != page.PageTypeFreelist {
@@ -319,7 +308,10 @@ func (a *Allocator) AllocMany(count int, hint uint64) ([]uint64, error) {
 		countFree := int(n.Count())
 		if countFree == 0 {
 			next := freelistNextPageID(data)
-			pageOps.updateChecksum(headID, data)
+			n.UpdateChecksum()
+			if allocatorInstrumentationEnabled {
+				a.observePageOperation(allocatorPageUpdateChecksum, headID)
+			}
 
 			recycled := a.head
 			a.head = next
@@ -350,7 +342,10 @@ func (a *Allocator) AllocMany(count int, hint uint64) ([]uint64, error) {
 		}
 
 		n.SetCount(uint16(countFree))
-		pageOps.updateChecksum(headID, data)
+		n.UpdateChecksum()
+		if allocatorInstrumentationEnabled {
+			a.observePageOperation(allocatorPageUpdateChecksum, headID)
+		}
 	}
 	return ids, nil
 }
@@ -376,17 +371,17 @@ func findRegionSlot(data []byte, count int, target, regionPages uint64, radius i
 // semantics while verifying and checksumming each mutated head once. Small
 // selections scan directly; larger selections reuse one transient range-max
 // index across head pages.
-func (a *Allocator) allocManyRegionLocked(count int, hint uint64, pageOps *allocatorPageOperations) ([]uint64, error) {
+func (a *Allocator) allocManyRegionLocked(count int, hint uint64) ([]uint64, error) {
 	if count == 2 {
-		return a.allocTwoRegionLocked(hint, pageOps)
+		return a.allocTwoRegionLocked(hint)
 	}
 	if count < regionIndexMinSelections {
-		return a.allocManyRegionScanLocked(count, hint, pageOps)
+		return a.allocManyRegionScanLocked(count, hint)
 	}
-	return a.allocManyRegionIndexedLocked(count, hint, pageOps)
+	return a.allocManyRegionIndexedLocked(count, hint)
 }
 
-func (a *Allocator) allocTwoRegionLocked(hint uint64, pageOps *allocatorPageOperations) ([]uint64, error) {
+func (a *Allocator) allocTwoRegionLocked(hint uint64) ([]uint64, error) {
 	ids := make([]uint64, 0, 2)
 	if a.preferAppend || a.head == 0 {
 		id, err := a.pager.Alloc(2)
@@ -401,12 +396,25 @@ func (a *Allocator) allocTwoRegionLocked(hint uint64, pageOps *allocatorPageOper
 	}
 
 	headID := a.head
-	data, err := pageOps.getForWrite(a.pager, headID)
+	if allocatorInstrumentationEnabled {
+		if err := a.injectedGetForWriteError(headID); err != nil {
+			a.observePageOperation(allocatorPageGetForWrite, headID)
+			return ids, err
+		}
+	}
+	data, err := a.pager.GetForWrite(headID)
+	if allocatorInstrumentationEnabled {
+		a.observePageOperation(allocatorPageGetForWrite, headID)
+	}
 	if err != nil {
 		return ids, err
 	}
 	n := node.NewNode(data)
-	if !pageOps.verifyChecksum(headID, data) {
+	checksumOK := n.VerifyChecksum()
+	if allocatorInstrumentationEnabled {
+		a.observePageOperation(allocatorPageVerifyChecksum, headID)
+	}
+	if !checksumOK {
 		return ids, errors.New("freelist head corrupted (AllocMany)")
 	}
 	if n.Type() != page.PageTypeFreelist {
@@ -416,7 +424,10 @@ func (a *Allocator) allocTwoRegionLocked(hint uint64, pageOps *allocatorPageOper
 	countFree := int(n.Count())
 	if countFree == 0 {
 		next := freelistNextPageID(data)
-		pageOps.updateChecksum(headID, data)
+		n.UpdateChecksum()
+		if allocatorInstrumentationEnabled {
+			a.observePageOperation(allocatorPageUpdateChecksum, headID)
+		}
 		a.head = next
 		a.pager.MarkUnverified(headID)
 		a.lastAlloc = headID
@@ -426,7 +437,7 @@ func (a *Allocator) allocTwoRegionLocked(hint uint64, pageOps *allocatorPageOper
 			a.stats.Pages--
 		}
 		ids = append(ids, headID)
-		tail, tailErr := a.allocManyRegionScanLocked(1, headID, pageOps)
+		tail, tailErr := a.allocManyRegionScanLocked(1, headID)
 		ids = append(ids, tail...)
 		return ids, tailErr
 	}
@@ -461,7 +472,10 @@ func (a *Allocator) allocTwoRegionLocked(hint uint64, pageOps *allocatorPageOper
 	}
 
 	n.SetCount(uint16(countFree))
-	pageOps.updateChecksum(headID, data)
+	n.UpdateChecksum()
+	if allocatorInstrumentationEnabled {
+		a.observePageOperation(allocatorPageUpdateChecksum, headID)
+	}
 	if countFree == 0 && len(ids) < 2 {
 		next := freelistNextPageID(data)
 		a.head = next
@@ -477,7 +491,7 @@ func (a *Allocator) allocTwoRegionLocked(hint uint64, pageOps *allocatorPageOper
 	return ids, nil
 }
 
-func (a *Allocator) allocManyRegionScanLocked(count int, hint uint64, pageOps *allocatorPageOperations) ([]uint64, error) {
+func (a *Allocator) allocManyRegionScanLocked(count int, hint uint64) ([]uint64, error) {
 	ids := make([]uint64, 0, count)
 	target := hint
 	for len(ids) < count {
@@ -497,12 +511,25 @@ func (a *Allocator) allocManyRegionScanLocked(count int, hint uint64, pageOps *a
 		}
 
 		headID := a.head
-		data, err := pageOps.getForWrite(a.pager, headID)
+		if allocatorInstrumentationEnabled {
+			if err := a.injectedGetForWriteError(headID); err != nil {
+				a.observePageOperation(allocatorPageGetForWrite, headID)
+				return ids, err
+			}
+		}
+		data, err := a.pager.GetForWrite(headID)
+		if allocatorInstrumentationEnabled {
+			a.observePageOperation(allocatorPageGetForWrite, headID)
+		}
 		if err != nil {
 			return ids, err
 		}
 		n := node.NewNode(data)
-		if !pageOps.verifyChecksum(headID, data) {
+		checksumOK := n.VerifyChecksum()
+		if allocatorInstrumentationEnabled {
+			a.observePageOperation(allocatorPageVerifyChecksum, headID)
+		}
+		if !checksumOK {
 			return ids, errors.New("freelist head corrupted (AllocMany)")
 		}
 		if n.Type() != page.PageTypeFreelist {
@@ -512,7 +539,10 @@ func (a *Allocator) allocManyRegionScanLocked(count int, hint uint64, pageOps *a
 		countFree := int(n.Count())
 		if countFree == 0 {
 			next := freelistNextPageID(data)
-			pageOps.updateChecksum(headID, data)
+			n.UpdateChecksum()
+			if allocatorInstrumentationEnabled {
+				a.observePageOperation(allocatorPageUpdateChecksum, headID)
+			}
 			a.head = next
 			a.pager.MarkUnverified(headID)
 			a.lastAlloc = headID
@@ -549,7 +579,10 @@ func (a *Allocator) allocManyRegionScanLocked(count int, hint uint64, pageOps *a
 		}
 
 		n.SetCount(uint16(countFree))
-		pageOps.updateChecksum(headID, data)
+		n.UpdateChecksum()
+		if allocatorInstrumentationEnabled {
+			a.observePageOperation(allocatorPageUpdateChecksum, headID)
+		}
 		for _, id := range ids[start:] {
 			a.recordReuseAllocation(id)
 		}
@@ -570,12 +603,12 @@ func (a *Allocator) allocManyRegionScanLocked(count int, hint uint64, pageOps *a
 	return ids, nil
 }
 
-func (a *Allocator) allocManyRegionIndexedLocked(count int, hint uint64, pageOps *allocatorPageOperations) ([]uint64, error) {
+func (a *Allocator) allocManyRegionIndexedLocked(count int, hint uint64) ([]uint64, error) {
 	var regionSlots regionSlotIndex
-	return a.allocManyRegionWithIndexLocked(count, hint, &regionSlots, pageOps)
+	return a.allocManyRegionWithIndexLocked(count, hint, &regionSlots)
 }
 
-func (a *Allocator) allocManyRegionWithIndexLocked(count int, hint uint64, regionSlots *regionSlotIndex, pageOps *allocatorPageOperations) ([]uint64, error) {
+func (a *Allocator) allocManyRegionWithIndexLocked(count int, hint uint64, regionSlots *regionSlotIndex) ([]uint64, error) {
 	ids := make([]uint64, 0, count)
 	target := hint
 	for len(ids) < count {
@@ -595,12 +628,25 @@ func (a *Allocator) allocManyRegionWithIndexLocked(count int, hint uint64, regio
 		}
 
 		headID := a.head
-		data, err := pageOps.getForWrite(a.pager, headID)
+		if allocatorInstrumentationEnabled {
+			if err := a.injectedGetForWriteError(headID); err != nil {
+				a.observePageOperation(allocatorPageGetForWrite, headID)
+				return ids, err
+			}
+		}
+		data, err := a.pager.GetForWrite(headID)
+		if allocatorInstrumentationEnabled {
+			a.observePageOperation(allocatorPageGetForWrite, headID)
+		}
 		if err != nil {
 			return ids, err
 		}
 		n := node.NewNode(data)
-		if !pageOps.verifyChecksum(headID, data) {
+		checksumOK := n.VerifyChecksum()
+		if allocatorInstrumentationEnabled {
+			a.observePageOperation(allocatorPageVerifyChecksum, headID)
+		}
+		if !checksumOK {
 			return ids, errors.New("freelist head corrupted (AllocMany)")
 		}
 		if n.Type() != page.PageTypeFreelist {
@@ -610,7 +656,10 @@ func (a *Allocator) allocManyRegionWithIndexLocked(count int, hint uint64, regio
 		countFree := int(n.Count())
 		if countFree == 0 {
 			next := freelistNextPageID(data)
-			pageOps.updateChecksum(headID, data)
+			n.UpdateChecksum()
+			if allocatorInstrumentationEnabled {
+				a.observePageOperation(allocatorPageUpdateChecksum, headID)
+			}
 			recycled := headID
 			a.head = next
 			a.pager.MarkUnverified(recycled)
@@ -662,7 +711,10 @@ func (a *Allocator) allocManyRegionWithIndexLocked(count int, hint uint64, regio
 		}
 
 		n.SetCount(uint16(countFree))
-		pageOps.updateChecksum(headID, data)
+		n.UpdateChecksum()
+		if allocatorInstrumentationEnabled {
+			a.observePageOperation(allocatorPageUpdateChecksum, headID)
+		}
 		for _, id := range ids[start:] {
 			a.recordReuseAllocation(id)
 		}
@@ -875,9 +927,8 @@ func (a *Allocator) Free(id uint64) error {
 // intentionally accepted and recorded exactly as repeated calls to Free would
 // record them; production callers remain responsible for avoiding double free.
 //
-// An I/O error after a valid prefix may leave that prefix freed, matching the
-// per-ID Free loop semantics. Callers that need prefix accounting continue to
-// use Free one ID at a time.
+// Errors after locking are returned as *FreeManyError so callers can identify
+// the committed prefix and retry only the unprocessed suffix.
 func (a *Allocator) FreeMany(ids []uint64) error {
 	for _, id := range ids {
 		if id == 0 {
@@ -890,20 +941,33 @@ func (a *Allocator) FreeMany(ids []uint64) error {
 
 	a.mu.Lock()
 	defer a.mu.Unlock()
-	pageOps := testAllocatorPageOperations
+	processed := 0
 
 	if a.head != 0 {
 		headID := a.head
-		data, err := pageOps.getForWrite(a.pager, headID)
+		if allocatorInstrumentationEnabled {
+			if err := a.injectedGetForWriteError(headID); err != nil {
+				a.observePageOperation(allocatorPageGetForWrite, headID)
+				return &FreeManyError{Processed: processed, Err: err}
+			}
+		}
+		data, err := a.pager.GetForWrite(headID)
+		if allocatorInstrumentationEnabled {
+			a.observePageOperation(allocatorPageGetForWrite, headID)
+		}
 		if err != nil {
-			return err
+			return &FreeManyError{Processed: processed, Err: err}
 		}
 		n := node.NewNode(data)
-		if !pageOps.verifyChecksum(headID, data) {
-			return errors.New("freelist head corrupted (FreeMany)")
+		checksumOK := n.VerifyChecksum()
+		if allocatorInstrumentationEnabled {
+			a.observePageOperation(allocatorPageVerifyChecksum, headID)
+		}
+		if !checksumOK {
+			return &FreeManyError{Processed: processed, Err: errors.New("freelist head corrupted (FreeMany)")}
 		}
 		if n.Type() != page.PageTypeFreelist {
-			return errors.New("invalid freelist page type")
+			return &FreeManyError{Processed: processed, Err: errors.New("invalid freelist page type")}
 		}
 
 		count := int(n.Count())
@@ -924,25 +988,30 @@ func (a *Allocator) FreeMany(ids []uint64) error {
 		if TestHookFreeManyBeforeChecksum != nil {
 			TestHookFreeManyBeforeChecksum()
 		}
-		pageOps.updateChecksum(headID, data)
+		n.UpdateChecksum()
+		if allocatorInstrumentationEnabled {
+			a.observePageOperation(allocatorPageUpdateChecksum, headID)
+		}
 		if take > 0 {
 			a.recordFreedPages(take, false)
+			processed += take
 			ids = ids[take:]
 		}
 	}
 
 	for len(ids) > 0 {
-		consumed, err := a.initHeadWithFreeIDs(ids[0], a.head, ids[1:], pageOps, true)
+		consumed, err := a.initHeadWithFreeIDs(ids[0], a.head, ids[1:], true)
 		if err != nil {
-			return err
+			return &FreeManyError{Processed: processed, Err: err}
 		}
 		a.recordFreedPages(consumed, true)
+		processed += consumed
 		ids = ids[consumed:]
 	}
 	return nil
 }
 
-func (a *Allocator) initHeadWithFreeIDs(id, next uint64, ids []uint64, pageOps *allocatorPageOperations, batch bool) (int, error) {
+func (a *Allocator) initHeadWithFreeIDs(id, next uint64, ids []uint64, batch bool) (int, error) {
 	take := len(ids)
 	if take > page.MaxFreeIDs {
 		take = page.MaxFreeIDs
@@ -952,7 +1021,16 @@ func (a *Allocator) initHeadWithFreeIDs(id, next uint64, ids []uint64, pageOps *
 		err  error
 	)
 	if batch {
-		data, err = pageOps.getForWrite(a.pager, id)
+		if allocatorInstrumentationEnabled {
+			if injectedErr := a.injectedGetForWriteError(id); injectedErr != nil {
+				a.observePageOperation(allocatorPageGetForWrite, id)
+				return 0, injectedErr
+			}
+		}
+		data, err = a.pager.GetForWrite(id)
+		if allocatorInstrumentationEnabled {
+			a.observePageOperation(allocatorPageGetForWrite, id)
+		}
 	} else {
 		data, err = a.pager.GetForWrite(id)
 	}
@@ -976,7 +1054,10 @@ func (a *Allocator) initHeadWithFreeIDs(id, next uint64, ids []uint64, pageOps *
 		TestHookFreeManyBeforeChecksum()
 	}
 	if batch {
-		pageOps.updateChecksum(id, data)
+		n.UpdateChecksum()
+		if allocatorInstrumentationEnabled {
+			a.observePageOperation(allocatorPageUpdateChecksum, id)
+		}
 	} else {
 		n.UpdateChecksum()
 	}
@@ -994,7 +1075,7 @@ func (a *Allocator) recordFreedPages(count int, newHead bool) {
 }
 
 func (a *Allocator) initHead(id, next uint64) error {
-	_, err := a.initHeadWithFreeIDs(id, next, nil, nil, false)
+	_, err := a.initHeadWithFreeIDs(id, next, nil, false)
 	return err
 }
 

--- a/TreeDB/freelist/allocator.go
+++ b/TreeDB/freelist/allocator.go
@@ -28,8 +28,6 @@ type Allocator struct {
 	// extending the file. This improves locality at the cost of reclaiming space
 	// later via vacuum.
 	preferAppend bool
-
-	testPageEvent func(allocatorPageEvent, uint64)
 }
 
 type allocatorPageEvent uint8
@@ -40,23 +38,25 @@ const (
 	allocatorPageUpdateChecksum
 )
 
+var testAllocatorPageEvent func(allocatorPageEvent, uint64)
+
 func (a *Allocator) getPageForWrite(pageID uint64) ([]byte, error) {
-	if a.testPageEvent != nil {
-		a.testPageEvent(allocatorPageGetForWrite, pageID)
+	if testAllocatorPageEvent != nil {
+		testAllocatorPageEvent(allocatorPageGetForWrite, pageID)
 	}
 	return a.pager.GetForWrite(pageID)
 }
 
 func (a *Allocator) verifyChecksum(pageID uint64, n *node.Node) bool {
-	if a.testPageEvent != nil {
-		a.testPageEvent(allocatorPageVerifyChecksum, pageID)
+	if testAllocatorPageEvent != nil {
+		testAllocatorPageEvent(allocatorPageVerifyChecksum, pageID)
 	}
 	return n.VerifyChecksum()
 }
 
 func (a *Allocator) updateChecksum(pageID uint64, n *node.Node) {
-	if a.testPageEvent != nil {
-		a.testPageEvent(allocatorPageUpdateChecksum, pageID)
+	if testAllocatorPageEvent != nil {
+		testAllocatorPageEvent(allocatorPageUpdateChecksum, pageID)
 	}
 	n.UpdateChecksum()
 }

--- a/TreeDB/freelist/allocator.go
+++ b/TreeDB/freelist/allocator.go
@@ -12,14 +12,6 @@ import (
 	"github.com/snissn/gomap/TreeDB/pager"
 )
 
-type allocatorPageOperation uint8
-
-const (
-	allocatorPageGetForWrite allocatorPageOperation = iota
-	allocatorPageVerifyChecksum
-	allocatorPageUpdateChecksum
-)
-
 var errCannotFreePageZero = errors.New("cannot free page 0")
 
 // FreeManyError reports an error after FreeMany committed a prefix of its
@@ -280,25 +272,12 @@ func (a *Allocator) AllocMany(count int, hint uint64) ([]uint64, error) {
 		}
 
 		headID := a.head
-		if allocatorInstrumentationEnabled {
-			if err := a.injectedGetForWriteError(headID); err != nil {
-				a.observePageOperation(allocatorPageGetForWrite, headID)
-				return ids, err
-			}
-		}
-		data, err := a.pager.GetForWrite(headID)
-		if allocatorInstrumentationEnabled {
-			a.observePageOperation(allocatorPageGetForWrite, headID)
-		}
+		data, err := a.batchGetForWrite(headID)
 		if err != nil {
 			return ids, err
 		}
 		n := node.NewNode(data)
-		checksumOK := n.VerifyChecksum()
-		if allocatorInstrumentationEnabled {
-			a.observePageOperation(allocatorPageVerifyChecksum, headID)
-		}
-		if !checksumOK {
+		if !a.batchVerifyChecksum(headID, n) {
 			return ids, errors.New("freelist head corrupted (AllocMany)")
 		}
 		if n.Type() != page.PageTypeFreelist {
@@ -308,10 +287,7 @@ func (a *Allocator) AllocMany(count int, hint uint64) ([]uint64, error) {
 		countFree := int(n.Count())
 		if countFree == 0 {
 			next := freelistNextPageID(data)
-			n.UpdateChecksum()
-			if allocatorInstrumentationEnabled {
-				a.observePageOperation(allocatorPageUpdateChecksum, headID)
-			}
+			a.batchUpdateChecksum(headID, n)
 
 			recycled := a.head
 			a.head = next
@@ -342,10 +318,7 @@ func (a *Allocator) AllocMany(count int, hint uint64) ([]uint64, error) {
 		}
 
 		n.SetCount(uint16(countFree))
-		n.UpdateChecksum()
-		if allocatorInstrumentationEnabled {
-			a.observePageOperation(allocatorPageUpdateChecksum, headID)
-		}
+		a.batchUpdateChecksum(headID, n)
 	}
 	return ids, nil
 }
@@ -396,25 +369,12 @@ func (a *Allocator) allocTwoRegionLocked(hint uint64) ([]uint64, error) {
 	}
 
 	headID := a.head
-	if allocatorInstrumentationEnabled {
-		if err := a.injectedGetForWriteError(headID); err != nil {
-			a.observePageOperation(allocatorPageGetForWrite, headID)
-			return ids, err
-		}
-	}
-	data, err := a.pager.GetForWrite(headID)
-	if allocatorInstrumentationEnabled {
-		a.observePageOperation(allocatorPageGetForWrite, headID)
-	}
+	data, err := a.batchGetForWrite(headID)
 	if err != nil {
 		return ids, err
 	}
 	n := node.NewNode(data)
-	checksumOK := n.VerifyChecksum()
-	if allocatorInstrumentationEnabled {
-		a.observePageOperation(allocatorPageVerifyChecksum, headID)
-	}
-	if !checksumOK {
+	if !a.batchVerifyChecksum(headID, n) {
 		return ids, errors.New("freelist head corrupted (AllocMany)")
 	}
 	if n.Type() != page.PageTypeFreelist {
@@ -424,10 +384,7 @@ func (a *Allocator) allocTwoRegionLocked(hint uint64) ([]uint64, error) {
 	countFree := int(n.Count())
 	if countFree == 0 {
 		next := freelistNextPageID(data)
-		n.UpdateChecksum()
-		if allocatorInstrumentationEnabled {
-			a.observePageOperation(allocatorPageUpdateChecksum, headID)
-		}
+		a.batchUpdateChecksum(headID, n)
 		a.head = next
 		a.pager.MarkUnverified(headID)
 		a.lastAlloc = headID
@@ -472,10 +429,7 @@ func (a *Allocator) allocTwoRegionLocked(hint uint64) ([]uint64, error) {
 	}
 
 	n.SetCount(uint16(countFree))
-	n.UpdateChecksum()
-	if allocatorInstrumentationEnabled {
-		a.observePageOperation(allocatorPageUpdateChecksum, headID)
-	}
+	a.batchUpdateChecksum(headID, n)
 	if countFree == 0 && len(ids) < 2 {
 		next := freelistNextPageID(data)
 		a.head = next
@@ -511,25 +465,12 @@ func (a *Allocator) allocManyRegionScanLocked(count int, hint uint64) ([]uint64,
 		}
 
 		headID := a.head
-		if allocatorInstrumentationEnabled {
-			if err := a.injectedGetForWriteError(headID); err != nil {
-				a.observePageOperation(allocatorPageGetForWrite, headID)
-				return ids, err
-			}
-		}
-		data, err := a.pager.GetForWrite(headID)
-		if allocatorInstrumentationEnabled {
-			a.observePageOperation(allocatorPageGetForWrite, headID)
-		}
+		data, err := a.batchGetForWrite(headID)
 		if err != nil {
 			return ids, err
 		}
 		n := node.NewNode(data)
-		checksumOK := n.VerifyChecksum()
-		if allocatorInstrumentationEnabled {
-			a.observePageOperation(allocatorPageVerifyChecksum, headID)
-		}
-		if !checksumOK {
+		if !a.batchVerifyChecksum(headID, n) {
 			return ids, errors.New("freelist head corrupted (AllocMany)")
 		}
 		if n.Type() != page.PageTypeFreelist {
@@ -539,10 +480,7 @@ func (a *Allocator) allocManyRegionScanLocked(count int, hint uint64) ([]uint64,
 		countFree := int(n.Count())
 		if countFree == 0 {
 			next := freelistNextPageID(data)
-			n.UpdateChecksum()
-			if allocatorInstrumentationEnabled {
-				a.observePageOperation(allocatorPageUpdateChecksum, headID)
-			}
+			a.batchUpdateChecksum(headID, n)
 			a.head = next
 			a.pager.MarkUnverified(headID)
 			a.lastAlloc = headID
@@ -579,10 +517,7 @@ func (a *Allocator) allocManyRegionScanLocked(count int, hint uint64) ([]uint64,
 		}
 
 		n.SetCount(uint16(countFree))
-		n.UpdateChecksum()
-		if allocatorInstrumentationEnabled {
-			a.observePageOperation(allocatorPageUpdateChecksum, headID)
-		}
+		a.batchUpdateChecksum(headID, n)
 		for _, id := range ids[start:] {
 			a.recordReuseAllocation(id)
 		}
@@ -628,25 +563,12 @@ func (a *Allocator) allocManyRegionWithIndexLocked(count int, hint uint64, regio
 		}
 
 		headID := a.head
-		if allocatorInstrumentationEnabled {
-			if err := a.injectedGetForWriteError(headID); err != nil {
-				a.observePageOperation(allocatorPageGetForWrite, headID)
-				return ids, err
-			}
-		}
-		data, err := a.pager.GetForWrite(headID)
-		if allocatorInstrumentationEnabled {
-			a.observePageOperation(allocatorPageGetForWrite, headID)
-		}
+		data, err := a.batchGetForWrite(headID)
 		if err != nil {
 			return ids, err
 		}
 		n := node.NewNode(data)
-		checksumOK := n.VerifyChecksum()
-		if allocatorInstrumentationEnabled {
-			a.observePageOperation(allocatorPageVerifyChecksum, headID)
-		}
-		if !checksumOK {
+		if !a.batchVerifyChecksum(headID, n) {
 			return ids, errors.New("freelist head corrupted (AllocMany)")
 		}
 		if n.Type() != page.PageTypeFreelist {
@@ -656,10 +578,7 @@ func (a *Allocator) allocManyRegionWithIndexLocked(count int, hint uint64, regio
 		countFree := int(n.Count())
 		if countFree == 0 {
 			next := freelistNextPageID(data)
-			n.UpdateChecksum()
-			if allocatorInstrumentationEnabled {
-				a.observePageOperation(allocatorPageUpdateChecksum, headID)
-			}
+			a.batchUpdateChecksum(headID, n)
 			recycled := headID
 			a.head = next
 			a.pager.MarkUnverified(recycled)
@@ -711,10 +630,7 @@ func (a *Allocator) allocManyRegionWithIndexLocked(count int, hint uint64, regio
 		}
 
 		n.SetCount(uint16(countFree))
-		n.UpdateChecksum()
-		if allocatorInstrumentationEnabled {
-			a.observePageOperation(allocatorPageUpdateChecksum, headID)
-		}
+		a.batchUpdateChecksum(headID, n)
 		for _, id := range ids[start:] {
 			a.recordReuseAllocation(id)
 		}
@@ -945,25 +861,12 @@ func (a *Allocator) FreeMany(ids []uint64) error {
 
 	if a.head != 0 {
 		headID := a.head
-		if allocatorInstrumentationEnabled {
-			if err := a.injectedGetForWriteError(headID); err != nil {
-				a.observePageOperation(allocatorPageGetForWrite, headID)
-				return &FreeManyError{Processed: processed, Err: err}
-			}
-		}
-		data, err := a.pager.GetForWrite(headID)
-		if allocatorInstrumentationEnabled {
-			a.observePageOperation(allocatorPageGetForWrite, headID)
-		}
+		data, err := a.batchGetForWrite(headID)
 		if err != nil {
 			return &FreeManyError{Processed: processed, Err: err}
 		}
 		n := node.NewNode(data)
-		checksumOK := n.VerifyChecksum()
-		if allocatorInstrumentationEnabled {
-			a.observePageOperation(allocatorPageVerifyChecksum, headID)
-		}
-		if !checksumOK {
+		if !a.batchVerifyChecksum(headID, n) {
 			return &FreeManyError{Processed: processed, Err: errors.New("freelist head corrupted (FreeMany)")}
 		}
 		if n.Type() != page.PageTypeFreelist {
@@ -988,10 +891,7 @@ func (a *Allocator) FreeMany(ids []uint64) error {
 		if TestHookFreeManyBeforeChecksum != nil {
 			TestHookFreeManyBeforeChecksum()
 		}
-		n.UpdateChecksum()
-		if allocatorInstrumentationEnabled {
-			a.observePageOperation(allocatorPageUpdateChecksum, headID)
-		}
+		a.batchUpdateChecksum(headID, n)
 		if take > 0 {
 			a.recordFreedPages(take, false)
 			processed += take
@@ -1021,16 +921,7 @@ func (a *Allocator) initHeadWithFreeIDs(id, next uint64, ids []uint64, batch boo
 		err  error
 	)
 	if batch {
-		if allocatorInstrumentationEnabled {
-			if injectedErr := a.injectedGetForWriteError(id); injectedErr != nil {
-				a.observePageOperation(allocatorPageGetForWrite, id)
-				return 0, injectedErr
-			}
-		}
-		data, err = a.pager.GetForWrite(id)
-		if allocatorInstrumentationEnabled {
-			a.observePageOperation(allocatorPageGetForWrite, id)
-		}
+		data, err = a.batchGetForWrite(id)
 	} else {
 		data, err = a.pager.GetForWrite(id)
 	}
@@ -1054,10 +945,7 @@ func (a *Allocator) initHeadWithFreeIDs(id, next uint64, ids []uint64, batch boo
 		TestHookFreeManyBeforeChecksum()
 	}
 	if batch {
-		n.UpdateChecksum()
-		if allocatorInstrumentationEnabled {
-			a.observePageOperation(allocatorPageUpdateChecksum, id)
-		}
+		a.batchUpdateChecksum(id, n)
 	} else {
 		n.UpdateChecksum()
 	}

--- a/TreeDB/freelist/allocator.go
+++ b/TreeDB/freelist/allocator.go
@@ -28,6 +28,8 @@ type Allocator struct {
 	preferAppend bool
 }
 
+var errCannotFreePageZero = errors.New("cannot free page 0")
+
 func freelistNextPageID(data []byte) uint64 {
 	return binary.LittleEndian.Uint64(data[page.PageHeaderSize : page.PageHeaderSize+8])
 }
@@ -51,6 +53,11 @@ func clearFreelistIDAt(data []byte, idx int) {
 // entry is written but before the page checksum is updated. It should remain
 // nil in production.
 var TestHookFreeBeforeChecksum func()
+
+// TestHookFreeManyBeforeChecksum is a test-only hook that fires once for each
+// freelist page FreeMany updates, immediately before its checksum is written.
+// It should remain nil in production.
+var TestHookFreeManyBeforeChecksum func()
 
 // Stats reports freelist metadata under the allocator lock.
 type Stats struct {
@@ -133,18 +140,7 @@ func (a *Allocator) AllocMany(count int, hint uint64) ([]uint64, error) {
 	defer a.mu.Unlock()
 
 	if a.regionPages > 0 && a.regionRadius > 0 {
-		ids := make([]uint64, 0, count)
-		var err error
-		for len(ids) < count {
-			id, allocErr := a.allocLocked(hint)
-			if allocErr != nil {
-				err = allocErr
-				break
-			}
-			ids = append(ids, id)
-			hint = id
-		}
-		return ids, err
+		return a.allocManyRegionLocked(count, hint)
 	}
 
 	ids := make([]uint64, 0, count)
@@ -212,6 +208,129 @@ func (a *Allocator) AllocMany(count int, hint uint64) ([]uint64, error) {
 		n.UpdateChecksum()
 	}
 	return ids, nil
+}
+
+// allocManyRegionLocked consumes all region-preferred entries from a verified
+// head page before falling back to LIFO entries from that same page. Region
+// preference is evaluated from the incoming hint (or last allocation); each
+// returned ID still advances lastAlloc for the next head-page selection.
+func (a *Allocator) allocManyRegionLocked(count int, hint uint64) ([]uint64, error) {
+	ids := make([]uint64, 0, count)
+	target := hint
+	for len(ids) < count {
+		if a.preferAppend || a.head == 0 {
+			allocCount := count - len(ids)
+			id, err := a.pager.Alloc(allocCount)
+			if err != nil {
+				return ids, err
+			}
+			a.stats.AllocPages += uint64(allocCount)
+			a.stats.AppendAllocPages += uint64(allocCount)
+			for i := 0; i < allocCount; i++ {
+				ids = append(ids, id+uint64(i))
+			}
+			a.lastAlloc = ids[len(ids)-1]
+			return ids, nil
+		}
+
+		data, err := a.pager.GetForWrite(a.head)
+		if err != nil {
+			return ids, err
+		}
+		n := node.NewNode(data)
+		if !n.VerifyChecksum() {
+			return ids, errors.New("freelist head corrupted (AllocMany)")
+		}
+		if n.Type() != page.PageTypeFreelist {
+			return ids, errors.New("invalid freelist page type")
+		}
+
+		countFree := int(n.Count())
+		if countFree == 0 {
+			next := freelistNextPageID(data)
+			recycled := a.head
+			a.head = next
+			a.recordReuseAllocation(recycled)
+			if a.stats.Pages > 0 {
+				a.stats.Pages--
+			}
+			ids = append(ids, recycled)
+			target = recycled
+			continue
+		}
+
+		start := len(ids)
+		need := count - start
+		selected := 0
+		if target == 0 {
+			target = a.lastAlloc
+		}
+		selectionTarget := target
+		var selectedSlots [page.MaxFreeIDs]bool
+		if selectionTarget != 0 {
+			for i := countFree - 1; i >= 0 && selected < need; i-- {
+				candidate := freelistIDAt(data, i)
+				if a.inRegion(candidate, selectionTarget/a.regionPages) {
+					ids = append(ids, candidate)
+					selectedSlots[i] = true
+					selected++
+					selectionTarget = candidate
+				}
+			}
+		}
+
+		if selected > 0 {
+			// Compact selected entries without re-verifying the page or updating
+			// its checksum for every ID.
+			write := 0
+			for i := 0; i < countFree; i++ {
+				if selectedSlots[i] {
+					continue
+				}
+				setFreelistIDAt(data, write, freelistIDAt(data, i))
+				write++
+			}
+			for i := write; i < countFree; i++ {
+				clearFreelistIDAt(data, i)
+			}
+			countFree = write
+		}
+
+		for countFree > 0 && len(ids) < count {
+			idx := countFree - 1
+			ids = append(ids, freelistIDAt(data, idx))
+			clearFreelistIDAt(data, idx)
+			countFree--
+		}
+
+		n.SetCount(uint16(countFree))
+		n.UpdateChecksum()
+		for _, id := range ids[start:] {
+			a.recordReuseAllocation(id)
+		}
+		if len(ids) > 0 {
+			target = ids[len(ids)-1]
+		}
+	}
+	return ids, nil
+}
+
+func (a *Allocator) inRegion(id, targetRegion uint64) bool {
+	region := id / a.regionPages
+	if region >= targetRegion {
+		return region-targetRegion <= uint64(a.regionRadius)
+	}
+	return targetRegion-region <= uint64(a.regionRadius)
+}
+
+func (a *Allocator) recordReuseAllocation(id uint64) {
+	a.pager.MarkUnverified(id)
+	a.lastAlloc = id
+	a.stats.AllocPages++
+	a.stats.ReuseAllocPages++
+	if a.stats.FreeIDs > 0 {
+		a.stats.FreeIDs--
+	}
 }
 
 func (a *Allocator) allocLocked(hint uint64) (uint64, error) {
@@ -340,7 +459,7 @@ func (a *Allocator) Free(id uint64) error {
 	defer a.mu.Unlock()
 
 	if id == 0 {
-		return errors.New("cannot free page 0")
+		return errCannotFreePageZero
 	}
 
 	if a.head == 0 {
@@ -391,27 +510,124 @@ func (a *Allocator) Free(id uint64) error {
 	return nil
 }
 
-func (a *Allocator) initHead(id, next uint64) error {
-	data, err := a.pager.GetForWrite(id)
-	if err != nil {
-		return err
+// FreeMany adds multiple pages to the freelist while holding the allocator
+// lock once. It validates page zero before mutating state. Duplicate IDs are
+// intentionally accepted and recorded exactly as repeated calls to Free would
+// record them; production callers remain responsible for avoiding double free.
+//
+// An I/O error after a valid prefix may leave that prefix freed, matching the
+// per-ID Free loop semantics. Callers that need prefix accounting continue to
+// use Free one ID at a time.
+func (a *Allocator) FreeMany(ids []uint64) error {
+	for _, id := range ids {
+		if id == 0 {
+			return errCannotFreePageZero
+		}
+	}
+	if len(ids) == 0 {
+		return nil
 	}
 
+	a.mu.Lock()
+	defer a.mu.Unlock()
+
+	for len(ids) > 0 {
+		if a.head == 0 {
+			consumed, err := a.initHeadWithFreeIDs(ids[0], 0, ids[1:], true)
+			if err != nil {
+				return err
+			}
+			a.recordFreedPages(consumed, true)
+			ids = ids[consumed:]
+			continue
+		}
+
+		data, err := a.pager.GetForWrite(a.head)
+		if err != nil {
+			return err
+		}
+		n := node.NewNode(data)
+		if !n.VerifyChecksum() {
+			return errors.New("freelist head corrupted (FreeMany)")
+		}
+		if n.Type() != page.PageTypeFreelist {
+			return errors.New("invalid freelist page type")
+		}
+
+		count := int(n.Count())
+		if count >= page.MaxFreeIDs {
+			consumed, err := a.initHeadWithFreeIDs(ids[0], a.head, ids[1:], true)
+			if err != nil {
+				return err
+			}
+			a.recordFreedPages(consumed, true)
+			ids = ids[consumed:]
+			continue
+		}
+
+		take := page.MaxFreeIDs - count
+		if take > len(ids) {
+			take = len(ids)
+		}
+		for i := 0; i < take; i++ {
+			setFreelistIDAt(data, count+i, ids[i])
+			n.SetCount(uint16(count + i + 1))
+			if TestHookFreeBeforeChecksum != nil {
+				TestHookFreeBeforeChecksum()
+			}
+		}
+		if TestHookFreeManyBeforeChecksum != nil {
+			TestHookFreeManyBeforeChecksum()
+		}
+		n.UpdateChecksum()
+		a.recordFreedPages(take, false)
+		ids = ids[take:]
+	}
+	return nil
+}
+
+func (a *Allocator) initHeadWithFreeIDs(id, next uint64, ids []uint64, batchHook bool) (int, error) {
+	take := len(ids)
+	if take > page.MaxFreeIDs {
+		take = page.MaxFreeIDs
+	}
+	data, err := a.pager.GetForWrite(id)
+	if err != nil {
+		return 0, err
+	}
 	n := node.NewNode(data)
 	n.SetPageID(id)
 	n.SetType(page.PageTypeFreelist)
 	n.SetCount(0)
-
-	body := page.FreelistPageBody{
-		NextPageID: next,
-		FreeIDs:    nil,
-	}
+	body := page.FreelistPageBody{NextPageID: next}
 	body.Encode(data[page.PageHeaderSize:])
-
+	for i := 0; i < take; i++ {
+		setFreelistIDAt(data, i, ids[i])
+		n.SetCount(uint16(i + 1))
+		if TestHookFreeBeforeChecksum != nil {
+			TestHookFreeBeforeChecksum()
+		}
+	}
+	if batchHook && TestHookFreeManyBeforeChecksum != nil {
+		TestHookFreeManyBeforeChecksum()
+	}
 	n.UpdateChecksum()
-
 	a.head = id
-	return nil
+	return take + 1, nil
+}
+
+func (a *Allocator) recordFreedPages(count int, newHead bool) {
+	a.stats.FreePages += uint64(count)
+	if newHead {
+		a.stats.Pages++
+		count--
+	}
+	a.stats.FreeIDs += uint64(count)
+}
+
+func (a *Allocator) initHead(id, next uint64) error {
+	_, err := a.initHeadWithFreeIDs(id, next, nil, false)
+	return err
 }
 
 // Stats returns freelist page counts while holding the allocator lock to avoid

--- a/TreeDB/freelist/allocator.go
+++ b/TreeDB/freelist/allocator.go
@@ -30,34 +30,35 @@ type Allocator struct {
 	preferAppend bool
 }
 
-type allocatorPageOperations interface {
-	getForWrite(*pager.Pager, uint64) ([]byte, error)
-	verifyChecksum(uint64, []byte) bool
-	updateChecksum(uint64, []byte)
+type allocatorPageOperations struct {
+	getForWriteFunc    func(*pager.Pager, uint64) ([]byte, error)
+	verifyChecksumFunc func(uint64, []byte) bool
+	updateChecksumFunc func(uint64, []byte)
 }
 
-type directAllocatorPageOperations struct{}
-
-func (directAllocatorPageOperations) getForWrite(p *pager.Pager, pageID uint64) ([]byte, error) {
-	return p.GetForWrite(pageID)
-}
-
-func (directAllocatorPageOperations) verifyChecksum(_ uint64, data []byte) bool {
-	return node.NewNode(data).VerifyChecksum()
-}
-
-func (directAllocatorPageOperations) updateChecksum(_ uint64, data []byte) {
-	node.NewNode(data).UpdateChecksum()
-}
-
-var testAllocatorPageOperations allocatorPageOperations
-
-func activeAllocatorPageOperations() allocatorPageOperations {
-	if testAllocatorPageOperations != nil {
-		return testAllocatorPageOperations
+func (ops *allocatorPageOperations) getForWrite(p *pager.Pager, pageID uint64) ([]byte, error) {
+	if ops == nil {
+		return p.GetForWrite(pageID)
 	}
-	return directAllocatorPageOperations{}
+	return ops.getForWriteFunc(p, pageID)
 }
+
+func (ops *allocatorPageOperations) verifyChecksum(pageID uint64, data []byte) bool {
+	if ops == nil {
+		return node.NewNode(data).VerifyChecksum()
+	}
+	return ops.verifyChecksumFunc(pageID, data)
+}
+
+func (ops *allocatorPageOperations) updateChecksum(pageID uint64, data []byte) {
+	if ops == nil {
+		node.NewNode(data).UpdateChecksum()
+		return
+	}
+	ops.updateChecksumFunc(pageID, data)
+}
+
+var testAllocatorPageOperations *allocatorPageOperations
 
 var errCannotFreePageZero = errors.New("cannot free page 0")
 
@@ -279,7 +280,7 @@ func (a *Allocator) AllocMany(count int, hint uint64) ([]uint64, error) {
 
 	a.mu.Lock()
 	defer a.mu.Unlock()
-	pageOps := activeAllocatorPageOperations()
+	pageOps := testAllocatorPageOperations
 
 	if a.regionPages > 0 && a.regionRadius > 0 {
 		return a.allocManyRegionLocked(count, hint, pageOps)
@@ -375,7 +376,7 @@ func findRegionSlot(data []byte, count int, target, regionPages uint64, radius i
 // semantics while verifying and checksumming each mutated head once. Small
 // selections scan directly; larger selections reuse one transient range-max
 // index across head pages.
-func (a *Allocator) allocManyRegionLocked(count int, hint uint64, pageOps allocatorPageOperations) ([]uint64, error) {
+func (a *Allocator) allocManyRegionLocked(count int, hint uint64, pageOps *allocatorPageOperations) ([]uint64, error) {
 	if count == 2 {
 		return a.allocTwoRegionLocked(hint, pageOps)
 	}
@@ -385,7 +386,7 @@ func (a *Allocator) allocManyRegionLocked(count int, hint uint64, pageOps alloca
 	return a.allocManyRegionIndexedLocked(count, hint, pageOps)
 }
 
-func (a *Allocator) allocTwoRegionLocked(hint uint64, pageOps allocatorPageOperations) ([]uint64, error) {
+func (a *Allocator) allocTwoRegionLocked(hint uint64, pageOps *allocatorPageOperations) ([]uint64, error) {
 	ids := make([]uint64, 0, 2)
 	if a.preferAppend || a.head == 0 {
 		id, err := a.pager.Alloc(2)
@@ -476,7 +477,7 @@ func (a *Allocator) allocTwoRegionLocked(hint uint64, pageOps allocatorPageOpera
 	return ids, nil
 }
 
-func (a *Allocator) allocManyRegionScanLocked(count int, hint uint64, pageOps allocatorPageOperations) ([]uint64, error) {
+func (a *Allocator) allocManyRegionScanLocked(count int, hint uint64, pageOps *allocatorPageOperations) ([]uint64, error) {
 	ids := make([]uint64, 0, count)
 	target := hint
 	for len(ids) < count {
@@ -569,12 +570,12 @@ func (a *Allocator) allocManyRegionScanLocked(count int, hint uint64, pageOps al
 	return ids, nil
 }
 
-func (a *Allocator) allocManyRegionIndexedLocked(count int, hint uint64, pageOps allocatorPageOperations) ([]uint64, error) {
+func (a *Allocator) allocManyRegionIndexedLocked(count int, hint uint64, pageOps *allocatorPageOperations) ([]uint64, error) {
 	var regionSlots regionSlotIndex
 	return a.allocManyRegionWithIndexLocked(count, hint, &regionSlots, pageOps)
 }
 
-func (a *Allocator) allocManyRegionWithIndexLocked(count int, hint uint64, regionSlots *regionSlotIndex, pageOps allocatorPageOperations) ([]uint64, error) {
+func (a *Allocator) allocManyRegionWithIndexLocked(count int, hint uint64, regionSlots *regionSlotIndex, pageOps *allocatorPageOperations) ([]uint64, error) {
 	ids := make([]uint64, 0, count)
 	target := hint
 	for len(ids) < count {
@@ -889,7 +890,7 @@ func (a *Allocator) FreeMany(ids []uint64) error {
 
 	a.mu.Lock()
 	defer a.mu.Unlock()
-	pageOps := activeAllocatorPageOperations()
+	pageOps := testAllocatorPageOperations
 
 	if a.head != 0 {
 		headID := a.head
@@ -931,7 +932,7 @@ func (a *Allocator) FreeMany(ids []uint64) error {
 	}
 
 	for len(ids) > 0 {
-		consumed, err := a.initHeadWithFreeIDs(ids[0], a.head, ids[1:], pageOps)
+		consumed, err := a.initHeadWithFreeIDs(ids[0], a.head, ids[1:], pageOps, true)
 		if err != nil {
 			return err
 		}
@@ -941,7 +942,7 @@ func (a *Allocator) FreeMany(ids []uint64) error {
 	return nil
 }
 
-func (a *Allocator) initHeadWithFreeIDs(id, next uint64, ids []uint64, pageOps allocatorPageOperations) (int, error) {
+func (a *Allocator) initHeadWithFreeIDs(id, next uint64, ids []uint64, pageOps *allocatorPageOperations, batch bool) (int, error) {
 	take := len(ids)
 	if take > page.MaxFreeIDs {
 		take = page.MaxFreeIDs
@@ -950,7 +951,7 @@ func (a *Allocator) initHeadWithFreeIDs(id, next uint64, ids []uint64, pageOps a
 		data []byte
 		err  error
 	)
-	if pageOps != nil {
+	if batch {
 		data, err = pageOps.getForWrite(a.pager, id)
 	} else {
 		data, err = a.pager.GetForWrite(id)
@@ -971,10 +972,10 @@ func (a *Allocator) initHeadWithFreeIDs(id, next uint64, ids []uint64, pageOps a
 			TestHookFreeBeforeChecksum()
 		}
 	}
-	if pageOps != nil && TestHookFreeManyBeforeChecksum != nil {
+	if batch && TestHookFreeManyBeforeChecksum != nil {
 		TestHookFreeManyBeforeChecksum()
 	}
-	if pageOps != nil {
+	if batch {
 		pageOps.updateChecksum(id, data)
 	} else {
 		n.UpdateChecksum()
@@ -993,7 +994,7 @@ func (a *Allocator) recordFreedPages(count int, newHead bool) {
 }
 
 func (a *Allocator) initHead(id, next uint64) error {
-	_, err := a.initHeadWithFreeIDs(id, next, nil, nil)
+	_, err := a.initHeadWithFreeIDs(id, next, nil, nil, false)
 	return err
 }
 

--- a/TreeDB/freelist/allocator.go
+++ b/TreeDB/freelist/allocator.go
@@ -40,16 +40,13 @@ const (
 
 var testAllocatorPageEvent func(allocatorPageEvent, uint64)
 
-func observeAllocatorPage(pageID uint64, verified, updated bool) {
-	if testAllocatorPageEvent == nil {
-		return
-	}
-	testAllocatorPageEvent(allocatorPageGetForWrite, pageID)
+func observeAllocatorPage(hook func(allocatorPageEvent, uint64), pageID uint64, verified, updated bool) {
+	hook(allocatorPageGetForWrite, pageID)
 	if verified {
-		testAllocatorPageEvent(allocatorPageVerifyChecksum, pageID)
+		hook(allocatorPageVerifyChecksum, pageID)
 	}
 	if updated {
-		testAllocatorPageEvent(allocatorPageUpdateChecksum, pageID)
+		hook(allocatorPageUpdateChecksum, pageID)
 	}
 }
 
@@ -322,7 +319,9 @@ func (a *Allocator) AllocMany(count int, hint uint64) ([]uint64, error) {
 				a.stats.Pages--
 			}
 			ids = append(ids, recycled)
-			observeAllocatorPage(headID, true, false)
+			if hook := testAllocatorPageEvent; hook != nil {
+				observeAllocatorPage(hook, headID, true, false)
+			}
 			continue
 		}
 
@@ -343,7 +342,9 @@ func (a *Allocator) AllocMany(count int, hint uint64) ([]uint64, error) {
 
 		n.SetCount(uint16(countFree))
 		n.UpdateChecksum()
-		observeAllocatorPage(headID, true, true)
+		if hook := testAllocatorPageEvent; hook != nil {
+			observeAllocatorPage(hook, headID, true, true)
+		}
 	}
 	return ids, nil
 }
@@ -418,7 +419,9 @@ func (a *Allocator) allocTwoRegionLocked(hint uint64) ([]uint64, error) {
 			a.stats.Pages--
 		}
 		ids = append(ids, headID)
-		observeAllocatorPage(headID, true, false)
+		if hook := testAllocatorPageEvent; hook != nil {
+			observeAllocatorPage(hook, headID, true, false)
+		}
 		tail, tailErr := a.allocManyRegionScanLocked(1, headID)
 		ids = append(ids, tail...)
 		return ids, tailErr
@@ -442,15 +445,21 @@ func (a *Allocator) allocTwoRegionLocked(hint uint64) ([]uint64, error) {
 		}
 		clearFreelistIDAt(data, lastSlot)
 		ids = append(ids, id)
+		a.pager.MarkUnverified(id)
+		a.lastAlloc = id
+		a.stats.AllocPages++
+		a.stats.ReuseAllocPages++
+		if a.stats.FreeIDs > 0 {
+			a.stats.FreeIDs--
+		}
 		countFree--
 		target = id
 	}
 
 	n.SetCount(uint16(countFree))
 	n.UpdateChecksum()
-	observeAllocatorPage(headID, true, true)
-	for _, id := range ids {
-		a.recordReuseAllocation(id)
+	if hook := testAllocatorPageEvent; hook != nil {
+		observeAllocatorPage(hook, headID, true, true)
 	}
 	if countFree == 0 && len(ids) < 2 {
 		next := freelistNextPageID(data)
@@ -512,7 +521,9 @@ func (a *Allocator) allocManyRegionScanLocked(count int, hint uint64) ([]uint64,
 			}
 			ids = append(ids, headID)
 			target = headID
-			observeAllocatorPage(headID, true, false)
+			if hook := testAllocatorPageEvent; hook != nil {
+				observeAllocatorPage(hook, headID, true, false)
+			}
 			continue
 		}
 
@@ -540,7 +551,9 @@ func (a *Allocator) allocManyRegionScanLocked(count int, hint uint64) ([]uint64,
 
 		n.SetCount(uint16(countFree))
 		n.UpdateChecksum()
-		observeAllocatorPage(headID, true, true)
+		if hook := testAllocatorPageEvent; hook != nil {
+			observeAllocatorPage(hook, headID, true, true)
+		}
 		for _, id := range ids[start:] {
 			a.recordReuseAllocation(id)
 		}
@@ -612,7 +625,9 @@ func (a *Allocator) allocManyRegionWithIndexLocked(count int, hint uint64, regio
 			}
 			ids = append(ids, recycled)
 			target = recycled
-			observeAllocatorPage(headID, true, false)
+			if hook := testAllocatorPageEvent; hook != nil {
+				observeAllocatorPage(hook, headID, true, false)
+			}
 			continue
 		}
 
@@ -654,7 +669,9 @@ func (a *Allocator) allocManyRegionWithIndexLocked(count int, hint uint64, regio
 
 		n.SetCount(uint16(countFree))
 		n.UpdateChecksum()
-		observeAllocatorPage(headID, true, true)
+		if hook := testAllocatorPageEvent; hook != nil {
+			observeAllocatorPage(hook, headID, true, true)
+		}
 		for _, id := range ids[start:] {
 			a.recordReuseAllocation(id)
 		}
@@ -919,7 +936,9 @@ func (a *Allocator) FreeMany(ids []uint64) error {
 			a.recordFreedPages(take, false)
 			ids = ids[take:]
 		}
-		observeAllocatorPage(headID, true, updated)
+		if hook := testAllocatorPageEvent; hook != nil {
+			observeAllocatorPage(hook, headID, true, updated)
+		}
 	}
 
 	for len(ids) > 0 {
@@ -966,7 +985,9 @@ func (a *Allocator) initHeadWithFreeIDs(id, next uint64, ids []uint64, batchHook
 	}
 	if batchHook {
 		n.UpdateChecksum()
-		observeAllocatorPage(id, false, true)
+		if hook := testAllocatorPageEvent; hook != nil {
+			observeAllocatorPage(hook, id, false, true)
+		}
 	} else {
 		n.UpdateChecksum()
 	}

--- a/TreeDB/freelist/allocator_benchmark_instrument_test.go
+++ b/TreeDB/freelist/allocator_benchmark_instrument_test.go
@@ -1,0 +1,83 @@
+//go:build treedb_freelist_instrument
+
+package freelist
+
+import "testing"
+
+type allocatorObservedMetrics struct {
+	gets         int
+	verifies     int
+	updates      int
+	pagesTouched int
+}
+
+func observedMetrics(a *Allocator) allocatorObservedMetrics {
+	var out allocatorObservedMetrics
+	for _, counts := range a.allPageOperationCounts() {
+		out.pagesTouched++
+		out.gets += counts.gets
+		out.verifies += counts.verifies
+		out.updates += counts.updates
+	}
+	return out
+}
+
+func (metrics *allocatorObservedMetrics) add(other allocatorObservedMetrics) {
+	metrics.gets += other.gets
+	metrics.verifies += other.verifies
+	metrics.updates += other.updates
+	metrics.pagesTouched += other.pagesTouched
+}
+
+func (metrics allocatorObservedMetrics) report(b *testing.B) {
+	b.ReportMetric(float64(metrics.pagesTouched)/float64(b.N), "pages_touched/op")
+	b.ReportMetric(float64(metrics.gets)/float64(b.N), "get_for_write/op")
+	b.ReportMetric(float64(metrics.verifies)/float64(b.N), "checksum_verifications/op")
+	b.ReportMetric(float64(metrics.updates)/float64(b.N), "checksum_updates/op")
+}
+
+func BenchmarkAllocator_FreeManyObservedOperations(b *testing.B) {
+	ids := allocatorBenchmarkIDsSlice()
+	root := b.TempDir()
+	var metrics allocatorObservedMetrics
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		b.StopTimer()
+		a, p, path := newAllocatorBenchmarkFixture(b, root, i)
+		a.resetPageOperationCounts()
+		b.StartTimer()
+		freeAllocatorBenchmarkIDs(b, a, ids, true)
+		b.StopTimer()
+		metrics.add(observedMetrics(a))
+		closeAllocatorBenchmarkFixture(b, p, path)
+	}
+	metrics.report(b)
+}
+
+func BenchmarkAllocator_AllocManyObservedOperations(b *testing.B) {
+	benchmarkAllocatorObservedOperations(b, allocatorBenchmarkIDs)
+}
+
+func BenchmarkAllocator_AllocMany2ObservedOperations(b *testing.B) {
+	benchmarkAllocatorObservedOperations(b, 2)
+}
+
+func benchmarkAllocatorObservedOperations(b *testing.B, count int) {
+	ids := allocatorBenchmarkIDsSlice()
+	root := b.TempDir()
+	var metrics allocatorObservedMetrics
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		b.StopTimer()
+		a, p, path := newAllocatorBenchmarkFixture(b, root, i)
+		populateAllocatorBenchmarkFreelist(b, a, ids)
+		a.SetFreelistRegion(allocatorBenchmarkRegion, 1)
+		a.resetPageOperationCounts()
+		b.StartTimer()
+		allocAllocatorBenchmarkIDs(b, a, count, true)
+		b.StopTimer()
+		metrics.add(observedMetrics(a))
+		closeAllocatorBenchmarkFixture(b, p, path)
+	}
+	metrics.report(b)
+}

--- a/TreeDB/freelist/allocator_benchmark_test.go
+++ b/TreeDB/freelist/allocator_benchmark_test.go
@@ -15,6 +15,8 @@ const (
 	allocatorBenchmarkRegionHint = 4 * allocatorBenchmarkRegion
 )
 
+var allocatorBenchmarkIDsSink []uint64
+
 type allocatorBenchmarkPageMetrics struct {
 	gets          int
 	verifications int
@@ -146,17 +148,24 @@ func allocAllocatorBenchmarkIDs(b *testing.B, a *Allocator, count int, many bool
 		if len(out) != count {
 			b.Fatalf("AllocMany returned %d IDs, want %d", len(out), count)
 		}
+		allocatorBenchmarkIDsSink = out
 		return
 	}
 
 	hint := uint64(allocatorBenchmarkRegionHint)
+	out := make([]uint64, 0, count)
 	for i := 0; i < count; i++ {
 		id, err := a.Alloc(hint)
 		if err != nil {
 			b.Fatalf("Alloc(%d): %v", hint, err)
 		}
+		out = append(out, id)
 		hint = id
 	}
+	if len(out) != count {
+		b.Fatalf("repeated Alloc returned %d IDs, want %d", len(out), count)
+	}
+	allocatorBenchmarkIDsSink = out
 }
 
 func allocatorBenchmarkIDsSlice() []uint64 {

--- a/TreeDB/freelist/allocator_benchmark_test.go
+++ b/TreeDB/freelist/allocator_benchmark_test.go
@@ -70,9 +70,9 @@ func benchmarkAllocatorFree(b *testing.B, many bool) {
 	if many {
 		a, p, path := newAllocatorBenchmarkFixture(b, root, b.N)
 		metrics = newAllocatorBenchmarkPageMetrics()
-		a.testPageEvent = metrics.observe
+		testAllocatorPageEvent = metrics.observe
 		freeAllocatorBenchmarkIDs(b, a, ids, true)
-		a.testPageEvent = nil
+		testAllocatorPageEvent = nil
 		closeAllocatorBenchmarkFixture(b, p, path)
 	}
 	benchmarkAllocatorMetrics(b, allocatorBenchmarkIDs, metrics)
@@ -127,9 +127,9 @@ func benchmarkAllocatorRegion(b *testing.B, count int, many bool) {
 		populateAllocatorBenchmarkFreelist(b, a, ids)
 		a.SetFreelistRegion(allocatorBenchmarkRegion, 1)
 		metrics = newAllocatorBenchmarkPageMetrics()
-		a.testPageEvent = metrics.observe
+		testAllocatorPageEvent = metrics.observe
 		allocAllocatorBenchmarkIDs(b, a, count, true)
-		a.testPageEvent = nil
+		testAllocatorPageEvent = nil
 		closeAllocatorBenchmarkFixture(b, p, path)
 	}
 	benchmarkAllocatorMetrics(b, count, metrics)

--- a/TreeDB/freelist/allocator_benchmark_test.go
+++ b/TreeDB/freelist/allocator_benchmark_test.go
@@ -1,0 +1,119 @@
+package freelist
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/snissn/gomap/TreeDB/page"
+	"github.com/snissn/gomap/TreeDB/pager"
+)
+
+const allocatorBenchmarkIDs = 10_000
+
+func BenchmarkAllocator_FreeMany(b *testing.B) {
+	benchmarkAllocatorFree(b, true)
+}
+
+func BenchmarkAllocator_Free(b *testing.B) {
+	benchmarkAllocatorFree(b, false)
+}
+
+func benchmarkAllocatorFree(b *testing.B, many bool) {
+	b.Helper()
+	ids := allocatorBenchmarkIDsSlice()
+	pagesTouched := (allocatorBenchmarkIDs + page.MaxFreeIDs) / (page.MaxFreeIDs + 1)
+	checksumUpdates := pagesTouched
+	if !many {
+		pagesTouched = allocatorBenchmarkIDs
+		checksumUpdates = allocatorBenchmarkIDs
+	}
+
+	root := b.TempDir()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		b.StopTimer()
+		a, p, path := newAllocatorBenchmarkFixture(b, root, i)
+		b.StartTimer()
+		if many {
+			if err := a.FreeMany(ids); err != nil {
+				b.Fatalf("FreeMany: %v", err)
+			}
+		} else {
+			for _, id := range ids {
+				if err := a.Free(id); err != nil {
+					b.Fatalf("Free(%d): %v", id, err)
+				}
+			}
+		}
+		b.StopTimer()
+		if err := p.Close(); err != nil {
+			b.Fatalf("Close: %v", err)
+		}
+		if err := os.Remove(path); err != nil {
+			b.Fatalf("Remove fixture: %v", err)
+		}
+	}
+	benchmarkAllocatorMetrics(b, allocatorBenchmarkIDs, pagesTouched, checksumUpdates)
+}
+
+func BenchmarkAllocator_AllocMany(b *testing.B) {
+	ids := allocatorBenchmarkIDsSlice()
+	pagesTouched := (allocatorBenchmarkIDs + page.MaxFreeIDs) / (page.MaxFreeIDs + 1)
+	root := b.TempDir()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		b.StopTimer()
+		a, p, path := newAllocatorBenchmarkFixture(b, root, i)
+		if err := a.FreeMany(ids); err != nil {
+			b.Fatalf("FreeMany setup: %v", err)
+		}
+		a.SetFreelistRegion(1024, 1)
+		a.lastAlloc = 4 * 1024
+		b.StartTimer()
+		out, err := a.AllocMany(allocatorBenchmarkIDs, 0)
+		if err != nil {
+			b.Fatalf("AllocMany: %v", err)
+		}
+		if len(out) != allocatorBenchmarkIDs {
+			b.Fatalf("AllocMany returned %d IDs, want %d", len(out), allocatorBenchmarkIDs)
+		}
+		b.StopTimer()
+		if err := p.Close(); err != nil {
+			b.Fatalf("Close: %v", err)
+		}
+		if err := os.Remove(path); err != nil {
+			b.Fatalf("Remove fixture: %v", err)
+		}
+	}
+	benchmarkAllocatorMetrics(b, allocatorBenchmarkIDs, pagesTouched, pagesTouched)
+}
+
+func allocatorBenchmarkIDsSlice() []uint64 {
+	ids := make([]uint64, allocatorBenchmarkIDs)
+	for i := range ids {
+		ids[i] = uint64(i + 1)
+	}
+	return ids
+}
+
+func newAllocatorBenchmarkFixture(b *testing.B, root string, iteration int) (*Allocator, *pager.Pager, string) {
+	b.Helper()
+	path := filepath.Join(root, fmt.Sprintf("%d.db", iteration))
+	p, err := pager.Open(path, 64*1024)
+	if err != nil {
+		b.Fatalf("Open: %v", err)
+	}
+	if _, err := p.Alloc(allocatorBenchmarkIDs + 1); err != nil {
+		_ = p.Close()
+		b.Fatalf("Alloc fixture: %v", err)
+	}
+	return New(p, 0), p, path
+}
+
+func benchmarkAllocatorMetrics(b *testing.B, ids, pagesTouched, checksumUpdates int) {
+	b.ReportMetric(float64(ids*b.N)/b.Elapsed().Seconds(), "ids/sec")
+	b.ReportMetric(float64(pagesTouched), "pages_touched/op")
+	b.ReportMetric(float64(checksumUpdates), "checksum_updates/op")
+}

--- a/TreeDB/freelist/allocator_benchmark_test.go
+++ b/TreeDB/freelist/allocator_benchmark_test.go
@@ -17,33 +17,6 @@ const (
 
 var allocatorBenchmarkIDsSink []uint64
 
-type allocatorBenchmarkPageMetrics struct {
-	gets          int
-	verifications int
-	updates       int
-	pagesTouched  int
-	seen          []bool
-}
-
-func newAllocatorBenchmarkPageMetrics() *allocatorBenchmarkPageMetrics {
-	return &allocatorBenchmarkPageMetrics{seen: make([]bool, allocatorBenchmarkIDs+1)}
-}
-
-func (metrics *allocatorBenchmarkPageMetrics) observe(event allocatorPageEvent, pageID uint64) {
-	if pageID < uint64(len(metrics.seen)) && !metrics.seen[pageID] {
-		metrics.seen[pageID] = true
-		metrics.pagesTouched++
-	}
-	switch event {
-	case allocatorPageGetForWrite:
-		metrics.gets++
-	case allocatorPageVerifyChecksum:
-		metrics.verifications++
-	case allocatorPageUpdateChecksum:
-		metrics.updates++
-	}
-}
-
 func BenchmarkAllocator_FreeMany(b *testing.B) {
 	benchmarkAllocatorFree(b, true)
 }
@@ -66,16 +39,7 @@ func benchmarkAllocatorFree(b *testing.B, many bool) {
 		closeAllocatorBenchmarkFixture(b, p, path)
 	}
 
-	var metrics *allocatorBenchmarkPageMetrics
-	if many {
-		a, p, path := newAllocatorBenchmarkFixture(b, root, b.N)
-		metrics = newAllocatorBenchmarkPageMetrics()
-		testAllocatorPageOperations = newRecordingAllocatorPageOperations(metrics.observe)
-		freeAllocatorBenchmarkIDs(b, a, ids, true)
-		testAllocatorPageOperations = nil
-		closeAllocatorBenchmarkFixture(b, p, path)
-	}
-	benchmarkAllocatorMetrics(b, allocatorBenchmarkIDs, metrics)
+	benchmarkAllocatorMetrics(b, allocatorBenchmarkIDs)
 }
 
 func freeAllocatorBenchmarkIDs(b *testing.B, a *Allocator, ids []uint64, many bool) {
@@ -121,18 +85,7 @@ func benchmarkAllocatorRegion(b *testing.B, count int, many bool) {
 		closeAllocatorBenchmarkFixture(b, p, path)
 	}
 
-	var metrics *allocatorBenchmarkPageMetrics
-	if many {
-		a, p, path := newAllocatorBenchmarkFixture(b, root, b.N)
-		populateAllocatorBenchmarkFreelist(b, a, ids)
-		a.SetFreelistRegion(allocatorBenchmarkRegion, 1)
-		metrics = newAllocatorBenchmarkPageMetrics()
-		testAllocatorPageOperations = newRecordingAllocatorPageOperations(metrics.observe)
-		allocAllocatorBenchmarkIDs(b, a, count, true)
-		testAllocatorPageOperations = nil
-		closeAllocatorBenchmarkFixture(b, p, path)
-	}
-	benchmarkAllocatorMetrics(b, count, metrics)
+	benchmarkAllocatorMetrics(b, count)
 }
 
 func populateAllocatorBenchmarkFreelist(b *testing.B, a *Allocator, ids []uint64) {
@@ -206,13 +159,6 @@ func closeAllocatorBenchmarkFixture(b *testing.B, p *pager.Pager, path string) {
 	}
 }
 
-func benchmarkAllocatorMetrics(b *testing.B, ids int, metrics *allocatorBenchmarkPageMetrics) {
+func benchmarkAllocatorMetrics(b *testing.B, ids int) {
 	b.ReportMetric(float64(ids*b.N)/b.Elapsed().Seconds(), "ids/sec")
-	if metrics == nil {
-		return
-	}
-	b.ReportMetric(float64(metrics.pagesTouched), "pages_touched/op")
-	b.ReportMetric(float64(metrics.gets), "get_for_write/op")
-	b.ReportMetric(float64(metrics.verifications), "checksum_verifications/op")
-	b.ReportMetric(float64(metrics.updates), "checksum_updates/op")
 }

--- a/TreeDB/freelist/allocator_benchmark_test.go
+++ b/TreeDB/freelist/allocator_benchmark_test.go
@@ -70,9 +70,9 @@ func benchmarkAllocatorFree(b *testing.B, many bool) {
 	if many {
 		a, p, path := newAllocatorBenchmarkFixture(b, root, b.N)
 		metrics = newAllocatorBenchmarkPageMetrics()
-		testAllocatorPageEvent = metrics.observe
+		testAllocatorPageOperations = newRecordingAllocatorPageOperations(metrics.observe)
 		freeAllocatorBenchmarkIDs(b, a, ids, true)
-		testAllocatorPageEvent = nil
+		testAllocatorPageOperations = nil
 		closeAllocatorBenchmarkFixture(b, p, path)
 	}
 	benchmarkAllocatorMetrics(b, allocatorBenchmarkIDs, metrics)
@@ -127,9 +127,9 @@ func benchmarkAllocatorRegion(b *testing.B, count int, many bool) {
 		populateAllocatorBenchmarkFreelist(b, a, ids)
 		a.SetFreelistRegion(allocatorBenchmarkRegion, 1)
 		metrics = newAllocatorBenchmarkPageMetrics()
-		testAllocatorPageEvent = metrics.observe
+		testAllocatorPageOperations = newRecordingAllocatorPageOperations(metrics.observe)
 		allocAllocatorBenchmarkIDs(b, a, count, true)
-		testAllocatorPageEvent = nil
+		testAllocatorPageOperations = nil
 		closeAllocatorBenchmarkFixture(b, p, path)
 	}
 	benchmarkAllocatorMetrics(b, count, metrics)

--- a/TreeDB/freelist/allocator_benchmark_test.go
+++ b/TreeDB/freelist/allocator_benchmark_test.go
@@ -66,12 +66,15 @@ func benchmarkAllocatorFree(b *testing.B, many bool) {
 		closeAllocatorBenchmarkFixture(b, p, path)
 	}
 
-	a, p, path := newAllocatorBenchmarkFixture(b, root, b.N)
-	metrics := newAllocatorBenchmarkPageMetrics()
-	a.testPageEvent = metrics.observe
-	freeAllocatorBenchmarkIDs(b, a, ids, many)
-	a.testPageEvent = nil
-	closeAllocatorBenchmarkFixture(b, p, path)
+	var metrics *allocatorBenchmarkPageMetrics
+	if many {
+		a, p, path := newAllocatorBenchmarkFixture(b, root, b.N)
+		metrics = newAllocatorBenchmarkPageMetrics()
+		a.testPageEvent = metrics.observe
+		freeAllocatorBenchmarkIDs(b, a, ids, true)
+		a.testPageEvent = nil
+		closeAllocatorBenchmarkFixture(b, p, path)
+	}
 	benchmarkAllocatorMetrics(b, allocatorBenchmarkIDs, metrics)
 }
 
@@ -118,14 +121,17 @@ func benchmarkAllocatorRegion(b *testing.B, count int, many bool) {
 		closeAllocatorBenchmarkFixture(b, p, path)
 	}
 
-	a, p, path := newAllocatorBenchmarkFixture(b, root, b.N)
-	populateAllocatorBenchmarkFreelist(b, a, ids)
-	a.SetFreelistRegion(allocatorBenchmarkRegion, 1)
-	metrics := newAllocatorBenchmarkPageMetrics()
-	a.testPageEvent = metrics.observe
-	allocAllocatorBenchmarkIDs(b, a, count, many)
-	a.testPageEvent = nil
-	closeAllocatorBenchmarkFixture(b, p, path)
+	var metrics *allocatorBenchmarkPageMetrics
+	if many {
+		a, p, path := newAllocatorBenchmarkFixture(b, root, b.N)
+		populateAllocatorBenchmarkFreelist(b, a, ids)
+		a.SetFreelistRegion(allocatorBenchmarkRegion, 1)
+		metrics = newAllocatorBenchmarkPageMetrics()
+		a.testPageEvent = metrics.observe
+		allocAllocatorBenchmarkIDs(b, a, count, true)
+		a.testPageEvent = nil
+		closeAllocatorBenchmarkFixture(b, p, path)
+	}
 	benchmarkAllocatorMetrics(b, count, metrics)
 }
 
@@ -202,6 +208,9 @@ func closeAllocatorBenchmarkFixture(b *testing.B, p *pager.Pager, path string) {
 
 func benchmarkAllocatorMetrics(b *testing.B, ids int, metrics *allocatorBenchmarkPageMetrics) {
 	b.ReportMetric(float64(ids*b.N)/b.Elapsed().Seconds(), "ids/sec")
+	if metrics == nil {
+		return
+	}
 	b.ReportMetric(float64(metrics.pagesTouched), "pages_touched/op")
 	b.ReportMetric(float64(metrics.gets), "get_for_write/op")
 	b.ReportMetric(float64(metrics.verifications), "checksum_verifications/op")

--- a/TreeDB/freelist/allocator_benchmark_test.go
+++ b/TreeDB/freelist/allocator_benchmark_test.go
@@ -6,11 +6,41 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/snissn/gomap/TreeDB/page"
 	"github.com/snissn/gomap/TreeDB/pager"
 )
 
-const allocatorBenchmarkIDs = 10_000
+const (
+	allocatorBenchmarkIDs        = 10_000
+	allocatorBenchmarkRegion     = 8192
+	allocatorBenchmarkRegionHint = 4 * allocatorBenchmarkRegion
+)
+
+type allocatorBenchmarkPageMetrics struct {
+	gets          int
+	verifications int
+	updates       int
+	pagesTouched  int
+	seen          []bool
+}
+
+func newAllocatorBenchmarkPageMetrics() *allocatorBenchmarkPageMetrics {
+	return &allocatorBenchmarkPageMetrics{seen: make([]bool, allocatorBenchmarkIDs+1)}
+}
+
+func (metrics *allocatorBenchmarkPageMetrics) observe(event allocatorPageEvent, pageID uint64) {
+	if pageID < uint64(len(metrics.seen)) && !metrics.seen[pageID] {
+		metrics.seen[pageID] = true
+		metrics.pagesTouched++
+	}
+	switch event {
+	case allocatorPageGetForWrite:
+		metrics.gets++
+	case allocatorPageVerifyChecksum:
+		metrics.verifications++
+	case allocatorPageUpdateChecksum:
+		metrics.updates++
+	}
+}
 
 func BenchmarkAllocator_FreeMany(b *testing.B) {
 	benchmarkAllocatorFree(b, true)
@@ -23,71 +53,110 @@ func BenchmarkAllocator_Free(b *testing.B) {
 func benchmarkAllocatorFree(b *testing.B, many bool) {
 	b.Helper()
 	ids := allocatorBenchmarkIDsSlice()
-	pagesTouched := (allocatorBenchmarkIDs + page.MaxFreeIDs) / (page.MaxFreeIDs + 1)
-	checksumUpdates := pagesTouched
-	if !many {
-		pagesTouched = allocatorBenchmarkIDs
-		checksumUpdates = allocatorBenchmarkIDs
-	}
-
 	root := b.TempDir()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		b.StopTimer()
 		a, p, path := newAllocatorBenchmarkFixture(b, root, i)
 		b.StartTimer()
-		if many {
-			if err := a.FreeMany(ids); err != nil {
-				b.Fatalf("FreeMany: %v", err)
-			}
-		} else {
-			for _, id := range ids {
-				if err := a.Free(id); err != nil {
-					b.Fatalf("Free(%d): %v", id, err)
-				}
-			}
-		}
+		freeAllocatorBenchmarkIDs(b, a, ids, many)
 		b.StopTimer()
-		if err := p.Close(); err != nil {
-			b.Fatalf("Close: %v", err)
+		closeAllocatorBenchmarkFixture(b, p, path)
+	}
+
+	a, p, path := newAllocatorBenchmarkFixture(b, root, b.N)
+	metrics := newAllocatorBenchmarkPageMetrics()
+	a.testPageEvent = metrics.observe
+	freeAllocatorBenchmarkIDs(b, a, ids, many)
+	a.testPageEvent = nil
+	closeAllocatorBenchmarkFixture(b, p, path)
+	benchmarkAllocatorMetrics(b, allocatorBenchmarkIDs, metrics)
+}
+
+func freeAllocatorBenchmarkIDs(b *testing.B, a *Allocator, ids []uint64, many bool) {
+	b.Helper()
+	if many {
+		if err := a.FreeMany(ids); err != nil {
+			b.Fatalf("FreeMany: %v", err)
 		}
-		if err := os.Remove(path); err != nil {
-			b.Fatalf("Remove fixture: %v", err)
+		return
+	}
+	for _, id := range ids {
+		if err := a.Free(id); err != nil {
+			b.Fatalf("Free(%d): %v", id, err)
 		}
 	}
-	benchmarkAllocatorMetrics(b, allocatorBenchmarkIDs, pagesTouched, checksumUpdates)
 }
 
 func BenchmarkAllocator_AllocMany(b *testing.B) {
+	benchmarkAllocatorRegion(b, allocatorBenchmarkIDs, true)
+}
+
+func BenchmarkAllocator_AllocMany2(b *testing.B) {
+	benchmarkAllocatorRegion(b, 2, true)
+}
+
+func BenchmarkAllocator_AllocRepeated2(b *testing.B) {
+	benchmarkAllocatorRegion(b, 2, false)
+}
+
+func benchmarkAllocatorRegion(b *testing.B, count int, many bool) {
+	b.Helper()
 	ids := allocatorBenchmarkIDsSlice()
-	pagesTouched := (allocatorBenchmarkIDs + page.MaxFreeIDs) / (page.MaxFreeIDs + 1)
 	root := b.TempDir()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		b.StopTimer()
 		a, p, path := newAllocatorBenchmarkFixture(b, root, i)
-		if err := a.FreeMany(ids); err != nil {
-			b.Fatalf("FreeMany setup: %v", err)
-		}
-		a.SetFreelistRegion(1024, 1)
-		a.lastAlloc = 4 * 1024
+		populateAllocatorBenchmarkFreelist(b, a, ids)
+		a.SetFreelistRegion(allocatorBenchmarkRegion, 1)
 		b.StartTimer()
-		out, err := a.AllocMany(allocatorBenchmarkIDs, 0)
+		allocAllocatorBenchmarkIDs(b, a, count, many)
+		b.StopTimer()
+		closeAllocatorBenchmarkFixture(b, p, path)
+	}
+
+	a, p, path := newAllocatorBenchmarkFixture(b, root, b.N)
+	populateAllocatorBenchmarkFreelist(b, a, ids)
+	a.SetFreelistRegion(allocatorBenchmarkRegion, 1)
+	metrics := newAllocatorBenchmarkPageMetrics()
+	a.testPageEvent = metrics.observe
+	allocAllocatorBenchmarkIDs(b, a, count, many)
+	a.testPageEvent = nil
+	closeAllocatorBenchmarkFixture(b, p, path)
+	benchmarkAllocatorMetrics(b, count, metrics)
+}
+
+func populateAllocatorBenchmarkFreelist(b *testing.B, a *Allocator, ids []uint64) {
+	b.Helper()
+	for _, id := range ids {
+		if err := a.Free(id); err != nil {
+			b.Fatalf("Free(%d) setup: %v", id, err)
+		}
+	}
+}
+
+func allocAllocatorBenchmarkIDs(b *testing.B, a *Allocator, count int, many bool) {
+	b.Helper()
+	if many {
+		out, err := a.AllocMany(count, allocatorBenchmarkRegionHint)
 		if err != nil {
 			b.Fatalf("AllocMany: %v", err)
 		}
-		if len(out) != allocatorBenchmarkIDs {
-			b.Fatalf("AllocMany returned %d IDs, want %d", len(out), allocatorBenchmarkIDs)
+		if len(out) != count {
+			b.Fatalf("AllocMany returned %d IDs, want %d", len(out), count)
 		}
-		b.StopTimer()
-		if err := p.Close(); err != nil {
-			b.Fatalf("Close: %v", err)
-		}
-		if err := os.Remove(path); err != nil {
-			b.Fatalf("Remove fixture: %v", err)
-		}
+		return
 	}
-	benchmarkAllocatorMetrics(b, allocatorBenchmarkIDs, pagesTouched, pagesTouched)
+
+	hint := uint64(allocatorBenchmarkRegionHint)
+	for i := 0; i < count; i++ {
+		id, err := a.Alloc(hint)
+		if err != nil {
+			b.Fatalf("Alloc(%d): %v", hint, err)
+		}
+		hint = id
+	}
 }
 
 func allocatorBenchmarkIDsSlice() []uint64 {
@@ -112,8 +181,20 @@ func newAllocatorBenchmarkFixture(b *testing.B, root string, iteration int) (*Al
 	return New(p, 0), p, path
 }
 
-func benchmarkAllocatorMetrics(b *testing.B, ids, pagesTouched, checksumUpdates int) {
+func closeAllocatorBenchmarkFixture(b *testing.B, p *pager.Pager, path string) {
+	b.Helper()
+	if err := p.Close(); err != nil {
+		b.Fatalf("Close: %v", err)
+	}
+	if err := os.Remove(path); err != nil {
+		b.Fatalf("Remove fixture: %v", err)
+	}
+}
+
+func benchmarkAllocatorMetrics(b *testing.B, ids int, metrics *allocatorBenchmarkPageMetrics) {
 	b.ReportMetric(float64(ids*b.N)/b.Elapsed().Seconds(), "ids/sec")
-	b.ReportMetric(float64(pagesTouched), "pages_touched/op")
-	b.ReportMetric(float64(checksumUpdates), "checksum_updates/op")
+	b.ReportMetric(float64(metrics.pagesTouched), "pages_touched/op")
+	b.ReportMetric(float64(metrics.gets), "get_for_write/op")
+	b.ReportMetric(float64(metrics.verifications), "checksum_verifications/op")
+	b.ReportMetric(float64(metrics.updates), "checksum_updates/op")
 }

--- a/TreeDB/freelist/allocator_free_many_test.go
+++ b/TreeDB/freelist/allocator_free_many_test.go
@@ -78,8 +78,8 @@ func TestAllocator_FreeMany_FillsHeadAndChains(t *testing.T) {
 	TestHookFreeManyBeforeChecksum = func() { checksumUpdates++ }
 	t.Cleanup(func() { TestHookFreeManyBeforeChecksum = nil })
 	events := allocatorPageEvents{}
-	a.testPageEvent = events.observe
-	t.Cleanup(func() { a.testPageEvent = nil })
+	testAllocatorPageEvent = events.observe
+	t.Cleanup(func() { testAllocatorPageEvent = nil })
 	if err := a.FreeMany(ids); err != nil {
 		t.Fatalf("FreeMany: %v", err)
 	}
@@ -335,9 +335,9 @@ func TestAllocator_RegionBiasedAllocMany_DrainsAndRecyclesHeadWithOneVerificatio
 	}
 
 	events := allocatorPageEvents{}
-	a.testPageEvent = events.observe
+	testAllocatorPageEvent = events.observe
 	got, err := a.AllocMany(3, freed[len(freed)-1])
-	a.testPageEvent = nil
+	testAllocatorPageEvent = nil
 	if err != nil {
 		t.Fatalf("AllocMany: %v", err)
 	}

--- a/TreeDB/freelist/allocator_free_many_test.go
+++ b/TreeDB/freelist/allocator_free_many_test.go
@@ -60,53 +60,42 @@ func (events allocatorPageEvents) observe(event allocatorPageEvent, pageID uint6
 	}
 }
 
-type recordingAllocatorPageOperations struct {
-	inner   allocatorPageOperations
-	observe func(allocatorPageEvent, uint64)
-}
-
-func newRecordingAllocatorPageOperations(observe func(allocatorPageEvent, uint64)) *recordingAllocatorPageOperations {
-	return &recordingAllocatorPageOperations{
-		inner:   directAllocatorPageOperations{},
-		observe: observe,
+func newRecordingAllocatorPageOperations(observe func(allocatorPageEvent, uint64)) *allocatorPageOperations {
+	var direct *allocatorPageOperations
+	return &allocatorPageOperations{
+		getForWriteFunc: func(p *pager.Pager, pageID uint64) ([]byte, error) {
+			observe(allocatorPageGetForWrite, pageID)
+			return direct.getForWrite(p, pageID)
+		},
+		verifyChecksumFunc: func(pageID uint64, data []byte) bool {
+			observe(allocatorPageVerifyChecksum, pageID)
+			return direct.verifyChecksum(pageID, data)
+		},
+		updateChecksumFunc: func(pageID uint64, data []byte) {
+			observe(allocatorPageUpdateChecksum, pageID)
+			direct.updateChecksum(pageID, data)
+		},
 	}
 }
 
-func (ops *recordingAllocatorPageOperations) getForWrite(p *pager.Pager, pageID uint64) ([]byte, error) {
-	ops.observe(allocatorPageGetForWrite, pageID)
-	return ops.inner.getForWrite(p, pageID)
-}
-
-func (ops *recordingAllocatorPageOperations) verifyChecksum(pageID uint64, data []byte) bool {
-	ops.observe(allocatorPageVerifyChecksum, pageID)
-	return ops.inner.verifyChecksum(pageID, data)
-}
-
-func (ops *recordingAllocatorPageOperations) updateChecksum(pageID uint64, data []byte) {
-	ops.observe(allocatorPageUpdateChecksum, pageID)
-	ops.inner.updateChecksum(pageID, data)
-}
-
-type duplicateAllocatorPageOperations struct {
-	inner allocatorPageOperations
-}
-
-func (ops duplicateAllocatorPageOperations) getForWrite(p *pager.Pager, pageID uint64) ([]byte, error) {
-	if _, err := ops.inner.getForWrite(p, pageID); err != nil {
-		return nil, err
+func newDuplicateAllocatorPageOperations(inner *allocatorPageOperations) *allocatorPageOperations {
+	return &allocatorPageOperations{
+		getForWriteFunc: func(p *pager.Pager, pageID uint64) ([]byte, error) {
+			if _, err := inner.getForWrite(p, pageID); err != nil {
+				return nil, err
+			}
+			return inner.getForWrite(p, pageID)
+		},
+		verifyChecksumFunc: func(pageID uint64, data []byte) bool {
+			first := inner.verifyChecksum(pageID, data)
+			second := inner.verifyChecksum(pageID, data)
+			return first && second
+		},
+		updateChecksumFunc: func(pageID uint64, data []byte) {
+			inner.updateChecksum(pageID, data)
+			inner.updateChecksum(pageID, data)
+		},
 	}
-	return ops.inner.getForWrite(p, pageID)
-}
-
-func (ops duplicateAllocatorPageOperations) verifyChecksum(pageID uint64, data []byte) bool {
-	first := ops.inner.verifyChecksum(pageID, data)
-	second := ops.inner.verifyChecksum(pageID, data)
-	return first && second
-}
-
-func (ops duplicateAllocatorPageOperations) updateChecksum(pageID uint64, data []byte) {
-	ops.inner.updateChecksum(pageID, data)
-	ops.inner.updateChecksum(pageID, data)
 }
 
 func installAllocatorPageOperationRecorder(t testing.TB, observe func(allocatorPageEvent, uint64)) {
@@ -141,7 +130,7 @@ func TestAllocator_PageOperationGateDetectsDuplicateCalls(t *testing.T) {
 	headID := a.Head()
 	events := allocatorPageEvents{}
 	recorder := newRecordingAllocatorPageOperations(events.observe)
-	testAllocatorPageOperations = duplicateAllocatorPageOperations{inner: recorder}
+	testAllocatorPageOperations = newDuplicateAllocatorPageOperations(recorder)
 	t.Cleanup(func() { testAllocatorPageOperations = nil })
 
 	if err := a.FreeMany([]uint64{3}); err != nil {

--- a/TreeDB/freelist/allocator_free_many_test.go
+++ b/TreeDB/freelist/allocator_free_many_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"errors"
 	"path/filepath"
+	"slices"
 	"sync"
 	"testing"
 
@@ -132,6 +133,7 @@ func TestAllocator_FreeMany_HookRunsBeforeChecksum(t *testing.T) {
 	if err := a.Free(2); err != nil {
 		t.Fatalf("Free(2): %v", err)
 	}
+	head := a.Head()
 
 	var once sync.Once
 	reached := make(chan struct{}, 1)
@@ -147,7 +149,7 @@ func TestAllocator_FreeMany_HookRunsBeforeChecksum(t *testing.T) {
 	done := make(chan error, 1)
 	go func() { done <- a.FreeMany([]uint64{1, 3}) }()
 	<-reached
-	if data := mustAllocatorPage(t, p, a.Head()); page.VerifyChecksumNonMutating(data) {
+	if data := mustAllocatorPage(t, p, head); page.VerifyChecksumNonMutating(data) {
 		t.Fatal("checksum was updated before the free hook released")
 	} else if got := node.NewNode(data).Count(); got != 1 {
 		t.Fatalf("count while free hook is paused = %d, want written prefix count 1", got)
@@ -156,7 +158,7 @@ func TestAllocator_FreeMany_HookRunsBeforeChecksum(t *testing.T) {
 	if err := <-done; err != nil {
 		t.Fatalf("FreeMany: %v", err)
 	}
-	if data := mustAllocatorPage(t, p, a.Head()); !page.VerifyChecksumNonMutating(data) {
+	if data := mustAllocatorPage(t, p, head); !page.VerifyChecksumNonMutating(data) {
 		t.Fatal("checksum was not updated after FreeMany completed")
 	}
 }
@@ -216,6 +218,94 @@ func TestAllocator_RegionBiasedAllocMany_BatchesNearbyUnverified(t *testing.T) {
 	after := a.Counters()
 	if after.AllocPages != before.AllocPages+2 || after.ReuseAllocPages != before.ReuseAllocPages+2 || after.FreeIDs != before.FreeIDs-2 {
 		t.Fatalf("unexpected counters after region AllocMany: before=%+v after=%+v", before, after)
+	}
+}
+
+func TestAllocator_RegionBiasedAllocMany_RecycledHeadDoesNotConsumeFreeIDStat(t *testing.T) {
+	freed := make([]uint64, page.MaxFreeIDs+3)
+	for i := range freed {
+		freed[i] = uint64(i + 1)
+	}
+	a, p := newAllocatorForFreeManyTest(t, len(freed)+1)
+	a.SetFreelistRegion(4, 1)
+	if err := a.FreeMany(freed); err != nil {
+		t.Fatalf("FreeMany: %v", err)
+	}
+
+	emptyHead := a.Head()
+	headData := mustAllocatorPage(t, p, emptyHead)
+	if got := node.NewNode(headData).Count(); got != 1 {
+		t.Fatalf("newest freelist head count = %d, want 1 before drain", got)
+	}
+	if got := freelistNextPageID(headData); got == 0 {
+		t.Fatal("expected an older freelist head after newest head")
+	}
+
+	drained, err := a.AllocMany(1, freed[len(freed)-1])
+	if err != nil {
+		t.Fatalf("drain AllocMany: %v", err)
+	}
+	if len(drained) != 1 || drained[0] != freed[len(freed)-1] {
+		t.Fatalf("drain AllocMany = %v, want [%d]", drained, freed[len(freed)-1])
+	}
+	if got := node.NewNode(mustAllocatorPage(t, p, emptyHead)).Count(); got != 0 {
+		t.Fatalf("newest freelist head count after drain = %d, want 0", got)
+	}
+
+	before := a.Counters()
+	if before.Pages != 2 || before.FreeIDs != page.MaxFreeIDs {
+		t.Fatalf("counters before recycling empty head = %+v, want 2 heads and %d body IDs", before, page.MaxFreeIDs)
+	}
+	got, err := a.AllocMany(2, emptyHead)
+	if err != nil {
+		t.Fatalf("recycle AllocMany: %v", err)
+	}
+	if len(got) != 2 || got[0] != emptyHead {
+		t.Fatalf("recycle AllocMany = %v, want empty head %d followed by one body ID", got, emptyHead)
+	}
+
+	after := a.Counters()
+	if after.Pages != before.Pages-1 {
+		t.Fatalf("freelist pages after recycling empty head = %d, want %d", after.Pages, before.Pages-1)
+	}
+	if after.FreeIDs != before.FreeIDs-1 {
+		t.Fatalf("free body IDs after recycling head and allocating one body ID = %d, want %d", after.FreeIDs, before.FreeIDs-1)
+	}
+	if after.AllocPages != before.AllocPages+2 || after.ReuseAllocPages != before.ReuseAllocPages+2 {
+		t.Fatalf("allocation counters after recycling empty head: before=%+v after=%+v", before, after)
+	}
+}
+
+func TestAllocator_RegionBiasedAllocMany_MatchesRepeatedAllocWithMovingHint(t *testing.T) {
+	newFixture := func(t *testing.T) *Allocator {
+		t.Helper()
+		a, _ := newAllocatorForFreeManyTest(t, 130)
+		a.SetFreelistRegion(10, 1)
+		if err := a.FreeMany([]uint64{1, 90, 95, 38, 115, 105}); err != nil {
+			t.Fatalf("FreeMany: %v", err)
+		}
+		return a
+	}
+
+	batched := newFixture(t)
+	got, err := batched.AllocMany(5, 129)
+	if err != nil {
+		t.Fatalf("AllocMany: %v", err)
+	}
+
+	repeated := newFixture(t)
+	want := make([]uint64, 0, len(got))
+	hint := uint64(129)
+	for range got {
+		id, err := repeated.Alloc(hint)
+		if err != nil {
+			t.Fatalf("Alloc(%d): %v", hint, err)
+		}
+		want = append(want, id)
+		hint = id
+	}
+	if !slices.Equal(got, want) {
+		t.Fatalf("AllocMany order = %v, repeated Alloc order = %v", got, want)
 	}
 }
 

--- a/TreeDB/freelist/allocator_free_many_test.go
+++ b/TreeDB/freelist/allocator_free_many_test.go
@@ -381,6 +381,40 @@ func TestAllocator_RegionBiasedAllocMany_MatchesRepeatedAllocWithMovingHint(t *t
 	}
 }
 
+func TestAllocator_RegionBiasedAllocMany_IndexedPathMatchesRepeatedAlloc(t *testing.T) {
+	freed := []uint64{1, 90, 95, 38, 115, 105, 12, 29, 81, 99, 130, 111, 72}
+	newFixture := func(t *testing.T) *Allocator {
+		t.Helper()
+		a, _ := newAllocatorForFreeManyTest(t, 140)
+		a.SetFreelistRegion(10, 1)
+		if err := a.FreeMany(freed); err != nil {
+			t.Fatalf("FreeMany: %v", err)
+		}
+		return a
+	}
+
+	batched := newFixture(t)
+	got, err := batched.AllocMany(10, 129)
+	if err != nil {
+		t.Fatalf("AllocMany: %v", err)
+	}
+
+	repeated := newFixture(t)
+	want := make([]uint64, 0, len(got))
+	hint := uint64(129)
+	for range got {
+		id, err := repeated.Alloc(hint)
+		if err != nil {
+			t.Fatalf("Alloc(%d): %v", hint, err)
+		}
+		want = append(want, id)
+		hint = id
+	}
+	if !slices.Equal(got, want) {
+		t.Fatalf("indexed AllocMany order = %v, repeated Alloc order = %v", got, want)
+	}
+}
+
 func mustAllocatorPage(t *testing.T, p *pager.Pager, id uint64) []byte {
 	t.Helper()
 	data, err := p.Get(id)

--- a/TreeDB/freelist/allocator_free_many_test.go
+++ b/TreeDB/freelist/allocator_free_many_test.go
@@ -1,0 +1,229 @@
+package freelist
+
+import (
+	"bytes"
+	"errors"
+	"path/filepath"
+	"sync"
+	"testing"
+
+	"github.com/snissn/gomap/TreeDB/node"
+	"github.com/snissn/gomap/TreeDB/page"
+	"github.com/snissn/gomap/TreeDB/pager"
+)
+
+func newAllocatorForFreeManyTest(t *testing.T, pages int) (*Allocator, *pager.Pager) {
+	t.Helper()
+	p, err := pager.Open(filepath.Join(t.TempDir(), "index.db"), 64*1024)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	if _, err := p.Alloc(pages); err != nil {
+		_ = p.Close()
+		t.Fatalf("Alloc(%d): %v", pages, err)
+	}
+	t.Cleanup(func() { _ = p.Close() })
+	return New(p, 0), p
+}
+
+func TestAllocator_FreeMany_FillsHeadAndChains(t *testing.T) {
+	a, p := newAllocatorForFreeManyTest(t, page.MaxFreeIDs+8)
+
+	seed := make([]uint64, page.MaxFreeIDs-1)
+	for i := range seed {
+		seed[i] = uint64(i + 1)
+	}
+	if err := a.FreeMany(seed); err != nil {
+		t.Fatalf("seed FreeMany: %v", err)
+	}
+
+	ids := []uint64{uint64(page.MaxFreeIDs - 1), uint64(page.MaxFreeIDs), uint64(page.MaxFreeIDs + 1), uint64(page.MaxFreeIDs + 2)}
+	checksumUpdates := 0
+	TestHookFreeManyBeforeChecksum = func() { checksumUpdates++ }
+	t.Cleanup(func() { TestHookFreeManyBeforeChecksum = nil })
+	if err := a.FreeMany(ids); err != nil {
+		t.Fatalf("FreeMany: %v", err)
+	}
+	if checksumUpdates != 2 {
+		t.Fatalf("FreeMany checksum updates = %d, want one per touched page (2)", checksumUpdates)
+	}
+
+	head := a.Head()
+	if head != ids[2] {
+		t.Fatalf("head = %d, want chained head %d", head, ids[2])
+	}
+	headData, err := p.Get(head)
+	if err != nil {
+		t.Fatalf("Get(head): %v", err)
+	}
+	headNode := node.NewNode(headData)
+	if !headNode.VerifyChecksum() {
+		t.Fatal("chained head checksum is invalid")
+	}
+	if headNode.Count() != 1 || freelistIDAt(headData, 0) != ids[3] {
+		t.Fatalf("chained head entries = count %d id %d, want count 1 id %d", headNode.Count(), freelistIDAt(headData, 0), ids[3])
+	}
+	if next := freelistNextPageID(headData); next != seed[0] {
+		t.Fatalf("chained head next = %d, want %d", next, seed[0])
+	}
+
+	oldData, err := p.Get(seed[0])
+	if err != nil {
+		t.Fatalf("Get(old head): %v", err)
+	}
+	oldNode := node.NewNode(oldData)
+	if oldNode.Count() != page.MaxFreeIDs {
+		t.Fatalf("old head count = %d, want %d", oldNode.Count(), page.MaxFreeIDs)
+	}
+	if !oldNode.VerifyChecksum() {
+		t.Fatal("filled head checksum is invalid")
+	}
+}
+
+func TestAllocator_FreeMany_RejectsPageZeroBeforeMutation(t *testing.T) {
+	a, p := newAllocatorForFreeManyTest(t, 6)
+	if err := a.Free(2); err != nil {
+		t.Fatalf("Free(2): %v", err)
+	}
+	beforeHead := a.Head()
+	before := append([]byte(nil), mustAllocatorPage(t, p, beforeHead)...)
+	beforeCounters := a.Counters()
+
+	err := a.FreeMany([]uint64{3, 0, 4})
+	if err == nil || !errors.Is(err, errCannotFreePageZero) {
+		t.Fatalf("FreeMany error = %v, want page-0 rejection", err)
+	}
+	if got := a.Head(); got != beforeHead {
+		t.Fatalf("head changed: got %d want %d", got, beforeHead)
+	}
+	after := mustAllocatorPage(t, p, beforeHead)
+	if !bytes.Equal(after, before) {
+		t.Fatal("freelist head changed after page-0 rejection")
+	}
+	if got := a.Counters(); got != beforeCounters {
+		t.Fatalf("counters changed after page-0 rejection: got %+v want %+v", got, beforeCounters)
+	}
+}
+
+func TestAllocator_FreeMany_DuplicatesMatchFreeLoop(t *testing.T) {
+	a, _ := newAllocatorForFreeManyTest(t, 8)
+	ids := []uint64{1, 1, 2}
+	if err := a.FreeMany(ids); err != nil {
+		t.Fatalf("FreeMany: %v", err)
+	}
+
+	got, err := a.AllocMany(len(ids), 0)
+	if err != nil {
+		t.Fatalf("AllocMany: %v", err)
+	}
+	want := []uint64{2, 1, 1}
+	if len(got) != len(want) {
+		t.Fatalf("AllocMany returned %d ids, want %d", len(got), len(want))
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("AllocMany[%d] = %d, want %d", i, got[i], want[i])
+		}
+	}
+}
+
+func TestAllocator_FreeMany_HookRunsBeforeChecksum(t *testing.T) {
+	a, p := newAllocatorForFreeManyTest(t, 6)
+	if err := a.Free(2); err != nil {
+		t.Fatalf("Free(2): %v", err)
+	}
+
+	var once sync.Once
+	reached := make(chan struct{}, 1)
+	release := make(chan struct{})
+	TestHookFreeBeforeChecksum = func() {
+		once.Do(func() {
+			reached <- struct{}{}
+			<-release
+		})
+	}
+	t.Cleanup(func() { TestHookFreeBeforeChecksum = nil })
+
+	done := make(chan error, 1)
+	go func() { done <- a.FreeMany([]uint64{1, 3}) }()
+	<-reached
+	if data := mustAllocatorPage(t, p, a.Head()); page.VerifyChecksumNonMutating(data) {
+		t.Fatal("checksum was updated before the free hook released")
+	} else if got := node.NewNode(data).Count(); got != 1 {
+		t.Fatalf("count while free hook is paused = %d, want written prefix count 1", got)
+	}
+	close(release)
+	if err := <-done; err != nil {
+		t.Fatalf("FreeMany: %v", err)
+	}
+	if data := mustAllocatorPage(t, p, a.Head()); !page.VerifyChecksumNonMutating(data) {
+		t.Fatal("checksum was not updated after FreeMany completed")
+	}
+}
+
+func TestAllocator_FreeMany_RejectsCorruptHead(t *testing.T) {
+	a, p := newAllocatorForFreeManyTest(t, 5)
+	if err := a.Free(2); err != nil {
+		t.Fatalf("Free(2): %v", err)
+	}
+	data, err := p.GetForWrite(a.Head())
+	if err != nil {
+		t.Fatalf("GetForWrite: %v", err)
+	}
+	data[page.PageHeaderSize] ^= 0xff
+
+	if err := a.FreeMany([]uint64{1, 3}); err == nil {
+		t.Fatal("FreeMany succeeded with corrupt freelist head")
+	}
+}
+
+func TestAllocator_RegionBiasedAllocMany_BatchesNearbyUnverified(t *testing.T) {
+	a, p := newAllocatorForFreeManyTest(t, 32)
+	a.SetFreelistRegion(4, 1)
+	if err := a.FreeMany([]uint64{1, 2, 9, 10, 29}); err != nil {
+		t.Fatalf("FreeMany: %v", err)
+	}
+	p.MarkVerified(9)
+	p.MarkVerified(10)
+	a.mu.Lock()
+	a.lastAlloc = 9
+	a.mu.Unlock()
+	before := a.Counters()
+
+	got, err := a.AllocMany(2, 0)
+	if err != nil {
+		t.Fatalf("AllocMany: %v", err)
+	}
+	want := map[uint64]bool{9: true, 10: true}
+	for _, id := range got {
+		if !want[id] {
+			t.Fatalf("region allocation returned %d, want only nearby pages", id)
+		}
+		delete(want, id)
+	}
+	if len(want) != 0 {
+		t.Fatalf("region allocation missed nearby pages: %v", want)
+	}
+	if p.IsVerified(9) || p.IsVerified(10) {
+		t.Fatal("reused region pages remained verified")
+	}
+	a.mu.Lock()
+	lastAlloc := a.lastAlloc
+	a.mu.Unlock()
+	if lastAlloc != got[len(got)-1] {
+		t.Fatalf("lastAlloc = %d, want final region allocation %d", lastAlloc, got[len(got)-1])
+	}
+	after := a.Counters()
+	if after.AllocPages != before.AllocPages+2 || after.ReuseAllocPages != before.ReuseAllocPages+2 || after.FreeIDs != before.FreeIDs-2 {
+		t.Fatalf("unexpected counters after region AllocMany: before=%+v after=%+v", before, after)
+	}
+}
+
+func mustAllocatorPage(t *testing.T, p *pager.Pager, id uint64) []byte {
+	t.Helper()
+	data, err := p.Get(id)
+	if err != nil {
+		t.Fatalf("Get(%d): %v", id, err)
+	}
+	return data
+}

--- a/TreeDB/freelist/allocator_free_many_test.go
+++ b/TreeDB/freelist/allocator_free_many_test.go
@@ -3,7 +3,6 @@ package freelist
 import (
 	"bytes"
 	"errors"
-	"fmt"
 	"path/filepath"
 	"slices"
 	"sync"
@@ -28,120 +27,6 @@ func newAllocatorForFreeManyTest(t *testing.T, pages int) (*Allocator, *pager.Pa
 	return New(p, 0), p
 }
 
-type allocatorPageEventCounts struct {
-	gets     int
-	verifies int
-	updates  int
-}
-
-type allocatorPageEvent uint8
-
-const (
-	allocatorPageGetForWrite allocatorPageEvent = iota
-	allocatorPageVerifyChecksum
-	allocatorPageUpdateChecksum
-)
-
-type allocatorPageEvents map[uint64]*allocatorPageEventCounts
-
-func (events allocatorPageEvents) observe(event allocatorPageEvent, pageID uint64) {
-	counts := events[pageID]
-	if counts == nil {
-		counts = &allocatorPageEventCounts{}
-		events[pageID] = counts
-	}
-	switch event {
-	case allocatorPageGetForWrite:
-		counts.gets++
-	case allocatorPageVerifyChecksum:
-		counts.verifies++
-	case allocatorPageUpdateChecksum:
-		counts.updates++
-	}
-}
-
-func newRecordingAllocatorPageOperations(observe func(allocatorPageEvent, uint64)) *allocatorPageOperations {
-	var direct *allocatorPageOperations
-	return &allocatorPageOperations{
-		getForWriteFunc: func(p *pager.Pager, pageID uint64) ([]byte, error) {
-			observe(allocatorPageGetForWrite, pageID)
-			return direct.getForWrite(p, pageID)
-		},
-		verifyChecksumFunc: func(pageID uint64, data []byte) bool {
-			observe(allocatorPageVerifyChecksum, pageID)
-			return direct.verifyChecksum(pageID, data)
-		},
-		updateChecksumFunc: func(pageID uint64, data []byte) {
-			observe(allocatorPageUpdateChecksum, pageID)
-			direct.updateChecksum(pageID, data)
-		},
-	}
-}
-
-func newDuplicateAllocatorPageOperations(inner *allocatorPageOperations) *allocatorPageOperations {
-	return &allocatorPageOperations{
-		getForWriteFunc: func(p *pager.Pager, pageID uint64) ([]byte, error) {
-			if _, err := inner.getForWrite(p, pageID); err != nil {
-				return nil, err
-			}
-			return inner.getForWrite(p, pageID)
-		},
-		verifyChecksumFunc: func(pageID uint64, data []byte) bool {
-			first := inner.verifyChecksum(pageID, data)
-			second := inner.verifyChecksum(pageID, data)
-			return first && second
-		},
-		updateChecksumFunc: func(pageID uint64, data []byte) {
-			inner.updateChecksum(pageID, data)
-			inner.updateChecksum(pageID, data)
-		},
-	}
-}
-
-func installAllocatorPageOperationRecorder(t testing.TB, observe func(allocatorPageEvent, uint64)) {
-	t.Helper()
-	testAllocatorPageOperations = newRecordingAllocatorPageOperations(observe)
-	t.Cleanup(func() { testAllocatorPageOperations = nil })
-}
-
-func assertAllocatorPageEvents(t *testing.T, events allocatorPageEvents, pageID uint64, want allocatorPageEventCounts) {
-	t.Helper()
-	if err := validateAllocatorPageEvents(events, pageID, want); err != nil {
-		t.Fatal(err)
-	}
-}
-
-func validateAllocatorPageEvents(events allocatorPageEvents, pageID uint64, want allocatorPageEventCounts) error {
-	got := events[pageID]
-	if got == nil {
-		got = &allocatorPageEventCounts{}
-	}
-	if *got != want {
-		return fmt.Errorf("page %d events = %+v, want %+v", pageID, *got, want)
-	}
-	return nil
-}
-
-func TestAllocator_PageOperationGateDetectsDuplicateCalls(t *testing.T) {
-	a, _ := newAllocatorForFreeManyTest(t, 6)
-	if err := a.Free(2); err != nil {
-		t.Fatalf("Free(2): %v", err)
-	}
-	headID := a.Head()
-	events := allocatorPageEvents{}
-	recorder := newRecordingAllocatorPageOperations(events.observe)
-	testAllocatorPageOperations = newDuplicateAllocatorPageOperations(recorder)
-	t.Cleanup(func() { testAllocatorPageOperations = nil })
-
-	if err := a.FreeMany([]uint64{3}); err != nil {
-		t.Fatalf("FreeMany: %v", err)
-	}
-	assertAllocatorPageEvents(t, events, headID, allocatorPageEventCounts{gets: 2, verifies: 2, updates: 2})
-	if err := validateAllocatorPageEvents(events, headID, allocatorPageEventCounts{gets: 1, verifies: 1, updates: 1}); err == nil {
-		t.Fatal("one-operation gate accepted deliberately duplicated calls")
-	}
-}
-
 func TestAllocator_FreeMany_FillsHeadAndChains(t *testing.T) {
 	a, p := newAllocatorForFreeManyTest(t, page.MaxFreeIDs+8)
 
@@ -157,8 +42,6 @@ func TestAllocator_FreeMany_FillsHeadAndChains(t *testing.T) {
 	checksumUpdates := 0
 	TestHookFreeManyBeforeChecksum = func() { checksumUpdates++ }
 	t.Cleanup(func() { TestHookFreeManyBeforeChecksum = nil })
-	events := allocatorPageEvents{}
-	installAllocatorPageOperationRecorder(t, events.observe)
 	if err := a.FreeMany(ids); err != nil {
 		t.Fatalf("FreeMany: %v", err)
 	}
@@ -196,8 +79,6 @@ func TestAllocator_FreeMany_FillsHeadAndChains(t *testing.T) {
 	if !oldNode.VerifyChecksum() {
 		t.Fatal("filled head checksum is invalid")
 	}
-	assertAllocatorPageEvents(t, events, seed[0], allocatorPageEventCounts{gets: 1, verifies: 1, updates: 1})
-	assertAllocatorPageEvents(t, events, ids[2], allocatorPageEventCounts{gets: 1, updates: 1})
 }
 
 func TestAllocator_FreeMany_FullHeadGetsFinalChecksumBeforeChaining(t *testing.T) {
@@ -210,9 +91,6 @@ func TestAllocator_FreeMany_FullHeadGetsFinalChecksumBeforeChaining(t *testing.T
 		t.Fatalf("seed FreeMany: %v", err)
 	}
 
-	fullHead := a.Head()
-	events := allocatorPageEvents{}
-	installAllocatorPageOperationRecorder(t, events.observe)
 	checksumUpdates := 0
 	TestHookFreeManyBeforeChecksum = func() { checksumUpdates++ }
 	t.Cleanup(func() { TestHookFreeManyBeforeChecksum = nil })
@@ -223,7 +101,6 @@ func TestAllocator_FreeMany_FullHeadGetsFinalChecksumBeforeChaining(t *testing.T
 	if checksumUpdates != 2 {
 		t.Fatalf("checksum updates = %d, want full transition head and new head (2)", checksumUpdates)
 	}
-	assertAllocatorPageEvents(t, events, fullHead, allocatorPageEventCounts{gets: 1, verifies: 1, updates: 1})
 }
 
 func TestAllocator_FreeMany_RejectsPageZeroBeforeMutation(t *testing.T) {
@@ -324,6 +201,33 @@ func TestAllocator_FreeMany_RejectsCorruptHead(t *testing.T) {
 	}
 }
 
+func TestAllocator_FreeMany_ErrorReportsCommittedPrefix(t *testing.T) {
+	a, _ := newAllocatorForFreeManyTest(t, page.MaxFreeIDs+2)
+	ids := make([]uint64, page.MaxFreeIDs+2)
+	for i := range ids {
+		ids[i] = uint64(i + 1)
+	}
+
+	err := a.FreeMany(ids)
+	if err == nil {
+		t.Fatal("FreeMany succeeded with an out-of-bounds transition head")
+	}
+	var batchErr *FreeManyError
+	if !errors.As(err, &batchErr) {
+		t.Fatalf("FreeMany error type = %T, want *FreeManyError", err)
+	}
+	if batchErr.Processed != page.MaxFreeIDs+1 {
+		t.Fatalf("processed prefix = %d, want %d", batchErr.Processed, page.MaxFreeIDs+1)
+	}
+	if !errors.Is(err, pager.ErrPageOutOfBounds) {
+		t.Fatalf("FreeMany error = %v, want pager.ErrPageOutOfBounds", err)
+	}
+	stats := a.Counters()
+	if got, want := stats.ReclaimablePages(), uint64(batchErr.Processed); got != want {
+		t.Fatalf("reclaimable pages = %d, want committed prefix %d", got, want)
+	}
+}
+
 func TestAllocator_RegionBiasedAllocMany_BatchesNearbyUnverified(t *testing.T) {
 	a, p := newAllocatorForFreeManyTest(t, 32)
 	a.SetFreelistRegion(4, 1)
@@ -401,8 +305,6 @@ func TestAllocator_RegionBiasedAllocMany_RecycledHeadDoesNotConsumeFreeIDStat(t 
 	if before.Pages != 2 || before.FreeIDs != page.MaxFreeIDs {
 		t.Fatalf("counters before recycling empty head = %+v, want 2 heads and %d body IDs", before, page.MaxFreeIDs)
 	}
-	events := allocatorPageEvents{}
-	installAllocatorPageOperationRecorder(t, events.observe)
 	got, err := a.AllocMany(2, emptyHead)
 	if err != nil {
 		t.Fatalf("recycle AllocMany: %v", err)
@@ -421,7 +323,6 @@ func TestAllocator_RegionBiasedAllocMany_RecycledHeadDoesNotConsumeFreeIDStat(t 
 	if after.AllocPages != before.AllocPages+2 || after.ReuseAllocPages != before.ReuseAllocPages+2 {
 		t.Fatalf("allocation counters after recycling empty head: before=%+v after=%+v", before, after)
 	}
-	assertAllocatorPageEvents(t, events, emptyHead, allocatorPageEventCounts{gets: 1, verifies: 1, updates: 1})
 }
 
 func TestAllocator_RegionBiasedAllocMany_DrainsAndRecyclesHeadWithOneVerification(t *testing.T) {
@@ -437,13 +338,10 @@ func TestAllocator_RegionBiasedAllocMany_DrainsAndRecyclesHeadWithOneVerificatio
 
 	newestHead := a.Head()
 	newestData := mustAllocatorPage(t, p, newestHead)
-	olderHead := freelistNextPageID(newestData)
 	if got := node.NewNode(newestData).Count(); got != 1 {
 		t.Fatalf("newest freelist head count = %d, want 1", got)
 	}
 
-	events := allocatorPageEvents{}
-	installAllocatorPageOperationRecorder(t, events.observe)
 	got, err := a.AllocMany(3, freed[len(freed)-1])
 	if err != nil {
 		t.Fatalf("AllocMany: %v", err)
@@ -451,8 +349,6 @@ func TestAllocator_RegionBiasedAllocMany_DrainsAndRecyclesHeadWithOneVerificatio
 	if len(got) != 3 || got[1] != newestHead {
 		t.Fatalf("AllocMany = %v, want body ID, recycled head %d, then older body ID", got, newestHead)
 	}
-	assertAllocatorPageEvents(t, events, newestHead, allocatorPageEventCounts{gets: 1, verifies: 1, updates: 1})
-	assertAllocatorPageEvents(t, events, olderHead, allocatorPageEventCounts{gets: 1, verifies: 1, updates: 1})
 }
 
 func TestAllocator_RegionBiasedAllocMany_MatchesRepeatedAllocWithMovingHint(t *testing.T) {

--- a/TreeDB/freelist/allocator_free_many_test.go
+++ b/TreeDB/freelist/allocator_free_many_test.go
@@ -27,6 +27,41 @@ func newAllocatorForFreeManyTest(t *testing.T, pages int) (*Allocator, *pager.Pa
 	return New(p, 0), p
 }
 
+type allocatorPageEventCounts struct {
+	gets     int
+	verifies int
+	updates  int
+}
+
+type allocatorPageEvents map[uint64]*allocatorPageEventCounts
+
+func (events allocatorPageEvents) observe(event allocatorPageEvent, pageID uint64) {
+	counts := events[pageID]
+	if counts == nil {
+		counts = &allocatorPageEventCounts{}
+		events[pageID] = counts
+	}
+	switch event {
+	case allocatorPageGetForWrite:
+		counts.gets++
+	case allocatorPageVerifyChecksum:
+		counts.verifies++
+	case allocatorPageUpdateChecksum:
+		counts.updates++
+	}
+}
+
+func assertAllocatorPageEvents(t *testing.T, events allocatorPageEvents, pageID uint64, want allocatorPageEventCounts) {
+	t.Helper()
+	got := events[pageID]
+	if got == nil {
+		got = &allocatorPageEventCounts{}
+	}
+	if *got != want {
+		t.Fatalf("page %d events = %+v, want %+v", pageID, *got, want)
+	}
+}
+
 func TestAllocator_FreeMany_FillsHeadAndChains(t *testing.T) {
 	a, p := newAllocatorForFreeManyTest(t, page.MaxFreeIDs+8)
 
@@ -42,6 +77,9 @@ func TestAllocator_FreeMany_FillsHeadAndChains(t *testing.T) {
 	checksumUpdates := 0
 	TestHookFreeManyBeforeChecksum = func() { checksumUpdates++ }
 	t.Cleanup(func() { TestHookFreeManyBeforeChecksum = nil })
+	events := allocatorPageEvents{}
+	a.testPageEvent = events.observe
+	t.Cleanup(func() { a.testPageEvent = nil })
 	if err := a.FreeMany(ids); err != nil {
 		t.Fatalf("FreeMany: %v", err)
 	}
@@ -79,6 +117,8 @@ func TestAllocator_FreeMany_FillsHeadAndChains(t *testing.T) {
 	if !oldNode.VerifyChecksum() {
 		t.Fatal("filled head checksum is invalid")
 	}
+	assertAllocatorPageEvents(t, events, seed[0], allocatorPageEventCounts{gets: 1, verifies: 1, updates: 1})
+	assertAllocatorPageEvents(t, events, ids[2], allocatorPageEventCounts{gets: 1, updates: 1})
 }
 
 func TestAllocator_FreeMany_RejectsPageZeroBeforeMutation(t *testing.T) {
@@ -274,6 +314,38 @@ func TestAllocator_RegionBiasedAllocMany_RecycledHeadDoesNotConsumeFreeIDStat(t 
 	if after.AllocPages != before.AllocPages+2 || after.ReuseAllocPages != before.ReuseAllocPages+2 {
 		t.Fatalf("allocation counters after recycling empty head: before=%+v after=%+v", before, after)
 	}
+}
+
+func TestAllocator_RegionBiasedAllocMany_DrainsAndRecyclesHeadWithOneVerification(t *testing.T) {
+	freed := make([]uint64, page.MaxFreeIDs+3)
+	for i := range freed {
+		freed[i] = uint64(i + 1)
+	}
+	a, p := newAllocatorForFreeManyTest(t, len(freed)+1)
+	a.SetFreelistRegion(10, 1)
+	if err := a.FreeMany(freed); err != nil {
+		t.Fatalf("FreeMany: %v", err)
+	}
+
+	newestHead := a.Head()
+	newestData := mustAllocatorPage(t, p, newestHead)
+	olderHead := freelistNextPageID(newestData)
+	if got := node.NewNode(newestData).Count(); got != 1 {
+		t.Fatalf("newest freelist head count = %d, want 1", got)
+	}
+
+	events := allocatorPageEvents{}
+	a.testPageEvent = events.observe
+	got, err := a.AllocMany(3, freed[len(freed)-1])
+	a.testPageEvent = nil
+	if err != nil {
+		t.Fatalf("AllocMany: %v", err)
+	}
+	if len(got) != 3 || got[1] != newestHead {
+		t.Fatalf("AllocMany = %v, want body ID, recycled head %d, then older body ID", got, newestHead)
+	}
+	assertAllocatorPageEvents(t, events, newestHead, allocatorPageEventCounts{gets: 1, verifies: 1, updates: 1})
+	assertAllocatorPageEvents(t, events, olderHead, allocatorPageEventCounts{gets: 1, verifies: 1, updates: 1})
 }
 
 func TestAllocator_RegionBiasedAllocMany_MatchesRepeatedAllocWithMovingHint(t *testing.T) {

--- a/TreeDB/freelist/allocator_free_many_test.go
+++ b/TreeDB/freelist/allocator_free_many_test.go
@@ -3,6 +3,7 @@ package freelist
 import (
 	"bytes"
 	"errors"
+	"fmt"
 	"path/filepath"
 	"slices"
 	"sync"
@@ -33,6 +34,14 @@ type allocatorPageEventCounts struct {
 	updates  int
 }
 
+type allocatorPageEvent uint8
+
+const (
+	allocatorPageGetForWrite allocatorPageEvent = iota
+	allocatorPageVerifyChecksum
+	allocatorPageUpdateChecksum
+)
+
 type allocatorPageEvents map[uint64]*allocatorPageEventCounts
 
 func (events allocatorPageEvents) observe(event allocatorPageEvent, pageID uint64) {
@@ -51,14 +60,96 @@ func (events allocatorPageEvents) observe(event allocatorPageEvent, pageID uint6
 	}
 }
 
+type recordingAllocatorPageOperations struct {
+	inner   allocatorPageOperations
+	observe func(allocatorPageEvent, uint64)
+}
+
+func newRecordingAllocatorPageOperations(observe func(allocatorPageEvent, uint64)) *recordingAllocatorPageOperations {
+	return &recordingAllocatorPageOperations{
+		inner:   directAllocatorPageOperations{},
+		observe: observe,
+	}
+}
+
+func (ops *recordingAllocatorPageOperations) getForWrite(p *pager.Pager, pageID uint64) ([]byte, error) {
+	ops.observe(allocatorPageGetForWrite, pageID)
+	return ops.inner.getForWrite(p, pageID)
+}
+
+func (ops *recordingAllocatorPageOperations) verifyChecksum(pageID uint64, data []byte) bool {
+	ops.observe(allocatorPageVerifyChecksum, pageID)
+	return ops.inner.verifyChecksum(pageID, data)
+}
+
+func (ops *recordingAllocatorPageOperations) updateChecksum(pageID uint64, data []byte) {
+	ops.observe(allocatorPageUpdateChecksum, pageID)
+	ops.inner.updateChecksum(pageID, data)
+}
+
+type duplicateAllocatorPageOperations struct {
+	inner allocatorPageOperations
+}
+
+func (ops duplicateAllocatorPageOperations) getForWrite(p *pager.Pager, pageID uint64) ([]byte, error) {
+	if _, err := ops.inner.getForWrite(p, pageID); err != nil {
+		return nil, err
+	}
+	return ops.inner.getForWrite(p, pageID)
+}
+
+func (ops duplicateAllocatorPageOperations) verifyChecksum(pageID uint64, data []byte) bool {
+	first := ops.inner.verifyChecksum(pageID, data)
+	second := ops.inner.verifyChecksum(pageID, data)
+	return first && second
+}
+
+func (ops duplicateAllocatorPageOperations) updateChecksum(pageID uint64, data []byte) {
+	ops.inner.updateChecksum(pageID, data)
+	ops.inner.updateChecksum(pageID, data)
+}
+
+func installAllocatorPageOperationRecorder(t testing.TB, observe func(allocatorPageEvent, uint64)) {
+	t.Helper()
+	testAllocatorPageOperations = newRecordingAllocatorPageOperations(observe)
+	t.Cleanup(func() { testAllocatorPageOperations = nil })
+}
+
 func assertAllocatorPageEvents(t *testing.T, events allocatorPageEvents, pageID uint64, want allocatorPageEventCounts) {
 	t.Helper()
+	if err := validateAllocatorPageEvents(events, pageID, want); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func validateAllocatorPageEvents(events allocatorPageEvents, pageID uint64, want allocatorPageEventCounts) error {
 	got := events[pageID]
 	if got == nil {
 		got = &allocatorPageEventCounts{}
 	}
 	if *got != want {
-		t.Fatalf("page %d events = %+v, want %+v", pageID, *got, want)
+		return fmt.Errorf("page %d events = %+v, want %+v", pageID, *got, want)
+	}
+	return nil
+}
+
+func TestAllocator_PageOperationGateDetectsDuplicateCalls(t *testing.T) {
+	a, _ := newAllocatorForFreeManyTest(t, 6)
+	if err := a.Free(2); err != nil {
+		t.Fatalf("Free(2): %v", err)
+	}
+	headID := a.Head()
+	events := allocatorPageEvents{}
+	recorder := newRecordingAllocatorPageOperations(events.observe)
+	testAllocatorPageOperations = duplicateAllocatorPageOperations{inner: recorder}
+	t.Cleanup(func() { testAllocatorPageOperations = nil })
+
+	if err := a.FreeMany([]uint64{3}); err != nil {
+		t.Fatalf("FreeMany: %v", err)
+	}
+	assertAllocatorPageEvents(t, events, headID, allocatorPageEventCounts{gets: 2, verifies: 2, updates: 2})
+	if err := validateAllocatorPageEvents(events, headID, allocatorPageEventCounts{gets: 1, verifies: 1, updates: 1}); err == nil {
+		t.Fatal("one-operation gate accepted deliberately duplicated calls")
 	}
 }
 
@@ -78,8 +169,7 @@ func TestAllocator_FreeMany_FillsHeadAndChains(t *testing.T) {
 	TestHookFreeManyBeforeChecksum = func() { checksumUpdates++ }
 	t.Cleanup(func() { TestHookFreeManyBeforeChecksum = nil })
 	events := allocatorPageEvents{}
-	testAllocatorPageEvent = events.observe
-	t.Cleanup(func() { testAllocatorPageEvent = nil })
+	installAllocatorPageOperationRecorder(t, events.observe)
 	if err := a.FreeMany(ids); err != nil {
 		t.Fatalf("FreeMany: %v", err)
 	}
@@ -119,6 +209,32 @@ func TestAllocator_FreeMany_FillsHeadAndChains(t *testing.T) {
 	}
 	assertAllocatorPageEvents(t, events, seed[0], allocatorPageEventCounts{gets: 1, verifies: 1, updates: 1})
 	assertAllocatorPageEvents(t, events, ids[2], allocatorPageEventCounts{gets: 1, updates: 1})
+}
+
+func TestAllocator_FreeMany_FullHeadGetsFinalChecksumBeforeChaining(t *testing.T) {
+	a, _ := newAllocatorForFreeManyTest(t, page.MaxFreeIDs+3)
+	seed := make([]uint64, page.MaxFreeIDs+1)
+	for i := range seed {
+		seed[i] = uint64(i + 1)
+	}
+	if err := a.FreeMany(seed); err != nil {
+		t.Fatalf("seed FreeMany: %v", err)
+	}
+
+	fullHead := a.Head()
+	events := allocatorPageEvents{}
+	installAllocatorPageOperationRecorder(t, events.observe)
+	checksumUpdates := 0
+	TestHookFreeManyBeforeChecksum = func() { checksumUpdates++ }
+	t.Cleanup(func() { TestHookFreeManyBeforeChecksum = nil })
+
+	if err := a.FreeMany([]uint64{uint64(page.MaxFreeIDs + 2)}); err != nil {
+		t.Fatalf("FreeMany: %v", err)
+	}
+	if checksumUpdates != 2 {
+		t.Fatalf("checksum updates = %d, want full transition head and new head (2)", checksumUpdates)
+	}
+	assertAllocatorPageEvents(t, events, fullHead, allocatorPageEventCounts{gets: 1, verifies: 1, updates: 1})
 }
 
 func TestAllocator_FreeMany_RejectsPageZeroBeforeMutation(t *testing.T) {
@@ -296,6 +412,8 @@ func TestAllocator_RegionBiasedAllocMany_RecycledHeadDoesNotConsumeFreeIDStat(t 
 	if before.Pages != 2 || before.FreeIDs != page.MaxFreeIDs {
 		t.Fatalf("counters before recycling empty head = %+v, want 2 heads and %d body IDs", before, page.MaxFreeIDs)
 	}
+	events := allocatorPageEvents{}
+	installAllocatorPageOperationRecorder(t, events.observe)
 	got, err := a.AllocMany(2, emptyHead)
 	if err != nil {
 		t.Fatalf("recycle AllocMany: %v", err)
@@ -314,6 +432,7 @@ func TestAllocator_RegionBiasedAllocMany_RecycledHeadDoesNotConsumeFreeIDStat(t 
 	if after.AllocPages != before.AllocPages+2 || after.ReuseAllocPages != before.ReuseAllocPages+2 {
 		t.Fatalf("allocation counters after recycling empty head: before=%+v after=%+v", before, after)
 	}
+	assertAllocatorPageEvents(t, events, emptyHead, allocatorPageEventCounts{gets: 1, verifies: 1, updates: 1})
 }
 
 func TestAllocator_RegionBiasedAllocMany_DrainsAndRecyclesHeadWithOneVerification(t *testing.T) {
@@ -335,9 +454,8 @@ func TestAllocator_RegionBiasedAllocMany_DrainsAndRecyclesHeadWithOneVerificatio
 	}
 
 	events := allocatorPageEvents{}
-	testAllocatorPageEvent = events.observe
+	installAllocatorPageOperationRecorder(t, events.observe)
 	got, err := a.AllocMany(3, freed[len(freed)-1])
-	testAllocatorPageEvent = nil
 	if err != nil {
 		t.Fatalf("AllocMany: %v", err)
 	}

--- a/TreeDB/freelist/allocator_instrument_test.go
+++ b/TreeDB/freelist/allocator_instrument_test.go
@@ -1,0 +1,185 @@
+//go:build treedb_freelist_instrument
+
+package freelist
+
+import (
+	"errors"
+	"fmt"
+	"sync"
+	"testing"
+
+	"github.com/snissn/gomap/TreeDB/node"
+	"github.com/snissn/gomap/TreeDB/page"
+)
+
+func validateAllocatorPageOperationCounts(pageID uint64, got, want allocatorPageOperationCounts) error {
+	if got != want {
+		return fmt.Errorf("page %d operations = %+v, want %+v", pageID, got, want)
+	}
+	return nil
+}
+
+func assertAllocatorPageOperationCounts(t *testing.T, a *Allocator, pageID uint64, want allocatorPageOperationCounts) {
+	t.Helper()
+	if err := validateAllocatorPageOperationCounts(pageID, a.pageOperationCounts(pageID), want); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func performObservedPageCycle(t *testing.T, a *Allocator, pageID uint64) {
+	t.Helper()
+	data, err := a.pager.GetForWrite(pageID)
+	a.observePageOperation(allocatorPageGetForWrite, pageID)
+	if err != nil {
+		t.Fatalf("GetForWrite(%d): %v", pageID, err)
+	}
+	n := node.NewNode(data)
+	checksumOK := n.VerifyChecksum()
+	a.observePageOperation(allocatorPageVerifyChecksum, pageID)
+	if !checksumOK {
+		t.Fatalf("VerifyChecksum(%d) = false", pageID)
+	}
+	n.UpdateChecksum()
+	a.observePageOperation(allocatorPageUpdateChecksum, pageID)
+}
+
+func TestAllocator_PageOperationGateDetectsActualDuplicateCalls(t *testing.T) {
+	a, _ := newAllocatorForFreeManyTest(t, 6)
+	if err := a.Free(2); err != nil {
+		t.Fatalf("Free(2): %v", err)
+	}
+	headID := a.Head()
+	a.resetPageOperationCounts()
+
+	performObservedPageCycle(t, a, headID)
+	performObservedPageCycle(t, a, headID)
+
+	got := a.pageOperationCounts(headID)
+	wantDuplicated := allocatorPageOperationCounts{gets: 2, verifies: 2, updates: 2}
+	if err := validateAllocatorPageOperationCounts(headID, got, wantDuplicated); err != nil {
+		t.Fatal(err)
+	}
+	if err := validateAllocatorPageOperationCounts(headID, got, allocatorPageOperationCounts{gets: 1, verifies: 1, updates: 1}); err == nil {
+		t.Fatal("one-operation gate accepted deliberately duplicated real operations")
+	}
+}
+
+func TestAllocator_FreeMany_ObservedOperationsMatchTouchedPages(t *testing.T) {
+	a, _ := newAllocatorForFreeManyTest(t, page.MaxFreeIDs+8)
+	seed := make([]uint64, page.MaxFreeIDs-1)
+	for i := range seed {
+		seed[i] = uint64(i + 1)
+	}
+	if err := a.FreeMany(seed); err != nil {
+		t.Fatalf("seed FreeMany: %v", err)
+	}
+	ids := []uint64{uint64(page.MaxFreeIDs - 1), uint64(page.MaxFreeIDs), uint64(page.MaxFreeIDs + 1), uint64(page.MaxFreeIDs + 2)}
+	a.resetPageOperationCounts()
+
+	if err := a.FreeMany(ids); err != nil {
+		t.Fatalf("FreeMany: %v", err)
+	}
+
+	assertAllocatorPageOperationCounts(t, a, seed[0], allocatorPageOperationCounts{gets: 1, verifies: 1, updates: 1})
+	assertAllocatorPageOperationCounts(t, a, ids[2], allocatorPageOperationCounts{gets: 1, updates: 1})
+}
+
+func TestAllocator_FreeMany_FullTransitionHeadObservedOnce(t *testing.T) {
+	a, _ := newAllocatorForFreeManyTest(t, page.MaxFreeIDs+3)
+	seed := make([]uint64, page.MaxFreeIDs+1)
+	for i := range seed {
+		seed[i] = uint64(i + 1)
+	}
+	if err := a.FreeMany(seed); err != nil {
+		t.Fatalf("seed FreeMany: %v", err)
+	}
+	fullHead := a.Head()
+	a.resetPageOperationCounts()
+
+	if err := a.FreeMany([]uint64{uint64(page.MaxFreeIDs + 2)}); err != nil {
+		t.Fatalf("FreeMany: %v", err)
+	}
+
+	assertAllocatorPageOperationCounts(t, a, fullHead, allocatorPageOperationCounts{gets: 1, verifies: 1, updates: 1})
+}
+
+func TestAllocator_RegionAllocMany_DrainedAndEmptyHeadsObservedOnce(t *testing.T) {
+	freed := make([]uint64, page.MaxFreeIDs+3)
+	for i := range freed {
+		freed[i] = uint64(i + 1)
+	}
+	a, p := newAllocatorForFreeManyTest(t, len(freed)+1)
+	a.SetFreelistRegion(10, 1)
+	if err := a.FreeMany(freed); err != nil {
+		t.Fatalf("FreeMany: %v", err)
+	}
+	newestHead := a.Head()
+	olderHead := freelistNextPageID(mustAllocatorPage(t, p, newestHead))
+	a.resetPageOperationCounts()
+
+	got, err := a.AllocMany(3, freed[len(freed)-1])
+	if err != nil {
+		t.Fatalf("AllocMany: %v", err)
+	}
+	if len(got) != 3 || got[1] != newestHead {
+		t.Fatalf("AllocMany = %v, want body ID, recycled head %d, then older body ID", got, newestHead)
+	}
+	assertAllocatorPageOperationCounts(t, a, newestHead, allocatorPageOperationCounts{gets: 1, verifies: 1, updates: 1})
+	assertAllocatorPageOperationCounts(t, a, olderHead, allocatorPageOperationCounts{gets: 1, verifies: 1, updates: 1})
+}
+
+func TestAllocator_InstrumentationDoesNotReplaceCorruptionResult(t *testing.T) {
+	a, p := newAllocatorForFreeManyTest(t, 5)
+	if err := a.Free(2); err != nil {
+		t.Fatalf("Free(2): %v", err)
+	}
+	headID := a.Head()
+	data, err := p.GetForWrite(headID)
+	if err != nil {
+		t.Fatalf("GetForWrite: %v", err)
+	}
+	data[page.PageHeaderSize] ^= 0xff
+	a.resetPageOperationCounts()
+
+	err = a.FreeMany([]uint64{1, 3})
+	var batchErr *FreeManyError
+	if err == nil || !errors.As(err, &batchErr) {
+		t.Fatal("FreeMany succeeded with a corrupt freelist head")
+	}
+	if batchErr.Processed != 0 || batchErr.Err == nil || batchErr.Err.Error() != "freelist head corrupted (FreeMany)" {
+		t.Fatalf("corruption error = %+v, want unchanged corruption result with zero processed IDs", batchErr)
+	}
+	assertAllocatorPageOperationCounts(t, a, headID, allocatorPageOperationCounts{gets: 1, verifies: 1})
+}
+
+func TestAllocator_InstrumentationConcurrentObservation(t *testing.T) {
+	a, _ := newAllocatorForFreeManyTest(t, 64)
+	if err := a.FreeMany([]uint64{1, 2, 3, 4, 5, 6, 7, 8}); err != nil {
+		t.Fatalf("seed FreeMany: %v", err)
+	}
+	a.SetFreelistRegion(4, 1)
+	a.resetPageOperationCounts()
+
+	var wg sync.WaitGroup
+	for range 4 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for range 100 {
+				ids, err := a.AllocMany(2, 4)
+				if err != nil {
+					t.Errorf("AllocMany: %v", err)
+					return
+				}
+				if err := a.FreeMany(ids); err != nil {
+					t.Errorf("FreeMany: %v", err)
+					return
+				}
+			}
+		}()
+	}
+	for range 1000 {
+		_ = a.allPageOperationCounts()
+	}
+	wg.Wait()
+}

--- a/TreeDB/freelist/allocator_instrument_test.go
+++ b/TreeDB/freelist/allocator_instrument_test.go
@@ -28,19 +28,15 @@ func assertAllocatorPageOperationCounts(t *testing.T, a *Allocator, pageID uint6
 
 func performObservedPageCycle(t *testing.T, a *Allocator, pageID uint64) {
 	t.Helper()
-	data, err := a.pager.GetForWrite(pageID)
-	a.observePageOperation(allocatorPageGetForWrite, pageID)
+	data, err := a.batchGetForWrite(pageID)
 	if err != nil {
 		t.Fatalf("GetForWrite(%d): %v", pageID, err)
 	}
 	n := node.NewNode(data)
-	checksumOK := n.VerifyChecksum()
-	a.observePageOperation(allocatorPageVerifyChecksum, pageID)
-	if !checksumOK {
+	if !a.batchVerifyChecksum(pageID, n) {
 		t.Fatalf("VerifyChecksum(%d) = false", pageID)
 	}
-	n.UpdateChecksum()
-	a.observePageOperation(allocatorPageUpdateChecksum, pageID)
+	a.batchUpdateChecksum(pageID, n)
 }
 
 func TestAllocator_PageOperationGateDetectsActualDuplicateCalls(t *testing.T) {

--- a/TreeDB/freelist/allocator_pl11_compare_benchmark_test.go
+++ b/TreeDB/freelist/allocator_pl11_compare_benchmark_test.go
@@ -1,0 +1,131 @@
+package freelist
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/snissn/gomap/TreeDB/pager"
+)
+
+const (
+	pl11CompareIDs        = 10_000
+	pl11CompareRegion     = 8192
+	pl11CompareRegionHint = 4 * pl11CompareRegion
+)
+
+var pl11CompareSink []uint64
+
+func BenchmarkPL11Compare_AllocMany2(b *testing.B) {
+	benchmarkPL11CompareRegion(b, 2, true)
+}
+
+func BenchmarkPL11Compare_AllocRepeated2(b *testing.B) {
+	benchmarkPL11CompareRegion(b, 2, false)
+}
+
+func BenchmarkPL11Compare_AllocMany10000(b *testing.B) {
+	benchmarkPL11CompareRegion(b, pl11CompareIDs, true)
+}
+
+func benchmarkPL11CompareRegion(b *testing.B, count int, many bool) {
+	b.Helper()
+	ids := make([]uint64, pl11CompareIDs)
+	for i := range ids {
+		ids[i] = uint64(i + 1)
+	}
+	root := b.TempDir()
+	path := filepath.Join(root, "fixture.db")
+	p, err := pager.Open(path, 64*1024)
+	if err != nil {
+		b.Fatalf("Open: %v", err)
+	}
+	if _, err := p.Alloc(pl11CompareIDs + 1); err != nil {
+		_ = p.Close()
+		b.Fatalf("Alloc fixture: %v", err)
+	}
+	a := New(p, 0)
+	for _, id := range ids {
+		if err := a.Free(id); err != nil {
+			b.Fatalf("Free(%d) setup: %v", id, err)
+		}
+	}
+	a.SetFreelistRegion(pl11CompareRegion, 1)
+	initialHead := a.head
+	initialLastAlloc := a.lastAlloc
+	initialStats := a.stats
+	snapshots := snapshotPL11CompareHeads(b, p, initialHead, count > 2)
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		b.StopTimer()
+		restorePL11CompareHeads(b, p, snapshots)
+		a.head = initialHead
+		a.lastAlloc = initialLastAlloc
+		a.stats = initialStats
+		b.StartTimer()
+		if many {
+			out, err := a.AllocMany(count, pl11CompareRegionHint)
+			if err != nil {
+				b.Fatalf("AllocMany: %v", err)
+			}
+			if len(out) != count {
+				b.Fatalf("AllocMany returned %d IDs, want %d", len(out), count)
+			}
+			pl11CompareSink = out
+		} else {
+			hint := uint64(pl11CompareRegionHint)
+			out := make([]uint64, 0, count)
+			for range count {
+				id, err := a.Alloc(hint)
+				if err != nil {
+					b.Fatalf("Alloc(%d): %v", hint, err)
+				}
+				out = append(out, id)
+				hint = id
+			}
+			pl11CompareSink = out
+		}
+	}
+	b.StopTimer()
+	if err := p.Close(); err != nil {
+		b.Fatalf("Close: %v", err)
+	}
+	if err := os.Remove(path); err != nil {
+		b.Fatalf("Remove fixture: %v", err)
+	}
+	b.ReportMetric(float64(count*b.N)/b.Elapsed().Seconds(), "ids/sec")
+}
+
+type pl11ComparePageSnapshot struct {
+	id   uint64
+	data []byte
+}
+
+func snapshotPL11CompareHeads(b *testing.B, p *pager.Pager, head uint64, all bool) []pl11ComparePageSnapshot {
+	b.Helper()
+	var snapshots []pl11ComparePageSnapshot
+	for head != 0 {
+		data, err := p.Get(head)
+		if err != nil {
+			b.Fatalf("Get(%d): %v", head, err)
+		}
+		snapshots = append(snapshots, pl11ComparePageSnapshot{id: head, data: append([]byte(nil), data...)})
+		if !all {
+			break
+		}
+		head = freelistNextPageID(data)
+	}
+	return snapshots
+}
+
+func restorePL11CompareHeads(b *testing.B, p *pager.Pager, snapshots []pl11ComparePageSnapshot) {
+	b.Helper()
+	for _, snapshot := range snapshots {
+		data, err := p.GetForWrite(snapshot.id)
+		if err != nil {
+			b.Fatalf("GetForWrite(%d): %v", snapshot.id, err)
+		}
+		copy(data, snapshot.data)
+	}
+}

--- a/TreeDB/freelist/allocator_pl11_compare_benchmark_test.go
+++ b/TreeDB/freelist/allocator_pl11_compare_benchmark_test.go
@@ -54,7 +54,7 @@ func benchmarkPL11CompareRegion(b *testing.B, count int, many bool) {
 	initialHead := a.head
 	initialLastAlloc := a.lastAlloc
 	initialStats := a.stats
-	snapshots := snapshotPL11CompareHeads(b, p, initialHead, count > 2)
+	snapshots := snapshotPL11CompareHeads(b, p, initialHead, true)
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {

--- a/TreeDB/freelist/allocator_state.go
+++ b/TreeDB/freelist/allocator_state.go
@@ -1,0 +1,32 @@
+//go:build !treedb_freelist_instrument
+
+package freelist
+
+import (
+	"sync"
+
+	"github.com/snissn/gomap/TreeDB/pager"
+)
+
+const allocatorInstrumentationEnabled = false
+
+type Allocator struct {
+	pager *pager.Pager
+	head  uint64
+	mu    sync.Mutex
+
+	lastAlloc    uint64
+	regionPages  uint64
+	regionRadius int
+
+	stats Stats
+
+	// preferAppend makes Alloc ignore the freelist and allocate new pages by
+	// extending the file. This improves locality at the cost of reclaiming space
+	// later via vacuum.
+	preferAppend bool
+}
+
+func (*Allocator) observePageOperation(allocatorPageOperation, uint64) {}
+
+func (*Allocator) injectedGetForWriteError(uint64) error { return nil }

--- a/TreeDB/freelist/allocator_state.go
+++ b/TreeDB/freelist/allocator_state.go
@@ -5,10 +5,9 @@ package freelist
 import (
 	"sync"
 
+	"github.com/snissn/gomap/TreeDB/node"
 	"github.com/snissn/gomap/TreeDB/pager"
 )
-
-const allocatorInstrumentationEnabled = false
 
 type Allocator struct {
 	pager *pager.Pager
@@ -27,6 +26,14 @@ type Allocator struct {
 	preferAppend bool
 }
 
-func (*Allocator) observePageOperation(allocatorPageOperation, uint64) {}
+func (a *Allocator) batchGetForWrite(pageID uint64) ([]byte, error) {
+	return a.pager.GetForWrite(pageID)
+}
 
-func (*Allocator) injectedGetForWriteError(uint64) error { return nil }
+func (*Allocator) batchVerifyChecksum(_ uint64, n *node.Node) bool {
+	return n.VerifyChecksum()
+}
+
+func (*Allocator) batchUpdateChecksum(_ uint64, n *node.Node) {
+	n.UpdateChecksum()
+}

--- a/TreeDB/freelist/allocator_state_instrument.go
+++ b/TreeDB/freelist/allocator_state_instrument.go
@@ -1,0 +1,118 @@
+//go:build treedb_freelist_instrument
+
+package freelist
+
+import (
+	"sync"
+
+	"github.com/snissn/gomap/TreeDB/pager"
+)
+
+const allocatorInstrumentationEnabled = true
+
+type allocatorPageOperationCounts struct {
+	gets     int
+	verifies int
+	updates  int
+}
+
+type allocatorInstrumentation struct {
+	mu               sync.Mutex
+	operations       map[uint64]allocatorPageOperationCounts
+	failAfterGets    int
+	failGetForWrite  error
+	injectedFailures int
+}
+
+type Allocator struct {
+	pager *pager.Pager
+	head  uint64
+	mu    sync.Mutex
+
+	lastAlloc    uint64
+	regionPages  uint64
+	regionRadius int
+
+	stats Stats
+
+	// preferAppend makes Alloc ignore the freelist and allocate new pages by
+	// extending the file. This improves locality at the cost of reclaiming space
+	// later via vacuum.
+	preferAppend bool
+
+	instrumentation allocatorInstrumentation
+}
+
+func (a *Allocator) observePageOperation(operation allocatorPageOperation, pageID uint64) {
+	a.instrumentation.mu.Lock()
+	defer a.instrumentation.mu.Unlock()
+	if a.instrumentation.operations == nil {
+		a.instrumentation.operations = make(map[uint64]allocatorPageOperationCounts)
+	}
+	counts := a.instrumentation.operations[pageID]
+	switch operation {
+	case allocatorPageGetForWrite:
+		counts.gets++
+	case allocatorPageVerifyChecksum:
+		counts.verifies++
+	case allocatorPageUpdateChecksum:
+		counts.updates++
+	}
+	a.instrumentation.operations[pageID] = counts
+}
+
+func (a *Allocator) injectedGetForWriteError(_ uint64) error {
+	a.instrumentation.mu.Lock()
+	defer a.instrumentation.mu.Unlock()
+	if a.instrumentation.failGetForWrite == nil {
+		return nil
+	}
+	if a.instrumentation.failAfterGets > 0 {
+		a.instrumentation.failAfterGets--
+		return nil
+	}
+	err := a.instrumentation.failGetForWrite
+	a.instrumentation.failGetForWrite = nil
+	a.instrumentation.injectedFailures++
+	return err
+}
+
+// TestInjectGetForWriteFailureAfter injects a one-shot batch GetForWrite
+// failure after successfulAttempts subsequent attempts. It exists only in
+// treedb_freelist_instrument builds.
+func (a *Allocator) TestInjectGetForWriteFailureAfter(successfulAttempts int, err error) {
+	a.instrumentation.mu.Lock()
+	defer a.instrumentation.mu.Unlock()
+	a.instrumentation.failAfterGets = successfulAttempts
+	a.instrumentation.failGetForWrite = err
+}
+
+// TestInjectedGetForWriteFailures returns the number of one-shot failures
+// consumed by this allocator. It exists only in instrumented builds.
+func (a *Allocator) TestInjectedGetForWriteFailures() int {
+	a.instrumentation.mu.Lock()
+	defer a.instrumentation.mu.Unlock()
+	return a.instrumentation.injectedFailures
+}
+
+func (a *Allocator) resetPageOperationCounts() {
+	a.instrumentation.mu.Lock()
+	defer a.instrumentation.mu.Unlock()
+	a.instrumentation.operations = nil
+}
+
+func (a *Allocator) pageOperationCounts(pageID uint64) allocatorPageOperationCounts {
+	a.instrumentation.mu.Lock()
+	defer a.instrumentation.mu.Unlock()
+	return a.instrumentation.operations[pageID]
+}
+
+func (a *Allocator) allPageOperationCounts() map[uint64]allocatorPageOperationCounts {
+	a.instrumentation.mu.Lock()
+	defer a.instrumentation.mu.Unlock()
+	out := make(map[uint64]allocatorPageOperationCounts, len(a.instrumentation.operations))
+	for pageID, counts := range a.instrumentation.operations {
+		out[pageID] = counts
+	}
+	return out
+}

--- a/TreeDB/freelist/allocator_state_instrument.go
+++ b/TreeDB/freelist/allocator_state_instrument.go
@@ -5,10 +5,17 @@ package freelist
 import (
 	"sync"
 
+	"github.com/snissn/gomap/TreeDB/node"
 	"github.com/snissn/gomap/TreeDB/pager"
 )
 
-const allocatorInstrumentationEnabled = true
+type allocatorPageOperation uint8
+
+const (
+	allocatorPageGetForWrite allocatorPageOperation = iota
+	allocatorPageVerifyChecksum
+	allocatorPageUpdateChecksum
+)
 
 type allocatorPageOperationCounts struct {
 	gets     int
@@ -59,6 +66,27 @@ func (a *Allocator) observePageOperation(operation allocatorPageOperation, pageI
 		counts.updates++
 	}
 	a.instrumentation.operations[pageID] = counts
+}
+
+func (a *Allocator) batchGetForWrite(pageID uint64) ([]byte, error) {
+	if err := a.injectedGetForWriteError(pageID); err != nil {
+		a.observePageOperation(allocatorPageGetForWrite, pageID)
+		return nil, err
+	}
+	data, err := a.pager.GetForWrite(pageID)
+	a.observePageOperation(allocatorPageGetForWrite, pageID)
+	return data, err
+}
+
+func (a *Allocator) batchVerifyChecksum(pageID uint64, n *node.Node) bool {
+	checksumOK := n.VerifyChecksum()
+	a.observePageOperation(allocatorPageVerifyChecksum, pageID)
+	return checksumOK
+}
+
+func (a *Allocator) batchUpdateChecksum(pageID uint64, n *node.Node) {
+	n.UpdateChecksum()
+	a.observePageOperation(allocatorPageUpdateChecksum, pageID)
 }
 
 func (a *Allocator) injectedGetForWriteError(_ uint64) error {


### PR DESCRIPTION
## Summary

Fixes #3642.

Parent tracker: #3630.

- Adds `freelist.Allocator.FreeMany(ids []uint64) error` with one allocator lock, deterministic page-0 rejection before mutation, explicit repeated-`Free` duplicate semantics, batched head fill/chaining, and unchanged on-disk format.
- Makes region-biased `AllocMany` batch work per verified head while preserving repeated `Alloc` selection order, swap-with-last mutation, moving hints, partial results, region preference, stats, and reused-page `MarkUnverified` behavior.
- Keeps the production `count=2` path bounded and allocation-stable; larger batches use the indexed selection path without returning to `O(count*MaxFreeIDs)` scans.
- Recycles freelist head pages through `Pages` accounting only. Head recycling never decrements `FreeIDs`; only allocated body IDs do.
- Routes online-vacuum retirement through `FreeMany` while preserving best-effort partial-I/O behavior: a committed prefix is not retried, and every unprocessed suffix ID is attempted exactly once through the prior per-ID path.

`allocTracker.FreeAll` and graveyard extraction remain per-ID because their successful-prefix error accounting is not equivalent to the vacuum best-effort contract.

## Build-Isolated Operation Evidence

The rejected mutable package-global operation seam is removed.

- Normal builds use `allocator_state.go` (`!treedb_freelist_instrument`). Its three delegates call `Pager.GetForWrite`, `Node.VerifyChecksum`, and `Node.UpdateChecksum` directly and inline completely.
- Instrumented tests use `allocator_state_instrument.go` (`treedb_freelist_instrument`). Counters and one-shot fault state are allocator-local and mutex-protected; installation cannot race across allocators or mutate process-global behavior.
- Observation wraps the actual operation sites and cannot replace returned pages, checksums, or errors. The explicit one-shot fault injector is separate and exists only in the instrumented build.
- `TestAllocator_PageOperationGateDetectsDuplicateCalls` deliberately executes each actual operation twice. The observer records `2/2/2`, and the gate rejects it when `1/1/1` is required.

Default-build compiler evidence at the final source tree:

```text
batchGetForWrite: inline cost 71
batchVerifyChecksum: inline cost 65
batchUpdateChecksum: inline cost 63
```

`go tool nm` and `go tool objdump` found no default-binary delegate symbols or calls. The normal binary therefore has no mutable hook, wrapper call, or instrumentation branch in these operation paths.

Observed operation benchmark, five samples, was stable in every sample:

| Batch | pages touched | `GetForWrite` | checksum verifies | checksum updates |
| --- | ---: | ---: | ---: | ---: |
| `FreeMany(10000)`, empty freelist | 20 | 20 | 0 | 20 |
| region `AllocMany(10000)` | 20 | 20 | 20 | 20 |
| region `AllocMany(2)` | 1 | 1 | 1 | 1 |

Zero verifies for the empty-freelist `FreeMany` fixture are expected because all heads are newly initialized. Preexisting-head tests require one get, one verify, and one final checksum update.

## Checksums and Crash Ordering

Every touched freelist page now receives exactly one final checksum update, including both transitions missed by the prior head:

- a full verified `FreeMany` head before a new head is chained;
- an already-empty verified region head before it is recycled.

The transition tests also preserve `Pages`, `FreeIDs`, reuse stats, and `MarkUnverified` behavior. A head drained to zero during one region batch is fetched, verified, and checksummed once before recycling.

`TestHookFreeBeforeChecksum` retains entry-before-checksum ordering. `TestHookFreeManyBeforeChecksum` runs immediately before the one final page checksum, including full transition heads; the test captures the head before entering the hook so it does not recurse into `allocator.mu`.

## Partial I/O Behavior

`FreeManyError` exposes the number of durably committed IDs:

```go
type FreeManyError struct {
    Processed int
    Err       error
}
```

`Processed` advances only after the page checksum and stats update commit. Online vacuum retries `retired[Processed:]` through `Free`, never the committed prefix. A deterministic instrumented test injects the second `GetForWrite` failure after one complete head, then proves:

- the injected error fires once;
- every suffix ID is attempted and becomes reclaimable;
- the committed prefix is not double-freed;
- allocating all retired IDs returns the exact original ID multiset.

Unknown error types conservatively retry the whole batch, preserving the old best-effort behavior.

## Validation

Validated head: `98419bcde53f2c98e5545f01922b39a4d7f59959`.

Current main and merge base: `9bb109dd0ed643448c065951eb72cdab99c47ac6`.

Focused correctness gate on the final source tree:

```sh
GOWORK=off go test ./TreeDB/freelist ./TreeDB/db \
  -run 'TestAllocator_FreeMany|TestAllocator_RegionBiasedAllocMany|TestVacuumFreeRetired' -count=1
# freelist 0.015s; db 0.015s
```

Instrumented race gate on the final source tree:

```sh
GOWORK=off go test -race -tags=treedb_freelist_instrument \
  ./TreeDB/freelist ./TreeDB/db \
  -run 'TestAllocator_(PageOperation|FreeMany_Observed|FreeMany_FullTransition|RegionAllocMany|Instrumentation)|TestVacuumFreeRetired' \
  -count=1
# freelist 1.027s; db 1.096s
```

Broader affected gates on the same production implementation before the final build-isolation inlining refinement:

```sh
GOWORK=off go test ./TreeDB/freelist ./TreeDB/db \
  -run 'TestAllocator|TestFreelist|TestVacuumIndexOnline|TestFragmentationReport|TestVacuumFreeRetired' -count=1
# freelist 0.010s; db 38.319s

GOWORK=off go test -race ./TreeDB/freelist ./TreeDB/db \
  -run 'TestAllocator_(FreeMany|RegionBiasedAllocMany)|TestVacuumFreeRetired|TestVacuumIndexOnline_ShrinksAndPreservesData|TestFragmentationReportWaitsForFreelistUpdate' \
  -count=1
# freelist 1.019s; db 1.611s

GOWORK=off go test ./TreeDB/freelist ./TreeDB/db -count=1
# freelist 0.009s; db 268.113s

GOWORK=off go vet ./TreeDB/freelist ./TreeDB/db
# pass
```

Coverage includes page-0 atomic rejection, duplicates, partial-prefix accounting, corrupt heads, entry-before-checksum crash ordering, full/empty transition checksums, trustworthy duplicate-operation rejection, two-head `FreeIDs` accounting, moving-hint exact-order comparison with repeated `Alloc`, stats/unverified marking, and online-vacuum suffix recovery.

## Interleaved Benchmarks

Host: Intel Core i5-11400F. Base: `9bb109dd0`. Timed candidate: `d388972d`, immediately before the final delegate-inlining commit. Implementation head `3e472415e` changes only the normal build delegate form; compiler and binary inspection above prove those delegates disappear into the same direct calls. Follow-up `98419bcde` only corrects benchmark fixture restoration.

Base and candidate used the identical committed benchmark source (`sha256 21f8b1060004429fc14cc06236c66b323b9edf3bf3987de92ce8cc90e4179f0b`), `GOMAXPROCS=1`, and `taskset -c 5`. Runs alternated base/head then head/base to reduce ordering bias.

### Production `AllocMany(2)`

Ten samples per revision, true `-benchtime=2s`:

| Benchmark | Current main | Candidate | Delta |
| --- | ---: | ---: | ---: |
| region `AllocMany(2)` | 1.485 us/op +/-5% | 1.218 us/op +/-1% | **-18.01%**, p=0.000 |
| IDs/sec | 1.347M +/-5% | 1.642M +/-1% | **+21.92%** |
| allocations | 16 B/op, 1 alloc/op | 16 B/op, 1 alloc/op | unchanged |

Candidate repeated region `Alloc` x2 was 1.481 us/op; batched `AllocMany(2)` was 17.76% faster. The count=2 no-regression gate passes with margin and unchanged allocations.

### Region `AllocMany(10000)`

Ten alternating samples per revision, `-benchtime=1000x`:

| Metric | Current main | Candidate | Delta |
| --- | ---: | ---: | ---: |
| time/op | 2833.0 us +/-17% | 792.2 us +/-4% | **-72.04%**, p=0.000 |
| IDs/sec | 3.530M | 12.624M | **+257.62%** |
| allocations | 80.00 KiB/op, 1 alloc/op | 80.00 KiB/op, 1 alloc/op | unchanged |

This is a 3.58x throughput improvement while preserving exact repeated-`Alloc` moving-target order.

### `FreeMany(10000)`

Candidate-only comparison, ten samples, `-benchtime=20x`:

| Path | time/op | IDs/sec | B/op | allocs/op |
| --- | ---: | ---: | ---: | ---: |
| repeated `Free` | 12.605 ms +/-1% | 793.4k | 1.055 KiB | 6 |
| `FreeMany` | 9.902 ms +/-2% | 1009.9k | 1.055 KiB | 6 |

`FreeMany` is 21.44% lower latency and 27.29% higher throughput, p=0.000, with unchanged fixture allocations.

## Review Status

Latest-head CI and fresh independent Codex and CodeRabbit reviews are required before merge.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved batch page allocation and reclamation for faster database maintenance.
  * Enhanced region-aware allocation to favor nearby reusable pages.
  * Added performance benchmarking coverage for allocation and reclamation workflows.

* **Reliability**
  * Improved recovery when page reclamation encounters partial failures.
  * Preserved reclaimable pages during interrupted maintenance operations.
  * Strengthened checksum handling and corruption detection during freelist updates.

* **Data Integrity**
  * Online vacuum now better preserves concurrent updates while reclaiming storage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Latest-head review follow-up

Commit `98419bcde` fixes the benchmark-fixture review finding by snapshotting the complete freelist head chain for every count, including the count-2 fallback path.

```sh
GOWORK=off go test ./TreeDB/freelist -count=1
GOWORK=off go test ./TreeDB/freelist -run "^$" -bench "^BenchmarkPL11Compare_(AllocMany2|AllocRepeated2)$" -benchtime=2x -count=1
# PASS
```