### PR TITLE
treedb: reuse leaf pack reachability plans across compaction passes

### DIFF
--- a/TreeDB/db/compact_storage.go
+++ b/TreeDB/db/compact_storage.go
@@ -1060,17 +1060,23 @@ func (state *compactStorageLeafPackPlanState) advance(db *DB, pack LeafGeneratio
 	}
 
 	live := cloneLeafGenerationLiveScanStats(state.live)
-	for generationID, moved := range result.sourceLiveMovedByGeneration {
-		remaining := live.Generations[generationID]
-		remaining.LivePages -= moved.LivePages
-		remaining.LiveBytes -= moved.LiveBytes
-		if remaining.LivePages < 0 {
-			remaining.LivePages = 0
+	if result.trackSourceLiveMoved {
+		for generationID, moved := range result.sourceLiveMovedByGeneration {
+			remaining := live.Generations[generationID]
+			remaining.LivePages -= moved.LivePages
+			remaining.LiveBytes -= moved.LiveBytes
+			if remaining.LivePages < 0 {
+				remaining.LivePages = 0
+			}
+			if remaining.LiveBytes < 0 {
+				remaining.LiveBytes = 0
+			}
+			live.Generations[generationID] = remaining
 		}
-		if remaining.LiveBytes < 0 {
-			remaining.LiveBytes = 0
+	} else {
+		for _, generationID := range pack.SourceGenerationIDs {
+			live.Generations[generationID] = leafGenerationLiveTotals{}
 		}
-		live.Generations[generationID] = remaining
 	}
 
 	createdGenerations := make(map[uint64]struct{})

--- a/TreeDB/db/compact_storage.go
+++ b/TreeDB/db/compact_storage.go
@@ -1048,7 +1048,7 @@ func (db *DB) compactStorageLeafGenerationPlan(ctx context.Context, opts LeafGen
 }
 
 func (state *compactStorageLeafPackPlanState) advance(db *DB, pack LeafGenerationPackStats, result leafGenerationPackCarryResult) {
-	if state == nil || !state.valid || db == nil || pack.CopyAborts != 0 || result.publishedState == nil {
+	if state == nil || !state.valid || db == nil || pack.CopyAborts != 0 || result.publishedState == nil || result.protectedRootsOverlapSourceMaintenance {
 		state.invalidate()
 		return
 	}

--- a/TreeDB/db/compact_storage.go
+++ b/TreeDB/db/compact_storage.go
@@ -1007,17 +1007,6 @@ func (state *compactStorageLeafPackPlanState) invalidate() {
 	*state = compactStorageLeafPackPlanState{}
 }
 
-func leafGenerationPlanStateKey(state *DBState, opts LeafGenerationPlanOptions) (treeReachabilityCacheKey, bool) {
-	key, ok := leafGenerationLiveStatsKeyForState(state)
-	if !ok {
-		return treeReachabilityCacheKey{}, false
-	}
-	if len(opts.ProtectedRootIDs) > 0 || len(opts.ProtectedSystemRootIDs) > 0 {
-		key.protectedRoots = leafGenerationProtectedRootsHash(opts.ProtectedRootIDs, opts.ProtectedSystemRootIDs)
-	}
-	return key, true
-}
-
 func (state *compactStorageLeafPackPlanState) resetFromPlan(plan LeafGenerationPlan) {
 	if state == nil || plan.liveStats.Generations == nil {
 		return

--- a/TreeDB/db/compact_storage.go
+++ b/TreeDB/db/compact_storage.go
@@ -517,6 +517,7 @@ func (db *DB) compactStorage(ctx context.Context, opts CompactStorageOptions) (s
 	}
 
 	compactLeafPackCreatedFileIDs := make(map[uint32]struct{})
+	var compactLeafPackPlanState compactStorageLeafPackPlanState
 	if opts.Mode == CompactStorageExhaustive {
 		sealedCurrent := false
 		if err := db.runCompactStoragePhase(&stats, "seal-current-leaf-generation", func() error {
@@ -540,7 +541,7 @@ func (db *DB) compactStorage(ctx context.Context, opts CompactStorageOptions) (s
 		if err := db.runCompactStoragePhase(&stats, phaseName, func() error {
 			var err error
 			protectedRootIDs, protectedSystemRootIDs := db.compactStorageLeafGenerationProtectedRootIDPair(opts)
-			pack, err = db.compactStorageLeafGenerationPackRunOnce(ctx, compactStorageLeafPackFromPlanOptions(opts, protectedRootIDs, protectedSystemRootIDs), !maintenanceLocked, compactLeafPackCreatedFileIDs)
+			pack, err = db.compactStorageLeafGenerationPackRunOnce(ctx, compactStorageLeafPackFromPlanOptions(opts, protectedRootIDs, protectedSystemRootIDs), !maintenanceLocked, compactLeafPackCreatedFileIDs, &compactLeafPackPlanState)
 			return err
 		}); err != nil {
 			return stats, err
@@ -575,6 +576,7 @@ func (db *DB) compactStorage(ctx context.Context, opts CompactStorageOptions) (s
 	}); err != nil {
 		return stats, err
 	}
+	compactLeafPackPlanState.invalidate()
 	if err := db.runCompactStoragePhase(&stats, "checkpoint-after-leaf-generation-gc", func() error {
 		return db.Checkpoint()
 	}); err != nil {
@@ -609,7 +611,8 @@ func (db *DB) compactStorage(ctx context.Context, opts CompactStorageOptions) (s
 		}
 	}
 
-	if err := db.settleCompactStorageGC(ctx, opts, &stats, !maintenanceLocked, compactLeafLog, compactLeafPackCreatedFileIDs, leafPackPassesRemaining, auditSession); err != nil {
+	compactLeafPackPlanState.invalidate()
+	if err := db.settleCompactStorageGC(ctx, opts, &stats, !maintenanceLocked, compactLeafLog, compactLeafPackCreatedFileIDs, leafPackPassesRemaining, auditSession, &compactLeafPackPlanState); err != nil {
 		return stats, err
 	}
 	// If index vacuum was unsupported, keep leaf-generation pins through final
@@ -727,7 +730,7 @@ func (db *DB) sealCompactStorageCurrentLeafGeneration(compactLeafLog *rewriteWri
 	return true, nil
 }
 
-func (db *DB) settleCompactStorageGC(ctx context.Context, opts CompactStorageOptions, stats *CompactStorageStats, lockMaintenance bool, compactLeafLog *rewriteWriter, ignoredLeafPackRawFileIDs map[uint32]struct{}, leafPackPassesRemaining int, auditSession *compactStorageAuditSession) error {
+func (db *DB) settleCompactStorageGC(ctx context.Context, opts CompactStorageOptions, stats *CompactStorageStats, lockMaintenance bool, compactLeafLog *rewriteWriter, ignoredLeafPackRawFileIDs map[uint32]struct{}, leafPackPassesRemaining int, auditSession *compactStorageAuditSession, leafPackPlanState *compactStorageLeafPackPlanState) error {
 	const maxSettlePasses = 4
 	for pass := 0; pass < maxSettlePasses; pass++ {
 		var audit CompactStorageStats
@@ -789,7 +792,7 @@ func (db *DB) settleCompactStorageGC(ctx context.Context, opts CompactStorageOpt
 			if err := db.runCompactStoragePhase(stats, phaseName, func() error {
 				var err error
 				protectedRootIDs, protectedSystemRootIDs := db.compactStorageLeafGenerationProtectedRootIDPair(opts)
-				pack, err = db.compactStorageLeafGenerationPackRunOnce(ctx, compactStorageLeafPackFromPlanOptions(opts, protectedRootIDs, protectedSystemRootIDs), lockMaintenance, ignoredLeafPackRawFileIDs)
+				pack, err = db.compactStorageLeafGenerationPackRunOnce(ctx, compactStorageLeafPackFromPlanOptions(opts, protectedRootIDs, protectedSystemRootIDs), lockMaintenance, ignoredLeafPackRawFileIDs, leafPackPlanState)
 				return err
 			}); err != nil {
 				return err
@@ -813,6 +816,7 @@ func (db *DB) settleCompactStorageGC(ctx context.Context, opts CompactStorageOpt
 			}
 		}
 		if debt.LeafGCGenerations > 0 {
+			leafPackPlanState.invalidate()
 			phaseName := fmt.Sprintf("settle-leaf-generation-gc-%d", pass+1)
 			if err := db.runCompactStoragePhase(stats, phaseName, func() error {
 				protectedRootIDs, protectedSystemRootIDs := db.compactStorageLeafGenerationProtectedRootIDPair(opts)
@@ -990,9 +994,118 @@ func compactStorageLeafPackSelectionErrorMeansNoDebt(err error) bool {
 
 const compactStorageLeafPackSkipRunCreated = "compact_storage_run_created"
 
-func (db *DB) compactStorageLeafGenerationPackRunOnce(ctx context.Context, opts LeafGenerationPackFromPlanOptions, lockMaintenance bool, ignoredRawFileIDs map[uint32]struct{}) (LeafGenerationPackRunOnceStats, error) {
+type compactStorageLeafPackPlanState struct {
+	key   treeReachabilityCacheKey
+	live  leafGenerationLiveScanStats
+	valid bool
+}
+
+func (state *compactStorageLeafPackPlanState) invalidate() {
+	if state == nil {
+		return
+	}
+	*state = compactStorageLeafPackPlanState{}
+}
+
+func leafGenerationPlanStateKey(state *DBState, opts LeafGenerationPlanOptions) (treeReachabilityCacheKey, bool) {
+	key, ok := leafGenerationLiveStatsKeyForState(state)
+	if !ok {
+		return treeReachabilityCacheKey{}, false
+	}
+	if len(opts.ProtectedRootIDs) > 0 || len(opts.ProtectedSystemRootIDs) > 0 {
+		key.protectedRoots = leafGenerationProtectedRootsHash(opts.ProtectedRootIDs, opts.ProtectedSystemRootIDs)
+	}
+	return key, true
+}
+
+func (state *compactStorageLeafPackPlanState) resetFromPlan(plan LeafGenerationPlan) {
+	if state == nil || plan.liveStats.Generations == nil {
+		return
+	}
+	state.key = plan.stateKey
+	state.live = cloneLeafGenerationLiveScanStats(plan.liveStats)
+	state.valid = true
+}
+
+func (db *DB) compactStorageLeafGenerationPlan(ctx context.Context, opts LeafGenerationPlanOptions, carry *compactStorageLeafPackPlanState) (LeafGenerationPlan, error) {
+	if carry != nil && carry.valid {
+		published := db.state.Load()
+		key, ok := leafGenerationPlanStateKey(published, opts)
+		if ok && key == carry.key && published.LeafGenerations != nil && published.LeafGenerations.sourceManifest != nil {
+			plan := db.leafGenerationPlanFromLiveStats(opts, published, published.LeafGenerations.sourceManifest, carry.live)
+			plan.stateKey = key
+			plan.liveStats = cloneLeafGenerationLiveScanStats(carry.live)
+			return plan, nil
+		}
+		carry.invalidate()
+	}
+	plan, err := db.LeafGenerationPlan(ctx, opts)
+	if err != nil {
+		return plan, err
+	}
+	carry.resetFromPlan(plan)
+	return plan, nil
+}
+
+func (state *compactStorageLeafPackPlanState) advance(db *DB, pack LeafGenerationPackStats, result leafGenerationPackCarryResult) {
+	if state == nil || !state.valid || db == nil || pack.CopyAborts != 0 || result.publishedState == nil {
+		state.invalidate()
+		return
+	}
+	sourceKey := result.sourceStateKey
+	sourceKey.protectedRoots = state.key.protectedRoots
+	if sourceKey != state.key || result.publishedState.LeafGenerations == nil {
+		state.invalidate()
+		return
+	}
+
+	live := cloneLeafGenerationLiveScanStats(state.live)
+	for generationID, moved := range result.sourceLiveMovedByGeneration {
+		remaining := live.Generations[generationID]
+		remaining.LivePages -= moved.LivePages
+		remaining.LiveBytes -= moved.LiveBytes
+		if remaining.LivePages < 0 {
+			remaining.LivePages = 0
+		}
+		if remaining.LiveBytes < 0 {
+			remaining.LiveBytes = 0
+		}
+		live.Generations[generationID] = remaining
+	}
+
+	createdGenerations := make(map[uint64]struct{})
+	view := result.publishedState.LeafGenerations
+	for _, rawFileID := range pack.CreatedFileIDs {
+		if generationID := view.FileToGeneration[rawFileID]; generationID != 0 {
+			createdGenerations[generationID] = struct{}{}
+		}
+	}
+	for generationID := range createdGenerations {
+		generation := view.Generations[generationID]
+		var bytesTotal int64
+		for _, rawFileID := range generation.FileIDs {
+			bytesTotal += leafGenerationRawFilePhysicalSize(db.dir, result.publishedState.ValueLogSet, rawFileID)
+		}
+		live.Generations[generationID] = leafGenerationLiveTotals{
+			LivePages: max(1, len(generation.FileIDs)),
+			LiveBytes: bytesTotal,
+		}
+	}
+
+	key, ok := leafGenerationLiveStatsKeyForState(result.publishedState)
+	if !ok {
+		state.invalidate()
+		return
+	}
+	key.protectedRoots = state.key.protectedRoots
+	state.key = key
+	state.live = live
+	state.valid = true
+}
+
+func (db *DB) compactStorageLeafGenerationPackRunOnce(ctx context.Context, opts LeafGenerationPackFromPlanOptions, lockMaintenance bool, ignoredRawFileIDs map[uint32]struct{}, carry *compactStorageLeafPackPlanState) (LeafGenerationPackRunOnceStats, error) {
 	var stats LeafGenerationPackRunOnceStats
-	plan, err := db.LeafGenerationPlan(ctx, leafGenerationPackFromPlanPlanOptions(opts))
+	plan, err := db.compactStorageLeafGenerationPlan(ctx, leafGenerationPackFromPlanPlanOptions(opts), carry)
 	if err != nil {
 		return stats, err
 	}
@@ -1008,12 +1121,15 @@ func (db *DB) compactStorageLeafGenerationPackRunOnce(ctx context.Context, opts 
 		return stats, nil
 	}
 	stats.Selection = selection
-	packStats, err := db.leafGenerationPackSelected(ctx, leafGenerationPackFromPlanPackOptions(opts, selection.GenerationIDs), selectedLeafGenerationPackPlan(selection), lockMaintenance)
+	var carryResult leafGenerationPackCarryResult
+	packStats, err := db.leafGenerationPackSelectedWithCarry(ctx, leafGenerationPackFromPlanPackOptions(opts, selection.GenerationIDs), selectedLeafGenerationPackPlan(selection), lockMaintenance, &carryResult)
 	if err != nil {
+		carry.invalidate()
 		return stats, err
 	}
 	stats.Pack = packStats
 	stats.Ran = true
+	carry.advance(db, packStats, carryResult)
 	return stats, nil
 }
 

--- a/TreeDB/db/compact_storage_audit_test.go
+++ b/TreeDB/db/compact_storage_audit_test.go
@@ -362,7 +362,7 @@ func TestCompactStorageAudit_ProtectedRootsOnlyExtendLeafProjection(t *testing.T
 		t.Fatalf("legacy leaf plan: %v", err)
 	}
 	gotLeaf := db.compactStorageLeafGenerationPlanFromAudit(leafOpts, input, got.leafGenerationLive)
-	if !reflect.DeepEqual(gotLeaf, wantLeaf) {
+	if !reflect.DeepEqual(compactStorageAuditPublicLeafPlan(gotLeaf), compactStorageAuditPublicLeafPlan(wantLeaf)) {
 		t.Fatalf("leaf plan mismatch:\nshared=%+v\nlegacy=%+v", gotLeaf, wantLeaf)
 	}
 
@@ -521,9 +521,15 @@ func TestCompactStorageAudit_ProtectedPagerRootsMatchLegacyWithMemoReuse(t *test
 		t.Fatalf("legacy leaf plan: %v", err)
 	}
 	gotLeaf := db.compactStorageLeafGenerationPlanFromAudit(leafOpts, input, got.leafGenerationLive)
-	if !reflect.DeepEqual(gotLeaf, wantLeaf) {
+	if !reflect.DeepEqual(compactStorageAuditPublicLeafPlan(gotLeaf), compactStorageAuditPublicLeafPlan(wantLeaf)) {
 		t.Fatalf("leaf plan mismatch:\nshared=%+v\nlegacy=%+v", gotLeaf, wantLeaf)
 	}
+}
+
+func compactStorageAuditPublicLeafPlan(plan LeafGenerationPlan) LeafGenerationPlan {
+	plan.stateKey = treeReachabilityCacheKey{}
+	plan.liveStats = leafGenerationLiveScanStats{}
+	return plan
 }
 
 func TestCompactStorageAudit_ProtectedRootsDoNotPoisonTrackerOrSubsequentGC(t *testing.T) {

--- a/TreeDB/db/compact_storage_audit_test.go
+++ b/TreeDB/db/compact_storage_audit_test.go
@@ -973,7 +973,7 @@ func TestCompactStorageAudit_PendingSegmentExcludedFromFencedDebtAndSettle(t *te
 	}
 
 	var settleStats CompactStorageStats
-	if err := db.settleCompactStorageGC(context.Background(), opts, &settleStats, true, nil, nil, 0, session); err != nil {
+	if err := db.settleCompactStorageGC(context.Background(), opts, &settleStats, true, nil, nil, 0, session, nil); err != nil {
 		t.Fatalf("settleCompactStorageGC: %v", err)
 	}
 	if len(settleStats.Phases) != 0 {

--- a/TreeDB/db/compact_storage_bench_test.go
+++ b/TreeDB/db/compact_storage_bench_test.go
@@ -10,6 +10,8 @@ import (
 
 func BenchmarkCompactStorageLeafPackMultiPass(b *testing.B) {
 	var liveScans, packPasses atomic.Uint64
+	var packPhaseNanos, packApplyNanos, packCopyNanos int64
+	var packPublishWaitNanos, packPublishHoldNanos int64
 	unregister := registerLeafGenerationLiveScanHook(func() { liveScans.Add(1) })
 	defer unregister()
 
@@ -44,6 +46,17 @@ func BenchmarkCompactStorageLeafPackMultiPass(b *testing.B) {
 			_ = db.Close()
 			b.Fatalf("ran leaf-pack passes=%d want at least 3", ranPacks)
 		}
+		for _, phase := range stats.Phases {
+			if len(phase.Name) >= len("leaf-generation-pack-") && phase.Name[:len("leaf-generation-pack-")] == "leaf-generation-pack-" {
+				packPhaseNanos += phase.WallTimeNanos
+			}
+		}
+		for _, pack := range stats.LeafGenerationPacks {
+			packApplyNanos += pack.Pack.WallTimeNanos
+			packCopyNanos += pack.Pack.CopyTimeNanos
+			packPublishWaitNanos += pack.Pack.PublishWaitNanos
+			packPublishHoldNanos += pack.Pack.PublishHoldNanos
+		}
 		db.compactStorageAfterPhase = nil
 		if err := db.Close(); err != nil {
 			b.Fatalf("close: %v", err)
@@ -53,6 +66,11 @@ func BenchmarkCompactStorageLeafPackMultiPass(b *testing.B) {
 	if b.N > 0 {
 		b.ReportMetric(float64(liveScans.Load())/float64(b.N), "live_scans/op")
 		b.ReportMetric(float64(packPasses.Load())/float64(b.N), "pack_passes/op")
+		b.ReportMetric(float64(packPhaseNanos)/float64(b.N), "pack_phase_ns/op")
+		b.ReportMetric(float64(packApplyNanos)/float64(b.N), "pack_apply_ns/op")
+		b.ReportMetric(float64(packCopyNanos)/float64(b.N), "pack_copy_ns/op")
+		b.ReportMetric(float64(packPublishWaitNanos)/float64(b.N), "pack_publish_wait_ns/op")
+		b.ReportMetric(float64(packPublishHoldNanos)/float64(b.N), "pack_publish_hold_ns/op")
 	}
 }
 

--- a/TreeDB/db/compact_storage_bench_test.go
+++ b/TreeDB/db/compact_storage_bench_test.go
@@ -4,8 +4,95 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"sync/atomic"
 	"testing"
 )
+
+func BenchmarkCompactStorageLeafPackMultiPass(b *testing.B) {
+	var liveScans, packPasses atomic.Uint64
+	unregister := registerLeafGenerationLiveScanHook(func() { liveScans.Add(1) })
+	defer unregister()
+
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		b.StopTimer()
+		db := openCompactStorageLeafPackBenchmarkFixture(b)
+		db.compactStorageAfterPhase = func(name string) {
+			if len(name) >= len("leaf-generation-pack-") && name[:len("leaf-generation-pack-")] == "leaf-generation-pack-" {
+				packPasses.Add(1)
+			}
+		}
+		b.StartTimer()
+
+		stats, err := db.CompactStorage(context.Background(), CompactStorageOptions{
+			LeafPackMaxPasses:             4,
+			LeafPackMaxGenerationsPerPass: 1,
+			LeafPackMinReclaimPerCopyPPM:  1,
+		})
+		b.StopTimer()
+		if err != nil {
+			_ = db.Close()
+			b.Fatalf("CompactStorage: %v", err)
+		}
+		ranPacks := 0
+		for _, pack := range stats.LeafGenerationPacks {
+			if pack.Ran {
+				ranPacks++
+			}
+		}
+		if ranPacks < 3 {
+			_ = db.Close()
+			b.Fatalf("ran leaf-pack passes=%d want at least 3", ranPacks)
+		}
+		db.compactStorageAfterPhase = nil
+		if err := db.Close(); err != nil {
+			b.Fatalf("close: %v", err)
+		}
+		b.StartTimer()
+	}
+	if b.N > 0 {
+		b.ReportMetric(float64(liveScans.Load())/float64(b.N), "live_scans/op")
+		b.ReportMetric(float64(packPasses.Load())/float64(b.N), "pack_passes/op")
+	}
+}
+
+func openCompactStorageLeafPackBenchmarkFixture(b *testing.B) *DB {
+	b.Helper()
+	dir := b.TempDir()
+	db, err := Open(Options{
+		Dir:                        dir,
+		Durability:                 DurabilityWALOffRelaxed,
+		DisableBackgroundPrune:     true,
+		IndexOuterLeavesInValueLog: true,
+		LeafPrefixCompression:      true,
+		IndexColumnarLeaves:        true,
+		IndexPackedValuePtr:        true,
+	})
+	if err != nil {
+		b.Fatalf("Open: %v", err)
+	}
+	leafLog := newRewriteWriter(ValueLogDirPath(dir), 0, 0, 64<<20)
+	leafLog.ConfigureLeafLog(LeafLogDirPath(dir), rewriteLeafLogLaneID, 0)
+	db.SetLeafPageLog(leafLog)
+
+	for generation := 0; generation < 4; generation++ {
+		writeLeafGenerationBenchKeyRange(b, db, "shared", 0, 4096, byte('a'+generation))
+		writeLeafGenerationBenchKeyRange(b, db, fmt.Sprintf("keep-%d", generation), 0, 64, byte('k'+generation))
+		if generation < 3 {
+			if err := leafLog.rotateLeaf(); err != nil {
+				_ = leafLog.Close()
+				_ = db.Close()
+				b.Fatalf("rotateLeaf generation %d: %v", generation, err)
+			}
+		}
+	}
+	db.SetLeafPageLog(nil)
+	if err := leafLog.Close(); err != nil {
+		_ = db.Close()
+		b.Fatalf("close leaf log: %v", err)
+	}
+	return db
+}
 
 func BenchmarkCompactStorageRewritePolicyMostlyLivePlan(b *testing.B) {
 	db := openCompactStorageRewritePolicyBenchmarkFixture(b, 2047, 1, 1024)

--- a/TreeDB/db/compact_storage_test.go
+++ b/TreeDB/db/compact_storage_test.go
@@ -2504,6 +2504,220 @@ func TestCompactStorageStopsLeafPackOnLowYieldResidualWithinPassBudget(t *testin
 	}
 }
 
+func TestCompactStorageLeafPackMultiPassReusesLiveScan(t *testing.T) {
+	d, leafLog, _ := openLeafGenerationPackTestDB(t)
+
+	writeLeafGenerationKeys(t, d, "left", 2048, 'a')
+	if err := leafLog.rotateLeaf(); err != nil {
+		t.Fatalf("rotateLeaf left: %v", err)
+	}
+	writeLeafGenerationKeyRange(t, d, "left", 0, 1024, 'b')
+
+	writeLeafGenerationKeys(t, d, "right", 2048, 'c')
+	if err := leafLog.rotateLeaf(); err != nil {
+		t.Fatalf("rotateLeaf right: %v", err)
+	}
+	writeLeafGenerationKeyRange(t, d, "right", 0, 1024, 'd')
+	writeLeafGenerationKeys(t, d, "current", 16, 'e')
+	d.SetLeafPageLog(nil)
+
+	scans := withLeafGenerationLiveScanCounter(t)
+	var scansAfterFirst, scansAfterSecond uint64
+	d.compactStorageAfterPhase = func(name string) {
+		switch name {
+		case "leaf-generation-pack-1":
+			scansAfterFirst = scans.Load()
+		case "leaf-generation-pack-2":
+			scansAfterSecond = scans.Load()
+		}
+	}
+	t.Cleanup(func() { d.compactStorageAfterPhase = nil })
+	stats, err := d.CompactStorage(context.Background(), CompactStorageOptions{
+		LeafPackMaxPasses:             3,
+		LeafPackMaxGenerationsPerPass: 1,
+		LeafPackMinReclaimPerCopyPPM:  1,
+	})
+	if err != nil {
+		t.Fatalf("CompactStorage: %v", err)
+	}
+	if got := compactStorageRanLeafPackCount(stats.LeafGenerationPacks); got < 2 {
+		t.Fatalf("ran leaf-pack passes=%d want at least 2, packs=%+v", got, stats.LeafGenerationPacks)
+	}
+	if scansAfterFirst == 0 || scansAfterSecond == 0 {
+		t.Fatalf("missing pack scan observations: after_first=%d after_second=%d", scansAfterFirst, scansAfterSecond)
+	}
+	if got, want := scansAfterSecond, scansAfterFirst; got != want {
+		t.Fatalf("second unchanged pack scan count=%d want unchanged from first=%d", got, want)
+	}
+}
+
+func TestCompactStorageLeafPackMultiPassRescansAfterForegroundCommit(t *testing.T) {
+	d, leafLog, _ := openLeafGenerationPackTestDB(t)
+
+	writeLeafGenerationKeys(t, d, "left", 2048, 'a')
+	if err := leafLog.rotateLeaf(); err != nil {
+		t.Fatalf("rotateLeaf left: %v", err)
+	}
+	writeLeafGenerationKeyRange(t, d, "left", 0, 1024, 'b')
+
+	writeLeafGenerationKeys(t, d, "right", 2048, 'c')
+	if err := leafLog.rotateLeaf(); err != nil {
+		t.Fatalf("rotateLeaf right: %v", err)
+	}
+	writeLeafGenerationKeyRange(t, d, "right", 0, 1024, 'd')
+	writeLeafGenerationKeys(t, d, "current", 16, 'e')
+	d.SetLeafPageLog(nil)
+
+	scans := withLeafGenerationLiveScanCounter(t)
+	injected := false
+	var scansAfterFirst, scansAfterSecond uint64
+	d.compactStorageAfterPhase = func(name string) {
+		switch name {
+		case "leaf-generation-pack-1":
+			scansAfterFirst = scans.Load()
+			if injected {
+				return
+			}
+			injected = true
+			state := d.State()
+			if state == nil {
+				t.Fatal("missing state before foreground commit")
+			}
+			if err := d.Commit(state.RootPageID); err != nil {
+				t.Fatalf("foreground same-root commit: %v", err)
+			}
+		case "leaf-generation-pack-2":
+			scansAfterSecond = scans.Load()
+		}
+	}
+	t.Cleanup(func() { d.compactStorageAfterPhase = nil })
+
+	stats, err := d.CompactStorage(context.Background(), CompactStorageOptions{
+		LeafPackMaxPasses:             3,
+		LeafPackMaxGenerationsPerPass: 1,
+		LeafPackMinReclaimPerCopyPPM:  1,
+	})
+	if err != nil {
+		t.Fatalf("CompactStorage: %v", err)
+	}
+	if !injected {
+		t.Fatal("foreground commit hook did not run")
+	}
+	if got := compactStorageRanLeafPackCount(stats.LeafGenerationPacks); got < 2 {
+		t.Fatalf("ran leaf-pack passes=%d want at least 2, packs=%+v", got, stats.LeafGenerationPacks)
+	}
+	if scansAfterFirst == 0 || scansAfterSecond == 0 {
+		t.Fatalf("missing pack scan observations: after_first=%d after_second=%d", scansAfterFirst, scansAfterSecond)
+	}
+	if got, want := scansAfterSecond, scansAfterFirst+1; got != want {
+		t.Fatalf("second dirty pack scan count=%d want one more than first=%d", got, scansAfterFirst)
+	}
+}
+
+func TestCompactStorageLeafPackCarryMatchesFreshPlan(t *testing.T) {
+	d, leafLog, _ := openLeafGenerationPackTestDB(t)
+
+	writeLeafGenerationKeys(t, d, "left", 2048, 'a')
+	if err := leafLog.rotateLeaf(); err != nil {
+		t.Fatalf("rotateLeaf left: %v", err)
+	}
+	writeLeafGenerationKeyRange(t, d, "left", 0, 1024, 'b')
+	writeLeafGenerationKeys(t, d, "right", 2048, 'c')
+	if err := leafLog.rotateLeaf(); err != nil {
+		t.Fatalf("rotateLeaf right: %v", err)
+	}
+	writeLeafGenerationKeyRange(t, d, "right", 0, 1024, 'd')
+	writeLeafGenerationKeys(t, d, "current", 16, 'e')
+	d.SetLeafPageLog(nil)
+
+	assertCompactStorageLeafPackCarryMatchesFreshPlan(t, d, nil, nil)
+}
+
+func TestCompactStorageLeafPackCarryMatchesFreshPlanWithProtectedResidual(t *testing.T) {
+	d, leafLog, _ := openLeafGenerationPackTestDB(t)
+
+	writeLeafGenerationKeys(t, d, "main", 2048, 'a')
+	detachedTable := mustFrozenSystemMemtable(t, systemRangeKVs(512, nil)...)
+	detachedRoot, err := d.PublishOrderedRootIterator(0, detachedTable.NewIterator(nil, nil))
+	if err != nil {
+		t.Fatalf("PublishOrderedRootIterator: %v", err)
+	}
+	if detachedRoot == 0 {
+		t.Fatal("expected detached protected root")
+	}
+	if err := leafLog.rotateLeaf(); err != nil {
+		t.Fatalf("rotateLeaf: %v", err)
+	}
+	writeLeafGenerationKeyRange(t, d, "main", 0, 1024, 'b')
+	writeLeafGenerationKeys(t, d, "current", 16, 'c')
+	d.SetLeafPageLog(nil)
+
+	assertCompactStorageLeafPackCarryMatchesFreshPlan(t, d, []uint64{detachedRoot}, nil)
+}
+
+func assertCompactStorageLeafPackCarryMatchesFreshPlan(t *testing.T, d *DB, protectedRootIDs, protectedSystemRootIDs []uint64) {
+	t.Helper()
+	opts := compactStorageLeafPackFromPlanOptions(normalizeCompactStorageOptions(CompactStorageOptions{
+		LeafPackMaxPasses:             2,
+		LeafPackMaxGenerationsPerPass: 1,
+		LeafPackMinReclaimPerCopyPPM:  1,
+	}), protectedRootIDs, protectedSystemRootIDs)
+	ignored := make(map[uint32]struct{})
+	var carry compactStorageLeafPackPlanState
+
+	first, err := d.compactStorageLeafGenerationPackRunOnce(context.Background(), opts, true, ignored, &carry)
+	if err != nil {
+		t.Fatalf("first leaf pack: %v", err)
+	}
+	if !first.Ran {
+		t.Fatalf("first leaf pack skipped: %+v", first)
+	}
+	compactStorageRememberLeafPackCreatedFileIDs(ignored, first)
+	pin := d.AcquireSnapshot()
+	if pin == nil {
+		t.Fatal("expected snapshot pin before carried plan")
+	}
+	defer func() { _ = pin.Close() }()
+
+	planOpts := leafGenerationPackFromPlanPlanOptions(opts)
+	carried, err := d.compactStorageLeafGenerationPlan(context.Background(), planOpts, &carry)
+	if err != nil {
+		t.Fatalf("carried plan: %v", err)
+	}
+	fresh, err := d.LeafGenerationPlan(context.Background(), planOpts)
+	if err != nil {
+		t.Fatalf("fresh plan: %v", err)
+	}
+	carried = compactStorageFilterIgnoredLeafPackPlan(carried, opts, ignored)
+	fresh = compactStorageFilterIgnoredLeafPackPlan(fresh, opts, ignored)
+
+	if !reflect.DeepEqual(carried.Candidates, fresh.Candidates) {
+		t.Fatalf("carried candidates differ from fresh scan:\ncarried=%+v\nfresh=%+v", carried.Candidates, fresh.Candidates)
+	}
+	if !reflect.DeepEqual(carried.CandidateGenerationIDs, fresh.CandidateGenerationIDs) ||
+		carried.CandidateBytesTotal != fresh.CandidateBytesTotal ||
+		carried.CandidateBytesLive != fresh.CandidateBytesLive ||
+		carried.CandidateBytesDead != fresh.CandidateBytesDead ||
+		carried.CandidateBytesToCopy != fresh.CandidateBytesToCopy ||
+		carried.CandidateLivePages != fresh.CandidateLivePages ||
+		carried.ExpectedReclaimBytes != fresh.ExpectedReclaimBytes ||
+		carried.ExpectedReclaimRatioPPM != fresh.ExpectedReclaimRatioPPM ||
+		carried.ExpectedReclaimPerByteCopiedPPM != fresh.ExpectedReclaimPerByteCopiedPPM ||
+		carried.Admission != fresh.Admission {
+		t.Fatalf("carried aggregate differs from fresh scan:\ncarried=%+v\nfresh=%+v", carried, fresh)
+	}
+}
+
+func compactStorageRanLeafPackCount(packs []LeafGenerationPackRunOnceStats) int {
+	ran := 0
+	for _, pack := range packs {
+		if pack.Ran {
+			ran++
+		}
+	}
+	return ran
+}
+
 func TestCompactStoragePlanIgnoresEmptyAndCurrentLeafGenerations(t *testing.T) {
 	d, leafLog, _ := openLeafGenerationPackTestDB(t)
 	d.SetLeafPageLog(nil)

--- a/TreeDB/db/compact_storage_test.go
+++ b/TreeDB/db/compact_storage_test.go
@@ -2655,6 +2655,48 @@ func TestCompactStorageLeafPackCarryMatchesFreshPlanWithProtectedResidual(t *tes
 	assertCompactStorageLeafPackCarryMatchesFreshPlan(t, d, []uint64{detachedRoot}, nil)
 }
 
+func TestCompactStorageLeafPackCarryRescansWhenProtectedRootsChange(t *testing.T) {
+	d, leafLog, _ := openLeafGenerationPackTestDB(t)
+
+	writeLeafGenerationKeys(t, d, "main", 512, 'a')
+	if err := leafLog.rotateLeaf(); err != nil {
+		t.Fatalf("rotateLeaf: %v", err)
+	}
+	writeLeafGenerationKeyRange(t, d, "main", 0, 256, 'b')
+	d.SetLeafPageLog(nil)
+
+	published := d.State()
+	if published == nil || published.RootPageID == 0 {
+		t.Fatal("expected published root")
+	}
+	opts := leafGenerationPackFromPlanPlanOptions(compactStorageLeafPackFromPlanOptions(
+		normalizeCompactStorageOptions(CompactStorageOptions{
+			LeafPackMaxGenerationsPerPass: 1,
+			LeafPackMinReclaimPerCopyPPM:  1,
+		}),
+		nil,
+		nil,
+	))
+
+	scans := withLeafGenerationLiveScanCounter(t)
+	var carry compactStorageLeafPackPlanState
+	if _, err := d.compactStorageLeafGenerationPlan(context.Background(), opts, &carry); err != nil {
+		t.Fatalf("initial carried plan: %v", err)
+	}
+	initialScans := scans.Load()
+	if initialScans == 0 {
+		t.Fatal("initial plan did not perform a live scan")
+	}
+
+	opts.ProtectedRootIDs = []uint64{published.RootPageID}
+	if _, err := d.compactStorageLeafGenerationPlan(context.Background(), opts, &carry); err != nil {
+		t.Fatalf("changed protected-root plan: %v", err)
+	}
+	if got, want := scans.Load(), initialScans+1; got != want {
+		t.Fatalf("changed protected roots live scans=%d want %d", got, want)
+	}
+}
+
 func assertCompactStorageLeafPackCarryMatchesFreshPlan(t *testing.T, d *DB, protectedRootIDs, protectedSystemRootIDs []uint64) {
 	t.Helper()
 	opts := compactStorageLeafPackFromPlanOptions(normalizeCompactStorageOptions(CompactStorageOptions{

--- a/TreeDB/db/compact_storage_test.go
+++ b/TreeDB/db/compact_storage_test.go
@@ -2655,6 +2655,59 @@ func TestCompactStorageLeafPackCarryMatchesFreshPlanWithProtectedResidual(t *tes
 	assertCompactStorageLeafPackCarryMatchesFreshPlan(t, d, []uint64{detachedRoot}, nil)
 }
 
+func TestCompactStorageLeafPackCarryRescansWhenProtectedRootIsRewritten(t *testing.T) {
+	d, leafLog, _ := openLeafGenerationPackTestDB(t)
+
+	writeLeafGenerationKeys(t, d, "main", 2048, 'a')
+	if err := leafLog.rotateLeaf(); err != nil {
+		t.Fatalf("rotateLeaf: %v", err)
+	}
+	writeLeafGenerationKeyRange(t, d, "main", 0, 1024, 'b')
+	writeLeafGenerationKeys(t, d, "current", 16, 'c')
+	d.SetLeafPageLog(nil)
+
+	published := d.State()
+	if published == nil || published.RootPageID == 0 {
+		t.Fatal("expected published root")
+	}
+	opts := compactStorageLeafPackFromPlanOptions(normalizeCompactStorageOptions(CompactStorageOptions{
+		LeafPackMaxPasses:             2,
+		LeafPackMaxGenerationsPerPass: 1,
+		LeafPackMinReclaimPerCopyPPM:  1,
+	}), []uint64{published.RootPageID}, nil)
+	ignored := make(map[uint32]struct{})
+	var carry compactStorageLeafPackPlanState
+	scans := withLeafGenerationLiveScanCounter(t)
+
+	first, err := d.compactStorageLeafGenerationPackRunOnce(context.Background(), opts, true, ignored, &carry)
+	if err != nil {
+		t.Fatalf("first leaf pack: %v", err)
+	}
+	if !first.Ran {
+		t.Fatalf("first leaf pack skipped: %+v", first)
+	}
+	compactStorageRememberLeafPackCreatedFileIDs(ignored, first)
+	scansAfterPack := scans.Load()
+
+	planOpts := leafGenerationPackFromPlanPlanOptions(opts)
+	carried, err := d.compactStorageLeafGenerationPlan(context.Background(), planOpts, &carry)
+	if err != nil {
+		t.Fatalf("post-pack plan: %v", err)
+	}
+	if got, want := scans.Load(), scansAfterPack+1; got != want {
+		t.Fatalf("post-pack live scans=%d want %d", got, want)
+	}
+	fresh, err := d.LeafGenerationPlan(context.Background(), planOpts)
+	if err != nil {
+		t.Fatalf("fresh plan: %v", err)
+	}
+	carried = compactStorageFilterIgnoredLeafPackPlan(carried, opts, ignored)
+	fresh = compactStorageFilterIgnoredLeafPackPlan(fresh, opts, ignored)
+	if !reflect.DeepEqual(compactStorageAuditPublicLeafPlan(carried), compactStorageAuditPublicLeafPlan(fresh)) {
+		t.Fatalf("post-pack plan differs from fresh scan:\ncarried=%+v\nfresh=%+v", carried, fresh)
+	}
+}
+
 func TestCompactStorageLeafPackCarryRescansWhenProtectedRootsChange(t *testing.T) {
 	d, leafLog, _ := openLeafGenerationPackTestDB(t)
 

--- a/TreeDB/db/db.go
+++ b/TreeDB/db/db.go
@@ -581,6 +581,7 @@ type treeReachabilityCacheKey struct {
 	rootID              uint64
 	systemRoot          uint64
 	leafGenerationStamp uint64
+	protectedRoots      [32]byte
 }
 
 type leafGenerationLiveStatsCache struct {

--- a/TreeDB/db/leaf_generation_pack.go
+++ b/TreeDB/db/leaf_generation_pack.go
@@ -95,10 +95,11 @@ type LeafGenerationPackStats struct {
 }
 
 type leafGenerationPackCarryResult struct {
-	sourceStateKey              treeReachabilityCacheKey
-	publishedState              *DBState
-	trackSourceLiveMoved        bool
-	sourceLiveMovedByGeneration map[uint64]leafGenerationLiveTotals
+	sourceStateKey                         treeReachabilityCacheKey
+	publishedState                         *DBState
+	trackSourceLiveMoved                   bool
+	protectedRootsOverlapSourceMaintenance bool
+	sourceLiveMovedByGeneration            map[uint64]leafGenerationLiveTotals
 }
 
 // LeafGenerationPack rewrites live leaf-log pages from sealed source generations
@@ -275,8 +276,10 @@ func (db *DB) leafGenerationPackLocked(ctx context.Context, opts LeafGenerationP
 		}
 
 		rewriteStats := leafRefRewriteRunStats{
-			trackCarry:           carry != nil,
-			trackSourceLiveMoved: carry != nil && (len(opts.ProtectedRootIDs) > 0 || len(opts.ProtectedSystemRootIDs) > 0),
+			trackCarry:             carry != nil,
+			trackSourceLiveMoved:   carry != nil && (len(opts.ProtectedRootIDs) > 0 || len(opts.ProtectedSystemRootIDs) > 0),
+			protectedRootIDs:       opts.ProtectedRootIDs,
+			protectedSystemRootIDs: opts.ProtectedSystemRootIDs,
 		}
 		copied, copiedBytes, rewriteErr := db.rewriteLeafRefsOnline(ctx, writer, ridAlloc, sourceValueIDs, nil, 0, 0, false, 0, opts.Sync, normalizeLeafGenerationPackLeafFrameK(opts.LeafFrameK), attempt, &rewriteStats)
 		closeErr := writer.Close()
@@ -289,6 +292,7 @@ func (db *DB) leafGenerationPackLocked(ctx context.Context, opts LeafGenerationP
 			carry.sourceStateKey = rewriteStats.sourceStateKey
 			carry.publishedState = rewriteStats.publishedState
 			carry.trackSourceLiveMoved = rewriteStats.trackSourceLiveMoved
+			carry.protectedRootsOverlapSourceMaintenance = rewriteStats.protectedRootsOverlapSourceMaintenance
 			carry.sourceLiveMovedByGeneration = cloneLeafGenerationLiveTotalsMap(rewriteStats.sourceLiveMovedByGeneration)
 		}
 		if errors.Is(rewriteErr, errLeafGenerationPackPublishConflict) {

--- a/TreeDB/db/leaf_generation_pack.go
+++ b/TreeDB/db/leaf_generation_pack.go
@@ -97,6 +97,7 @@ type LeafGenerationPackStats struct {
 type leafGenerationPackCarryResult struct {
 	sourceStateKey              treeReachabilityCacheKey
 	publishedState              *DBState
+	trackSourceLiveMoved        bool
 	sourceLiveMovedByGeneration map[uint64]leafGenerationLiveTotals
 }
 
@@ -273,7 +274,10 @@ func (db *DB) leafGenerationPackLocked(ctx context.Context, opts LeafGenerationP
 			writer.SetLeafDictMode(leafDictID, leafDictBytes, leafDictUseRawPages)
 		}
 
-		rewriteStats := leafRefRewriteRunStats{trackSourceLiveMoved: carry != nil}
+		rewriteStats := leafRefRewriteRunStats{
+			trackCarry:           carry != nil,
+			trackSourceLiveMoved: carry != nil && (len(opts.ProtectedRootIDs) > 0 || len(opts.ProtectedSystemRootIDs) > 0),
+		}
 		copied, copiedBytes, rewriteErr := db.rewriteLeafRefsOnline(ctx, writer, ridAlloc, sourceValueIDs, nil, 0, 0, false, 0, opts.Sync, normalizeLeafGenerationPackLeafFrameK(opts.LeafFrameK), attempt, &rewriteStats)
 		closeErr := writer.Close()
 		removeErr := removeLeafGenerationPackStagingDirFn(stagingDir)
@@ -284,6 +288,7 @@ func (db *DB) leafGenerationPackLocked(ctx context.Context, opts LeafGenerationP
 		if carry != nil {
 			carry.sourceStateKey = rewriteStats.sourceStateKey
 			carry.publishedState = rewriteStats.publishedState
+			carry.trackSourceLiveMoved = rewriteStats.trackSourceLiveMoved
 			carry.sourceLiveMovedByGeneration = cloneLeafGenerationLiveTotalsMap(rewriteStats.sourceLiveMovedByGeneration)
 		}
 		if errors.Is(rewriteErr, errLeafGenerationPackPublishConflict) {

--- a/TreeDB/db/leaf_generation_pack.go
+++ b/TreeDB/db/leaf_generation_pack.go
@@ -94,6 +94,12 @@ type LeafGenerationPackStats struct {
 	WallTimeNanos                   int64
 }
 
+type leafGenerationPackCarryResult struct {
+	sourceStateKey              treeReachabilityCacheKey
+	publishedState              *DBState
+	sourceLiveMovedByGeneration map[uint64]leafGenerationLiveTotals
+}
+
 // LeafGenerationPack rewrites live leaf-log pages from sealed source generations
 // into a fresh leaf-log output so the old generations can later be reclaimed by
 // ordinary generation GC.
@@ -137,10 +143,14 @@ func (db *DB) LeafGenerationPack(ctx context.Context, opts LeafGenerationPackOpt
 	if err != nil {
 		return stats, err
 	}
-	return db.leafGenerationPackLocked(ctx, opts, selectedPlan, stats)
+	return db.leafGenerationPackLocked(ctx, opts, selectedPlan, stats, nil)
 }
 
 func (db *DB) leafGenerationPackSelected(ctx context.Context, opts LeafGenerationPackOptions, selectedPlan LeafGenerationPlan, lockMaintenance bool) (stats LeafGenerationPackStats, err error) {
+	return db.leafGenerationPackSelectedWithCarry(ctx, opts, selectedPlan, lockMaintenance, nil)
+}
+
+func (db *DB) leafGenerationPackSelectedWithCarry(ctx context.Context, opts LeafGenerationPackOptions, selectedPlan LeafGenerationPlan, lockMaintenance bool, carry *leafGenerationPackCarryResult) (stats LeafGenerationPackStats, err error) {
 	if db == nil {
 		return stats, fmt.Errorf("missing db")
 	}
@@ -178,10 +188,10 @@ func (db *DB) leafGenerationPackSelected(ctx context.Context, opts LeafGeneratio
 	stats.ExpectedReclaimBytes = selectedPlan.ExpectedReclaimBytes
 	stats.ExpectedReclaimRatioPPM = selectedPlan.ExpectedReclaimRatioPPM
 	stats.ExpectedReclaimPerByteCopiedPPM = selectedPlan.ExpectedReclaimPerByteCopiedPPM
-	return db.leafGenerationPackLocked(ctx, opts, selectedPlan, stats)
+	return db.leafGenerationPackLocked(ctx, opts, selectedPlan, stats, carry)
 }
 
-func (db *DB) leafGenerationPackLocked(ctx context.Context, opts LeafGenerationPackOptions, selectedPlan LeafGenerationPlan, stats LeafGenerationPackStats) (LeafGenerationPackStats, error) {
+func (db *DB) leafGenerationPackLocked(ctx context.Context, opts LeafGenerationPackOptions, selectedPlan LeafGenerationPlan, stats LeafGenerationPackStats, carry *leafGenerationPackCarryResult) (LeafGenerationPackStats, error) {
 	rawSourceIDs, matchedGenerations, err := db.resolveLeafGenerationPackSourceFileIDs(opts.GenerationIDs)
 	if err != nil {
 		return stats, err
@@ -263,7 +273,7 @@ func (db *DB) leafGenerationPackLocked(ctx context.Context, opts LeafGenerationP
 			writer.SetLeafDictMode(leafDictID, leafDictBytes, leafDictUseRawPages)
 		}
 
-		var rewriteStats leafRefRewriteRunStats
+		rewriteStats := leafRefRewriteRunStats{trackSourceLiveMoved: carry != nil}
 		copied, copiedBytes, rewriteErr := db.rewriteLeafRefsOnline(ctx, writer, ridAlloc, sourceValueIDs, nil, 0, 0, false, 0, opts.Sync, normalizeLeafGenerationPackLeafFrameK(opts.LeafFrameK), attempt, &rewriteStats)
 		closeErr := writer.Close()
 		removeErr := removeLeafGenerationPackStagingDirFn(stagingDir)
@@ -271,6 +281,11 @@ func (db *DB) leafGenerationPackLocked(ctx context.Context, opts LeafGenerationP
 		stats.PublishWaitNanos += rewriteStats.PublishWaitNanos
 		stats.PublishHoldNanos += rewriteStats.PublishHoldNanos
 		stats.PrivatePagesAllocated += rewriteStats.PrivatePages
+		if carry != nil {
+			carry.sourceStateKey = rewriteStats.sourceStateKey
+			carry.publishedState = rewriteStats.publishedState
+			carry.sourceLiveMovedByGeneration = cloneLeafGenerationLiveTotalsMap(rewriteStats.sourceLiveMovedByGeneration)
+		}
 		if errors.Is(rewriteErr, errLeafGenerationPackPublishConflict) {
 			stats.CopyAborts++
 			stats.RetryCopyTimeNanos += rewriteStats.CopyTimeNanos

--- a/TreeDB/db/leaf_generation_pack_rewrite.go
+++ b/TreeDB/db/leaf_generation_pack_rewrite.go
@@ -1277,7 +1277,7 @@ func (db *DB) rewriteLeafRefsOnline(ctx context.Context, writer *rewriteWriter, 
 	if db.indexOuterLeavesInValueLog {
 		leafCtx.zipper.SetLeafPageLog(&leafRefRewritePageAppender{ctx: leafCtx})
 	}
-	if runStats != nil && runStats.trackSourceLiveMoved {
+	if runStats != nil {
 		defer func() {
 			runStats.InternalPagesVisited = leafCtx.internalVisited
 			runStats.SubtreesPruned = leafCtx.subtreesPruned

--- a/TreeDB/db/leaf_generation_pack_rewrite.go
+++ b/TreeDB/db/leaf_generation_pack_rewrite.go
@@ -188,20 +188,23 @@ func (a *leafRefRewritePageAppender) AppendLeafPage(leafPage []byte) (page.LeafL
 }
 
 type leafRefRewriteRunStats struct {
-	InternalPagesVisited        int
-	SubtreesPruned              int
-	LeafFramesWritten           int
-	MaxLeafFrameK               int
-	CopyTimeNanos               int64
-	PublishWaitNanos            int64
-	PublishHoldNanos            int64
-	PrivatePages                int
-	PublishConflict             bool
-	trackCarry                  bool
-	trackSourceLiveMoved        bool
-	sourceStateKey              treeReachabilityCacheKey
-	publishedState              *DBState
-	sourceLiveMovedByGeneration map[uint64]leafGenerationLiveTotals
+	InternalPagesVisited                   int
+	SubtreesPruned                         int
+	LeafFramesWritten                      int
+	MaxLeafFrameK                          int
+	CopyTimeNanos                          int64
+	PublishWaitNanos                       int64
+	PublishHoldNanos                       int64
+	PrivatePages                           int
+	PublishConflict                        bool
+	trackCarry                             bool
+	trackSourceLiveMoved                   bool
+	protectedRootIDs                       []uint64
+	protectedSystemRootIDs                 []uint64
+	sourceStateKey                         treeReachabilityCacheKey
+	publishedState                         *DBState
+	protectedRootsOverlapSourceMaintenance bool
+	sourceLiveMovedByGeneration            map[uint64]leafGenerationLiveTotals
 }
 
 type leafGenerationPackCopyPhase uint8
@@ -1196,6 +1199,17 @@ func (db *DB) rewriteLeafRefsOnline(ctx context.Context, writer *rewriteWriter, 
 	basis := captureLeafGenerationPackCopyBasis(snap, sourceIDs, singleSourceID, hasSingleSourceID)
 	if runStats != nil && runStats.trackCarry {
 		runStats.sourceStateKey, _ = leafGenerationLiveStatsKeyForState(snap.state)
+		if runStats.trackSourceLiveMoved {
+			runStats.protectedRootsOverlapSourceMaintenance, err = leafGenerationProtectedRootsOverlapMaintenance(
+				ctx,
+				snap,
+				runStats.protectedRootIDs,
+				runStats.protectedSystemRootIDs,
+			)
+			if err != nil {
+				return 0, 0, fmt.Errorf("leaf generation pack: compare protected roots with source maintenance roots: %w", err)
+			}
+		}
 	}
 
 	stagingPager, err := pager.NewOverlay(db.chunkSize, leafGenerationPackPrivatePageIDBase, idx.pager)

--- a/TreeDB/db/leaf_generation_pack_rewrite.go
+++ b/TreeDB/db/leaf_generation_pack_rewrite.go
@@ -169,6 +169,10 @@ type leafRefRewriteCtx struct {
 	leafFrames      int
 	maxLeafFrameK   int
 
+	sourceScan                  *leafGenerationScanContext
+	sourceGenerationByFile      map[uint32]uint64
+	sourceLiveMovedByGeneration map[uint64]leafGenerationLiveTotals
+
 	readRefreshRetried bool
 }
 
@@ -184,15 +188,19 @@ func (a *leafRefRewritePageAppender) AppendLeafPage(leafPage []byte) (page.LeafL
 }
 
 type leafRefRewriteRunStats struct {
-	InternalPagesVisited int
-	SubtreesPruned       int
-	LeafFramesWritten    int
-	MaxLeafFrameK        int
-	CopyTimeNanos        int64
-	PublishWaitNanos     int64
-	PublishHoldNanos     int64
-	PrivatePages         int
-	PublishConflict      bool
+	InternalPagesVisited        int
+	SubtreesPruned              int
+	LeafFramesWritten           int
+	MaxLeafFrameK               int
+	CopyTimeNanos               int64
+	PublishWaitNanos            int64
+	PublishHoldNanos            int64
+	PrivatePages                int
+	PublishConflict             bool
+	trackSourceLiveMoved        bool
+	sourceStateKey              treeReachabilityCacheKey
+	publishedState              *DBState
+	sourceLiveMovedByGeneration map[uint64]leafGenerationLiveTotals
 }
 
 type leafGenerationPackCopyPhase uint8
@@ -611,6 +619,9 @@ func (c *leafRefRewriteCtx) rewriteLeafRef(ptr page.LeafLogPtr) (page.ChildRef, 
 	if err != nil {
 		return page.ChildRef{}, false, err
 	}
+	if err := c.noteSourceLeafMoved(ptr); err != nil {
+		return page.ChildRef{}, false, err
+	}
 	next := page.LeafLogChildRef(leafLogPtr)
 	c.storeLeafPtrRemap(ptr, next)
 	return next, true, nil
@@ -648,12 +659,56 @@ func (c *leafRefRewriteCtx) rewriteLeafRefBatch(ptrs []page.LeafLogPtr) ([]page.
 		for i, newPtr := range newPtrs {
 			ref := page.LeafLogChildRef(newPtr)
 			oldPtr := ptrs[start+i]
+			if err := c.noteSourceLeafMoved(oldPtr); err != nil {
+				return nil, err
+			}
 			c.storeLeafPtrRemap(oldPtr, ref)
 			out[start+i] = ref
 		}
 		start = end
 	}
 	return out, nil
+}
+
+func (c *leafRefRewriteCtx) noteSourceLeafMoved(ptr page.LeafLogPtr) error {
+	if c == nil || c.db == nil || c.sourceScan == nil || c.sourceScan.snap == nil || c.sourceScan.snap.state == nil {
+		return nil
+	}
+	generationID := c.sourceGenerationByFile[ptr.FileID]
+	if generationID == 0 {
+		return nil
+	}
+	recordLen := ptr.RecordLength()
+	if recordLen == 0 {
+		var err error
+		recordLen, err = c.db.valueLogRecordLengthForRewriteInSet(ptr.ValuePtr(), c.sourceScan.snap.state.ValueLogSet)
+		if err != nil {
+			return err
+		}
+	}
+	liveBytes := recordLen
+	if liveBytes <= ^uint32(0)-4 {
+		liveBytes += 4
+	}
+	if ptr.IsGrouped() {
+		info, grouped, err := c.db.leafGenerationGroupedFrameInfo(c.sourceScan, ptr, recordLen)
+		if err != nil {
+			return err
+		}
+		if grouped {
+			if contribution, ok := info.liveByteContribution(ptr.SubIndex); ok {
+				liveBytes = contribution
+			}
+		}
+	}
+	if c.sourceLiveMovedByGeneration == nil {
+		c.sourceLiveMovedByGeneration = make(map[uint64]leafGenerationLiveTotals)
+	}
+	totals := c.sourceLiveMovedByGeneration[generationID]
+	totals.LivePages++
+	totals.LiveBytes += int64(liveBytes)
+	c.sourceLiveMovedByGeneration[generationID] = totals
+	return nil
 }
 
 func (c *leafRefRewriteCtx) rewriteNode(id uint64) (uint64, bool, error) {
@@ -1138,6 +1193,9 @@ func (db *DB) rewriteLeafRefsOnline(ctx context.Context, writer *rewriteWriter, 
 	rootID := snap.state.RootPageID
 	sysRoot := snap.state.SystemRootPageID
 	basis := captureLeafGenerationPackCopyBasis(snap, sourceIDs, singleSourceID, hasSingleSourceID)
+	if runStats != nil && runStats.trackSourceLiveMoved {
+		runStats.sourceStateKey, _ = leafGenerationLiveStatsKeyForState(snap.state)
+	}
 
 	stagingPager, err := pager.NewOverlay(db.chunkSize, leafGenerationPackPrivatePageIDBase, idx.pager)
 	if err != nil {
@@ -1189,6 +1247,15 @@ func (db *DB) rewriteLeafRefsOnline(ctx context.Context, writer *rewriteWriter, 
 		maxCopiedBytes:       maxCopiedBytes,
 		leafFrameK:           leafFrameK,
 	}
+	if runStats != nil && runStats.trackSourceLiveMoved {
+		leafCtx.sourceScan = &leafGenerationScanContext{
+			snap:          snap,
+			groupedFrames: newLeafGenerationGroupedFrameScanCache(leafGenerationGroupedFrameScanCacheEntries),
+		}
+		if snap.state.LeafGenerations != nil {
+			leafCtx.sourceGenerationByFile = snap.state.LeafGenerations.FileToGeneration
+		}
+	}
 	privateLeafReader, err := valuelog.NewManager(writer.leafDir)
 	if err != nil {
 		return 0, 0, fmt.Errorf("vlog-rewrite: open private leaf reader: %w", err)
@@ -1210,7 +1277,7 @@ func (db *DB) rewriteLeafRefsOnline(ctx context.Context, writer *rewriteWriter, 
 	if db.indexOuterLeavesInValueLog {
 		leafCtx.zipper.SetLeafPageLog(&leafRefRewritePageAppender{ctx: leafCtx})
 	}
-	if runStats != nil {
+	if runStats != nil && runStats.trackSourceLiveMoved {
 		defer func() {
 			runStats.InternalPagesVisited = leafCtx.internalVisited
 			runStats.SubtreesPruned = leafCtx.subtreesPruned
@@ -1558,6 +1625,10 @@ func (db *DB) rewriteLeafRefsOnline(ctx context.Context, writer *rewriteWriter, 
 		return cleanupAndUnlock(fmt.Errorf("vlog-rewrite: finalize rewritten leaf refs: %w", finalizeErr))
 	}
 	db.invalidateLeafGenerationSubtreeStats(publishAlloc.Pages())
+	if runStats != nil {
+		runStats.publishedState = db.state.Load()
+		runStats.sourceLiveMovedByGeneration = cloneLeafGenerationLiveTotalsMap(leafCtx.sourceLiveMovedByGeneration)
+	}
 	commitTimingPrintf("treedb: leaf_pack_publish relocate=%s page_sync=%s dir_wait=%s register=%s finalize=%s total=%s\n", relocateDuration, pageSyncDuration, dirWaitDuration, registerDuration, finalizeDuration, time.Since(publishStarted))
 	unlockPublish()
 	db.finalizeCommitPostWork(post)

--- a/TreeDB/db/leaf_generation_pack_rewrite.go
+++ b/TreeDB/db/leaf_generation_pack_rewrite.go
@@ -197,6 +197,7 @@ type leafRefRewriteRunStats struct {
 	PublishHoldNanos            int64
 	PrivatePages                int
 	PublishConflict             bool
+	trackCarry                  bool
 	trackSourceLiveMoved        bool
 	sourceStateKey              treeReachabilityCacheKey
 	publishedState              *DBState
@@ -1193,7 +1194,7 @@ func (db *DB) rewriteLeafRefsOnline(ctx context.Context, writer *rewriteWriter, 
 	rootID := snap.state.RootPageID
 	sysRoot := snap.state.SystemRootPageID
 	basis := captureLeafGenerationPackCopyBasis(snap, sourceIDs, singleSourceID, hasSingleSourceID)
-	if runStats != nil && runStats.trackSourceLiveMoved {
+	if runStats != nil && runStats.trackCarry {
 		runStats.sourceStateKey, _ = leafGenerationLiveStatsKeyForState(snap.state)
 	}
 
@@ -1625,9 +1626,11 @@ func (db *DB) rewriteLeafRefsOnline(ctx context.Context, writer *rewriteWriter, 
 		return cleanupAndUnlock(fmt.Errorf("vlog-rewrite: finalize rewritten leaf refs: %w", finalizeErr))
 	}
 	db.invalidateLeafGenerationSubtreeStats(publishAlloc.Pages())
-	if runStats != nil {
+	if runStats != nil && runStats.trackCarry {
 		runStats.publishedState = db.state.Load()
-		runStats.sourceLiveMovedByGeneration = cloneLeafGenerationLiveTotalsMap(leafCtx.sourceLiveMovedByGeneration)
+		if runStats.trackSourceLiveMoved {
+			runStats.sourceLiveMovedByGeneration = cloneLeafGenerationLiveTotalsMap(leafCtx.sourceLiveMovedByGeneration)
+		}
 	}
 	commitTimingPrintf("treedb: leaf_pack_publish relocate=%s page_sync=%s dir_wait=%s register=%s finalize=%s total=%s\n", relocateDuration, pageSyncDuration, dirWaitDuration, registerDuration, finalizeDuration, time.Since(publishStarted))
 	unlockPublish()

--- a/TreeDB/db/leaf_generation_plan.go
+++ b/TreeDB/db/leaf_generation_plan.go
@@ -2,6 +2,7 @@ package db
 
 import (
 	"context"
+	"crypto/sha256"
 	"encoding/binary"
 	"errors"
 	"fmt"
@@ -605,7 +606,66 @@ func (db *DB) leafGenerationLiveStatsForSnapshotWithProtectedRoots(ctx context.C
 	if len(protectedRootIDs) == 0 && len(protectedSystemRootIDs) == 0 {
 		return db.leafGenerationLiveStatsForSnapshot(ctx, snap)
 	}
-	return db.leafGenerationLiveStatsForSnapshotUncachedWithProtectedRoots(ctx, snap, protectedRootIDs, protectedSystemRootIDs)
+	if snap == nil || snap.state == nil {
+		return db.leafGenerationLiveStatsForSnapshotUncachedWithProtectedRoots(ctx, snap, protectedRootIDs, protectedSystemRootIDs)
+	}
+	cacheKey, cacheable := leafGenerationLiveStatsKeyForState(snap.state)
+	if cacheable {
+		cacheKey.protectedRoots = leafGenerationProtectedRootsHash(protectedRootIDs, protectedSystemRootIDs)
+		if stats, ok := db.loadCachedLeafGenerationLiveStats(cacheKey); ok {
+			return stats, nil
+		}
+	}
+	runLeafGenerationLiveScanHook()
+	stats, err := db.scanLeafGenerationLiveStatsWithOptions(ctx, snap, leafGenerationLiveStatsScanOptions{
+		DisableCache:           true,
+		ProtectedRootIDs:       protectedRootIDs,
+		ProtectedSystemRootIDs: protectedSystemRootIDs,
+	})
+	if err != nil {
+		return leafGenerationLiveScanStats{}, err
+	}
+	if cacheable {
+		db.storeCachedLeafGenerationLiveStats(cacheKey, stats)
+	}
+	return stats, nil
+}
+
+// leafGenerationProtectedRootsHash makes cache identity independent of caller
+// ordering and duplicates while retaining the user/system root distinction.
+func leafGenerationProtectedRootsHash(rootIDs, systemRootIDs []uint64) [32]byte {
+	canonicalize := func(ids []uint64) []uint64 {
+		if len(ids) == 0 {
+			return nil
+		}
+		seen := make(map[uint64]struct{}, len(ids))
+		out := make([]uint64, 0, len(ids))
+		for _, id := range ids {
+			if id == 0 {
+				continue
+			}
+			if _, ok := seen[id]; ok {
+				continue
+			}
+			seen[id] = struct{}{}
+			out = append(out, id)
+		}
+		sort.Slice(out, func(i, j int) bool { return out[i] < out[j] })
+		return out
+	}
+	h := sha256.New()
+	var buf [8]byte
+	for _, roots := range [][]uint64{canonicalize(rootIDs), canonicalize(systemRootIDs)} {
+		binary.LittleEndian.PutUint64(buf[:], uint64(len(roots)))
+		_, _ = h.Write(buf[:])
+		for _, rootID := range roots {
+			binary.LittleEndian.PutUint64(buf[:], rootID)
+			_, _ = h.Write(buf[:])
+		}
+	}
+	var out [32]byte
+	copy(out[:], h.Sum(nil))
+	return out
 }
 
 func (db *DB) leafGenerationLiveStatsForSnapshotUncached(ctx context.Context, snap *Snapshot) (leafGenerationLiveScanStats, error) {

--- a/TreeDB/db/leaf_generation_plan.go
+++ b/TreeDB/db/leaf_generation_plan.go
@@ -690,6 +690,39 @@ func leafGenerationProtectedRootsHash(rootIDs, systemRootIDs []uint64) [32]byte 
 	return out
 }
 
+func leafGenerationProtectedRootsOverlapMaintenance(ctx context.Context, snap *Snapshot, rootIDs, systemRootIDs []uint64) (bool, error) {
+	maintenanceRoots, err := maintenanceRootsForSnapshotWithContext(ctx, snap)
+	if err != nil {
+		return false, err
+	}
+	maintenanceRootIDs := make(map[uint64]struct{}, len(maintenanceRoots))
+	for _, root := range maintenanceRoots {
+		if root.rootID != 0 {
+			maintenanceRootIDs[root.rootID] = struct{}{}
+		}
+	}
+	for _, rootID := range rootIDs {
+		if _, ok := maintenanceRootIDs[rootID]; ok && rootID != 0 {
+			return true, nil
+		}
+	}
+	for _, systemRootID := range systemRootIDs {
+		if systemRootID == 0 {
+			continue
+		}
+		protectedRoots, err := collectMaintenanceRootsForSystemRootWithContext(ctx, snap.idx.pager, &snap.reader, systemRootID)
+		if err != nil {
+			return false, err
+		}
+		for _, root := range protectedRoots {
+			if _, ok := maintenanceRootIDs[root.rootID]; ok && root.rootID != 0 {
+				return true, nil
+			}
+		}
+	}
+	return false, nil
+}
+
 func (db *DB) leafGenerationLiveStatsForSnapshotUncached(ctx context.Context, snap *Snapshot) (leafGenerationLiveScanStats, error) {
 	return db.leafGenerationLiveStatsForSnapshotUncachedWithProtectedRoots(ctx, snap, nil, nil)
 }

--- a/TreeDB/db/leaf_generation_plan.go
+++ b/TreeDB/db/leaf_generation_plan.go
@@ -255,14 +255,22 @@ func (db *DB) LeafGenerationPlan(ctx context.Context, opts LeafGenerationPlanOpt
 		return plan, err
 	}
 	plan = db.leafGenerationPlanFromLiveStats(opts, snap.state, manifest, liveScan)
-	if key, ok := leafGenerationLiveStatsKeyForState(snap.state); ok {
-		if len(opts.ProtectedRootIDs) > 0 || len(opts.ProtectedSystemRootIDs) > 0 {
-			key.protectedRoots = leafGenerationProtectedRootsHash(opts.ProtectedRootIDs, opts.ProtectedSystemRootIDs)
-		}
+	if key, ok := leafGenerationPlanStateKey(snap.state, opts); ok {
 		plan.stateKey = key
 	}
 	plan.liveStats = cloneLeafGenerationLiveScanStats(liveScan)
 	return plan, nil
+}
+
+func leafGenerationPlanStateKey(state *DBState, opts LeafGenerationPlanOptions) (treeReachabilityCacheKey, bool) {
+	key, ok := leafGenerationLiveStatsKeyForState(state)
+	if !ok {
+		return treeReachabilityCacheKey{}, false
+	}
+	if len(opts.ProtectedRootIDs) > 0 || len(opts.ProtectedSystemRootIDs) > 0 {
+		key.protectedRoots = leafGenerationProtectedRootsHash(opts.ProtectedRootIDs, opts.ProtectedSystemRootIDs)
+	}
+	return key, true
 }
 
 func (db *DB) leafGenerationPlanFromLiveStats(opts LeafGenerationPlanOptions, state *DBState, manifest *leafGenerationManifest, liveScan leafGenerationLiveScanStats) LeafGenerationPlan {

--- a/TreeDB/db/leaf_generation_plan.go
+++ b/TreeDB/db/leaf_generation_plan.go
@@ -89,6 +89,9 @@ type LeafGenerationPlan struct {
 	ExpectedReclaimRatioPPM         int
 	ExpectedReclaimPerByteCopiedPPM int
 	Admission                       string
+
+	stateKey  treeReachabilityCacheKey
+	liveStats leafGenerationLiveScanStats
 }
 
 type leafGenerationLiveScanStats struct {
@@ -251,8 +254,27 @@ func (db *DB) LeafGenerationPlan(ctx context.Context, opts LeafGenerationPlanOpt
 	if err != nil {
 		return plan, err
 	}
+	plan = db.leafGenerationPlanFromLiveStats(opts, snap.state, manifest, liveScan)
+	if key, ok := leafGenerationLiveStatsKeyForState(snap.state); ok {
+		if len(opts.ProtectedRootIDs) > 0 || len(opts.ProtectedSystemRootIDs) > 0 {
+			key.protectedRoots = leafGenerationProtectedRootsHash(opts.ProtectedRootIDs, opts.ProtectedSystemRootIDs)
+		}
+		plan.stateKey = key
+	}
+	plan.liveStats = cloneLeafGenerationLiveScanStats(liveScan)
+	return plan, nil
+}
 
-	set := snap.state.ValueLogSet
+func (db *DB) leafGenerationPlanFromLiveStats(opts LeafGenerationPlanOptions, state *DBState, manifest *leafGenerationManifest, liveScan leafGenerationLiveScanStats) LeafGenerationPlan {
+	var plan LeafGenerationPlan
+	if state == nil || manifest == nil {
+		plan.Admission = leafGenerationPlanAdmissionNoCandidates
+		return plan
+	}
+	plan.CurrentCommitSeq = state.CommitSeq
+	plan.CurrentGenerationID = manifest.CurrentGenerationID
+
+	set := state.ValueLogSet
 	plan.Generations = make([]LeafGenerationPlanGeneration, 0, len(manifest.Generations))
 	plan.Candidates = make([]LeafGenerationPlanGeneration, 0, len(manifest.Generations))
 	for _, gen := range manifest.Generations {
@@ -305,7 +327,7 @@ func (db *DB) LeafGenerationPlan(ctx context.Context, opts LeafGenerationPlanOpt
 	plan.ExpectedReclaimRatioPPM = ratioPPM(plan.CandidateBytesDead, plan.CandidateBytesTotal)
 	plan.ExpectedReclaimPerByteCopiedPPM = ratioPPM(plan.CandidateBytesDead, plan.CandidateBytesToCopy)
 	plan.Admission = leafGenerationPlanAdmission(opts, plan)
-	return plan, nil
+	return plan
 }
 
 func leafGenerationPlanAdmission(opts LeafGenerationPlanOptions, plan LeafGenerationPlan) string {

--- a/TreeDB/db/leaf_generation_plan_test.go
+++ b/TreeDB/db/leaf_generation_plan_test.go
@@ -861,7 +861,7 @@ func TestLeafGenerationPlan_CachesProtectedRootsCanonically(t *testing.T) {
 		ProtectedRootIDs:       []uint64{state.RootPageID},
 		ProtectedSystemRootIDs: []uint64{state.SystemRootPageID},
 	}); err != nil {
-		t.Fatalf("LeafGenerationPlan reordered roots: %v", err)
+		t.Fatalf("LeafGenerationPlan deduplicated roots: %v", err)
 	}
 	if got, want := counter.Load(), uint64(1); got != want {
 		t.Fatalf("scan count after reordered protected plan=%d, want %d", got, want)
@@ -873,6 +873,28 @@ func TestLeafGenerationPlan_CachesProtectedRootsCanonically(t *testing.T) {
 	}
 	if got, want := counter.Load(), uint64(2); got != want {
 		t.Fatalf("scan count after changed protected plan=%d, want %d", got, want)
+	}
+}
+
+func TestLeafGenerationProtectedRootsHashCanonicalizesOrderAndKeepsRootKindsDistinct(t *testing.T) {
+	first := leafGenerationProtectedRootsHash(
+		[]uint64{9, 3, 5, 3, 0},
+		[]uint64{17, 11, 17, 0},
+	)
+	reordered := leafGenerationProtectedRootsHash(
+		[]uint64{5, 9, 3},
+		[]uint64{11, 17},
+	)
+	if first != reordered {
+		t.Fatalf("canonical hashes differ: first=%x reordered=%x", first, reordered)
+	}
+
+	swappedKinds := leafGenerationProtectedRootsHash(
+		[]uint64{11, 17},
+		[]uint64{3, 5, 9},
+	)
+	if first == swappedKinds {
+		t.Fatalf("user/system root distinction lost: hash=%x", first)
 	}
 }
 

--- a/TreeDB/db/leaf_generation_plan_test.go
+++ b/TreeDB/db/leaf_generation_plan_test.go
@@ -834,6 +834,48 @@ func TestLeafGenerationPlan_CachesLiveStatsPerPublishedState(t *testing.T) {
 	}
 }
 
+func TestLeafGenerationPlan_CachesProtectedRootsCanonically(t *testing.T) {
+	db, leafLog := openLeafGenerationGCTestDB(t)
+	writeLeafGenerationKeys(t, db, "k", 64, 'a')
+	if err := leafLog.rotateLeaf(); err != nil {
+		t.Fatalf("rotateLeaf: %v", err)
+	}
+	writeLeafGenerationKeyRange(t, db, "k", 0, 16, 'b')
+	state := db.State()
+	if state == nil {
+		t.Fatal("expected published state")
+	}
+
+	counter := withLeafGenerationLiveScanCounter(t)
+	first := LeafGenerationPlanOptions{
+		ProtectedRootIDs:       []uint64{state.RootPageID, state.RootPageID},
+		ProtectedSystemRootIDs: []uint64{state.SystemRootPageID, state.SystemRootPageID},
+	}
+	if _, err := db.LeafGenerationPlan(context.Background(), first); err != nil {
+		t.Fatalf("LeafGenerationPlan first: %v", err)
+	}
+	if got, want := counter.Load(), uint64(1); got != want {
+		t.Fatalf("scan count after first protected plan=%d, want %d", got, want)
+	}
+	if _, err := db.LeafGenerationPlan(context.Background(), LeafGenerationPlanOptions{
+		ProtectedRootIDs:       []uint64{state.RootPageID},
+		ProtectedSystemRootIDs: []uint64{state.SystemRootPageID},
+	}); err != nil {
+		t.Fatalf("LeafGenerationPlan reordered roots: %v", err)
+	}
+	if got, want := counter.Load(), uint64(1); got != want {
+		t.Fatalf("scan count after reordered protected plan=%d, want %d", got, want)
+	}
+	if _, err := db.LeafGenerationPlan(context.Background(), LeafGenerationPlanOptions{
+		ProtectedRootIDs: []uint64{state.RootPageID},
+	}); err != nil {
+		t.Fatalf("LeafGenerationPlan changed roots: %v", err)
+	}
+	if got, want := counter.Load(), uint64(2); got != want {
+		t.Fatalf("scan count after changed protected plan=%d, want %d", got, want)
+	}
+}
+
 func TestLeafGenerationPlan_ReusesCachedSubtreesAcrossRootChanges(t *testing.T) {
 	db, _ := openLeafGenerationGCTestDB(t)
 	counter := withLeafGenerationSubtreeCacheMissCounter(t)


### PR DESCRIPTION
## Objective

Reuse leaf-generation reachability plans across consecutive `CompactStorage` pack publications without weakening selection validation, detached-root safety, or foreground-change invalidation.

Closes #3640. Advances #3630. The measured next wall-time limiter is tracked in #3666.

Exact base: `b70f1d4f73b27f2bc596babf51ab1eae475aaf4b`  
Exact head: `d81d84e6df02c205e1c41e8237cc6347e07fc368`

## Cache and carry design

- `treeReachabilityCacheKey` now includes a SHA-256 identity for protected roots.
- User roots and system roots are sorted/deduplicated independently, zero roots are ignored, and the two root kinds remain distinct in the hash.
- Protected-root `LeafGenerationPlan` calls now use the same bounded live-stats cache as unprotected plans, keyed by exact commit/root/system-root/leaf-generation state plus protected-root identity.
- A private `compactStorageLeafPackPlanState` carries exact per-generation live totals between pack passes.
- Every carried plan is rebuilt against the current immutable manifest, so physical `BytesTotal`, `PinnedCount`, `AgeCommits`, eligibility, ranking, and aggregate fields are refreshed rather than copied stale.
- A successful pack records the exact copy-source state token and exact post-publish `DBState` while publication is still exclusive.
- Without detached protected roots, all selected source live totals are cleared after successful publication. With protected roots, rewrite traversal records exact pages/physical byte contribution moved per source generation, including grouped-frame proportional accounting, and leaves detached-root residuals live.
- Run-created output generations remain conservatively live and are excluded by the existing `compact_storage_run_created` filter.

No public API or on-disk format changes.

## Invalidation and safety

Carry is discarded and the next plan rescans when:

- current state differs from the exact expected post-publish token;
- protected-root identity changes;
- pack copy conflicts or retries;
- publication does not produce an exact state token;
- leaf-generation GC or index vacuum changes maintenance state;
- revalidation cannot prove the carried state.

A same-root foreground commit therefore rescans even though root IDs are unchanged. Pack executor validation remains authoritative. Stale state fails safe by rescanning/skipping; no deletion or reclamation decision trusts the carried plan.

## TDD and correctness evidence

New/updated tests prove:

- protected roots reorder/deduplicate canonically, while user/system root kinds remain distinct;
- repeated identical protected-root plans hit cache;
- unchanged pass 2 performs no additional live scan;
- a foreground same-root commit adds exactly one scan;
- changing only protected roots adds exactly one scan;
- carried candidates and aggregates equal a fresh plan;
- detached protected-root residuals also match a fresh plan;
- public traversal/frame statistics remain populated for ordinary pack calls;
- shared-audit parity compares the public plan contract, not private carry metadata.

The initial red multi-pass test observed `2` scans after two passes where `1` was required. A whole-run assertion initially observed `5`, correctly exposing unrelated audit/GC scans; the final test measures the exact pack-1 to pack-2 interval.

## Performance evidence

Benchmark source is byte-identical on base/head, SHA-256 `96c767caffeedfe244be6a935016b37d8c84b7d849c39360dfa14e593b7afb3d`. The fixture creates three sparse sealed generations, bounds packing to one generation per pass, runs four real `CompactStorage` pack phases, and excludes setup from the timer.

```sh
taskset -c 2 env GOWORK=off GOMEMLIMIT=4GiB GOMAXPROCS=1 \
  go test -p 1 ./TreeDB/db -run '^$' \
  -bench '^BenchmarkCompactStorageLeafPackMultiPass$' \
  -benchtime=3x -count=1 -benchmem
```

Median of six interleaved base/head pairs:

| Metric | Base | Head | Result |
| --- | ---: | ---: | --- |
| live scans/op | 6 | 3 | -50% |
| plan overhead/op (`pack_phase - pack_apply`) | 0.654 ms | 0.256 ms | -60.8% |
| pack apply/op | 83.99 ms | 83.36 ms | flat / measured next limiter |
| total CompactStorage wall | 142.53 ms | 146.46 ms | host is bimodal; no wall win claimed |
| B/op | 3.94 MB | 3.89 MB | -1.3% |
| allocs/op | 4,336 | 4,080 | -5.9% |

The issue's preferred >=30% end-to-end wall target is not met. Scaling the live index from 4K to 64K keys did not change the classification because existing subtree-stat reuse makes repeated scans cheap. The ticket explicitly permits a measured next-bottleneck link; #3666 owns the dominant 66-87 ms/op fixed pack apply path with stage counters, profiles, TDD, and PL-01 durability/concurrency gates. This PR claims the scan/planning reduction only.

## Exact-head validation

```sh
GOWORK=off GOMEMLIMIT=4GiB GOMAXPROCS=2 go test -p 1 ./TreeDB/db \
  -run 'TestLeafGenerationPlan|TestLeafGenerationPack|TestCompactStorage.*LeafPack' -count=1
# PASS 8.432s

GOWORK=off GOMEMLIMIT=4GiB GOMAXPROCS=2 go test -race -p 1 ./TreeDB/db \
  -run 'TestCompactStorageLeafPackCarry|TestCompactStorageLeafPackMultiPass|TestLeafGenerationPlan_CachesProtectedRootsCanonically|TestLeafGenerationProtectedRootsHash' -count=3
# PASS 5.602s

GOWORK=off GOMEMLIMIT=4GiB GOMAXPROCS=2 go test -p 1 ./TreeDB/db -count=1
# PASS 262.214s

GOWORK=off GOMEMLIMIT=4GiB GOMAXPROCS=2 go test -p 1 ./TreeDB -count=1
# PASS 45.152s

GOWORK=off GOMEMLIMIT=4GiB GOMAXPROCS=2 go vet ./TreeDB/db
GOWORK=off GOMEMLIMIT=4GiB GOMAXPROCS=2 GOOS=windows GOARCH=amd64 go test -c ./TreeDB/db -o /tmp/gomap-pl09-db-windows.test.exe
# PASS
```

Worktree is clean and `git diff --check` passes. Latest-head CI and mature Codex/CodeRabbit reviews are required before merge.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved storage compaction by reusing live-data analysis across multiple packing passes.
  * Added safeguards to refresh analysis when database changes or protected roots are updated.
  * Enhanced tracking of data movement during compaction.

* **Tests**
  * Added coverage for multi-pass compaction, rescanning scenarios, protected roots, and cache behavior.
  * Added a benchmark for measuring multi-pass leaf packing performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->