### PR TITLE
TreeDB: define ordered external-version MVCC codec

### DIFF
--- a/TreeDB/docs/spec/contracts.md
+++ b/TreeDB/docs/spec/contracts.md
@@ -24,6 +24,37 @@ Status:
 - The tree is ordered and range-addressable.
 - Collection/document APIs may keep separate non-empty logical ID contracts.
 
+### 1.1 Target external-timestamp MVCC key contract
+
+The opt-in codec in `TreeDB/internal/mvcckey` establishes the physical ordering
+contract for the external-version MVCC work tracked by
+https://github.com/snissn/gomap/issues/3668. It is not a read/write MVCC engine
+and does not change current raw KV behavior.
+
+- Caller-assigned versions are nonzero `uint64` timestamps. Timestamp zero is
+  rejected rather than remapped.
+- Logical keys are arbitrary bytes, including empty and embedded zero bytes.
+- Encoded order is logical key ascending and timestamp descending. Equal-key
+  scans therefore encounter the newest version first.
+- `EntryRevision` remains TreeDB's native current-entry validation token. It is
+  not an external timestamp, historical version, or MVCC visibility boundary.
+- Namespace, logical-prefix, and exact-logical-key/all-version bounds are
+  half-open byte ranges suitable for TreeDB iterators. Bound construction is
+  available in append-to-caller-buffer form.
+- Exact-key bounds reject logical keys whose eventual timestamp-bearing key
+  cannot fit the codec envelope. Logical-prefix bounds are prefix-sized and may
+  therefore be valid even when a same-sized exact key is not encodable.
+- The version-1 namespace is owned only by an MVCC layer that explicitly opts
+  in. Existing raw APIs neither encode keys nor reject that range; a mixed-use
+  owner must keep unrelated raw physical writes out of the reserved range.
+- The codec format and internal Go API are pre-alpha. A format change may
+  require rebuilding experimental DB directories rather than migration.
+
+Atomic `CommitAt`, snapshot reads such as `GetAt`, retained-version iteration,
+discard floors, Dgraph metadata, TTL, subscriptions, and conditional
+transactions are separate contracts owned by descendant issues. None are
+implied by the codec package.
+
 ## 2. Read Contracts
 
 ### 2.1 `Get`

--- a/TreeDB/docs/spec/storage-format.md
+++ b/TreeDB/docs/spec/storage-format.md
@@ -54,6 +54,54 @@ value storage managed by reachability-based GC and rewrite/compaction. The
 single-group provider/storage boundary is defined in
 `TreeDB/docs/spec/raftcluster.md`.
 
+## 1.1 Opt-in external-version MVCC key subspace
+
+Issue [#3670](https://github.com/snissn/gomap/issues/3670) defines a pre-alpha,
+opt-in physical-key codec for a later caller-assigned MVCC layer. The codec is
+implemented in `TreeDB/internal/mvcckey`; existing raw TreeDB reads, writes,
+`EntryRevision`, page formats, and command-WAL frames do not invoke it.
+
+Version 1 physical keys use this byte layout:
+
+```text
+00 54 44 42 4d 56 43 43 01  escaped-logical-key  00 00  u64be(^timestamp)
+|--------- "TDBMVCC" v1 ---------|                       |----- 8 bytes -----|
+```
+
+Encoding rules:
+
+- logical keys are arbitrary byte strings, including the empty key;
+- each logical `00` byte is escaped as `00 ff`; every other byte is copied;
+- `00 00` terminates the escaped logical key;
+- the caller-assigned timestamp is a nonzero `uint64`; zero is reserved and
+  rejected;
+- the timestamp suffix is the big-endian bitwise complement of the timestamp;
+- malformed escapes, missing/truncated/extra suffix bytes, timestamp zero, and
+  keys outside the exact versioned marker fail explicitly;
+- the format envelope is at most `65535` encoded bytes and is checked before
+  allocation. TreeDB's 4096-byte pages and the selected leaf/value shape may
+  impose a smaller usable physical-key limit.
+
+The escape is order-preserving. If one logical key is a prefix of another, its
+`00 00` terminator sorts before either a copied nonzero extension byte or the
+`00 ff` encoding of a zero extension byte. For equal logical keys,
+`u64be(^timestamp)` sorts larger timestamps first. Physical byte order is
+therefore `(logical key ascending, timestamp descending)`.
+
+The marker reserves the half-open physical range
+`[00 54 44 42 4d 56 43 43 01, 00 54 44 42 4d 56 43 43 02)` when the opt-in
+layer owns a TreeDB keyspace. Logical-prefix bounds use the marker plus an
+escaped, unterminated logical prefix. All-version bounds for one logical key use
+the marker plus the escaped key and `00 00` terminator. The exclusive upper
+bound is the lexicographic successor of that physical prefix. Exact-key bounds
+enforce the same full-key size envelope as `Encode`; logical-prefix bounds are
+limited only by their own encoded bound size.
+
+This namespace does not make raw TreeDB keys non-empty or silently reserve a
+prefix in existing raw APIs. A later MVCC owner must prevent unrelated raw
+writes from entering its reserved physical range. The namespace marker makes
+MVCC physical keys non-empty even when the logical key is empty.
+
 ## 2. Index Page Basics
 
 ### 2.1 Fixed page size

--- a/TreeDB/docs/spec/verification.md
+++ b/TreeDB/docs/spec/verification.md
@@ -244,6 +244,42 @@ Required performance evidence:
   them with non-skipped benchmarks and allocation evidence before closing the
   feature stack.
 
+## 10.2 External-Version MVCC Key Codec
+
+Invariant:
+
+- The opt-in external-version codec round-trips arbitrary logical bytes and
+  orders physical keys by logical key ascending, timestamp descending.
+- Timestamp zero, wrong namespace versions, malformed escapes,
+  missing/truncated/extra suffixes, and encoded keys above the uint16 envelope
+  fail explicitly before the caller can persist an ambiguous key.
+- Namespace, logical-prefix, and exact-key/all-version half-open bounds contain
+  exactly their intended version-1 physical keys.
+- The codec remains separate from raw TreeDB operations and from
+  `EntryRevision`; adding it does not alter existing raw key encoding or the
+  on-page entry-revision domain.
+
+Coverage:
+
+- `TreeDB/internal/mvcckey/codec_test.go`:
+  - arbitrary-byte and timestamp-extreme round trips;
+  - randomized order equivalence against the `(key asc, timestamp desc)`
+    oracle;
+  - namespace, logical-prefix, and all-version bound membership;
+  - malformed/truncated/wrong-version rejection;
+  - exact maximum-size acceptance and one-byte-over rejection.
+- `TreeDB/internal/mvcckey/codec_fuzz_test.go`:
+  - `FuzzRoundTrip`;
+  - `FuzzDecodeNeverPanics`.
+- `TreeDB/internal/mvcckey/codec_bench_test.go`:
+  - `BenchmarkEncode` and `BenchmarkDecode` for allocating and reusable-buffer
+    paths;
+  - `BenchmarkLogicalPrefixBounds`.
+
+The codec is a new opt-in path, so its performance gate is absolute cost and
+allocation behavior rather than a before/after raw-TreeDB result. Existing raw
+benchmarks must remain unchanged because no current raw API calls this package.
+
 ## 11. Collections Native Fast Path
 
 Invariant:

--- a/TreeDB/external_mvcc_codec_compat_test.go
+++ b/TreeDB/external_mvcc_codec_compat_test.go
@@ -1,0 +1,41 @@
+package treedb
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/snissn/gomap/TreeDB/internal/mvcckey"
+)
+
+func TestExternalMVCCCodecIsOptInAndDoesNotReplaceEntryRevision(t *testing.T) {
+	db, err := Open(Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	// Existing raw APIs continue to accept and store their caller-provided bytes
+	// verbatim, even when those bytes begin with the opt-in namespace marker.
+	rawKey := mvcckey.AppendNamespaceLower(nil)
+	if err := db.Set(rawKey, []byte("raw")); err != nil {
+		t.Fatalf("Set raw key: %v", err)
+	}
+	got, revision, err := db.GetVersioned(rawKey)
+	if err != nil {
+		t.Fatalf("GetVersioned raw key: %v", err)
+	}
+	if !bytes.Equal(got, []byte("raw")) || revision == LegacyEntryRevision {
+		t.Fatalf("GetVersioned=(%q,%d), want raw with native EntryRevision", got, revision)
+	}
+
+	physical, err := mvcckey.Encode(rawKey, 7)
+	if err != nil {
+		t.Fatalf("Encode: %v", err)
+	}
+	if bytes.Equal(physical, rawKey) {
+		t.Fatal("MVCC encoding unexpectedly reused the raw logical key")
+	}
+	if got, err := db.Get(physical); err != nil || got != nil {
+		t.Fatalf("Get opt-in physical key=(%x,%v), want absent,nil", got, err)
+	}
+}

--- a/TreeDB/internal/mvcckey/codec.go
+++ b/TreeDB/internal/mvcckey/codec.go
@@ -1,0 +1,274 @@
+// Package mvcckey defines TreeDB's opt-in physical-key encoding for
+// caller-assigned MVCC timestamps.
+//
+// The package is internal because TreeDB is pre-alpha and this format is not a
+// stable public API. Raw TreeDB key/value operations do not use this encoding.
+package mvcckey
+
+import (
+	"bytes"
+	"encoding/binary"
+	"errors"
+	"math"
+)
+
+const (
+	// TimestampSize is the encoded size of an external timestamp.
+	TimestampSize = 8
+	// MaxEncodedKeySize is the codec envelope. TreeDB pages may impose a
+	// smaller physical-key limit for a particular value and page shape.
+	MaxEncodedKeySize = math.MaxUint16
+)
+
+var (
+	ErrZeroTimestamp  = errors.New("mvcckey: timestamp zero is reserved")
+	ErrKeyTooLarge    = errors.New("mvcckey: encoded key exceeds uint16 envelope")
+	ErrWrongNamespace = errors.New("mvcckey: key is outside the external-version namespace")
+	ErrMalformedKey   = errors.New("mvcckey: malformed external-version key")
+)
+
+// namespaceV1 is a versioned physical-key subspace: NUL + "TDBMVCC" + v1.
+// The subspace is reserved only when the opt-in MVCC layer owns the DB keyspace.
+var namespaceV1 = [...]byte{0x00, 'T', 'D', 'B', 'M', 'V', 'C', 'C', 0x01}
+
+// EncodedLen reports the exact number of bytes needed by Encode.
+func EncodedLen(logical []byte) (int, error) {
+	// Every byte contributes at least one encoded byte. Reject impossible input
+	// before scanning it or performing arithmetic that could overflow.
+	const fixed = len(namespaceV1) + 2 + TimestampSize
+	if len(logical) > MaxEncodedKeySize-fixed {
+		return 0, ErrKeyTooLarge
+	}
+
+	zeros := 0
+	for _, b := range logical {
+		if b == 0 {
+			zeros++
+		}
+	}
+	encodedLen := fixed + len(logical) + zeros
+	if encodedLen > MaxEncodedKeySize {
+		return 0, ErrKeyTooLarge
+	}
+	return encodedLen, nil
+}
+
+// Encode returns the physical key for logical at timestamp. Logical keys may
+// contain arbitrary bytes and may be empty. Timestamp zero is reserved.
+func Encode(logical []byte, timestamp uint64) ([]byte, error) {
+	return Append(nil, logical, timestamp)
+}
+
+// Append appends the physical key to dst. On error it returns dst unchanged.
+func Append(dst, logical []byte, timestamp uint64) ([]byte, error) {
+	if timestamp == 0 {
+		return dst, ErrZeroTimestamp
+	}
+	encodedLen, err := EncodedLen(logical)
+	if err != nil {
+		return dst, err
+	}
+
+	start := len(dst)
+	dst = grow(dst, encodedLen)
+	dst = append(dst, namespaceV1[:]...)
+	dst = appendEscaped(dst, logical)
+	dst = append(dst, 0x00, 0x00)
+	var suffix [TimestampSize]byte
+	binary.BigEndian.PutUint64(suffix[:], ^timestamp)
+	dst = append(dst, suffix[:]...)
+	if len(dst)-start != encodedLen {
+		panic("mvcckey: internal encoded length mismatch")
+	}
+	return dst, nil
+}
+
+// Decode returns the logical key and caller-assigned timestamp. The returned
+// logical key is newly allocated.
+func Decode(physical []byte) ([]byte, uint64, error) {
+	return DecodeAppend(nil, physical)
+}
+
+// DecodeAppend appends the decoded logical key to dst. On error it returns dst
+// unchanged and timestamp zero.
+func DecodeAppend(dst, physical []byte) ([]byte, uint64, error) {
+	if len(physical) > MaxEncodedKeySize {
+		return dst, 0, ErrKeyTooLarge
+	}
+	if !bytes.HasPrefix(physical, namespaceV1[:]) {
+		return dst, 0, ErrWrongNamespace
+	}
+	if len(physical) < len(namespaceV1)+2+TimestampSize {
+		return dst, 0, ErrMalformedKey
+	}
+
+	bodyEnd, decodedLen, timestamp, err := inspect(physical)
+	if err != nil {
+		return dst, 0, err
+	}
+	start := len(dst)
+	dst = grow(dst, decodedLen)
+	for i := len(namespaceV1); i < bodyEnd; {
+		if physical[i] != 0 {
+			dst = append(dst, physical[i])
+			i++
+			continue
+		}
+		dst = append(dst, 0)
+		i += 2
+	}
+	if len(dst)-start != decodedLen {
+		panic("mvcckey: internal decoded length mismatch")
+	}
+	return dst, timestamp, nil
+}
+
+// InNamespace reports whether physical begins with the version-1 MVCC marker.
+// It does not validate the remainder of the key.
+func InNamespace(physical []byte) bool {
+	return bytes.HasPrefix(physical, namespaceV1[:])
+}
+
+// AppendNamespaceLower appends the inclusive lower bound of the v1 namespace.
+func AppendNamespaceLower(dst []byte) []byte {
+	return append(dst, namespaceV1[:]...)
+}
+
+// AppendNamespaceUpper appends the exclusive upper bound of the v1 namespace.
+func AppendNamespaceUpper(dst []byte) []byte {
+	dst = append(dst, namespaceV1[:]...)
+	dst[len(dst)-1]++
+	return dst
+}
+
+// AppendLogicalPrefixLower appends the inclusive physical lower bound for all
+// MVCC keys whose decoded logical key begins with logicalPrefix.
+func AppendLogicalPrefixLower(dst, logicalPrefix []byte) ([]byte, error) {
+	encodedLen, err := escapedPrefixLen(logicalPrefix)
+	if err != nil {
+		return dst, err
+	}
+	dst = grow(dst, encodedLen)
+	dst = append(dst, namespaceV1[:]...)
+	return appendEscaped(dst, logicalPrefix), nil
+}
+
+// AppendLogicalPrefixUpper appends the exclusive physical upper bound for all
+// MVCC keys whose decoded logical key begins with logicalPrefix.
+func AppendLogicalPrefixUpper(dst, logicalPrefix []byte) ([]byte, error) {
+	start := len(dst)
+	var err error
+	dst, err = AppendLogicalPrefixLower(dst, logicalPrefix)
+	if err != nil {
+		return dst, err
+	}
+	return prefixSuccessor(dst, start), nil
+}
+
+// AppendKeyVersionsLower appends the inclusive lower bound for every encoded
+// version of exactly logical.
+func AppendKeyVersionsLower(dst, logical []byte) ([]byte, error) {
+	if _, err := EncodedLen(logical); err != nil {
+		return dst, err
+	}
+	prefixLen, err := escapedPrefixLen(logical)
+	if err != nil {
+		return dst, err
+	}
+	dst = grow(dst, prefixLen+2)
+	dst = append(dst, namespaceV1[:]...)
+	dst = appendEscaped(dst, logical)
+	return append(dst, 0x00, 0x00), nil
+}
+
+// AppendKeyVersionsUpper appends the exclusive upper bound for every encoded
+// version of exactly logical.
+func AppendKeyVersionsUpper(dst, logical []byte) ([]byte, error) {
+	start := len(dst)
+	var err error
+	dst, err = AppendKeyVersionsLower(dst, logical)
+	if err != nil {
+		return dst, err
+	}
+	return prefixSuccessor(dst, start), nil
+}
+
+func escapedPrefixLen(logical []byte) (int, error) {
+	if len(logical) > MaxEncodedKeySize-len(namespaceV1) {
+		return 0, ErrKeyTooLarge
+	}
+	zeros := 0
+	for _, b := range logical {
+		if b == 0 {
+			zeros++
+		}
+	}
+	encodedLen := len(namespaceV1) + len(logical) + zeros
+	if encodedLen > MaxEncodedKeySize {
+		return 0, ErrKeyTooLarge
+	}
+	return encodedLen, nil
+}
+
+func inspect(physical []byte) (bodyEnd int, decodedLen int, timestamp uint64, err error) {
+	for i := len(namespaceV1); i < len(physical); {
+		if physical[i] != 0 {
+			decodedLen++
+			i++
+			continue
+		}
+		if i+1 >= len(physical) {
+			return 0, 0, 0, ErrMalformedKey
+		}
+		switch physical[i+1] {
+		case 0xff:
+			decodedLen++
+			i += 2
+		case 0x00:
+			bodyEnd = i
+			i += 2
+			if len(physical)-i != TimestampSize {
+				return 0, 0, 0, ErrMalformedKey
+			}
+			timestamp = ^binary.BigEndian.Uint64(physical[i:])
+			if timestamp == 0 {
+				return 0, 0, 0, ErrZeroTimestamp
+			}
+			return bodyEnd, decodedLen, timestamp, nil
+		default:
+			return 0, 0, 0, ErrMalformedKey
+		}
+	}
+	return 0, 0, 0, ErrMalformedKey
+}
+
+func appendEscaped(dst, logical []byte) []byte {
+	for _, b := range logical {
+		if b == 0 {
+			dst = append(dst, 0x00, 0xff)
+			continue
+		}
+		dst = append(dst, b)
+	}
+	return dst
+}
+
+func grow(dst []byte, additional int) []byte {
+	if cap(dst)-len(dst) >= additional {
+		return dst
+	}
+	n := len(dst) + additional
+	out := make([]byte, len(dst), n)
+	copy(out, dst)
+	return out
+}
+
+func prefixSuccessor(dst []byte, start int) []byte {
+	for i := len(dst) - 1; i >= start; i-- {
+		if dst[i] != 0xff {
+			dst[i]++
+			return dst[:i+1]
+		}
+	}
+	panic("mvcckey: namespace has no finite successor")
+}

--- a/TreeDB/internal/mvcckey/codec_bench_test.go
+++ b/TreeDB/internal/mvcckey/codec_bench_test.go
@@ -1,0 +1,106 @@
+package mvcckey
+
+import (
+	"fmt"
+	"testing"
+)
+
+func BenchmarkEncode(b *testing.B) {
+	for _, size := range []int{16, 64, 256} {
+		key := benchmarkKey(size)
+		b.Run(fmt.Sprintf("bytes=%d/allocate", size), func(b *testing.B) {
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				encoded, err := Encode(key, uint64(i)+1)
+				if err != nil {
+					b.Fatal(err)
+				}
+				benchmarkBytes = encoded
+			}
+		})
+		b.Run(fmt.Sprintf("bytes=%d/reuse", size), func(b *testing.B) {
+			needed, err := EncodedLen(key)
+			if err != nil {
+				b.Fatal(err)
+			}
+			dst := make([]byte, 0, needed)
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				encoded, err := Append(dst[:0], key, uint64(i)+1)
+				if err != nil {
+					b.Fatal(err)
+				}
+				benchmarkBytes = encoded
+			}
+		})
+	}
+}
+
+func BenchmarkDecode(b *testing.B) {
+	for _, size := range []int{16, 64, 256} {
+		encoded, err := Encode(benchmarkKey(size), 42)
+		if err != nil {
+			b.Fatal(err)
+		}
+		b.Run(fmt.Sprintf("bytes=%d/allocate", size), func(b *testing.B) {
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				decoded, timestamp, err := Decode(encoded)
+				if err != nil {
+					b.Fatal(err)
+				}
+				benchmarkBytes, benchmarkTimestamp = decoded, timestamp
+			}
+		})
+		b.Run(fmt.Sprintf("bytes=%d/reuse", size), func(b *testing.B) {
+			dst := make([]byte, 0, size)
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				decoded, timestamp, err := DecodeAppend(dst[:0], encoded)
+				if err != nil {
+					b.Fatal(err)
+				}
+				benchmarkBytes, benchmarkTimestamp = decoded, timestamp
+			}
+		})
+	}
+}
+
+func BenchmarkLogicalPrefixBounds(b *testing.B) {
+	key := benchmarkKey(64)
+	lower := make([]byte, 0, 128)
+	upper := make([]byte, 0, 128)
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		var err error
+		lower, err = AppendLogicalPrefixLower(lower[:0], key)
+		if err != nil {
+			b.Fatal(err)
+		}
+		upper, err = AppendLogicalPrefixUpper(upper[:0], key)
+		if err != nil {
+			b.Fatal(err)
+		}
+		benchmarkBytes = lower
+		benchmarkBytes2 = upper
+	}
+}
+
+func benchmarkKey(size int) []byte {
+	key := make([]byte, size)
+	for i := range key {
+		key[i] = byte(i*31 + 7)
+		if i%17 == 0 {
+			key[i] = 0
+		}
+	}
+	return key
+}
+
+var (
+	benchmarkBytes     []byte
+	benchmarkBytes2    []byte
+	benchmarkTimestamp uint64
+)

--- a/TreeDB/internal/mvcckey/codec_fuzz_test.go
+++ b/TreeDB/internal/mvcckey/codec_fuzz_test.go
@@ -1,0 +1,45 @@
+package mvcckey
+
+import (
+	"bytes"
+	"errors"
+	"testing"
+)
+
+func FuzzRoundTrip(f *testing.F) {
+	f.Add([]byte(nil), uint64(1))
+	f.Add([]byte{0, 1, 0xff, 0}, ^uint64(0))
+	f.Add([]byte("logical-key"), uint64(42))
+	f.Fuzz(func(t *testing.T, logical []byte, timestamp uint64) {
+		if timestamp == 0 {
+			timestamp = 1
+		}
+		encoded, err := Encode(logical, timestamp)
+		if err != nil {
+			if errors.Is(err, ErrKeyTooLarge) {
+				return
+			}
+			t.Fatalf("Encode: %v", err)
+		}
+		decoded, gotTimestamp, err := Decode(encoded)
+		if err != nil {
+			t.Fatalf("Decode: %v", err)
+		}
+		if !bytes.Equal(decoded, logical) || gotTimestamp != timestamp {
+			t.Fatalf("Decode=(%x,%d), want (%x,%d)", decoded, gotTimestamp, logical, timestamp)
+		}
+	})
+}
+
+func FuzzDecodeNeverPanics(f *testing.F) {
+	f.Add([]byte(nil))
+	f.Add(namespaceV1[:])
+	valid, err := Encode([]byte{0, 'k'}, 1)
+	if err != nil {
+		f.Fatal(err)
+	}
+	f.Add(valid)
+	f.Fuzz(func(t *testing.T, physical []byte) {
+		_, _, _ = Decode(physical)
+	})
+}

--- a/TreeDB/internal/mvcckey/codec_test.go
+++ b/TreeDB/internal/mvcckey/codec_test.go
@@ -1,0 +1,269 @@
+package mvcckey
+
+import (
+	"bytes"
+	"errors"
+	"math"
+	"math/rand"
+	"sort"
+	"testing"
+)
+
+func TestEncodeDecodeRoundTrip(t *testing.T) {
+	tests := []struct {
+		name string
+		key  []byte
+		ts   uint64
+	}{
+		{name: "empty", key: nil, ts: 1},
+		{name: "embedded zeros", key: []byte{0, 'a', 0, 0xff, 0}, ts: 42},
+		{name: "physical marker as logical bytes", key: append([]byte(nil), namespaceV1[:]...), ts: math.MaxUint64},
+		{name: "all bytes", key: allBytes(), ts: 1 << 63},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			encoded, err := Encode(tt.key, tt.ts)
+			if err != nil {
+				t.Fatalf("Encode: %v", err)
+			}
+			if !InNamespace(encoded) {
+				t.Fatalf("encoded key is outside namespace: %x", encoded)
+			}
+			decoded, ts, err := Decode(encoded)
+			if err != nil {
+				t.Fatalf("Decode: %v", err)
+			}
+			if !bytes.Equal(decoded, tt.key) || ts != tt.ts {
+				t.Fatalf("Decode=(%x,%d), want (%x,%d)", decoded, ts, tt.key, tt.ts)
+			}
+		})
+	}
+}
+
+func TestAppendPreservesPrefixAndErrorLeavesDestinationUnchanged(t *testing.T) {
+	dst := []byte("caller:")
+	got, err := Append(dst[:len(dst):len(dst)], []byte("key"), 9)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(got[:len(dst)], dst) {
+		t.Fatalf("prefix changed: %x", got[:len(dst)])
+	}
+
+	before := append([]byte(nil), dst...)
+	got, err = Append(dst, []byte("key"), 0)
+	if !errors.Is(err, ErrZeroTimestamp) || !bytes.Equal(got, before) {
+		t.Fatalf("Append zero timestamp=(%x,%v), want unchanged,%v", got, err, ErrZeroTimestamp)
+	}
+}
+
+func TestEncodedOrderingMatchesLogicalKeyAscendingTimestampDescending(t *testing.T) {
+	rng := rand.New(rand.NewSource(3670))
+	type item struct {
+		key     []byte
+		ts      uint64
+		encoded []byte
+	}
+	items := make([]item, 0, 2000)
+	for i := 0; i < 2000; i++ {
+		key := make([]byte, rng.Intn(40))
+		_, _ = rng.Read(key)
+		if i%7 == 0 && len(key) != 0 {
+			key[rng.Intn(len(key))] = 0
+		}
+		ts := rng.Uint64()
+		if ts == 0 {
+			ts = 1
+		}
+		encoded, err := Encode(key, ts)
+		if err != nil {
+			t.Fatal(err)
+		}
+		items = append(items, item{key: key, ts: ts, encoded: encoded})
+	}
+
+	byLogical := append([]item(nil), items...)
+	sort.Slice(byLogical, func(i, j int) bool {
+		if cmp := bytes.Compare(byLogical[i].key, byLogical[j].key); cmp != 0 {
+			return cmp < 0
+		}
+		return byLogical[i].ts > byLogical[j].ts
+	})
+	byPhysical := append([]item(nil), items...)
+	sort.Slice(byPhysical, func(i, j int) bool {
+		return bytes.Compare(byPhysical[i].encoded, byPhysical[j].encoded) < 0
+	})
+	for i := range byLogical {
+		if !bytes.Equal(byLogical[i].key, byPhysical[i].key) || byLogical[i].ts != byPhysical[i].ts {
+			t.Fatalf("order mismatch at %d: logical=(%x,%d) physical=(%x,%d)", i, byLogical[i].key, byLogical[i].ts, byPhysical[i].key, byPhysical[i].ts)
+		}
+	}
+}
+
+func TestLogicalPrefixAndKeyVersionBounds(t *testing.T) {
+	logicalKeys := [][]byte{nil, {0}, {0, 1}, {'a'}, {'a', 0}, {'a', 0, 'b'}, {'a', 'b'}, {'b'}}
+	var physical [][]byte
+	for _, key := range logicalKeys {
+		for _, ts := range []uint64{1, 2, math.MaxUint64} {
+			encoded, err := Encode(key, ts)
+			if err != nil {
+				t.Fatal(err)
+			}
+			physical = append(physical, encoded)
+		}
+	}
+
+	for _, prefix := range logicalKeys {
+		lower, err := AppendLogicalPrefixLower(nil, prefix)
+		if err != nil {
+			t.Fatal(err)
+		}
+		upper, err := AppendLogicalPrefixUpper(nil, prefix)
+		if err != nil {
+			t.Fatal(err)
+		}
+		for _, encoded := range physical {
+			decoded, _, err := Decode(encoded)
+			if err != nil {
+				t.Fatal(err)
+			}
+			inBounds := bytes.Compare(encoded, lower) >= 0 && bytes.Compare(encoded, upper) < 0
+			if inBounds != bytes.HasPrefix(decoded, prefix) {
+				t.Fatalf("prefix=%x key=%x bounds=%v want=%v lower=%x upper=%x", prefix, decoded, inBounds, bytes.HasPrefix(decoded, prefix), lower, upper)
+			}
+		}
+	}
+
+	for _, target := range logicalKeys {
+		lower, err := AppendKeyVersionsLower(nil, target)
+		if err != nil {
+			t.Fatal(err)
+		}
+		upper, err := AppendKeyVersionsUpper(nil, target)
+		if err != nil {
+			t.Fatal(err)
+		}
+		for _, encoded := range physical {
+			decoded, _, err := Decode(encoded)
+			if err != nil {
+				t.Fatal(err)
+			}
+			inBounds := bytes.Compare(encoded, lower) >= 0 && bytes.Compare(encoded, upper) < 0
+			if inBounds != bytes.Equal(decoded, target) {
+				t.Fatalf("target=%x key=%x bounds=%v want=%v", target, decoded, inBounds, bytes.Equal(decoded, target))
+			}
+		}
+	}
+}
+
+func TestNamespaceBounds(t *testing.T) {
+	lower := AppendNamespaceLower(nil)
+	upper := AppendNamespaceUpper(nil)
+	if bytes.Compare(lower, upper) >= 0 {
+		t.Fatalf("namespace bounds not increasing: %x >= %x", lower, upper)
+	}
+	encoded, err := Encode(nil, 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if bytes.Compare(encoded, lower) < 0 || bytes.Compare(encoded, upper) >= 0 {
+		t.Fatalf("encoded key %x outside [%x,%x)", encoded, lower, upper)
+	}
+	wrongVersion := append([]byte(nil), namespaceV1[:]...)
+	wrongVersion[len(wrongVersion)-1]++
+	wrongVersion = append(wrongVersion, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1)
+	if _, _, err := Decode(wrongVersion); !errors.Is(err, ErrWrongNamespace) {
+		t.Fatalf("Decode wrong version err=%v, want %v", err, ErrWrongNamespace)
+	}
+}
+
+func TestDecodeRejectsMalformedKeys(t *testing.T) {
+	valid, err := Encode([]byte{'a', 0, 'b'}, 7)
+	if err != nil {
+		t.Fatal(err)
+	}
+	zeroTimestamp := append([]byte(nil), valid...)
+	for i := len(zeroTimestamp) - TimestampSize; i < len(zeroTimestamp); i++ {
+		zeroTimestamp[i] = 0xff
+	}
+
+	tests := []struct {
+		name string
+		key  []byte
+		want error
+	}{
+		{name: "empty", key: nil, want: ErrWrongNamespace},
+		{name: "marker only", key: namespaceV1[:], want: ErrMalformedKey},
+		{name: "truncated timestamp", key: valid[:len(valid)-1], want: ErrMalformedKey},
+		{name: "extra timestamp byte", key: append(append([]byte(nil), valid...), 0), want: ErrMalformedKey},
+		{name: "invalid escape", key: append(append([]byte(nil), namespaceV1[:]...), 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1), want: ErrMalformedKey},
+		{name: "missing terminator", key: append(append([]byte(nil), namespaceV1[:]...), 'a', 0, 0, 0, 0, 0, 0, 0, 0), want: ErrMalformedKey},
+		{name: "zero timestamp", key: zeroTimestamp, want: ErrZeroTimestamp},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			prefix := []byte("keep:")
+			got, _, err := DecodeAppend(prefix, tt.key)
+			if !errors.Is(err, tt.want) {
+				t.Fatalf("DecodeAppend err=%v, want %v", err, tt.want)
+			}
+			if !bytes.Equal(got, prefix) {
+				t.Fatalf("DecodeAppend changed destination on error: %x", got)
+			}
+		})
+	}
+}
+
+func TestEncodedLengthMaximumBoundary(t *testing.T) {
+	const fixed = len(namespaceV1) + 2 + TimestampSize
+	maxNoZero := bytes.Repeat([]byte{'x'}, MaxEncodedKeySize-fixed)
+	encoded, err := Encode(maxNoZero, 1)
+	if err != nil {
+		t.Fatalf("Encode exact maximum: %v", err)
+	}
+	if len(encoded) != MaxEncodedKeySize {
+		t.Fatalf("encoded length=%d, want %d", len(encoded), MaxEncodedKeySize)
+	}
+	if _, err := Encode(append(maxNoZero, 'x'), 1); !errors.Is(err, ErrKeyTooLarge) {
+		t.Fatalf("Encode one over err=%v, want %v", err, ErrKeyTooLarge)
+	}
+	if _, err := AppendKeyVersionsLower(nil, maxNoZero); err != nil {
+		t.Fatalf("AppendKeyVersionsLower exact maximum: %v", err)
+	}
+	if _, err := AppendKeyVersionsUpper(nil, append(maxNoZero, 'x')); !errors.Is(err, ErrKeyTooLarge) {
+		t.Fatalf("AppendKeyVersionsUpper one over err=%v, want %v", err, ErrKeyTooLarge)
+	}
+
+	maxZeros := bytes.Repeat([]byte{0}, (MaxEncodedKeySize-fixed)/2)
+	if _, err := Encode(maxZeros, 1); err != nil {
+		t.Fatalf("Encode maximum all-zero key: %v", err)
+	}
+	if _, err := Encode(append(maxZeros, 0), 1); !errors.Is(err, ErrKeyTooLarge) {
+		t.Fatalf("Encode all-zero one over err=%v, want %v", err, ErrKeyTooLarge)
+	}
+}
+
+func TestTimestampExtremesSortNewestFirst(t *testing.T) {
+	oldest, err := Encode([]byte("k"), 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	newest, err := Encode([]byte("k"), math.MaxUint64)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if bytes.Compare(newest, oldest) >= 0 {
+		t.Fatalf("newest key %x must sort before oldest %x", newest, oldest)
+	}
+	if _, err := Encode([]byte("k"), 0); !errors.Is(err, ErrZeroTimestamp) {
+		t.Fatalf("zero timestamp err=%v, want %v", err, ErrZeroTimestamp)
+	}
+}
+
+func allBytes() []byte {
+	out := make([]byte, 256)
+	for i := range out {
+		out[i] = byte(i)
+	}
+	return out
+}


### PR DESCRIPTION
## Objective

Define the pre-alpha, opt-in physical-key codec and ordering contract needed by TreeDB's caller-assigned MVCC stack. This closes #3670 and unblocks atomic `CommitAt`/`GetAt` work without changing raw TreeDB keys or `EntryRevision` semantics.

Parent: #3668

## Context

Dgraph requires externally assigned commit timestamps, read-at-timestamp behavior, and all-version scans. TreeDB's native `EntryRevision` is a current-entry validation token, so it must remain a separate domain.

## Non-goals

- No `CommitAt`, `GetAt`, retained-version iterator, discard/pruning, or write-engine implementation.
- No Dgraph metadata, Badger types, TTL, subscriptions, or conditional-transaction dependency.
- No public stable API or format-compatibility promise.
- No changes to `TreeDB/public.go` or snapshot iterator wrappers owned by #3671.

## Design

- Adds internal package `TreeDB/internal/mvcckey`.
- Physical layout: versioned marker `00 54 44 42 4d 56 43 43 01`, logical bytes with `00 -> 00 ff`, `00 00` terminator, then big-endian `^timestamp`.
- Nonzero caller timestamps sort descending within each logical key; logical keys sort ascending under `bytes.Compare`.
- Namespace, logical-prefix, and exact-key/all-version bounds are half-open. Exact-key bounds enforce the full timestamp-bearing encoded-size envelope.
- Encode/decode and bounds have caller-buffer append forms; reusable-buffer benchmark paths allocate zero bytes.
- Maximum encoded size is checked before allocation. TreeDB pages may impose a smaller physical limit.

## Scope

- Includes: codec, error contract, bounds, property/table/fuzz tests, microbenchmarks, one raw-compatibility test, and storage/contracts/verification docs.
- Excludes: all engine integration and public API work.

## Correctness

Exact commands run on commit `18cf173b1`:

- `cd TreeDB && GOWORK=off go test ./internal/mvcckey -count=1`
- `cd TreeDB && GOWORK=off go test . -run TestExternalMVCCCodecIsOptInAndDoesNotReplaceEntryRevision -count=1`
- `cd TreeDB && GOWORK=off go test ./docs -count=1`
- `cd TreeDB && GOWORK=off go test -race ./internal/mvcckey -count=1`
- `cd TreeDB && GOWORK=off go test ./internal/mvcckey -run '^$' -fuzz '^FuzzRoundTrip$' -fuzztime=3s` (845,001 executions)
- `cd TreeDB && GOWORK=off go test ./internal/mvcckey -run '^$' -fuzz '^FuzzDecodeNeverPanics$' -fuzztime=3s` (873,731 executions)
- `cd TreeDB && GOWORK=off go vet ./internal/mvcckey`
- `cd TreeDB && GOWORK=off go test ./... -count=1`

Coverage includes arbitrary/empty/embedded-zero keys, timestamp extremes, randomized order equivalence, namespace and range bounds, malformed escapes, truncated/extra suffixes, wrong namespace versions, exact maximum-size acceptance, and one-over rejection.

## Performance

Command:

`cd TreeDB && GOMAXPROCS=1 GOWORK=off go test ./internal/mvcckey -run '^$' -bench 'BenchmarkEncode|BenchmarkDecode|BenchmarkLogicalPrefixBounds' -benchmem -benchtime=200ms -count=5`

Linux amd64, Intel i5-11400F. Values are median-of-5.

| Operation | Logical bytes | Path | ns/op | ops/s | B/op | allocs/op |
| --- | ---: | --- | ---: | ---: | ---: | ---: |
| Encode | 16 | allocate | 56.36 | 17.74M | 48 | 1 |
| Encode | 16 | reuse | 26.13 | 38.27M | 0 | 0 |
| Encode | 64 | allocate | 112.2 | 8.91M | 96 | 1 |
| Encode | 64 | reuse | 86.96 | 11.50M | 0 | 0 |
| Encode | 256 | allocate | 469.7 | 2.13M | 320 | 1 |
| Encode | 256 | reuse | 440.0 | 2.27M | 0 | 0 |
| Decode | 16 | allocate | 48.92 | 20.44M | 16 | 1 |
| Decode | 16 | reuse | 28.13 | 35.55M | 0 | 0 |
| Decode | 64 | allocate | 114.6 | 8.73M | 64 | 1 |
| Decode | 64 | reuse | 91.46 | 10.93M | 0 | 0 |
| Decode | 256 | allocate | 454.1 | 2.20M | 256 | 1 |
| Decode | 256 | reuse | 400.3 | 2.50M | 0 | 0 |
| Prefix lower+upper | 64 | reuse | 239.7 | 4.17M | 0 | 0 |

Gate status: pass. This is a new opt-in package with no production imports; current raw TreeDB code paths do not call the codec, so there is no before/after raw-path regression surface in this PR.

## Rollout / Toggle Plan

- Default setting: unused/off; descendants must explicitly import and use the internal codec.
- Disable: do not enable the future external-version MVCC owner.
- Pre-alpha directories using this format may require rebuild if the format changes.

## Follow-ups

- #3672 implements atomic externally timestamped commit/read behavior after this PR merges.
- #3669 implements all-version iteration and pruning after the commit/read contract lands.

## AI Review Loop

- Codex latest-head review: not requested by this worker; coordinator owns the mature-PR review gate.
- Copilot latest-head review: not requested.
- CodeRabbit latest-head review: not requested.

## Checklist

- [x] Single objective and bounded ownership surface
- [x] Caps checked before allocation
- [x] Malformed/truncated encodings fail closed
- [x] Deterministic, property, fuzz, compatibility, and exact-boundary tests
- [x] Focused, race, docs, vet, and broad TreeDB suites pass
- [x] Relevant benchmark with median-of-5 and allocation evidence
- [x] Storage format, behavioral contracts, and verification matrix updated
