### PR TITLE
perf(treedb): feed value-log ref deltas from apply

### DIFF
--- a/TreeDB/db/batch.go
+++ b/TreeDB/db/batch.go
@@ -343,6 +343,7 @@ func (b *Batch) writeOptimistic(sync bool, intent *commandWALBatchIntent, maxEnt
 	tracker := newAllocTracker(idx.allocator)
 	z := idx.zipper.CloneWithAllocator(tracker)
 	applyOpts := b.flushApplyOptions()
+	applyOpts.CollectOldPointerRefs = b.db.shouldCollectValueLogRefDelta(baseSeq)
 	prepareBuf := b.db.acquireFlushApplyReadOnlyPrepareBuffer(applyOpts)
 	if prepareBuf != nil {
 		applyOpts.ReadOnlyPrepare = prepareBuf.opts
@@ -385,7 +386,7 @@ func (b *Batch) writeOptimistic(sync bool, intent *commandWALBatchIntent, maxEnt
 		hook()
 	}
 	entries, ranges := b.batch.ApplyPlan()
-	vlogRefDelta, err := b.db.buildValueLogRefDelta(idx.pager, rootID, baseSeq, entries, ranges)
+	vlogRefDelta, err := b.db.buildValueLogRefDelta(idx.pager, rootID, baseSeq, entries, ranges, &applyResult.OldPointerRefs, applyResult.OldPointerRefsCollected)
 	if err != nil {
 		b.db.releasePendingValueLogAppendFileIDsFromBatch(b.batch)
 		b.db.observeRawBatchSpanNativePublishFallback(rawSpanPlan, spanNativePublishSnapshot, FlushSpanRunFallbackOutputOwnershipFailure)
@@ -568,6 +569,7 @@ func (b *Batch) writeSerialized(sync bool, intent *commandWALBatchIntent, maxEnt
 	}
 
 	applyOpts := b.flushApplyOptions()
+	applyOpts.CollectOldPointerRefs = b.db.shouldCollectValueLogRefDelta(baseSeq)
 	prepareBuf := b.db.acquireFlushApplyReadOnlyPrepareBuffer(applyOpts)
 	if prepareBuf != nil {
 		applyOpts.ReadOnlyPrepare = prepareBuf.opts
@@ -602,7 +604,7 @@ func (b *Batch) writeSerialized(sync bool, intent *commandWALBatchIntent, maxEnt
 		return err
 	}
 	entries, ranges := b.batch.ApplyPlan()
-	vlogRefDelta, err := b.db.buildValueLogRefDelta(idx.pager, rootID, baseSeq, entries, ranges)
+	vlogRefDelta, err := b.db.buildValueLogRefDelta(idx.pager, rootID, baseSeq, entries, ranges, &applyResult.OldPointerRefs, applyResult.OldPointerRefsCollected)
 	if err != nil {
 		b.db.releasePendingValueLogAppendFileIDsFromBatch(b.batch)
 		b.db.observeRawBatchSpanNativePublishFallback(rawSpanPlan, spanNativePublishSnapshot, FlushSpanRunFallbackOutputOwnershipFailure)

--- a/TreeDB/db/flush_apply_options.go
+++ b/TreeDB/db/flush_apply_options.go
@@ -30,7 +30,7 @@ func (db *DB) flushApplyOptions() zipper.ApplyOptions {
 }
 
 func flushApplyUseOptions(opts zipper.ApplyOptions) bool {
-	return opts.ParallelApplyConcurrency > 1 || opts.SpanNativeApply || opts.PrepareReadOnly
+	return opts.ParallelApplyConcurrency > 1 || opts.SpanNativeApply || opts.PrepareReadOnly || opts.CollectOldPointerRefs
 }
 
 func (db *DB) observeFlushApplyPrepareResult(result zipper.ApplyResult, err error) {

--- a/TreeDB/db/vlog_gc_incremental.go
+++ b/TreeDB/db/vlog_gc_incremental.go
@@ -19,6 +19,7 @@ import (
 	"github.com/snissn/gomap/TreeDB/page"
 	"github.com/snissn/gomap/TreeDB/pager"
 	"github.com/snissn/gomap/TreeDB/tree"
+	"github.com/snissn/gomap/TreeDB/zipper"
 )
 
 const (
@@ -52,6 +53,11 @@ var scanValueLogRefCountsHook struct {
 	fn func()
 }
 
+var lookupValueLogRefAtKeyHook struct {
+	mu sync.Mutex
+	fn func()
+}
+
 func registerScanValueLogRefCountsHook(hook func()) func() {
 	scanValueLogRefCountsHook.mu.Lock()
 	prev := scanValueLogRefCountsHook.fn
@@ -68,6 +74,27 @@ func runScanValueLogRefCountsHook() {
 	scanValueLogRefCountsHook.mu.Lock()
 	hook := scanValueLogRefCountsHook.fn
 	scanValueLogRefCountsHook.mu.Unlock()
+	if hook != nil {
+		hook()
+	}
+}
+
+func registerLookupValueLogRefAtKeyHook(hook func()) func() {
+	lookupValueLogRefAtKeyHook.mu.Lock()
+	prev := lookupValueLogRefAtKeyHook.fn
+	lookupValueLogRefAtKeyHook.fn = hook
+	lookupValueLogRefAtKeyHook.mu.Unlock()
+	return func() {
+		lookupValueLogRefAtKeyHook.mu.Lock()
+		lookupValueLogRefAtKeyHook.fn = prev
+		lookupValueLogRefAtKeyHook.mu.Unlock()
+	}
+}
+
+func runLookupValueLogRefAtKeyHook() {
+	lookupValueLogRefAtKeyHook.mu.Lock()
+	hook := lookupValueLogRefAtKeyHook.fn
+	lookupValueLogRefAtKeyHook.mu.Unlock()
 	if hook != nil {
 		hook()
 	}
@@ -649,14 +676,43 @@ func collectValueLogRefCounts(ctx context.Context, db *DB, it iterator.UnsafeIte
 	return it.Error()
 }
 
-func (db *DB) buildValueLogRefDelta(p *pager.Pager, rootID uint64, baseSeq uint64, entries []batchpkg.Entry, ranges []batchpkg.DeleteRange) (*valueLogRefDelta, error) {
-	if db == nil || db.valueLogRefTracker == nil || !db.valueLogRefTracker.canTrack(baseSeq) {
-		return nil, nil
-	}
-	if db.indexOuterLeavesInValueLog {
+func (db *DB) shouldCollectValueLogRefDelta(baseSeq uint64) bool {
+	return db != nil && db.valueLogRefTracker != nil && db.valueLogRefTracker.canTrack(baseSeq) && !db.indexOuterLeavesInValueLog
+}
+
+func (db *DB) buildValueLogRefDelta(p *pager.Pager, rootID uint64, baseSeq uint64, entries []batchpkg.Entry, ranges []batchpkg.DeleteRange, oldPointerRefs *zipper.PointerRefCounts, oldPointerRefsCollected bool) (*valueLogRefDelta, error) {
+	if !db.shouldCollectValueLogRefDelta(baseSeq) {
 		return nil, nil
 	}
 	delta := newValueLogRefDelta()
+	if oldPointerRefsCollected {
+		var countErr error
+		oldPointerRefs.ForEach(func(fileID uint32, count uint64) bool {
+			if !page.IsValueLogFileID(fileID) {
+				return true
+			}
+			if count > uint64(^uint64(0)>>1) {
+				countErr = fmt.Errorf("treedb: value-log ref decrement overflow for file %d: %d", fileID, count)
+				return false
+			}
+			delta.add(fileID, -int64(count))
+			return true
+		})
+		if countErr != nil {
+			releaseValueLogRefDelta(delta)
+			return nil, countErr
+		}
+		for i := range entries {
+			if entries[i].Type == batchpkg.OpPut && entries[i].IsPtr && page.IsValueLogFileID(entries[i].ValuePtr.FileID) {
+				delta.add(entries[i].ValuePtr.FileID, 1)
+			}
+		}
+		return delta, nil
+	}
+
+	// Fail safe for any caller that requests tracking without apply-fed evidence.
+	// This preserves correctness while making the normal foreground path measurable
+	// through lookupValueLogRefAtKeyHook.
 	if p == nil {
 		return delta, nil
 	}
@@ -706,6 +762,7 @@ func (db *DB) newNoopValueLogRefDeltaIfTrackable(baseSeq uint64) *valueLogRefDel
 }
 
 func lookupValueLogRefAtKey(tr *tree.Tree, key []byte) (uint32, bool, error) {
+	runLookupValueLogRefAtKeyHook()
 	if tr == nil {
 		return 0, false, nil
 	}

--- a/TreeDB/db/vlog_gc_incremental_apply_test.go
+++ b/TreeDB/db/vlog_gc_incremental_apply_test.go
@@ -1,0 +1,130 @@
+package db
+
+import (
+	"fmt"
+	"sync/atomic"
+	"testing"
+
+	batchpkg "github.com/snissn/gomap/TreeDB/batch"
+	"github.com/snissn/gomap/TreeDB/page"
+)
+
+func TestValueLogRefTrackerApplyPathAvoidsPointLookups(t *testing.T) {
+	d, err := Open(Options{Dir: t.TempDir(), DisableBackgroundPrune: true})
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer func() { _ = d.Close() }()
+
+	const count = 64
+	seed := d.NewBatch().(*Batch)
+	for i := 0; i < count; i++ {
+		ptr := page.ValuePtr{FileID: page.ValueLogFileID(1), Offset: uint64(i + 1), Length: 64}
+		if err := seed.SetPointer([]byte(fmt.Sprintf("key-%06d", i)), ptr); err != nil {
+			t.Fatalf("seed SetPointer %d: %v", i, err)
+		}
+	}
+	if err := seed.Write(); err != nil {
+		t.Fatalf("seed Write: %v", err)
+	}
+	_ = seed.Close()
+
+	var lookups atomic.Uint64
+	restore := registerLookupValueLogRefAtKeyHook(func() { lookups.Add(1) })
+	defer restore()
+
+	update := d.NewBatch().(*Batch)
+	for i := 0; i < count; i++ {
+		ptr := page.ValuePtr{FileID: page.ValueLogFileID(2), Offset: uint64(i + 1000), Length: 96}
+		if err := update.SetPointer([]byte(fmt.Sprintf("key-%06d", i)), ptr); err != nil {
+			t.Fatalf("update SetPointer %d: %v", i, err)
+		}
+	}
+	if err := update.Write(); err != nil {
+		t.Fatalf("update Write: %v", err)
+	}
+	_ = update.Close()
+
+	if got := lookups.Load(); got != 0 {
+		t.Fatalf("lookupValueLogRefAtKey calls=%d want 0", got)
+	}
+}
+
+func TestBuildValueLogRefDeltaFallsBackWhenApplyEvidenceMissing(t *testing.T) {
+	d, err := Open(Options{Dir: t.TempDir(), DisableBackgroundPrune: true})
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer func() { _ = d.Close() }()
+
+	seed := d.NewBatch().(*Batch)
+	for i := 0; i < 4; i++ {
+		ptr := page.ValuePtr{FileID: page.ValueLogFileID(31), Offset: uint64(i + 1), Length: 64}
+		if err := seed.SetPointer([]byte(fmt.Sprintf("key-%06d", i)), ptr); err != nil {
+			t.Fatalf("seed SetPointer: %v", err)
+		}
+	}
+	if err := seed.Write(); err != nil {
+		t.Fatalf("seed Write: %v", err)
+	}
+	_ = seed.Close()
+
+	idx := d.idx.Load()
+	d.mu.RLock()
+	rootID := d.meta.UserRootPageID
+	baseSeq := d.meta.CommitSeq
+	d.mu.RUnlock()
+	entries := make([]batchpkg.Entry, 4)
+	for i := range entries {
+		entries[i] = batchpkg.Entry{Key: []byte(fmt.Sprintf("key-%06d", i)), Type: batchpkg.OpDelete}
+	}
+
+	var lookups atomic.Uint64
+	restore := registerLookupValueLogRefAtKeyHook(func() { lookups.Add(1) })
+	defer restore()
+	delta, err := d.buildValueLogRefDelta(idx.pager, rootID, baseSeq, entries, nil, nil, false)
+	if err != nil {
+		t.Fatalf("buildValueLogRefDelta: %v", err)
+	}
+	defer releaseValueLogRefDelta(delta)
+	if got, want := lookups.Load(), uint64(len(entries)); got != want {
+		t.Fatalf("fallback lookup calls=%d want %d", got, want)
+	}
+}
+
+func TestValueLogRefTrackerPreservesSharedPointerMultiplicity(t *testing.T) {
+	d, err := Open(Options{Dir: t.TempDir(), DisableBackgroundPrune: true})
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer func() { _ = d.Close() }()
+
+	shared := page.ValuePtr{FileID: page.ValueLogFileID(7), Offset: 100, Length: 256}
+	seed := d.NewBatch().(*Batch)
+	for _, key := range []string{"a", "b"} {
+		if err := seed.SetPointer([]byte(key), shared); err != nil {
+			t.Fatalf("seed SetPointer %q: %v", key, err)
+		}
+	}
+	if err := seed.Write(); err != nil {
+		t.Fatalf("seed Write: %v", err)
+	}
+	_ = seed.Close()
+
+	removeOne := d.NewBatch().(*Batch)
+	if err := removeOne.Delete([]byte("a")); err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+	if err := removeOne.Write(); err != nil {
+		t.Fatalf("delete Write: %v", err)
+	}
+	_ = removeOne.Close()
+
+	seq, counts, ok := d.valueLogRefTracker.dirtySnapshot()
+	if !ok || seq != d.currentCommitSeq() {
+		t.Fatalf("tracker snapshot ok=%v seq=%d current=%d", ok, seq, d.currentCommitSeq())
+	}
+	if got, want := counts[shared.FileID], uint64(1); got != want {
+		t.Fatalf("shared pointer count=%d want %d", got, want)
+	}
+}

--- a/TreeDB/db/vlog_gc_incremental_bench_test.go
+++ b/TreeDB/db/vlog_gc_incremental_bench_test.go
@@ -1,0 +1,63 @@
+package db
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/snissn/gomap/TreeDB/page"
+)
+
+func BenchmarkValueLogRefDeltaOverwrite(b *testing.B) {
+	const batchSize = 1024
+	keys := make([][]byte, batchSize)
+	for i := range keys {
+		keys[i] = []byte(fmt.Sprintf("key-%06d", i))
+	}
+
+	for _, trackerEnabled := range []bool{true, false} {
+		name := "tracker_disabled"
+		if trackerEnabled {
+			name = "tracker_enabled"
+		}
+		b.Run(name, func(b *testing.B) {
+			d, err := Open(Options{Dir: b.TempDir(), DisableBackgroundPrune: true})
+			if err != nil {
+				b.Fatalf("Open: %v", err)
+			}
+			defer func() { _ = d.Close() }()
+
+			seed := d.NewBatch().(*Batch)
+			for i, key := range keys {
+				ptr := page.ValuePtr{FileID: page.ValueLogFileID(1), Offset: uint64(i + 1), Length: 64}
+				if err := seed.SetPointer(key, ptr); err != nil {
+					b.Fatalf("seed SetPointer: %v", err)
+				}
+			}
+			if err := seed.Write(); err != nil {
+				b.Fatalf("seed Write: %v", err)
+			}
+			_ = seed.Close()
+			if !trackerEnabled {
+				d.valueLogRefTracker = nil
+			}
+
+			b.ReportAllocs()
+			b.ReportMetric(batchSize, "overwrites/op")
+			b.ResetTimer()
+			for n := 0; n < b.N; n++ {
+				fileID := page.ValueLogFileID(uint32(2 + n%2))
+				update := d.NewBatch().(*Batch)
+				for i, key := range keys {
+					ptr := page.ValuePtr{FileID: fileID, Offset: uint64(n*batchSize + i + 1), Length: 96}
+					if err := update.SetPointer(key, ptr); err != nil {
+						b.Fatalf("SetPointer: %v", err)
+					}
+				}
+				if err := update.Write(); err != nil {
+					b.Fatalf("Write: %v", err)
+				}
+				_ = update.Close()
+			}
+		})
+	}
+}

--- a/TreeDB/db/vlog_gc_test.go
+++ b/TreeDB/db/vlog_gc_test.go
@@ -1019,10 +1019,16 @@ func seedValueLogRefIncrementalParityFixture(t *testing.T, db *DB, dir string, i
 	_ = b.Close()
 
 	b = db.NewBatch().(*Batch)
+	if err := b.DeleteRange(key(90), key(120)); err != nil {
+		t.Fatalf("delete range: %v", err)
+	}
 	for i := 0; i < 90; i++ {
 		if err := b.Delete(key(i)); err != nil {
 			t.Fatalf("delete %d: %v", i, err)
 		}
+	}
+	if err := b.Delete(key(100)); err != nil {
+		t.Fatalf("delete inside range: %v", err)
 	}
 	for i := 160; i < 280; i++ {
 		if err := b.SetPointer(key(i), ptrsB[i-160]); err != nil {

--- a/TreeDB/zipper/old_pointer_refs_test.go
+++ b/TreeDB/zipper/old_pointer_refs_test.go
@@ -1,0 +1,126 @@
+package zipper
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/snissn/gomap/TreeDB/batch"
+	"github.com/snissn/gomap/TreeDB/page"
+)
+
+func pointerApplyBatch(t *testing.T, start, end int, fileID uint32) *batch.Batch {
+	t.Helper()
+	b := batch.New(panicValueReader{}, page.DefaultInlineThreshold)
+	for i := start; i < end; i++ {
+		ptr := page.ValuePtr{FileID: fileID, Offset: uint64(i + 1), Length: 64}
+		if err := b.SetPointer([]byte(fmt.Sprintf("key-%06d", i)), ptr); err != nil {
+			t.Fatalf("SetPointer %d: %v", i, err)
+		}
+	}
+	return b
+}
+
+func TestApplyWithOptionsCollectsOldPointerRefsForPointsAndRange(t *testing.T) {
+	_, z := newParallelApplyTestZipper(t)
+	root := newParallelApplyEmptyLeafRoot(t, z)
+	fileID := page.ValueLogFileID(1)
+	seed := pointerApplyBatch(t, 0, 256, fileID)
+	root, _, _, err := z.Apply(root, seed)
+	_ = seed.Close()
+	if err != nil {
+		t.Fatalf("seed Apply: %v", err)
+	}
+
+	delta := pointerApplyBatch(t, 0, 64, page.ValueLogFileID(2))
+	defer func() { _ = delta.Close() }()
+	for i := 64; i < 128; i++ {
+		if err := delta.Delete([]byte(fmt.Sprintf("key-%06d", i))); err != nil {
+			t.Fatalf("Delete %d: %v", i, err)
+		}
+	}
+	if err := delta.DeleteRange([]byte("key-000128"), []byte("key-000192")); err != nil {
+		t.Fatalf("DeleteRange: %v", err)
+	}
+
+	result, err := z.ApplyWithOptions(root, delta, ApplyOptions{CollectOldPointerRefs: true})
+	if err != nil {
+		t.Fatalf("ApplyWithOptions: %v", err)
+	}
+	if !result.OldPointerRefsCollected {
+		t.Fatal("old pointer refs were not marked collected")
+	}
+	if got, want := result.OldPointerRefs.Count(fileID), uint64(192); got != want {
+		t.Fatalf("old pointer refs=%d want %d", got, want)
+	}
+	if got := result.OldPointerRefs.Count(page.ValueLogFileID(2)); got != 0 {
+		t.Fatalf("new pointer file appeared in old refs: %d", got)
+	}
+}
+
+func TestApplyWithOptionsParallelCollectsOldPointerRefsExactlyOnce(t *testing.T) {
+	_, z := newParallelApplyTestZipper(t)
+	root := newParallelApplyEmptyLeafRoot(t, z)
+	fileID := page.ValueLogFileID(11)
+	seed := pointerApplyBatch(t, 0, 12000, fileID)
+	root, _, _, err := z.Apply(root, seed)
+	_ = seed.Close()
+	if err != nil {
+		t.Fatalf("seed Apply: %v", err)
+	}
+
+	update := pointerApplyBatch(t, 0, 9000, page.ValueLogFileID(12))
+	defer func() { _ = update.Close() }()
+	pool := NewApplyWorkerPool(4)
+	defer pool.Close()
+	result, err := z.ApplyWithOptions(root, update, ApplyOptions{
+		CollectOldPointerRefs:     true,
+		PrepareReadOnly:           true,
+		ReadOnlyPrepareWorkers:    4,
+		ParallelApplyConcurrency:  4,
+		ParallelApplyWorkerPool:   pool,
+		ParallelApplyMinSpans:     1,
+		ParallelApplyMinSpanOps:   1,
+		ParallelApplyMinSpanBytes: 1,
+	})
+	if err != nil {
+		t.Fatalf("parallel ApplyWithOptions: %v", err)
+	}
+	if !result.ParallelApplyUsed {
+		t.Fatal("parallel apply path was not used")
+	}
+	if got, want := result.OldPointerRefs.Count(fileID), uint64(9000); got != want {
+		t.Fatalf("parallel old pointer refs=%d want %d", got, want)
+	}
+}
+
+func TestApplyWithOptionsSpanNativeCollectsOldPointerRefsExactlyOnce(t *testing.T) {
+	_, z := newParallelApplyTestZipper(t)
+	root := newParallelApplyEmptyLeafRoot(t, z)
+	fileID := page.ValueLogFileID(21)
+	seed := pointerApplyBatch(t, 0, 2000, fileID)
+	root, _, _, err := z.Apply(root, seed)
+	_ = seed.Close()
+	if err != nil {
+		t.Fatalf("seed Apply: %v", err)
+	}
+
+	update := pointerApplyBatch(t, 250, 1750, page.ValueLogFileID(22))
+	defer func() { _ = update.Close() }()
+	pool := NewApplyWorkerPool(4)
+	defer pool.Close()
+	result, err := z.ApplyWithOptions(root, update, ApplyOptions{
+		CollectOldPointerRefs:    true,
+		SpanNativeApply:          true,
+		ParallelApplyConcurrency: 4,
+		ParallelApplyWorkerPool:  pool,
+	})
+	if err != nil {
+		t.Fatalf("span-native ApplyWithOptions: %v", err)
+	}
+	if !result.SpanNativeUsed {
+		t.Fatal("span-native apply path was not used")
+	}
+	if got, want := result.OldPointerRefs.Count(fileID), uint64(1500); got != want {
+		t.Fatalf("span-native old pointer refs=%d want %d", got, want)
+	}
+}

--- a/TreeDB/zipper/pointer_ref_counts.go
+++ b/TreeDB/zipper/pointer_ref_counts.go
@@ -1,0 +1,91 @@
+package zipper
+
+const pointerRefCountsInlineCapacity = 8
+
+type pointerRefCountEntry struct {
+	fileID uint32
+	count  uint64
+}
+
+// PointerRefCounts is an apply-attempt-local count of pointer references by
+// file ID. Typical batches stay in the inline representation; unusually wide
+// batches promote to a map.
+type PointerRefCounts struct {
+	inline  [pointerRefCountsInlineCapacity]pointerRefCountEntry
+	inlineN uint8
+	counts  map[uint32]uint64
+}
+
+func (c *PointerRefCounts) add(fileID uint32, count uint64) {
+	if c == nil || fileID == 0 || count == 0 {
+		return
+	}
+	if c.counts == nil {
+		for i := uint8(0); i < c.inlineN; i++ {
+			if c.inline[i].fileID == fileID {
+				c.inline[i].count += count
+				return
+			}
+		}
+		if int(c.inlineN) < len(c.inline) {
+			c.inline[c.inlineN] = pointerRefCountEntry{fileID: fileID, count: count}
+			c.inlineN++
+			return
+		}
+		c.counts = make(map[uint32]uint64, pointerRefCountsInlineCapacity*2)
+		for i := uint8(0); i < c.inlineN; i++ {
+			entry := c.inline[i]
+			c.counts[entry.fileID] = entry.count
+			c.inline[i] = pointerRefCountEntry{}
+		}
+		c.inlineN = 0
+	}
+	c.counts[fileID] += count
+}
+
+func (c *PointerRefCounts) merge(src *PointerRefCounts) {
+	if c == nil || src == nil {
+		return
+	}
+	src.ForEach(func(fileID uint32, count uint64) bool {
+		c.add(fileID, count)
+		return true
+	})
+}
+
+// Count returns the number of removed pointer references for fileID.
+func (c *PointerRefCounts) Count(fileID uint32) uint64 {
+	if c == nil || fileID == 0 {
+		return 0
+	}
+	if c.counts != nil {
+		return c.counts[fileID]
+	}
+	for i := uint8(0); i < c.inlineN; i++ {
+		if c.inline[i].fileID == fileID {
+			return c.inline[i].count
+		}
+	}
+	return 0
+}
+
+// ForEach visits each non-zero file count until fn returns false.
+func (c *PointerRefCounts) ForEach(fn func(fileID uint32, count uint64) bool) {
+	if c == nil || fn == nil {
+		return
+	}
+	if c.counts != nil {
+		for fileID, count := range c.counts {
+			if count != 0 && !fn(fileID, count) {
+				return
+			}
+		}
+		return
+	}
+	for i := uint8(0); i < c.inlineN; i++ {
+		entry := c.inline[i]
+		if entry.count != 0 && !fn(entry.fileID, entry.count) {
+			return
+		}
+	}
+}

--- a/TreeDB/zipper/pointer_ref_counts_test.go
+++ b/TreeDB/zipper/pointer_ref_counts_test.go
@@ -1,0 +1,24 @@
+package zipper
+
+import "testing"
+
+func TestPointerRefCountsInlinePromotionAndMerge(t *testing.T) {
+	var left PointerRefCounts
+	for i := uint32(1); i <= pointerRefCountsInlineCapacity+2; i++ {
+		left.add(i, uint64(i))
+	}
+	if left.counts == nil {
+		t.Fatal("counts did not promote after inline capacity")
+	}
+
+	var right PointerRefCounts
+	right.add(1, 10)
+	right.add(100, 20)
+	left.merge(&right)
+	if got, want := left.Count(1), uint64(11); got != want {
+		t.Fatalf("merged count for file 1=%d want %d", got, want)
+	}
+	if got, want := left.Count(100), uint64(20); got != want {
+		t.Fatalf("merged count for file 100=%d want %d", got, want)
+	}
+}

--- a/TreeDB/zipper/read_only_prepare.go
+++ b/TreeDB/zipper/read_only_prepare.go
@@ -15,6 +15,11 @@ import (
 
 // ApplyOptions configures a root apply attempt.
 type ApplyOptions struct {
+	// CollectOldPointerRefs asks the apply engine to count pointer entries removed
+	// by overwrites, point deletes, and range deletes while it already owns the old
+	// leaf entry. Counts are attempt-local and returned only for successful apply.
+	CollectOldPointerRefs bool
+
 	// PrepareReadOnly asks ApplyWithOptions to run the read-only preparation
 	// pass before applying the delta. This is opt-in because it traverses the
 	// captured root in addition to the apply pass. It does not publish roots,
@@ -75,6 +80,10 @@ type ApplyResult struct {
 	RootID              uint64
 	PendingRetiredPages []uint64
 	Metrics             adaptive.Metrics
+	OldPointerRefs      PointerRefCounts
+	// OldPointerRefsCollected distinguishes a successful empty count from a path
+	// that did not collect apply-fed reference evidence.
+	OldPointerRefsCollected bool
 
 	// ReadOnlyPrepare is populated only when ApplyOptions.PrepareReadOnly is
 	// true or opt-in parallel apply needs the M1 span plan for gating. It is
@@ -937,6 +946,10 @@ func (z *Zipper) ApplyWithOptions(rootID uint64, b *batch.Batch, opts ApplyOptio
 	}
 
 	applyCfg := applyRunConfig{}
+	var oldPointerRefs PointerRefCounts
+	if opts.CollectOldPointerRefs {
+		applyCfg.oldPointerRefs = &oldPointerRefs
+	}
 	if opts.ParallelApplyConcurrency > 1 && prepared.DeleteRanges == 0 {
 		workers := resolveParallelApplyWorkers(opts, prepared.LeafSpanSummary())
 		if workers > 1 {
@@ -950,6 +963,10 @@ func (z *Zipper) ApplyWithOptions(rootID uint64, b *batch.Batch, opts ApplyOptio
 	result.RootID = newRoot
 	result.PendingRetiredPages = retired
 	result.Metrics = metrics
+	if err == nil && opts.CollectOldPointerRefs {
+		result.OldPointerRefs = oldPointerRefs
+		result.OldPointerRefsCollected = true
+	}
 	result.ReadOnlyPrepare = prepared
 	result.ReadOnlyPrepareNs = preparedNs
 	if result.ReadOnlyPrepareWorkerSummary.TargetWorkers == 0 && prepareRequested {

--- a/TreeDB/zipper/span_native_apply.go
+++ b/TreeDB/zipper/span_native_apply.go
@@ -380,6 +380,10 @@ func (z *Zipper) applySpanNativeWithPrepared(rootID uint64, ops []batch.Entry, p
 	defer coordinatorScratch.releaseSpanRangeRetired(rangeRetired)
 	rangeSplits := coordinatorScratch.acquireSpanRangeSplits(len(workerRanges))
 	defer coordinatorScratch.releaseSpanRangeSplits(rangeSplits)
+	var rangeOldPointerRefs []PointerRefCounts
+	if opts.CollectOldPointerRefs {
+		rangeOldPointerRefs = make([]PointerRefCounts, len(workerRanges))
+	}
 	var firstErr error
 	var errOnce sync.Once
 	var workerBusyNs atomic.Int64
@@ -423,6 +427,9 @@ func (z *Zipper) applySpanNativeWithPrepared(rootID uint64, ops []batch.Entry, p
 			}
 		}
 		workerApplyCfg := applyRunConfig{maxParallelWorkers: 1, leafPagePersister: leafPagePersister}
+		if rangeOldPointerRefs != nil {
+			workerApplyCfg.oldPointerRefs = &rangeOldPointerRefs[job]
+		}
 		for i := workerRange.FirstSpan; i < end; i++ {
 			span := prepared.LeafSpans[i]
 			newRef, splits, err := z.writeRecursive(span.Ref, ops[span.PointOpStart:span.PointOpEnd], nil, false, nil, &localMetrics, span.LowKey, span.HighKey, &localRetired, workerScratch, false, workerApplyCfg)
@@ -548,6 +555,12 @@ func (z *Zipper) applySpanNativeWithPrepared(rootID uint64, ops []batch.Entry, p
 		metrics.ZipperApplyWallNs = time.Since(applyStart).Nanoseconds()
 		return ApplyResult{Metrics: metrics, PendingRetiredPages: retired}, true, firstErr
 	}
+	var oldPointerRefs PointerRefCounts
+	if opts.CollectOldPointerRefs {
+		for i := range rangeOldPointerRefs {
+			oldPointerRefs.merge(&rangeOldPointerRefs[i])
+		}
+	}
 	rootReduceStart := time.Now()
 	newRootID, err := z.reduceSpanNativeRootWithContext(rootID, spanNativeLeafReplacements{spans: prepared.LeafSpans, outputs: &outputs}, &metrics, &retired, coordinatorScratch)
 	metrics.ZipperRootReduceNs += time.Since(rootReduceStart).Nanoseconds()
@@ -556,12 +569,14 @@ func (z *Zipper) applySpanNativeWithPrepared(rootID uint64, ops []batch.Entry, p
 		return ApplyResult{Metrics: metrics, PendingRetiredPages: retired}, true, err
 	}
 	return ApplyResult{
-		RootID:              newRootID,
-		PendingRetiredPages: retired,
-		Metrics:             metrics,
-		SpanNativeEligible:  true,
-		SpanNativeWorkers:   scheduledWorkers,
-		SpanNativeUsed:      true,
+		RootID:                  newRootID,
+		PendingRetiredPages:     retired,
+		Metrics:                 metrics,
+		SpanNativeEligible:      true,
+		SpanNativeWorkers:       scheduledWorkers,
+		SpanNativeUsed:          true,
+		OldPointerRefs:          oldPointerRefs,
+		OldPointerRefsCollected: opts.CollectOldPointerRefs,
 	}, true, nil
 }
 

--- a/TreeDB/zipper/zipper.go
+++ b/TreeDB/zipper/zipper.go
@@ -1721,6 +1721,7 @@ type applyRunConfig struct {
 	maxParallelWorkers int
 	workerPool         *ApplyWorkerPool
 	leafPagePersister  leafPagePersistSink
+	oldPointerRefs     *PointerRefCounts
 }
 
 // Apply applies the batch to the tree rooted at rootID.
@@ -2553,6 +2554,9 @@ func (z *Zipper) mergeLeaf(oldNode *node.Node, builder *node.Builder, ops []batc
 		if flags&node.FlagPointer == 0 {
 			return
 		}
+		if cfg.oldPointerRefs != nil {
+			cfg.oldPointerRefs.add(ptr.FileID, 1)
+		}
 		metrics.SlabDeadBytes += int(ptr.Length)
 		if metrics.SlabDeadBytesByFile == nil {
 			metrics.SlabDeadBytesByFile = make(map[uint32]int64, 4)
@@ -3133,6 +3137,10 @@ func (z *Zipper) mergeInternal(oldNode *node.Node, builder *node.Builder, ops []
 			childCfg.maxParallelWorkers = 1
 		}
 		var childScratches []*mergeScratch
+		var childOldPointerRefs []PointerRefCounts
+		if cfg.oldPointerRefs != nil {
+			childOldPointerRefs = make([]PointerRefCounts, len(children))
+		}
 		if scratch != nil {
 			childScratches = scratch.acquireSpanWorkerScratchSlots(len(children))
 			defer func() {
@@ -3154,7 +3162,11 @@ func (z *Zipper) mergeInternal(oldNode *node.Node, builder *node.Builder, ops []
 			}
 			var childMetrics adaptive.Metrics
 			childRet := children[i].retired[:0]
-			ncID, cs, err := z.writeRecursive(children[i].child, children[i].ops, nil, maintenance, budget, &childMetrics, children[i].low, children[i].high, &childRet, childScratch, false, childCfg)
+			localCfg := childCfg
+			if childOldPointerRefs != nil {
+				localCfg.oldPointerRefs = &childOldPointerRefs[i]
+			}
+			ncID, cs, err := z.writeRecursive(children[i].child, children[i].ops, nil, maintenance, budget, &childMetrics, children[i].low, children[i].high, &childRet, childScratch, false, localCfg)
 			if err != nil {
 				errOnce.Do(func() { firstErr = err })
 				return
@@ -3197,6 +3209,9 @@ func (z *Zipper) mergeInternal(oldNode *node.Node, builder *node.Builder, ops []
 			mergeMetrics(metrics, &children[i].childStat)
 			if retired != nil && len(children[i].retired) > 0 {
 				*retired = append(*retired, children[i].retired...)
+			}
+			if childOldPointerRefs != nil {
+				cfg.oldPointerRefs.merge(&childOldPointerRefs[i])
 			}
 		}
 	} else {


### PR DESCRIPTION
Closes #3643
Parent: #3630

## Problem

Tracked foreground batches rebuilt the value-log reference delta after zipper apply by calling `GetEntry` once per point mutation against the pre-image root. A 64-key overwrite test observed 64 redundant lookups, and the paired baseline benchmark showed a large tracker tax.

## Design

- Add opt-in `CollectOldPointerRefs` apply evidence with an inline-by-default count accumulator keyed by pointer file ID.
- Count removed pointer references at the existing leaf ownership point used for dead-byte accounting.
- Keep serial apply attempt-local.
- Give generic parallel child jobs and span-native work ranges private accumulators; merge them on the coordinator only after every worker succeeds.
- Build DB `valueLogRefDelta` negatives from successful apply evidence and preserve positive put counts for pending-append pin release.
- Retain the old range/point lookup builder as a fail-safe fallback when apply evidence is absent.
- Keep the tracker disabled for outer-leaf mode and preserve underflow/mismatch invalidation.

This preserves delete-range exactly-once behavior because the apply engine emits a removed entry only when it actually consumes that old leaf entry. Failed applies, optimistic retries, and failed finalization never publish the attempt-local counts.

## TDD and correctness evidence

New tests cover:

- zero foreground `lookupValueLogRefAtKey` calls (`64 -> 0`)
- serial overwrite, point-delete, and range-delete emission
- 9,000 parallel worker-pool overwrites counted exactly once
- 1,500 span-native overwrites counted exactly once
- mixed point/range tracker parity against a full scan
- grouped/shared pointer multiplicity
- inline-to-map accumulator promotion and merge
- legacy lookup fallback instrumentation
- existing failed-finalize tracker rollback

Commands:

```text
GOWORK=off GOMEMLIMIT=4GiB GOMAXPROCS=2 go test -p 1 ./TreeDB/db -run 'TestValueLogGC_Incremental|TestValueLogRefTracker|TestCommandWAL|TestOrderedRoot|TestMaintenanceRoots|TestBuildValueLogRefDeltaFallsBackWhenApplyEvidenceMissing' -count=1
PASS (latest head, 4.595s)

GOWORK=off GOMEMLIMIT=4GiB GOMAXPROCS=2 go test -race -p 1 ./TreeDB/zipper -run 'TestApplyWithOptions(CollectsOldPointerRefsForPointsAndRange|ParallelCollectsOldPointerRefsExactlyOnce|SpanNativeCollectsOldPointerRefsExactlyOnce)|TestPointerRefCountsInlinePromotionAndMerge' -count=3
PASS (latest head, 1.828s)

GOWORK=off GOMEMLIMIT=4GiB GOMAXPROCS=2 go test -race -p 1 ./TreeDB/db -run 'TestValueLogGC_Incremental|TestValueLogRefTracker|TestBuildValueLogRefDeltaFallsBackWhenApplyEvidenceMissing' -count=1
PASS

GOWORK=off GOMEMLIMIT=4GiB GOMAXPROCS=2 go test -p 1 ./TreeDB/db -count=1
PASS (354.943s)

GOWORK=off GOMEMLIMIT=4GiB GOMAXPROCS=2 go test -p 1 ./TreeDB -count=1
PASS (55.316s)

GOWORK=off go vet ./TreeDB/db ./TreeDB/zipper
PASS

GOWORK=off GOOS=windows GOARCH=amd64 go test -c ./TreeDB/db
GOWORK=off GOOS=windows GOARCH=amd64 go test -c ./TreeDB/zipper
PASS
```

The full-package runs were on the implementation commit before rebasing over the independent external-MVCC codec merge. The issue-focused and race gates were rerun on the current head.

## Performance evidence

Identical benchmark source on base `e05733d85` and candidate, `GOMAXPROCS=2`, `-benchtime=500ms -count=8`, analyzed with `benchstat`:

| row | base | candidate | delta |
| --- | ---: | ---: | ---: |
| tracker enabled | 515.9 us/op | 270.3 us/op | **-47.61%**, p=0.000 |
| tracker disabled | 195.5 us/op | 235.7 us/op | no significant change, p=0.130 |
| tracker-enabled bytes | 43.94 KiB/op | 44.01 KiB/op | +0.17% |
| tracker-enabled allocs | 99/op | 99/op | unchanged |

This clears the issue's alternate gate of at least 20% faster than tracker-enabled baseline. It does not claim the stricter within-5%-of-disabled ceiling.

Required exact regex, `-benchmem -count=5`, passed in 332.954s. Candidate medians:

| row | median |
| --- | ---: |
| tracker-enabled overwrite | 234.0 us/op, 45,058 B/op, 99 allocs/op |
| tracker-disabled overwrite | 188.8 us/op, 44,752 B/op, 98 allocs/op |
| range delete 4,096 | 376.8 us/op |
| point delete 4,096 | 675.2 us/op |

```text
GOWORK=off GOMAXPROCS=2 go test ./TreeDB/db -run '^$' -bench 'BenchmarkValueLogRefDelta|BenchmarkBatchOverwrite|BenchmarkBatchDeleteRange' -benchmem -count=5
```
