### PR TITLE
treedb: move value-log GC scan outside publish lock

### DIFF
--- a/TreeDB/db/vlog_gc.go
+++ b/TreeDB/db/vlog_gc.go
@@ -171,7 +171,7 @@ func (db *DB) valueLogGC(ctx context.Context, opts ValueLogGCOptions, lockMainte
 		const maxStaleScanRetries = 1
 		for attempt := 0; ; attempt++ {
 			var err error
-			referenced, _, scannedSeq, err = db.referencedValueLogSegmentsWithSourceAtSeq(ctx)
+			referenced, _, scannedSeq, err = db.referencedValueLogSegmentsForGCAtSeq(ctx)
 			if err != nil {
 				return stats, err
 			}

--- a/TreeDB/db/vlog_gc.go
+++ b/TreeDB/db/vlog_gc.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"sync"
 
 	"github.com/snissn/gomap/TreeDB/internal/valuelog"
 )
@@ -19,6 +20,32 @@ const valueLogKeepRecentSegmentsPerLane = 2
 // second no-refresh read after the fallback Refresh call.
 var valueLogGCPostRefreshCurrentSetNoRefresh = func(vm *valuelog.Manager) *valuelog.Set {
 	return vm.CurrentSetNoRefresh()
+}
+
+var valueLogGCPostScanHook struct {
+	mu sync.Mutex
+	fn func()
+}
+
+func registerValueLogGCPostScanHook(hook func()) func() {
+	valueLogGCPostScanHook.mu.Lock()
+	prev := valueLogGCPostScanHook.fn
+	valueLogGCPostScanHook.fn = hook
+	valueLogGCPostScanHook.mu.Unlock()
+	return func() {
+		valueLogGCPostScanHook.mu.Lock()
+		valueLogGCPostScanHook.fn = prev
+		valueLogGCPostScanHook.mu.Unlock()
+	}
+}
+
+func runValueLogGCPostScanHook() {
+	valueLogGCPostScanHook.mu.Lock()
+	hook := valueLogGCPostScanHook.fn
+	valueLogGCPostScanHook.mu.Unlock()
+	if hook != nil {
+		hook()
+	}
 }
 
 // ValueLogGCOptions controls value-log garbage collection.
@@ -131,23 +158,40 @@ func (db *DB) valueLogGC(ctx context.Context, opts ValueLogGCOptions, lockMainte
 	if vm == nil {
 		return stats, fmt.Errorf("value log manager unavailable")
 	}
-	if !opts.DryRun {
-		// Publish preparation can flush value-log segments before the root that
-		// references them is installed. Serialize the reachability scan and delete
-		// phase with that prepared-publish window so GC cannot classify those
-		// segments against the previous root and remove them prematurely.
-		db.publishPrepareMu.Lock()
-		defer db.publishPrepareMu.Unlock()
-	}
-
 	observedOnly := len(opts.ObservedSourceFileIDs) > 0 && opts.ObservedSourceAssumeUnreferenced
 	var referenced map[uint32]struct{}
+	var scannedSeq uint64
 	if !observedOnly {
-		var err error
-		referenced, err = db.referencedValueLogSegments(ctx)
-		if err != nil {
-			return stats, err
+		// A full scan is O(N), so it must never run while publishPrepareMu is
+		// exclusively held. A root published after this scan can first-reference
+		// an old segment, therefore a changed commit sequence is retried outside
+		// the lock once and then conservatively aborts this GC pass.
+		const maxStaleScanRetries = 1
+		for attempt := 0; ; attempt++ {
+			var err error
+			referenced, _, scannedSeq, err = db.referencedValueLogSegmentsWithSourceAtSeq(ctx)
+			if err != nil {
+				return stats, err
+			}
+			runValueLogGCPostScanHook()
+			if opts.DryRun {
+				break
+			}
+
+			db.publishPrepareMu.Lock()
+			if db.currentCommitSeq() == scannedSeq {
+				break
+			}
+			db.publishPrepareMu.Unlock()
+			if attempt == maxStaleScanRetries {
+				return stats, nil
+			}
 		}
+	} else if !opts.DryRun {
+		db.publishPrepareMu.Lock()
+	}
+	if !opts.DryRun {
+		defer db.publishPrepareMu.Unlock()
 	}
 
 	// Prefer no-refresh snapshots to avoid repeated filesystem scans on the hot

--- a/TreeDB/db/vlog_gc.go
+++ b/TreeDB/db/vlog_gc.go
@@ -163,9 +163,11 @@ func (db *DB) valueLogGC(ctx context.Context, opts ValueLogGCOptions, lockMainte
 	var scannedSeq uint64
 	if !observedOnly {
 		// A full scan is O(N), so it must never run while publishPrepareMu is
-		// exclusively held. A root published after this scan can first-reference
-		// an old segment, therefore a changed commit sequence is retried outside
-		// the lock once and then conservatively aborts this GC pass.
+		// exclusively held. Safety invariant: GC never zombifies a segment from a
+		// referenced set older than the root visible while the exclusive lock is
+		// held. A post-scan root can first-reference an old segment, so a changed
+		// commit sequence is retried outside the lock once and then conservatively
+		// aborts this GC pass.
 		const maxStaleScanRetries = 1
 		for attempt := 0; ; attempt++ {
 			var err error
@@ -194,6 +196,9 @@ func (db *DB) valueLogGC(ctx context.Context, opts ValueLogGCOptions, lockMainte
 		defer db.publishPrepareMu.Unlock()
 	}
 
+	// Commit-sequence equality fences published roots, not prepared output. The
+	// current/recent and pending-append keep sets below are therefore computed
+	// from the value-log topology while publish preparation remains excluded.
 	// Prefer no-refresh snapshots to avoid repeated filesystem scans on the hot
 	// path. Fall back to a refresh if the manager has not yet discovered any
 	// segments (or if another process created segments on disk).

--- a/TreeDB/db/vlog_gc_incremental.go
+++ b/TreeDB/db/vlog_gc_incremental.go
@@ -237,6 +237,7 @@ func (d *valueLogRefDelta) forEachChange(fn func(fileID uint32, change int64) er
 
 type valueLogRefTracker struct {
 	mu        sync.RWMutex
+	revision  uint64
 	commitSeq uint64
 	counts    map[uint32]uint64
 	valid     bool
@@ -282,17 +283,51 @@ func (t *valueLogRefTracker) replace(counts map[uint32]uint64, commitSeq uint64,
 		next[fileID] = n
 	}
 	t.mu.Lock()
-	// A fallback scan may finish after a concurrent commit advanced the tracker.
-	// Do not replace newer exact counts with an older snapshot.
-	if t.commitSeq > commitSeq {
+	t.counts = next
+	t.commitSeq = commitSeq
+	t.valid = true
+	t.dirty = dirty
+	t.revision++
+	t.mu.Unlock()
+}
+
+func (t *valueLogRefTracker) revisionSnapshot() uint64 {
+	if t == nil {
+		return 0
+	}
+	t.mu.RLock()
+	revision := t.revision
+	t.mu.RUnlock()
+	return revision
+}
+
+func (t *valueLogRefTracker) replaceUnlessAdvanced(counts map[uint32]uint64, commitSeq uint64, dirty bool, observedRevision uint64) bool {
+	if t == nil {
+		return false
+	}
+	next := make(map[uint32]uint64, len(counts))
+	for fileID, n := range counts {
+		if n == 0 {
+			continue
+		}
+		next[fileID] = n
+	}
+	t.mu.Lock()
+	// A GC fallback scan may finish after a concurrent commit advanced exact
+	// counts. Preserve that advancement, but still allow ordinary stale-ahead
+	// tracker corruption to be repaired when the tracker did not change during
+	// the scan.
+	if t.revision != observedRevision && t.commitSeq > commitSeq {
 		t.mu.Unlock()
-		return
+		return false
 	}
 	t.counts = next
 	t.commitSeq = commitSeq
 	t.valid = true
 	t.dirty = dirty
+	t.revision++
 	t.mu.Unlock()
+	return true
 }
 
 func (t *valueLogRefTracker) invalidate() {
@@ -301,6 +336,7 @@ func (t *valueLogRefTracker) invalidate() {
 	}
 	t.mu.Lock()
 	t.valid = false
+	t.revision++
 	t.mu.Unlock()
 }
 
@@ -346,6 +382,7 @@ func (t *valueLogRefTracker) applyDelta(nextCommitSeq uint64, delta *valueLogRef
 
 	t.commitSeq = nextCommitSeq
 	t.dirty = true
+	t.revision++
 	return nil
 }
 
@@ -393,7 +430,10 @@ func (t *valueLogRefTracker) markClean(commitSeq uint64) {
 	}
 	t.mu.Lock()
 	if t.valid && t.commitSeq == commitSeq {
-		t.dirty = false
+		if t.dirty {
+			t.dirty = false
+			t.revision++
+		}
 	}
 	t.mu.Unlock()
 }
@@ -504,11 +544,21 @@ func (db *DB) referencedValueLogSegmentsWithSource(ctx context.Context) (map[uin
 }
 
 func (db *DB) referencedValueLogSegmentsWithSourceAtSeq(ctx context.Context) (map[uint32]struct{}, valueLogRefResolutionSource, uint64, error) {
+	return db.referencedValueLogSegmentsWithSourceAtSeqPolicy(ctx, false)
+}
+
+func (db *DB) referencedValueLogSegmentsForGCAtSeq(ctx context.Context) (map[uint32]struct{}, valueLogRefResolutionSource, uint64, error) {
+	return db.referencedValueLogSegmentsWithSourceAtSeqPolicy(ctx, true)
+}
+
+func (db *DB) referencedValueLogSegmentsWithSourceAtSeqPolicy(ctx context.Context, guardConcurrentAdvance bool) (map[uint32]struct{}, valueLogRefResolutionSource, uint64, error) {
 	if ctx == nil {
 		ctx = context.Background()
 	}
 	seq := db.currentCommitSeq()
+	var trackerRevisionBeforeScan uint64
 	if db.valueLogRefTracker != nil {
+		trackerRevisionBeforeScan = db.valueLogRefTracker.revisionSnapshot()
 		if refs, ok := db.valueLogRefTracker.referencedSet(seq); ok {
 			return refs, valueLogRefResolutionSourceTracker, seq, nil
 		}
@@ -524,7 +574,11 @@ func (db *DB) referencedValueLogSegmentsWithSourceAtSeq(ctx context.Context) (ma
 		return nil, valueLogRefResolutionSourceFallbackScan, 0, err
 	}
 	if db.valueLogRefTracker != nil {
-		db.valueLogRefTracker.replace(counts, scannedSeq, true)
+		if guardConcurrentAdvance {
+			db.valueLogRefTracker.replaceUnlessAdvanced(counts, scannedSeq, true, trackerRevisionBeforeScan)
+		} else {
+			db.valueLogRefTracker.replace(counts, scannedSeq, true)
+		}
 	}
 	refs := make(map[uint32]struct{}, len(counts))
 	for fileID, n := range counts {

--- a/TreeDB/db/vlog_gc_incremental.go
+++ b/TreeDB/db/vlog_gc_incremental.go
@@ -282,6 +282,12 @@ func (t *valueLogRefTracker) replace(counts map[uint32]uint64, commitSeq uint64,
 		next[fileID] = n
 	}
 	t.mu.Lock()
+	// A fallback scan may finish after a concurrent commit advanced the tracker.
+	// Do not replace newer exact counts with an older snapshot.
+	if t.commitSeq > commitSeq {
+		t.mu.Unlock()
+		return
+	}
 	t.counts = next
 	t.commitSeq = commitSeq
 	t.valid = true
@@ -493,24 +499,29 @@ func (db *DB) referencedValueLogSegments(ctx context.Context) (map[uint32]struct
 }
 
 func (db *DB) referencedValueLogSegmentsWithSource(ctx context.Context) (map[uint32]struct{}, valueLogRefResolutionSource, error) {
+	refs, source, _, err := db.referencedValueLogSegmentsWithSourceAtSeq(ctx)
+	return refs, source, err
+}
+
+func (db *DB) referencedValueLogSegmentsWithSourceAtSeq(ctx context.Context) (map[uint32]struct{}, valueLogRefResolutionSource, uint64, error) {
 	if ctx == nil {
 		ctx = context.Background()
 	}
 	seq := db.currentCommitSeq()
 	if db.valueLogRefTracker != nil {
 		if refs, ok := db.valueLogRefTracker.referencedSet(seq); ok {
-			return refs, valueLogRefResolutionSourceTracker, nil
+			return refs, valueLogRefResolutionSourceTracker, seq, nil
 		}
 	}
 	counts, scannedSeq, err := db.scanValueLogRefCounts(ctx)
 	if err != nil && errors.Is(err, valuelog.ErrFileNotFound) {
 		if refreshErr := db.RefreshValueLogSet(); refreshErr != nil {
-			return nil, valueLogRefResolutionSourceFallbackScan, refreshErr
+			return nil, valueLogRefResolutionSourceFallbackScan, 0, refreshErr
 		}
 		counts, scannedSeq, err = db.scanValueLogRefCounts(ctx)
 	}
 	if err != nil {
-		return nil, valueLogRefResolutionSourceFallbackScan, err
+		return nil, valueLogRefResolutionSourceFallbackScan, 0, err
 	}
 	if db.valueLogRefTracker != nil {
 		db.valueLogRefTracker.replace(counts, scannedSeq, true)
@@ -522,7 +533,7 @@ func (db *DB) referencedValueLogSegmentsWithSource(ctx context.Context) (map[uin
 		}
 		refs[fileID] = struct{}{}
 	}
-	return refs, valueLogRefResolutionSourceFallbackScan, nil
+	return refs, valueLogRefResolutionSourceFallbackScan, scannedSeq, nil
 }
 
 func (db *DB) scanValueLogRefCounts(ctx context.Context) (map[uint32]uint64, uint64, error) {

--- a/TreeDB/db/vlog_gc_lock_bench_test.go
+++ b/TreeDB/db/vlog_gc_lock_bench_test.go
@@ -1,0 +1,82 @@
+package db
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+)
+
+// BenchmarkValueLogGCPublishDuringPausedFullScan isolates the lock-scope
+// regression fixed by PL-04. The deterministic pause represents an expensive
+// fallback reachability scan: on the old implementation a concurrent publish
+// waits for the pause, while the split implementation publishes before the
+// GC enters its short exclusive phase.
+func BenchmarkValueLogGCPublishDuringPausedFullScan(b *testing.B) {
+	const scanPause = 25 * time.Millisecond
+	type gcResult struct {
+		stats ValueLogGCStats
+		err   error
+	}
+
+	var publishElapsed time.Duration
+	var segmentsDeleted int
+	for i := 0; i < b.N; i++ {
+		b.StopTimer()
+		db, err := Open(Options{Dir: b.TempDir()})
+		if err != nil {
+			b.Fatalf("open: %v", err)
+		}
+		appendPointersInNewSegmentBench(b, db.dir, 0, 1, 8_000, 1, func(int) []byte { return []byte("old") })
+		appendPointersInNewSegmentBench(b, db.dir, 0, 2, 9_000, 1, func(int) []byte { return []byte("active") })
+		if err := db.RefreshValueLogSet(); err != nil {
+			_ = db.Close()
+			b.Fatalf("refresh value-log set: %v", err)
+		}
+		db.valueLogRefTracker.invalidate()
+
+		scanStarted := make(chan struct{})
+		releaseScan := make(chan struct{})
+		var hookOnce sync.Once
+		restore := registerScanValueLogRefCountsHook(func() {
+			hookOnce.Do(func() {
+				close(scanStarted)
+				<-releaseScan
+			})
+		})
+		gcDone := make(chan gcResult, 1)
+		go func() {
+			stats, err := db.ValueLogGC(context.Background(), ValueLogGCOptions{})
+			gcDone <- gcResult{stats: stats, err: err}
+		}()
+		<-scanStarted
+		key := []byte(fmt.Sprintf("publish-during-scan-%d", i))
+		time.AfterFunc(scanPause, func() { close(releaseScan) })
+
+		b.StartTimer()
+		started := time.Now()
+		err = db.Set(key, []byte("ok"))
+		publishElapsed += time.Since(started)
+		b.StopTimer()
+		if err != nil {
+			restore()
+			_ = db.Close()
+			b.Fatalf("publish during scan: %v", err)
+		}
+		result := <-gcDone
+		restore()
+		if result.err != nil {
+			_ = db.Close()
+			b.Fatalf("ValueLogGC: %v", result.err)
+		}
+		segmentsDeleted += result.stats.SegmentsDeleted
+		if err := db.Close(); err != nil {
+			b.Fatalf("close: %v", err)
+		}
+	}
+
+	b.ReportMetric(float64(publishElapsed.Nanoseconds())/float64(b.N), "publish-ns/op")
+	b.ReportMetric(float64(scanPause.Nanoseconds()), "scan-pause-ns/op")
+	b.ReportMetric(float64(segmentsDeleted)/float64(b.N), "segments-deleted/op")
+}

--- a/TreeDB/db/vlog_gc_test.go
+++ b/TreeDB/db/vlog_gc_test.go
@@ -559,16 +559,41 @@ func setValueLogPointer(t *testing.T, db *DB, key []byte, ptr page.ValuePtr) {
 	}
 }
 
-func TestValueLogRefTracker_StaleReplaceDoesNotRegressCommitSeq(t *testing.T) {
+func TestValueLogRefTracker_GCReplaceDoesNotRegressConcurrentAdvance(t *testing.T) {
 	tracker := newValueLogRefTracker()
-	tracker.replace(map[uint32]uint64{11: 1}, 7, true)
 	tracker.replace(map[uint32]uint64{12: 1}, 6, true)
+	observedRevision := tracker.revisionSnapshot()
+	advanced := make(chan struct{})
+	go func() {
+		tracker.replace(map[uint32]uint64{11: 1}, 7, true)
+		close(advanced)
+	}()
+	<-advanced
+	if tracker.replaceUnlessAdvanced(map[uint32]uint64{12: 1}, 6, true, observedRevision) {
+		t.Fatal("GC fallback replaced tracker after concurrent sequence advance")
+	}
 	refs, ok := tracker.referencedSet(7)
 	if !ok {
-		t.Fatal("stale replace regressed tracker commit sequence")
+		t.Fatal("GC fallback regressed tracker commit sequence")
 	}
 	if _, ok := refs[11]; !ok {
-		t.Fatalf("newer tracker counts were replaced by stale scan: %v", refs)
+		t.Fatalf("concurrently advanced counts were replaced by stale scan: %v", refs)
+	}
+}
+
+func TestValueLogRefTracker_GCReplaceRepairsUnchangedStaleAheadState(t *testing.T) {
+	tracker := newValueLogRefTracker()
+	tracker.replace(map[uint32]uint64{11: 1}, 7, true)
+	observedRevision := tracker.revisionSnapshot()
+	if !tracker.replaceUnlessAdvanced(map[uint32]uint64{12: 1}, 6, true, observedRevision) {
+		t.Fatal("unchanged stale-ahead tracker was not repaired")
+	}
+	refs, ok := tracker.referencedSet(6)
+	if !ok {
+		t.Fatal("repaired tracker does not match scanned sequence")
+	}
+	if _, ok := refs[12]; !ok {
+		t.Fatalf("repaired tracker counts = %v, want file 12", refs)
 	}
 }
 

--- a/TreeDB/db/vlog_gc_test.go
+++ b/TreeDB/db/vlog_gc_test.go
@@ -371,6 +371,9 @@ func TestValueLogGC_FullScanDoesNotBlockPublishBeforeLockedPhase(t *testing.T) {
 
 	scanStarted := make(chan struct{})
 	releaseScan := make(chan struct{})
+	var releaseOnce sync.Once
+	release := func() { releaseOnce.Do(func() { close(releaseScan) }) }
+	defer release()
 	var once sync.Once
 	restore := registerScanValueLogRefCountsHook(func() {
 		once.Do(func() {
@@ -397,7 +400,7 @@ func TestValueLogGC_FullScanDoesNotBlockPublishBeforeLockedPhase(t *testing.T) {
 	case <-time.After(time.Second):
 		t.Fatal("publish blocked while value-log GC full scan was paused")
 	}
-	close(releaseScan)
+	release()
 	if err := <-gcDone; err != nil {
 		t.Fatalf("ValueLogGC: %v", err)
 	}
@@ -420,6 +423,9 @@ func TestValueLogGC_PostScanFirstReferenceToOldSegmentIsSafe(t *testing.T) {
 
 	postScan := make(chan struct{})
 	releaseGC := make(chan struct{})
+	var releaseOnce sync.Once
+	release := func() { releaseOnce.Do(func() { close(releaseGC) }) }
+	defer release()
 	var once sync.Once
 	restore := registerValueLogGCPostScanHook(func() {
 		once.Do(func() {
@@ -435,12 +441,109 @@ func TestValueLogGC_PostScanFirstReferenceToOldSegmentIsSafe(t *testing.T) {
 	}()
 	<-postScan
 	setValueLogPointer(t, db, []byte("old-first-reference"), oldPtr)
-	close(releaseGC)
+	release()
 	if err := <-gcDone; err != nil {
 		t.Fatalf("ValueLogGC: %v", err)
 	}
 	if _, err := os.Stat(oldPath); err != nil {
 		t.Fatalf("old segment first referenced after scan was removed: %v", err)
+	}
+}
+
+func TestValueLogGC_PostScanNewSegmentIsSafe(t *testing.T) {
+	db, err := Open(Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	appendPointersInNewSegment(t, db.dir, 0, 1, 5_000, 1, func(int) []byte { return []byte("old") })
+	appendPointersInNewSegment(t, db.dir, 0, 2, 6_000, 1, func(int) []byte { return []byte("active") })
+	if err := db.RefreshValueLogSet(); err != nil {
+		t.Fatalf("refresh value-log set: %v", err)
+	}
+	db.valueLogRefTracker.invalidate() // Exercise the full-scan fallback split.
+
+	postScan := make(chan struct{})
+	releaseGC := make(chan struct{})
+	var releaseOnce sync.Once
+	release := func() { releaseOnce.Do(func() { close(releaseGC) }) }
+	defer release()
+	var hookOnce sync.Once
+	restore := registerValueLogGCPostScanHook(func() {
+		hookOnce.Do(func() {
+			close(postScan)
+			<-releaseGC
+		})
+	})
+	defer restore()
+	gcDone := make(chan error, 1)
+	go func() {
+		_, err := db.ValueLogGC(context.Background(), ValueLogGCOptions{})
+		gcDone <- err
+	}()
+	<-postScan
+
+	newPtr := appendPointersInNewSegment(t, db.dir, 0, 3, 7_000, 1, func(int) []byte { return []byte("new") })[0]
+	if err := db.RefreshValueLogSet(); err != nil {
+		t.Fatalf("refresh post-scan value-log set: %v", err)
+	}
+	key := []byte("post-scan-new-segment")
+	setValueLogPointer(t, db, key, newPtr)
+	release()
+	if err := <-gcDone; err != nil {
+		t.Fatalf("ValueLogGC: %v", err)
+	}
+	newPath := filepath.Join(ValueLogDirPath(db.dir), "value-l0-000003.log")
+	if _, err := os.Stat(newPath); err != nil {
+		t.Fatalf("segment created and referenced after scan was removed: %v", err)
+	}
+	got, err := db.Get(key)
+	if err != nil {
+		t.Fatalf("get post-scan pointer: %v", err)
+	}
+	if string(got) != "new" {
+		t.Fatalf("get post-scan pointer = %q, want %q", got, "new")
+	}
+}
+
+func TestValueLogGC_RepeatedPostScanPublicationAbortsWithoutDelete(t *testing.T) {
+	db, err := Open(Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	appendPointersInNewSegment(t, db.dir, 0, 1, 8_000, 1, func(int) []byte { return []byte("old") })
+	appendPointersInNewSegment(t, db.dir, 0, 2, 9_000, 1, func(int) []byte { return []byte("active") })
+	if err := db.RefreshValueLogSet(); err != nil {
+		t.Fatalf("refresh value-log set: %v", err)
+	}
+	db.valueLogRefTracker.invalidate()
+	oldPath := filepath.Join(ValueLogDirPath(db.dir), "value-l0-000001.log")
+
+	var attempts int
+	var publishErr error
+	restore := registerValueLogGCPostScanHook(func() {
+		attempts++
+		publishErr = db.Set([]byte(fmt.Sprintf("publish-after-scan-%d", attempts)), []byte("ok"))
+	})
+	stats, err := db.ValueLogGC(context.Background(), ValueLogGCOptions{})
+	restore()
+	if err != nil {
+		t.Fatalf("ValueLogGC: %v", err)
+	}
+	if publishErr != nil {
+		t.Fatalf("publish after scan: %v", publishErr)
+	}
+	if attempts != 2 {
+		t.Fatalf("scan attempts = %d, want bounded initial attempt plus one retry", attempts)
+	}
+	if stats.SegmentsDeleted != 0 || stats.BytesDeleted != 0 {
+		t.Fatalf("stale retry deleted segments: %+v", stats)
+	}
+	if _, err := os.Stat(oldPath); err != nil {
+		t.Fatalf("bounded stale retry removed an unvalidated segment: %v", err)
 	}
 }
 

--- a/TreeDB/db/vlog_gc_test.go
+++ b/TreeDB/db/vlog_gc_test.go
@@ -8,7 +8,9 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/snissn/gomap/TreeDB/internal/valuelog"
 	"github.com/snissn/gomap/TreeDB/page"
@@ -350,6 +352,120 @@ func TestValueLogGC_KeepsPendingValueLogAppenderSegments(t *testing.T) {
 	pendingPath := filepath.Join(dir, "value_vlog", "value-l0-000002.log")
 	if _, err := os.Stat(pendingPath); err != nil {
 		t.Fatalf("pending segment missing after GC: %v", err)
+	}
+}
+
+func TestValueLogGC_FullScanDoesNotBlockPublishBeforeLockedPhase(t *testing.T) {
+	db, err := Open(Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	appendPointersInNewSegment(t, db.dir, 0, 1, 1_000, 1, func(int) []byte { return []byte("old") })
+	appendPointersInNewSegment(t, db.dir, 0, 2, 2_000, 1, func(int) []byte { return []byte("active") })
+	if err := db.RefreshValueLogSet(); err != nil {
+		t.Fatalf("refresh value-log set: %v", err)
+	}
+	db.valueLogRefTracker.invalidate()
+
+	scanStarted := make(chan struct{})
+	releaseScan := make(chan struct{})
+	var once sync.Once
+	restore := registerScanValueLogRefCountsHook(func() {
+		once.Do(func() {
+			close(scanStarted)
+			<-releaseScan
+		})
+	})
+	defer restore()
+
+	gcDone := make(chan error, 1)
+	go func() {
+		_, err := db.ValueLogGC(context.Background(), ValueLogGCOptions{})
+		gcDone <- err
+	}()
+	<-scanStarted
+
+	publishDone := make(chan error, 1)
+	go func() { publishDone <- db.Set([]byte("publish-during-gc-scan"), []byte("ok")) }()
+	select {
+	case err := <-publishDone:
+		if err != nil {
+			t.Fatalf("publish during scan: %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("publish blocked while value-log GC full scan was paused")
+	}
+	close(releaseScan)
+	if err := <-gcDone; err != nil {
+		t.Fatalf("ValueLogGC: %v", err)
+	}
+}
+
+func TestValueLogGC_PostScanFirstReferenceToOldSegmentIsSafe(t *testing.T) {
+	db, err := Open(Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	oldPtr := appendPointersInNewSegment(t, db.dir, 0, 1, 3_000, 1, func(int) []byte { return []byte("old") })[0]
+	appendPointersInNewSegment(t, db.dir, 0, 2, 4_000, 1, func(int) []byte { return []byte("active") })
+	if err := db.RefreshValueLogSet(); err != nil {
+		t.Fatalf("refresh value-log set: %v", err)
+	}
+	db.valueLogRefTracker.invalidate() // Exercise the full-scan fallback split.
+	oldPath := filepath.Join(ValueLogDirPath(db.dir), "value-l0-000001.log")
+
+	postScan := make(chan struct{})
+	releaseGC := make(chan struct{})
+	var once sync.Once
+	restore := registerValueLogGCPostScanHook(func() {
+		once.Do(func() {
+			close(postScan)
+			<-releaseGC
+		})
+	})
+	defer restore()
+	gcDone := make(chan error, 1)
+	go func() {
+		_, err := db.ValueLogGC(context.Background(), ValueLogGCOptions{})
+		gcDone <- err
+	}()
+	<-postScan
+	setValueLogPointer(t, db, []byte("old-first-reference"), oldPtr)
+	close(releaseGC)
+	if err := <-gcDone; err != nil {
+		t.Fatalf("ValueLogGC: %v", err)
+	}
+	if _, err := os.Stat(oldPath); err != nil {
+		t.Fatalf("old segment first referenced after scan was removed: %v", err)
+	}
+}
+
+func setValueLogPointer(t *testing.T, db *DB, key []byte, ptr page.ValuePtr) {
+	t.Helper()
+	b := db.NewBatch().(*Batch)
+	defer b.Close()
+	if err := b.SetPointer(key, ptr); err != nil {
+		t.Fatalf("set pointer: %v", err)
+	}
+	if err := b.Write(); err != nil {
+		t.Fatalf("write pointer: %v", err)
+	}
+}
+
+func TestValueLogRefTracker_StaleReplaceDoesNotRegressCommitSeq(t *testing.T) {
+	tracker := newValueLogRefTracker()
+	tracker.replace(map[uint32]uint64{11: 1}, 7, true)
+	tracker.replace(map[uint32]uint64{12: 1}, 6, true)
+	refs, ok := tracker.referencedSet(7)
+	if !ok {
+		t.Fatal("stale replace regressed tracker commit sequence")
+	}
+	if _, ok := refs[11]; !ok {
+		t.Fatalf("newer tracker counts were replaced by stale scan: %v", refs)
 	}
 }
 


### PR DESCRIPTION
## Summary

Fixes #3639  
Parent: #3630

- move value-log GC reachability resolution before the exclusive `publishPrepareMu` phase
- fence the scanned referenced set against the root commit sequence under the lock, retry once outside the lock, and conservatively abort after a second mismatch
- compute current/recent/protected/pending-append keep sets only inside the locked phase against the current value-log topology
- prevent a fallback scan from overwriting tracker counts advanced concurrently during that scan, while preserving existing stale-ahead tracker repair
- add deterministic old-segment, new-segment, paused-scan publish, bounded-retry, tracker, race, and paired performance coverage

Base: `2c1cab846aa803aba7d7ef2c6a2026d3420da56e`  
Head: `ad9469c68e1004306be479a741fa655ec53b07c9`

## Deletion-safety invariant

GC never zombifies a segment from a referenced set older than the published root visible while `publishPrepareMu` is exclusively held.

The pre-lock scan returns both the referenced segment set and its snapshot `CommitSeq`. The locked phase may classify/delete only when the current sequence exactly matches that scanned sequence. One mismatch unlocks and retries the full operation outside the lock; a second mismatch returns without marking or deleting segments.

Sequence equality fences published roots only. Prepared-but-unpublished output can exist without changing `CommitSeq`, so the current/recent segment set and `pendingValueLogAppendFileIDs()` are intentionally read under the same exclusive lock used for candidate classification. This retains the existing prepared-output safety contract.

The implementation does not use a file-ID/newer-segment fence. A post-scan root can first-reference an old segment via a pre-built `ValuePtr`; the exact sequence fence and bounded rescan cover that case.

## Tracker contract

Fallback scans used by GC capture a private tracker revision before scanning. Replacement is skipped only when the tracker changed during the scan and now contains counts for a sequence newer than the scanned sequence. This prevents concurrent exact counts from being rolled back.

Ordinary fallback consumers retain unconditional exact-scan repair. An unchanged stale-ahead tracker can therefore still be replaced by the current scanned sequence, preserving the CompactStorage recovery contract tested by `TestCompactStorageFencedReclaimFallsBackWhenTrackerStale`.

## Failure modes

| Interleaving | Result |
| --- | --- |
| no root change during scan | short locked classification/delete phase proceeds |
| one post-scan root publication | unlock, rescan outside the lock, then revalidate |
| publications after both scan attempts | safe zero-delete abort |
| old unreferenced segment gains first reference | sequence mismatch forces rescan; segment remains readable |
| new segment is created and first referenced | sequence mismatch forces rescan; new segment remains readable |
| prepared output exists without root publication | locked current/recent/pending keep sets protect it |
| tracker advances while fallback scan runs | revision guard preserves newer exact counts |
| tracker is stale-ahead but unchanged | fallback scan repairs it to the current sequence |
| context cancellation or scan error | existing error propagation; no candidate publication |

## Regression and TDD evidence

The exact base reproduces the original lock-scope failure: while a fallback scan is deterministically paused for 25 ms, a concurrent publish waits about 25.5 ms. On the head, the same publish finishes around 1.2 ms before GC enters its exclusive phase.

The initial worker milestone committed the first behavior tests with the implementation, so no separate red execution was preserved for those tests. The subsequent full-package gate did produce and preserve a real red/green cycle: `TestCompactStorageFencedReclaimFallsBackWhenTrackerStale` failed because the first tracker guard blocked stale-ahead repair. The guard was redesigned around a private revision token; the existing regression plus new concurrent-advance and stale-repair tests then passed repeatedly and under race.

Added deterministic coverage:

- `TestValueLogGC_FullScanDoesNotBlockPublishBeforeLockedPhase`
- `TestValueLogGC_PostScanFirstReferenceToOldSegmentIsSafe`
- `TestValueLogGC_PostScanNewSegmentIsSafe`
- `TestValueLogGC_RepeatedPostScanPublicationAbortsWithoutDelete`
- `TestValueLogRefTracker_GCReplaceDoesNotRegressConcurrentAdvance`
- `TestValueLogRefTracker_GCReplaceRepairsUnchangedStaleAheadState`
- `BenchmarkValueLogGCPublishDuringPausedFullScan`

## Validation

All commands ran on the final integrated head:

```sh
GOMEMLIMIT=4GiB GOMAXPROCS=2 GOWORK=off go test -p 1 ./TreeDB/db ./TreeDB \
  -run 'TestValueLogGC|TestMaintenanceRoots|TestCommandWAL|TestPublish|TestCompactStorageFencedReclaimFallsBackWhenTrackerStale' \
  -count=1 -timeout=10m
# PASS: db 5.227s; TreeDB 0.378s

GOMEMLIMIT=4GiB GOMAXPROCS=2 GOWORK=off go test -race -p 1 ./TreeDB/db \
  -run 'TestValueLogGC|TestValueLogRefTracker_GCReplace' -count=1 -timeout=10m
# PASS: db 1.842s

GOWORK=off go test ./TreeDB/db \
  -run 'TestCompactStorageFencedReclaimFallsBackWhenTrackerStale|TestValueLogRefTracker_GCReplace|TestValueLogGC_(FullScanDoesNotBlockPublishBeforeLockedPhase|PostScanFirstReferenceToOldSegmentIsSafe|PostScanNewSegmentIsSafe|RepeatedPostScanPublicationAbortsWithoutDelete)' \
  -count=20
# PASS: db 2.794s

GOWORK=off go test -race ./TreeDB/db \
  -run 'TestValueLogRefTracker_GCReplace|TestValueLogGC_(FullScanDoesNotBlockPublishBeforeLockedPhase|PostScanFirstReferenceToOldSegmentIsSafe|PostScanNewSegmentIsSafe|RepeatedPostScanPublicationAbortsWithoutDelete)' \
  -count=10
# PASS: db 3.293s

GOMEMLIMIT=4GiB GOMAXPROCS=2 GOWORK=off go test -p 1 ./TreeDB/db -count=1 -timeout=10m
# PASS: db 245.298s

GOMEMLIMIT=4GiB GOMAXPROCS=2 GOWORK=off go vet ./TreeDB/db
git diff --check
# PASS
```

## Performance gate

Host: Linux amd64, Intel i5-11400F, Go 1.26.0. The identical benchmark file was applied to a detached exact-base worktree and committed on the head. Each side ran 20 externally alternating samples with one benchmark operation per process:

```sh
GOWORK=off go test ./TreeDB/db -run '^$' \
  -bench '^BenchmarkValueLogGCPublishDuringPausedFullScan$' \
  -benchtime=1x -count=1 -benchmem
```

The 25 ms deterministic scan pause isolates the active window. Setup and GC completion are outside the benchmark timer; the timed region is the concurrent `DB.Set`. Every base and head sample reports exactly one eligible segment deleted.

| Metric, n=20 | Base `2c1cab846a` | Head `ad9469c68` | Result |
| --- | ---: | ---: | ---: |
| publish median | 25.527 ms | 1.190 ms | 21.45x lower |
| publish p95 | 25.590 ms | 1.221 ms | 20.96x lower |
| publish p99 | 25.626 ms | 1.229 ms | 20.85x lower |
| benchmark median | 25.545 ms/op | 1.203 ms/op | 21.23x lower |
| median B/op | 67,184 | 34,960 | -47.97% |
| median allocs/op | 319 | 75 | -76.49% |
| segments deleted/op | 1.0 | 1.0 | unchanged |

This passes the required >=10x lock-window reduction at median, p95, and p99 without weakening GC effectiveness.

## Compatibility and scope

- no on-disk format or persistent metadata encoding change
- no public API change
- persistent value-log pointers and deletion eligibility semantics remain unchanged
- observed-only GC keeps its existing locked behavior and skips the reachability scan as before
- CompactStorage shared-audit work remains owned by PL-03; this PR changes only value-log GC scan/validation and tracker replacement fencing

Rollback is a normal code revert; no migration or persisted toggle is involved.
