### PR TITLE
TreeDB: add atomic CommitAt and snapshot-correct GetAt

### DIFF
--- a/.github/scripts/check_mvcc_raw_path_gate.py
+++ b/.github/scripts/check_mvcc_raw_path_gate.py
@@ -1,0 +1,262 @@
+#!/usr/bin/env python3
+"""Check paired TreeDB raw-path benchmark medians without third-party modules."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import statistics
+import tempfile
+from dataclasses import dataclass
+from pathlib import Path
+
+
+BENCHMARKS = (
+    "BenchmarkGetVersioned",
+    "BenchmarkConditionalTxnBaselineBatchWrite",
+)
+BENCH_RE = re.compile(
+    r"^(Benchmark(?:GetVersioned|ConditionalTxnBaselineBatchWrite))(?:-\d+)?\s+"
+    r"\d+\s+([0-9.]+)\s+ns/op\s+([0-9.]+)\s+B/op\s+"
+    r"([0-9.]+)\s+allocs/op\s*$"
+)
+
+
+@dataclass(frozen=True)
+class Sample:
+    ns_per_op: float
+    bytes_per_op: float
+    allocs_per_op: float
+
+
+def parse_benchmarks(path: Path, expected_samples: int) -> dict[str, list[Sample]]:
+    samples = {name: [] for name in BENCHMARKS}
+    for line in path.read_text(encoding="utf-8", errors="replace").splitlines():
+        match = BENCH_RE.match(line.strip())
+        if match is None:
+            continue
+        name, ns_per_op, bytes_per_op, allocs_per_op = match.groups()
+        samples[name].append(
+            Sample(float(ns_per_op), float(bytes_per_op), float(allocs_per_op))
+        )
+
+    for name, rows in samples.items():
+        if len(rows) != expected_samples:
+            raise ValueError(
+                f"{path}: expected {expected_samples} samples for {name}, got {len(rows)}"
+            )
+    return samples
+
+
+def median_sample(samples: list[Sample]) -> Sample:
+    return Sample(
+        statistics.median(sample.ns_per_op for sample in samples),
+        statistics.median(sample.bytes_per_op for sample in samples),
+        statistics.median(sample.allocs_per_op for sample in samples),
+    )
+
+
+def evaluate(
+    baseline: dict[str, list[Sample]],
+    candidate: dict[str, list[Sample]],
+    max_regression_percent: float,
+) -> tuple[bool, list[dict[str, object]]]:
+    passed = True
+    results: list[dict[str, object]] = []
+    for name in BENCHMARKS:
+        base = median_sample(baseline[name])
+        head = median_sample(candidate[name])
+        ns_delta_percent = ((head.ns_per_op / base.ns_per_op) - 1.0) * 100.0
+        timing_pass = ns_delta_percent <= max_regression_percent
+        bytes_pass = head.bytes_per_op <= base.bytes_per_op
+        allocs_pass = head.allocs_per_op <= base.allocs_per_op
+        row_pass = timing_pass and bytes_pass and allocs_pass
+        passed = passed and row_pass
+        results.append(
+            {
+                "benchmark": name,
+                "baseline": {
+                    "ns_per_op": base.ns_per_op,
+                    "bytes_per_op": base.bytes_per_op,
+                    "allocs_per_op": base.allocs_per_op,
+                },
+                "candidate": {
+                    "ns_per_op": head.ns_per_op,
+                    "bytes_per_op": head.bytes_per_op,
+                    "allocs_per_op": head.allocs_per_op,
+                },
+                "ns_delta_percent": ns_delta_percent,
+                "timing_pass": timing_pass,
+                "bytes_pass": bytes_pass,
+                "allocs_pass": allocs_pass,
+                "pass": row_pass,
+            }
+        )
+    return passed, results
+
+
+def render_markdown(
+    baseline_sha: str,
+    candidate_sha: str,
+    expected_samples: int,
+    max_regression_percent: float,
+    passed: bool,
+    results: list[dict[str, object]],
+) -> str:
+    lines = [
+        "## TreeDB MVCC raw-path gate",
+        "",
+        f"- result: **{'PASS' if passed else 'FAIL'}**",
+        f"- baseline: `{baseline_sha}`",
+        f"- candidate: `{candidate_sha}`",
+        f"- samples: {expected_samples} per revision, alternating sequential order",
+        f"- timing threshold: candidate median <= baseline median + {max_regression_percent:g}%",
+        "- allocation threshold: candidate median B/op and allocs/op must not increase",
+        "",
+        "| Benchmark | Base ns/op | Head ns/op | Delta | Base B/op | Head B/op | Base allocs/op | Head allocs/op | Result |",
+        "| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | --- |",
+    ]
+    for row in results:
+        base = row["baseline"]
+        head = row["candidate"]
+        assert isinstance(base, dict)
+        assert isinstance(head, dict)
+        lines.append(
+            "| {benchmark} | {base_ns:.3f} | {head_ns:.3f} | {delta:+.2f}% | "
+            "{base_bytes:.3f} | {head_bytes:.3f} | {base_allocs:.3f} | "
+            "{head_allocs:.3f} | {status} |".format(
+                benchmark=row["benchmark"],
+                base_ns=base["ns_per_op"],
+                head_ns=head["ns_per_op"],
+                delta=row["ns_delta_percent"],
+                base_bytes=base["bytes_per_op"],
+                head_bytes=head["bytes_per_op"],
+                base_allocs=base["allocs_per_op"],
+                head_allocs=head["allocs_per_op"],
+                status="PASS" if row["pass"] else "FAIL",
+            )
+        )
+    lines.append("")
+    return "\n".join(lines)
+
+
+def synthetic_log(
+    ns_scale: float = 1.0,
+    bytes_delta: float = 0.0,
+    alloc_delta: float = 0.0,
+) -> str:
+    lines: list[str] = []
+    for index in range(7):
+        for bench_index, name in enumerate(BENCHMARKS):
+            ns_per_op = (1000.0 + bench_index * 9000.0 + index) * ns_scale
+            bytes_per_op = 128.0 + bench_index * 128.0 + bytes_delta
+            allocs_per_op = 2.0 + bench_index + alloc_delta
+            lines.append(
+                f"{name}-1 1000 {ns_per_op:.3f} ns/op "
+                f"{bytes_per_op:.3f} B/op {allocs_per_op:.3f} allocs/op"
+            )
+    return "\n".join(lines) + "\n"
+
+
+def self_test() -> None:
+    with tempfile.TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        baseline_path = root / "baseline.txt"
+        candidate_path = root / "candidate.txt"
+        baseline_path.write_text(synthetic_log(), encoding="utf-8")
+        candidate_path.write_text(synthetic_log(ns_scale=1.04), encoding="utf-8")
+        baseline = parse_benchmarks(baseline_path, 7)
+        candidate = parse_benchmarks(candidate_path, 7)
+        passed, _ = evaluate(baseline, candidate, 5.0)
+        if not passed:
+            raise AssertionError("4% timing change should pass")
+
+        candidate_path.write_text(synthetic_log(ns_scale=1.06), encoding="utf-8")
+        candidate = parse_benchmarks(candidate_path, 7)
+        passed, _ = evaluate(baseline, candidate, 5.0)
+        if passed:
+            raise AssertionError("6% timing regression should fail")
+
+        candidate_path.write_text(synthetic_log(alloc_delta=1.0), encoding="utf-8")
+        candidate = parse_benchmarks(candidate_path, 7)
+        passed, _ = evaluate(baseline, candidate, 5.0)
+        if passed:
+            raise AssertionError("allocation regression should fail")
+
+        candidate_path.write_text(synthetic_log(bytes_delta=1.0), encoding="utf-8")
+        candidate = parse_benchmarks(candidate_path, 7)
+        passed, _ = evaluate(baseline, candidate, 5.0)
+        if passed:
+            raise AssertionError("byte allocation regression should fail")
+
+        candidate_path.write_text("", encoding="utf-8")
+        try:
+            parse_benchmarks(candidate_path, 7)
+        except ValueError:
+            pass
+        else:
+            raise AssertionError("missing benchmark rows should fail")
+    print("check_mvcc_raw_path_gate.py self-test: PASS")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--baseline")
+    parser.add_argument("--candidate")
+    parser.add_argument("--baseline-sha")
+    parser.add_argument("--candidate-sha")
+    parser.add_argument("--expected-samples", type=int, default=7)
+    parser.add_argument("--max-regression-percent", type=float, default=5.0)
+    parser.add_argument("--json-output")
+    parser.add_argument("--markdown-output")
+    parser.add_argument("--self-test", action="store_true")
+    args = parser.parse_args()
+
+    if args.self_test:
+        self_test()
+        return 0
+
+    required = (
+        "baseline",
+        "candidate",
+        "baseline_sha",
+        "candidate_sha",
+        "json_output",
+        "markdown_output",
+    )
+    missing = [name for name in required if getattr(args, name) in (None, "")]
+    if missing:
+        parser.error("missing required arguments: " + ", ".join(missing))
+
+    baseline = parse_benchmarks(Path(args.baseline), args.expected_samples)
+    candidate = parse_benchmarks(Path(args.candidate), args.expected_samples)
+    passed, results = evaluate(
+        baseline, candidate, args.max_regression_percent
+    )
+    payload = {
+        "pass": passed,
+        "baseline_sha": args.baseline_sha,
+        "candidate_sha": args.candidate_sha,
+        "expected_samples": args.expected_samples,
+        "max_regression_percent": args.max_regression_percent,
+        "results": results,
+    }
+    Path(args.json_output).write_text(
+        json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+    )
+    markdown = render_markdown(
+        args.baseline_sha,
+        args.candidate_sha,
+        args.expected_samples,
+        args.max_regression_percent,
+        passed,
+        results,
+    )
+    Path(args.markdown_output).write_text(markdown, encoding="utf-8")
+    print(markdown, end="")
+    return 0 if passed else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/scripts/check_mvcc_raw_path_gate.py
+++ b/.github/scripts/check_mvcc_raw_path_gate.py
@@ -61,6 +61,8 @@ def evaluate(
     baseline: dict[str, list[Sample]],
     candidate: dict[str, list[Sample]],
     max_regression_percent: float,
+    max_bytes_regression_percent: float,
+    max_bytes_regression_absolute: float,
 ) -> tuple[bool, list[dict[str, object]]]:
     passed = True
     results: list[dict[str, object]] = []
@@ -69,7 +71,12 @@ def evaluate(
         head = median_sample(candidate[name])
         ns_delta_percent = ((head.ns_per_op / base.ns_per_op) - 1.0) * 100.0
         timing_pass = ns_delta_percent <= max_regression_percent
-        bytes_pass = head.bytes_per_op <= base.bytes_per_op
+        bytes_delta = head.bytes_per_op - base.bytes_per_op
+        bytes_tolerance = min(
+            base.bytes_per_op * max_bytes_regression_percent / 100.0,
+            max_bytes_regression_absolute,
+        )
+        bytes_pass = bytes_delta <= bytes_tolerance
         allocs_pass = head.allocs_per_op <= base.allocs_per_op
         row_pass = timing_pass and bytes_pass and allocs_pass
         passed = passed and row_pass
@@ -87,6 +94,8 @@ def evaluate(
                     "allocs_per_op": head.allocs_per_op,
                 },
                 "ns_delta_percent": ns_delta_percent,
+                "bytes_delta": bytes_delta,
+                "bytes_tolerance": bytes_tolerance,
                 "timing_pass": timing_pass,
                 "bytes_pass": bytes_pass,
                 "allocs_pass": allocs_pass,
@@ -101,6 +110,8 @@ def render_markdown(
     candidate_sha: str,
     expected_samples: int,
     max_regression_percent: float,
+    max_bytes_regression_percent: float,
+    max_bytes_regression_absolute: float,
     passed: bool,
     results: list[dict[str, object]],
 ) -> str:
@@ -112,10 +123,13 @@ def render_markdown(
         f"- candidate: `{candidate_sha}`",
         f"- samples: {expected_samples} per revision, alternating sequential order",
         f"- timing threshold: candidate median <= baseline median + {max_regression_percent:g}%",
-        "- allocation threshold: candidate median B/op and allocs/op must not increase",
+        "- allocs/op threshold: candidate median must not increase",
+        "- B/op jitter threshold: candidate median may increase by at most the smaller of "
+        f"{max_bytes_regression_percent:g}% or {max_bytes_regression_absolute:g} B; "
+        "zero-B baselines remain strict",
         "",
-        "| Benchmark | Base ns/op | Head ns/op | Delta | Base B/op | Head B/op | Base allocs/op | Head allocs/op | Result |",
-        "| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | --- |",
+        "| Benchmark | Base ns/op | Head ns/op | Delta | Base B/op | Head B/op | B tolerance | Base allocs/op | Head allocs/op | Result |",
+        "| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | --- |",
     ]
     for row in results:
         base = row["baseline"]
@@ -124,7 +138,7 @@ def render_markdown(
         assert isinstance(head, dict)
         lines.append(
             "| {benchmark} | {base_ns:.3f} | {head_ns:.3f} | {delta:+.2f}% | "
-            "{base_bytes:.3f} | {head_bytes:.3f} | {base_allocs:.3f} | "
+            "{base_bytes:.3f} | {head_bytes:.3f} | {bytes_tolerance:.3f} | {base_allocs:.3f} | "
             "{head_allocs:.3f} | {status} |".format(
                 benchmark=row["benchmark"],
                 base_ns=base["ns_per_op"],
@@ -132,6 +146,7 @@ def render_markdown(
                 delta=row["ns_delta_percent"],
                 base_bytes=base["bytes_per_op"],
                 head_bytes=head["bytes_per_op"],
+                bytes_tolerance=row["bytes_tolerance"],
                 base_allocs=base["allocs_per_op"],
                 head_allocs=head["allocs_per_op"],
                 status="PASS" if row["pass"] else "FAIL",
@@ -143,6 +158,7 @@ def render_markdown(
 
 def synthetic_log(
     ns_scale: float = 1.0,
+    bytes_base: float = 128.0,
     bytes_delta: float = 0.0,
     alloc_delta: float = 0.0,
 ) -> str:
@@ -150,7 +166,7 @@ def synthetic_log(
     for index in range(7):
         for bench_index, name in enumerate(BENCHMARKS):
             ns_per_op = (1000.0 + bench_index * 9000.0 + index) * ns_scale
-            bytes_per_op = 128.0 + bench_index * 128.0 + bytes_delta
+            bytes_per_op = bytes_base + bench_index * bytes_base + bytes_delta
             allocs_per_op = 2.0 + bench_index + alloc_delta
             lines.append(
                 f"{name}-1 1000 {ns_per_op:.3f} ns/op "
@@ -168,27 +184,57 @@ def self_test() -> None:
         candidate_path.write_text(synthetic_log(ns_scale=1.04), encoding="utf-8")
         baseline = parse_benchmarks(baseline_path, 7)
         candidate = parse_benchmarks(candidate_path, 7)
-        passed, _ = evaluate(baseline, candidate, 5.0)
+        passed, _ = evaluate(baseline, candidate, 5.0, 1.0, 64.0)
         if not passed:
             raise AssertionError("4% timing change should pass")
 
         candidate_path.write_text(synthetic_log(ns_scale=1.06), encoding="utf-8")
         candidate = parse_benchmarks(candidate_path, 7)
-        passed, _ = evaluate(baseline, candidate, 5.0)
+        passed, _ = evaluate(baseline, candidate, 5.0, 1.0, 64.0)
         if passed:
             raise AssertionError("6% timing regression should fail")
 
         candidate_path.write_text(synthetic_log(alloc_delta=1.0), encoding="utf-8")
         candidate = parse_benchmarks(candidate_path, 7)
-        passed, _ = evaluate(baseline, candidate, 5.0)
+        passed, _ = evaluate(baseline, candidate, 5.0, 1.0, 64.0)
         if passed:
             raise AssertionError("allocation regression should fail")
 
-        candidate_path.write_text(synthetic_log(bytes_delta=1.0), encoding="utf-8")
+        baseline_path.write_text(synthetic_log(bytes_base=100.0), encoding="utf-8")
+        candidate_path.write_text(
+            synthetic_log(bytes_base=100.0, bytes_delta=1.0), encoding="utf-8"
+        )
+        baseline = parse_benchmarks(baseline_path, 7)
         candidate = parse_benchmarks(candidate_path, 7)
-        passed, _ = evaluate(baseline, candidate, 5.0)
+        passed, _ = evaluate(baseline, candidate, 5.0, 1.0, 64.0)
+        if not passed:
+            raise AssertionError("B/op increase at the 1% boundary should pass")
+
+        candidate_path.write_text(
+            synthetic_log(bytes_base=100.0, bytes_delta=1.001), encoding="utf-8"
+        )
+        candidate = parse_benchmarks(candidate_path, 7)
+        passed, _ = evaluate(baseline, candidate, 5.0, 1.0, 64.0)
         if passed:
-            raise AssertionError("byte allocation regression should fail")
+            raise AssertionError("B/op increase above the 1% boundary should fail")
+
+        baseline_path.write_text(synthetic_log(bytes_base=10000.0), encoding="utf-8")
+        candidate_path.write_text(
+            synthetic_log(bytes_base=10000.0, bytes_delta=64.0), encoding="utf-8"
+        )
+        baseline = parse_benchmarks(baseline_path, 7)
+        candidate = parse_benchmarks(candidate_path, 7)
+        passed, _ = evaluate(baseline, candidate, 5.0, 1.0, 64.0)
+        if not passed:
+            raise AssertionError("B/op increase at the 64 B boundary should pass")
+
+        candidate_path.write_text(
+            synthetic_log(bytes_base=10000.0, bytes_delta=64.001), encoding="utf-8"
+        )
+        candidate = parse_benchmarks(candidate_path, 7)
+        passed, _ = evaluate(baseline, candidate, 5.0, 1.0, 64.0)
+        if passed:
+            raise AssertionError("B/op increase above the 64 B boundary should fail")
 
         candidate_path.write_text("", encoding="utf-8")
         try:
@@ -208,6 +254,8 @@ def main() -> int:
     parser.add_argument("--candidate-sha")
     parser.add_argument("--expected-samples", type=int, default=7)
     parser.add_argument("--max-regression-percent", type=float, default=5.0)
+    parser.add_argument("--max-bytes-regression-percent", type=float, default=1.0)
+    parser.add_argument("--max-bytes-regression-absolute", type=float, default=64.0)
     parser.add_argument("--json-output")
     parser.add_argument("--markdown-output")
     parser.add_argument("--self-test", action="store_true")
@@ -216,6 +264,14 @@ def main() -> int:
     if args.self_test:
         self_test()
         return 0
+
+    for name in (
+        "max_regression_percent",
+        "max_bytes_regression_percent",
+        "max_bytes_regression_absolute",
+    ):
+        if getattr(args, name) < 0:
+            parser.error(f"--{name.replace('_', '-')} must be non-negative")
 
     required = (
         "baseline",
@@ -232,7 +288,11 @@ def main() -> int:
     baseline = parse_benchmarks(Path(args.baseline), args.expected_samples)
     candidate = parse_benchmarks(Path(args.candidate), args.expected_samples)
     passed, results = evaluate(
-        baseline, candidate, args.max_regression_percent
+        baseline,
+        candidate,
+        args.max_regression_percent,
+        args.max_bytes_regression_percent,
+        args.max_bytes_regression_absolute,
     )
     payload = {
         "pass": passed,
@@ -240,6 +300,8 @@ def main() -> int:
         "candidate_sha": args.candidate_sha,
         "expected_samples": args.expected_samples,
         "max_regression_percent": args.max_regression_percent,
+        "max_bytes_regression_percent": args.max_bytes_regression_percent,
+        "max_bytes_regression_absolute": args.max_bytes_regression_absolute,
         "results": results,
     }
     Path(args.json_output).write_text(
@@ -250,6 +312,8 @@ def main() -> int:
         args.candidate_sha,
         args.expected_samples,
         args.max_regression_percent,
+        args.max_bytes_regression_percent,
+        args.max_bytes_regression_absolute,
         passed,
         results,
     )

--- a/.github/workflows/treedb-tests.yml
+++ b/.github/workflows/treedb-tests.yml
@@ -5,8 +5,101 @@ on:
 
 permissions:
   contents: read
+  pull-requests: read
 
 jobs:
+  mvcc-raw-path-gate:
+    name: mvcc raw-path gate (linux)
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    steps:
+      - name: Resolve open PR and relevant paths
+        id: scope
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          HEAD_SHA: ${{ github.sha }}
+          REPOSITORY: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          gh api \
+            -H "Accept: application/vnd.github+json" \
+            "/repos/${REPOSITORY}/commits/${HEAD_SHA}/pulls" > "$RUNNER_TEMP/pulls.json"
+          pr_row=$(jq -r --arg head "$HEAD_SHA" \
+            '.[] | select(.state == "open" and .head.sha == $head) | [.number, .base.sha, .head.sha] | @tsv' \
+            "$RUNNER_TEMP/pulls.json" | head -1)
+          if [[ -z "$pr_row" ]]; then
+            echo "run=false" >> "$GITHUB_OUTPUT"
+            echo "No open PR has exact head ${HEAD_SHA}; skipping MVCC raw-path gate."
+            exit 0
+          fi
+          IFS=$'\t' read -r pr_number base_sha head_sha <<< "$pr_row"
+          gh api --paginate \
+            -H "Accept: application/vnd.github+json" \
+            "/repos/${REPOSITORY}/pulls/${pr_number}/files?per_page=100" \
+            --jq '.[].filename' > "$RUNNER_TEMP/pr-files.txt"
+          cat "$RUNNER_TEMP/pr-files.txt"
+          if grep -Eq '^((TreeDB/(mvcc|internal/mvcckey|db)/)|scripts/mvcc_raw_path_gate\.sh$|\.github/scripts/check_mvcc_raw_path_gate\.py$|\.github/workflows/treedb-tests\.yml$)' \
+            "$RUNNER_TEMP/pr-files.txt"; then
+            echo "run=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "run=false" >> "$GITHUB_OUTPUT"
+            echo "No MVCC/raw-gate relevant path changed; skipping."
+          fi
+          echo "pr_number=$pr_number" >> "$GITHUB_OUTPUT"
+          echo "base_sha=$base_sha" >> "$GITHUB_OUTPUT"
+          echo "head_sha=$head_sha" >> "$GITHUB_OUTPUT"
+
+      - name: Checkout exact PR head
+        if: steps.scope.outputs.run == 'true'
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ steps.scope.outputs.head_sha }}
+          fetch-depth: 0
+
+      - name: Setup Go
+        if: steps.scope.outputs.run == 'true'
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: false
+
+      - name: Gate self-checks
+        if: steps.scope.outputs.run == 'true'
+        run: |
+          bash -n scripts/mvcc_raw_path_gate.sh
+          python3 .github/scripts/check_mvcc_raw_path_gate.py --self-test
+
+      - name: Compare exact base and head
+        if: steps.scope.outputs.run == 'true'
+        env:
+          BASELINE_HASH: ${{ steps.scope.outputs.base_sha }}
+          CANDIDATE_HASH: ${{ steps.scope.outputs.head_sha }}
+          RUNS: "7"
+          BENCHTIME: 2s
+          CPUSET: "0"
+          MAX_REGRESSION_PERCENT: "5"
+          SCRIPT_GOWORK: "off"
+          OUT_DIR: ${{ runner.temp }}/mvcc-raw-path-gate
+        run: ./scripts/mvcc_raw_path_gate.sh
+
+      - name: Add benchmark summary
+        if: always() && steps.scope.outputs.run == 'true'
+        run: |
+          if [[ -f "$RUNNER_TEMP/mvcc-raw-path-gate/summary.md" ]]; then
+            cat "$RUNNER_TEMP/mvcc-raw-path-gate/summary.md" >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "MVCC raw-path gate did not produce a summary." >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+      - name: Upload benchmark evidence
+        if: always() && steps.scope.outputs.run == 'true'
+        uses: actions/upload-artifact@v4
+        with:
+          name: mvcc-raw-path-gate-${{ steps.scope.outputs.head_sha }}
+          path: ${{ runner.temp }}/mvcc-raw-path-gate
+          if-no-files-found: error
+
   test:
     name: ${{ matrix.name }}
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/treedb-tests.yml
+++ b/.github/workflows/treedb-tests.yml
@@ -79,6 +79,8 @@ jobs:
           BENCHTIME: 2s
           CPUSET: "0"
           MAX_REGRESSION_PERCENT: "5"
+          MAX_BYTES_REGRESSION_PERCENT: "1"
+          MAX_BYTES_REGRESSION_ABSOLUTE: "64"
           SCRIPT_GOWORK: "off"
           OUT_DIR: ${{ runner.temp }}/mvcc-raw-path-gate
         run: ./scripts/mvcc_raw_path_gate.sh

--- a/TreeDB/docs/spec/contracts.md
+++ b/TreeDB/docs/spec/contracts.md
@@ -71,7 +71,9 @@ The opt-in `TreeDB/mvcc` package owns the first read/write use of this codec:
   it does not materialize the key's history.
 - Read results distinguish absent, present, and tombstoned states. Malformed
   physical keys/value envelopes and underlying iterator/storage errors are
-  returned explicitly. Present values are caller-owned copies.
+  returned explicitly. Storage failures wrap `ErrStorage` while retaining the
+  underlying error for `errors.Is`/`errors.As`. Present values are caller-owned
+  copies.
 
 Retained-version iteration, discard floors, Dgraph metadata, TTL,
 subscriptions, and conditional transactions remain separate contracts owned by

--- a/TreeDB/docs/spec/contracts.md
+++ b/TreeDB/docs/spec/contracts.md
@@ -55,6 +55,8 @@ The opt-in `TreeDB/mvcc` package owns the first read/write use of this codec:
 - `CommitAt(timestamp, mutations, mode)` rejects timestamp zero, invalid commit
   modes, oversized logical keys, and duplicate logical keys before creating a
   TreeDB batch. Nil and empty logical keys have the same duplicate identity.
+- After timestamp/mode and non-nil Store validation, an empty mutation list is a
+  no-op that does not access TreeDB or probe its durability/open state.
 - Duplicate logical keys within one batch are rejected; they are not resolved
   by order-dependent last-write-wins behavior. Separate successful commits to
   the same logical key and timestamp address one physical version, so the later

--- a/TreeDB/docs/spec/contracts.md
+++ b/TreeDB/docs/spec/contracts.md
@@ -50,10 +50,33 @@ and does not change current raw KV behavior.
 - The codec format and internal Go API are pre-alpha. A format change may
   require rebuilding experimental DB directories rather than migration.
 
-Atomic `CommitAt`, snapshot reads such as `GetAt`, retained-version iteration,
-discard floors, Dgraph metadata, TTL, subscriptions, and conditional
-transactions are separate contracts owned by descendant issues. None are
-implied by the codec package.
+The opt-in `TreeDB/mvcc` package owns the first read/write use of this codec:
+
+- `CommitAt(timestamp, mutations, mode)` rejects timestamp zero, invalid commit
+  modes, oversized logical keys, and duplicate logical keys before creating a
+  TreeDB batch. Nil and empty logical keys have the same duplicate identity.
+- Duplicate logical keys within one batch are rejected; they are not resolved
+  by order-dependent last-write-wins behavior. Separate successful commits to
+  the same logical key and timestamp address one physical version, so the later
+  commit replaces the earlier version.
+- All puts and tombstones in one call are stored through one TreeDB atomic
+  batch. A storage error may be commit-ambiguous, but the batch is wholly
+  visible or wholly absent, never partially visible.
+- `CommitRelaxed` uses `Batch.Write` and promises atomic visibility without an
+  fsync boundary. `CommitDurable` is accepted only when TreeDB is configured in
+  `DurabilityDurable` mode and uses `Batch.WriteSync`.
+- `GetAt(key, readTimestamp)` creates a physical lower bound at
+  `(key, readTimestamp)` and seeks directly into the exact-key range. It returns
+  the newest retained version whose timestamp is at most the read timestamp;
+  it does not materialize the key's history.
+- Read results distinguish absent, present, and tombstoned states. Malformed
+  physical keys/value envelopes and underlying iterator/storage errors are
+  returned explicitly. Present values are caller-owned copies.
+
+Retained-version iteration, discard floors, Dgraph metadata, TTL,
+subscriptions, and conditional transactions remain separate contracts owned by
+descendant issues. `TreeDB/mvcc` does not reinterpret `EntryRevision` and does
+not perform conflict detection.
 
 ## 2. Read Contracts
 

--- a/TreeDB/docs/spec/recovery.md
+++ b/TreeDB/docs/spec/recovery.md
@@ -169,7 +169,23 @@ If command LSN `N` is ready but a lower LSN is neither already applied nor part
 of the same publish boundary, recovery must stop or fail closed rather than
 publishing `N` out of order.
 
-### 4.4 Cleanup
+### 4.4 External-version MVCC batches
+
+`TreeDB/mvcc.CommitAt` uses the existing raw batch recovery path; it does not
+add an independent timestamp log or recovery sidecar. Every physical key in a
+logical commit carries the same caller timestamp, and every physical value
+carries either a present-value or tombstone envelope. Recovery therefore
+replays or skips the underlying raw batch as one unit under the same command-WAL
+frame or legacy batch fence rules described above.
+
+A durable-mode successful `CommitDurable` is process-crash recoverable without
+`Close` or `Checkpoint`. A relaxed commit has no such per-call promise; a later
+successful `Checkpoint`/safe `Close` establishes the mode's documented reopen
+boundary. Truncated WAL tails may discard an incomplete final batch but must not
+publish a prefix. Malformed MVCC key/value records are not guessed or repaired:
+`GetAt` reports them explicitly if they occupy the requested visible position.
+
+### 4.5 Cleanup
 
 After successful replay:
 

--- a/TreeDB/docs/spec/storage-format.md
+++ b/TreeDB/docs/spec/storage-format.md
@@ -97,10 +97,24 @@ bound is the lexicographic successor of that physical prefix. Exact-key bounds
 enforce the same full-key size envelope as `Encode`; logical-prefix bounds are
 limited only by their own encoded bound size.
 
+The `TreeDB/mvcc` owner stores a one-byte record-kind envelope as the physical
+value:
+
+```text
+01 <logical value bytes>   // present value; the payload may be empty
+02                         // tombstone; trailing bytes are malformed
+```
+
+An empty physical value or unknown record-kind byte is malformed. Logical
+tombstones are values in this reserved subspace rather than raw TreeDB delete
+operations so historical deletion markers remain seekable. This record format,
+like the key codec, is pre-alpha and may require rebuilding experimental DB
+directories after a format change.
+
 This namespace does not make raw TreeDB keys non-empty or silently reserve a
-prefix in existing raw APIs. A later MVCC owner must prevent unrelated raw
-writes from entering its reserved physical range. The namespace marker makes
-MVCC physical keys non-empty even when the logical key is empty.
+prefix in existing raw APIs. The MVCC owner must prevent unrelated raw writes
+from entering its reserved physical range. The namespace marker makes MVCC
+physical keys non-empty even when the logical key is empty.
 
 ## 2. Index Page Basics
 

--- a/TreeDB/docs/spec/verification.md
+++ b/TreeDB/docs/spec/verification.md
@@ -280,6 +280,44 @@ The codec is a new opt-in path, so its performance gate is absolute cost and
 allocation behavior rather than a before/after raw-TreeDB result. Existing raw
 benchmarks must remain unchanged because no current raw API calls this package.
 
+## 10.3 External-Version MVCC Commit and Point Read
+
+Invariants:
+
+- one `CommitAt` call is one atomic TreeDB batch at one nonzero caller
+  timestamp, with deterministic pre-write duplicate rejection;
+- puts, empty values, and historical tombstones remain distinguishable;
+- `GetAt` returns the newest retained version at or below the read timestamp by
+  a direct bounded seek, without collecting version history;
+- durable commits require durable TreeDB mode and survive a process crash;
+  relaxed commits require a later checkpoint/close boundary for reopen proof;
+- storage failures may leave the whole batch present or absent but never leave
+  a visible prefix; malformed records and storage errors fail explicitly;
+- raw TreeDB and `EntryRevision` paths do not invoke this opt-in layer.
+
+Coverage:
+
+- `TreeDB/mvcc/mvcc_test.go`:
+  - golden overwrite/tombstone/read-before/exact/between/max histories and
+    repeated commits at one physical timestamp;
+  - multi-key atomicity, duplicate/nil-empty-key rejection, and validation
+    before storage write;
+  - injected pre-commit, post-commit, and staging failures proving all-or-none
+    visibility;
+  - malformed envelope and underlying closed-storage errors;
+  - durable/relaxed mode gates, checkpoint plus close/reopen, and durable child
+    process crash recovery without `Close`;
+  - deterministic randomized comparison with an in-memory MVCC oracle;
+  - concurrent readers under the race detector.
+- `TreeDB/mvcc/mvcc_bench_test.go`:
+  - single and 32-key `CommitAt` versus an equivalent direct TreeDB batch;
+  - `GetAt` versus an equivalent direct bounded seek at version depths 1, 8,
+    and 64, including allocation counts.
+
+The raw regression gate uses unchanged existing point/batch benchmarks from the
+same base and head. Because `TreeDB/mvcc` is opt-in and not called by raw APIs,
+any repeatable raw-path regression or allocation increase blocks closeout.
+
 ## 11. Collections Native Fast Path
 
 Invariant:

--- a/TreeDB/docs/spec/verification.md
+++ b/TreeDB/docs/spec/verification.md
@@ -292,7 +292,8 @@ Invariants:
 - durable commits require durable TreeDB mode and survive a process crash;
   relaxed commits require a later checkpoint/close boundary for reopen proof;
 - storage failures may leave the whole batch present or absent but never leave
-  a visible prefix; malformed records and storage errors fail explicitly;
+  a visible prefix; malformed records fail with `ErrMalformedRecord`, while
+  storage errors wrap `ErrStorage` and their underlying cause;
 - raw TreeDB and `EntryRevision` paths do not invoke this opt-in layer.
 
 Coverage:

--- a/TreeDB/docs/spec/write-path-and-durability.md
+++ b/TreeDB/docs/spec/write-path-and-durability.md
@@ -197,7 +197,28 @@ must remain outside that final serialized boundary.
 
 - `SetSync`, `DeleteSync`, `Batch.WriteSync`: in durable mode, fsync durability boundary; in relaxed modes, relaxed boundary only.
 
-### 5.3 Collection API Durability
+### 5.3 External-version MVCC commits
+
+The opt-in `TreeDB/mvcc.Store.CommitAt` stages every encoded put/tombstone for a
+caller timestamp into one raw TreeDB batch. Validation and duplicate detection
+finish before batch creation. A staging error closes the unwritten batch; a
+commit error may be ambiguous as to whether the whole batch published, but
+partial visibility is forbidden by the underlying batch boundary.
+
+- `CommitRelaxed` calls `Batch.Write`. It is an atomic visibility boundary, not
+  an fsync promise. Survival follows the configured relaxed mode and later
+  checkpoint/close boundaries.
+- `CommitDurable` fails with `ErrDurabilityUnavailable` unless the handle's
+  effective mode is `DurabilityDurable`, then calls `Batch.WriteSync`. A nil
+  return covers the configured WAL/value payload fsync recovery boundary; it
+  does not force an immediate backend-root checkpoint.
+- Empty mutation lists are no-ops and do not manufacture a sync boundary.
+
+External timestamps are key bytes in the reserved MVCC subspace. They neither
+select TreeDB's internal commit sequence nor invoke conditional transactions;
+the caller owns conflict detection and timestamp assignment.
+
+### 5.4 Collection API Durability
 
 Collection mutators do not have separate `*Sync` Go methods. Their baseline
 acknowledgement is mode-dependent. Current shipped collection write-domain

--- a/TreeDB/docs/spec/write-path-and-durability.md
+++ b/TreeDB/docs/spec/write-path-and-durability.md
@@ -212,7 +212,9 @@ partial visibility is forbidden by the underlying batch boundary.
   effective mode is `DurabilityDurable`, then calls `Batch.WriteSync`. A nil
   return covers the configured WAL/value payload fsync recovery boundary; it
   does not force an immediate backend-root checkpoint.
-- Empty mutation lists are no-ops and do not manufacture a sync boundary.
+- After timestamp/mode and non-nil Store validation, empty mutation lists are
+  no-ops: they do not access storage, probe the handle's open/durability state,
+  or manufacture a sync boundary.
 
 External timestamps are key bytes in the reserved MVCC subspace. They neither
 select TreeDB's internal commit sequence nor invoke conditional transactions;

--- a/TreeDB/mvcc/mvcc.go
+++ b/TreeDB/mvcc/mvcc.go
@@ -131,7 +131,14 @@ func (s *Store) CommitAt(timestamp uint64, mutations []Mutation, mode CommitMode
 	}
 	for i := range mutations {
 		mutation := &mutations[i]
+		physical, err := mvcckey.Encode(mutation.Key, timestamp)
+		if err != nil {
+			return fmt.Errorf("%w at key index %d: %w", ErrInvalidKey, i, err)
+		}
 		if seen != nil {
+			// Encode validates the bounded codec envelope before the caller key is
+			// copied into duplicate-detection state. Reuse physical below so this
+			// validation does not introduce a second encoding pass.
 			identity := string(mutation.Key)
 			if _, exists := seen[identity]; exists {
 				return fmt.Errorf("%w: key index %d", ErrDuplicateKey, i)
@@ -139,10 +146,6 @@ func (s *Store) CommitAt(timestamp uint64, mutations []Mutation, mode CommitMode
 			seen[identity] = struct{}{}
 		}
 
-		physical, err := mvcckey.Encode(mutation.Key, timestamp)
-		if err != nil {
-			return fmt.Errorf("%w at key index %d: %w", ErrInvalidKey, i, err)
-		}
 		staged[i].physical = physical
 		if mutation.Delete {
 			staged[i].record = []byte{recordTombstoneV1}

--- a/TreeDB/mvcc/mvcc.go
+++ b/TreeDB/mvcc/mvcc.go
@@ -1,0 +1,243 @@
+// Package mvcc provides an opt-in external-timestamp MVCC layer over TreeDB.
+//
+// A Store owns TreeDB's reserved external-MVCC physical-key namespace. Mixing
+// unrelated raw TreeDB writes into that namespace is unsupported. The package
+// is pre-alpha: its API and on-disk record format may change without migration.
+package mvcc
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"strings"
+
+	treedb "github.com/snissn/gomap/TreeDB"
+	"github.com/snissn/gomap/TreeDB/internal/mvcckey"
+)
+
+// CommitMode selects the acknowledgement and durability boundary for CommitAt.
+type CommitMode uint8
+
+const (
+	// CommitRelaxed publishes one atomic TreeDB batch with Batch.Write. It does
+	// not promise an fsync boundary and may be lost after a crash.
+	CommitRelaxed CommitMode = iota
+	// CommitDurable requires a TreeDB opened in DurabilityDurable mode and
+	// publishes one atomic batch with Batch.WriteSync.
+	CommitDurable
+)
+
+// Mutation is one logical-key mutation in a CommitAt batch. Delete selects a
+// tombstone; otherwise Value is stored verbatim, including nil/empty values.
+type Mutation struct {
+	Key    []byte
+	Value  []byte
+	Delete bool
+}
+
+// ReadState identifies the visibility result returned by GetAt.
+type ReadState uint8
+
+const (
+	// Absent means no retained version exists at or below the read timestamp.
+	Absent ReadState = iota
+	// Present means Value and Timestamp describe the visible retained value.
+	Present
+	// Tombstone means Timestamp identifies the visible deletion marker.
+	Tombstone
+)
+
+// Result is the newest retained version visible at a requested timestamp.
+// Value is a caller-owned copy for Present results.
+type Result struct {
+	State     ReadState
+	Value     []byte
+	Timestamp uint64
+}
+
+var (
+	ErrZeroTimestamp         = errors.New("mvcc: timestamp zero is reserved")
+	ErrDuplicateKey          = errors.New("mvcc: duplicate logical key in batch")
+	ErrInvalidCommitMode     = errors.New("mvcc: invalid commit mode")
+	ErrDurabilityUnavailable = errors.New("mvcc: durable commit requires durable TreeDB mode")
+	ErrInvalidKey            = errors.New("mvcc: invalid logical key")
+	ErrMalformedRecord       = errors.New("mvcc: malformed physical record")
+)
+
+const (
+	recordValueV1     byte = 0x01
+	recordTombstoneV1 byte = 0x02
+)
+
+type treeDB interface {
+	Iterator(start, end []byte) (treedb.Iterator, error)
+	NewBatchWithSize(size int) treedb.Batch
+	DurabilityMode() string
+}
+
+// Store owns the external-version namespace of one TreeDB handle.
+type Store struct {
+	db treeDB
+}
+
+// New returns an opt-in MVCC store over db. Callers must not use raw writes in
+// the reserved MVCC namespace while the Store owns it.
+func New(db *treedb.DB) *Store {
+	return newStore(db)
+}
+
+func newStore(db treeDB) *Store {
+	return &Store{db: db}
+}
+
+// CommitAt atomically writes all mutations at one caller-assigned timestamp.
+//
+// Duplicate logical keys, including nil and empty keys (which are the same
+// logical key), are rejected before a TreeDB batch is created. This deliberately
+// avoids an order-dependent last-write-wins policy. Empty batches are no-ops.
+// A returned storage error can be commit-ambiguous, but visibility is always
+// whole-batch: readers may see all mutations or none, never a prefix.
+func (s *Store) CommitAt(timestamp uint64, mutations []Mutation, mode CommitMode) error {
+	if timestamp == 0 {
+		return ErrZeroTimestamp
+	}
+	if mode != CommitRelaxed && mode != CommitDurable {
+		return ErrInvalidCommitMode
+	}
+	if s == nil || s.db == nil {
+		return fmt.Errorf("mvcc: create batch: %w", treedb.ErrClosed)
+	}
+	if mode == CommitDurable && !durableTreeDBMode(s.db.DurabilityMode()) {
+		return fmt.Errorf("%w: configured mode %q", ErrDurabilityUnavailable, s.db.DurabilityMode())
+	}
+	if len(mutations) == 0 {
+		return nil
+	}
+
+	type stagedMutation struct {
+		physical []byte
+		record   []byte
+	}
+	staged := make([]stagedMutation, len(mutations))
+	var seen map[string]struct{}
+	if len(mutations) > 1 {
+		seen = make(map[string]struct{}, len(mutations))
+	}
+	for i := range mutations {
+		mutation := &mutations[i]
+		if seen != nil {
+			identity := string(mutation.Key)
+			if _, exists := seen[identity]; exists {
+				return fmt.Errorf("%w: key index %d", ErrDuplicateKey, i)
+			}
+			seen[identity] = struct{}{}
+		}
+
+		physical, err := mvcckey.Encode(mutation.Key, timestamp)
+		if err != nil {
+			return fmt.Errorf("%w at key index %d: %w", ErrInvalidKey, i, err)
+		}
+		staged[i].physical = physical
+		if mutation.Delete {
+			staged[i].record = []byte{recordTombstoneV1}
+			continue
+		}
+		record := make([]byte, 1+len(mutation.Value))
+		record[0] = recordValueV1
+		copy(record[1:], mutation.Value)
+		staged[i].record = record
+	}
+
+	batch := s.db.NewBatchWithSize(len(staged))
+	if batch == nil {
+		return fmt.Errorf("mvcc: create batch: %w", treedb.ErrClosed)
+	}
+	for i := range staged {
+		if err := batch.Set(staged[i].physical, staged[i].record); err != nil {
+			return errors.Join(fmt.Errorf("mvcc: stage key index %d: %w", i, err), batch.Close())
+		}
+	}
+
+	var err error
+	if mode == CommitDurable {
+		err = batch.WriteSync()
+	} else {
+		err = batch.Write()
+	}
+	if err != nil {
+		err = fmt.Errorf("mvcc: commit batch: %w", err)
+	}
+	return errors.Join(err, batch.Close())
+}
+
+// GetAt returns the newest retained version of logical at or below timestamp.
+// The lookup constructs an exact lower bound at timestamp and seeks TreeDB
+// directly into that key/time region; it does not materialize key history.
+func (s *Store) GetAt(logical []byte, timestamp uint64) (result Result, err error) {
+	if timestamp == 0 {
+		return Result{}, ErrZeroTimestamp
+	}
+	if s == nil || s.db == nil {
+		return Result{}, fmt.Errorf("mvcc: open iterator: %w", treedb.ErrClosed)
+	}
+
+	lower, err := mvcckey.Encode(logical, timestamp)
+	if err != nil {
+		return Result{}, fmt.Errorf("%w: %w", ErrInvalidKey, err)
+	}
+	upper, err := mvcckey.AppendKeyVersionsUpper(nil, logical)
+	if err != nil {
+		return Result{}, fmt.Errorf("%w: %w", ErrInvalidKey, err)
+	}
+	it, err := s.db.Iterator(lower, upper)
+	if err != nil {
+		return Result{}, fmt.Errorf("mvcc: open iterator: %w", err)
+	}
+	defer func() {
+		if closeErr := it.Close(); closeErr != nil {
+			err = errors.Join(err, fmt.Errorf("mvcc: close iterator: %w", closeErr))
+		}
+	}()
+
+	if !it.Valid() {
+		if iterErr := it.Error(); iterErr != nil {
+			return Result{}, fmt.Errorf("mvcc: iterate: %w", iterErr)
+		}
+		return Result{State: Absent}, nil
+	}
+
+	physical := it.Key()
+	decoded, version, decodeErr := mvcckey.Decode(physical)
+	if decodeErr != nil || !bytes.Equal(decoded, logical) || version > timestamp {
+		if decodeErr == nil {
+			decodeErr = errors.New("decoded key or timestamp is outside requested bound")
+		}
+		return Result{}, fmt.Errorf("%w: %w", ErrMalformedRecord, decodeErr)
+	}
+	record := it.Value()
+	if iterErr := it.Error(); iterErr != nil {
+		return Result{}, fmt.Errorf("mvcc: read value: %w", iterErr)
+	}
+	if len(record) == 0 {
+		return Result{}, fmt.Errorf("%w: empty value envelope", ErrMalformedRecord)
+	}
+	switch record[0] {
+	case recordValueV1:
+		return Result{
+			State:     Present,
+			Value:     append([]byte(nil), record[1:]...),
+			Timestamp: version,
+		}, nil
+	case recordTombstoneV1:
+		if len(record) != 1 {
+			return Result{}, fmt.Errorf("%w: tombstone has payload", ErrMalformedRecord)
+		}
+		return Result{State: Tombstone, Timestamp: version}, nil
+	default:
+		return Result{}, fmt.Errorf("%w: unknown envelope tag 0x%02x", ErrMalformedRecord, record[0])
+	}
+}
+
+func durableTreeDBMode(mode string) bool {
+	return mode == "wal_on_sync" || strings.HasPrefix(mode, "wal_on_sync+")
+}

--- a/TreeDB/mvcc/mvcc.go
+++ b/TreeDB/mvcc/mvcc.go
@@ -99,6 +99,8 @@ func newStore(db treeDB) *Store {
 // Duplicate logical keys, including nil and empty keys (which are the same
 // logical key), are rejected before a TreeDB batch is created. This deliberately
 // avoids an order-dependent last-write-wins policy. Empty batches are no-ops.
+// After timestamp, mode, and non-nil Store validation, an empty batch returns
+// without accessing TreeDB or checking its configured durability/open state.
 // A returned storage error can be commit-ambiguous, but visibility is always
 // whole-batch: readers may see all mutations or none, never a prefix.
 func (s *Store) CommitAt(timestamp uint64, mutations []Mutation, mode CommitMode) error {
@@ -111,11 +113,11 @@ func (s *Store) CommitAt(timestamp uint64, mutations []Mutation, mode CommitMode
 	if s == nil || s.db == nil {
 		return storageError("create batch", treedb.ErrClosed)
 	}
-	if mode == CommitDurable && !durableTreeDBMode(s.db.DurabilityMode()) {
-		return fmt.Errorf("%w: configured mode %q", ErrDurabilityUnavailable, s.db.DurabilityMode())
-	}
 	if len(mutations) == 0 {
 		return nil
+	}
+	if mode == CommitDurable && !durableTreeDBMode(s.db.DurabilityMode()) {
+		return fmt.Errorf("%w: configured mode %q", ErrDurabilityUnavailable, s.db.DurabilityMode())
 	}
 
 	type stagedMutation struct {

--- a/TreeDB/mvcc/mvcc.go
+++ b/TreeDB/mvcc/mvcc.go
@@ -62,6 +62,7 @@ var (
 	ErrDurabilityUnavailable = errors.New("mvcc: durable commit requires durable TreeDB mode")
 	ErrInvalidKey            = errors.New("mvcc: invalid logical key")
 	ErrMalformedRecord       = errors.New("mvcc: malformed physical record")
+	ErrStorage               = errors.New("mvcc: storage error")
 )
 
 const (
@@ -83,6 +84,9 @@ type Store struct {
 // New returns an opt-in MVCC store over db. Callers must not use raw writes in
 // the reserved MVCC namespace while the Store owns it.
 func New(db *treedb.DB) *Store {
+	if db == nil {
+		return &Store{}
+	}
 	return newStore(db)
 }
 
@@ -105,7 +109,7 @@ func (s *Store) CommitAt(timestamp uint64, mutations []Mutation, mode CommitMode
 		return ErrInvalidCommitMode
 	}
 	if s == nil || s.db == nil {
-		return fmt.Errorf("mvcc: create batch: %w", treedb.ErrClosed)
+		return storageError("create batch", treedb.ErrClosed)
 	}
 	if mode == CommitDurable && !durableTreeDBMode(s.db.DurabilityMode()) {
 		return fmt.Errorf("%w: configured mode %q", ErrDurabilityUnavailable, s.db.DurabilityMode())
@@ -150,11 +154,12 @@ func (s *Store) CommitAt(timestamp uint64, mutations []Mutation, mode CommitMode
 
 	batch := s.db.NewBatchWithSize(len(staged))
 	if batch == nil {
-		return fmt.Errorf("mvcc: create batch: %w", treedb.ErrClosed)
+		return storageError("create batch", treedb.ErrClosed)
 	}
 	for i := range staged {
 		if err := batch.Set(staged[i].physical, staged[i].record); err != nil {
-			return errors.Join(fmt.Errorf("mvcc: stage key index %d: %w", i, err), batch.Close())
+			stageErr := storageError(fmt.Sprintf("stage key index %d", i), err)
+			return errors.Join(stageErr, storageError("close batch", batch.Close()))
 		}
 	}
 
@@ -165,9 +170,9 @@ func (s *Store) CommitAt(timestamp uint64, mutations []Mutation, mode CommitMode
 		err = batch.Write()
 	}
 	if err != nil {
-		err = fmt.Errorf("mvcc: commit batch: %w", err)
+		err = storageError("commit batch", err)
 	}
-	return errors.Join(err, batch.Close())
+	return errors.Join(err, storageError("close batch", batch.Close()))
 }
 
 // GetAt returns the newest retained version of logical at or below timestamp.
@@ -178,7 +183,7 @@ func (s *Store) GetAt(logical []byte, timestamp uint64) (result Result, err erro
 		return Result{}, ErrZeroTimestamp
 	}
 	if s == nil || s.db == nil {
-		return Result{}, fmt.Errorf("mvcc: open iterator: %w", treedb.ErrClosed)
+		return Result{}, storageError("open iterator", treedb.ErrClosed)
 	}
 
 	lower, err := mvcckey.Encode(logical, timestamp)
@@ -191,17 +196,17 @@ func (s *Store) GetAt(logical []byte, timestamp uint64) (result Result, err erro
 	}
 	it, err := s.db.Iterator(lower, upper)
 	if err != nil {
-		return Result{}, fmt.Errorf("mvcc: open iterator: %w", err)
+		return Result{}, storageError("open iterator", err)
 	}
 	defer func() {
 		if closeErr := it.Close(); closeErr != nil {
-			err = errors.Join(err, fmt.Errorf("mvcc: close iterator: %w", closeErr))
+			err = errors.Join(err, storageError("close iterator", closeErr))
 		}
 	}()
 
 	if !it.Valid() {
 		if iterErr := it.Error(); iterErr != nil {
-			return Result{}, fmt.Errorf("mvcc: iterate: %w", iterErr)
+			return Result{}, storageError("iterate", iterErr)
 		}
 		return Result{State: Absent}, nil
 	}
@@ -216,7 +221,7 @@ func (s *Store) GetAt(logical []byte, timestamp uint64) (result Result, err erro
 	}
 	record := it.Value()
 	if iterErr := it.Error(); iterErr != nil {
-		return Result{}, fmt.Errorf("mvcc: read value: %w", iterErr)
+		return Result{}, storageError("read value", iterErr)
 	}
 	if len(record) == 0 {
 		return Result{}, fmt.Errorf("%w: empty value envelope", ErrMalformedRecord)
@@ -240,4 +245,11 @@ func (s *Store) GetAt(logical []byte, timestamp uint64) (result Result, err erro
 
 func durableTreeDBMode(mode string) bool {
 	return mode == "wal_on_sync" || strings.HasPrefix(mode, "wal_on_sync+")
+}
+
+func storageError(operation string, err error) error {
+	if err == nil {
+		return nil
+	}
+	return fmt.Errorf("%w: %s: %w", ErrStorage, operation, err)
 }

--- a/TreeDB/mvcc/mvcc_bench_test.go
+++ b/TreeDB/mvcc/mvcc_bench_test.go
@@ -1,0 +1,125 @@
+package mvcc
+
+import (
+	"fmt"
+	"testing"
+
+	treedb "github.com/snissn/gomap/TreeDB"
+	"github.com/snissn/gomap/TreeDB/internal/mvcckey"
+)
+
+func openBenchDB(b *testing.B) *treedb.DB {
+	b.Helper()
+	db := openTestDB(b, b.TempDir(), treedb.DurabilityWALOffRelaxed)
+	b.Cleanup(func() { _ = db.Close() })
+	return db
+}
+
+func BenchmarkCommitAt(b *testing.B) {
+	for _, batchSize := range []int{1, 32} {
+		b.Run(fmt.Sprintf("DirectTreeDB/%d", batchSize), func(b *testing.B) {
+			db := openBenchDB(b)
+			value := []byte("value")
+			logicalKeys := make([][]byte, batchSize)
+			for i := range logicalKeys {
+				logicalKeys[i] = []byte(fmt.Sprintf("key-%03d", i))
+			}
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				write := db.NewBatchWithSize(batchSize)
+				for keyIndex := 0; keyIndex < batchSize; keyIndex++ {
+					key, err := mvcckey.Encode(logicalKeys[keyIndex], uint64(i+1))
+					if err != nil {
+						b.Fatal(err)
+					}
+					if err := write.Set(key, append([]byte{recordValueV1}, value...)); err != nil {
+						b.Fatal(err)
+					}
+				}
+				if err := write.Write(); err != nil {
+					b.Fatal(err)
+				}
+				if err := write.Close(); err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+		b.Run(fmt.Sprintf("MVCC/%d", batchSize), func(b *testing.B) {
+			db := openBenchDB(b)
+			store := New(db)
+			mutations := make([]Mutation, batchSize)
+			for i := range mutations {
+				mutations[i] = Mutation{Key: []byte(fmt.Sprintf("key-%03d", i)), Value: []byte("value")}
+			}
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				if err := store.CommitAt(uint64(i+1), mutations, CommitRelaxed); err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	}
+}
+
+func BenchmarkGetAt(b *testing.B) {
+	for _, depth := range []int{1, 8, 64} {
+		b.Run(fmt.Sprintf("DirectSeek/%d", depth), func(b *testing.B) {
+			db, key := prepareGetAtBench(b, depth)
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				value, err := directSeek(db, key, uint64(depth+1))
+				if err != nil || len(value) == 0 {
+					b.Fatalf("directSeek value=%q err=%v", value, err)
+				}
+			}
+		})
+		b.Run(fmt.Sprintf("MVCC/%d", depth), func(b *testing.B) {
+			db, key := prepareGetAtBench(b, depth)
+			store := New(db)
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				result, err := store.GetAt(key, uint64(depth+1))
+				if err != nil || result.State != Present || len(result.Value) == 0 {
+					b.Fatalf("GetAt result=%+v err=%v", result, err)
+				}
+			}
+		})
+	}
+}
+
+func prepareGetAtBench(b *testing.B, depth int) (*treedb.DB, []byte) {
+	b.Helper()
+	db := openBenchDB(b)
+	store := New(db)
+	key := []byte("benchmark-key")
+	for timestamp := 1; timestamp <= depth; timestamp++ {
+		if err := store.CommitAt(uint64(timestamp), []Mutation{{Key: key, Value: []byte("value")}}, CommitRelaxed); err != nil {
+			b.Fatalf("prepare CommitAt: %v", err)
+		}
+	}
+	return db, key
+}
+
+func directSeek(db *treedb.DB, logical []byte, timestamp uint64) ([]byte, error) {
+	lower, err := mvcckey.Encode(logical, timestamp)
+	if err != nil {
+		return nil, err
+	}
+	upper, err := mvcckey.AppendKeyVersionsUpper(nil, logical)
+	if err != nil {
+		return nil, err
+	}
+	it, err := db.Iterator(lower, upper)
+	if err != nil {
+		return nil, err
+	}
+	defer it.Close()
+	if !it.Valid() {
+		return nil, it.Error()
+	}
+	return it.ValueCopy(nil), nil
+}

--- a/TreeDB/mvcc/mvcc_test.go
+++ b/TreeDB/mvcc/mvcc_test.go
@@ -9,7 +9,9 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strconv"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -125,6 +127,38 @@ func TestCommitAtValidationPrecedesStorageWrite(t *testing.T) {
 	if got := spy.created.Load(); got != 0 {
 		t.Fatalf("batches created after validation failures = %d, want 0", got)
 	}
+}
+
+func TestCommitAtOversizedKeyRejectsBeforeDuplicateIdentityAllocation(t *testing.T) {
+	spy := &validationSpyDB{}
+	store := newStore(spy)
+	oversized := make([]byte, 16<<20)
+	mutations := []Mutation{
+		{Key: []byte("valid-before-oversized"), Value: []byte("must-not-publish")},
+		{Key: oversized, Value: []byte("invalid")},
+		{Key: []byte("valid-after-oversized"), Value: []byte("must-not-publish")},
+	}
+
+	runtime.GC()
+	var before, after runtime.MemStats
+	runtime.ReadMemStats(&before)
+	err := store.CommitAt(1, mutations, CommitRelaxed)
+	runtime.ReadMemStats(&after)
+	if !errors.Is(err, ErrInvalidKey) || !strings.Contains(err.Error(), "key index 1") {
+		t.Fatalf("oversized multi-mutation error = %v, want ErrInvalidKey at index 1", err)
+	}
+	if got := spy.created.Load(); got != 0 {
+		t.Fatalf("batches created after oversized-key rejection = %d, want 0", got)
+	}
+	// The 16 MiB caller-owned key is intentionally much larger than the codec
+	// envelope. Rejecting it must not copy it into duplicate-detection state.
+	// TotalAlloc remains useful after the temporary state is freed; a retained
+	// []byte-to-string conversion before validation would add at least 16 MiB.
+	allocated := after.TotalAlloc - before.TotalAlloc
+	if allocated > 2<<20 {
+		t.Fatalf("oversized-key validation allocated %d bytes, want <= %d", allocated, 2<<20)
+	}
+	t.Logf("oversized-key validation allocated %d bytes without creating a batch", allocated)
 }
 
 func TestCommitAtInjectedFailureIsAllOrNone(t *testing.T) {
@@ -429,6 +463,23 @@ type batchSpyDB struct {
 	created atomic.Int64
 }
 
+type validationSpyDB struct {
+	created atomic.Int64
+}
+
+func (*validationSpyDB) Iterator(_, _ []byte) (treedb.Iterator, error) {
+	panic("Iterator must not be called during CommitAt validation")
+}
+
+func (db *validationSpyDB) NewBatchWithSize(_ int) treedb.Batch {
+	db.created.Add(1)
+	panic("NewBatchWithSize must not be called during CommitAt validation")
+}
+
+func (*validationSpyDB) DurabilityMode() string {
+	return string(treedb.DurabilityWALOffRelaxed)
+}
+
 func (db *batchSpyDB) NewBatchWithSize(size int) treedb.Batch {
 	db.created.Add(1)
 	return db.DB.NewBatchWithSize(size)
@@ -505,3 +556,4 @@ func (b *stageFailureBatch) Set(key, value []byte) error {
 // contract instead of testing a narrower fake API.
 var _ treedb.Batch = (*writeFailureBatch)(nil)
 var _ treedb.Batch = (*stageFailureBatch)(nil)
+var _ treeDB = (*validationSpyDB)(nil)

--- a/TreeDB/mvcc/mvcc_test.go
+++ b/TreeDB/mvcc/mvcc_test.go
@@ -142,6 +142,9 @@ func TestCommitAtInjectedFailureIsAllOrNone(t *testing.T) {
 			if !errors.Is(err, injected) {
 				t.Fatalf("CommitAt error = %v, want injected", err)
 			}
+			if !errors.Is(err, ErrStorage) {
+				t.Fatalf("CommitAt error = %v, want ErrStorage", err)
+			}
 			want := Absent
 			if afterCommit {
 				want = Present
@@ -218,8 +221,18 @@ func TestGetAtMalformedAndStorageErrors(t *testing.T) {
 	if err := db.Close(); err != nil {
 		t.Fatalf("Close: %v", err)
 	}
-	if _, err := store.GetAt([]byte("bad-value"), 9); !errors.Is(err, treedb.ErrClosed) {
-		t.Fatalf("GetAt closed error=%v want ErrClosed", err)
+	if _, err := store.GetAt([]byte("bad-value"), 9); !errors.Is(err, treedb.ErrClosed) || !errors.Is(err, ErrStorage) {
+		t.Fatalf("GetAt closed error=%v want ErrStorage wrapping ErrClosed", err)
+	}
+}
+
+func TestNilStoreReturnsStorageErrors(t *testing.T) {
+	store := New(nil)
+	if err := store.CommitAt(1, []Mutation{{Key: []byte("k")}}, CommitRelaxed); !errors.Is(err, ErrStorage) || !errors.Is(err, treedb.ErrClosed) {
+		t.Fatalf("CommitAt nil store error=%v", err)
+	}
+	if _, err := store.GetAt([]byte("k"), 1); !errors.Is(err, ErrStorage) || !errors.Is(err, treedb.ErrClosed) {
+		t.Fatalf("GetAt nil store error=%v", err)
 	}
 }
 

--- a/TreeDB/mvcc/mvcc_test.go
+++ b/TreeDB/mvcc/mvcc_test.go
@@ -1,0 +1,482 @@
+package mvcc
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"math"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	treedb "github.com/snissn/gomap/TreeDB"
+	"github.com/snissn/gomap/TreeDB/internal/mvcckey"
+)
+
+func openTestDB(t testing.TB, dir string, durability treedb.DurabilityMode) *treedb.DB {
+	t.Helper()
+	db, err := treedb.Open(treedb.Options{
+		Dir:                          dir,
+		Durability:                   durability,
+		CommandWAL:                   durability != treedb.DurabilityWALOffRelaxed,
+		DisableSideStores:            true,
+		BackgroundCheckpointInterval: -1,
+	})
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	return db
+}
+
+func requireResult(t testing.TB, store *Store, key []byte, readTimestamp uint64, state ReadState, version uint64, value []byte) {
+	t.Helper()
+	got, err := store.GetAt(key, readTimestamp)
+	if err != nil {
+		t.Fatalf("GetAt(%q,%d): %v", key, readTimestamp, err)
+	}
+	if got.State != state || got.Timestamp != version || !bytes.Equal(got.Value, value) {
+		t.Fatalf("GetAt(%q,%d) = {state:%d ts:%d value:%q}, want {state:%d ts:%d value:%q}", key, readTimestamp, got.State, got.Timestamp, got.Value, state, version, value)
+	}
+}
+
+func TestCommitAtGetAtGoldenHistories(t *testing.T) {
+	db := openTestDB(t, t.TempDir(), treedb.DurabilityDurable)
+	defer db.Close()
+	store := New(db)
+	key := []byte{'k', 0, 'x'}
+
+	if err := store.CommitAt(10, []Mutation{{Key: key, Value: []byte("ten")}}, CommitRelaxed); err != nil {
+		t.Fatalf("CommitAt(10): %v", err)
+	}
+	if err := store.CommitAt(30, []Mutation{{Key: key, Value: []byte("thirty")}}, CommitRelaxed); err != nil {
+		t.Fatalf("CommitAt(30): %v", err)
+	}
+	if err := store.CommitAt(40, []Mutation{{Key: key, Delete: true}}, CommitRelaxed); err != nil {
+		t.Fatalf("CommitAt(40 tombstone): %v", err)
+	}
+	if err := store.CommitAt(50, []Mutation{{Key: key, Value: nil}}, CommitRelaxed); err != nil {
+		t.Fatalf("CommitAt(50 empty): %v", err)
+	}
+
+	requireResult(t, store, key, 1, Absent, 0, nil)
+	requireResult(t, store, key, 10, Present, 10, []byte("ten"))
+	requireResult(t, store, key, 20, Present, 10, []byte("ten"))
+	requireResult(t, store, key, 30, Present, 30, []byte("thirty"))
+	requireResult(t, store, key, 40, Tombstone, 40, nil)
+	requireResult(t, store, key, 49, Tombstone, 40, nil)
+	requireResult(t, store, key, math.MaxUint64, Present, 50, []byte{})
+
+	// Separate commits at the same logical key/timestamp address one physical
+	// version. The later successful atomic commit deterministically replaces it.
+	if err := store.CommitAt(30, []Mutation{{Key: key, Value: []byte("thirty-replaced")}}, CommitRelaxed); err != nil {
+		t.Fatalf("CommitAt duplicate timestamp: %v", err)
+	}
+	requireResult(t, store, key, 30, Present, 30, []byte("thirty-replaced"))
+}
+
+func TestCommitAtMultiKeyAtomicAndDuplicatePolicy(t *testing.T) {
+	db := openTestDB(t, t.TempDir(), treedb.DurabilityDurable)
+	defer db.Close()
+	store := New(db)
+
+	mutations := []Mutation{
+		{Key: nil, Value: []byte("empty")},
+		{Key: []byte("b"), Value: []byte("bee")},
+		{Key: []byte("c"), Delete: true},
+	}
+	if err := store.CommitAt(7, mutations, CommitRelaxed); err != nil {
+		t.Fatalf("CommitAt: %v", err)
+	}
+	requireResult(t, store, []byte{}, 7, Present, 7, []byte("empty"))
+	requireResult(t, store, []byte("b"), 7, Present, 7, []byte("bee"))
+	requireResult(t, store, []byte("c"), 7, Tombstone, 7, nil)
+
+	err := store.CommitAt(8, []Mutation{
+		{Key: nil, Value: []byte("first")},
+		{Key: []byte{}, Delete: true},
+	}, CommitRelaxed)
+	if !errors.Is(err, ErrDuplicateKey) {
+		t.Fatalf("duplicate error = %v, want ErrDuplicateKey", err)
+	}
+	requireResult(t, store, nil, 8, Present, 7, []byte("empty"))
+}
+
+func TestCommitAtValidationPrecedesStorageWrite(t *testing.T) {
+	db := openTestDB(t, t.TempDir(), treedb.DurabilityDurable)
+	defer db.Close()
+	spy := &batchSpyDB{DB: db}
+	store := newStore(spy)
+
+	if err := store.CommitAt(0, []Mutation{{Key: []byte("k")}}, CommitRelaxed); !errors.Is(err, ErrZeroTimestamp) {
+		t.Fatalf("zero timestamp error = %v", err)
+	}
+	if err := store.CommitAt(1, []Mutation{{Key: []byte("k")}}, CommitMode(99)); !errors.Is(err, ErrInvalidCommitMode) {
+		t.Fatalf("invalid mode error = %v", err)
+	}
+	tooLarge := bytes.Repeat([]byte{0}, mvcckey.MaxEncodedKeySize)
+	if err := store.CommitAt(1, []Mutation{{Key: tooLarge}}, CommitRelaxed); !errors.Is(err, ErrInvalidKey) {
+		t.Fatalf("oversized key error = %v", err)
+	}
+	if got := spy.created.Load(); got != 0 {
+		t.Fatalf("batches created after validation failures = %d, want 0", got)
+	}
+}
+
+func TestCommitAtInjectedFailureIsAllOrNone(t *testing.T) {
+	for _, afterCommit := range []bool{false, true} {
+		t.Run(fmt.Sprintf("after_commit_%t", afterCommit), func(t *testing.T) {
+			dir := t.TempDir()
+			db := openTestDB(t, dir, treedb.DurabilityDurable)
+			injected := errors.New("injected batch failure")
+			writer := newStore(&writeFailureDB{DB: db, afterCommit: afterCommit, err: injected})
+			reader := New(db)
+			err := writer.CommitAt(11, []Mutation{
+				{Key: []byte("a"), Value: []byte("A")},
+				{Key: []byte("b"), Value: []byte("B")},
+			}, CommitRelaxed)
+			if !errors.Is(err, injected) {
+				t.Fatalf("CommitAt error = %v, want injected", err)
+			}
+			want := Absent
+			if afterCommit {
+				want = Present
+			}
+			for _, key := range []string{"a", "b"} {
+				got, getErr := reader.GetAt([]byte(key), 11)
+				if getErr != nil {
+					t.Fatalf("GetAt(%q): %v", key, getErr)
+				}
+				if got.State != want {
+					t.Fatalf("GetAt(%q).State=%d want %d", key, got.State, want)
+				}
+			}
+			if err := db.Close(); err != nil {
+				t.Fatalf("Close after injected failure: %v", err)
+			}
+			db = openTestDB(t, dir, treedb.DurabilityDurable)
+			defer db.Close()
+			reader = New(db)
+			for _, key := range []string{"a", "b"} {
+				got, getErr := reader.GetAt([]byte(key), 11)
+				if getErr != nil {
+					t.Fatalf("reopened GetAt(%q): %v", key, getErr)
+				}
+				if got.State != want {
+					t.Fatalf("reopened GetAt(%q).State=%d want %d", key, got.State, want)
+				}
+			}
+		})
+	}
+}
+
+func TestCommitAtInjectedStagingFailurePublishesNothing(t *testing.T) {
+	db := openTestDB(t, t.TempDir(), treedb.DurabilityDurable)
+	defer db.Close()
+	injected := errors.New("injected staging failure")
+	writer := newStore(&stageFailureDB{DB: db, failAt: 1, err: injected})
+	err := writer.CommitAt(12, []Mutation{
+		{Key: []byte("a"), Value: []byte("A")},
+		{Key: []byte("b"), Value: []byte("B")},
+	}, CommitRelaxed)
+	if !errors.Is(err, injected) {
+		t.Fatalf("CommitAt error=%v want injected", err)
+	}
+	reader := New(db)
+	requireResult(t, reader, []byte("a"), 12, Absent, 0, nil)
+	requireResult(t, reader, []byte("b"), 12, Absent, 0, nil)
+}
+
+func TestGetAtMalformedAndStorageErrors(t *testing.T) {
+	db := openTestDB(t, t.TempDir(), treedb.DurabilityDurable)
+	store := New(db)
+	physical, err := mvcckey.Encode([]byte("bad-value"), 9)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := db.Set(physical, []byte{recordTombstoneV1, 0xff}); err != nil {
+		t.Fatalf("raw malformed Set: %v", err)
+	}
+	if _, err := store.GetAt([]byte("bad-value"), 9); !errors.Is(err, ErrMalformedRecord) {
+		t.Fatalf("GetAt malformed value error=%v want ErrMalformedRecord", err)
+	}
+	physical, err = mvcckey.Encode([]byte("bad-key"), 9)
+	if err != nil {
+		t.Fatal(err)
+	}
+	physical = append(physical, 0x00)
+	if err := db.Set(physical, []byte{recordValueV1, 'x'}); err != nil {
+		t.Fatalf("raw malformed key Set: %v", err)
+	}
+	if _, err := store.GetAt([]byte("bad-key"), 9); !errors.Is(err, ErrMalformedRecord) {
+		t.Fatalf("GetAt malformed key error=%v want ErrMalformedRecord", err)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	if _, err := store.GetAt([]byte("bad-value"), 9); !errors.Is(err, treedb.ErrClosed) {
+		t.Fatalf("GetAt closed error=%v want ErrClosed", err)
+	}
+}
+
+func TestCommitAtDurabilityModesAndReopen(t *testing.T) {
+	t.Run("durable", func(t *testing.T) {
+		dir := t.TempDir()
+		db := openTestDB(t, dir, treedb.DurabilityDurable)
+		if err := New(db).CommitAt(21, []Mutation{{Key: []byte("k"), Value: []byte("durable")}}, CommitDurable); err != nil {
+			t.Fatalf("CommitAt durable: %v", err)
+		}
+		if err := db.Close(); err != nil {
+			t.Fatalf("Close: %v", err)
+		}
+		db = openTestDB(t, dir, treedb.DurabilityDurable)
+		defer db.Close()
+		requireResult(t, New(db), []byte("k"), 21, Present, 21, []byte("durable"))
+	})
+
+	for _, durability := range []treedb.DurabilityMode{treedb.DurabilityWALOnRelaxed, treedb.DurabilityWALOffRelaxed} {
+		t.Run("relaxed_"+strconv.Itoa(int(durability)), func(t *testing.T) {
+			dir := t.TempDir()
+			db := openTestDB(t, dir, durability)
+			store := New(db)
+			if err := store.CommitAt(22, []Mutation{{Key: []byte("k"), Value: []byte("relaxed")}}, CommitDurable); !errors.Is(err, ErrDurabilityUnavailable) {
+				t.Fatalf("durable request error=%v want ErrDurabilityUnavailable", err)
+			}
+			requireResult(t, store, []byte("k"), 22, Absent, 0, nil)
+			if err := store.CommitAt(22, []Mutation{{Key: []byte("k"), Value: []byte("relaxed")}}, CommitRelaxed); err != nil {
+				t.Fatalf("CommitAt relaxed: %v", err)
+			}
+			if err := db.Checkpoint(); err != nil {
+				t.Fatalf("Checkpoint: %v", err)
+			}
+			if err := db.Close(); err != nil {
+				t.Fatalf("Close: %v", err)
+			}
+			db = openTestDB(t, dir, durability)
+			defer db.Close()
+			requireResult(t, New(db), []byte("k"), 22, Present, 22, []byte("relaxed"))
+		})
+	}
+}
+
+func TestCommitAtDurableProcessCrashRecovery(t *testing.T) {
+	const childEnv = "TREEDB_MVCC_CRASH_CHILD"
+	if dir := os.Getenv(childEnv); dir != "" {
+		db := openTestDB(t, dir, treedb.DurabilityDurable)
+		if err := New(db).CommitAt(31, []Mutation{
+			{Key: []byte("a"), Value: []byte("A")},
+			{Key: []byte("b"), Delete: true},
+		}, CommitDurable); err != nil {
+			t.Fatalf("child CommitAt: %v", err)
+		}
+		// Deliberately skip Close to exercise WAL recovery after process death.
+		os.Exit(0)
+	}
+
+	dir := t.TempDir()
+	cmd := exec.Command(os.Args[0], "-test.run=^TestCommitAtDurableProcessCrashRecovery$")
+	cmd.Env = append(os.Environ(), childEnv+"="+dir)
+	if output, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("crash child: %v\n%s", err, output)
+	}
+	segments, err := filepath.Glob(filepath.Join(dir, "wal", "*.log"))
+	if err != nil || len(segments) == 0 {
+		t.Fatalf("discover crash WAL segments: files=%v err=%v", segments, err)
+	}
+	tail, err := os.OpenFile(segments[len(segments)-1], os.O_WRONLY|os.O_APPEND, 0)
+	if err != nil {
+		t.Fatalf("open crash WAL tail: %v", err)
+	}
+	if _, err := tail.Write([]byte{0x7f, 0x01, 0x02}); err != nil {
+		_ = tail.Close()
+		t.Fatalf("append truncated crash WAL tail: %v", err)
+	}
+	if err := tail.Close(); err != nil {
+		t.Fatalf("close crash WAL tail: %v", err)
+	}
+	db := openTestDB(t, dir, treedb.DurabilityDurable)
+	defer db.Close()
+	store := New(db)
+	requireResult(t, store, []byte("a"), 31, Present, 31, []byte("A"))
+	requireResult(t, store, []byte("b"), 31, Tombstone, 31, nil)
+}
+
+func TestGetAtRandomizedOracle(t *testing.T) {
+	db := openTestDB(t, t.TempDir(), treedb.DurabilityDurable)
+	defer db.Close()
+	store := New(db)
+	rng := rand.New(rand.NewSource(3672))
+	type oracleVersion struct {
+		timestamp uint64
+		value     []byte
+		deleted   bool
+	}
+	oracle := make(map[string]map[uint64]oracleVersion)
+	keys := [][]byte{nil, []byte("a"), []byte{'a', 0}, []byte("z")}
+
+	for step := 0; step < 500; step++ {
+		key := keys[rng.Intn(len(keys))]
+		timestamp := uint64(1 + rng.Intn(100))
+		deleted := rng.Intn(5) == 0
+		value := []byte(fmt.Sprintf("v-%d-%d", step, rng.Intn(10)))
+		if err := store.CommitAt(timestamp, []Mutation{{Key: key, Value: value, Delete: deleted}}, CommitRelaxed); err != nil {
+			t.Fatalf("step %d CommitAt: %v", step, err)
+		}
+		byTimestamp := oracle[string(key)]
+		if byTimestamp == nil {
+			byTimestamp = make(map[uint64]oracleVersion)
+			oracle[string(key)] = byTimestamp
+		}
+		byTimestamp[timestamp] = oracleVersion{timestamp: timestamp, value: append([]byte(nil), value...), deleted: deleted}
+
+		for probe := 0; probe < 4; probe++ {
+			probeKey := keys[rng.Intn(len(keys))]
+			readTimestamp := uint64(1 + rng.Intn(110))
+			got, err := store.GetAt(probeKey, readTimestamp)
+			if err != nil {
+				t.Fatalf("step %d GetAt: %v", step, err)
+			}
+			want := Result{State: Absent}
+			for ts, version := range oracle[string(probeKey)] {
+				if ts <= readTimestamp && ts > want.Timestamp {
+					want.Timestamp = ts
+					want.Value = append([]byte(nil), version.value...)
+					want.State = Present
+					if version.deleted {
+						want.State = Tombstone
+						want.Value = nil
+					}
+				}
+			}
+			if got.State != want.State || got.Timestamp != want.Timestamp || !bytes.Equal(got.Value, want.Value) {
+				t.Fatalf("step %d GetAt(%q,%d)=%+v want %+v", step, probeKey, readTimestamp, got, want)
+			}
+		}
+	}
+}
+
+func TestGetAtConcurrentReaders(t *testing.T) {
+	db := openTestDB(t, t.TempDir(), treedb.DurabilityDurable)
+	defer db.Close()
+	store := New(db)
+	const commits = 100
+	for ts := uint64(1); ts <= commits; ts++ {
+		if err := store.CommitAt(ts, []Mutation{{Key: []byte("k"), Value: []byte(strconv.FormatUint(ts, 10))}}, CommitRelaxed); err != nil {
+			t.Fatalf("CommitAt(%d): %v", ts, err)
+		}
+	}
+
+	var wg sync.WaitGroup
+	errCh := make(chan error, 8)
+	for reader := 0; reader < 8; reader++ {
+		reader := reader
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			rng := rand.New(rand.NewSource(int64(3672 + reader)))
+			for probe := 0; probe < 250; probe++ {
+				ts := uint64(1 + rng.Intn(commits))
+				got, err := store.GetAt([]byte("k"), ts)
+				if err != nil {
+					errCh <- err
+					return
+				}
+				if got.State != Present || got.Timestamp != ts || string(got.Value) != strconv.FormatUint(ts, 10) {
+					errCh <- fmt.Errorf("GetAt(%d)=%+v", ts, got)
+					return
+				}
+			}
+		}()
+	}
+	wg.Wait()
+	close(errCh)
+	for err := range errCh {
+		t.Error(err)
+	}
+}
+
+type batchSpyDB struct {
+	*treedb.DB
+	created atomic.Int64
+}
+
+func (db *batchSpyDB) NewBatchWithSize(size int) treedb.Batch {
+	db.created.Add(1)
+	return db.DB.NewBatchWithSize(size)
+}
+
+var errInjectedBatch = errors.New("injected batch failure")
+
+type writeFailureDB struct {
+	*treedb.DB
+	afterCommit bool
+	err         error
+}
+
+func (db *writeFailureDB) NewBatchWithSize(size int) treedb.Batch {
+	return &writeFailureBatch{Batch: db.DB.NewBatchWithSize(size), afterCommit: db.afterCommit, err: db.err}
+}
+
+type writeFailureBatch struct {
+	treedb.Batch
+	afterCommit bool
+	err         error
+}
+
+func (b *writeFailureBatch) Write() error {
+	if b.afterCommit {
+		if err := b.Batch.Write(); err != nil {
+			return err
+		}
+	}
+	if b.err != nil {
+		return b.err
+	}
+	return errInjectedBatch
+}
+
+func (b *writeFailureBatch) WriteSync() error {
+	if b.afterCommit {
+		if err := b.Batch.WriteSync(); err != nil {
+			return err
+		}
+	}
+	if b.err != nil {
+		return b.err
+	}
+	return errInjectedBatch
+}
+
+type stageFailureDB struct {
+	*treedb.DB
+	failAt int
+	err    error
+}
+
+func (db *stageFailureDB) NewBatchWithSize(size int) treedb.Batch {
+	return &stageFailureBatch{Batch: db.DB.NewBatchWithSize(size), failAt: db.failAt, err: db.err}
+}
+
+type stageFailureBatch struct {
+	treedb.Batch
+	sets   int
+	failAt int
+	err    error
+}
+
+func (b *stageFailureBatch) Set(key, value []byte) error {
+	if b.sets == b.failAt {
+		return b.err
+	}
+	b.sets++
+	return b.Batch.Set(key, value)
+}
+
+// Keep compile-time coverage that injected batches retain the complete public
+// contract instead of testing a narrower fake API.
+var _ treedb.Batch = (*writeFailureBatch)(nil)
+var _ treedb.Batch = (*stageFailureBatch)(nil)

--- a/TreeDB/mvcc/mvcc_test.go
+++ b/TreeDB/mvcc/mvcc_test.go
@@ -234,6 +234,15 @@ func TestNilStoreReturnsStorageErrors(t *testing.T) {
 	if _, err := store.GetAt([]byte("k"), 1); !errors.Is(err, ErrStorage) || !errors.Is(err, treedb.ErrClosed) {
 		t.Fatalf("GetAt nil store error=%v", err)
 	}
+
+	db := openTestDB(t, t.TempDir(), treedb.DurabilityDurable)
+	store = New(db)
+	if err := db.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	if err := store.CommitAt(1, nil, CommitDurable); err != nil {
+		t.Fatalf("empty CommitAt on closed non-nil store must not access storage: %v", err)
+	}
 }
 
 func TestCommitAtDurabilityModesAndReopen(t *testing.T) {
@@ -256,6 +265,9 @@ func TestCommitAtDurabilityModesAndReopen(t *testing.T) {
 			dir := t.TempDir()
 			db := openTestDB(t, dir, durability)
 			store := New(db)
+			if err := store.CommitAt(22, nil, CommitDurable); err != nil {
+				t.Fatalf("empty durable CommitAt must be a no-op: %v", err)
+			}
 			if err := store.CommitAt(22, []Mutation{{Key: []byte("k"), Value: []byte("relaxed")}}, CommitDurable); !errors.Is(err, ErrDurabilityUnavailable) {
 				t.Fatalf("durable request error=%v want ErrDurabilityUnavailable", err)
 			}

--- a/docs/API_STABILITY.md
+++ b/docs/API_STABILITY.md
@@ -33,6 +33,9 @@ changes until the project reaches a stable post-pre-alpha phase.
 
 - Anything in an `internal/` directory (Go’s internal visibility rules apply).
 - Most packages under `TreeDB/*` and `HashDB/*` other than the root package are implementation details.
+- `TreeDB/mvcc` is an explicitly opt-in, pre-alpha downstream integration
+  surface. It is importable for pinned experiments, but its Go API and reserved
+  physical-key/value format are not yet stable compatibility promises.
 
 ### Tooling / Benchmarks (not stable)
 

--- a/scripts/mvcc_raw_path_gate.sh
+++ b/scripts/mvcc_raw_path_gate.sh
@@ -1,0 +1,140 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+cd "$ROOT"
+
+BASELINE_HASH="${BASELINE_HASH:?BASELINE_HASH is required}"
+CANDIDATE_HASH="${CANDIDATE_HASH:-HEAD}"
+RUNS="${RUNS:-7}"
+BENCHTIME="${BENCHTIME:-2s}"
+CPUSET="${CPUSET:-0}"
+MAX_REGRESSION_PERCENT="${MAX_REGRESSION_PERCENT:-5}"
+SCRIPT_GOWORK="${SCRIPT_GOWORK:-off}"
+OUT_DIR="${OUT_DIR:-$ROOT/artifacts/mvcc_raw_path_gate}"
+BENCH_REGEX='^(BenchmarkGetVersioned|BenchmarkConditionalTxnBaselineBatchWrite)$'
+
+if ! [[ "$RUNS" =~ ^[1-9][0-9]*$ ]]; then
+  echo "RUNS must be a positive integer" >&2
+  exit 2
+fi
+if ! [[ "$BENCHTIME" =~ ^[1-9][0-9]*(ms|s|x)$ ]]; then
+  echo "BENCHTIME must be a positive Go benchmark duration or iteration count" >&2
+  exit 2
+fi
+for command in git go lscpu ps python3 realpath taskset sha256sum; do
+  if ! command -v "$command" >/dev/null 2>&1; then
+    echo "missing required command: $command" >&2
+    exit 2
+  fi
+done
+
+OUT_DIR=$(realpath -m "$OUT_DIR")
+if [[ -z "$OUT_DIR" || "$OUT_DIR" == "/" || "$OUT_DIR" == "$ROOT" ]]; then
+  echo "refusing unsafe OUT_DIR: $OUT_DIR" >&2
+  exit 2
+fi
+
+if ! git cat-file -e "${BASELINE_HASH}^{commit}" >/dev/null 2>&1; then
+  git fetch --no-tags origin "$BASELINE_HASH"
+fi
+BASELINE_SHA=$(git rev-parse "${BASELINE_HASH}^{commit}")
+CANDIDATE_SHA=$(git rev-parse "${CANDIDATE_HASH}^{commit}")
+CHECKED_OUT_SHA=$(git rev-parse "HEAD^{commit}")
+if [[ "$CHECKED_OUT_SHA" != "$CANDIDATE_SHA" ]]; then
+  echo "candidate mismatch: checkout=$CHECKED_OUT_SHA requested=$CANDIDATE_SHA" >&2
+  exit 2
+fi
+if [[ "$BASELINE_SHA" == "$CANDIDATE_SHA" ]]; then
+  echo "baseline and candidate resolve to the same commit" >&2
+  exit 2
+fi
+
+rm -rf "$OUT_DIR"
+mkdir -p "$OUT_DIR"
+TMP_ROOT=$(mktemp -d "${RUNNER_TEMP:-${TMPDIR:-/tmp}}/mvcc-raw-path-gate.XXXXXX")
+BASELINE_WT="$TMP_ROOT/baseline"
+cleanup() {
+  git worktree remove --force "$BASELINE_WT" >/dev/null 2>&1 || true
+  rm -rf "$TMP_ROOT"
+}
+trap cleanup EXIT
+git worktree add --detach "$BASELINE_WT" "$BASELINE_SHA" >/dev/null
+
+ENVIRONMENT="$OUT_DIR/environment.txt"
+PROCESSES="$OUT_DIR/processes.txt"
+BASELINE_LOG="$OUT_DIR/baseline.txt"
+CANDIDATE_LOG="$OUT_DIR/candidate.txt"
+SUMMARY_JSON="$OUT_DIR/summary.json"
+SUMMARY_MD="$OUT_DIR/summary.md"
+BASELINE_BIN="$TMP_ROOT/baseline.test"
+CANDIDATE_BIN="$TMP_ROOT/candidate.test"
+
+{
+  echo "baseline_sha=$BASELINE_SHA"
+  echo "candidate_sha=$CANDIDATE_SHA"
+  echo "runs=$RUNS"
+  echo "benchtime=$BENCHTIME"
+  echo "cpuset=$CPUSET"
+  echo "gomaxprocs=1"
+  echo "max_regression_percent=$MAX_REGRESSION_PERCENT"
+  echo "github_runner_image=${ImageOS:-unknown} ${ImageVersion:-unknown}"
+  echo "runner_arch=${RUNNER_ARCH:-unknown}"
+  echo "runner_os=${RUNNER_OS:-unknown}"
+  go version
+  uname -a
+  lscpu
+} >"$ENVIRONMENT"
+
+env GOWORK="$SCRIPT_GOWORK" go test -c -trimpath -buildvcs=false \
+  -o "$CANDIDATE_BIN" ./TreeDB/db
+(
+  cd "$BASELINE_WT"
+  env GOWORK="$SCRIPT_GOWORK" go test -c -trimpath -buildvcs=false \
+    -o "$BASELINE_BIN" ./TreeDB/db
+)
+(
+  cd "$TMP_ROOT"
+  sha256sum baseline.test candidate.test
+) | tee "$OUT_DIR/binary-sha256.txt"
+
+: >"$BASELINE_LOG"
+: >"$CANDIDATE_LOG"
+: >"$PROCESSES"
+run_sample() {
+  local revision="$1"
+  local sample="$2"
+  local binary="$3"
+  local output="$4"
+  {
+    echo "--- before revision=$revision sample=$sample at $(date -Iseconds) ---"
+    ps -eo pid,ppid,etime,%cpu,cmd --sort=-%cpu | head -20 || true
+  } >>"$PROCESSES"
+  taskset -c "$CPUSET" env GOMAXPROCS=1 "$binary" \
+    -test.run '^$' \
+    -test.bench "$BENCH_REGEX" \
+    -test.benchtime="$BENCHTIME" \
+    -test.count=1 >>"$output"
+}
+
+for ((sample = 1; sample <= RUNS; sample++)); do
+  if ((sample % 2 == 1)); then
+    run_sample baseline "$sample" "$BASELINE_BIN" "$BASELINE_LOG"
+    run_sample candidate "$sample" "$CANDIDATE_BIN" "$CANDIDATE_LOG"
+  else
+    run_sample candidate "$sample" "$CANDIDATE_BIN" "$CANDIDATE_LOG"
+    run_sample baseline "$sample" "$BASELINE_BIN" "$BASELINE_LOG"
+  fi
+done
+
+python3 .github/scripts/check_mvcc_raw_path_gate.py \
+  --baseline "$BASELINE_LOG" \
+  --candidate "$CANDIDATE_LOG" \
+  --baseline-sha "$BASELINE_SHA" \
+  --candidate-sha "$CANDIDATE_SHA" \
+  --expected-samples "$RUNS" \
+  --max-regression-percent "$MAX_REGRESSION_PERCENT" \
+  --json-output "$SUMMARY_JSON" \
+  --markdown-output "$SUMMARY_MD"
+
+echo "mvcc raw-path gate artifacts: $OUT_DIR"

--- a/scripts/mvcc_raw_path_gate.sh
+++ b/scripts/mvcc_raw_path_gate.sh
@@ -10,6 +10,8 @@ RUNS="${RUNS:-7}"
 BENCHTIME="${BENCHTIME:-2s}"
 CPUSET="${CPUSET:-0}"
 MAX_REGRESSION_PERCENT="${MAX_REGRESSION_PERCENT:-5}"
+MAX_BYTES_REGRESSION_PERCENT="${MAX_BYTES_REGRESSION_PERCENT:-1}"
+MAX_BYTES_REGRESSION_ABSOLUTE="${MAX_BYTES_REGRESSION_ABSOLUTE:-64}"
 SCRIPT_GOWORK="${SCRIPT_GOWORK:-off}"
 OUT_DIR="${OUT_DIR:-$ROOT/artifacts/mvcc_raw_path_gate}"
 BENCH_REGEX='^(BenchmarkGetVersioned|BenchmarkConditionalTxnBaselineBatchWrite)$'
@@ -78,6 +80,8 @@ CANDIDATE_BIN="$TMP_ROOT/candidate.test"
   echo "cpuset=$CPUSET"
   echo "gomaxprocs=1"
   echo "max_regression_percent=$MAX_REGRESSION_PERCENT"
+  echo "max_bytes_regression_percent=$MAX_BYTES_REGRESSION_PERCENT"
+  echo "max_bytes_regression_absolute=$MAX_BYTES_REGRESSION_ABSOLUTE"
   echo "github_runner_image=${ImageOS:-unknown} ${ImageVersion:-unknown}"
   echo "runner_arch=${RUNNER_ARCH:-unknown}"
   echo "runner_os=${RUNNER_OS:-unknown}"
@@ -134,6 +138,8 @@ python3 .github/scripts/check_mvcc_raw_path_gate.py \
   --candidate-sha "$CANDIDATE_SHA" \
   --expected-samples "$RUNS" \
   --max-regression-percent "$MAX_REGRESSION_PERCENT" \
+  --max-bytes-regression-percent "$MAX_BYTES_REGRESSION_PERCENT" \
+  --max-bytes-regression-absolute "$MAX_BYTES_REGRESSION_ABSOLUTE" \
   --json-output "$SUMMARY_JSON" \
   --markdown-output "$SUMMARY_MD"
 


### PR DESCRIPTION
Closes #3672

Parent: #3668  
Predecessor: #3670, merged by #3685 at `e84eeb5719dabb0e5c6e6d7e525a8c624fdf3cdf`

## What changed

- adds the opt-in, pre-alpha `TreeDB/mvcc` package over the merged ordered external-version codec;
- commits puts and historical tombstones at one nonzero caller timestamp through one TreeDB atomic batch;
- rejects duplicate logical keys, including nil/empty aliases, before creating a batch (no order-dependent last-write-wins inside a logical commit);
- treats an empty mutation list as storage-free after timestamp/mode/non-nil Store validation, without probing a closed handle or relaxed durability mode;
- exposes explicit `CommitRelaxed` and fail-closed `CommitDurable` modes;
- performs `GetAt` by constructing the requested key/time lower bound and opening one exact-key bounded iterator, without history materialization;
- distinguishes absent, present, tombstone, malformed-record, and `ErrStorage` results while retaining underlying storage errors for `errors.Is`/`errors.As`;
- documents the value/tombstone envelope, durability boundary, recovery behavior, contracts, verification matrix, and experimental API status.
- adds a path-scoped hosted raw-path gate that resolves the exact open-PR base/head SHAs, builds both revisions with one toolchain, runs seven alternating sequential samples on one pinned CPU, and uploads raw/environment/hash/JSON/Markdown evidence.
- validates and encodes each logical key before copying it into duplicate-detection state, reusing the encoded key for staging so arbitrarily oversized invalid keys fail without an unbounded allocation or a second encoding pass.

The layer does not perform conflict detection, conditional transactions, TTL, metadata, pruning, or reinterpret `EntryRevision`. Dgraph remains the timestamp/conflict owner.

## Atomicity and durability

- validation and duplicate detection complete before batch creation;
- all physical mutations use one `Batch.Write`/`Batch.WriteSync` call;
- injected pre-commit failures leave the whole batch absent; injected post-commit errors leave the whole batch present; both remain all-or-none after reopen;
- `CommitRelaxed` is an atomic visibility boundary without an fsync promise;
- `CommitDurable` is accepted only for an effective `DurabilityDurable` TreeDB handle and uses `WriteSync`;
- durable child-process crash recovery passes without `Close`, including an appended truncated WAL tail;
- relaxed WAL-on and WAL-off fixtures pass after `Checkpoint` plus close/reopen.

## Tests

Latest local verification at `9742a1b13`:

```text
GOWORK=off go test ./TreeDB/mvcc
GOWORK=off go test -race ./TreeDB/mvcc
GOWORK=off go vet ./TreeDB/mvcc
GOWORK=off go test ./TreeDB
git diff --check
bash -n scripts/mvcc_raw_path_gate.sh
python3 .github/scripts/check_mvcc_raw_path_gate.py --self-test
GOWORK=off go test ./TreeDB/mvcc -run '^TestCommitAtOversizedKeyRejectsBeforeDuplicateIdentityAllocation$' -count=10
GOWORK=off go test ./TreeDB/mvcc -run '^(TestCommitAtInjectedFailureIsAllOrNone|TestCommitAtInjectedStagingFailurePublishesNothing|TestGetAtRandomizedOracle|TestCommitAtOversizedKeyRejectsBeforeDuplicateIdentityAllocation)$' -count=10
```

Coverage includes golden overwrite/tombstone/exact/between/max histories, duplicate timestamps, randomized oracle comparison, multi-key and injected all-or-none failures, malformed keys/envelopes, explicit durability modes, checkpoint/reopen, process-crash/truncated-tail recovery, and concurrent readers.

The oversized multi-mutation regression measured 16,779,912 bytes allocated on the reviewed pre-fix head versus 2,696 bytes after the fix, returns `ErrInvalidKey` at key index 1, and proves that no TreeDB batch is created or mutation published.

The fixed-head 500-iteration, seven-sample MVCC comparator rerun preserved every B/op and allocs/op median versus implementation head `61eb9d70f`, including batch-32 at 106 allocations. No comparator approaches the 2x profile trigger.

## MVCC overhead

Command:

```text
GOMAXPROCS=1 GOWORK=off go test ./TreeDB/mvcc -run '^$' -bench '^(BenchmarkCommitAt|BenchmarkGetAt)$' -benchtime=500x -count=7
```

Median of seven samples on an i5-11400F; fixtures and timed boundaries are identical within each direct/MVCC pair:

Measured at implementation head `61eb9d70f`; subsequent commits only add and calibrate the hosted verification infrastructure.

| Operation | Direct | MVCC | Delta | Direct ops/s | MVCC ops/s | Allocations |
| --- | ---: | ---: | ---: | ---: | ---: | ---: |
| commit, 1 key | 2,411 ns/op | 3,387 ns/op | +40.5% | 414,766 | 295,246 | 8 -> 8 |
| commit, 32 keys | 13,555 ns/op | 13,869 ns/op | +2.3% | 73,774 | 72,103 | 102 -> 106 |
| GetAt, depth 1 | 1,835 ns/op | 1,974 ns/op | +7.6% | 544,959 | 506,586 | 10 -> 11 |
| GetAt, depth 8 | 1,943 ns/op | 2,278 ns/op | +17.2% | 514,668 | 438,982 | 14 -> 15 |
| GetAt, depth 64 | 1,243 ns/op | 1,330 ns/op | +7.0% | 804,505 | 751,880 | 14 -> 15 |

No comparator exceeds the 2x profile trigger. The point-read allocation is the explicit decoded/result value ownership boundary. Batched commit adds bounded prevalidation/staging bookkeeping; single-key commit retains the same allocation count as its direct comparator.

## Existing raw-path gate

The first fresh hosted run compared exact PR base `e84eeb5719dabb0e5c6e6d7e525a8c624fdf3cdf` with infrastructure head `e05df5fca424a366b03633d9bd4b7556763b5fd9`. Both compiled raw `TreeDB/db` test binaries had the same SHA-256:

```text
420622ae5cd2f6c9cd40ed64b3e2f5a0622e3ea8bdfe09c92d451667d5f597de
```

On `ubuntu-24.04` image `20260705.232.1`, Go 1.26.4, AMD EPYC 7763, one pinned CPU, seven alternating 2-second samples:

| Existing raw benchmark | Baseline median | Head median | Delta | B/op | Allocations |
| --- | ---: | ---: | ---: | ---: | ---: |
| `BenchmarkGetVersioned` | 438.8 ns/op | 440.9 ns/op | +0.48% | 0 -> 0 | 0 -> 0 |
| `BenchmarkConditionalTxnBaselineBatchWrite` | 28,046 ns/op | 27,922 ns/op | -0.44% | 13,291 -> 13,292 | 30 -> 30 |

The first job correctly proved the timing and allocation-count gates, but falsely failed on a one-byte B/op median difference despite byte-identical binaries; individual samples varied by several reported B/op within each revision. That run is retained as [calibration evidence](https://github.com/snissn/gomap/actions/runs/29127555395/job/86476280313), not final acceptance.

The gate now keeps allocs/op strict and gives Go's integer B/op estimator an explicit bounded jitter allowance: the smaller of 1% or 64 B, with zero-B baselines strict. Self-tests cover pass/fail boundaries for timing, allocs/op, both B/op caps, and missing samples.

Final acceptance command on the fresh runner:

```text
BASELINE_HASH=e84eeb5719dabb0e5c6e6d7e525a8c624fdf3cdf \
CANDIDATE_HASH=9742a1b13ca949661c626f815b0a211ffdacf3b9 \
RUNS=7 BENCHTIME=2s CPUSET=0 GOMAXPROCS=1 \
MAX_REGRESSION_PERCENT=5 MAX_BYTES_REGRESSION_PERCENT=1 \
MAX_BYTES_REGRESSION_ABSOLUTE=64 SCRIPT_GOWORK=off \
./scripts/mvcc_raw_path_gate.sh
```

The [exact-head hosted gate passed at `9742a1b13`](https://github.com/snissn/gomap/actions/runs/29128536173/job/86479163541) on the same pinned runner shape and again produced byte-identical raw test binaries (`420622ae5cd2f6c9cd40ed64b3e2f5a0622e3ea8bdfe09c92d451667d5f597de`):

| Existing raw benchmark | Baseline median | Head median | Delta | B/op | Allocations |
| --- | ---: | ---: | ---: | ---: | ---: |
| `BenchmarkGetVersioned` | 439.4 ns/op | 442.2 ns/op | +0.64% | 0 -> 0 | 0 -> 0 |
| `BenchmarkConditionalTxnBaselineBatchWrite` | 28,654 ns/op | 28,915 ns/op | +0.91% | 13,293 -> 13,294 (within 64 B cap) | 30 -> 30 |

The [uploaded exact-head artifact](https://github.com/snissn/gomap/actions/runs/29128536173/artifacts/8241233623) contains the raw logs, exact environment, process snapshots, hashes, JSON, and Markdown summary. Earlier local samples that overlapped unrelated suites remain discarded and are not used.

## Risk and compatibility

- the package exclusively owns its reserved physical namespace; unrelated raw writes in that range are unsupported and malformed records fail closed;
- the API and key/value format remain explicitly pre-alpha and may require rebuilding experimental directories;
- no existing raw TreeDB API imports or invokes this package.

AI review follow-up and thread resolution are coordinator-owned. The implementation, latest-head local evidence, and exact-head hosted raw-path gate are ready.
