### PR TITLE
treedb: expose snapshot-bound seek iterators

### DIFF
--- a/.github/scripts/snapshot_iterator_bench/main.go
+++ b/.github/scripts/snapshot_iterator_bench/main.go
@@ -1,0 +1,298 @@
+package main
+
+import (
+	"bufio"
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"os"
+	"regexp"
+	"sort"
+	"strconv"
+	"strings"
+)
+
+const benchmarkPrefix = "BenchmarkSnapshotIteratorSeekNext/"
+
+var cpuSuffix = regexp.MustCompile(`-\d+$`)
+
+type rowKey struct {
+	Keys      int
+	Mode      string
+	Operation string
+}
+
+type sample struct {
+	NSPerOp     float64
+	BytesPerOp  float64
+	AllocsPerOp float64
+}
+
+type metadata struct {
+	Head        string `json:"head"`
+	RunnerImage string `json:"runner_image"`
+	CPU         string `json:"cpu"`
+	GoVersion   string `json:"go_version"`
+}
+
+type caseResult struct {
+	Keys                 int     `json:"keys"`
+	Operation            string  `json:"operation"`
+	Samples              int     `json:"samples"`
+	SnapshotMedianNS     float64 `json:"snapshot_median_ns_per_op"`
+	PublicMedianNS       float64 `json:"public_median_ns_per_op"`
+	DeltaPercent         float64 `json:"delta_percent"`
+	SnapshotMedianBytes  float64 `json:"snapshot_median_bytes_per_op"`
+	PublicMedianBytes    float64 `json:"public_median_bytes_per_op"`
+	SnapshotMedianAllocs float64 `json:"snapshot_median_allocs_per_op"`
+	PublicMedianAllocs   float64 `json:"public_median_allocs_per_op"`
+	TimingPassed         bool    `json:"timing_passed"`
+	AllocationGatePassed bool    `json:"allocation_gate_passed"`
+	Passed               bool    `json:"passed"`
+}
+
+type report struct {
+	Metadata             metadata     `json:"metadata"`
+	RequiredSamples      int          `json:"required_samples"`
+	MaxRegressionPercent float64      `json:"max_regression_percent"`
+	Cases                []caseResult `json:"cases"`
+	Violations           []string     `json:"violations,omitempty"`
+	Passed               bool         `json:"passed"`
+}
+
+func main() {
+	var inputPath, jsonPath, markdownPath string
+	var meta metadata
+	var requiredSamples int
+	var maxRegression float64
+	flag.StringVar(&inputPath, "bench-output", "", "path to raw go benchmark output")
+	flag.StringVar(&jsonPath, "json-output", "", "path for the machine-readable report")
+	flag.StringVar(&markdownPath, "markdown-output", "", "path for the Markdown report")
+	flag.StringVar(&meta.Head, "head", "", "exact git commit under test")
+	flag.StringVar(&meta.RunnerImage, "runner-image", "", "hosted runner image")
+	flag.StringVar(&meta.CPU, "cpu", "", "runner CPU description")
+	flag.StringVar(&meta.GoVersion, "go-version", "", "Go toolchain description")
+	flag.IntVar(&requiredSamples, "samples", 7, "required samples per benchmark row")
+	flag.Float64Var(&maxRegression, "max-regression", 0.05, "maximum snapshot/public median regression fraction")
+	flag.Parse()
+
+	if inputPath == "" || jsonPath == "" || markdownPath == "" {
+		fatal(errors.New("-bench-output, -json-output, and -markdown-output are required"))
+	}
+	raw, err := os.ReadFile(inputPath)
+	if err != nil {
+		fatal(fmt.Errorf("read benchmark output: %w", err))
+	}
+	rows, err := parseBenchmarkOutput(string(raw))
+	if err != nil {
+		fatal(err)
+	}
+	rep := evaluate(rows, meta, requiredSamples, maxRegression)
+	if err := writeReports(rep, jsonPath, markdownPath); err != nil {
+		fatal(err)
+	}
+	for _, violation := range rep.Violations {
+		fmt.Printf("::error::%s\n", violation)
+	}
+	if !rep.Passed {
+		os.Exit(1)
+	}
+}
+
+func fatal(err error) {
+	fmt.Fprintln(os.Stderr, err)
+	os.Exit(2)
+}
+
+func parseBenchmarkOutput(raw string) (map[rowKey][]sample, error) {
+	rows := make(map[rowKey][]sample)
+	scanner := bufio.NewScanner(strings.NewReader(raw))
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if !strings.HasPrefix(line, benchmarkPrefix) {
+			continue
+		}
+		fields := strings.Fields(line)
+		if len(fields) < 8 {
+			return nil, fmt.Errorf("malformed snapshot iterator benchmark row: %q", line)
+		}
+		key, err := parseRowKey(cpuSuffix.ReplaceAllString(fields[0], ""))
+		if err != nil {
+			return nil, err
+		}
+		ns, err := metric(fields, "ns/op")
+		if err != nil {
+			return nil, fmt.Errorf("%s: %w", fields[0], err)
+		}
+		bytesPerOp, err := metric(fields, "B/op")
+		if err != nil {
+			return nil, fmt.Errorf("%s: %w", fields[0], err)
+		}
+		allocs, err := metric(fields, "allocs/op")
+		if err != nil {
+			return nil, fmt.Errorf("%s: %w", fields[0], err)
+		}
+		rows[key] = append(rows[key], sample{NSPerOp: ns, BytesPerOp: bytesPerOp, AllocsPerOp: allocs})
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, fmt.Errorf("scan benchmark output: %w", err)
+	}
+	return rows, nil
+}
+
+func parseRowKey(name string) (rowKey, error) {
+	parts := strings.Split(name, "/")
+	if len(parts) != 3 || parts[0] != strings.TrimSuffix(benchmarkPrefix, "/") {
+		return rowKey{}, fmt.Errorf("unexpected snapshot iterator benchmark name %q", name)
+	}
+	keysText, ok := strings.CutPrefix(parts[1], "keys=")
+	if !ok {
+		return rowKey{}, fmt.Errorf("missing key count in benchmark name %q", name)
+	}
+	keys, err := strconv.Atoi(keysText)
+	if err != nil {
+		return rowKey{}, fmt.Errorf("invalid key count in benchmark name %q", name)
+	}
+	modeOperation := parts[2]
+	if strings.HasPrefix(modeOperation, "public_") {
+		var ok bool
+		modeOperation, ok = strings.CutSuffix(modeOperation, "_baseline")
+		if !ok {
+			return rowKey{}, fmt.Errorf("public benchmark is not labeled as a baseline in %q", name)
+		}
+	}
+	mode, operation, ok := strings.Cut(modeOperation, "_")
+	if !ok || (mode != "snapshot" && mode != "public") || (operation != "seek" && operation != "next") {
+		return rowKey{}, fmt.Errorf("unexpected mode/operation in benchmark name %q", name)
+	}
+	return rowKey{Keys: keys, Mode: mode, Operation: operation}, nil
+}
+
+func metric(fields []string, unit string) (float64, error) {
+	for i := 1; i < len(fields); i++ {
+		if fields[i] != unit {
+			continue
+		}
+		value, err := strconv.ParseFloat(fields[i-1], 64)
+		if err != nil {
+			return 0, fmt.Errorf("parse %s value %q: %w", unit, fields[i-1], err)
+		}
+		return value, nil
+	}
+	return 0, fmt.Errorf("missing %s", unit)
+}
+
+func evaluate(rows map[rowKey][]sample, meta metadata, requiredSamples int, maxRegression float64) report {
+	rep := report{
+		Metadata:             meta,
+		RequiredSamples:      requiredSamples,
+		MaxRegressionPercent: maxRegression * 100,
+	}
+	for _, keys := range []int{1024, 16384} {
+		for _, operation := range []string{"seek", "next"} {
+			snapshot := rows[rowKey{Keys: keys, Mode: "snapshot", Operation: operation}]
+			public := rows[rowKey{Keys: keys, Mode: "public", Operation: operation}]
+			if len(snapshot) != requiredSamples || len(public) != requiredSamples {
+				rep.Violations = append(rep.Violations, fmt.Sprintf(
+					"keys=%d operation=%s requires %d samples per mode; snapshot=%d public=%d",
+					keys, operation, requiredSamples, len(snapshot), len(public)))
+				continue
+			}
+			snapshotNS := median(samplesMetric(snapshot, func(s sample) float64 { return s.NSPerOp }))
+			publicNS := median(samplesMetric(public, func(s sample) float64 { return s.NSPerOp }))
+			snapshotBytes := median(samplesMetric(snapshot, func(s sample) float64 { return s.BytesPerOp }))
+			publicBytes := median(samplesMetric(public, func(s sample) float64 { return s.BytesPerOp }))
+			snapshotAllocs := median(samplesMetric(snapshot, func(s sample) float64 { return s.AllocsPerOp }))
+			publicAllocs := median(samplesMetric(public, func(s sample) float64 { return s.AllocsPerOp }))
+			delta := 0.0
+			if publicNS > 0 {
+				delta = ((snapshotNS / publicNS) - 1) * 100
+			}
+			timingPassed := publicNS > 0 && snapshotNS <= publicNS*(1+maxRegression)
+			allocationPassed := snapshotBytes <= publicBytes && snapshotAllocs <= publicAllocs
+			result := caseResult{
+				Keys: keys, Operation: operation, Samples: requiredSamples,
+				SnapshotMedianNS: snapshotNS, PublicMedianNS: publicNS, DeltaPercent: delta,
+				SnapshotMedianBytes: snapshotBytes, PublicMedianBytes: publicBytes,
+				SnapshotMedianAllocs: snapshotAllocs, PublicMedianAllocs: publicAllocs,
+				TimingPassed: timingPassed, AllocationGatePassed: allocationPassed,
+				Passed: timingPassed && allocationPassed,
+			}
+			rep.Cases = append(rep.Cases, result)
+			if !timingPassed {
+				rep.Violations = append(rep.Violations, fmt.Sprintf(
+					"keys=%d operation=%s snapshot median %.3f ns/op exceeds public %.3f ns/op by %.2f%% (max %.2f%%)",
+					keys, operation, snapshotNS, publicNS, delta, maxRegression*100))
+			}
+			if !allocationPassed {
+				rep.Violations = append(rep.Violations, fmt.Sprintf(
+					"keys=%d operation=%s allocation increase: snapshot %.0f B/op %.0f allocs/op; public %.0f B/op %.0f allocs/op",
+					keys, operation, snapshotBytes, snapshotAllocs, publicBytes, publicAllocs))
+			}
+		}
+	}
+	rep.Passed = len(rep.Violations) == 0 && len(rep.Cases) == 4
+	return rep
+}
+
+func samplesMetric(samples []sample, pick func(sample) float64) []float64 {
+	values := make([]float64, len(samples))
+	for i := range samples {
+		values[i] = pick(samples[i])
+	}
+	return values
+}
+
+func median(values []float64) float64 {
+	values = append([]float64(nil), values...)
+	sort.Float64s(values)
+	mid := len(values) / 2
+	if len(values)%2 == 1 {
+		return values[mid]
+	}
+	return (values[mid-1] + values[mid]) / 2
+}
+
+func writeReports(rep report, jsonPath, markdownPath string) error {
+	encoded, err := json.MarshalIndent(rep, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal report: %w", err)
+	}
+	if err := os.WriteFile(jsonPath, append(encoded, '\n'), 0o644); err != nil {
+		return fmt.Errorf("write JSON report: %w", err)
+	}
+	if err := os.WriteFile(markdownPath, []byte(markdown(rep)), 0o644); err != nil {
+		return fmt.Errorf("write Markdown report: %w", err)
+	}
+	return nil
+}
+
+func markdown(rep report) string {
+	status := "PASS"
+	if !rep.Passed {
+		status = "FAIL"
+	}
+	var b strings.Builder
+	fmt.Fprintf(&b, "## Snapshot iterator performance gate: %s\n\n", status)
+	fmt.Fprintf(&b, "- Exact head: `%s`\n- Runner: `%s`\n- CPU: `%s`\n- Go: `%s`\n", rep.Metadata.Head, rep.Metadata.RunnerImage, rep.Metadata.CPU, rep.Metadata.GoVersion)
+	fmt.Fprintf(&b, "- Gate: snapshot median <= public median + %.2f%%; no B/op or allocs/op increase; %d samples per row.\n\n", rep.MaxRegressionPercent, rep.RequiredSamples)
+	b.WriteString("| keys | operation | snapshot median | public median | delta | snapshot/public B/op | snapshot/public allocs/op | result |\n")
+	b.WriteString("|---:|---|---:|---:|---:|---:|---:|---|\n")
+	for _, result := range rep.Cases {
+		rowStatus := "PASS"
+		if !result.Passed {
+			rowStatus = "FAIL"
+		}
+		fmt.Fprintf(&b, "| %d | %s | %.3f ns/op | %.3f ns/op | %+.2f%% | %.0f / %.0f | %.0f / %.0f | %s |\n",
+			result.Keys, result.Operation, result.SnapshotMedianNS, result.PublicMedianNS, result.DeltaPercent,
+			result.SnapshotMedianBytes, result.PublicMedianBytes, result.SnapshotMedianAllocs, result.PublicMedianAllocs, rowStatus)
+	}
+	if len(rep.Violations) > 0 {
+		b.WriteString("\nViolations:\n\n")
+		for _, violation := range rep.Violations {
+			fmt.Fprintf(&b, "- %s\n", violation)
+		}
+	}
+	return b.String()
+}

--- a/.github/scripts/snapshot_iterator_bench/main_test.go
+++ b/.github/scripts/snapshot_iterator_bench/main_test.go
@@ -1,0 +1,75 @@
+package main
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+)
+
+func benchmarkFixture(snapshotNS, publicNS, snapshotBytes, publicBytes float64, samples int) string {
+	var b strings.Builder
+	for _, keys := range []int{1024, 16384} {
+		for _, operation := range []string{"seek", "next"} {
+			for _, mode := range []string{"snapshot", "public"} {
+				ns := publicNS
+				bytesPerOp := publicBytes
+				if mode == "snapshot" {
+					ns = snapshotNS
+					bytesPerOp = snapshotBytes
+				}
+				rowName := mode + "_" + operation
+				if mode == "public" {
+					rowName += "_baseline"
+				}
+				for i := 0; i < samples; i++ {
+					fmt.Fprintf(&b, "BenchmarkSnapshotIteratorSeekNext/keys=%d/%s-4 1000 %.3f ns/op %.0f B/op 0 allocs/op\n",
+						keys, rowName, ns+float64(i%3), bytesPerOp)
+				}
+			}
+		}
+	}
+	return b.String()
+}
+
+func TestEvaluatePassesSameBinaryGate(t *testing.T) {
+	rows, err := parseBenchmarkOutput(benchmarkFixture(104, 100, 0, 0, 7))
+	if err != nil {
+		t.Fatal(err)
+	}
+	rep := evaluate(rows, metadata{Head: "deadbeef"}, 7, 0.05)
+	if !rep.Passed || len(rep.Cases) != 4 || len(rep.Violations) != 0 {
+		t.Fatalf("report = %+v, want passing four-case report", rep)
+	}
+	if got := markdown(rep); !strings.Contains(got, "Exact head: `deadbeef`") || !strings.Contains(got, "PASS") {
+		t.Fatalf("unexpected Markdown report:\n%s", got)
+	}
+}
+
+func TestEvaluateRejectsTimingAndAllocationRegression(t *testing.T) {
+	rows, err := parseBenchmarkOutput(benchmarkFixture(106, 100, 8, 0, 7))
+	if err != nil {
+		t.Fatal(err)
+	}
+	rep := evaluate(rows, metadata{}, 7, 0.05)
+	if rep.Passed || len(rep.Violations) != 8 {
+		t.Fatalf("violations = %d, passed = %v; want two violations per case", len(rep.Violations), rep.Passed)
+	}
+}
+
+func TestEvaluateRejectsMissingSamples(t *testing.T) {
+	rows, err := parseBenchmarkOutput(benchmarkFixture(100, 100, 0, 0, 6))
+	if err != nil {
+		t.Fatal(err)
+	}
+	rep := evaluate(rows, metadata{}, 7, 0.05)
+	if rep.Passed || len(rep.Violations) != 4 || len(rep.Cases) != 0 {
+		t.Fatalf("report = %+v, want four missing-sample violations", rep)
+	}
+}
+
+func TestParseBenchmarkOutputRejectsMissingAllocationMetric(t *testing.T) {
+	_, err := parseBenchmarkOutput("BenchmarkSnapshotIteratorSeekNext/keys=1024/snapshot_seek-4 1000 100 ns/op 0 B/op\n")
+	if err == nil || !strings.Contains(err.Error(), "malformed") {
+		t.Fatalf("error = %v, want malformed row", err)
+	}
+}

--- a/.github/workflows/treedb-tests.yml
+++ b/.github/workflows/treedb-tests.yml
@@ -559,12 +559,13 @@ jobs:
             echo "runner_image=${ImageOS:-unknown}-${ImageVersion:-unknown}"
             echo "cpu=$(lscpu | sed -n 's/^Model name:[[:space:]]*//p' | head -n 1)"
             echo "go=$(go version)"
+            echo "gomaxprocs=1"
             echo "kernel=$(uname -a)"
           } | tee artifacts/snapshot_iterator_perf/environment.txt
 
       - name: Run same-binary snapshot iterator benchmark
         run: |
-          go test ./TreeDB -run '^$' \
+          GOMAXPROCS=1 go test ./TreeDB -run '^$' \
             -bench '^BenchmarkSnapshotIteratorSeekNext/keys=(1024|16384)/(snapshot_(seek|next)|public_(seek|next)_baseline)$' \
             -benchmem -benchtime=500ms -count=7 \
             | tee artifacts/snapshot_iterator_perf/raw.txt

--- a/.github/workflows/treedb-tests.yml
+++ b/.github/workflows/treedb-tests.yml
@@ -531,3 +531,71 @@ jobs:
 
           echo "incompressible auto-vs-off gate failed after ${max_attempts} attempts"
           exit 1
+
+  snapshot-iterator-perf:
+    name: snapshot-iterator-perf (linux)
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+          cache-dependency-path: |
+            go.sum
+
+      - name: Test snapshot iterator benchmark parser
+        run: go test ./.github/scripts/snapshot_iterator_bench
+
+      - name: Capture exact-head runner metadata
+        run: |
+          mkdir -p artifacts/snapshot_iterator_perf
+          {
+            echo "head=$(git rev-parse HEAD)"
+            echo "runner_image=${ImageOS:-unknown}-${ImageVersion:-unknown}"
+            echo "cpu=$(lscpu | sed -n 's/^Model name:[[:space:]]*//p' | head -n 1)"
+            echo "go=$(go version)"
+            echo "kernel=$(uname -a)"
+          } | tee artifacts/snapshot_iterator_perf/environment.txt
+
+      - name: Run same-binary snapshot iterator benchmark
+        run: |
+          go test ./TreeDB -run '^$' \
+            -bench '^BenchmarkSnapshotIteratorSeekNext/keys=(1024|16384)/(snapshot_(seek|next)|public_(seek|next)_baseline)$' \
+            -benchmem -benchtime=500ms -count=7 \
+            | tee artifacts/snapshot_iterator_perf/raw.txt
+
+      - name: Check snapshot iterator performance gate
+        run: |
+          go run ./.github/scripts/snapshot_iterator_bench \
+            -bench-output artifacts/snapshot_iterator_perf/raw.txt \
+            -json-output artifacts/snapshot_iterator_perf/report.json \
+            -markdown-output artifacts/snapshot_iterator_perf/report.md \
+            -head "$(git rev-parse HEAD)" \
+            -runner-image "${ImageOS:-unknown}-${ImageVersion:-unknown}" \
+            -cpu "$(lscpu | sed -n 's/^Model name:[[:space:]]*//p' | head -n 1)" \
+            -go-version "$(go version)" \
+            -samples 7 \
+            -max-regression 0.05
+
+      - name: Publish snapshot iterator summary
+        if: always()
+        run: |
+          if [[ -f artifacts/snapshot_iterator_perf/report.md ]]; then
+            cat artifacts/snapshot_iterator_perf/report.md >> "${GITHUB_STEP_SUMMARY}"
+          else
+            echo "## Snapshot iterator performance gate: no report generated" >> "${GITHUB_STEP_SUMMARY}"
+          fi
+
+      - name: Upload snapshot iterator performance evidence
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: snapshot-iterator-perf-${{ github.sha }}
+          path: artifacts/snapshot_iterator_perf/
+          if-no-files-found: error
+          retention-days: 14

--- a/TreeDB/caching/db.go
+++ b/TreeDB/caching/db.go
@@ -36669,6 +36669,9 @@ func (it *singleSourceIterator) Seek(key []byte) {
 	if it.reverse && key != nil && it.start != nil && bytes.Compare(key, it.start) < 0 {
 		return
 	}
+	if !it.reverse && it.start != nil && (key == nil || bytes.Compare(key, it.start) < 0) {
+		key = it.start
+	}
 	it.iter.Seek(key)
 	it.advance()
 }

--- a/TreeDB/caching/db.go
+++ b/TreeDB/caching/db.go
@@ -32123,7 +32123,7 @@ func (db *DB) Iterator(start, end []byte) (merging.Iterator, error) {
 	}
 
 	if len(sources) == 1 {
-		out := newSingleSourceIterator(sources[0].Iter, start, end)
+		out := newSingleSourceIterator(sources[0].Iter, start, end, false)
 		return decorateIterator(out, 1), nil
 	}
 
@@ -32240,6 +32240,19 @@ func (it *concatUnsafeIterator) Next() {
 		panic("iterator invalid")
 	}
 	it.cur.Next()
+	it.advance()
+}
+
+func (it *concatUnsafeIterator) Seek(key []byte) {
+	it.err = nil
+	if it.first != nil {
+		it.first.Seek(key)
+	}
+	if it.second != nil {
+		it.second.Seek(key)
+	}
+	it.cur = it.first
+	it.usingFirst = true
 	it.advance()
 }
 
@@ -32510,7 +32523,7 @@ func (db *DB) ReverseIterator(start, end []byte) (merging.Iterator, error) {
 	}
 
 	if len(sources) == 1 {
-		out := newSingleSourceIterator(sources[0].Iter, start, end)
+		out := newSingleSourceIterator(sources[0].Iter, start, end, true)
 		return decorateIterator(out, 1), nil
 	}
 
@@ -36606,17 +36619,19 @@ func (b *Batch) GetByteSize() (int, error) {
 // singleSourceIterator wraps a single UnsafeIterator to satisfy merging.Iterator,
 // skipping tombstones.
 type singleSourceIterator struct {
-	iter  iterator.UnsafeIterator
-	valid bool
-	start []byte
-	end   []byte
+	iter    iterator.UnsafeIterator
+	valid   bool
+	start   []byte
+	end     []byte
+	reverse bool
 }
 
-func newSingleSourceIterator(iter iterator.UnsafeIterator, start, end []byte) merging.Iterator {
+func newSingleSourceIterator(iter iterator.UnsafeIterator, start, end []byte, reverse bool) merging.Iterator {
 	it := &singleSourceIterator{
-		iter:  iter,
-		start: start,
-		end:   end,
+		iter:    iter,
+		start:   start,
+		end:     end,
+		reverse: reverse,
 	}
 	// Iterator is already sought to start by the caller
 	it.advance()
@@ -36626,6 +36641,9 @@ func newSingleSourceIterator(iter iterator.UnsafeIterator, start, end []byte) me
 func (it *singleSourceIterator) advance() {
 	it.valid = false
 	for it.iter.Valid() {
+		if it.reverse && it.start != nil && bytes.Compare(it.iter.UnsafeKey(), it.start) < 0 {
+			return
+		}
 		if it.end != nil && bytes.Compare(it.iter.UnsafeKey(), it.end) >= 0 {
 			return
 		}
@@ -36643,6 +36661,15 @@ func (it *singleSourceIterator) Next() {
 		panic("iterator invalid")
 	}
 	it.iter.Next()
+	it.advance()
+}
+
+func (it *singleSourceIterator) Seek(key []byte) {
+	it.valid = false
+	if it.reverse && key != nil && it.start != nil && bytes.Compare(key, it.start) < 0 {
+		return
+	}
+	it.iter.Seek(key)
 	it.advance()
 }
 
@@ -36684,6 +36711,7 @@ type emptyIterator struct {
 }
 
 func (it *emptyIterator) Next()                     { panic("iterator invalid") }
+func (it *emptyIterator) Seek([]byte)               {}
 func (it *emptyIterator) Valid() bool               { return false }
 func (it *emptyIterator) Key() []byte               { panic("iterator invalid") }
 func (it *emptyIterator) Value() []byte             { panic("iterator invalid") }

--- a/TreeDB/caching/flush_pool_helpers_test.go
+++ b/TreeDB/caching/flush_pool_helpers_test.go
@@ -1190,6 +1190,7 @@ type stubMergingIterator struct {
 }
 
 func (it *stubMergingIterator) Next()                       {}
+func (it *stubMergingIterator) Seek([]byte)                 {}
 func (it *stubMergingIterator) Valid() bool                 { return false }
 func (it *stubMergingIterator) Key() []byte                 { return nil }
 func (it *stubMergingIterator) Value() []byte               { return nil }

--- a/TreeDB/caching/raw_kv_parity_test.go
+++ b/TreeDB/caching/raw_kv_parity_test.go
@@ -44,7 +44,7 @@ func TestRawKVParityKeyRangePreservesConcreteEmptyKey(t *testing.T) {
 }
 
 func TestRawKVParitySnapshotGetEntryPreservesEmptyKeyAndValue(t *testing.T) {
-	db, backend := newCachedSnapshotPoolTestDB(t)
+	db, backend := newCachedSnapshotTestDB(t)
 	defer func() {
 		_ = db.Close()
 		_ = backend.Close()
@@ -80,7 +80,7 @@ func TestRawKVParitySnapshotGetEntryPreservesEmptyKeyAndValue(t *testing.T) {
 }
 
 func TestRawKVParityCachedUpdateEmptyKeyNilValue(t *testing.T) {
-	db, backend := newCachedSnapshotPoolTestDB(t)
+	db, backend := newCachedSnapshotTestDB(t)
 	defer func() {
 		_ = db.Close()
 		_ = backend.Close()

--- a/TreeDB/caching/root_domain.go
+++ b/TreeDB/caching/root_domain.go
@@ -807,7 +807,7 @@ func (l backendSnapshotLookup) Iterator(start, end []byte) (iterator.UnsafeItera
 	if l.rootID != 0 {
 		return l.snapshot.IteratorAtRoot(l.rootID, start, end)
 	}
-	return l.snapshot.Iterator(start, end)
+	return l.snapshot.IteratorWithOptions(start, end, backenddb.IteratorOptions{})
 }
 
 func (l backendSnapshotLookup) ReverseIterator(start, end []byte) (iterator.UnsafeIterator, error) {
@@ -822,7 +822,7 @@ func (l backendSnapshotLookup) ReverseIterator(start, end []byte) (iterator.Unsa
 	if l.rootID != 0 {
 		return l.snapshot.ReverseIteratorAtRoot(l.rootID, start, end)
 	}
-	return l.snapshot.ReverseIterator(start, end)
+	return l.snapshot.ReverseIteratorWithOptions(start, end, backenddb.IteratorOptions{})
 }
 
 func rootDomainSnapshotFromMemtableView(view *memtableView, shardIdx int, includeMutable bool) rootDomainSnapshot {
@@ -1793,7 +1793,7 @@ func (s rootDomainSnapshot) hasPrefixesSorted(prefixes [][]byte, out []bool) err
 
 	var it merging.Iterator
 	if len(sources) == 1 {
-		it = newSingleSourceIterator(sources[0].Iter, prefixes[0], nil)
+		it = newSingleSourceIterator(sources[0].Iter, prefixes[0], nil, false)
 	} else {
 		it = merging.NewMergingIterator(sources, prefixes[0], nil)
 	}

--- a/TreeDB/caching/snapshot.go
+++ b/TreeDB/caching/snapshot.go
@@ -46,6 +46,7 @@ type Snapshot struct {
 	closed     atomic.Bool
 	generation atomic.Uint64
 	finalized  atomic.Bool
+	readState  atomic.Uint64
 	iteratorMu sync.Mutex
 	iterators  map[*snapshotBoundIterator]struct{}
 }
@@ -68,6 +69,7 @@ func getSnapshot() *Snapshot {
 	snap.iteratorMu.Lock()
 	snap.generation.Add(1)
 	snap.closed.Store(true)
+	snap.readState.Store(snapshotReadClosedBit)
 	snap.iteratorMu.Unlock()
 	return snap
 }
@@ -78,6 +80,7 @@ func activateSnapshot(snap *Snapshot) *Snapshot {
 	}
 	snap.iteratorMu.Lock()
 	snap.closed.Store(false)
+	snap.readState.Store(0)
 	snap.iteratorMu.Unlock()
 	return snap
 }
@@ -98,6 +101,7 @@ func putSnapshot(snap *Snapshot) {
 	snap.publishedRoots = nil
 	snap.iteratorMu.Lock()
 	clear(snap.iterators)
+	snap.readState.Store(snapshotReadClosedBit)
 	snap.closed.Store(true)
 	snap.finalized.Store(false)
 	snap.iteratorMu.Unlock()
@@ -323,21 +327,33 @@ func (db *DB) AcquireSnapshot() *Snapshot {
 }
 
 func (s *Snapshot) Pager() *pager.Pager {
-	if s == nil || s.backend == nil {
+	if err := s.beginRead(); err != nil {
+		return nil
+	}
+	defer s.endRead()
+	if s.backend == nil {
 		return nil
 	}
 	return s.backend.Pager()
 }
 
 func (s *Snapshot) State() *backenddb.DBState {
-	if s == nil || s.backend == nil {
+	if err := s.beginRead(); err != nil {
+		return nil
+	}
+	defer s.endRead()
+	if s.backend == nil {
 		return nil
 	}
 	return s.backend.State()
 }
 
 func (s *Snapshot) StateToken() (backenddb.StateToken, bool) {
-	if s == nil || s.backend == nil {
+	if err := s.beginRead(); err != nil {
+		return backenddb.StateToken{}, false
+	}
+	defer s.endRead()
+	if s.backend == nil {
 		return backenddb.StateToken{}, false
 	}
 	return s.backend.StateToken()
@@ -352,6 +368,7 @@ func (s *Snapshot) Close() error {
 		s.iteratorMu.Unlock()
 		return nil
 	}
+	s.readState.Or(snapshotReadClosedBit)
 	s.invalidateBoundIteratorsLocked()
 	s.iteratorMu.Unlock()
 	return s.finalizeCloseIfUnreferenced()
@@ -359,7 +376,7 @@ func (s *Snapshot) Close() error {
 
 func (s *Snapshot) finalizeCloseIfUnreferenced() error {
 	s.iteratorMu.Lock()
-	if len(s.iterators) != 0 || !s.finalized.CompareAndSwap(false, true) {
+	if len(s.iterators) != 0 || s.readState.Load() != snapshotReadClosedBit || !s.finalized.CompareAndSwap(false, true) {
 		s.iteratorMu.Unlock()
 		return nil
 	}
@@ -706,6 +723,10 @@ func (s *Snapshot) ReverseIterate(start, end []byte, fn func(key, value []byte) 
 }
 
 func (s *Snapshot) iterate(start, end []byte, reverse bool, fn func(key, value []byte) error) (err error) {
+	if err := s.beginRead(); err != nil {
+		return err
+	}
+	s.endRead()
 	if fn == nil {
 		return errors.New("treedb: snapshot iterate nil callback")
 	}
@@ -742,10 +763,14 @@ func (s *Snapshot) iterate(start, end []byte, reverse bool, fn func(key, value [
 }
 
 func (s *Snapshot) GetAppend(key, dst []byte) ([]byte, error) {
-	key = normalizeRawKVPointKey(key)
 	if s == nil {
 		return dst, tree.ErrKeyNotFound
 	}
+	if err := s.beginRead(); err != nil {
+		return dst, err
+	}
+	defer s.endRead()
+	key = normalizeRawKVPointKey(key)
 	// Critical fast path for parallel point reads:
 	// consult only mutable/immutable memtables first, then query published/backend
 	// directly via append APIs. This avoids a published GetEntry pre-read that can
@@ -861,10 +886,14 @@ func (s *Snapshot) GetAppend(key, dst []byte) ([]byte, error) {
 }
 
 func (s *Snapshot) GetVersionedAppend(key, dst []byte) ([]byte, page.EntryRevision, error) {
-	key = normalizeRawKVPointKey(key)
 	if s == nil {
 		return dst, page.LegacyEntryRevision, tree.ErrKeyNotFound
 	}
+	if err := s.beginRead(); err != nil {
+		return dst, page.LegacyEntryRevision, err
+	}
+	defer s.endRead()
+	key = normalizeRawKVPointKey(key)
 	oldLen := len(dst)
 	val, ptr, flags, revision, found := s.lookupCachedRootDomainEntryWithRevision(key)
 	if found {
@@ -922,6 +951,10 @@ func (s *Snapshot) GetVersioned(key []byte) ([]byte, page.EntryRevision, error) 
 }
 
 func (s *Snapshot) Get(key []byte) ([]byte, error) {
+	if err := s.beginRead(); err != nil {
+		return nil, err
+	}
+	defer s.endRead()
 	key = normalizeRawKVPointKey(key)
 	snap, val, ptr, flags, found, source := s.lookupRootDomainSnapshotEntry(key)
 	if found {
@@ -998,6 +1031,14 @@ func (s *Snapshot) Get(key []byte) ([]byte, error) {
 }
 
 func (s *Snapshot) GetUnsafe(key []byte) ([]byte, error) {
+	if err := s.beginRead(); err != nil {
+		return nil, err
+	}
+	defer s.endRead()
+	return s.getUnsafeOpen(key)
+}
+
+func (s *Snapshot) getUnsafeOpen(key []byte) ([]byte, error) {
 	key = normalizeRawKVPointKey(key)
 	snap, val, ptr, flags, found, source := s.lookupRootDomainSnapshotEntry(key)
 	if found {
@@ -1034,18 +1075,22 @@ func (s *Snapshot) GetUnsafe(key []byte) ([]byte, error) {
 // GetManyView calls fn once for each key with a read-only value view. Values
 // are valid only until fn returns and must be copied before retaining.
 func (s *Snapshot) GetManyView(keys [][]byte, fn tree.GetManyViewFunc) error {
-	keys = normalizeRawKVPointKeys(keys)
+	if err := s.beginRead(); err != nil {
+		return err
+	}
+	defer s.endRead()
 	if fn == nil {
 		return errors.New("caching snapshot: GetManyView nil callback")
 	}
+	keys = normalizeRawKVPointKeys(keys)
 	if len(keys) == 0 {
 		return nil
 	}
-	if s == nil || s.closed.Load() || s.backend == nil {
+	if s.backend == nil {
 		return backenddb.ErrClosed
 	}
 	for i, key := range keys {
-		val, err := s.GetUnsafe(key)
+		val, err := s.getUnsafeOpen(key)
 		if err == tree.ErrKeyNotFound {
 			if err := fn(i, key, nil, false); err != nil {
 				return err
@@ -1066,6 +1111,14 @@ func (s *Snapshot) GetManyView(keys [][]byte, fn tree.GetManyViewFunc) error {
 }
 
 func (s *Snapshot) Has(key []byte) (bool, error) {
+	if err := s.beginRead(); err != nil {
+		return false, err
+	}
+	defer s.endRead()
+	return s.hasOpen(key)
+}
+
+func (s *Snapshot) hasOpen(key []byte) (bool, error) {
 	key = normalizeRawKVPointKey(key)
 	_, _, flags, found := s.lookupCachedRootDomainEntry(key)
 	if found {
@@ -1082,6 +1135,10 @@ func (s *Snapshot) Has(key []byte) (bool, error) {
 }
 
 func (s *Snapshot) HasMany(keys [][]byte) ([]bool, error) {
+	if err := s.beginRead(); err != nil {
+		return nil, err
+	}
+	defer s.endRead()
 	keys = normalizeRawKVPointKeys(keys)
 	out := make([]bool, len(keys))
 	if len(keys) == 0 {
@@ -1092,7 +1149,7 @@ func (s *Snapshot) HasMany(keys [][]byte) ([]bool, error) {
 	}
 	if memtableViewHasRangeSpans(s.view) {
 		for i, key := range keys {
-			ok, err := s.Has(key)
+			ok, err := s.hasOpen(key)
 			if err != nil {
 				return nil, err
 			}
@@ -1192,6 +1249,10 @@ type prefixProbeRef struct {
 }
 
 func (s *Snapshot) HasPrefixes(prefixes [][]byte) ([]bool, error) {
+	if err := s.beginRead(); err != nil {
+		return nil, err
+	}
+	defer s.endRead()
 	out := make([]bool, len(prefixes))
 	if len(prefixes) == 0 {
 		return out, nil
@@ -1300,6 +1361,10 @@ func snapshotRawKVLeafEntryWithRevision(key []byte, val []byte, ptr page.ValuePt
 }
 
 func (s *Snapshot) GetEntry(key []byte) (node.LeafEntry, error) {
+	if err := s.beginRead(); err != nil {
+		return node.LeafEntry{}, err
+	}
+	defer s.endRead()
 	key = normalizeRawKVPointKey(key)
 	val, ptr, flags, revision, found := s.lookupQueueEntryWithRevision(key)
 	if found {
@@ -1316,6 +1381,10 @@ func (s *Snapshot) GetEntry(key []byte) (node.LeafEntry, error) {
 }
 
 func (s *Snapshot) GetEntryExact(key []byte) (node.LeafEntry, error) {
+	if err := s.beginRead(); err != nil {
+		return node.LeafEntry{}, err
+	}
+	defer s.endRead()
 	key = normalizeRawKVPointKey(key)
 	val, ptr, flags, revision, found := s.lookupQueueEntryWithRevision(key)
 	if found {

--- a/TreeDB/caching/snapshot.go
+++ b/TreeDB/caching/snapshot.go
@@ -44,6 +44,7 @@ type Snapshot struct {
 	publishedRoots  *publishedRootSet
 
 	closed     atomic.Bool
+	generation atomic.Uint64
 	finalized  atomic.Bool
 	iteratorMu sync.Mutex
 	iterators  map[*snapshotBoundIterator]struct{}
@@ -71,7 +72,20 @@ func getSnapshot() *Snapshot {
 	if snap == nil {
 		snap = &Snapshot{}
 	}
+	snap.iteratorMu.Lock()
+	snap.generation.Add(1)
+	snap.closed.Store(true)
+	snap.iteratorMu.Unlock()
+	return snap
+}
+
+func activateSnapshot(snap *Snapshot) *Snapshot {
+	if snap == nil {
+		return nil
+	}
+	snap.iteratorMu.Lock()
 	snap.closed.Store(false)
+	snap.iteratorMu.Unlock()
 	return snap
 }
 
@@ -91,9 +105,9 @@ func putSnapshot(snap *Snapshot) {
 	snap.publishedRoots = nil
 	snap.iteratorMu.Lock()
 	clear(snap.iterators)
-	snap.iteratorMu.Unlock()
 	snap.closed.Store(true)
 	snap.finalized.Store(false)
+	snap.iteratorMu.Unlock()
 	snapshotPool.Put(snap)
 }
 
@@ -211,7 +225,7 @@ func (db *DB) AcquireSnapshot() *Snapshot {
 		snap.backend = backendSnap
 		snap.backendRootID = backendRootID
 		snap.backendFallback = backendSnapshotLookup{db: db, snapshot: backendSnap, rootID: backendRootID}
-		return snap
+		return activateSnapshot(snap)
 	}
 
 	view := db.retainMemtableView()
@@ -312,7 +326,7 @@ func (db *DB) AcquireSnapshot() *Snapshot {
 	if snap.publishedRoots == nil {
 		db.rootPublishStats.backendFallbacks.Add(1)
 	}
-	return snap
+	return activateSnapshot(snap)
 }
 
 func (s *Snapshot) Pager() *pager.Pager {
@@ -340,10 +354,13 @@ func (s *Snapshot) Close() error {
 	if s == nil {
 		return nil
 	}
+	s.iteratorMu.Lock()
 	if !s.closed.CompareAndSwap(false, true) {
+		s.iteratorMu.Unlock()
 		return nil
 	}
-	s.invalidateBoundIterators()
+	s.invalidateBoundIteratorsLocked()
+	s.iteratorMu.Unlock()
 	return s.finalizeCloseIfUnreferenced()
 }
 
@@ -647,17 +664,9 @@ func (s *Snapshot) iteratorSources(start, end []byte, reverse bool) ([]merging.I
 // Iterator returns a stable iterator over the snapshot's queued memtables plus
 // its backend snapshot.
 func (s *Snapshot) Iterator(start, end []byte) (publiciterator.Iterator, error) {
-	sources, err := s.iteratorSources(start, end, false)
-	if err != nil {
-		return nil, err
-	}
-	if len(sources) == 0 {
-		return s.bindIterator(&emptyIterator{start: start, end: end})
-	}
-	if len(sources) == 1 {
-		return s.bindIterator(newSingleSourceIterator(sources[0].Iter, start, end, false))
-	}
-	return s.bindIterator(merging.NewMergingIterator(sources, start, end))
+	return s.bindNewIterator(func() (merging.Iterator, error) {
+		return s.buildIteratorLocked(start, end, false)
+	})
 }
 
 // Iterate calls fn for each visible key/value pair in [start, end) using this
@@ -671,17 +680,28 @@ func (s *Snapshot) Iterate(start, end []byte, fn func(key, value []byte) error) 
 // ReverseIterator returns a stable reverse iterator over the snapshot's queued
 // memtables plus its backend snapshot.
 func (s *Snapshot) ReverseIterator(start, end []byte) (publiciterator.Iterator, error) {
-	sources, err := s.iteratorSources(start, end, true)
+	return s.bindNewIterator(func() (merging.Iterator, error) {
+		return s.buildIteratorLocked(start, end, true)
+	})
+}
+
+// buildIteratorLocked accesses the snapshot's pinned view and backend and must
+// run while iteratorMu is held by bindNewIterator.
+func (s *Snapshot) buildIteratorLocked(start, end []byte, reverse bool) (merging.Iterator, error) {
+	sources, err := s.iteratorSources(start, end, reverse)
 	if err != nil {
 		return nil, err
 	}
 	if len(sources) == 0 {
-		return s.bindIterator(&emptyIterator{start: start, end: end})
+		return &emptyIterator{start: start, end: end}, nil
 	}
 	if len(sources) == 1 {
-		return s.bindIterator(newSingleSourceIterator(sources[0].Iter, start, end, true))
+		return newSingleSourceIterator(sources[0].Iter, start, end, reverse), nil
 	}
-	return s.bindIterator(merging.NewReverseMergingIterator(sources, start, end))
+	if reverse {
+		return merging.NewReverseMergingIterator(sources, start, end), nil
+	}
+	return merging.NewMergingIterator(sources, start, end), nil
 }
 
 // ReverseIterate calls fn for each visible key/value pair in [start, end) in

--- a/TreeDB/caching/snapshot.go
+++ b/TreeDB/caching/snapshot.go
@@ -12,6 +12,7 @@ import (
 	backenddb "github.com/snissn/gomap/TreeDB/db"
 	"github.com/snissn/gomap/TreeDB/internal/iterator"
 	"github.com/snissn/gomap/TreeDB/internal/merging"
+	publiciterator "github.com/snissn/gomap/TreeDB/iterator"
 	"github.com/snissn/gomap/TreeDB/node"
 	"github.com/snissn/gomap/TreeDB/page"
 	"github.com/snissn/gomap/TreeDB/pager"
@@ -42,7 +43,10 @@ type Snapshot struct {
 	rootIterator    rootDomainSnapshot
 	publishedRoots  *publishedRootSet
 
-	closed atomic.Bool
+	closed     atomic.Bool
+	finalized  atomic.Bool
+	iteratorMu sync.Mutex
+	iterators  map[*snapshotBoundIterator]struct{}
 }
 
 type ownedReadScratch struct {
@@ -85,7 +89,11 @@ func putSnapshot(snap *Snapshot) {
 	snap.rootSystem = rootDomainSnapshot{}
 	snap.rootIterator = rootDomainSnapshot{}
 	snap.publishedRoots = nil
+	snap.iteratorMu.Lock()
+	clear(snap.iterators)
+	snap.iteratorMu.Unlock()
 	snap.closed.Store(true)
+	snap.finalized.Store(false)
 	snapshotPool.Put(snap)
 }
 
@@ -335,7 +343,17 @@ func (s *Snapshot) Close() error {
 	if !s.closed.CompareAndSwap(false, true) {
 		return nil
 	}
+	s.invalidateBoundIterators()
+	return s.finalizeCloseIfUnreferenced()
+}
 
+func (s *Snapshot) finalizeCloseIfUnreferenced() error {
+	s.iteratorMu.Lock()
+	if len(s.iterators) != 0 || !s.finalized.CompareAndSwap(false, true) {
+		s.iteratorMu.Unlock()
+		return nil
+	}
+	s.iteratorMu.Unlock()
 	var err error
 	if s.backend != nil {
 		err = s.backend.Close()
@@ -601,13 +619,13 @@ func (s *Snapshot) iteratorSources(start, end []byte, reverse bool) ([]merging.I
 	if reverse {
 		diskIter, ok, err = rootDomainPublishedReverseIterator(rootSnap, start, end)
 		if !ok {
-			diskIter, err = s.backend.ReverseIterator(start, end)
+			diskIter, err = s.backend.ReverseIteratorWithOptions(start, end, backenddb.IteratorOptions{})
 			ok = true
 		}
 	} else {
 		diskIter, ok, err = rootDomainPublishedIterator(rootSnap, start, end)
 		if !ok {
-			diskIter, err = s.backend.Iterator(start, end)
+			diskIter, err = s.backend.IteratorWithOptions(start, end, backenddb.IteratorOptions{})
 			ok = true
 		}
 	}
@@ -628,18 +646,18 @@ func (s *Snapshot) iteratorSources(start, end []byte, reverse bool) ([]merging.I
 
 // Iterator returns a stable iterator over the snapshot's queued memtables plus
 // its backend snapshot.
-func (s *Snapshot) Iterator(start, end []byte) (merging.Iterator, error) {
+func (s *Snapshot) Iterator(start, end []byte) (publiciterator.Iterator, error) {
 	sources, err := s.iteratorSources(start, end, false)
 	if err != nil {
 		return nil, err
 	}
 	if len(sources) == 0 {
-		return &emptyIterator{start: start, end: end}, nil
+		return s.bindIterator(&emptyIterator{start: start, end: end})
 	}
 	if len(sources) == 1 {
-		return newSingleSourceIterator(sources[0].Iter, start, end), nil
+		return s.bindIterator(newSingleSourceIterator(sources[0].Iter, start, end, false))
 	}
-	return merging.NewMergingIterator(sources, start, end), nil
+	return s.bindIterator(merging.NewMergingIterator(sources, start, end))
 }
 
 // Iterate calls fn for each visible key/value pair in [start, end) using this
@@ -652,18 +670,18 @@ func (s *Snapshot) Iterate(start, end []byte, fn func(key, value []byte) error) 
 
 // ReverseIterator returns a stable reverse iterator over the snapshot's queued
 // memtables plus its backend snapshot.
-func (s *Snapshot) ReverseIterator(start, end []byte) (merging.Iterator, error) {
+func (s *Snapshot) ReverseIterator(start, end []byte) (publiciterator.Iterator, error) {
 	sources, err := s.iteratorSources(start, end, true)
 	if err != nil {
 		return nil, err
 	}
 	if len(sources) == 0 {
-		return &emptyIterator{start: start, end: end}, nil
+		return s.bindIterator(&emptyIterator{start: start, end: end})
 	}
 	if len(sources) == 1 {
-		return newSingleSourceIterator(sources[0].Iter, start, end), nil
+		return s.bindIterator(newSingleSourceIterator(sources[0].Iter, start, end, true))
 	}
-	return merging.NewReverseMergingIterator(sources, start, end), nil
+	return s.bindIterator(merging.NewReverseMergingIterator(sources, start, end))
 }
 
 // ReverseIterate calls fn for each visible key/value pair in [start, end) in
@@ -678,7 +696,7 @@ func (s *Snapshot) iterate(start, end []byte, reverse bool, fn func(key, value [
 	if fn == nil {
 		return errors.New("treedb: snapshot iterate nil callback")
 	}
-	var it merging.Iterator
+	var it publiciterator.Iterator
 	if reverse {
 		it, err = s.ReverseIterator(start, end)
 	} else {

--- a/TreeDB/caching/snapshot.go
+++ b/TreeDB/caching/snapshot.go
@@ -60,18 +60,11 @@ var ownedReadScratchPool = sync.Pool{
 	},
 }
 
-// snapshotPool keeps the cached Snapshot wrapper off the heap-heavy per-key
-// read path. Snapshot.Close returns objects here after releasing backend and
-// memtable-view references; callers must not use a Snapshot after Close.
-var snapshotPool = sync.Pool{
-	New: func() any { return &Snapshot{} },
-}
-
 func getSnapshot() *Snapshot {
-	snap, _ := snapshotPool.Get().(*Snapshot)
-	if snap == nil {
-		snap = &Snapshot{}
-	}
+	// Exported Snapshot handles must have unique identities. Reusing an address
+	// would let a stale pointer retained after Close operate on the new snapshot;
+	// no generation stored in the reused object can distinguish those aliases.
+	snap := &Snapshot{}
 	snap.iteratorMu.Lock()
 	snap.generation.Add(1)
 	snap.closed.Store(true)
@@ -108,7 +101,7 @@ func putSnapshot(snap *Snapshot) {
 	snap.closed.Store(true)
 	snap.finalized.Store(false)
 	snap.iteratorMu.Unlock()
-	snapshotPool.Put(snap)
+	// Do not make the exported handle reusable. A stale alias must remain closed.
 }
 
 func getOwnedReadScratch() *ownedReadScratch {

--- a/TreeDB/caching/snapshot_closed_surface_test.go
+++ b/TreeDB/caching/snapshot_closed_surface_test.go
@@ -1,0 +1,147 @@
+package caching
+
+import (
+	"errors"
+	"testing"
+
+	backenddb "github.com/snissn/gomap/TreeDB/db"
+	publiciterator "github.com/snissn/gomap/TreeDB/iterator"
+)
+
+func TestCachedSnapshotClosedSurfaceRejectsReadsAndInvalidatesAllIterators(t *testing.T) {
+	cached, backend := newCachedSnapshotTestDB(t)
+	defer func() {
+		_ = cached.Close()
+		_ = backend.Close()
+	}()
+	if err := cached.Set([]byte("key"), []byte("value")); err != nil {
+		t.Fatal(err)
+	}
+
+	snap := cached.AcquireSnapshot()
+	if snap == nil {
+		t.Fatal("AcquireSnapshot=nil")
+	}
+	constructors := []struct {
+		name string
+		fn   func() (publiciterator.Iterator, error)
+	}{
+		{"iterator", func() (publiciterator.Iterator, error) { return snap.Iterator(nil, nil) }},
+		{"reverse_iterator", func() (publiciterator.Iterator, error) { return snap.ReverseIterator(nil, nil) }},
+	}
+	iters := make([]publiciterator.Iterator, 0, len(constructors))
+	for _, ctor := range constructors {
+		it, err := ctor.fn()
+		if err != nil {
+			t.Fatalf("%s: %v", ctor.name, err)
+		}
+		if !it.Valid() {
+			t.Fatalf("%s initially invalid: %v", ctor.name, it.Error())
+		}
+		iters = append(iters, it)
+	}
+
+	if err := snap.Close(); err != nil {
+		t.Fatalf("Snapshot.Close: %v", err)
+	}
+	if snap.db == nil {
+		t.Fatal("cached snapshot released pinned state while iterators remained open")
+	}
+	for i, it := range iters {
+		if it.Valid() {
+			t.Fatalf("iterator %d remained valid after Snapshot.Close", i)
+		}
+		if err := it.Error(); !errors.Is(err, backenddb.ErrClosed) {
+			t.Fatalf("iterator %d error=%v want ErrClosed", i, err)
+		}
+	}
+
+	called := false
+	checks := []struct {
+		name string
+		fn   func() error
+	}{
+		{"get", func() error { _, err := snap.Get([]byte("key")); return err }},
+		{"get_append", func() error {
+			dst := []byte("prefix")
+			out, err := snap.GetAppend([]byte("key"), dst)
+			if string(out) != "prefix" {
+				t.Fatalf("GetAppend mutated dst: %q", out)
+			}
+			return err
+		}},
+		{"get_versioned", func() error { _, _, err := snap.GetVersioned([]byte("key")); return err }},
+		{"get_versioned_append", func() error { _, _, err := snap.GetVersionedAppend([]byte("key"), nil); return err }},
+		{"get_many_empty", func() error { return snap.GetManyView(nil, nil) }},
+		{"get_many", func() error {
+			return snap.GetManyView([][]byte{[]byte("key")}, func(int, []byte, []byte, bool) error {
+				called = true
+				return nil
+			})
+		}},
+		{"get_unsafe", func() error { _, err := snap.GetUnsafe([]byte("key")); return err }},
+		{"has", func() error { _, err := snap.Has([]byte("key")); return err }},
+		{"has_many_empty", func() error { _, err := snap.HasMany(nil); return err }},
+		{"has_many", func() error { _, err := snap.HasMany([][]byte{[]byte("key")}); return err }},
+		{"has_prefixes_empty", func() error { _, err := snap.HasPrefixes(nil); return err }},
+		{"has_prefixes", func() error { _, err := snap.HasPrefixes([][]byte{[]byte("k")}); return err }},
+		{"get_entry", func() error { _, err := snap.GetEntry([]byte("key")); return err }},
+		{"get_entry_exact", func() error { _, err := snap.GetEntryExact([]byte("key")); return err }},
+		{"iterate", func() error { return snap.Iterate(nil, nil, func([]byte, []byte) error { called = true; return nil }) }},
+		{"reverse_iterate", func() error {
+			return snap.ReverseIterate(nil, nil, func([]byte, []byte) error { called = true; return nil })
+		}},
+	}
+	for _, check := range checks {
+		if err := check.fn(); !errors.Is(err, backenddb.ErrClosed) {
+			t.Errorf("%s error=%v want ErrClosed", check.name, err)
+		}
+	}
+	if called {
+		t.Fatal("closed cached snapshot invoked a read callback")
+	}
+	if snap.Pager() != nil || snap.State() != nil {
+		t.Fatal("closed cached snapshot exposed Pager or State")
+	}
+	if _, ok := snap.StateToken(); ok {
+		t.Fatal("closed cached snapshot exposed StateToken")
+	}
+
+	for i, it := range iters {
+		if err := it.Close(); err != nil {
+			t.Fatalf("iterator %d Close: %v", i, err)
+		}
+		if i+1 < len(iters) && snap.db == nil {
+			t.Fatalf("cached snapshot released state with %d iterators still open", len(iters)-i-1)
+		}
+	}
+	if snap.db != nil {
+		t.Fatal("cached snapshot retained state after final iterator close")
+	}
+}
+
+func TestCachedSnapshotReadCallbackCanCloseOwner(t *testing.T) {
+	cached, backend := newCachedSnapshotTestDB(t)
+	defer func() {
+		_ = cached.Close()
+		_ = backend.Close()
+	}()
+	if err := cached.Set([]byte("key"), []byte("value")); err != nil {
+		t.Fatal(err)
+	}
+	snap := cached.AcquireSnapshot()
+	if snap == nil {
+		t.Fatal("AcquireSnapshot=nil")
+	}
+	if err := snap.GetManyView([][]byte{[]byte("key")}, func(int, []byte, []byte, bool) error {
+		return snap.Close()
+	}); err != nil {
+		t.Fatalf("GetManyView: %v", err)
+	}
+	if snap.db != nil {
+		t.Fatal("cached snapshot retained pinned state after callback read completed")
+	}
+	if _, err := snap.Get([]byte("key")); !errors.Is(err, backenddb.ErrClosed) {
+		t.Fatalf("post-callback Get error=%v want ErrClosed", err)
+	}
+}

--- a/TreeDB/caching/snapshot_iterator_creation_test.go
+++ b/TreeDB/caching/snapshot_iterator_creation_test.go
@@ -124,3 +124,42 @@ func TestCachedSnapshotIteratorCreationRejectsStaleGeneration(t *testing.T) {
 		t.Fatal("stale generation accessed cached snapshot fields")
 	}
 }
+
+func TestCachedSnapshotIteratorDoubleCloseDetachesPooledOwner(t *testing.T) {
+	cached, backend := newCachedSnapshotPoolTestDB(t)
+	defer func() {
+		_ = cached.Close()
+		_ = backend.Close()
+	}()
+
+	snap := cached.AcquireSnapshot()
+	if snap == nil {
+		t.Fatal("AcquireSnapshot=nil")
+	}
+	it, err := snap.bindNewIterator(func() (merging.Iterator, error) {
+		return snap.buildIteratorLocked(nil, nil, false)
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	bound := it.(*snapshotBoundIterator)
+	if err := snap.Close(); err != nil {
+		t.Fatalf("Snapshot.Close: %v", err)
+	}
+	if err := it.Close(); err != nil {
+		t.Fatalf("Iterator.Close: %v", err)
+	}
+	if bound.owner != nil {
+		t.Fatal("closed iterator retained pooled cached snapshot owner")
+	}
+
+	reused := getSnapshot()
+	generation := snap.generation.Load()
+	if err := it.Close(); err != nil {
+		t.Fatalf("second Iterator.Close: %v", err)
+	}
+	if snap.generation.Load() != generation || snap.finalized.Load() {
+		t.Fatal("double iterator close mutated a pooled cached snapshot generation")
+	}
+	putSnapshot(reused)
+}

--- a/TreeDB/caching/snapshot_iterator_creation_test.go
+++ b/TreeDB/caching/snapshot_iterator_creation_test.go
@@ -7,9 +7,10 @@ import (
 
 	backenddb "github.com/snissn/gomap/TreeDB/db"
 	"github.com/snissn/gomap/TreeDB/internal/merging"
+	publiciterator "github.com/snissn/gomap/TreeDB/iterator"
 )
 
-func TestCachedSnapshotIteratorCreationSerializesCloseAndPoolReuse(t *testing.T) {
+func TestCachedSnapshotIteratorCreationSerializesCloseAndRelease(t *testing.T) {
 	cached, backend := newCachedSnapshotPoolTestDB(t)
 	defer func() {
 		_ = cached.Close()
@@ -62,7 +63,7 @@ func TestCachedSnapshotIteratorCreationSerializesCloseAndPoolReuse(t *testing.T)
 				t.Fatal("second AcquireSnapshot=nil")
 			}
 			if other == snap {
-				t.Fatal("cached snapshot was returned to pool before iterator registration completed")
+				t.Fatal("AcquireSnapshot reused a cached snapshot handle during iterator registration")
 			}
 			if err := other.Close(); err != nil {
 				t.Fatalf("second Snapshot.Close: %v", err)
@@ -122,6 +123,49 @@ func TestCachedSnapshotIteratorCreationRejectsStaleGeneration(t *testing.T) {
 	}
 	if createCalled {
 		t.Fatal("stale generation accessed cached snapshot fields")
+	}
+}
+
+func TestCachedSnapshotIteratorCreationRejectsClosedHandleAfterNewAcquisition(t *testing.T) {
+	cached, backend := newCachedSnapshotPoolTestDB(t)
+	defer func() {
+		_ = cached.Close()
+		_ = backend.Close()
+	}()
+	if err := cached.Set([]byte("old"), []byte("value")); err != nil {
+		t.Fatal(err)
+	}
+
+	stale := cached.AcquireSnapshot()
+	if stale == nil {
+		t.Fatal("AcquireSnapshot=nil")
+	}
+	if err := stale.Close(); err != nil {
+		t.Fatalf("stale Snapshot.Close: %v", err)
+	}
+	fresh := cached.AcquireSnapshot()
+	if fresh == nil {
+		t.Fatal("fresh AcquireSnapshot=nil")
+	}
+	defer fresh.Close()
+	if fresh == stale {
+		t.Fatal("AcquireSnapshot reused an exported cached snapshot handle")
+	}
+
+	for _, reverse := range []bool{false, true} {
+		var it publiciterator.Iterator
+		var err error
+		if reverse {
+			it, err = stale.ReverseIterator(nil, nil)
+		} else {
+			it, err = stale.Iterator(nil, nil)
+		}
+		if !errors.Is(err, backenddb.ErrClosed) {
+			t.Fatalf("reverse=%v stale iterator error=%v want ErrClosed", reverse, err)
+		}
+		if it != nil {
+			t.Fatalf("reverse=%v stale handle returned an iterator", reverse)
+		}
 	}
 }
 

--- a/TreeDB/caching/snapshot_iterator_creation_test.go
+++ b/TreeDB/caching/snapshot_iterator_creation_test.go
@@ -125,7 +125,7 @@ func TestCachedSnapshotIteratorCreationRejectsStaleGeneration(t *testing.T) {
 	}
 }
 
-func TestCachedSnapshotIteratorDoubleCloseDetachesPooledOwner(t *testing.T) {
+func TestCachedSnapshotIteratorDoubleCloseCannotMutateDetachedOwner(t *testing.T) {
 	cached, backend := newCachedSnapshotPoolTestDB(t)
 	defer func() {
 		_ = cached.Close()
@@ -143,6 +143,13 @@ func TestCachedSnapshotIteratorDoubleCloseDetachesPooledOwner(t *testing.T) {
 		t.Fatal(err)
 	}
 	bound := it.(*snapshotBoundIterator)
+	keeper, err := snap.bindNewIterator(func() (merging.Iterator, error) {
+		return snap.buildIteratorLocked(nil, nil, false)
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer keeper.Close()
 	if err := snap.Close(); err != nil {
 		t.Fatalf("Snapshot.Close: %v", err)
 	}
@@ -150,16 +157,20 @@ func TestCachedSnapshotIteratorDoubleCloseDetachesPooledOwner(t *testing.T) {
 		t.Fatalf("Iterator.Close: %v", err)
 	}
 	if bound.owner != nil {
-		t.Fatal("closed iterator retained pooled cached snapshot owner")
+		t.Fatal("closed iterator retained cached snapshot owner")
 	}
 
-	reused := getSnapshot()
 	generation := snap.generation.Load()
+	if snap.finalized.Load() {
+		t.Fatal("keeper did not pin closed cached snapshot owner")
+	}
 	if err := it.Close(); err != nil {
 		t.Fatalf("second Iterator.Close: %v", err)
 	}
 	if snap.generation.Load() != generation || snap.finalized.Load() {
-		t.Fatal("double iterator close mutated a pooled cached snapshot generation")
+		t.Fatal("double iterator close mutated detached cached snapshot owner")
 	}
-	putSnapshot(reused)
+	if err := keeper.Close(); err != nil {
+		t.Fatalf("keeper Iterator.Close: %v", err)
+	}
 }

--- a/TreeDB/caching/snapshot_iterator_creation_test.go
+++ b/TreeDB/caching/snapshot_iterator_creation_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func TestCachedSnapshotIteratorCreationSerializesCloseAndRelease(t *testing.T) {
-	cached, backend := newCachedSnapshotPoolTestDB(t)
+	cached, backend := newCachedSnapshotTestDB(t)
 	defer func() {
 		_ = cached.Close()
 		_ = backend.Close()
@@ -91,7 +91,7 @@ func TestCachedSnapshotIteratorCreationSerializesCloseAndRelease(t *testing.T) {
 }
 
 func TestCachedSnapshotIteratorCreationRejectsStaleGeneration(t *testing.T) {
-	cached, backend := newCachedSnapshotPoolTestDB(t)
+	cached, backend := newCachedSnapshotTestDB(t)
 	defer func() {
 		_ = cached.Close()
 		_ = backend.Close()
@@ -127,7 +127,7 @@ func TestCachedSnapshotIteratorCreationRejectsStaleGeneration(t *testing.T) {
 }
 
 func TestCachedSnapshotIteratorCreationRejectsClosedHandleAfterNewAcquisition(t *testing.T) {
-	cached, backend := newCachedSnapshotPoolTestDB(t)
+	cached, backend := newCachedSnapshotTestDB(t)
 	defer func() {
 		_ = cached.Close()
 		_ = backend.Close()
@@ -170,7 +170,7 @@ func TestCachedSnapshotIteratorCreationRejectsClosedHandleAfterNewAcquisition(t 
 }
 
 func TestCachedSnapshotIteratorDoubleCloseCannotMutateDetachedOwner(t *testing.T) {
-	cached, backend := newCachedSnapshotPoolTestDB(t)
+	cached, backend := newCachedSnapshotTestDB(t)
 	defer func() {
 		_ = cached.Close()
 		_ = backend.Close()

--- a/TreeDB/caching/snapshot_iterator_creation_test.go
+++ b/TreeDB/caching/snapshot_iterator_creation_test.go
@@ -1,0 +1,126 @@
+package caching
+
+import (
+	"errors"
+	"runtime"
+	"testing"
+
+	backenddb "github.com/snissn/gomap/TreeDB/db"
+	"github.com/snissn/gomap/TreeDB/internal/merging"
+)
+
+func TestCachedSnapshotIteratorCreationSerializesCloseAndPoolReuse(t *testing.T) {
+	cached, backend := newCachedSnapshotPoolTestDB(t)
+	defer func() {
+		_ = cached.Close()
+		_ = backend.Close()
+	}()
+	if err := cached.Set([]byte("old"), []byte("value")); err != nil {
+		t.Fatal(err)
+	}
+
+	for _, reverse := range []bool{false, true} {
+		t.Run(map[bool]string{false: "forward", true: "reverse"}[reverse], func(t *testing.T) {
+			snap := cached.AcquireSnapshot()
+			if snap == nil {
+				t.Fatal("AcquireSnapshot=nil")
+			}
+
+			enteredCreate := make(chan struct{})
+			releaseCreate := make(chan struct{})
+			type iteratorResult struct {
+				it  merging.Iterator
+				err error
+			}
+			iteratorDone := make(chan iteratorResult, 1)
+			go func() {
+				it, err := snap.bindNewIterator(func() (merging.Iterator, error) {
+					close(enteredCreate)
+					<-releaseCreate
+					return snap.buildIteratorLocked(nil, nil, reverse)
+				})
+				iteratorDone <- iteratorResult{it: it, err: err}
+			}()
+			<-enteredCreate
+
+			closeStarted := make(chan struct{})
+			closeDone := make(chan error, 1)
+			go func() {
+				close(closeStarted)
+				closeDone <- snap.Close()
+			}()
+			<-closeStarted
+			for i := 0; i < 100; i++ {
+				runtime.Gosched()
+			}
+			if snap.closed.Load() {
+				t.Fatal("Close changed cached snapshot generation while iterator creation held iteratorMu")
+			}
+
+			other := cached.AcquireSnapshot()
+			if other == nil {
+				t.Fatal("second AcquireSnapshot=nil")
+			}
+			if other == snap {
+				t.Fatal("cached snapshot was returned to pool before iterator registration completed")
+			}
+			if err := other.Close(); err != nil {
+				t.Fatalf("second Snapshot.Close: %v", err)
+			}
+
+			close(releaseCreate)
+			result := <-iteratorDone
+			if result.err != nil {
+				t.Fatalf("iterator creation: %v", result.err)
+			}
+			if err := <-closeDone; err != nil {
+				t.Fatalf("Snapshot.Close: %v", err)
+			}
+			if result.it.Valid() {
+				t.Fatal("iterator remained valid after serialized snapshot close")
+			}
+			if err := result.it.Error(); !errors.Is(err, backenddb.ErrClosed) {
+				t.Fatalf("iterator Error=%v want ErrClosed", err)
+			}
+			if err := result.it.Close(); err != nil {
+				t.Fatalf("Iterator.Close: %v", err)
+			}
+		})
+	}
+}
+
+func TestCachedSnapshotIteratorCreationRejectsStaleGeneration(t *testing.T) {
+	cached, backend := newCachedSnapshotPoolTestDB(t)
+	defer func() {
+		_ = cached.Close()
+		_ = backend.Close()
+	}()
+	if err := cached.Set([]byte("old"), []byte("value")); err != nil {
+		t.Fatal(err)
+	}
+	snap := cached.AcquireSnapshot()
+	if snap == nil {
+		t.Fatal("AcquireSnapshot=nil")
+	}
+	defer snap.Close()
+
+	staleGeneration := snap.generation.Load()
+	snap.iteratorMu.Lock()
+	snap.generation.Add(1)
+	snap.closed.Store(false)
+	snap.iteratorMu.Unlock()
+	createCalled := false
+	it, err := snap.bindNewIteratorAtGeneration(staleGeneration, func() (merging.Iterator, error) {
+		createCalled = true
+		return snap.buildIteratorLocked(nil, nil, false)
+	})
+	if !errors.Is(err, backenddb.ErrClosed) {
+		t.Fatalf("bind stale generation error=%v want ErrClosed", err)
+	}
+	if it != nil {
+		t.Fatal("stale generation returned an iterator")
+	}
+	if createCalled {
+		t.Fatal("stale generation accessed cached snapshot fields")
+	}
+}

--- a/TreeDB/caching/snapshot_iterator_lifetime.go
+++ b/TreeDB/caching/snapshot_iterator_lifetime.go
@@ -20,32 +20,48 @@ type snapshotBoundIterator struct {
 	end       []byte
 }
 
-func (s *Snapshot) bindIterator(inner merging.Iterator) (merging.Iterator, error) {
+func (s *Snapshot) bindNewIterator(create func() (merging.Iterator, error)) (merging.Iterator, error) {
+	if s == nil || create == nil {
+		return nil, backenddb.ErrClosed
+	}
+	return s.bindNewIteratorAtGeneration(s.generation.Load(), create)
+}
+
+func (s *Snapshot) bindNewIteratorAtGeneration(generation uint64, create func() (merging.Iterator, error)) (merging.Iterator, error) {
+	if s == nil || create == nil {
+		return nil, backenddb.ErrClosed
+	}
+	s.iteratorMu.Lock()
+	defer s.iteratorMu.Unlock()
+	if s.closed.Load() || generation != s.generation.Load() {
+		return nil, backenddb.ErrClosed
+	}
+	inner, err := create()
+	if err != nil {
+		return nil, err
+	}
+	return s.bindIteratorLocked(inner)
+}
+
+// bindIteratorLocked registers inner while s.iteratorMu is held. Callers hold
+// that lock across the closed check and all snapshot-backed source creation.
+func (s *Snapshot) bindIteratorLocked(inner merging.Iterator) (merging.Iterator, error) {
 	if inner == nil {
 		return nil, backenddb.ErrClosed
 	}
 	start, end := inner.Domain()
 	it := &snapshotBoundIterator{owner: s, inner: inner, start: start, end: end}
-	s.iteratorMu.Lock()
-	if s.closed.Load() {
-		s.iteratorMu.Unlock()
-		_ = inner.Close()
-		return nil, backenddb.ErrClosed
-	}
 	if s.iterators == nil {
 		s.iterators = make(map[*snapshotBoundIterator]struct{})
 	}
 	s.iterators[it] = struct{}{}
-	s.iteratorMu.Unlock()
 	return it, nil
 }
 
-func (s *Snapshot) invalidateBoundIterators() {
-	s.iteratorMu.Lock()
+func (s *Snapshot) invalidateBoundIteratorsLocked() {
 	for it := range s.iterators {
 		it.closed.Store(true)
 	}
-	s.iteratorMu.Unlock()
 }
 
 func (it *snapshotBoundIterator) begin() bool {

--- a/TreeDB/caching/snapshot_iterator_lifetime.go
+++ b/TreeDB/caching/snapshot_iterator_lifetime.go
@@ -1,0 +1,134 @@
+package caching
+
+import (
+	"errors"
+	"sync"
+	"sync/atomic"
+
+	backenddb "github.com/snissn/gomap/TreeDB/db"
+	"github.com/snissn/gomap/TreeDB/internal/merging"
+)
+
+type snapshotBoundIterator struct {
+	owner *Snapshot
+	inner merging.Iterator
+
+	closed    atomic.Bool
+	closeOnce sync.Once
+	closeErr  error
+	start     []byte
+	end       []byte
+}
+
+func (s *Snapshot) bindIterator(inner merging.Iterator) (merging.Iterator, error) {
+	if inner == nil {
+		return nil, backenddb.ErrClosed
+	}
+	start, end := inner.Domain()
+	it := &snapshotBoundIterator{owner: s, inner: inner, start: start, end: end}
+	s.iteratorMu.Lock()
+	if s.closed.Load() {
+		s.iteratorMu.Unlock()
+		_ = inner.Close()
+		return nil, backenddb.ErrClosed
+	}
+	if s.iterators == nil {
+		s.iterators = make(map[*snapshotBoundIterator]struct{})
+	}
+	s.iterators[it] = struct{}{}
+	s.iteratorMu.Unlock()
+	return it, nil
+}
+
+func (s *Snapshot) invalidateBoundIterators() {
+	s.iteratorMu.Lock()
+	for it := range s.iterators {
+		it.closed.Store(true)
+	}
+	s.iteratorMu.Unlock()
+}
+
+func (it *snapshotBoundIterator) begin() bool {
+	return it != nil && !it.closed.Load() && it.inner != nil
+}
+
+func (it *snapshotBoundIterator) closeInner() {
+	it.closeOnce.Do(func() { it.closeErr = it.inner.Close() })
+}
+
+func (it *snapshotBoundIterator) Valid() bool {
+	if !it.begin() {
+		return false
+	}
+	return it.inner.Valid()
+}
+
+func (it *snapshotBoundIterator) Next() {
+	if !it.begin() {
+		return
+	}
+	it.inner.Next()
+}
+
+func (it *snapshotBoundIterator) Seek(key []byte) {
+	if !it.begin() {
+		return
+	}
+	it.inner.Seek(key)
+}
+
+func (it *snapshotBoundIterator) Key() []byte {
+	if !it.begin() {
+		return nil
+	}
+	return it.inner.Key()
+}
+
+func (it *snapshotBoundIterator) Value() []byte {
+	if !it.begin() {
+		return nil
+	}
+	return it.inner.Value()
+}
+
+func (it *snapshotBoundIterator) KeyCopy(dst []byte) []byte {
+	if !it.begin() {
+		return dst[:0]
+	}
+	return it.inner.KeyCopy(dst)
+}
+
+func (it *snapshotBoundIterator) ValueCopy(dst []byte) []byte {
+	if !it.begin() {
+		return dst[:0]
+	}
+	return it.inner.ValueCopy(dst)
+}
+
+func (it *snapshotBoundIterator) Error() error {
+	if it == nil || it.closed.Load() || !it.begin() {
+		return backenddb.ErrClosed
+	}
+	return it.inner.Error()
+}
+
+func (it *snapshotBoundIterator) Close() error {
+	if it == nil {
+		return nil
+	}
+	it.closed.Store(true)
+	it.closeInner()
+	if it.owner != nil {
+		owner := it.owner
+		owner.iteratorMu.Lock()
+		delete(owner.iterators, it)
+		shouldFinalize := owner.closed.Load() && len(owner.iterators) == 0
+		owner.iteratorMu.Unlock()
+		if shouldFinalize {
+			it.closeErr = errors.Join(it.closeErr, owner.finalizeCloseIfUnreferenced())
+		}
+	}
+	return it.closeErr
+}
+
+func (it *snapshotBoundIterator) Domain() ([]byte, []byte) { return it.start, it.end }

--- a/TreeDB/caching/snapshot_iterator_lifetime.go
+++ b/TreeDB/caching/snapshot_iterator_lifetime.go
@@ -68,10 +68,6 @@ func (it *snapshotBoundIterator) begin() bool {
 	return it != nil && !it.closed.Load() && it.inner != nil
 }
 
-func (it *snapshotBoundIterator) closeInner() {
-	it.closeOnce.Do(func() { it.closeErr = it.inner.Close() })
-}
-
 func (it *snapshotBoundIterator) Valid() bool {
 	if !it.begin() {
 		return false
@@ -133,17 +129,22 @@ func (it *snapshotBoundIterator) Close() error {
 		return nil
 	}
 	it.closed.Store(true)
-	it.closeInner()
-	if it.owner != nil {
-		owner := it.owner
-		owner.iteratorMu.Lock()
-		delete(owner.iterators, it)
-		shouldFinalize := owner.closed.Load() && len(owner.iterators) == 0
-		owner.iteratorMu.Unlock()
-		if shouldFinalize {
-			it.closeErr = errors.Join(it.closeErr, owner.finalizeCloseIfUnreferenced())
+	it.closeOnce.Do(func() {
+		if it.inner != nil {
+			it.closeErr = it.inner.Close()
 		}
-	}
+		owner := it.owner
+		it.owner = nil
+		if owner != nil {
+			owner.iteratorMu.Lock()
+			delete(owner.iterators, it)
+			shouldFinalize := owner.closed.Load() && len(owner.iterators) == 0
+			owner.iteratorMu.Unlock()
+			if shouldFinalize {
+				it.closeErr = errors.Join(it.closeErr, owner.finalizeCloseIfUnreferenced())
+			}
+		}
+	})
 	return it.closeErr
 }
 

--- a/TreeDB/caching/snapshot_iterator_test.go
+++ b/TreeDB/caching/snapshot_iterator_test.go
@@ -1,12 +1,74 @@
 package caching
 
 import (
+	"bytes"
 	"reflect"
 	"testing"
 
 	backenddb "github.com/snissn/gomap/TreeDB/db"
 	"github.com/snissn/gomap/TreeDB/internal/memtable"
+	"github.com/snissn/gomap/TreeDB/internal/merging"
 )
+
+func TestSingleSourceIteratorForwardSeekClampsToStart(t *testing.T) {
+	newIterator := func(t *testing.T, keys ...string) merging.Iterator {
+		t.Helper()
+		mt, err := memtable.NewWithCapacityMode(0, memtable.ModeSkiplist)
+		if err != nil {
+			t.Fatalf("new memtable: %v", err)
+		}
+		for _, key := range keys {
+			mt.Set([]byte(key), []byte("value/"+key))
+		}
+		mt.Freeze()
+		start := []byte("m")
+		return newSingleSourceIterator(mt.NewIterator(start, nil), start, nil, false)
+	}
+
+	t.Run("mixed domain", func(t *testing.T) {
+		it := newIterator(t, "a", "c", "m", "z")
+		defer it.Close()
+		for _, test := range []struct {
+			name   string
+			target []byte
+			want   []byte
+		}{
+			{name: "nil", target: nil, want: []byte("m")},
+			{name: "below", target: []byte("a"), want: []byte("m")},
+			{name: "start", target: []byte("m"), want: []byte("m")},
+			{name: "inside", target: []byte("n"), want: []byte("z")},
+			{name: "above", target: []byte{0xff}},
+		} {
+			t.Run(test.name, func(t *testing.T) {
+				it.Seek(test.target)
+				if test.want == nil {
+					if it.Valid() {
+						t.Fatalf("Seek(%x) key=%q want invalid", test.target, it.Key())
+					}
+				} else if !it.Valid() || !bytes.Equal(it.Key(), test.want) {
+					t.Fatalf("Seek(%x) valid=%v key=%q want %q", test.target, it.Valid(), it.Key(), test.want)
+				}
+				if err := it.Error(); err != nil {
+					t.Fatalf("Seek(%x) error=%v", test.target, err)
+				}
+			})
+		}
+	})
+
+	t.Run("all data below start", func(t *testing.T) {
+		it := newIterator(t, "a", "c")
+		defer it.Close()
+		for _, target := range [][]byte{nil, []byte("a"), []byte("m"), {0xff}} {
+			it.Seek(target)
+			if it.Valid() {
+				t.Fatalf("Seek(%x) key=%q want invalid", target, it.Key())
+			}
+			if err := it.Error(); err != nil {
+				t.Fatalf("Seek(%x) error=%v", target, err)
+			}
+		}
+	})
+}
 
 func TestSnapshotIterator_QueueValueOverridesPublishedAndTombstoneHidesPublished(t *testing.T) {
 	dir := t.TempDir()

--- a/TreeDB/caching/snapshot_pool_test.go
+++ b/TreeDB/caching/snapshot_pool_test.go
@@ -25,7 +25,7 @@ func newCachedSnapshotPoolTestDB(t *testing.T) (*DB, *backenddb.DB) {
 	return cached, backend
 }
 
-func TestAcquireSnapshot_CachedPathAllocsAfterWarm(t *testing.T) {
+func TestAcquireSnapshot_CachedPathAllocsAreBounded(t *testing.T) {
 	cached, backend := newCachedSnapshotPoolTestDB(t)
 	defer func() {
 		_ = cached.Close()
@@ -59,8 +59,11 @@ func TestAcquireSnapshot_CachedPathAllocsAfterWarm(t *testing.T) {
 			panic(err)
 		}
 	})
-	if allocs > 0.1 {
-		t.Fatalf("cached AcquireSnapshot allocs/run=%f want <= 0.1", allocs)
+	// Each acquisition deliberately allocates distinct exported cached and
+	// backend handles. Reusing either address would allow a stale pointer to
+	// operate on a later snapshot; keep the safety cost bounded to those handles.
+	if allocs > 2.1 {
+		t.Fatalf("cached AcquireSnapshot allocs/run=%f want <= 2.1", allocs)
 	}
 }
 

--- a/TreeDB/caching/snapshot_pool_test.go
+++ b/TreeDB/caching/snapshot_pool_test.go
@@ -10,7 +10,7 @@ import (
 	backenddb "github.com/snissn/gomap/TreeDB/db"
 )
 
-func newCachedSnapshotPoolTestDB(t *testing.T) (*DB, *backenddb.DB) {
+func newCachedSnapshotTestDB(t *testing.T) (*DB, *backenddb.DB) {
 	t.Helper()
 	dir := t.TempDir()
 	backend, err := backenddb.Open(backenddb.Options{Dir: dir})
@@ -26,7 +26,7 @@ func newCachedSnapshotPoolTestDB(t *testing.T) (*DB, *backenddb.DB) {
 }
 
 func TestAcquireSnapshot_CachedPathAllocsAreBounded(t *testing.T) {
-	cached, backend := newCachedSnapshotPoolTestDB(t)
+	cached, backend := newCachedSnapshotTestDB(t)
 	defer func() {
 		_ = cached.Close()
 		_ = backend.Close()
@@ -67,14 +67,14 @@ func TestAcquireSnapshot_CachedPathAllocsAreBounded(t *testing.T) {
 	}
 }
 
-func TestAcquireSnapshot_CachedPathSnapshotIsolationAcrossReuse(t *testing.T) {
-	cached, backend := newCachedSnapshotPoolTestDB(t)
+func TestAcquireSnapshot_CachedPathSnapshotIsolationAcrossAcquisitions(t *testing.T) {
+	cached, backend := newCachedSnapshotTestDB(t)
 	defer func() {
 		_ = cached.Close()
 		_ = backend.Close()
 	}()
 
-	key := []byte("snapshot-reuse-isolation")
+	key := []byte("snapshot-acquisition-isolation")
 	if err := cached.Set(key, []byte("old")); err != nil {
 		t.Fatalf("Set old: %v", err)
 	}
@@ -110,7 +110,7 @@ func TestAcquireSnapshot_CachedPathSnapshotIsolationAcrossReuse(t *testing.T) {
 }
 
 func TestAcquireSnapshot_CachedPathConcurrentAcquireCloseWithWrites(t *testing.T) {
-	cached, backend := newCachedSnapshotPoolTestDB(t)
+	cached, backend := newCachedSnapshotTestDB(t)
 	defer func() {
 		_ = cached.Close()
 		_ = backend.Close()

--- a/TreeDB/caching/snapshot_read_lifetime.go
+++ b/TreeDB/caching/snapshot_read_lifetime.go
@@ -1,0 +1,31 @@
+package caching
+
+import backenddb "github.com/snissn/gomap/TreeDB/db"
+
+const snapshotReadClosedBit uint64 = 1 << 63
+
+// beginRead pins the snapshot's readable state against concurrent Close.
+// Callers must pair a nil result with endRead.
+func (s *Snapshot) beginRead() error {
+	if s == nil {
+		return backenddb.ErrClosed
+	}
+	for {
+		state := s.readState.Load()
+		if state&snapshotReadClosedBit != 0 {
+			return backenddb.ErrClosed
+		}
+		if s.readState.CompareAndSwap(state, state+1) {
+			return nil
+		}
+	}
+}
+
+func (s *Snapshot) endRead() {
+	if s == nil {
+		return
+	}
+	if s.readState.Add(^uint64(0)) == snapshotReadClosedBit {
+		_ = s.finalizeCloseIfUnreferenced()
+	}
+}

--- a/TreeDB/caching/snapshot_test.go
+++ b/TreeDB/caching/snapshot_test.go
@@ -321,8 +321,11 @@ func TestAcquireSnapshot_AllocsBoundedAfterWarmPath(t *testing.T) {
 			t.Fatalf("Close: %v", err)
 		}
 	})
-	if allocs > 1.1 {
-		t.Fatalf("AcquireSnapshot allocs/run=%f, want <= 1.1 after warm path", allocs)
+	// Distinct exported cached and backend handles are the two intentional
+	// allocations. Their addresses cannot be reused safely while callers may
+	// retain a closed pointer.
+	if allocs > 2.1 {
+		t.Fatalf("AcquireSnapshot allocs/run=%f, want <= 2.1 after warm path", allocs)
 	}
 }
 

--- a/TreeDB/collections/column_physical_query_test.go
+++ b/TreeDB/collections/column_physical_query_test.go
@@ -3969,6 +3969,12 @@ func TestColumnPhysicalQuerySerialDictInt64SidecarParityM1634(t *testing.T) {
 	}
 }
 
+// columnPhysicalQueryOneShotSnapshotHandleAllocsM1634 accounts for the unique
+// cached and backend snapshot handles acquired by RunColumnPhysicalQuery. The
+// handles intentionally cannot be pooled because a stale exported pointer must
+// never become valid for a later snapshot.
+const columnPhysicalQueryOneShotSnapshotHandleAllocsM1634 = 2
+
 func TestColumnPhysicalQuerySerialSidecarAllocationBudgetM1634(t *testing.T) {
 	events := columnPhysicalQueryFixtureEventsM13B(2048)
 	collection, closeFn := openColumnPhysicalQueryFixtureM13B(t, events)
@@ -4037,7 +4043,7 @@ func TestColumnPhysicalQuerySerialSidecarAllocationBudgetM1634(t *testing.T) {
 					panic(fmt.Sprintf("bad sidecar result groups=%d diagnostics=%+v", len(result.Groups), result.Diagnostics))
 				}
 			})
-			maxAllocs := tc.maxAllocs
+			maxAllocs := tc.maxAllocs + columnPhysicalQueryOneShotSnapshotHandleAllocsM1634
 			if runtime.GOOS == "windows" {
 				// Windows CI carries extra runtime/path allocation noise in this
 				// routed one-shot path; keep the stricter budget on Unix hosts

--- a/TreeDB/collections/column_physical_query_test.go
+++ b/TreeDB/collections/column_physical_query_test.go
@@ -3975,6 +3975,12 @@ func TestColumnPhysicalQuerySerialDictInt64SidecarParityM1634(t *testing.T) {
 // never become valid for a later snapshot.
 const columnPhysicalQueryOneShotSnapshotHandleAllocsM1634 = 2
 
+// columnPhysicalQueryOneShotRootIteratorHandleAllocsM1634 accounts for the
+// three root iterators used to load a physical-query snapshot view. Root
+// iterators are snapshot-bound handles so Close can invalidate them and defer
+// snapshot cleanup until they are released.
+const columnPhysicalQueryOneShotRootIteratorHandleAllocsM1634 = 3
+
 func TestColumnPhysicalQuerySerialSidecarAllocationBudgetM1634(t *testing.T) {
 	events := columnPhysicalQueryFixtureEventsM13B(2048)
 	collection, closeFn := openColumnPhysicalQueryFixtureM13B(t, events)
@@ -4043,7 +4049,9 @@ func TestColumnPhysicalQuerySerialSidecarAllocationBudgetM1634(t *testing.T) {
 					panic(fmt.Sprintf("bad sidecar result groups=%d diagnostics=%+v", len(result.Groups), result.Diagnostics))
 				}
 			})
-			maxAllocs := tc.maxAllocs + columnPhysicalQueryOneShotSnapshotHandleAllocsM1634
+			maxAllocs := tc.maxAllocs +
+				columnPhysicalQueryOneShotSnapshotHandleAllocsM1634 +
+				columnPhysicalQueryOneShotRootIteratorHandleAllocsM1634
 			if runtime.GOOS == "windows" {
 				// Windows CI carries extra runtime/path allocation noise in this
 				// routed one-shot path; keep the stricter budget on Unix hosts

--- a/TreeDB/conditional_txn.go
+++ b/TreeDB/conditional_txn.go
@@ -168,6 +168,14 @@ func (s conditionalTxnSnapshot) ReverseIterate(start, end []byte, fn func(key, v
 	return ErrConditionalTxnUnsupported
 }
 
+func (s conditionalTxnSnapshot) Iterator(start, end []byte) (Iterator, error) {
+	return nil, ErrConditionalTxnUnsupported
+}
+
+func (s conditionalTxnSnapshot) ReverseIterator(start, end []byte) (Iterator, error) {
+	return nil, ErrConditionalTxnUnsupported
+}
+
 func (tx *ConditionalTxn) recordSnapshotReadVersion(key []byte, revision EntryRevision, found bool) error {
 	if tx == nil {
 		return ErrConditionalTxnClosed

--- a/TreeDB/db/api.go
+++ b/TreeDB/db/api.go
@@ -759,6 +759,10 @@ func (s *Snapshot) ReverseIterate(start, end []byte, fn func(key, value []byte) 
 }
 
 func (s *Snapshot) iterate(start, end []byte, reverse bool, fn func(key, value []byte) error) (err error) {
+	if err := s.beginRead(); err != nil {
+		return err
+	}
+	s.endRead()
 	if fn == nil {
 		return errors.New("treedb: snapshot iterate nil callback")
 	}

--- a/TreeDB/db/api.go
+++ b/TreeDB/db/api.go
@@ -700,10 +700,9 @@ func (s *Snapshot) Iterator(start, end []byte) (publiciterator.Iterator, error) 
 // IteratorWithOptions returns an iterator bound to an existing snapshot with
 // explicit value materialization controls.
 func (s *Snapshot) IteratorWithOptions(start, end []byte, opts IteratorOptions) (iterator.UnsafeIterator, error) {
-	if s == nil || s.closed.Load() {
-		return nil, ErrClosed
-	}
-	return s.bindIterator(s.tree.IteratorWithOptions(start, end, opts))
+	return s.bindNewIterator(func() iterator.UnsafeIterator {
+		return s.buildIteratorLocked(start, end, opts, false)
+	})
 }
 
 // Iterate calls fn for each visible key/value pair in [start, end) using this
@@ -737,10 +736,18 @@ func (s *Snapshot) ReverseIterator(start, end []byte) (publiciterator.Iterator, 
 // ReverseIteratorWithOptions returns a reverse iterator bound to an existing
 // snapshot with explicit value materialization controls.
 func (s *Snapshot) ReverseIteratorWithOptions(start, end []byte, opts IteratorOptions) (iterator.UnsafeIterator, error) {
-	if s == nil || s.closed.Load() {
-		return nil, ErrClosed
+	return s.bindNewIterator(func() iterator.UnsafeIterator {
+		return s.buildIteratorLocked(start, end, opts, true)
+	})
+}
+
+// buildIteratorLocked reads the snapshot's pinned tree and must run while
+// iteratorMu is held by bindNewIterator.
+func (s *Snapshot) buildIteratorLocked(start, end []byte, opts IteratorOptions, reverse bool) iterator.UnsafeIterator {
+	if reverse {
+		return s.tree.ReverseIteratorWithOptions(start, end, opts)
 	}
-	return s.bindIterator(s.tree.ReverseIteratorWithOptions(start, end, opts))
+	return s.tree.IteratorWithOptions(start, end, opts)
 }
 
 // ReverseIterate calls fn for each visible key/value pair in [start, end) in

--- a/TreeDB/db/api.go
+++ b/TreeDB/db/api.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/snissn/gomap/TreeDB/internal/iterator"
 	"github.com/snissn/gomap/TreeDB/internal/valuelog"
+	publiciterator "github.com/snissn/gomap/TreeDB/iterator"
 	"github.com/snissn/gomap/TreeDB/page"
 	"github.com/snissn/gomap/TreeDB/tree"
 )
@@ -692,7 +693,7 @@ func (db *DB) IteratorWithOptions(start, end []byte, opts IteratorOptions) (iter
 }
 
 // Iterator returns an iterator bound to an existing snapshot.
-func (s *Snapshot) Iterator(start, end []byte) (iterator.UnsafeIterator, error) {
+func (s *Snapshot) Iterator(start, end []byte) (publiciterator.Iterator, error) {
 	return s.IteratorWithOptions(start, end, IteratorOptions{})
 }
 
@@ -702,7 +703,7 @@ func (s *Snapshot) IteratorWithOptions(start, end []byte, opts IteratorOptions) 
 	if s == nil || s.closed.Load() {
 		return nil, ErrClosed
 	}
-	return s.tree.IteratorWithOptions(start, end, opts), nil
+	return s.bindIterator(s.tree.IteratorWithOptions(start, end, opts))
 }
 
 // Iterate calls fn for each visible key/value pair in [start, end) using this
@@ -729,7 +730,7 @@ func (db *DB) ReverseIteratorWithOptions(start, end []byte, opts IteratorOptions
 }
 
 // ReverseIterator returns a reverse iterator bound to an existing snapshot.
-func (s *Snapshot) ReverseIterator(start, end []byte) (iterator.UnsafeIterator, error) {
+func (s *Snapshot) ReverseIterator(start, end []byte) (publiciterator.Iterator, error) {
 	return s.ReverseIteratorWithOptions(start, end, IteratorOptions{})
 }
 
@@ -739,7 +740,7 @@ func (s *Snapshot) ReverseIteratorWithOptions(start, end []byte, opts IteratorOp
 	if s == nil || s.closed.Load() {
 		return nil, ErrClosed
 	}
-	return s.tree.ReverseIteratorWithOptions(start, end, opts), nil
+	return s.bindIterator(s.tree.ReverseIteratorWithOptions(start, end, opts))
 }
 
 // ReverseIterate calls fn for each visible key/value pair in [start, end) in
@@ -754,7 +755,7 @@ func (s *Snapshot) iterate(start, end []byte, reverse bool, fn func(key, value [
 	if fn == nil {
 		return errors.New("treedb: snapshot iterate nil callback")
 	}
-	var it iterator.UnsafeIterator
+	var it publiciterator.Iterator
 	if reverse {
 		it, err = s.ReverseIterator(start, end)
 	} else {

--- a/TreeDB/db/batch_delete_range_test.go
+++ b/TreeDB/db/batch_delete_range_test.go
@@ -143,7 +143,7 @@ func TestBatchDeleteRangeIteratorVisibilityMixedBatch(t *testing.T) {
 	}
 	assertIteratorKVs(t, it, []string{"k000=v000", "k003=after", "k005=v005"})
 
-	snapIt, err := snap.Iterator(nil, nil)
+	snapIt, err := snap.IteratorWithOptions(nil, nil, IteratorOptions{})
 	if err != nil {
 		t.Fatalf("snapshot Iterator: %v", err)
 	}

--- a/TreeDB/db/db.go
+++ b/TreeDB/db/db.go
@@ -1327,6 +1327,11 @@ type Options struct {
 	MaxWALBytes int64
 }
 
+// Snapshot is a consistent point-in-time database view.
+//
+// Snapshot pointers are single-use: after Close returns, callers must discard
+// the pointer and any later method call remains invalid even after subsequent
+// snapshots are acquired.
 type Snapshot struct {
 	db                     *DB
 	idx                    *indexGen

--- a/TreeDB/db/db.go
+++ b/TreeDB/db/db.go
@@ -1354,6 +1354,7 @@ type Snapshot struct {
 	closed                  atomic.Bool
 	generation              atomic.Uint64
 	finalized               atomic.Bool
+	readState               atomic.Uint64
 	iteratorMu              sync.Mutex
 	iterators               map[*snapshotBoundIterator]struct{}
 	treePager               *pager.Pager
@@ -1383,24 +1384,30 @@ func registryHintFromSnapshot(s *Snapshot) int {
 }
 
 func (s *Snapshot) Pager() *pager.Pager {
-	if s == nil || s.idx == nil {
+	if err := s.beginRead(); err != nil {
+		return nil
+	}
+	defer s.endRead()
+	if s.idx == nil {
 		return nil
 	}
 	return s.idx.pager
 }
 
 func (s *Snapshot) State() *DBState {
-	if s == nil {
+	if err := s.beginRead(); err != nil {
 		return nil
 	}
+	defer s.endRead()
 	return cloneDBState(s.state)
 }
 
 // StateToken returns the immutable scalar state pinned by the snapshot.
 func (s *Snapshot) StateToken() (StateToken, bool) {
-	if s == nil {
+	if err := s.beginRead(); err != nil {
 		return StateToken{}, false
 	}
+	defer s.endRead()
 	return stateTokenFromState(s.state)
 }
 
@@ -1521,6 +1528,7 @@ func (db *DB) AcquireSnapshot() *Snapshot {
 	}
 	snap.iteratorMu.Lock()
 	snap.closed.Store(false)
+	snap.readState.Store(0)
 	snap.iteratorMu.Unlock()
 	return snap
 }
@@ -1556,6 +1564,7 @@ func (s *Snapshot) Close() error {
 		s.iteratorMu.Unlock()
 		return nil
 	}
+	s.readState.Or(snapshotReadClosedBit)
 	s.invalidateBoundIteratorsLocked()
 	s.iteratorMu.Unlock()
 	return s.finalizeCloseIfUnreferenced()
@@ -1563,7 +1572,7 @@ func (s *Snapshot) Close() error {
 
 func (s *Snapshot) finalizeCloseIfUnreferenced() error {
 	s.iteratorMu.Lock()
-	if len(s.iterators) != 0 || !s.finalized.CompareAndSwap(false, true) {
+	if len(s.iterators) != 0 || s.readState.Load() != snapshotReadClosedBit || !s.finalized.CompareAndSwap(false, true) {
 		s.iteratorMu.Unlock()
 		return nil
 	}
@@ -3298,18 +3307,30 @@ func (db *DB) Prune() {
 
 // Get returns value from snapshot.
 func (s *Snapshot) Get(key []byte) ([]byte, error) {
+	if err := s.beginRead(); err != nil {
+		return nil, err
+	}
+	defer s.endRead()
 	return s.tree.Get(normalizeRawKVPointKey(key))
 }
 
 // GetAppend appends the value for key to dst and returns the grown slice.
 // If key is not found, it returns dst and tree.ErrKeyNotFound.
 func (s *Snapshot) GetAppend(key, dst []byte) ([]byte, error) {
+	if err := s.beginRead(); err != nil {
+		return dst, err
+	}
+	defer s.endRead()
 	return s.tree.GetAppend(normalizeRawKVPointKey(key), dst)
 }
 
 // GetVersionedAppend appends the value for key to dst and returns the native
 // entry revision stored with the visible leaf entry.
 func (s *Snapshot) GetVersionedAppend(key, dst []byte) ([]byte, page.EntryRevision, error) {
+	if err := s.beginRead(); err != nil {
+		return dst, page.LegacyEntryRevision, err
+	}
+	defer s.endRead()
 	return s.tree.GetVersionedAppend(normalizeRawKVPointKey(key), dst)
 }
 
@@ -3334,33 +3355,54 @@ func (s *Snapshot) GetVersioned(key []byte) ([]byte, page.EntryRevision, error) 
 // GetManyView calls fn once for each key with a read-only value view.
 // Values are valid until fn returns and must be copied before retaining.
 func (s *Snapshot) GetManyView(keys [][]byte, fn GetManyViewFunc) error {
-	keys = normalizeRawKVPointKeys(keys)
-	if s == nil || s.closed.Load() {
-		return ErrClosed
+	if err := s.beginRead(); err != nil {
+		return err
 	}
+	defer s.endRead()
+	keys = normalizeRawKVPointKeys(keys)
 	return s.tree.GetManyView(keys, fn)
 }
 
 // GetUnsafe returns a zero-copy view of the value from the snapshot.
 // The slice is valid until the snapshot is closed.
 func (s *Snapshot) GetUnsafe(key []byte) ([]byte, error) {
+	if err := s.beginRead(); err != nil {
+		return nil, err
+	}
+	defer s.endRead()
 	return s.tree.GetUnsafe(normalizeRawKVPointKey(key))
 }
 
 func (s *Snapshot) Has(key []byte) (bool, error) {
+	if err := s.beginRead(); err != nil {
+		return false, err
+	}
+	defer s.endRead()
 	return s.tree.Has(normalizeRawKVPointKey(key))
 }
 
 func (s *Snapshot) HasMany(keys [][]byte) ([]bool, error) {
+	if err := s.beginRead(); err != nil {
+		return nil, err
+	}
+	defer s.endRead()
 	return s.tree.HasMany(normalizeRawKVPointKeys(keys))
 }
 
 func (s *Snapshot) HasPrefixes(prefixes [][]byte) ([]bool, error) {
+	if err := s.beginRead(); err != nil {
+		return nil, err
+	}
+	defer s.endRead()
 	return s.tree.HasPrefixes(prefixes)
 }
 
 // GetEntry returns the persisted leaf entry for key.
 func (s *Snapshot) GetEntry(key []byte) (node.LeafEntry, error) {
+	if err := s.beginRead(); err != nil {
+		return node.LeafEntry{}, err
+	}
+	defer s.endRead()
 	return s.tree.GetEntry(normalizeRawKVPointKey(key))
 }
 

--- a/TreeDB/db/db.go
+++ b/TreeDB/db/db.go
@@ -1347,6 +1347,7 @@ type Snapshot struct {
 	rootTreesMu             sync.Mutex
 	rootTrees               []snapshotRootTree
 	closed                  atomic.Bool
+	generation              atomic.Uint64
 	finalized               atomic.Bool
 	iteratorMu              sync.Mutex
 	iterators               map[*snapshotBoundIterator]struct{}
@@ -1513,7 +1514,9 @@ func (db *DB) AcquireSnapshot() *Snapshot {
 			snap.treeRoot = 0
 		}
 	}
+	snap.iteratorMu.Lock()
 	snap.closed.Store(false)
+	snap.iteratorMu.Unlock()
 	return snap
 }
 
@@ -1543,10 +1546,13 @@ func (s *Snapshot) Close() error {
 	if s == nil {
 		return nil
 	}
+	s.iteratorMu.Lock()
 	if !s.closed.CompareAndSwap(false, true) {
+		s.iteratorMu.Unlock()
 		return nil
 	}
-	s.invalidateBoundIterators()
+	s.invalidateBoundIteratorsLocked()
+	s.iteratorMu.Unlock()
 	return s.finalizeCloseIfUnreferenced()
 }
 

--- a/TreeDB/db/db.go
+++ b/TreeDB/db/db.go
@@ -1347,6 +1347,9 @@ type Snapshot struct {
 	rootTreesMu             sync.Mutex
 	rootTrees               []snapshotRootTree
 	closed                  atomic.Bool
+	finalized               atomic.Bool
+	iteratorMu              sync.Mutex
+	iterators               map[*snapshotBoundIterator]struct{}
 	treePager               *pager.Pager
 	treeRoot                uint64
 	// registryShardHint is used to route reader registrations to a stable fast
@@ -1543,7 +1546,17 @@ func (s *Snapshot) Close() error {
 	if !s.closed.CompareAndSwap(false, true) {
 		return nil
 	}
+	s.invalidateBoundIterators()
+	return s.finalizeCloseIfUnreferenced()
+}
 
+func (s *Snapshot) finalizeCloseIfUnreferenced() error {
+	s.iteratorMu.Lock()
+	if len(s.iterators) != 0 || !s.finalized.CompareAndSwap(false, true) {
+		s.iteratorMu.Unlock()
+		return nil
+	}
+	s.iteratorMu.Unlock()
 	var err error
 	if s.vlogPinned && s.state != nil && s.state.ValueLogSet != nil && s.vlogManager != nil {
 		if relErr := s.vlogManager.Release(s.state.ValueLogSet); relErr != nil {

--- a/TreeDB/db/pool_bench_test.go
+++ b/TreeDB/db/pool_bench_test.go
@@ -13,6 +13,9 @@ func BenchmarkSnapshotPool(b *testing.B) {
 	defer db.Close()
 
 	b.ResetTimer()
+	// The historical name is retained for benchmark continuity. Snapshot
+	// handles now have unique identities and intentionally allocate once per
+	// acquisition; SnapshotPool still owns their cleanup contract.
 	b.RunParallel(func(pb *testing.PB) {
 		for pb.Next() {
 			s := db.AcquireSnapshot()

--- a/TreeDB/db/pools.go
+++ b/TreeDB/db/pools.go
@@ -61,6 +61,7 @@ func (p *SnapshotPool) Put(s *Snapshot) {
 	s.registryID = 0
 	s.iteratorMu.Lock()
 	clear(s.iterators)
+	s.readState.Store(snapshotReadClosedBit)
 	s.closed.Store(true)
 	s.finalized.Store(false)
 	s.iteratorMu.Unlock()

--- a/TreeDB/db/pools.go
+++ b/TreeDB/db/pools.go
@@ -20,23 +20,20 @@ type Iterator interface {
 	Reset(start, end []byte)
 }
 
-// SnapshotPool manages a pool of Snapshot objects to reduce allocation overhead.
-type SnapshotPool struct {
-	pool sync.Pool
-}
+// SnapshotPool centralizes Snapshot allocation and cleanup.
+//
+// Exported Snapshot handles are deliberately not reused. A caller can retain a
+// pointer after Close, and reactivating that same address would let the stale
+// alias operate on an unrelated snapshot. No generation stored in the reused
+// object can distinguish those aliases.
+type SnapshotPool struct{}
 
 func NewSnapshotPool() *SnapshotPool {
-	return &SnapshotPool{
-		pool: sync.Pool{
-			New: func() interface{} {
-				return &Snapshot{registryShardHint: snapshotShardHintUnset}
-			},
-		},
-	}
+	return &SnapshotPool{}
 }
 
 func (p *SnapshotPool) Get() *Snapshot {
-	s := p.pool.Get().(*Snapshot)
+	s := &Snapshot{registryShardHint: snapshotShardHintUnset}
 	s.iteratorMu.Lock()
 	s.generation.Add(1)
 	s.closed.Store(true)
@@ -67,12 +64,7 @@ func (p *SnapshotPool) Put(s *Snapshot) {
 	s.closed.Store(true)
 	s.finalized.Store(false)
 	s.iteratorMu.Unlock()
-	// treePager/treeRoot are intentionally preserved as a pooled cache key for
-	// the next AcquireSnapshot() on this same object. registryShardHint is also
-	// preserved so the same pooled Snapshot keeps a stable fast registry shard.
-	// The reader backing address is stable per pooled Snapshot object, so Reset
-	// can be skipped safely when pager+root are unchanged.
-	p.pool.Put(s)
+	// Do not make the exported handle reusable. See SnapshotPool's contract.
 }
 
 type ghostIndex struct {

--- a/TreeDB/db/pools.go
+++ b/TreeDB/db/pools.go
@@ -36,7 +36,12 @@ func NewSnapshotPool() *SnapshotPool {
 }
 
 func (p *SnapshotPool) Get() *Snapshot {
-	return p.pool.Get().(*Snapshot)
+	s := p.pool.Get().(*Snapshot)
+	s.iteratorMu.Lock()
+	s.generation.Add(1)
+	s.closed.Store(true)
+	s.iteratorMu.Unlock()
+	return s
 }
 
 func (p *SnapshotPool) Put(s *Snapshot) {
@@ -59,9 +64,9 @@ func (p *SnapshotPool) Put(s *Snapshot) {
 	s.registryID = 0
 	s.iteratorMu.Lock()
 	clear(s.iterators)
-	s.iteratorMu.Unlock()
-	s.closed.Store(false)
+	s.closed.Store(true)
 	s.finalized.Store(false)
+	s.iteratorMu.Unlock()
 	// treePager/treeRoot are intentionally preserved as a pooled cache key for
 	// the next AcquireSnapshot() on this same object. registryShardHint is also
 	// preserved so the same pooled Snapshot keeps a stable fast registry shard.

--- a/TreeDB/db/pools.go
+++ b/TreeDB/db/pools.go
@@ -57,7 +57,11 @@ func (p *SnapshotPool) Put(s *Snapshot) {
 	s.leafGenerationPinSet = nil
 	s.reader = valueReader{}
 	s.registryID = 0
+	s.iteratorMu.Lock()
+	clear(s.iterators)
+	s.iteratorMu.Unlock()
 	s.closed.Store(false)
+	s.finalized.Store(false)
 	// treePager/treeRoot are intentionally preserved as a pooled cache key for
 	// the next AcquireSnapshot() on this same object. registryShardHint is also
 	// preserved so the same pooled Snapshot keeps a stable fast registry shard.

--- a/TreeDB/db/root_snapshot.go
+++ b/TreeDB/db/root_snapshot.go
@@ -11,8 +11,9 @@ import (
 // SnapshotRootReader is a root-bound read view owned by a Snapshot.
 // It is valid only while the parent Snapshot remains open.
 type SnapshotRootReader struct {
-	tree tree.Tree
-	ok   bool
+	owner *Snapshot
+	tree  tree.Tree
+	ok    bool
 }
 
 func (s *Snapshot) treeAtRoot(rootID uint64) (*tree.Tree, error) {
@@ -39,28 +40,48 @@ func (s *Snapshot) treeAtRoot(rootID uint64) (*tree.Tree, error) {
 }
 
 func (s *Snapshot) ReaderAtRoot(rootID uint64) (SnapshotRootReader, error) {
+	if err := s.beginRead(); err != nil {
+		return SnapshotRootReader{}, err
+	}
+	defer s.endRead()
 	tr, err := s.treeAtRoot(rootID)
 	if err != nil {
 		return SnapshotRootReader{}, err
 	}
-	return SnapshotRootReader{tree: *tr, ok: true}, nil
+	return SnapshotRootReader{owner: s, tree: *tr, ok: true}, nil
+}
+
+func (r *SnapshotRootReader) beginRead() error {
+	if r == nil || !r.ok || r.owner == nil {
+		return ErrClosed
+	}
+	if err := r.owner.beginRead(); err != nil {
+		return err
+	}
+	return nil
 }
 
 func (r *SnapshotRootReader) GetAppend(key, dst []byte) ([]byte, error) {
-	if r == nil || !r.ok {
-		return dst, tree.ErrKeyNotFound
+	if err := r.beginRead(); err != nil {
+		return dst, err
 	}
+	defer r.owner.endRead()
 	return r.tree.GetAppend(key, dst)
 }
 
 func (r *SnapshotRootReader) GetManyView(keys [][]byte, fn GetManyViewFunc) error {
-	if r == nil || !r.ok {
-		return tree.ErrKeyNotFound
+	if err := r.beginRead(); err != nil {
+		return err
 	}
+	defer r.owner.endRead()
 	return r.tree.GetManyView(keys, fn)
 }
 
 func (s *Snapshot) GetEntryAtRoot(rootID uint64, key []byte) (node.LeafEntry, error) {
+	if err := s.beginRead(); err != nil {
+		return node.LeafEntry{}, err
+	}
+	defer s.endRead()
 	tr, err := s.treeAtRoot(rootID)
 	if err != nil {
 		return node.LeafEntry{}, err
@@ -69,6 +90,10 @@ func (s *Snapshot) GetEntryAtRoot(rootID uint64, key []byte) (node.LeafEntry, er
 }
 
 func (s *Snapshot) GetAtRoot(rootID uint64, key []byte) ([]byte, error) {
+	if err := s.beginRead(); err != nil {
+		return nil, err
+	}
+	defer s.endRead()
 	tr, err := s.treeAtRoot(rootID)
 	if err != nil {
 		return nil, err
@@ -77,6 +102,10 @@ func (s *Snapshot) GetAtRoot(rootID uint64, key []byte) ([]byte, error) {
 }
 
 func (s *Snapshot) GetAppendAtRoot(rootID uint64, key, dst []byte) ([]byte, error) {
+	if err := s.beginRead(); err != nil {
+		return dst, err
+	}
+	defer s.endRead()
 	tr, err := s.treeAtRoot(rootID)
 	if err != nil {
 		return dst, err
@@ -85,6 +114,10 @@ func (s *Snapshot) GetAppendAtRoot(rootID uint64, key, dst []byte) ([]byte, erro
 }
 
 func (s *Snapshot) GetManyViewAtRoot(rootID uint64, keys [][]byte, fn GetManyViewFunc) error {
+	if err := s.beginRead(); err != nil {
+		return err
+	}
+	defer s.endRead()
 	tr, err := s.treeAtRoot(rootID)
 	if err != nil {
 		return err
@@ -93,6 +126,10 @@ func (s *Snapshot) GetManyViewAtRoot(rootID uint64, keys [][]byte, fn GetManyVie
 }
 
 func (s *Snapshot) GetUnsafeAtRoot(rootID uint64, key []byte) ([]byte, error) {
+	if err := s.beginRead(); err != nil {
+		return nil, err
+	}
+	defer s.endRead()
 	tr, err := s.treeAtRoot(rootID)
 	if err != nil {
 		return nil, err
@@ -105,11 +142,26 @@ func (s *Snapshot) IteratorAtRoot(rootID uint64, start, end []byte) (iterator.Un
 }
 
 func (s *Snapshot) IteratorAtRootWithOptions(rootID uint64, start, end []byte, opts IteratorOptions) (iterator.UnsafeIterator, error) {
+	return s.bindRootIterator(rootID, start, end, opts, false)
+}
+
+func (s *Snapshot) bindRootIterator(rootID uint64, start, end []byte, opts IteratorOptions, reverse bool) (iterator.UnsafeIterator, error) {
+	if s == nil {
+		return nil, ErrClosed
+	}
+	s.iteratorMu.Lock()
+	defer s.iteratorMu.Unlock()
+	if s.closed.Load() {
+		return nil, ErrClosed
+	}
 	tr, err := s.treeAtRoot(rootID)
 	if err != nil {
 		return nil, err
 	}
-	return tr.IteratorWithOptions(start, end, opts), nil
+	if reverse {
+		return s.bindIteratorLocked(tr.ReverseIteratorWithOptions(start, end, opts))
+	}
+	return s.bindIteratorLocked(tr.IteratorWithOptions(start, end, opts))
 }
 
 func (s *Snapshot) ReverseIteratorAtRoot(rootID uint64, start, end []byte) (iterator.UnsafeIterator, error) {
@@ -117,14 +169,14 @@ func (s *Snapshot) ReverseIteratorAtRoot(rootID uint64, start, end []byte) (iter
 }
 
 func (s *Snapshot) ReverseIteratorAtRootWithOptions(rootID uint64, start, end []byte, opts IteratorOptions) (iterator.UnsafeIterator, error) {
-	tr, err := s.treeAtRoot(rootID)
-	if err != nil {
-		return nil, err
-	}
-	return tr.ReverseIteratorWithOptions(start, end, opts), nil
+	return s.bindRootIterator(rootID, start, end, opts, true)
 }
 
 func (s *Snapshot) HasManyAtRoot(rootID uint64, keys [][]byte) ([]bool, error) {
+	if err := s.beginRead(); err != nil {
+		return nil, err
+	}
+	defer s.endRead()
 	out := make([]bool, len(keys))
 	if len(keys) == 0 {
 		return out, nil
@@ -140,6 +192,10 @@ func (s *Snapshot) HasManyAtRoot(rootID uint64, keys [][]byte) ([]bool, error) {
 }
 
 func (s *Snapshot) HasAnySortedAtRoot(rootID uint64, keys [][]byte) (bool, error) {
+	if err := s.beginRead(); err != nil {
+		return false, err
+	}
+	defer s.endRead()
 	if len(keys) == 0 {
 		return false, nil
 	}
@@ -158,6 +214,10 @@ func (s *Snapshot) HasAnySortedAtRoot(rootID uint64, keys [][]byte) (bool, error
 }
 
 func (s *Snapshot) HasPrefixesAtRoot(rootID uint64, prefixes [][]byte) ([]bool, error) {
+	if err := s.beginRead(); err != nil {
+		return nil, err
+	}
+	defer s.endRead()
 	out := make([]bool, len(prefixes))
 	if len(prefixes) == 0 {
 		return out, nil

--- a/TreeDB/db/snapshot_closed_surface_test.go
+++ b/TreeDB/db/snapshot_closed_surface_test.go
@@ -1,0 +1,225 @@
+package db
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/snissn/gomap/TreeDB/internal/iterator"
+)
+
+func TestSnapshotClosedSurfaceRejectsReadsAndInvalidatesAllIterators(t *testing.T) {
+	d, err := Open(Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer d.Close()
+	if err := d.SetSync([]byte("key"), []byte("value")); err != nil {
+		t.Fatal(err)
+	}
+
+	snap := d.AcquireSnapshot()
+	if snap == nil {
+		t.Fatal("AcquireSnapshot=nil")
+	}
+	token, ok := snap.StateToken()
+	if !ok || token.RootPageID == 0 {
+		t.Fatalf("StateToken=%+v ok=%v", token, ok)
+	}
+	rootID := token.RootPageID
+	reader, err := snap.ReaderAtRoot(rootID)
+	if err != nil {
+		t.Fatalf("ReaderAtRoot: %v", err)
+	}
+
+	constructors := []struct {
+		name string
+		fn   func() (iterator.UnsafeIterator, error)
+	}{
+		{"public_iterator", func() (iterator.UnsafeIterator, error) {
+			it, err := snap.Iterator(nil, nil)
+			if err != nil {
+				return nil, err
+			}
+			return it.(iterator.UnsafeIterator), nil
+		}},
+		{"iterator", func() (iterator.UnsafeIterator, error) { return snap.IteratorWithOptions(nil, nil, IteratorOptions{}) }},
+		{"public_reverse_iterator", func() (iterator.UnsafeIterator, error) {
+			it, err := snap.ReverseIterator(nil, nil)
+			if err != nil {
+				return nil, err
+			}
+			return it.(iterator.UnsafeIterator), nil
+		}},
+		{"reverse_iterator", func() (iterator.UnsafeIterator, error) {
+			return snap.ReverseIteratorWithOptions(nil, nil, IteratorOptions{})
+		}},
+		{"root_iterator", func() (iterator.UnsafeIterator, error) { return snap.IteratorAtRoot(rootID, nil, nil) }},
+		{"root_iterator_options", func() (iterator.UnsafeIterator, error) {
+			return snap.IteratorAtRootWithOptions(rootID, nil, nil, IteratorOptions{})
+		}},
+		{"root_reverse_iterator", func() (iterator.UnsafeIterator, error) { return snap.ReverseIteratorAtRoot(rootID, nil, nil) }},
+		{"root_reverse_iterator_options", func() (iterator.UnsafeIterator, error) {
+			return snap.ReverseIteratorAtRootWithOptions(rootID, nil, nil, IteratorOptions{})
+		}},
+	}
+	iters := make([]iterator.UnsafeIterator, 0, len(constructors))
+	for _, ctor := range constructors {
+		it, err := ctor.fn()
+		if err != nil {
+			t.Fatalf("%s: %v", ctor.name, err)
+		}
+		if !it.Valid() {
+			t.Fatalf("%s initially invalid: %v", ctor.name, it.Error())
+		}
+		iters = append(iters, it)
+	}
+
+	if err := snap.Close(); err != nil {
+		t.Fatalf("Snapshot.Close: %v", err)
+	}
+	if snap.db == nil {
+		t.Fatal("snapshot released pinned state while iterators remained open")
+	}
+	for i, it := range iters {
+		if it.Valid() {
+			t.Fatalf("iterator %d remained valid after Snapshot.Close", i)
+		}
+		if err := it.Error(); !errors.Is(err, ErrClosed) {
+			t.Fatalf("iterator %d error=%v want ErrClosed", i, err)
+		}
+	}
+
+	called := false
+	checks := []struct {
+		name string
+		fn   func() error
+	}{
+		{"get", func() error { _, err := snap.Get([]byte("key")); return err }},
+		{"get_append", func() error {
+			dst := []byte("prefix")
+			out, err := snap.GetAppend([]byte("key"), dst)
+			if string(out) != "prefix" {
+				t.Fatalf("GetAppend mutated dst: %q", out)
+			}
+			return err
+		}},
+		{"get_versioned", func() error { _, _, err := snap.GetVersioned([]byte("key")); return err }},
+		{"get_versioned_append", func() error { _, _, err := snap.GetVersionedAppend([]byte("key"), nil); return err }},
+		{"get_many_empty", func() error { return snap.GetManyView(nil, nil) }},
+		{"get_many", func() error {
+			return snap.GetManyView([][]byte{[]byte("key")}, func(int, []byte, []byte, bool) error {
+				called = true
+				return nil
+			})
+		}},
+		{"get_unsafe", func() error { _, err := snap.GetUnsafe([]byte("key")); return err }},
+		{"has", func() error { _, err := snap.Has([]byte("key")); return err }},
+		{"has_many_empty", func() error { _, err := snap.HasMany(nil); return err }},
+		{"has_many", func() error { _, err := snap.HasMany([][]byte{[]byte("key")}); return err }},
+		{"has_prefixes_empty", func() error { _, err := snap.HasPrefixes(nil); return err }},
+		{"has_prefixes", func() error { _, err := snap.HasPrefixes([][]byte{[]byte("k")}); return err }},
+		{"get_entry", func() error { _, err := snap.GetEntry([]byte("key")); return err }},
+		{"get_entry_exact", func() error { _, err := snap.GetEntryExact([]byte("key")); return err }},
+		{"iterate", func() error { return snap.Iterate(nil, nil, func([]byte, []byte) error { called = true; return nil }) }},
+		{"reverse_iterate", func() error {
+			return snap.ReverseIterate(nil, nil, func([]byte, []byte) error { called = true; return nil })
+		}},
+		{"reader_at_root", func() error { _, err := snap.ReaderAtRoot(rootID); return err }},
+		{"root_get", func() error { _, err := snap.GetAtRoot(rootID, []byte("key")); return err }},
+		{"root_get_append", func() error { _, err := snap.GetAppendAtRoot(rootID, []byte("key"), nil); return err }},
+		{"root_get_many_empty", func() error { return snap.GetManyViewAtRoot(rootID, nil, nil) }},
+		{"root_get_unsafe", func() error { _, err := snap.GetUnsafeAtRoot(rootID, []byte("key")); return err }},
+		{"root_get_entry", func() error { _, err := snap.GetEntryAtRoot(rootID, []byte("key")); return err }},
+		{"root_has_many_empty", func() error { _, err := snap.HasManyAtRoot(rootID, nil); return err }},
+		{"root_has_any_empty", func() error { _, err := snap.HasAnySortedAtRoot(rootID, nil); return err }},
+		{"root_has_prefixes_empty", func() error { _, err := snap.HasPrefixesAtRoot(rootID, nil); return err }},
+		{"root_reader_get", func() error { _, err := reader.GetAppend([]byte("key"), nil); return err }},
+		{"root_reader_get_many_empty", func() error { return reader.GetManyView(nil, nil) }},
+	}
+	for _, check := range checks {
+		if err := check.fn(); !errors.Is(err, ErrClosed) {
+			t.Errorf("%s error=%v want ErrClosed", check.name, err)
+		}
+	}
+	if called {
+		t.Fatal("closed snapshot invoked a read callback")
+	}
+	if snap.Pager() != nil || snap.State() != nil {
+		t.Fatal("closed snapshot exposed Pager or State")
+	}
+	if _, ok := snap.StateToken(); ok {
+		t.Fatal("closed snapshot exposed StateToken")
+	}
+
+	for i, it := range iters {
+		if err := it.Close(); err != nil {
+			t.Fatalf("iterator %d Close: %v", i, err)
+		}
+		if i+1 < len(iters) && snap.db == nil {
+			t.Fatalf("snapshot released state with %d iterators still open", len(iters)-i-1)
+		}
+	}
+	if snap.db != nil {
+		t.Fatal("snapshot retained state after final iterator close")
+	}
+}
+
+func TestSnapshotReadCallbackCanCloseOwner(t *testing.T) {
+	d, err := Open(Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer d.Close()
+	if err := d.SetSync([]byte("key"), []byte("value")); err != nil {
+		t.Fatal(err)
+	}
+	snap := d.AcquireSnapshot()
+	if snap == nil {
+		t.Fatal("AcquireSnapshot=nil")
+	}
+	if err := snap.GetManyView([][]byte{[]byte("key")}, func(int, []byte, []byte, bool) error {
+		return snap.Close()
+	}); err != nil {
+		t.Fatalf("GetManyView: %v", err)
+	}
+	if snap.db != nil {
+		t.Fatal("snapshot retained pinned state after callback read completed")
+	}
+	if _, err := snap.Get([]byte("key")); !errors.Is(err, ErrClosed) {
+		t.Fatalf("post-callback Get error=%v want ErrClosed", err)
+	}
+}
+
+func TestSnapshotRootReaderCallbackCanCloseOwner(t *testing.T) {
+	d, err := Open(Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer d.Close()
+	if err := d.SetSync([]byte("key"), []byte("value")); err != nil {
+		t.Fatal(err)
+	}
+	snap := d.AcquireSnapshot()
+	if snap == nil {
+		t.Fatal("AcquireSnapshot=nil")
+	}
+	token, ok := snap.StateToken()
+	if !ok {
+		t.Fatal("StateToken unavailable")
+	}
+	reader, err := snap.ReaderAtRoot(token.RootPageID)
+	if err != nil {
+		t.Fatalf("ReaderAtRoot: %v", err)
+	}
+	if err := reader.GetManyView([][]byte{[]byte("key")}, func(int, []byte, []byte, bool) error {
+		return snap.Close()
+	}); err != nil {
+		t.Fatalf("SnapshotRootReader.GetManyView: %v", err)
+	}
+	if snap.db != nil {
+		t.Fatal("snapshot retained pinned state after root-reader callback completed")
+	}
+	if _, err := reader.GetAppend([]byte("key"), nil); !errors.Is(err, ErrClosed) {
+		t.Fatalf("post-callback GetAppend error=%v want ErrClosed", err)
+	}
+}

--- a/TreeDB/db/snapshot_iterator_creation_test.go
+++ b/TreeDB/db/snapshot_iterator_creation_test.go
@@ -1,0 +1,122 @@
+package db
+
+import (
+	"errors"
+	"runtime"
+	"testing"
+
+	"github.com/snissn/gomap/TreeDB/internal/iterator"
+)
+
+func TestSnapshotIteratorCreationSerializesCloseAndPoolReuse(t *testing.T) {
+	d, err := Open(Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer d.Close()
+	if err := d.SetSync([]byte("old"), []byte("value")); err != nil {
+		t.Fatal(err)
+	}
+
+	for _, reverse := range []bool{false, true} {
+		t.Run(map[bool]string{false: "forward", true: "reverse"}[reverse], func(t *testing.T) {
+			snap := d.AcquireSnapshot()
+			if snap == nil {
+				t.Fatal("AcquireSnapshot=nil")
+			}
+
+			enteredCreate := make(chan struct{})
+			releaseCreate := make(chan struct{})
+			type iteratorResult struct {
+				it  iterator.UnsafeIterator
+				err error
+			}
+			iteratorDone := make(chan iteratorResult, 1)
+			go func() {
+				it, err := snap.bindNewIterator(func() iterator.UnsafeIterator {
+					close(enteredCreate)
+					<-releaseCreate
+					return snap.buildIteratorLocked(nil, nil, IteratorOptions{}, reverse)
+				})
+				iteratorDone <- iteratorResult{it: it, err: err}
+			}()
+			<-enteredCreate
+
+			closeStarted := make(chan struct{})
+			closeDone := make(chan error, 1)
+			go func() {
+				close(closeStarted)
+				closeDone <- snap.Close()
+			}()
+			<-closeStarted
+			for i := 0; i < 100; i++ {
+				runtime.Gosched()
+			}
+			if snap.closed.Load() {
+				t.Fatal("Close changed snapshot generation while iterator creation held iteratorMu")
+			}
+
+			other := d.AcquireSnapshot()
+			if other == nil {
+				t.Fatal("second AcquireSnapshot=nil")
+			}
+			if other == snap {
+				t.Fatal("snapshot was returned to pool before iterator registration completed")
+			}
+			if err := other.Close(); err != nil {
+				t.Fatalf("second Snapshot.Close: %v", err)
+			}
+
+			close(releaseCreate)
+			result := <-iteratorDone
+			if result.err != nil {
+				t.Fatalf("iterator creation: %v", result.err)
+			}
+			if err := <-closeDone; err != nil {
+				t.Fatalf("Snapshot.Close: %v", err)
+			}
+			if result.it.Valid() {
+				t.Fatal("iterator remained valid after serialized snapshot close")
+			}
+			if err := result.it.Error(); !errors.Is(err, ErrClosed) {
+				t.Fatalf("iterator Error=%v want ErrClosed", err)
+			}
+			if err := result.it.Close(); err != nil {
+				t.Fatalf("Iterator.Close: %v", err)
+			}
+		})
+	}
+}
+
+func TestSnapshotIteratorCreationRejectsStaleGeneration(t *testing.T) {
+	d, err := Open(Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer d.Close()
+	snap := d.AcquireSnapshot()
+	if snap == nil {
+		t.Fatal("AcquireSnapshot=nil")
+	}
+	defer snap.Close()
+
+	staleGeneration := snap.generation.Load()
+	snap.iteratorMu.Lock()
+	snap.generation.Add(1)
+	snap.closed.Store(false)
+	snap.iteratorMu.Unlock()
+	createCalled := false
+	it, err := snap.bindNewIteratorAtGeneration(staleGeneration, func() iterator.UnsafeIterator {
+		createCalled = true
+		return snap.buildIteratorLocked(nil, nil, IteratorOptions{}, false)
+	})
+	if !errors.Is(err, ErrClosed) {
+		t.Fatalf("bind stale generation error=%v want ErrClosed", err)
+	}
+	if it != nil {
+		t.Fatal("stale generation returned an iterator")
+	}
+	if createCalled {
+		t.Fatal("stale generation accessed snapshot fields")
+	}
+}

--- a/TreeDB/db/snapshot_iterator_creation_test.go
+++ b/TreeDB/db/snapshot_iterator_creation_test.go
@@ -1,11 +1,13 @@
 package db
 
 import (
+	"bytes"
 	"errors"
 	"runtime"
 	"testing"
 
 	"github.com/snissn/gomap/TreeDB/internal/iterator"
+	publiciterator "github.com/snissn/gomap/TreeDB/iterator"
 )
 
 func TestSnapshotIteratorCreationSerializesCloseAndPoolReuse(t *testing.T) {
@@ -212,5 +214,130 @@ func TestBackendSnapshotIteratorEmptyDomainSeekRemainsEmpty(t *testing.T) {
 				}
 			})
 		}
+	}
+}
+
+func TestBackendSnapshotIteratorOpenEndedLowerBoundSeekRemainsEmpty(t *testing.T) {
+	d, err := Open(Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer d.Close()
+	for _, key := range []string{"a", "c"} {
+		if err := d.SetSync([]byte(key), []byte(key)); err != nil {
+			t.Fatal(err)
+		}
+	}
+	snap := d.AcquireSnapshot()
+	if snap == nil {
+		t.Fatal("AcquireSnapshot=nil")
+	}
+	defer snap.Close()
+
+	start := []byte("m")
+	targets := []struct {
+		name string
+		key  []byte
+	}{
+		{name: "nil", key: nil},
+		{name: "below", key: []byte("a")},
+		{name: "inside", key: []byte("m")},
+		{name: "above", key: []byte{0xff}},
+	}
+	for _, reverse := range []bool{false, true} {
+		name := map[bool]string{false: "forward", true: "reverse"}[reverse]
+		t.Run(name, func(t *testing.T) {
+			var it publiciterator.Iterator
+			var err error
+			if reverse {
+				it, err = snap.ReverseIterator(start, nil)
+			} else {
+				it, err = snap.Iterator(start, nil)
+			}
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer it.Close()
+			if it.Valid() {
+				t.Fatalf("iterator construction exposed key %q below start %q", it.Key(), start)
+			}
+			for _, target := range targets {
+				t.Run(target.name, func(t *testing.T) {
+					it.Seek(target.key)
+					if it.Valid() {
+						t.Fatalf("Seek(%x) exposed key %q below start %q", target.key, it.Key(), start)
+					}
+					if err := it.Error(); err != nil {
+						t.Fatalf("Seek(%x) error=%v", target.key, err)
+					}
+				})
+			}
+		})
+	}
+}
+
+func TestBackendSnapshotIteratorOpenEndedLowerBoundSeekClampsToDomain(t *testing.T) {
+	d, err := Open(Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer d.Close()
+	for _, key := range []string{"a", "c", "m", "z"} {
+		if err := d.SetSync([]byte(key), []byte(key)); err != nil {
+			t.Fatal(err)
+		}
+	}
+	snap := d.AcquireSnapshot()
+	if snap == nil {
+		t.Fatal("AcquireSnapshot=nil")
+	}
+	defer snap.Close()
+
+	start := []byte("m")
+	tests := []struct {
+		name    string
+		target  []byte
+		forward []byte
+		reverse []byte
+	}{
+		{name: "nil", target: nil, forward: []byte("m"), reverse: []byte("z")},
+		{name: "below", target: []byte("a"), forward: []byte("m")},
+		{name: "inside", target: []byte("n"), forward: []byte("z"), reverse: []byte("m")},
+		{name: "above", target: []byte{0xff}, reverse: []byte("z")},
+	}
+	for _, reverse := range []bool{false, true} {
+		name := map[bool]string{false: "forward", true: "reverse"}[reverse]
+		t.Run(name, func(t *testing.T) {
+			var it publiciterator.Iterator
+			var err error
+			if reverse {
+				it, err = snap.ReverseIterator(start, nil)
+			} else {
+				it, err = snap.Iterator(start, nil)
+			}
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer it.Close()
+			for _, test := range tests {
+				t.Run(test.name, func(t *testing.T) {
+					it.Seek(test.target)
+					want := test.forward
+					if reverse {
+						want = test.reverse
+					}
+					if want == nil {
+						if it.Valid() {
+							t.Fatalf("Seek(%x) key=%q want invalid", test.target, it.Key())
+						}
+					} else if !it.Valid() || !bytes.Equal(it.Key(), want) {
+						t.Fatalf("Seek(%x) valid=%v key=%q want %q", test.target, it.Valid(), it.Key(), want)
+					}
+					if err := it.Error(); err != nil {
+						t.Fatalf("Seek(%x) error=%v", test.target, err)
+					}
+				})
+			}
+		})
 	}
 }

--- a/TreeDB/db/snapshot_iterator_creation_test.go
+++ b/TreeDB/db/snapshot_iterator_creation_test.go
@@ -121,6 +121,48 @@ func TestSnapshotIteratorCreationRejectsStaleGeneration(t *testing.T) {
 	}
 }
 
+func TestSnapshotIteratorDoubleCloseDetachesPooledOwner(t *testing.T) {
+	d, err := Open(Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer d.Close()
+	// Isolate this test's pool so the returned object is the next object reused.
+	d.snapPool = NewSnapshotPool()
+
+	snap := d.AcquireSnapshot()
+	if snap == nil {
+		t.Fatal("AcquireSnapshot=nil")
+	}
+	it, err := snap.IteratorWithOptions(nil, nil, IteratorOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	bound := it.(*snapshotBoundIterator)
+	if err := snap.Close(); err != nil {
+		t.Fatalf("Snapshot.Close: %v", err)
+	}
+	if err := it.Close(); err != nil {
+		t.Fatalf("Iterator.Close: %v", err)
+	}
+	if bound.owner != nil {
+		t.Fatal("closed iterator retained pooled snapshot owner")
+	}
+
+	reused := d.snapPool.Get()
+	if reused != snap {
+		t.Fatal("snapshot pool did not reuse the just-returned snapshot")
+	}
+	generation := reused.generation.Load()
+	if err := it.Close(); err != nil {
+		t.Fatalf("second Iterator.Close: %v", err)
+	}
+	if reused.generation.Load() != generation || reused.finalized.Load() {
+		t.Fatal("double iterator close mutated a reused snapshot generation")
+	}
+	d.snapPool.Put(reused)
+}
+
 func TestBackendSnapshotIteratorEmptyDomainSeekRemainsEmpty(t *testing.T) {
 	d, err := Open(Options{Dir: t.TempDir()})
 	if err != nil {

--- a/TreeDB/db/snapshot_iterator_creation_test.go
+++ b/TreeDB/db/snapshot_iterator_creation_test.go
@@ -10,7 +10,7 @@ import (
 	publiciterator "github.com/snissn/gomap/TreeDB/iterator"
 )
 
-func TestSnapshotIteratorCreationSerializesCloseAndPoolReuse(t *testing.T) {
+func TestSnapshotIteratorCreationSerializesCloseAndRelease(t *testing.T) {
 	d, err := Open(Options{Dir: t.TempDir()})
 	if err != nil {
 		t.Fatal(err)
@@ -63,7 +63,7 @@ func TestSnapshotIteratorCreationSerializesCloseAndPoolReuse(t *testing.T) {
 				t.Fatal("second AcquireSnapshot=nil")
 			}
 			if other == snap {
-				t.Fatal("snapshot was returned to pool before iterator registration completed")
+				t.Fatal("AcquireSnapshot reused a snapshot handle during iterator registration")
 			}
 			if err := other.Close(); err != nil {
 				t.Fatalf("second Snapshot.Close: %v", err)
@@ -120,6 +120,45 @@ func TestSnapshotIteratorCreationRejectsStaleGeneration(t *testing.T) {
 	}
 	if createCalled {
 		t.Fatal("stale generation accessed snapshot fields")
+	}
+}
+
+func TestSnapshotIteratorCreationRejectsClosedHandleAfterNewAcquisition(t *testing.T) {
+	d, err := Open(Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer d.Close()
+
+	stale := d.AcquireSnapshot()
+	if stale == nil {
+		t.Fatal("AcquireSnapshot=nil")
+	}
+	if err := stale.Close(); err != nil {
+		t.Fatalf("stale Snapshot.Close: %v", err)
+	}
+	fresh := d.AcquireSnapshot()
+	if fresh == nil {
+		t.Fatal("fresh AcquireSnapshot=nil")
+	}
+	defer fresh.Close()
+	if fresh == stale {
+		t.Fatal("AcquireSnapshot reused an exported snapshot handle")
+	}
+
+	for _, reverse := range []bool{false, true} {
+		var it iterator.UnsafeIterator
+		if reverse {
+			it, err = stale.ReverseIteratorWithOptions(nil, nil, IteratorOptions{})
+		} else {
+			it, err = stale.IteratorWithOptions(nil, nil, IteratorOptions{})
+		}
+		if !errors.Is(err, ErrClosed) {
+			t.Fatalf("reverse=%v stale iterator error=%v want ErrClosed", reverse, err)
+		}
+		if it != nil {
+			t.Fatalf("reverse=%v stale handle returned an iterator", reverse)
+		}
 	}
 }
 

--- a/TreeDB/db/snapshot_iterator_creation_test.go
+++ b/TreeDB/db/snapshot_iterator_creation_test.go
@@ -120,3 +120,55 @@ func TestSnapshotIteratorCreationRejectsStaleGeneration(t *testing.T) {
 		t.Fatal("stale generation accessed snapshot fields")
 	}
 }
+
+func TestBackendSnapshotIteratorEmptyDomainSeekRemainsEmpty(t *testing.T) {
+	d, err := Open(Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer d.Close()
+	for _, key := range []string{"a", "m", "z"} {
+		if err := d.SetSync([]byte(key), []byte(key)); err != nil {
+			t.Fatal(err)
+		}
+	}
+	snap := d.AcquireSnapshot()
+	if snap == nil {
+		t.Fatal("AcquireSnapshot=nil")
+	}
+	defer snap.Close()
+
+	for _, bounds := range []struct {
+		name       string
+		start, end []byte
+	}{
+		{name: "equal", start: []byte("m"), end: []byte("m")},
+		{name: "inverted", start: []byte("z"), end: []byte("a")},
+	} {
+		for _, reverse := range []bool{false, true} {
+			name := bounds.name + map[bool]string{false: "/forward", true: "/reverse"}[reverse]
+			t.Run(name, func(t *testing.T) {
+				var it iterator.UnsafeIterator
+				var err error
+				if reverse {
+					it, err = snap.ReverseIteratorWithOptions(bounds.start, bounds.end, IteratorOptions{})
+				} else {
+					it, err = snap.IteratorWithOptions(bounds.start, bounds.end, IteratorOptions{})
+				}
+				if err != nil {
+					t.Fatal(err)
+				}
+				defer it.Close()
+				for _, target := range [][]byte{nil, []byte("a"), []byte("m"), []byte("z"), {0xff}} {
+					it.Seek(target)
+					if it.Valid() {
+						t.Fatalf("Seek(%x) exposed key %x from empty domain", target, it.UnsafeKey())
+					}
+					if err := it.Error(); err != nil {
+						t.Fatalf("Seek(%x) error=%v", target, err)
+					}
+				}
+			})
+		}
+	}
+}

--- a/TreeDB/db/snapshot_iterator_creation_test.go
+++ b/TreeDB/db/snapshot_iterator_creation_test.go
@@ -123,14 +123,12 @@ func TestSnapshotIteratorCreationRejectsStaleGeneration(t *testing.T) {
 	}
 }
 
-func TestSnapshotIteratorDoubleCloseDetachesPooledOwner(t *testing.T) {
+func TestSnapshotIteratorDoubleCloseCannotMutateDetachedOwner(t *testing.T) {
 	d, err := Open(Options{Dir: t.TempDir()})
 	if err != nil {
 		t.Fatal(err)
 	}
 	defer d.Close()
-	// Isolate this test's pool so the returned object is the next object reused.
-	d.snapPool = NewSnapshotPool()
 
 	snap := d.AcquireSnapshot()
 	if snap == nil {
@@ -141,6 +139,11 @@ func TestSnapshotIteratorDoubleCloseDetachesPooledOwner(t *testing.T) {
 		t.Fatal(err)
 	}
 	bound := it.(*snapshotBoundIterator)
+	keeper, err := snap.IteratorWithOptions(nil, nil, IteratorOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer keeper.Close()
 	if err := snap.Close(); err != nil {
 		t.Fatalf("Snapshot.Close: %v", err)
 	}
@@ -148,21 +151,22 @@ func TestSnapshotIteratorDoubleCloseDetachesPooledOwner(t *testing.T) {
 		t.Fatalf("Iterator.Close: %v", err)
 	}
 	if bound.owner != nil {
-		t.Fatal("closed iterator retained pooled snapshot owner")
+		t.Fatal("closed iterator retained snapshot owner")
 	}
 
-	reused := d.snapPool.Get()
-	if reused != snap {
-		t.Fatal("snapshot pool did not reuse the just-returned snapshot")
+	generation := snap.generation.Load()
+	if snap.finalized.Load() {
+		t.Fatal("keeper did not pin closed snapshot owner")
 	}
-	generation := reused.generation.Load()
 	if err := it.Close(); err != nil {
 		t.Fatalf("second Iterator.Close: %v", err)
 	}
-	if reused.generation.Load() != generation || reused.finalized.Load() {
-		t.Fatal("double iterator close mutated a reused snapshot generation")
+	if snap.generation.Load() != generation || snap.finalized.Load() {
+		t.Fatal("double iterator close mutated detached snapshot owner")
 	}
-	d.snapPool.Put(reused)
+	if err := keeper.Close(); err != nil {
+		t.Fatalf("keeper Iterator.Close: %v", err)
+	}
 }
 
 func TestBackendSnapshotIteratorEmptyDomainSeekRemainsEmpty(t *testing.T) {

--- a/TreeDB/db/snapshot_iterator_lifetime.go
+++ b/TreeDB/db/snapshot_iterator_lifetime.go
@@ -9,8 +9,8 @@ import (
 	"github.com/snissn/gomap/TreeDB/page"
 )
 
-// snapshotBoundIterator prevents a pooled Snapshot from being returned and
-// reused until every iterator invalidated by Snapshot.Close is itself closed.
+// snapshotBoundIterator prevents a Snapshot from releasing its pinned state
+// until every iterator invalidated by Snapshot.Close is itself closed.
 // Registration and closure use a mutex; the steady-state path uses one atomic
 // closed check and does not allocate.
 type snapshotBoundIterator struct {

--- a/TreeDB/db/snapshot_iterator_lifetime.go
+++ b/TreeDB/db/snapshot_iterator_lifetime.go
@@ -24,32 +24,45 @@ type snapshotBoundIterator struct {
 	end       []byte
 }
 
-func (s *Snapshot) bindIterator(inner iterator.UnsafeIterator) (iterator.UnsafeIterator, error) {
+func (s *Snapshot) bindNewIterator(create func() iterator.UnsafeIterator) (iterator.UnsafeIterator, error) {
+	if s == nil || create == nil {
+		return nil, ErrClosed
+	}
+	return s.bindNewIteratorAtGeneration(s.generation.Load(), create)
+}
+
+func (s *Snapshot) bindNewIteratorAtGeneration(generation uint64, create func() iterator.UnsafeIterator) (iterator.UnsafeIterator, error) {
+	if s == nil || create == nil {
+		return nil, ErrClosed
+	}
+	s.iteratorMu.Lock()
+	defer s.iteratorMu.Unlock()
+	if s.closed.Load() || generation != s.generation.Load() {
+		return nil, ErrClosed
+	}
+	return s.bindIteratorLocked(create())
+}
+
+// bindIteratorLocked registers inner while s.iteratorMu is held. Iterator
+// creation holds that lock from the closed check through construction and this
+// registration, so Snapshot.Close cannot recycle s between those steps.
+func (s *Snapshot) bindIteratorLocked(inner iterator.UnsafeIterator) (iterator.UnsafeIterator, error) {
 	if inner == nil {
 		return nil, ErrClosed
 	}
 	start, end := inner.Domain()
 	it := &snapshotBoundIterator{owner: s, inner: inner, start: start, end: end}
-	s.iteratorMu.Lock()
-	if s.closed.Load() {
-		s.iteratorMu.Unlock()
-		_ = inner.Close()
-		return nil, ErrClosed
-	}
 	if s.iterators == nil {
 		s.iterators = make(map[*snapshotBoundIterator]struct{})
 	}
 	s.iterators[it] = struct{}{}
-	s.iteratorMu.Unlock()
 	return it, nil
 }
 
-func (s *Snapshot) invalidateBoundIterators() {
-	s.iteratorMu.Lock()
+func (s *Snapshot) invalidateBoundIteratorsLocked() {
 	for it := range s.iterators {
 		it.closed.Store(true)
 	}
-	s.iteratorMu.Unlock()
 }
 
 func (it *snapshotBoundIterator) begin() bool {

--- a/TreeDB/db/snapshot_iterator_lifetime.go
+++ b/TreeDB/db/snapshot_iterator_lifetime.go
@@ -69,10 +69,6 @@ func (it *snapshotBoundIterator) begin() bool {
 	return it != nil && !it.closed.Load() && it.inner != nil
 }
 
-func (it *snapshotBoundIterator) closeInner() {
-	it.closeOnce.Do(func() { it.closeErr = it.inner.Close() })
-}
-
 func (it *snapshotBoundIterator) Valid() bool {
 	if !it.begin() {
 		return false
@@ -169,17 +165,22 @@ func (it *snapshotBoundIterator) Close() error {
 		return nil
 	}
 	it.closed.Store(true)
-	it.closeInner()
-	if it.owner != nil {
-		owner := it.owner
-		owner.iteratorMu.Lock()
-		delete(owner.iterators, it)
-		shouldFinalize := owner.closed.Load() && len(owner.iterators) == 0
-		owner.iteratorMu.Unlock()
-		if shouldFinalize {
-			it.closeErr = errors.Join(it.closeErr, owner.finalizeCloseIfUnreferenced())
+	it.closeOnce.Do(func() {
+		if it.inner != nil {
+			it.closeErr = it.inner.Close()
 		}
-	}
+		owner := it.owner
+		it.owner = nil
+		if owner != nil {
+			owner.iteratorMu.Lock()
+			delete(owner.iterators, it)
+			shouldFinalize := owner.closed.Load() && len(owner.iterators) == 0
+			owner.iteratorMu.Unlock()
+			if shouldFinalize {
+				it.closeErr = errors.Join(it.closeErr, owner.finalizeCloseIfUnreferenced())
+			}
+		}
+	})
 	return it.closeErr
 }
 

--- a/TreeDB/db/snapshot_iterator_lifetime.go
+++ b/TreeDB/db/snapshot_iterator_lifetime.go
@@ -1,0 +1,173 @@
+package db
+
+import (
+	"errors"
+	"sync"
+	"sync/atomic"
+
+	"github.com/snissn/gomap/TreeDB/internal/iterator"
+	"github.com/snissn/gomap/TreeDB/page"
+)
+
+// snapshotBoundIterator prevents a pooled Snapshot from being returned and
+// reused until every iterator invalidated by Snapshot.Close is itself closed.
+// Registration and closure use a mutex; the steady-state path uses one atomic
+// closed check and does not allocate.
+type snapshotBoundIterator struct {
+	owner *Snapshot
+	inner iterator.UnsafeIterator
+
+	closed    atomic.Bool
+	closeOnce sync.Once
+	closeErr  error
+	start     []byte
+	end       []byte
+}
+
+func (s *Snapshot) bindIterator(inner iterator.UnsafeIterator) (iterator.UnsafeIterator, error) {
+	if inner == nil {
+		return nil, ErrClosed
+	}
+	start, end := inner.Domain()
+	it := &snapshotBoundIterator{owner: s, inner: inner, start: start, end: end}
+	s.iteratorMu.Lock()
+	if s.closed.Load() {
+		s.iteratorMu.Unlock()
+		_ = inner.Close()
+		return nil, ErrClosed
+	}
+	if s.iterators == nil {
+		s.iterators = make(map[*snapshotBoundIterator]struct{})
+	}
+	s.iterators[it] = struct{}{}
+	s.iteratorMu.Unlock()
+	return it, nil
+}
+
+func (s *Snapshot) invalidateBoundIterators() {
+	s.iteratorMu.Lock()
+	for it := range s.iterators {
+		it.closed.Store(true)
+	}
+	s.iteratorMu.Unlock()
+}
+
+func (it *snapshotBoundIterator) begin() bool {
+	return it != nil && !it.closed.Load() && it.inner != nil
+}
+
+func (it *snapshotBoundIterator) closeInner() {
+	it.closeOnce.Do(func() { it.closeErr = it.inner.Close() })
+}
+
+func (it *snapshotBoundIterator) Valid() bool {
+	if !it.begin() {
+		return false
+	}
+	return it.inner.Valid()
+}
+
+func (it *snapshotBoundIterator) Next() {
+	if !it.begin() {
+		return
+	}
+	it.inner.Next()
+}
+
+func (it *snapshotBoundIterator) Seek(key []byte) {
+	if !it.begin() {
+		return
+	}
+	it.inner.Seek(key)
+}
+
+func (it *snapshotBoundIterator) UnsafeKey() []byte {
+	if !it.begin() {
+		return nil
+	}
+	return it.inner.UnsafeKey()
+}
+
+func (it *snapshotBoundIterator) UnsafeValue() []byte {
+	if !it.begin() {
+		return nil
+	}
+	return it.inner.UnsafeValue()
+}
+
+func (it *snapshotBoundIterator) UnsafeEntry() ([]byte, page.ValuePtr, byte) {
+	if !it.begin() {
+		return nil, page.ValuePtr{}, 0
+	}
+	return it.inner.UnsafeEntry()
+}
+
+func (it *snapshotBoundIterator) UnsafeEntryWithRevision() ([]byte, page.ValuePtr, byte, page.EntryRevision) {
+	if !it.begin() {
+		return nil, page.ValuePtr{}, 0, page.LegacyEntryRevision
+	}
+	return iterator.UnsafeEntryWithRevision(it.inner)
+}
+
+func (it *snapshotBoundIterator) Key() []byte {
+	if !it.begin() {
+		return nil
+	}
+	return it.inner.Key()
+}
+
+func (it *snapshotBoundIterator) Value() []byte {
+	if !it.begin() {
+		return nil
+	}
+	return it.inner.Value()
+}
+
+func (it *snapshotBoundIterator) KeyCopy(dst []byte) []byte {
+	if !it.begin() {
+		return dst[:0]
+	}
+	return it.inner.KeyCopy(dst)
+}
+
+func (it *snapshotBoundIterator) ValueCopy(dst []byte) []byte {
+	if !it.begin() {
+		return dst[:0]
+	}
+	return it.inner.ValueCopy(dst)
+}
+
+func (it *snapshotBoundIterator) IsDeleted() bool {
+	if !it.begin() {
+		return false
+	}
+	return it.inner.IsDeleted()
+}
+
+func (it *snapshotBoundIterator) Error() error {
+	if it == nil || it.closed.Load() || !it.begin() {
+		return ErrClosed
+	}
+	return it.inner.Error()
+}
+
+func (it *snapshotBoundIterator) Close() error {
+	if it == nil {
+		return nil
+	}
+	it.closed.Store(true)
+	it.closeInner()
+	if it.owner != nil {
+		owner := it.owner
+		owner.iteratorMu.Lock()
+		delete(owner.iterators, it)
+		shouldFinalize := owner.closed.Load() && len(owner.iterators) == 0
+		owner.iteratorMu.Unlock()
+		if shouldFinalize {
+			it.closeErr = errors.Join(it.closeErr, owner.finalizeCloseIfUnreferenced())
+		}
+	}
+	return it.closeErr
+}
+
+func (it *snapshotBoundIterator) Domain() ([]byte, []byte) { return it.start, it.end }

--- a/TreeDB/db/snapshot_read_lifetime.go
+++ b/TreeDB/db/snapshot_read_lifetime.go
@@ -1,0 +1,29 @@
+package db
+
+const snapshotReadClosedBit uint64 = 1 << 63
+
+// beginRead pins the snapshot's readable state against concurrent Close.
+// Callers must pair a nil result with endRead.
+func (s *Snapshot) beginRead() error {
+	if s == nil {
+		return ErrClosed
+	}
+	for {
+		state := s.readState.Load()
+		if state&snapshotReadClosedBit != 0 {
+			return ErrClosed
+		}
+		if s.readState.CompareAndSwap(state, state+1) {
+			return nil
+		}
+	}
+}
+
+func (s *Snapshot) endRead() {
+	if s == nil {
+		return
+	}
+	if s.readState.Add(^uint64(0)) == snapshotReadClosedBit {
+		_ = s.finalizeCloseIfUnreferenced()
+	}
+}

--- a/TreeDB/db/snapshot_view_test.go
+++ b/TreeDB/db/snapshot_view_test.go
@@ -961,21 +961,23 @@ func TestSnapshotPool_PutClearsLeafGenerationRefs(t *testing.T) {
 	snap.leafGenerationPinSet = &leafGenerationPinSet{}
 	pool.Put(snap)
 
-	reused := pool.Get()
-	if len(reused.leafGenerationIDs) != 0 {
-		t.Fatalf("expected pooled snapshot ids slice to be reset, got len=%d", len(reused.leafGenerationIDs))
+	if len(snap.leafGenerationIDs) != 0 {
+		t.Fatalf("expected released snapshot ids slice to be reset, got len=%d", len(snap.leafGenerationIDs))
 	}
-	if len(reused.leafGenerationPinnedIDs) != 0 {
-		t.Fatalf("expected pooled snapshot pinned ids slice to be reset, got len=%d", len(reused.leafGenerationPinnedIDs))
+	if len(snap.leafGenerationPinnedIDs) != 0 {
+		t.Fatalf("expected released snapshot pinned ids slice to be reset, got len=%d", len(snap.leafGenerationPinnedIDs))
 	}
-	if len(reused.leafGenerationRefs) != 0 {
-		t.Fatalf("expected pooled snapshot refs slice to be reset, got len=%d", len(reused.leafGenerationRefs))
+	if len(snap.leafGenerationRefs) != 0 {
+		t.Fatalf("expected released snapshot refs slice to be reset, got len=%d", len(snap.leafGenerationRefs))
 	}
-	if cap(reused.leafGenerationRefs) > 0 && reused.leafGenerationRefs[:1][0] != nil {
-		t.Fatalf("expected pooled snapshot refs backing array to be cleared")
+	if cap(snap.leafGenerationRefs) > 0 && snap.leafGenerationRefs[:1][0] != nil {
+		t.Fatalf("expected released snapshot refs backing array to be cleared")
 	}
-	if reused.leafGenerationPinSet != nil {
-		t.Fatalf("expected pooled snapshot pin set to be cleared")
+	if snap.leafGenerationPinSet != nil {
+		t.Fatalf("expected released snapshot pin set to be cleared")
+	}
+	if fresh := pool.Get(); fresh == snap {
+		t.Fatal("SnapshotPool reused an exported snapshot handle")
 	}
 }
 

--- a/TreeDB/docs/spec/contracts.md
+++ b/TreeDB/docs/spec/contracts.md
@@ -235,12 +235,25 @@ read/precondition validation.
 ### 4.3 Iterator lifetime
 
 - Iterators are point-in-time views.
-- `Key()`/`Value()` data is a read-only view valid only until next movement/close.
+- `Key()`/`Value()` data is a read-only view valid only until the next
+  `Next`, `Seek`, iterator `Close`, or owning snapshot `Close`.
 - Callers must not retain or mutate `Key()`/`Value()` views across iterator movement.
 - `KeyCopy`/`ValueCopy` provide caller-owned stable copies that may be retained after movement/close.
 - Iterator must be closed.
 
-### 4.4 Cached-mode iterator semantics
+### 4.4 Seek
+
+- `Seek` never changes the iterator's original half-open `[start,end)` domain.
+- On a forward iterator, `Seek(target)` selects the least visible key greater
+  than or equal to `target`.
+- On a reverse iterator, `Seek(target)` selects the greatest visible key less
+  than or equal to `target`; a nil target selects the greatest key in the
+  domain.
+- Seeking before or after the domain clamps to the first eligible key or makes
+  the iterator invalid, respectively. Tombstones and shadowed source versions
+  are never exposed.
+
+### 4.5 Cached-mode iterator semantics
 
 When the cached layer is enabled:
 
@@ -252,6 +265,16 @@ When the cached layer is enabled:
 ## 5. Snapshot Contracts
 
 - Snapshots are point-in-time readers and MUST be closed to release retention pressure.
+- `Snapshot.Iterator` and `Snapshot.ReverseIterator` bind iterators to that
+  snapshot's pinned view. Closing the snapshot immediately invalidates every
+  outstanding bound iterator. After snapshot closure, iterator movement and
+  seek are no-ops, accessors return no view, `Valid` is false, and `Error`
+  returns `ErrClosed`; iterator `Close` remains idempotent. Physical snapshot
+  reclamation is deferred until those invalidated iterators are closed, so a
+  close racing `Next` or `Seek` cannot recycle their backing snapshot.
+- Snapshot iterator creation racing snapshot closure either returns a fully
+  registered iterator or fails with `ErrClosed`; it must not return an iterator
+  backed by a recycled snapshot object.
 - In cached mode, snapshots MUST include buffered memtable writes and MUST be snapshot-isolated (writes after snapshot acquisition are not visible through the snapshot).
 - `Snapshot.Get` / `Snapshot.GetAppend` return `ErrKeyNotFound` for missing/tombstoned keys (unlike `DB.Get`, which returns `(nil, nil)` on miss).
 - Under the planned user-command WAL contract, collection scans and snapshots

--- a/TreeDB/internal/merging/merging.go
+++ b/TreeDB/internal/merging/merging.go
@@ -2,6 +2,7 @@ package merging
 
 import (
 	"bytes"
+	"errors"
 
 	"github.com/snissn/gomap/TreeDB/internal/iterator"
 	"github.com/snissn/gomap/TreeDB/page"
@@ -26,6 +27,37 @@ type Iterator interface {
 type IteratorSource struct {
 	Iter     iterator.UnsafeIterator
 	Priority int
+}
+
+func joinIteratorError(current, next error) error {
+	if next == nil {
+		return current
+	}
+	if current == nil {
+		return next
+	}
+	return errors.Join(current, next)
+}
+
+func twoIteratorErrors(first, second iterator.UnsafeIterator) error {
+	var err error
+	if first != nil {
+		err = joinIteratorError(err, first.Error())
+	}
+	if second != nil {
+		err = joinIteratorError(err, second.Error())
+	}
+	return err
+}
+
+func sourceIteratorErrors(sources []IteratorSource) error {
+	var err error
+	for _, src := range sources {
+		if src.Iter != nil {
+			err = joinIteratorError(err, src.Iter.Error())
+		}
+	}
+	return err
 }
 
 // heapItem is an internal wrapper for the min-heap.
@@ -164,6 +196,11 @@ func (mi *MergingIterator) Seek(key []byte) {
 	for _, src := range mi.sources {
 		src.Iter.Seek(key)
 	}
+	mi.err = sourceIteratorErrors(mi.sources)
+	if mi.err != nil {
+		mi.h = mi.h[:0]
+		return
+	}
 	mi.rebuildHeap()
 	mi.advance()
 }
@@ -179,6 +216,9 @@ func (mi *MergingIterator) Next() {
 
 	if mi.hasCur {
 		mi.cur.iter.Next()
+		if mi.captureIteratorError(mi.cur.iter) {
+			return
+		}
 		if mi.cur.iter.Valid() {
 			mi.cur.key = mi.cur.iter.UnsafeKey()
 			mi.h.push(mi.cur)
@@ -209,6 +249,9 @@ func (mi *MergingIterator) advance() {
 			if next != nil && bytes.Equal(next.key, currentKey) {
 				shadowed := mi.h.pop()
 				shadowed.iter.Next()
+				if mi.captureIteratorError(shadowed.iter) {
+					return
+				}
 				if shadowed.iter.Valid() {
 					shadowed.key = shadowed.iter.UnsafeKey()
 					mi.h.push(shadowed)
@@ -221,6 +264,9 @@ func (mi *MergingIterator) advance() {
 		// If tombstone, advance winner and continue.
 		if top.iter.IsDeleted() {
 			top.iter.Next()
+			if mi.captureIteratorError(top.iter) {
+				return
+			}
 			if top.iter.Valid() {
 				top.key = top.iter.UnsafeKey()
 				mi.h.push(top)
@@ -234,6 +280,21 @@ func (mi *MergingIterator) advance() {
 		mi.valid = true
 		return
 	}
+}
+
+func (mi *MergingIterator) captureIteratorError(iter iterator.UnsafeIterator) bool {
+	if iter == nil {
+		return false
+	}
+	err := iter.Error()
+	if err == nil {
+		return false
+	}
+	mi.err = joinIteratorError(mi.err, err)
+	mi.cur = heapItem{}
+	mi.hasCur = false
+	mi.valid = false
+	return true
 }
 
 func (mi *MergingIterator) Valid() bool {

--- a/TreeDB/internal/merging/merging.go
+++ b/TreeDB/internal/merging/merging.go
@@ -11,6 +11,7 @@ import (
 // Key/Value are views, valid until the next Next()/Close().
 type Iterator interface {
 	Next()
+	Seek(key []byte)
 	Valid() bool
 	Key() []byte
 	Value() []byte
@@ -112,13 +113,14 @@ func (h *iteratorHeap) down(i0, n int) bool {
 
 // MergingIterator merges multiple sorted iterators.
 type MergingIterator struct {
-	h      iteratorHeap
-	cur    heapItem
-	hasCur bool
-	valid  bool
-	err    error
-	start  []byte
-	end    []byte
+	sources []IteratorSource
+	h       iteratorHeap
+	cur     heapItem
+	hasCur  bool
+	valid   bool
+	err     error
+	start   []byte
+	end     []byte
 }
 
 func NewMergingIterator(sources []IteratorSource, start, end []byte) Iterator {
@@ -128,26 +130,42 @@ func NewMergingIterator(sources []IteratorSource, start, end []byte) Iterator {
 		return NewTwoWayMerger(sources[0].Iter, sources[1].Iter, start, end)
 	}
 
-	h := make(iteratorHeap, 0, len(sources))
-	for _, src := range sources {
-		if src.Iter.Valid() {
-			h = append(h, heapItem{
-				iter:     src.Iter,
-				priority: src.Priority,
-				key:      src.Iter.UnsafeKey(), // View valid until src.Iter.Next()
-			})
-		} else {
-			_ = src.Iter.Close()
-		}
-	}
-	// Heapify.
-	for i := len(h)/2 - 1; i >= 0; i-- {
-		(&h).down(i, len(h))
-	}
-
-	mi := &MergingIterator{h: h, start: start, end: end}
+	mi := &MergingIterator{sources: sources, start: start, end: end}
+	mi.rebuildHeap()
 	mi.advance()
 	return mi
+}
+
+func (mi *MergingIterator) rebuildHeap() {
+	mi.h = mi.h[:0]
+	for _, src := range mi.sources {
+		if src.Iter.Valid() {
+			mi.h = append(mi.h, heapItem{
+				iter:     src.Iter,
+				priority: src.Priority,
+				key:      src.Iter.UnsafeKey(),
+			})
+		}
+	}
+	for i := len(mi.h)/2 - 1; i >= 0; i-- {
+		(&mi.h).down(i, len(mi.h))
+	}
+}
+
+// Seek positions the iterator at the first visible key greater than or equal
+// to key, restricted to the iterator's original [start, end) domain.
+func (mi *MergingIterator) Seek(key []byte) {
+	mi.err = nil
+	mi.hasCur = false
+	mi.valid = false
+	if mi.start != nil && (key == nil || bytes.Compare(key, mi.start) < 0) {
+		key = mi.start
+	}
+	for _, src := range mi.sources {
+		src.Iter.Seek(key)
+	}
+	mi.rebuildHeap()
+	mi.advance()
 }
 
 func (mi *MergingIterator) Next() {
@@ -164,8 +182,6 @@ func (mi *MergingIterator) Next() {
 		if mi.cur.iter.Valid() {
 			mi.cur.key = mi.cur.iter.UnsafeKey()
 			mi.h.push(mi.cur)
-		} else {
-			_ = mi.cur.iter.Close()
 		}
 		mi.hasCur = false
 	}
@@ -182,7 +198,7 @@ func (mi *MergingIterator) advance() {
 		currentKey := top.key
 
 		if mi.end != nil && bytes.Compare(currentKey, mi.end) >= 0 {
-			// Put it back so Close() can close everything.
+			// Preserve the source position; Seek may reactivate it later.
 			mi.h.push(top)
 			return
 		}
@@ -196,8 +212,6 @@ func (mi *MergingIterator) advance() {
 				if shadowed.iter.Valid() {
 					shadowed.key = shadowed.iter.UnsafeKey()
 					mi.h.push(shadowed)
-				} else {
-					_ = shadowed.iter.Close()
 				}
 			} else {
 				break
@@ -210,8 +224,6 @@ func (mi *MergingIterator) advance() {
 			if top.iter.Valid() {
 				top.key = top.iter.UnsafeKey()
 				mi.h.push(top)
-			} else {
-				_ = top.iter.Close()
 			}
 			continue
 		}
@@ -286,20 +298,15 @@ func (mi *MergingIterator) Error() error {
 
 func (mi *MergingIterator) Close() error {
 	var firstErr error
-
-	if mi.hasCur {
-		if err := mi.cur.iter.Close(); err != nil && firstErr == nil {
-			firstErr = err
-		}
-		mi.hasCur = false
-	}
-
-	for _, item := range mi.h {
-		if err := item.iter.Close(); err != nil && firstErr == nil { // Call Close() on UnsafeIterator
+	for _, src := range mi.sources {
+		if err := src.Iter.Close(); err != nil && firstErr == nil {
 			firstErr = err
 		}
 	}
-
+	mi.sources = nil
+	mi.h = nil
+	mi.hasCur = false
+	mi.valid = false
 	return firstErr
 }
 

--- a/TreeDB/internal/merging/merging_test.go
+++ b/TreeDB/internal/merging/merging_test.go
@@ -63,6 +63,53 @@ type valueErrorUnsafeIter struct {
 	valueCopied bool
 }
 
+type seekErrorUnsafeIter struct {
+	*mockUnsafeIter
+	err    error
+	seeked bool
+}
+
+type seekAdvanceErrorUnsafeIter struct {
+	*mockUnsafeIter
+	err    error
+	armed  bool
+	failed bool
+}
+
+func (m *seekAdvanceErrorUnsafeIter) Seek(key []byte) {
+	m.mockUnsafeIter.Seek(key)
+	m.armed = true
+	m.failed = false
+}
+
+func (m *seekAdvanceErrorUnsafeIter) Next() {
+	m.mockUnsafeIter.Next()
+	if m.armed {
+		m.failed = true
+		m.idx = len(m.data)
+	}
+}
+
+func (m *seekAdvanceErrorUnsafeIter) Error() error {
+	if m.failed {
+		return m.err
+	}
+	return nil
+}
+
+func (m *seekErrorUnsafeIter) Seek(key []byte) {
+	m.seeked = true
+	m.mockUnsafeIter.Seek(key)
+	m.idx = len(m.data)
+}
+
+func (m *seekErrorUnsafeIter) Error() error {
+	if m.seeked {
+		return m.err
+	}
+	return nil
+}
+
 func (m *valueErrorUnsafeIter) UnsafeValue() []byte {
 	m.valueLoaded = true
 	return nil
@@ -223,6 +270,96 @@ func TestTwoWayMergerSurfacesCurrentValueError(t *testing.T) {
 		t.Fatalf("first key = %q, want A", merged.Key())
 	}
 	_ = merged.Value()
+	if !errors.Is(merged.Error(), want) {
+		t.Fatalf("Error() = %v, want %v", merged.Error(), want)
+	}
+}
+
+func TestTwoWayMergerSeekFailsClosedOnNonCurrentSourceError(t *testing.T) {
+	want := errors.New("two-way seek failed")
+	broken := &seekErrorUnsafeIter{
+		mockUnsafeIter: &mockUnsafeIter{data: []entry{{k: "A", v: "bad"}}},
+		err:            want,
+	}
+	healthy := &mockUnsafeIter{data: []entry{{k: "B", v: "ok"}}}
+	merged := NewTwoWayMerger(broken, healthy, nil, nil)
+	defer merged.Close()
+
+	merged.Seek([]byte("B"))
+	if merged.Valid() {
+		t.Fatal("merged iterator exposed a partial result after source seek error")
+	}
+	if !errors.Is(merged.Error(), want) {
+		t.Fatalf("Error() = %v, want %v", merged.Error(), want)
+	}
+}
+
+func TestHeapMergingIteratorSeekReportsEverySourceError(t *testing.T) {
+	wantFirst := errors.New("first heap seek failed")
+	wantSecond := errors.New("second heap seek failed")
+	first := &seekErrorUnsafeIter{
+		mockUnsafeIter: &mockUnsafeIter{data: []entry{{k: "A", v: "bad"}}},
+		err:            wantFirst,
+	}
+	second := &seekErrorUnsafeIter{
+		mockUnsafeIter: &mockUnsafeIter{data: []entry{{k: "B", v: "bad"}}},
+		err:            wantSecond,
+	}
+	healthy := &mockUnsafeIter{data: []entry{{k: "C", v: "ok"}}}
+	merged := NewMergingIterator([]IteratorSource{
+		{Iter: first, Priority: 0},
+		{Iter: second, Priority: 1},
+		{Iter: healthy, Priority: 2},
+	}, nil, nil)
+	defer merged.Close()
+
+	merged.Seek([]byte("A"))
+	if merged.Valid() {
+		t.Fatal("heap iterator exposed a partial result after source seek errors")
+	}
+	if got := merged.Error(); !errors.Is(got, wantFirst) || !errors.Is(got, wantSecond) {
+		t.Fatalf("Error() = %v, want both %v and %v", got, wantFirst, wantSecond)
+	}
+}
+
+func TestTwoWayMergerSeekReportsErrorFromTombstoneAdvance(t *testing.T) {
+	want := errors.New("two-way tombstone advance failed")
+	broken := &seekAdvanceErrorUnsafeIter{
+		mockUnsafeIter: &mockUnsafeIter{data: []entry{{k: "A", del: true}}},
+		err:            want,
+	}
+	healthy := &mockUnsafeIter{data: []entry{{k: "B", v: "partial"}}}
+	merged := NewTwoWayMerger(broken, healthy, nil, nil)
+	defer merged.Close()
+
+	merged.Seek([]byte("A"))
+	if merged.Valid() {
+		t.Fatal("two-way iterator exposed a partial result after tombstone advance error")
+	}
+	if !errors.Is(merged.Error(), want) {
+		t.Fatalf("Error() = %v, want %v", merged.Error(), want)
+	}
+}
+
+func TestHeapMergingIteratorSeekReportsErrorFromTombstoneAdvance(t *testing.T) {
+	want := errors.New("heap tombstone advance failed")
+	broken := &seekAdvanceErrorUnsafeIter{
+		mockUnsafeIter: &mockUnsafeIter{data: []entry{{k: "A", del: true}}},
+		err:            want,
+	}
+	middle := &mockUnsafeIter{data: []entry{{k: "B", v: "partial"}}}
+	oldest := &mockUnsafeIter{data: []entry{{k: "C", v: "partial"}}}
+	merged := NewMergingIterator([]IteratorSource{
+		{Iter: broken, Priority: 0},
+		{Iter: middle, Priority: 1},
+		{Iter: oldest, Priority: 2},
+	}, nil, nil)
+	defer merged.Close()
+
+	merged.Seek([]byte("A"))
+	if merged.Valid() {
+		t.Fatal("heap iterator exposed a partial result after tombstone advance error")
+	}
 	if !errors.Is(merged.Error(), want) {
 		t.Fatalf("Error() = %v, want %v", merged.Error(), want)
 	}

--- a/TreeDB/internal/merging/reverse.go
+++ b/TreeDB/internal/merging/reverse.go
@@ -86,13 +86,14 @@ func (h *reverseIteratorHeap) down(i0, n int) bool {
 
 // ReverseMergingIterator merges multiple reverse-sorted iterators.
 type ReverseMergingIterator struct {
-	h      reverseIteratorHeap
-	cur    reverseHeapItem
-	hasCur bool
-	valid  bool
-	err    error
-	start  []byte
-	end    []byte
+	sources []IteratorSource
+	h       reverseIteratorHeap
+	cur     reverseHeapItem
+	hasCur  bool
+	valid   bool
+	err     error
+	start   []byte
+	end     []byte
 }
 
 func NewReverseMergingIterator(sources []IteratorSource, start, end []byte) Iterator {
@@ -101,26 +102,43 @@ func NewReverseMergingIterator(sources []IteratorSource, start, end []byte) Iter
 		return NewReverseTwoWayMerger(sources[0].Iter, sources[1].Iter, start, end)
 	}
 
-	h := make(reverseIteratorHeap, 0, len(sources))
-	for _, src := range sources {
+	mi := &ReverseMergingIterator{sources: sources, start: start, end: end}
+	mi.rebuildHeap()
+	mi.advance()
+	return mi
+}
+
+func (mi *ReverseMergingIterator) rebuildHeap() {
+	mi.h = mi.h[:0]
+	for _, src := range mi.sources {
 		if src.Iter.Valid() {
-			h = append(h, reverseHeapItem{
+			mi.h = append(mi.h, reverseHeapItem{
 				iter:     src.Iter,
 				priority: src.Priority,
 				key:      src.Iter.UnsafeKey(),
 			})
-		} else {
-			_ = src.Iter.Close()
 		}
 	}
-	// Heapify.
-	for i := len(h)/2 - 1; i >= 0; i-- {
-		(&h).down(i, len(h))
+	for i := len(mi.h)/2 - 1; i >= 0; i-- {
+		(&mi.h).down(i, len(mi.h))
 	}
+}
 
-	mi := &ReverseMergingIterator{h: h, start: start, end: end}
+// Seek positions the iterator at the first visible key less than or equal to
+// key, restricted to the iterator's original [start, end) domain. A nil key
+// seeks to the greatest key in the domain.
+func (mi *ReverseMergingIterator) Seek(key []byte) {
+	mi.err = nil
+	mi.hasCur = false
+	mi.valid = false
+	if key != nil && mi.start != nil && bytes.Compare(key, mi.start) < 0 {
+		return
+	}
+	for _, src := range mi.sources {
+		src.Iter.Seek(key)
+	}
+	mi.rebuildHeap()
 	mi.advance()
-	return mi
 }
 
 func (mi *ReverseMergingIterator) Next() {
@@ -137,8 +155,6 @@ func (mi *ReverseMergingIterator) Next() {
 		if mi.cur.iter.Valid() {
 			mi.cur.key = mi.cur.iter.UnsafeKey()
 			mi.h.push(mi.cur)
-		} else {
-			_ = mi.cur.iter.Close()
 		}
 		mi.hasCur = false
 	}
@@ -166,8 +182,6 @@ func (mi *ReverseMergingIterator) advance() {
 			if top.iter.Valid() {
 				top.key = top.iter.UnsafeKey()
 				mi.h.push(top)
-			} else {
-				_ = top.iter.Close()
 			}
 			continue
 		}
@@ -181,8 +195,6 @@ func (mi *ReverseMergingIterator) advance() {
 				if shadowed.iter.Valid() {
 					shadowed.key = shadowed.iter.UnsafeKey()
 					mi.h.push(shadowed)
-				} else {
-					_ = shadowed.iter.Close()
 				}
 			} else {
 				break
@@ -195,8 +207,6 @@ func (mi *ReverseMergingIterator) advance() {
 			if top.iter.Valid() {
 				top.key = top.iter.UnsafeKey()
 				mi.h.push(top)
-			} else {
-				_ = top.iter.Close()
 			}
 			continue
 		}
@@ -257,20 +267,15 @@ func (mi *ReverseMergingIterator) Error() error {
 
 func (mi *ReverseMergingIterator) Close() error {
 	var firstErr error
-
-	if mi.hasCur {
-		if err := mi.cur.iter.Close(); err != nil && firstErr == nil {
-			firstErr = err
-		}
-		mi.hasCur = false
-	}
-
-	for _, item := range mi.h {
-		if err := item.iter.Close(); err != nil && firstErr == nil {
+	for _, src := range mi.sources {
+		if err := src.Iter.Close(); err != nil && firstErr == nil {
 			firstErr = err
 		}
 	}
-
+	mi.sources = nil
+	mi.h = nil
+	mi.hasCur = false
+	mi.valid = false
 	return firstErr
 }
 
@@ -309,6 +314,21 @@ func (m *ReverseTwoWayMerger) Next() {
 	if m.cur != nil {
 		m.cur.Next()
 	}
+	m.advance()
+}
+
+// Seek positions the iterator at the first visible key less than or equal to
+// key, restricted to the iterator's original [start, end) domain. A nil key
+// seeks to the greatest key in the domain.
+func (m *ReverseTwoWayMerger) Seek(key []byte) {
+	m.err = nil
+	m.cur = nil
+	m.valid = false
+	if key != nil && m.start != nil && bytes.Compare(key, m.start) < 0 {
+		return
+	}
+	m.src1.Seek(key)
+	m.src2.Seek(key)
 	m.advance()
 }
 

--- a/TreeDB/internal/merging/reverse.go
+++ b/TreeDB/internal/merging/reverse.go
@@ -137,6 +137,11 @@ func (mi *ReverseMergingIterator) Seek(key []byte) {
 	for _, src := range mi.sources {
 		src.Iter.Seek(key)
 	}
+	mi.err = sourceIteratorErrors(mi.sources)
+	if mi.err != nil {
+		mi.h = mi.h[:0]
+		return
+	}
 	mi.rebuildHeap()
 	mi.advance()
 }
@@ -152,6 +157,9 @@ func (mi *ReverseMergingIterator) Next() {
 
 	if mi.hasCur {
 		mi.cur.iter.Next()
+		if mi.captureIteratorError(mi.cur.iter) {
+			return
+		}
 		if mi.cur.iter.Valid() {
 			mi.cur.key = mi.cur.iter.UnsafeKey()
 			mi.h.push(mi.cur)
@@ -179,6 +187,9 @@ func (mi *ReverseMergingIterator) advance() {
 		// Upper bound is exclusive; if a source yields >= end, advance it and continue.
 		if mi.end != nil && bytes.Compare(currentKey, mi.end) >= 0 {
 			top.iter.Next()
+			if mi.captureIteratorError(top.iter) {
+				return
+			}
 			if top.iter.Valid() {
 				top.key = top.iter.UnsafeKey()
 				mi.h.push(top)
@@ -192,6 +203,9 @@ func (mi *ReverseMergingIterator) advance() {
 			if next != nil && bytes.Equal(next.key, currentKey) {
 				shadowed := mi.h.pop()
 				shadowed.iter.Next()
+				if mi.captureIteratorError(shadowed.iter) {
+					return
+				}
 				if shadowed.iter.Valid() {
 					shadowed.key = shadowed.iter.UnsafeKey()
 					mi.h.push(shadowed)
@@ -204,6 +218,9 @@ func (mi *ReverseMergingIterator) advance() {
 		// If tombstone, advance winner and continue.
 		if top.iter.IsDeleted() {
 			top.iter.Next()
+			if mi.captureIteratorError(top.iter) {
+				return
+			}
 			if top.iter.Valid() {
 				top.key = top.iter.UnsafeKey()
 				mi.h.push(top)
@@ -216,6 +233,21 @@ func (mi *ReverseMergingIterator) advance() {
 		mi.valid = true
 		return
 	}
+}
+
+func (mi *ReverseMergingIterator) captureIteratorError(iter iterator.UnsafeIterator) bool {
+	if iter == nil {
+		return false
+	}
+	err := iter.Error()
+	if err == nil {
+		return false
+	}
+	mi.err = joinIteratorError(mi.err, err)
+	mi.cur = reverseHeapItem{}
+	mi.hasCur = false
+	mi.valid = false
+	return true
 }
 
 func (mi *ReverseMergingIterator) Valid() bool { return mi.valid }
@@ -313,6 +345,9 @@ func (m *ReverseTwoWayMerger) Next() {
 	}
 	if m.cur != nil {
 		m.cur.Next()
+		if m.captureIteratorError(m.cur) {
+			return
+		}
 	}
 	m.advance()
 }
@@ -329,6 +364,10 @@ func (m *ReverseTwoWayMerger) Seek(key []byte) {
 	}
 	m.src1.Seek(key)
 	m.src2.Seek(key)
+	m.err = twoIteratorErrors(m.src1, m.src2)
+	if m.err != nil {
+		return
+	}
 	m.advance()
 }
 
@@ -350,6 +389,9 @@ func (m *ReverseTwoWayMerger) advance() {
 				// Keys equal: src1 wins, src2 is shadowed.
 				winner = m.src1
 				m.src2.Next()
+				if m.captureIteratorError(m.src2) {
+					return
+				}
 			}
 		case m.src1.Valid():
 			winner = m.src1
@@ -362,6 +404,9 @@ func (m *ReverseTwoWayMerger) advance() {
 		// Exclusive end (upper bound): skip keys >= end.
 		if m.end != nil && bytes.Compare(k, m.end) >= 0 {
 			winner.Next()
+			if m.captureIteratorError(winner) {
+				return
+			}
 			continue
 		}
 
@@ -372,6 +417,9 @@ func (m *ReverseTwoWayMerger) advance() {
 
 		if winner.IsDeleted() {
 			winner.Next()
+			if m.captureIteratorError(winner) {
+				return
+			}
 			continue
 		}
 
@@ -379,6 +427,20 @@ func (m *ReverseTwoWayMerger) advance() {
 		m.valid = true
 		return
 	}
+}
+
+func (m *ReverseTwoWayMerger) captureIteratorError(iter iterator.UnsafeIterator) bool {
+	if iter == nil {
+		return false
+	}
+	err := iter.Error()
+	if err == nil {
+		return false
+	}
+	m.err = joinIteratorError(m.err, err)
+	m.valid = false
+	m.cur = nil
+	return true
 }
 
 func (m *ReverseTwoWayMerger) Valid() bool { return m.valid }

--- a/TreeDB/internal/merging/reverse_test.go
+++ b/TreeDB/internal/merging/reverse_test.go
@@ -69,6 +69,53 @@ type valueErrorUnsafeReverseIter struct {
 	valueCopied bool
 }
 
+type seekErrorUnsafeReverseIter struct {
+	*mockUnsafeReverseIter
+	err    error
+	seeked bool
+}
+
+type seekAdvanceErrorUnsafeReverseIter struct {
+	*mockUnsafeReverseIter
+	err    error
+	armed  bool
+	failed bool
+}
+
+func (m *seekAdvanceErrorUnsafeReverseIter) Seek(key []byte) {
+	m.mockUnsafeReverseIter.Seek(key)
+	m.armed = true
+	m.failed = false
+}
+
+func (m *seekAdvanceErrorUnsafeReverseIter) Next() {
+	m.mockUnsafeReverseIter.Next()
+	if m.armed {
+		m.failed = true
+		m.idx = -1
+	}
+}
+
+func (m *seekAdvanceErrorUnsafeReverseIter) Error() error {
+	if m.failed {
+		return m.err
+	}
+	return nil
+}
+
+func (m *seekErrorUnsafeReverseIter) Seek(key []byte) {
+	m.seeked = true
+	m.mockUnsafeReverseIter.Seek(key)
+	m.idx = -1
+}
+
+func (m *seekErrorUnsafeReverseIter) Error() error {
+	if m.seeked {
+		return m.err
+	}
+	return nil
+}
+
 func (m *valueErrorUnsafeReverseIter) UnsafeValue() []byte {
 	m.valueLoaded = true
 	return nil
@@ -190,6 +237,99 @@ func TestReverseTwoWayMergerSurfacesCurrentValueError(t *testing.T) {
 		t.Fatalf("first key = %q, want Z", merged.Key())
 	}
 	_ = merged.Value()
+	if !errors.Is(merged.Error(), want) {
+		t.Fatalf("Error() = %v, want %v", merged.Error(), want)
+	}
+}
+
+func TestReverseTwoWayMergerSeekFailsClosedOnNonCurrentSourceError(t *testing.T) {
+	want := errors.New("reverse two-way seek failed")
+	broken := &seekErrorUnsafeReverseIter{
+		mockUnsafeReverseIter: &mockUnsafeReverseIter{
+			data: []entry{{k: "Z", v: "bad"}},
+			idx:  0,
+		},
+		err: want,
+	}
+	healthy := &mockUnsafeReverseIter{data: []entry{{k: "B", v: "ok"}}, idx: 0}
+	merged := NewReverseTwoWayMerger(broken, healthy, nil, nil)
+	defer merged.Close()
+
+	merged.Seek([]byte("Z"))
+	if merged.Valid() {
+		t.Fatal("reverse merged iterator exposed a partial result after source seek error")
+	}
+	if !errors.Is(merged.Error(), want) {
+		t.Fatalf("Error() = %v, want %v", merged.Error(), want)
+	}
+}
+
+func TestReverseHeapMergingIteratorSeekReportsEverySourceError(t *testing.T) {
+	wantFirst := errors.New("first reverse heap seek failed")
+	wantSecond := errors.New("second reverse heap seek failed")
+	first := &seekErrorUnsafeReverseIter{
+		mockUnsafeReverseIter: &mockUnsafeReverseIter{data: []entry{{k: "Z", v: "bad"}}, idx: 0},
+		err:                   wantFirst,
+	}
+	second := &seekErrorUnsafeReverseIter{
+		mockUnsafeReverseIter: &mockUnsafeReverseIter{data: []entry{{k: "Y", v: "bad"}}, idx: 0},
+		err:                   wantSecond,
+	}
+	healthy := &mockUnsafeReverseIter{data: []entry{{k: "X", v: "ok"}}, idx: 0}
+	merged := NewReverseMergingIterator([]IteratorSource{
+		{Iter: first, Priority: 0},
+		{Iter: second, Priority: 1},
+		{Iter: healthy, Priority: 2},
+	}, nil, nil)
+	defer merged.Close()
+
+	merged.Seek([]byte("Z"))
+	if merged.Valid() {
+		t.Fatal("reverse heap iterator exposed a partial result after source seek errors")
+	}
+	if got := merged.Error(); !errors.Is(got, wantFirst) || !errors.Is(got, wantSecond) {
+		t.Fatalf("Error() = %v, want both %v and %v", got, wantFirst, wantSecond)
+	}
+}
+
+func TestReverseTwoWayMergerSeekReportsErrorFromTombstoneAdvance(t *testing.T) {
+	want := errors.New("reverse two-way tombstone advance failed")
+	broken := &seekAdvanceErrorUnsafeReverseIter{
+		mockUnsafeReverseIter: &mockUnsafeReverseIter{data: []entry{{k: "Z", del: true}}, idx: 0},
+		err:                   want,
+	}
+	healthy := &mockUnsafeReverseIter{data: []entry{{k: "Y", v: "partial"}}, idx: 0}
+	merged := NewReverseTwoWayMerger(broken, healthy, nil, nil)
+	defer merged.Close()
+
+	merged.Seek([]byte("Z"))
+	if merged.Valid() {
+		t.Fatal("reverse two-way iterator exposed a partial result after tombstone advance error")
+	}
+	if !errors.Is(merged.Error(), want) {
+		t.Fatalf("Error() = %v, want %v", merged.Error(), want)
+	}
+}
+
+func TestReverseHeapMergingIteratorSeekReportsErrorFromTombstoneAdvance(t *testing.T) {
+	want := errors.New("reverse heap tombstone advance failed")
+	broken := &seekAdvanceErrorUnsafeReverseIter{
+		mockUnsafeReverseIter: &mockUnsafeReverseIter{data: []entry{{k: "Z", del: true}}, idx: 0},
+		err:                   want,
+	}
+	middle := &mockUnsafeReverseIter{data: []entry{{k: "Y", v: "partial"}}, idx: 0}
+	oldest := &mockUnsafeReverseIter{data: []entry{{k: "X", v: "partial"}}, idx: 0}
+	merged := NewReverseMergingIterator([]IteratorSource{
+		{Iter: broken, Priority: 0},
+		{Iter: middle, Priority: 1},
+		{Iter: oldest, Priority: 2},
+	}, nil, nil)
+	defer merged.Close()
+
+	merged.Seek([]byte("Z"))
+	if merged.Valid() {
+		t.Fatal("reverse heap iterator exposed a partial result after tombstone advance error")
+	}
 	if !errors.Is(merged.Error(), want) {
 		t.Fatalf("Error() = %v, want %v", merged.Error(), want)
 	}

--- a/TreeDB/internal/merging/twoway.go
+++ b/TreeDB/internal/merging/twoway.go
@@ -48,6 +48,18 @@ func (m *TwoWayMerger) Next() {
 	m.advance()
 }
 
+// Seek positions the iterator at the first visible key greater than or equal
+// to key, restricted to the iterator's original [start, end) domain.
+func (m *TwoWayMerger) Seek(key []byte) {
+	if m.start != nil && (key == nil || bytes.Compare(key, m.start) < 0) {
+		key = m.start
+	}
+	m.err = nil
+	m.src1.Seek(key)
+	m.src2.Seek(key)
+	m.advance()
+}
+
 func (m *TwoWayMerger) advance() {
 	m.valid = false // Assume invalid until an item is found
 	m.cur = nil

--- a/TreeDB/internal/merging/twoway.go
+++ b/TreeDB/internal/merging/twoway.go
@@ -44,6 +44,9 @@ func (m *TwoWayMerger) Next() {
 	}
 	if m.cur != nil {
 		m.cur.Next()
+		if m.captureIteratorError(m.cur) {
+			return
+		}
 	}
 	m.advance()
 }
@@ -55,8 +58,14 @@ func (m *TwoWayMerger) Seek(key []byte) {
 		key = m.start
 	}
 	m.err = nil
+	m.cur = nil
+	m.valid = false
 	m.src1.Seek(key)
 	m.src2.Seek(key)
+	m.err = twoIteratorErrors(m.src1, m.src2)
+	if m.err != nil {
+		return
+	}
 	m.advance()
 }
 
@@ -78,6 +87,9 @@ func (m *TwoWayMerger) advance() {
 				// Keys equal: src1 wins, src2 is shadowed.
 				winner = m.src1
 				m.src2.Next()
+				if m.captureIteratorError(m.src2) {
+					return
+				}
 			}
 		case m.src1.Valid():
 			winner = m.src1
@@ -94,12 +106,18 @@ func (m *TwoWayMerger) advance() {
 		// Handle range bounds (inclusive start) - only needed if Seek doesn't handle it
 		if m.start != nil && bytes.Compare(k, m.start) < 0 {
 			winner.Next()
+			if m.captureIteratorError(winner) {
+				return
+			}
 			continue
 		}
 
 		// If tombstone, skip it (and keep searching).
 		if winner.IsDeleted() {
 			winner.Next()
+			if m.captureIteratorError(winner) {
+				return
+			}
 			continue
 		}
 
@@ -109,6 +127,20 @@ func (m *TwoWayMerger) advance() {
 		m.valid = true
 		return
 	}
+}
+
+func (m *TwoWayMerger) captureIteratorError(iter iterator.UnsafeIterator) bool {
+	if iter == nil {
+		return false
+	}
+	err := iter.Error()
+	if err == nil {
+		return false
+	}
+	m.err = joinIteratorError(m.err, err)
+	m.valid = false
+	m.cur = nil
+	return true
 }
 
 func (m *TwoWayMerger) Valid() bool {

--- a/TreeDB/iterator/iterator.go
+++ b/TreeDB/iterator/iterator.go
@@ -1,0 +1,17 @@
+// Package iterator defines TreeDB's public, storage-neutral iterator contract.
+package iterator
+
+// Iterator scans one immutable point-in-time view over a fixed half-open key
+// domain. Key and Value return read-only views that remain valid only until the
+// next Next, Seek, or Close. Copy methods return caller-owned bytes.
+type Iterator interface {
+	Valid() bool
+	Next()
+	Seek(key []byte)
+	Key() []byte
+	Value() []byte
+	KeyCopy(dst []byte) []byte
+	ValueCopy(dst []byte) []byte
+	Close() error
+	Error() error
+}

--- a/TreeDB/public.go
+++ b/TreeDB/public.go
@@ -22,6 +22,7 @@ import (
 	"github.com/snissn/gomap/TreeDB/internal/dictdb"
 	"github.com/snissn/gomap/TreeDB/internal/limits"
 	"github.com/snissn/gomap/TreeDB/internal/templatedb"
+	publiciterator "github.com/snissn/gomap/TreeDB/iterator"
 	"github.com/snissn/gomap/TreeDB/page"
 	"github.com/snissn/gomap/TreeDB/template"
 )
@@ -78,25 +79,12 @@ const (
 	defaultAdaptiveMaxBacklogBytes int64 = 2 << 30
 )
 
-// Iterator is the public iterator contract returned by TreeDB.
-//
-// Semantics (performance-first; callers must treat returned slices as
-// read-only):
-//   - Key() and Value() return views valid only until the next Next()/Close()
-//     on the same iterator.
-//   - Do not retain or mutate Key()/Value() views across iterator movement.
-//   - KeyCopy/ValueCopy return caller-owned stable bytes, reusing dst capacity
-//     when possible.
-type Iterator interface {
-	Valid() bool
-	Next()
-	Key() []byte
-	Value() []byte
-	KeyCopy(dst []byte) []byte
-	ValueCopy(dst []byte) []byte
-	Close() error
-	Error() error
-}
+// Iterator is the public storage-neutral iterator contract returned by TreeDB.
+// Seek remains inside the original [start,end) domain: forward iterators choose
+// the first key >= target, while reverse iterators choose the first key <=
+// target (nil seeks to the greatest key). See package TreeDB/iterator for view
+// ownership rules.
+type Iterator = publiciterator.Iterator
 
 // Batch is the public batch contract returned by TreeDB.
 // Both cached and backend implementations satisfy it.

--- a/TreeDB/snapshot.go
+++ b/TreeDB/snapshot.go
@@ -10,7 +10,9 @@ import (
 //
 // In cached mode, snapshots include writes that are buffered in memtables.
 //
-// TreeDB is pre-alpha; this interface may change without notice.
+// Iterators created from a snapshot are owned by it: Close invalidates every
+// outstanding iterator, which callers must still close to release its retained
+// resources. TreeDB is pre-alpha; this interface may change without notice.
 type Snapshot interface {
 	Pager() *pager.Pager
 	State() *backenddb.DBState
@@ -26,6 +28,8 @@ type Snapshot interface {
 	HasPrefixes(prefixes [][]byte) ([]bool, error)
 	Iterate(start, end []byte, fn func(key, value []byte) error) error
 	ReverseIterate(start, end []byte, fn func(key, value []byte) error) error
+	Iterator(start, end []byte) (Iterator, error)
+	ReverseIterator(start, end []byte) (Iterator, error)
 
 	GetEntry(key []byte) (node.LeafEntry, error)
 	GetEntryExact(key []byte) (node.LeafEntry, error)

--- a/TreeDB/snapshot.go
+++ b/TreeDB/snapshot.go
@@ -12,7 +12,9 @@ import (
 //
 // Iterators created from a snapshot are owned by it: Close invalidates every
 // outstanding iterator, which callers must still close to release its retained
-// resources. TreeDB is pre-alpha; this interface may change without notice.
+// resources. After Close, point reads return db.ErrClosed, Pager and State
+// return nil, and all iterator constructors return db.ErrClosed. TreeDB is
+// pre-alpha; this interface may change without notice.
 type Snapshot interface {
 	Pager() *pager.Pager
 	State() *backenddb.DBState

--- a/TreeDB/snapshot_fastpath_test.go
+++ b/TreeDB/snapshot_fastpath_test.go
@@ -74,7 +74,7 @@ func TestAcquireSnapshot_BackendFastPathAfterCheckpointIsStable(t *testing.T) {
 	}
 }
 
-func TestAcquireSnapshot_BackendFastPathAllocsAfterWarm(t *testing.T) {
+func TestAcquireSnapshot_BackendFastPathAllocsAreBounded(t *testing.T) {
 	d, err := Open(Options{Dir: t.TempDir(), FlushThreshold: 1 << 30})
 	if err != nil {
 		t.Fatalf("open: %v", err)
@@ -107,8 +107,11 @@ func TestAcquireSnapshot_BackendFastPathAllocsAfterWarm(t *testing.T) {
 			panic(err)
 		}
 	})
-	if allocs > 0.1 {
-		t.Fatalf("backend fast-path AcquireSnapshot allocs/run=%f want <= 0.1", allocs)
+	// The backend fast path intentionally allocates one uniquely-addressed
+	// exported handle. Reusing its address would let a stale pointer operate on a
+	// later snapshot.
+	if allocs > 1.1 {
+		t.Fatalf("backend fast-path AcquireSnapshot allocs/run=%f want <= 1.1", allocs)
 	}
 }
 

--- a/TreeDB/snapshot_iterate_test.go
+++ b/TreeDB/snapshot_iterate_test.go
@@ -213,6 +213,12 @@ func TestConditionalTxnSnapshotUsesPinnedPointViewAndRangeFailsClosed(t *testing
 	}); !errors.Is(err, ErrConditionalTxnUnsupported) {
 		t.Fatalf("tx snapshot Iterate error=%v, want ErrConditionalTxnUnsupported", err)
 	}
+	if _, err := snap.Iterator(nil, nil); !errors.Is(err, ErrConditionalTxnUnsupported) {
+		t.Fatalf("tx snapshot Iterator error=%v, want ErrConditionalTxnUnsupported", err)
+	}
+	if _, err := snap.ReverseIterator(nil, nil); !errors.Is(err, ErrConditionalTxnUnsupported) {
+		t.Fatalf("tx snapshot ReverseIterator error=%v, want ErrConditionalTxnUnsupported", err)
+	}
 
 	if err := tx.Commit(); !errors.Is(err, ErrConcurrentModification) {
 		t.Fatalf("tx.Commit error=%v, want ErrConcurrentModification", err)

--- a/TreeDB/snapshot_seek_iterator_bench_test.go
+++ b/TreeDB/snapshot_seek_iterator_bench_test.go
@@ -1,0 +1,90 @@
+package treedb
+
+import (
+	"encoding/binary"
+	"fmt"
+	"testing"
+)
+
+var snapshotIteratorBenchSink byte
+
+func BenchmarkSnapshotIteratorSeekNext(b *testing.B) {
+	for _, keyCount := range []int{1 << 10, 1 << 14} {
+		b.Run(fmt.Sprintf("keys=%d", keyCount), func(b *testing.B) {
+			d, err := Open(Options{Dir: b.TempDir(), FlushThreshold: 1 << 30})
+			if err != nil {
+				b.Fatal(err)
+			}
+			defer d.Close()
+			keys := make([][]byte, keyCount)
+			for i := range keys {
+				key := make([]byte, 8)
+				binary.BigEndian.PutUint64(key, uint64(i*2))
+				keys[i] = key
+				if err := d.Set(key, key); err != nil {
+					b.Fatal(err)
+				}
+			}
+			if err := d.Checkpoint(); err != nil {
+				b.Fatal(err)
+			}
+			snap := d.AcquireSnapshot()
+			if snap == nil {
+				b.Fatal("AcquireSnapshot=nil")
+			}
+			defer snap.Close()
+
+			snapshotIt, err := snap.Iterator(nil, nil)
+			if err != nil {
+				b.Fatal(err)
+			}
+			defer snapshotIt.Close()
+			publicIt, err := d.Iterator(nil, nil)
+			if err != nil {
+				b.Fatal(err)
+			}
+			defer publicIt.Close()
+
+			b.Run("snapshot_seek", func(b *testing.B) {
+				b.ReportAllocs()
+				for i := 0; i < b.N; i++ {
+					snapshotIt.Seek(keys[i%len(keys)])
+					if snapshotIt.Valid() {
+						snapshotIteratorBenchSink ^= snapshotIt.Key()[0]
+					}
+				}
+			})
+			b.Run("public_seek_baseline", func(b *testing.B) {
+				b.ReportAllocs()
+				for i := 0; i < b.N; i++ {
+					publicIt.Seek(keys[i%len(keys)])
+					if publicIt.Valid() {
+						snapshotIteratorBenchSink ^= publicIt.Key()[0]
+					}
+				}
+			})
+			b.Run("snapshot_next", func(b *testing.B) {
+				b.ReportAllocs()
+				snapshotIt.Seek(nil)
+				for i := 0; i < b.N; i++ {
+					if !snapshotIt.Valid() {
+						snapshotIt.Seek(nil)
+					}
+					snapshotIteratorBenchSink ^= snapshotIt.Key()[0]
+					snapshotIt.Next()
+				}
+			})
+			b.Run("public_next_baseline", func(b *testing.B) {
+				b.ReportAllocs()
+				publicIt.Seek(nil)
+				for i := 0; i < b.N; i++ {
+					if !publicIt.Valid() {
+						publicIt.Seek(nil)
+					}
+					snapshotIteratorBenchSink ^= publicIt.Key()[0]
+					publicIt.Next()
+				}
+			})
+		})
+	}
+}

--- a/TreeDB/snapshot_seek_iterator_test.go
+++ b/TreeDB/snapshot_seek_iterator_test.go
@@ -1,0 +1,277 @@
+package treedb
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"math/rand"
+	"sort"
+	"sync"
+	"testing"
+)
+
+func TestSnapshotIteratorSeekContract(t *testing.T) {
+	d, err := Open(Options{Dir: t.TempDir(), FlushThreshold: 1 << 30})
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer d.Close()
+
+	entries := []struct{ key, value []byte }{
+		{[]byte{}, []byte("empty")},
+		{[]byte{0x00, 0xff}, []byte("binary-low")},
+		{[]byte("a"), []byte("a-value")},
+		{[]byte("c"), []byte("c-value")},
+		{[]byte("e"), []byte("e-value")},
+		{[]byte("p/0"), []byte("prefix-0")},
+		{[]byte{'p', '/', 0xff}, []byte("prefix-ff")},
+	}
+	for _, entry := range entries {
+		if err := d.Set(entry.key, entry.value); err != nil {
+			t.Fatalf("Set(%x): %v", entry.key, err)
+		}
+	}
+	if err := d.Set([]byte("deleted"), []byte("gone")); err != nil {
+		t.Fatal(err)
+	}
+	if err := d.Checkpoint(); err != nil {
+		t.Fatal(err)
+	}
+	if err := d.Set([]byte("c"), []byte("c-new")); err != nil {
+		t.Fatal(err)
+	}
+	if err := d.Delete([]byte("deleted")); err != nil {
+		t.Fatal(err)
+	}
+
+	snap := d.AcquireSnapshot()
+	if snap == nil {
+		t.Fatal("AcquireSnapshot=nil")
+	}
+	defer snap.Close()
+	if err := d.Set([]byte("b"), []byte("post-snapshot")); err != nil {
+		t.Fatal(err)
+	}
+
+	forward, err := snap.Iterator(nil, nil)
+	if err != nil {
+		t.Fatalf("Iterator: %v", err)
+	}
+	defer forward.Close()
+	assertSeekKey(t, forward, nil, []byte{})
+	assertSeekKey(t, forward, []byte("c"), []byte("c"))
+	assertSeekKey(t, forward, []byte("d"), []byte("e"))
+	assertSeekKey(t, forward, []byte{0xff, 0xff}, nil)
+	forward.Seek([]byte("a"))
+	owned := forward.KeyCopy(nil)
+	forward.Next()
+	if !bytes.Equal(owned, []byte("a")) {
+		t.Fatalf("KeyCopy changed after Next: %x", owned)
+	}
+	if forward.Valid() && bytes.Equal(forward.Key(), []byte("b")) {
+		t.Fatal("snapshot exposed post-acquire write")
+	}
+
+	reverse, err := snap.ReverseIterator(nil, nil)
+	if err != nil {
+		t.Fatalf("ReverseIterator: %v", err)
+	}
+	defer reverse.Close()
+	assertSeekKey(t, reverse, nil, []byte{'p', '/', 0xff})
+	assertSeekKey(t, reverse, []byte("c"), []byte("c"))
+	assertSeekKey(t, reverse, []byte("d"), []byte("c"))
+	assertSeekKey(t, reverse, []byte{0x00}, []byte{})
+	assertSeekKey(t, reverse, []byte{}, []byte{})
+
+	prefix, err := snap.Iterator([]byte("p/"), []byte("p0"))
+	if err != nil {
+		t.Fatalf("prefix Iterator: %v", err)
+	}
+	defer prefix.Close()
+	assertSeekKey(t, prefix, []byte("a"), []byte("p/0"))
+	assertSeekKey(t, prefix, []byte("p/1"), []byte{'p', '/', 0xff})
+	assertSeekKey(t, prefix, []byte("p0"), nil)
+	prefixReverse, err := snap.ReverseIterator([]byte("p/"), []byte("p0"))
+	if err != nil {
+		t.Fatalf("prefix ReverseIterator: %v", err)
+	}
+	defer prefixReverse.Close()
+	assertSeekKey(t, prefixReverse, []byte("z"), []byte{'p', '/', 0xff})
+	assertSeekKey(t, prefixReverse, []byte("a"), nil)
+	emptyReverse, err := snap.ReverseIterator([]byte("q"), []byte("r"))
+	if err != nil {
+		t.Fatalf("empty ReverseIterator: %v", err)
+	}
+	defer emptyReverse.Close()
+	assertSeekKey(t, emptyReverse, nil, nil)
+}
+
+func assertSeekKey(t *testing.T, it Iterator, target, want []byte) {
+	t.Helper()
+	it.Seek(target)
+	if want == nil {
+		if it.Valid() {
+			t.Fatalf("Seek(%x) key=%x want invalid", target, it.Key())
+		}
+		if err := it.Error(); err != nil {
+			t.Fatalf("Seek(%x) error=%v", target, err)
+		}
+		return
+	}
+	if !it.Valid() {
+		t.Fatalf("Seek(%x) invalid, error=%v want=%x", target, it.Error(), want)
+	}
+	if got := it.Key(); !bytes.Equal(got, want) {
+		t.Fatalf("Seek(%x) key=%x want=%x", target, got, want)
+	}
+}
+
+func TestSnapshotIteratorSeekRandomizedOracle(t *testing.T) {
+	d, err := Open(Options{Dir: t.TempDir(), FlushThreshold: 1 << 30})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer d.Close()
+	rng := rand.New(rand.NewSource(3671))
+	set := make(map[string]struct{})
+	for len(set) < 256 {
+		key := make([]byte, 1+rng.Intn(8))
+		_, _ = rng.Read(key)
+		set[string(key)] = struct{}{}
+	}
+	keys := make([][]byte, 0, len(set))
+	for key := range set {
+		b := []byte(key)
+		keys = append(keys, b)
+		if err := d.Set(b, b); err != nil {
+			t.Fatal(err)
+		}
+	}
+	sort.Slice(keys, func(i, j int) bool { return bytes.Compare(keys[i], keys[j]) < 0 })
+	snap := d.AcquireSnapshot()
+	if snap == nil {
+		t.Fatal("AcquireSnapshot=nil")
+	}
+	defer snap.Close()
+	fwd, err := snap.Iterator(nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer fwd.Close()
+	rev, err := snap.ReverseIterator(nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer rev.Close()
+	for i := 0; i < 512; i++ {
+		target := make([]byte, rng.Intn(9))
+		_, _ = rng.Read(target)
+		fi := sort.Search(len(keys), func(j int) bool { return bytes.Compare(keys[j], target) >= 0 })
+		if fi == len(keys) {
+			assertSeekKey(t, fwd, target, nil)
+		} else {
+			assertSeekKey(t, fwd, target, keys[fi])
+		}
+		ri := sort.Search(len(keys), func(j int) bool { return bytes.Compare(keys[j], target) > 0 }) - 1
+		if ri < 0 {
+			assertSeekKey(t, rev, target, nil)
+		} else {
+			assertSeekKey(t, rev, target, keys[ri])
+		}
+	}
+}
+
+func TestSnapshotCloseInvalidatesOutstandingIterator(t *testing.T) {
+	d, err := Open(Options{Dir: t.TempDir(), FlushThreshold: 1 << 30})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer d.Close()
+	for i := 0; i < 128; i++ {
+		key := []byte(fmt.Sprintf("key/%04d", i))
+		if err := d.Set(key, key); err != nil {
+			t.Fatal(err)
+		}
+	}
+	snap := d.AcquireSnapshot()
+	it, err := snap.Iterator(nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var wg sync.WaitGroup
+	started := make(chan struct{})
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		close(started)
+		for i := 0; i < 10_000; i++ {
+			it.Seek([]byte("key/0064"))
+			if !it.Valid() {
+				return
+			}
+			_ = it.Key()
+			it.Next()
+		}
+	}()
+	<-started
+	if err := snap.Close(); err != nil {
+		t.Fatalf("Snapshot.Close: %v", err)
+	}
+	wg.Wait()
+	if it.Valid() {
+		t.Fatal("iterator remained valid after snapshot close")
+	}
+	if got := it.Key(); got != nil {
+		t.Fatalf("Key after snapshot close=%x want nil", got)
+	}
+	if err := it.Error(); !errors.Is(err, ErrClosed) {
+		t.Fatalf("Error after snapshot close=%v want ErrClosed", err)
+	}
+	it.Seek(nil)
+	it.Next()
+	if err := it.Close(); err != nil {
+		t.Fatalf("Iterator.Close after snapshot close: %v", err)
+	}
+}
+
+func TestSnapshotIteratorSeekAfterReopen(t *testing.T) {
+	dir := t.TempDir()
+	d, err := Open(Options{Dir: dir})
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, key := range []string{"persist/a", "persist/c", "persist/e"} {
+		if err := d.SetSync([]byte(key), []byte(key)); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := d.Checkpoint(); err != nil {
+		t.Fatal(err)
+	}
+	if err := d.Close(); err != nil {
+		t.Fatal(err)
+	}
+	d, err = Open(Options{Dir: dir})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer d.Close()
+	snap := d.AcquireSnapshot()
+	if snap == nil {
+		t.Fatal("AcquireSnapshot=nil")
+	}
+	defer snap.Close()
+	it, err := snap.Iterator([]byte("persist/"), []byte("persist0"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer it.Close()
+	assertSeekKey(t, it, []byte("persist/b"), []byte("persist/c"))
+	rev, err := snap.ReverseIterator([]byte("persist/"), []byte("persist0"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer rev.Close()
+	assertSeekKey(t, rev, []byte("persist/d"), []byte("persist/c"))
+}

--- a/TreeDB/snapshot_seek_iterator_test.go
+++ b/TreeDB/snapshot_seek_iterator_test.go
@@ -327,3 +327,124 @@ func TestSnapshotIteratorEmptyDomainSeekRemainsEmpty(t *testing.T) {
 		}
 	}
 }
+
+func TestSnapshotIteratorOpenEndedLowerBoundSeekRemainsEmpty(t *testing.T) {
+	d, err := Open(Options{Dir: t.TempDir(), FlushThreshold: 1 << 30})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer d.Close()
+	if err := d.Set([]byte("a"), []byte("backend")); err != nil {
+		t.Fatal(err)
+	}
+	if err := d.Checkpoint(); err != nil {
+		t.Fatal(err)
+	}
+	if err := d.Set([]byte("c"), []byte("cached")); err != nil {
+		t.Fatal(err)
+	}
+	snap := d.AcquireSnapshot()
+	if snap == nil {
+		t.Fatal("AcquireSnapshot=nil")
+	}
+	defer snap.Close()
+
+	start := []byte("m")
+	targets := []struct {
+		name string
+		key  []byte
+	}{
+		{name: "nil", key: nil},
+		{name: "below", key: []byte("a")},
+		{name: "inside", key: []byte("m")},
+		{name: "above", key: []byte{0xff}},
+	}
+	for _, reverse := range []bool{false, true} {
+		name := map[bool]string{false: "forward", true: "reverse"}[reverse]
+		t.Run(name, func(t *testing.T) {
+			var it Iterator
+			var err error
+			if reverse {
+				it, err = snap.ReverseIterator(start, nil)
+			} else {
+				it, err = snap.Iterator(start, nil)
+			}
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer it.Close()
+			if it.Valid() {
+				t.Fatalf("iterator construction exposed key %q below start %q", it.Key(), start)
+			}
+			for _, target := range targets {
+				t.Run(target.name, func(t *testing.T) {
+					assertSeekKey(t, it, target.key, nil)
+				})
+			}
+		})
+	}
+}
+
+func TestSnapshotIteratorOpenEndedLowerBoundSeekClampsToDomain(t *testing.T) {
+	d, err := Open(Options{Dir: t.TempDir(), FlushThreshold: 1 << 30})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer d.Close()
+	for _, key := range []string{"a", "m"} {
+		if err := d.Set([]byte(key), []byte("backend/"+key)); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := d.Checkpoint(); err != nil {
+		t.Fatal(err)
+	}
+	for _, key := range []string{"c", "z"} {
+		if err := d.Set([]byte(key), []byte("cached/"+key)); err != nil {
+			t.Fatal(err)
+		}
+	}
+	snap := d.AcquireSnapshot()
+	if snap == nil {
+		t.Fatal("AcquireSnapshot=nil")
+	}
+	defer snap.Close()
+
+	start := []byte("m")
+	tests := []struct {
+		name    string
+		target  []byte
+		forward []byte
+		reverse []byte
+	}{
+		{name: "nil", target: nil, forward: []byte("m"), reverse: []byte("z")},
+		{name: "below", target: []byte("a"), forward: []byte("m")},
+		{name: "inside", target: []byte("n"), forward: []byte("z"), reverse: []byte("m")},
+		{name: "above", target: []byte{0xff}, reverse: []byte("z")},
+	}
+	for _, reverse := range []bool{false, true} {
+		name := map[bool]string{false: "forward", true: "reverse"}[reverse]
+		t.Run(name, func(t *testing.T) {
+			var it Iterator
+			var err error
+			if reverse {
+				it, err = snap.ReverseIterator(start, nil)
+			} else {
+				it, err = snap.Iterator(start, nil)
+			}
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer it.Close()
+			for _, test := range tests {
+				t.Run(test.name, func(t *testing.T) {
+					want := test.forward
+					if reverse {
+						want = test.reverse
+					}
+					assertSeekKey(t, it, test.target, want)
+				})
+			}
+		})
+	}
+}

--- a/TreeDB/snapshot_seek_iterator_test.go
+++ b/TreeDB/snapshot_seek_iterator_test.go
@@ -275,3 +275,55 @@ func TestSnapshotIteratorSeekAfterReopen(t *testing.T) {
 	defer rev.Close()
 	assertSeekKey(t, rev, []byte("persist/d"), []byte("persist/c"))
 }
+
+func TestSnapshotIteratorEmptyDomainSeekRemainsEmpty(t *testing.T) {
+	d, err := Open(Options{Dir: t.TempDir(), FlushThreshold: 1 << 30})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer d.Close()
+	for _, key := range []string{"a", "m", "z"} {
+		if err := d.Set([]byte(key), []byte(key)); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := d.Checkpoint(); err != nil {
+		t.Fatal(err)
+	}
+	if err := d.Set([]byte("cached"), []byte("cached")); err != nil {
+		t.Fatal(err)
+	}
+	snap := d.AcquireSnapshot()
+	if snap == nil {
+		t.Fatal("AcquireSnapshot=nil")
+	}
+	defer snap.Close()
+
+	for _, bounds := range []struct {
+		name       string
+		start, end []byte
+	}{
+		{name: "equal", start: []byte("m"), end: []byte("m")},
+		{name: "inverted", start: []byte("z"), end: []byte("a")},
+	} {
+		for _, reverse := range []bool{false, true} {
+			name := bounds.name + map[bool]string{false: "/forward", true: "/reverse"}[reverse]
+			t.Run(name, func(t *testing.T) {
+				var it Iterator
+				var err error
+				if reverse {
+					it, err = snap.ReverseIterator(bounds.start, bounds.end)
+				} else {
+					it, err = snap.Iterator(bounds.start, bounds.end)
+				}
+				if err != nil {
+					t.Fatal(err)
+				}
+				defer it.Close()
+				for _, target := range [][]byte{nil, []byte("a"), []byte("m"), []byte("z"), {0xff}} {
+					assertSeekKey(t, it, target, nil)
+				}
+			})
+		}
+	}
+}

--- a/TreeDB/tree/iterator.go
+++ b/TreeDB/tree/iterator.go
@@ -515,22 +515,7 @@ func (t *Tree) ReverseIteratorWithOptions(start, end []byte, opts IteratorOption
 		return t.acquireIterator(nil, nil, mode, opts.IncludeTombstones, true)
 	}
 	it := t.acquireIterator(start, end, mode, opts.IncludeTombstones, true)
-	// Reverse seek: Find >= end, then step back.
-	if end == nil {
-		it.seekRightMost()
-	} else {
-		it.Seek(end)
-		if it.valid {
-			// Standard seek positions at the first key >= end; reverse iteration
-			// then steps once to land on the first key < end.
-			if compareTreeKey(it.currKey, end) >= 0 {
-				it.stepBackward()
-			}
-		} else if it.err == nil {
-			// seek(end) fell off the end (no error, just exhausted).
-			it.seekRightMost()
-		}
-	}
+	it.Seek(nil)
 
 	// Check Start bound
 	if it.valid && it.start != nil && compareTreeKey(it.currKey, it.start) < 0 {
@@ -1052,8 +1037,45 @@ func (it *Iterator) Close() error {
 }
 
 func (it *Iterator) Seek(key []byte) {
+	if it.reverse {
+		it.seekReverse(key)
+		return
+	}
 	it.seek(key)
 	// Check bounds? Handled in loadCurrent
+}
+
+func (it *Iterator) seekReverse(key []byte) {
+	if key == nil || (it.end != nil && compareTreeKey(key, it.end) >= 0) {
+		if it.end == nil {
+			it.seekRightMost()
+			return
+		}
+		it.seek(it.end)
+		if it.valid {
+			if compareTreeKey(it.currKey, it.end) >= 0 {
+				it.stepBackward()
+			}
+		} else if it.err == nil {
+			it.seekRightMost()
+		}
+		if it.valid && it.start != nil && compareTreeKey(it.currKey, it.start) < 0 {
+			it.valid = false
+		}
+		return
+	}
+
+	it.seek(key)
+	if it.valid {
+		if compareTreeKey(it.currKey, key) > 0 {
+			it.stepBackward()
+		}
+	} else if it.err == nil {
+		it.seekRightMost()
+	}
+	if it.valid && it.start != nil && compareTreeKey(it.currKey, it.start) < 0 {
+		it.valid = false
+	}
 }
 
 func (it *Iterator) IsDeleted() bool {

--- a/TreeDB/tree/iterator.go
+++ b/TreeDB/tree/iterator.go
@@ -383,6 +383,7 @@ type Iterator struct {
 	mode              IteratorMode
 	includeTombstones bool
 	reverse           bool
+	emptyDomain       bool
 	verifyAlways      bool
 }
 
@@ -477,6 +478,7 @@ func (t *Tree) acquireIterator(start, end []byte, mode IteratorMode, includeTomb
 		mode:              mode,
 		includeTombstones: includeTombstones,
 		reverse:           reverse,
+		emptyDomain:       start != nil && end != nil && compareTreeKey(start, end) >= 0,
 		verifyAlways:      t.pager != nil && t.pager.VerifyOnRead(),
 		slabAppender:      t.slabAppender,
 		slabBatcher:       t.slabBatcher,
@@ -493,7 +495,7 @@ func (t *Tree) acquireIterator(start, end []byte, mode IteratorMode, includeTomb
 func (t *Tree) IteratorWithOptions(start, end []byte, opts IteratorOptions) iterator.UnsafeIterator {
 	mode := normalizeIteratorMode(opts.Mode)
 	if start != nil && end != nil && compareTreeKey(start, end) >= 0 {
-		return t.acquireIterator(nil, nil, mode, opts.IncludeTombstones, false) // Invalid immediately
+		return t.acquireIterator(start, end, mode, opts.IncludeTombstones, false)
 	}
 	it := t.acquireIterator(start, end, mode, opts.IncludeTombstones, false)
 	it.Seek(start)
@@ -512,7 +514,7 @@ func (t *Tree) ReverseIterator(start, end []byte) iterator.UnsafeIterator {
 func (t *Tree) ReverseIteratorWithOptions(start, end []byte, opts IteratorOptions) iterator.UnsafeIterator {
 	mode := normalizeIteratorMode(opts.Mode)
 	if start != nil && end != nil && compareTreeKey(start, end) >= 0 {
-		return t.acquireIterator(nil, nil, mode, opts.IncludeTombstones, true)
+		return t.acquireIterator(start, end, mode, opts.IncludeTombstones, true)
 	}
 	it := t.acquireIterator(start, end, mode, opts.IncludeTombstones, true)
 	it.Seek(nil)
@@ -1037,6 +1039,9 @@ func (it *Iterator) Close() error {
 }
 
 func (it *Iterator) Seek(key []byte) {
+	if it.emptyDomain {
+		return
+	}
 	if it.reverse {
 		it.seekReverse(key)
 		return

--- a/TreeDB/tree/iterator.go
+++ b/TreeDB/tree/iterator.go
@@ -1046,6 +1046,9 @@ func (it *Iterator) Seek(key []byte) {
 		it.seekReverse(key)
 		return
 	}
+	if it.start != nil && (key == nil || compareTreeKey(key, it.start) < 0) {
+		key = it.start
+	}
 	it.seek(key)
 	// Check bounds? Handled in loadCurrent
 }
@@ -1054,15 +1057,15 @@ func (it *Iterator) seekReverse(key []byte) {
 	if key == nil || (it.end != nil && compareTreeKey(key, it.end) >= 0) {
 		if it.end == nil {
 			it.seekRightMost()
-			return
-		}
-		it.seek(it.end)
-		if it.valid {
-			if compareTreeKey(it.currKey, it.end) >= 0 {
-				it.stepBackward()
+		} else {
+			it.seek(it.end)
+			if it.valid {
+				if compareTreeKey(it.currKey, it.end) >= 0 {
+					it.stepBackward()
+				}
+			} else if it.err == nil {
+				it.seekRightMost()
 			}
-		} else if it.err == nil {
-			it.seekRightMost()
 		}
 		if it.valid && it.start != nil && compareTreeKey(it.currKey, it.start) < 0 {
 			it.valid = false
@@ -1075,7 +1078,7 @@ func (it *Iterator) seekReverse(key []byte) {
 		if compareTreeKey(it.currKey, key) > 0 {
 			it.stepBackward()
 		}
-	} else if it.err == nil {
+	} else if it.err == nil && (it.start == nil || compareTreeKey(key, it.start) >= 0) {
 		it.seekRightMost()
 	}
 	if it.valid && it.start != nil && compareTreeKey(it.currKey, it.start) < 0 {

--- a/TreeDB/tree/iterator_test.go
+++ b/TreeDB/tree/iterator_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 	"unsafe"
 
+	"github.com/snissn/gomap/TreeDB/internal/iterator"
 	"github.com/snissn/gomap/TreeDB/internal/valuelog"
 	"github.com/snissn/gomap/TreeDB/node"
 	"github.com/snissn/gomap/TreeDB/page"
@@ -321,6 +322,91 @@ func TestIterator(t *testing.T) {
 			t.Errorf("Expected %d items, got %d", len(expected), i)
 		}
 		it.Close()
+	})
+
+	t.Run("OpenEndedLowerBoundSeekRemainsEmpty", func(t *testing.T) {
+		start := []byte("Z")
+		targets := []struct {
+			name string
+			key  []byte
+		}{
+			{name: "nil", key: nil},
+			{name: "below", key: []byte("A")},
+			{name: "inside", key: []byte("Z")},
+			{name: "above", key: []byte{0xff}},
+		}
+		for _, reverse := range []bool{false, true} {
+			name := map[bool]string{false: "forward", true: "reverse"}[reverse]
+			t.Run(name, func(t *testing.T) {
+				var it iterator.UnsafeIterator
+				if reverse {
+					it = tr.ReverseIterator(start, nil)
+				} else {
+					it = tr.Iterator(start, nil)
+				}
+				defer it.Close()
+				if it.Valid() {
+					t.Fatalf("iterator construction exposed key %q below start %q", it.Key(), start)
+				}
+				for _, target := range targets {
+					t.Run(target.name, func(t *testing.T) {
+						it.Seek(target.key)
+						if it.Valid() {
+							t.Fatalf("Seek(%x) exposed key %q below start %q", target.key, it.Key(), start)
+						}
+						if err := it.Error(); err != nil {
+							t.Fatalf("Seek(%x) error=%v", target.key, err)
+						}
+					})
+				}
+			})
+		}
+	})
+
+	t.Run("OpenEndedLowerBoundSeekClampsToDomain", func(t *testing.T) {
+		start := []byte("D")
+		tests := []struct {
+			name    string
+			target  []byte
+			forward string
+			reverse string
+		}{
+			{name: "nil", target: nil, forward: "E", reverse: "G"},
+			{name: "below", target: []byte("A"), forward: "E"},
+			{name: "inside", target: []byte("F"), forward: "G", reverse: "E"},
+			{name: "above", target: []byte{0xff}, reverse: "G"},
+		}
+		for _, reverse := range []bool{false, true} {
+			name := map[bool]string{false: "forward", true: "reverse"}[reverse]
+			t.Run(name, func(t *testing.T) {
+				var it iterator.UnsafeIterator
+				if reverse {
+					it = tr.ReverseIterator(start, nil)
+				} else {
+					it = tr.Iterator(start, nil)
+				}
+				defer it.Close()
+				for _, test := range tests {
+					t.Run(test.name, func(t *testing.T) {
+						it.Seek(test.target)
+						want := test.forward
+						if reverse {
+							want = test.reverse
+						}
+						if want == "" {
+							if it.Valid() {
+								t.Fatalf("Seek(%x) key=%q want invalid", test.target, it.Key())
+							}
+						} else if !it.Valid() || string(it.Key()) != want {
+							t.Fatalf("Seek(%x) valid=%v key=%q want %q", test.target, it.Valid(), it.Key(), want)
+						}
+						if err := it.Error(); err != nil {
+							t.Fatalf("Seek(%x) error=%v", test.target, err)
+						}
+					})
+				}
+			})
+		}
 	})
 
 	t.Run("ViewSemantics", func(t *testing.T) {


### PR DESCRIPTION
Closes #3671
Part of #3668

## Goal

Expose snapshot-bound forward and reverse iterators with seek semantics on TreeDB's public API, while preserving snapshot isolation and deterministic behavior after snapshot close.

## What changed

- Added `Seek` to the public storage-neutral iterator contract and added `Snapshot.Iterator` / `Snapshot.ReverseIterator` to the public snapshot surface.
- Implemented seek/reset support in forward and reverse tree, two-way, N-way, cached single-source, and concatenated iterator paths without materializing the keyspace.
- Defined forward seek as the least visible key `>= target` and reverse seek as the greatest visible key `<= target`, always inside the original `[start,end)` domain. Reverse `Seek(nil)` selects the greatest in-domain key.
- Kept tombstone and source-precedence filtering intact when an iterator is re-seeked.
- Bound iterators to snapshot lifetime. Snapshot close atomically invalidates outstanding iterators; `Valid` becomes false, `Key`/`Value` return nil, `Next`/`Seek` become no-ops, and `Error` reports `ErrClosed`. Physical snapshot reclamation waits for the invalidated iterators to close, making snapshot-close races safe without a steady-state mutex or allocation.
- Made conditional-transaction snapshot range iteration fail closed with `ErrConditionalTxnUnsupported`.
- Updated the public contract spec and API ownership comments.

No on-disk format, WAL, historical-version encoding, Dgraph metadata, transaction/conflict, or bulk-builder behavior changes.

## TDD / start test plan

Tests were written first in the working tree and initially failed to compile before the public methods and seek contract existed. Coverage includes:

- empty and binary keys;
- exact, between, before-range, and after-range seeks;
- forward and reverse prefix boundaries, including an empty reverse domain;
- deletes/tombstones and cached/backend source shadowing;
- snapshot isolation from post-acquire writes;
- `KeyCopy` ownership across movement;
- randomized forward/reverse comparison against a sorted in-memory oracle;
- synced writes, checkpoint, close, reopen, and durable seek behavior.

## Close / lifetime test plan

- Race snapshot close against repeated iterator `Seek`, `Valid`, `Key`, and `Next` calls.
- Assert post-close invalid state, nil views, `ErrClosed`, no-op movement, and idempotent iterator close.
- Defer physical snapshot release until all registered iterators close so pooled snapshot objects and pinned backing resources cannot be recycled under an active operation.
- Reject iterator creation if registration loses a race with snapshot close.

## Verification

Exact rebased head `343dae09099ce94f18f0bcf5e5bb1f6abbe8d8f8` (base `e84eeb571`):

```text
GOWORK=off go test ./TreeDB -run 'TestSnapshotIteratorSeekContract|TestSnapshotIteratorSeekRandomizedOracle|TestSnapshotCloseInvalidatesOutstandingIterator|TestSnapshotIteratorSeekAfterReopen|TestConditionalTxnSnapshotUsesPinnedPointViewAndRangeFailsClosed' -count=1
PASS

GOWORK=off go test -race ./TreeDB -run 'TestSnapshotIteratorSeekContract|TestSnapshotIteratorSeekRandomizedOracle|TestSnapshotCloseInvalidatesOutstandingIterator|TestSnapshotIteratorSeekAfterReopen' -count=1
PASS

GOWORK=off go vet ./...
PASS
```

Additional implementation-head verification before the clean rebase:

```text
GOWORK=off go test ./...
PASS

GOWORK=off go test ./TreeDB/tree ./TreeDB/internal/merging ./TreeDB/caching -count=1
PASS

GOWORK=off go test -race ./TreeDB/caching ./TreeDB/db -run 'SnapshotIterator|IteratorSnapshotIsolation|Snapshot.*Iterator|ReverseIterator' -count=1
PASS
```

## Creation/close pool-reuse follow-up

Coordinator review identified a creation-vs-close race in which inner iterator construction occurred before registration acquired the snapshot lock. The fix now serializes both forward and reverse creation with close from the closed/generation check through all snapshot-backed source construction and registration. Pooled snapshots remain closed until full reinitialization, and a monotonically increasing generation rejects a caller that captured the pre-close generation but reaches the lock after pool reuse.

Deterministic tests pause creation before registration, start close, verify the snapshot cannot change generation or return to the pool, then resume and verify invalidation. Separate stale-generation seams prove that both backend and cached wrappers reject an old generation without touching snapshot fields.

Exact head verification:

```text
GOWORK=off go test ./TreeDB/db ./TreeDB/caching -run 'SnapshotIteratorCreation(SerializesCloseAndPoolReuse|RejectsStaleGeneration)' -count=50
PASS

GOWORK=off go test -race ./TreeDB/db ./TreeDB/caching -run 'SnapshotIteratorCreation(SerializesCloseAndPoolReuse|RejectsStaleGeneration)' -count=20
PASS

GOWORK=off go test ./TreeDB -run 'TestSnapshotIteratorSeekContract|TestSnapshotCloseInvalidatesOutstandingIterator' -count=10
PASS

GOWORK=off go vet ./TreeDB/db ./TreeDB/caching
PASS
```

The broader lock-serialization implementation also passed `GOWORK=off go test ./TreeDB/db ./TreeDB/caching -count=1` (db 299.8s, caching 77.0s) and `GOWORK=off go vet ./...` before the generation-token hardening was added.

## Empty-domain seek review follow-up

Review identified that equal or inverted tree ranges were initially invalid but could become unbounded after `Seek`. The underlying pooled tree iterator now preserves the original bounds and a persistent `emptyDomain` state; forward and reverse `Seek` are permanent no-ops for that state. Public backend and cached snapshot regressions cover equal and inverted bounds in both directions with nil, before-range, in-range, and after-range targets.

Exact head verification:

```text
GOWORK=off go test ./TreeDB ./TreeDB/db -run 'Test(Snapshot|BackendSnapshot)IteratorEmptyDomainSeekRemainsEmpty' -count=50
PASS

GOWORK=off go test -race ./TreeDB ./TreeDB/db -run 'Test(Snapshot|BackendSnapshot)IteratorEmptyDomainSeekRemainsEmpty|TestSnapshotCloseInvalidatesOutstandingIterator' -count=10
PASS

GOWORK=off go test ./TreeDB ./TreeDB/tree -count=1
PASS

GOWORK=off go vet ./TreeDB ./TreeDB/tree
PASS
```

The isolated five-sample 500 ms seek/next rerun remained allocation-free. Median snapshot vs public-baseline deltas were +0.6% seek / -10.0% next at 1,024 keys and +1.4% seek / -9.0% next at 16,384 keys, within the <=5% regression gate.

## Exact-head review hardening

Reviewed intermediate head `23479e13ecbdf29ce83a11674b97a5058b40ad60` includes the review fixes from `61ecb895e` plus the hosted performance gate; the final exact head is documented below.

- Backend and cached snapshot-bound iterators now close their inner iterator, deregister and detach their owner, and finalize deferred snapshot resources under one `sync.Once`. Double close cannot mutate or requeue a pooled Snapshot.
- Forward and reverse two-way and heap mergers collect all errors immediately after `Seek`, fail closed, and also capture errors raised by internal advancement of tombstones, duplicate shadows, and reverse out-of-range rows. Public `Next` uses the same O(1) per-advanced-source check.
- Deterministic regressions cover backend and cached pool return/detachment plus immediate and internal-advance source errors in every merger variant.

Current implementation verification:

```text
GOWORK=off go test ./TreeDB/internal/merging -count=1
PASS

GOWORK=off go test -race ./TreeDB/internal/merging -run Seek -count=20
PASS

GOWORK=off go test -race ./TreeDB/db -run SnapshotIterator -count=10
PASS

GOWORK=off go test -race ./TreeDB/caching -run CachedSnapshotIterator -count=20
PASS

GOWORK=off GOMAXPROCS=2 go test -p 1 ./TreeDB ./TreeDB/tree ./TreeDB/internal/merging -count=1
PASS (TreeDB 65.0s)

GOWORK=off GOMAXPROCS=2 go test -p 1 ./TreeDB/db ./TreeDB/caching -count=1
PASS (db 359.5s; caching 76.9s under unrelated host load)

GOWORK=off GOMAXPROCS=2 go vet ./TreeDB ./TreeDB/tree ./TreeDB/internal/merging ./TreeDB/db ./TreeDB/caching ./.github/scripts/snapshot_iterator_bench
PASS

go test ./.github/scripts/snapshot_iterator_bench
PASS
```

## Hosted current-head performance gate

The TreeDB workflow now has an independent `snapshot-iterator-perf (linux)` job. It checks out and records the exact push head, pins `GOMAXPROCS=1`, runs the 1,024- and 16,384-key snapshot/public seek and next rows for seven samples at 500 ms or longer, and compares medians from the same binary. The repo-local stdlib-only parser enforces at most 5% snapshot regression and no B/op or allocs/op increase. Parser self-tests, raw output, runner image/CPU/Go metadata, JSON, Markdown, the Actions step summary, and an exact-head artifact are part of the job.

Exact-head hosted evidence passed for `23479e13ecbdf29ce83a11674b97a5058b40ad60` on Ubuntu 24 image `20260705.232.1`, AMD EPYC 7763, Go 1.26.4, and `GOMAXPROCS=1`. Seven 500 ms samples per row produced -0.65% seek / -9.00% next at 1,024 keys and +3.18% seek / -8.73% next at 16,384 keys. Every row reported 0 B/op and 0 allocs/op, so the <=5% median timing gate and no-allocation-increase gate both passed. Evidence: [hosted job](https://github.com/snissn/gomap/actions/runs/29127799548/job/86477001188) and [exact-head artifact `snapshot-iterator-perf-23479e13...`](https://github.com/snissn/gomap/actions/runs/29127799548/artifacts/8241027799).

For historical context, the prior clean isolated measurement on head `343dae090` was +0.6% seek / -10.0% next at 1,024 keys and +1.4% seek / -9.0% next at 16,384 keys, also with 0 B/op and 0 allocs/op.

## Performance evidence

Setup (`Open`, writes, checkpoint, snapshot and iterator creation) is outside each timed sub-benchmark. Timed loops contain only `Seek` plus validity/key observation, or `Next` plus wraparound seek. Five 500 ms samples were collected on Linux/amd64, Intel i5-11400F, Go 1.26. Both sides use the same public cached TreeDB and data; the baseline is the pre-existing public DB iterator path.

```text
go test ./TreeDB -run '^$' -bench '^BenchmarkSnapshotIteratorSeekNext/keys=1024/(snapshot|public)_(seek|next)' -benchmem -benchtime=500ms -count=5
go test ./TreeDB -run '^$' -bench '^BenchmarkSnapshotIteratorSeekNext/keys=16384/(snapshot|public)_(seek|next)' -benchmem -benchtime=500ms -count=5
```

| keys | operation | snapshot median | public baseline median | delta |
|---:|---|---:|---:|---:|
| 1,024 | seek | 307.2 ns/op | 326.9 ns/op | -6.0% |
| 1,024 | next | 38.69 ns/op | 41.86 ns/op | -7.6% |
| 16,384 | seek | 281.1 ns/op | 293.5 ns/op | -4.2% |
| 16,384 | next | 36.13 ns/op | 38.09 ns/op | -5.1% |

Every measured case reports `0 B/op` and `0 allocs/op`. The lifetime guard adds one atomic closed-state load to steady-state iterator operations and no mutex acquisition or allocation. The requested <=5% median regression gate passes; no case regressed.

## Risk assessment

- The main compatibility change is adding `Seek` to iterator interfaces and narrowing public snapshot iterator returns to the storage-neutral contract. Internal callers that need pointer projection continue to use `IteratorWithOptions`.
- N-way mergers now retain exhausted sources until iterator close so later seek can reactivate them; explicit iterator close remains required.
- Snapshot resources remain pinned if a caller closes the snapshot but leaks a bound iterator. This is intentional for race safety and is documented alongside the existing mandatory iterator-close rule.
- CI and review are still required on the latest head before merge. No AI review has been requested in this handoff.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added/strengthened `Seek` support for snapshot and merged iterators (forward + reverse), including empty-range and open-ended bound behavior.
  * Expanded the public iterator API/contract with stable `KeyCopy`/`ValueCopy` semantics and clarified ownership/lifetime.

* **Bug Fixes**
  * Prevented partial/invalid iteration results after `Seek`/advance failures; improved error aggregation and propagation.
  * Snapshot close now reliably invalidates outstanding iterators and improves safe reuse/pool behavior.

* **Documentation / Tests / CI**
  * Updated iterator and snapshot lifecycle documentation, added lifecycle/seek tests, and added iterator seek performance gating in CI.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
## Open-ended lower-bound review follow-up

Current head `8cdffaf7e1c8b91f726b1d369edc09585c7b117c` fixes the reviewed open-ended range violations.

- Forward tree `Seek(nil)` and seeks below a non-nil start now clamp to the fixed lower bound.
- Reverse `Seek(nil)` with no end bound now shares the lower-bound validation, so an all-below tree stays invalid.
- Reverse seeks below the lower bound no longer use the rightmost-key fallback discovered while expanding the review regression matrix.
- Direct tree, public backend snapshot, and cached/merged snapshot tests cover forward and reverse open-ended ranges with nil, below-bound, in-domain, and above-domain targets, both when all data is below the start and when the domain contains keys.

Current-head verification:

```text
GOWORK=off go test ./TreeDB/tree -run '^TestIterator$/^OpenEndedLowerBoundSeek(RemainsEmpty|ClampsToDomain)$' -count=50
PASS

GOWORK=off go test ./TreeDB/db -run '^TestBackendSnapshotIteratorOpenEndedLowerBoundSeek(RemainsEmpty|ClampsToDomain)$' -count=50
PASS

GOWORK=off go test ./TreeDB -run '^TestSnapshotIteratorOpenEndedLowerBoundSeek(RemainsEmpty|ClampsToDomain)$' -count=50
PASS

GOWORK=off go test -race ./TreeDB/tree -run '^TestIterator$/^OpenEndedLowerBoundSeek(RemainsEmpty|ClampsToDomain)$' -count=10
PASS

GOWORK=off go test -race ./TreeDB/db -run '^TestBackendSnapshotIteratorOpenEndedLowerBoundSeek(RemainsEmpty|ClampsToDomain)$' -count=10
PASS

GOWORK=off go test -race ./TreeDB -run '^TestSnapshotIteratorOpenEndedLowerBoundSeek(RemainsEmpty|ClampsToDomain)$' -count=10
PASS

GOWORK=off GOMAXPROCS=2 go test -p 1 ./TreeDB/tree ./TreeDB ./TreeDB/db ./TreeDB/caching -count=1
PASS (tree 0.016s; TreeDB 66.340s; db 288.832s; caching 57.232s)

GOWORK=off GOMAXPROCS=2 go vet ./TreeDB/tree ./TreeDB ./TreeDB/db ./TreeDB/caching
PASS
```

That intermediate-head CI was superseded after the lower-bound review fixes; final exact-head evidence is recorded below.
## Cached single-source lower-bound follow-up

Final head `45f04187c8d5cbaa0c1870611c5ba68341442b40` also closes the cached single-source forward-seek gap.

- `singleSourceIterator.Seek` clamps nil and below-start forward targets before delegating to its source.
- The focused regression uses a real skiplist memtable iterator that can re-seek before its construction start.
- Mixed-domain and all-data-below-start cases cover nil, below-bound, exact-start, in-domain, and above-domain targets.

Final-head verification:

```text
GOWORK=off go test ./TreeDB/caching -run '^TestSingleSourceIteratorForwardSeekClampsToStart$' -count=50
PASS

GOWORK=off go test -race ./TreeDB/caching -run '^TestSingleSourceIteratorForwardSeekClampsToStart$' -count=20
PASS

GOWORK=off GOMAXPROCS=2 go test -p 1 ./TreeDB/caching ./TreeDB -count=1
PASS (caching 57.049s; TreeDB 44.903s)

GOWORK=off GOMAXPROCS=2 go vet ./TreeDB/caching ./TreeDB
PASS
```

The hosted performance run for intermediate head `45f04187c8d5cbaa0c1870611c5ba68341442b40` passed its timing and allocation gates. Final exact-head performance evidence is recorded below.
## Race-shard test determinism follow-up

Final head `ed5f7307a16d1d8b3eb3935d22a6a13dbca42e89` removes a brittle `sync.Pool` identity assumption from the cached snapshot double-close regression. The failing race shard was not a data race: the test assumed that the next pool `Get` returned the snapshot it had just finalized, which `sync.Pool` explicitly does not guarantee.

The rewritten test registers a second iterator to pin the closed owner outside the pool, closes and detaches the iterator under test, then proves a second close cannot change the pinned owner's generation or finalized state. Closing the keeper finally exercises normal finalization. This deterministically tests the ownership invariant without touching an object after pool insertion or adding a production pool seam.

Final-head verification:

```text
GOWORK=off go test ./TreeDB/caching -run '^TestCachedSnapshotIterator(DoubleCloseCannotMutateDetachedOwner|CreationSerializesCloseAndPoolReuse|CreationRejectsStaleGeneration)$' -count=100
PASS

GOWORK=off GOGC=1 go test -race ./TreeDB/caching -run '^TestCachedSnapshotIterator(DoubleCloseCannotMutateDetachedOwner|CreationSerializesCloseAndPoolReuse|CreationRejectsStaleGeneration)$' -count=100
PASS

GOWORK=off GOMAXPROCS=2 go test -p 1 ./TreeDB/caching -count=1
PASS (70.942s)

GOWORK=off GOMAXPROCS=2 go vet ./TreeDB/caching
PASS
```
## Backend and cached race-shard determinism follow-up

Intermediate head `6fbe35800a8853da2d716bcb5b4cb517e1be0579` applies the deterministic detached-owner pattern to both snapshot implementations. This supersedes the cached-only `ed5f7307a` follow-up; all workflow runs for that intermediate head were cancelled.

Both regressions now keep the closed snapshot out of its pool with a second registered iterator, close and detach the iterator under test, and verify that a second close cannot change the pinned owner's generation or finalized state. The keeper is then closed to exercise normal finalization. Neither test assumes pool reuse order or accesses an object after pool insertion.

Final-head verification:

```text
GOWORK=off go test ./TreeDB/db ./TreeDB/caching -run '^(TestSnapshotIterator|TestCachedSnapshotIterator)(DoubleCloseCannotMutateDetachedOwner|CreationSerializesCloseAndPoolReuse|CreationRejectsStaleGeneration)$' -count=100
PASS

GOWORK=off GOGC=1 go test -race ./TreeDB/db ./TreeDB/caching -run '^(TestSnapshotIterator|TestCachedSnapshotIterator)(DoubleCloseCannotMutateDetachedOwner|CreationSerializesCloseAndPoolReuse|CreationRejectsStaleGeneration)$' -count=100
PASS

GOWORK=off GOMAXPROCS=2 go test -p 1 ./TreeDB/db ./TreeDB/caching -count=1
PASS (db 283.694s; caching 70.697s under concurrent host load)

GOWORK=off GOMAXPROCS=2 go vet ./TreeDB/db ./TreeDB/caching
PASS
```

Final exact-head hosted performance passed at `6fbe35800a8853da2d716bcb5b4cb517e1be0579` on Ubuntu 24 image `20260705.232.1`, AMD EPYC 7763, Go 1.26.4, and `GOMAXPROCS=1`. Across seven samples per row, snapshot seek/next versus the public baseline was -3.08%/-9.08% at 1,024 keys and +0.34%/-8.99% at 16,384 keys, with 0 B/op and 0 allocs/op in every row. The <=5% timing gate and strict allocation gate both passed. Evidence: [exact-head hosted job](https://github.com/snissn/gomap/actions/runs/29130402433/job/86484526759) and [artifact `snapshot-iterator-perf-6fbe35800...`](https://github.com/snissn/gomap/actions/runs/29130402433/artifacts/8241949332).

## Unique snapshot-handle closeout

Intermediate head `17f2024fc6576ad39e02fa1ca019262bd05672e7` closes the stale-alias gap identified by exact-head review. An exported `*Snapshot` address cannot distinguish an old alias from a new owner after object reuse, so backend and cached snapshot handles now have unique identities and are never reactivated after `Close`. Cleanup and pinned-state release remain centralized; a later pooled-backing-state split could recover the allocation without reusing the public handle, but that broader refactor is outside this PR.

Deterministic backend and cached regressions close one handle, acquire another, verify distinct identity, and prove both forward and reverse iterator creation from the stale handle return `ErrClosed`. The cleanup regression separately verifies that the released object is cleared and that the next handle has a new identity.

Current-head verification:

```text
GOWORK=off go test -race ./TreeDB/db ./TreeDB/caching -run 'Test(SnapshotIteratorCreationRejectsClosedHandleAfterNewAcquisition|CachedSnapshotIteratorCreationRejectsClosedHandleAfterNewAcquisition)$' -count=100
PASS

GOWORK=off go test -race ./TreeDB/db ./TreeDB/caching -run 'SnapshotIterator|SnapshotPool' -count=10
PASS

GOWORK=off go vet ./TreeDB/db ./TreeDB/caching
PASS

GOWORK=off go test ./TreeDB/caching
PASS (94.579s)

GOWORK=off go test ./TreeDB/db
PASS (378.917s)
```

The correctness cost is explicit and bounded: cached acquisition measures exactly 2 allocs/run (one cached and one backend handle), while `BenchmarkSnapshotPool` measures 133.5–138.2 ns/op, 480 B/op, and 1 alloc/op for the backend handle. Snapshot seek/next remains governed by the hosted exact-head timing and strict zero-allocation gate. That gate passed at `17f2024fc6576ad39e02fa1ca019262bd05672e7` on Ubuntu 24 image `20260705.232.1`, AMD EPYC 7763, Go 1.26.4, and `GOMAXPROCS=1`. Across seven samples per row, snapshot seek/next versus the public baseline was -1.44%/-7.80% at 1,024 keys and +1.91%/-8.55% at 16,384 keys, with 0 B/op and 0 allocs/op in every row. Evidence: [exact-head hosted job](https://github.com/snissn/gomap/actions/runs/29131399507/job/86487297304) and [artifact `snapshot-iterator-perf-17f2024f...`](https://github.com/snissn/gomap/actions/runs/29131399507/artifacts/8242161324). That matrix was superseded by the allocation-contract closeout below.

## Snapshot acquisition allocation-contract follow-up

Intermediate head `faa4b0e497947f6f66f7682d6dfd23ec88b533e2` updates the remaining root backend fast-path allocation assertion to the safety design's measured one unique exported handle. The gate is tight at <=1.1 allocs/run; cached fast-path and queued acquisitions remain bounded at <=2.1 allocs/run for their cached plus backend handles. Stale pool/reuse naming in the cached tests was also removed.

Current-head local verification:

```text
GOWORK=off go test ./TreeDB -run '^TestAcquireSnapshot_BackendFastPathAllocsAreBounded$' -count=5
PASS (observed exactly 1 alloc/run)

GOWORK=off go test ./TreeDB
PASS (58.594s)

GOWORK=off go vet ./TreeDB
PASS

GOWORK=off go test ./TreeDB/caching -run '^$'
PASS
```

The hosted iterator performance gate passed at exact head `faa4b0e497947f6f66f7682d6dfd23ec88b533e2` on Ubuntu 24 image `20260705.232.1`, AMD EPYC 7763, Go 1.26.4, and `GOMAXPROCS=1`. Across seven samples per row, snapshot seek/next versus the public baseline was -1.01%/-8.69% at 1,024 keys and +1.86%/-8.42% at 16,384 keys, with 0 B/op and 0 allocs/op in every row. Evidence: [exact-head hosted job](https://github.com/snissn/gomap/actions/runs/29131719297/job/86488199518) and [artifact `snapshot-iterator-perf-faa4b0e4...`](https://github.com/snissn/gomap/actions/runs/29131719297/artifacts/8242275833). That matrix was superseded by the one-shot query allocation-contract closeout below.

## One-shot query allocation-contract closeout

Current head `fc76d7cf38c3dabfce618b7e72a782fdc7e528c0` updates the one exact end-to-end collections allocation guard affected by unique snapshot identities. `RunColumnPhysicalQuery` acquires one cached and one backend exported handle, so a named, documented +2 handle cost is added once to the per-case maximum while all eight underlying query budgets remain unchanged. Production code is unchanged.

The audit found no other exact one-shot collections budget requiring adjustment: the other one-shot allocation test compares small-versus-large slope, where the fixed +2 cancels, while exact zero-allocation budgets use prepared runners and do not acquire a snapshot per measured run.

Current-head local verification:

```text
GOWORK=off go test ./TreeDB/collections -run '^TestColumnPhysicalQuerySerialSidecarAllocationBudgetM1634$' -count=5
PASS

GOWORK=off go test ./TreeDB/collections
PASS (141.427s)

GOWORK=off go vet ./TreeDB/collections
PASS
```

The hosted iterator performance gate passed at exact head `fc76d7cf38c3dabfce618b7e72a782fdc7e528c0` on Ubuntu 24 image `20260705.232.1`, AMD EPYC 7763, Go 1.26.4, and `GOMAXPROCS=1`. Across seven samples per row, snapshot seek/next versus the public baseline was -1.89%/-8.60% at 1,024 keys and +2.57%/-8.31% at 16,384 keys, with 0 B/op and 0 allocs/op in every row. Evidence: [exact-head hosted job](https://github.com/snissn/gomap/actions/runs/29132070654/job/86489164301) and [artifact `snapshot-iterator-perf-fc76d7cf...`](https://github.com/snissn/gomap/actions/runs/29132070654/artifacts/8242364023). The remaining exact-head CI matrix and Codex review are in progress.


## Closed snapshot read and root-iterator lifetime closeout

Final head `fdb8edd080c6a05d6a52409316329bb7c784b9aa` closes the two remaining exact-head review findings.

- Backend and cached point reads now acquire a lock-free read reference only while the snapshot is open. `Close` atomically blocks new reads, invalidates every registered iterator, and defers physical cleanup until active reads and iterators drain. Read callbacks may call `Close` without deadlock; the last returning reader performs deferred finalization.
- The closed-state contract covers point reads, bulk/prefix reads including empty-input fast paths, entry reads, metadata access, root reads, and previously acquired root readers. Closed reads return `ErrClosed`; `Pager`/`State` return nil and `StateToken` reports unavailable.
- Forward and reverse root iterators, including the options variants, now use the same snapshot-bound wrapper and reference accounting as ordinary snapshot iterators. Snapshot close invalidates them immediately and cleanup waits for their explicit close.
- The exported-handle allocation policy remains unchanged. A nil cached `GetAppend`/`GetVersionedAppend` retains its historical not-found behavior; only real closed handles use `ErrClosed`.

Exact-head verification:

```text
GOWORK=off go test -race ./TreeDB/db ./TreeDB/caching -run 'Test(SnapshotClosedSurfaceRejectsReadsAndInvalidatesAllIterators|SnapshotReadCallbackCanCloseOwner|SnapshotRootReaderCallbackCanCloseOwner|CachedSnapshotClosedSurfaceRejectsReadsAndInvalidatesAllIterators|CachedSnapshotReadCallbackCanCloseOwner)$' -count=100
PASS (db 12.398s; caching 9.523s)

GOWORK=off go test ./TreeDB/db
PASS (287.087s)

GOWORK=off go test ./TreeDB/caching
PASS (71.441s)

GOWORK=off go test ./TreeDB
PASS (61.197s)

GOWORK=off go vet ./TreeDB/db ./TreeDB/caching ./TreeDB
PASS
```

Same-host, single-core, five-sample 500 ms point-read measurements compare final head with its immediate predecessor `fc76d7cf38c3dabfce618b7e72a782fdc7e528c0`. Median `snapshot_get_append_at_root` changed from 153.3 to 166.5 ns/op (+8.6%); `bound_reader_get_append` changed from 136.1 to 150.6 ns/op (+10.7%). Both remain 0 B/op and 0 allocs/op. A rejected mutex implementation measured roughly +22% and +30%; the retained lock-free reference state avoids read serialization while paying the explicit close-safety cost. The iterator seek/next <=5% gate remains independent and must pass on this exact head in the hosted job.


## Root-iterator allocation guard closeout

Final head `39e54525664bca1be54a1cb527025cd01e452a73` updates the existing one-shot column-query allocation guard for the three root iterators used to load each physical-query snapshot view. The underlying per-query budgets remain unchanged; a named +3 allowance records the snapshot-bound wrapper objects required for close invalidation and deferred cleanup, alongside the existing named +2 allowance for unique snapshot handles.

```text
GOWORK=off GOMAXPROCS=2 go test -p 1 ./TreeDB/collections -run '^TestColumnPhysicalQuerySerialSidecarAllocationBudgetM1634$' -count=10
PASS

GOWORK=off GOMAXPROCS=2 go test -p 1 ./TreeDB/collections
PASS (81.827s)
```

The superseded `fdb8edd08` hosted iterator performance job passed in 1m54s with exact-head artifact `8242754723`. The same hosted gate must pass again on final head `39e545256` before merge.

