### PR TITLE
db: extract shared maintenance reachability scanner

### DIFF
--- a/TreeDB/db/compact_storage_audit.go
+++ b/TreeDB/db/compact_storage_audit.go
@@ -447,9 +447,8 @@ func (db *DB) scanCompactStorageAudit(ctx context.Context, in *compactStorageAud
 		Collectors: maintenanceReachabilityValueLogRefCounts |
 			maintenanceReachabilityValueLogLiveBytes |
 			maintenanceReachabilityLeafGenerationTotals,
-		ProtectedRootIDs:        in.protectedRootIDs,
-		ProtectedSystemRootIDs:  in.protectedSystemRootIDs,
-		DisableLeafSubtreeCache: true,
+		ProtectedRootIDs:       in.protectedRootIDs,
+		ProtectedSystemRootIDs: in.protectedSystemRootIDs,
 	})
 	raw := compactStorageAuditRaw{
 		valueLogRefCounts:          result.valueLogRefCounts,

--- a/TreeDB/db/compact_storage_audit.go
+++ b/TreeDB/db/compact_storage_audit.go
@@ -440,6 +440,33 @@ func compactStorageAuditKeyMissReason(previous, current compactStorageAuditKey) 
 }
 
 func (db *DB) scanCompactStorageAudit(ctx context.Context, in *compactStorageAuditInput) (compactStorageAuditRaw, error) {
+	if in == nil {
+		return compactStorageAuditRaw{}, fmt.Errorf("compact storage audit: missing input")
+	}
+	result, err := db.maintenanceReachabilityScan(ctx, in.snap, maintenanceReachabilityScanOptions{
+		Collectors: maintenanceReachabilityValueLogRefCounts |
+			maintenanceReachabilityValueLogLiveBytes |
+			maintenanceReachabilityLeafGenerationTotals,
+		ProtectedRootIDs:        in.protectedRootIDs,
+		ProtectedSystemRootIDs:  in.protectedSystemRootIDs,
+		DisableLeafSubtreeCache: true,
+	})
+	raw := compactStorageAuditRaw{
+		valueLogRefCounts:          result.valueLogRefCounts,
+		valueLogReferencedSegments: result.valueLogReferencedSegments,
+		valueLogLiveBytesBySegment: result.valueLogLiveBytesBySegment,
+		leafGenerationLive:         result.leafGenerationLive,
+		counters:                   result.counters,
+	}
+	if err == nil {
+		runCompactStorageSharedAuditScanHook(raw.counters)
+	}
+	return raw, err
+}
+
+// scanCompactStorageAuditLegacy remains during staged consumer migration so
+// equivalence tests can compare the extracted scanner with the PL-03 walk.
+func (db *DB) scanCompactStorageAuditLegacy(ctx context.Context, in *compactStorageAuditInput) (compactStorageAuditRaw, error) {
 	raw := compactStorageAuditRaw{
 		valueLogRefCounts:          make(map[uint32]uint64),
 		valueLogReferencedSegments: make(map[uint32]struct{}),

--- a/TreeDB/db/maintenance_reachability.go
+++ b/TreeDB/db/maintenance_reachability.go
@@ -386,7 +386,7 @@ func (db *DB) maintenanceReachabilityScan(ctx context.Context, snap *Snapshot, o
 			return nil, fmt.Errorf("maintenance reachability: invalid page type %d on page %d", n.Type(), pageID)
 		}
 		memo[pageID] = entry
-		if collectLeaf && !verifyAlways {
+		if collectLeaf && !opts.DisableLeafSubtreeCache && !verifyAlways {
 			db.storeLeafGenerationSubtreeStats(pageID, entry.leafTotals)
 		}
 		return entry.leafTotals, nil

--- a/TreeDB/db/maintenance_reachability.go
+++ b/TreeDB/db/maintenance_reachability.go
@@ -1,0 +1,461 @@
+package db
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/snissn/gomap/TreeDB/internal/valuelog"
+	"github.com/snissn/gomap/TreeDB/node"
+	"github.com/snissn/gomap/TreeDB/page"
+)
+
+type maintenanceReachabilityCollectors uint8
+
+const (
+	maintenanceReachabilityValueLogRefCounts maintenanceReachabilityCollectors = 1 << iota
+	maintenanceReachabilityValueLogLiveBytes
+	maintenanceReachabilityLeafGenerationTotals
+)
+
+func (c maintenanceReachabilityCollectors) has(want maintenanceReachabilityCollectors) bool {
+	return c&want != 0
+}
+
+type maintenanceReachabilityScanOptions struct {
+	Collectors              maintenanceReachabilityCollectors
+	ProtectedRootIDs        []uint64
+	ProtectedSystemRootIDs  []uint64
+	DisableLeafSubtreeCache bool
+}
+
+type maintenanceReachabilityResult struct {
+	valueLogRefCounts          map[uint32]uint64
+	valueLogReferencedSegments map[uint32]struct{}
+	valueLogLiveBytesBySegment map[uint32]int64
+	leafGenerationLive         leafGenerationLiveScanStats
+	counters                   CompactStorageAuditStats
+
+	// Internal evidence for collector-selection tests. These count actual
+	// expensive collector work, not merely selected collectors.
+	recordLengthLookups  uint64
+	leafFrameProjections uint64
+}
+
+type maintenanceReachabilityRoot struct {
+	maintenanceRoot
+	valueLogProjection bool
+}
+
+func maintenanceReachabilityRoots(ctx context.Context, snap *Snapshot, protectedRootIDs, protectedSystemRootIDs []uint64, projectValueLog bool) ([]maintenanceReachabilityRoot, error) {
+	roots, err := maintenanceRootsForSnapshotWithContext(ctx, snap)
+	if err != nil {
+		return nil, err
+	}
+	roots = dedupeMaintenanceRootsByRootID(roots)
+	out := make([]maintenanceReachabilityRoot, 0, len(roots)+len(protectedRootIDs)+len(protectedSystemRootIDs))
+	for _, root := range roots {
+		out = append(out, maintenanceReachabilityRoot{
+			maintenanceRoot:    root,
+			valueLogProjection: projectValueLog,
+		})
+	}
+
+	seen := make(map[uint64]struct{}, len(out)+len(protectedRootIDs)+len(protectedSystemRootIDs))
+	for _, root := range out {
+		seen[root.rootID] = struct{}{}
+	}
+	addProtected := func(root maintenanceRoot) {
+		if root.rootID == 0 {
+			return
+		}
+		if _, ok := seen[root.rootID]; ok {
+			return
+		}
+		seen[root.rootID] = struct{}{}
+		out = append(out, maintenanceReachabilityRoot{maintenanceRoot: root})
+	}
+	for _, rootID := range protectedRootIDs {
+		addProtected(maintenanceRoot{kind: maintenanceRootUser, rootID: rootID})
+	}
+	for _, systemRootID := range protectedSystemRootIDs {
+		protected, err := collectMaintenanceRootsForSystemRootWithContext(ctx, snap.idx.pager, &snap.reader, systemRootID)
+		if err != nil {
+			return nil, err
+		}
+		for _, root := range protected {
+			addProtected(root)
+		}
+	}
+	return out, nil
+}
+
+func (db *DB) maintenanceReachabilityScan(ctx context.Context, snap *Snapshot, opts maintenanceReachabilityScanOptions) (maintenanceReachabilityResult, error) {
+	var result maintenanceReachabilityResult
+	if snap == nil || snap.state == nil || snap.idx == nil || snap.idx.pager == nil {
+		return result, fmt.Errorf("maintenance reachability: missing snapshot state")
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	collectRefs := opts.Collectors.has(maintenanceReachabilityValueLogRefCounts)
+	collectLive := opts.Collectors.has(maintenanceReachabilityValueLogLiveBytes)
+	collectLeaf := opts.Collectors.has(maintenanceReachabilityLeafGenerationTotals)
+	collectValueLog := collectRefs || collectLive
+	if collectRefs {
+		result.valueLogRefCounts = make(map[uint32]uint64)
+		result.valueLogReferencedSegments = make(map[uint32]struct{})
+	}
+	if collectLive {
+		result.valueLogLiveBytesBySegment = make(map[uint32]int64)
+	}
+	if collectLeaf {
+		result.leafGenerationLive.Generations = make(map[uint64]leafGenerationLiveTotals)
+	}
+	if opts.Collectors == 0 {
+		return result, nil
+	}
+
+	var leafScan *leafGenerationScanContext
+	var err error
+	if collectLeaf {
+		leafScan, err = db.newCompactStorageLeafScanContext(snap)
+		if err != nil {
+			return result, err
+		}
+	}
+	roots, err := maintenanceReachabilityRoots(ctx, snap, opts.ProtectedRootIDs, opts.ProtectedSystemRootIDs, collectValueLog)
+	if err != nil {
+		return result, err
+	}
+	result.counters.RootSets = uint64(len(roots))
+	valueLogRootCount := 0
+	for _, root := range roots {
+		if root.valueLogProjection {
+			valueLogRootCount++
+		}
+	}
+	directValueLogProjection := valueLogRootCount == 1
+
+	type valueLogSegmentTally struct {
+		references uint64
+		liveBytes  int64
+		pointers   uint64
+	}
+	type memoEntry struct {
+		leafTotals       leafGenerationSubtreeStats
+		children         []uint64
+		valueLogTallies  map[uint32]valueLogSegmentTally
+		groupedRecords   map[uint32][]uint64
+		valueLogComplete bool
+	}
+
+	segmentTallies := make(map[uint32]valueLogSegmentTally)
+	var directGroupedRecordStarts map[uint32]map[uint64]struct{}
+	var groupedRecordLengths map[uint32]map[uint64]int64
+	if collectLive {
+		directGroupedRecordStarts = make(map[uint32]map[uint64]struct{})
+		if !directValueLogProjection {
+			groupedRecordLengths = make(map[uint32]map[uint64]int64)
+		}
+	}
+	verifyAlways := snap.idx.pager.VerifyOnRead()
+	leafCacheOnly := collectLeaf && !collectValueLog && !opts.DisableLeafSubtreeCache && !verifyAlways
+	if leafScan != nil {
+		leafScan.cacheEnabled = leafCacheOnly
+	}
+	memo := make(map[uint64]memoEntry, 64)
+	childStacks := make([][]uint64, 0, 8)
+	leafScratch := make([]byte, 0, page.PageSize)
+
+	scanLeafValues := func(n node.Node, entry *memoEntry) error {
+		for i := uint16(0); i < n.Count(); i++ {
+			_, ptr, flags, err := n.GetLeafValueView(i)
+			if err != nil {
+				return err
+			}
+			if flags&node.FlagPointer == 0 || !page.IsValueLogFileID(ptr.FileID) {
+				continue
+			}
+			if directValueLogProjection {
+				result.counters.PointerProjections++
+				tally := segmentTallies[ptr.FileID]
+				if collectRefs {
+					tally.references++
+				}
+				if collectLive {
+					if page.ValuePtrIsGrouped(ptr) {
+						if ptr.Offset < 4 {
+							return fmt.Errorf("maintenance reachability: invalid grouped pointer offset %d", ptr.Offset)
+						}
+						starts := directGroupedRecordStarts[ptr.FileID]
+						if starts == nil {
+							starts = make(map[uint64]struct{})
+							directGroupedRecordStarts[ptr.FileID] = starts
+						}
+						start := ptr.Offset - 4
+						if _, ok := starts[start]; ok {
+							result.counters.GroupedRecordDedupeHits++
+							segmentTallies[ptr.FileID] = tally
+							continue
+						}
+						starts[start] = struct{}{}
+					}
+					result.recordLengthLookups++
+					hint := page.ValuePtrRecordLength(ptr)
+					recordLen, err := db.valueLogRecordLengthForRewriteInSet(ptr, snap.state.ValueLogSet)
+					if err != nil {
+						return err
+					}
+					if hint == 0 {
+						result.counters.PhysicalBytesRead += valuelog.HeaderSize
+					}
+					tally.liveBytes += int64(recordLen)
+				}
+				segmentTallies[ptr.FileID] = tally
+				continue
+			}
+
+			if entry.valueLogTallies == nil {
+				entry.valueLogTallies = make(map[uint32]valueLogSegmentTally)
+			}
+			tally := entry.valueLogTallies[ptr.FileID]
+			tally.pointers++
+			if collectRefs {
+				tally.references++
+			}
+			if collectLive {
+				if page.ValuePtrIsGrouped(ptr) {
+					if ptr.Offset < 4 {
+						return fmt.Errorf("maintenance reachability: invalid grouped pointer offset %d", ptr.Offset)
+					}
+					lengths := groupedRecordLengths[ptr.FileID]
+					if lengths == nil {
+						lengths = make(map[uint64]int64)
+						groupedRecordLengths[ptr.FileID] = lengths
+					}
+					start := ptr.Offset - 4
+					recordLen, ok := lengths[start]
+					if !ok {
+						result.recordLengthLookups++
+						hint := page.ValuePtrRecordLength(ptr)
+						length, err := db.valueLogRecordLengthForRewriteInSet(ptr, snap.state.ValueLogSet)
+						if err != nil {
+							return err
+						}
+						if hint == 0 {
+							result.counters.PhysicalBytesRead += valuelog.HeaderSize
+						}
+						recordLen = int64(length)
+						lengths[start] = recordLen
+					} else if recordLen < 0 {
+						recordLen = -recordLen
+					}
+					if entry.groupedRecords == nil {
+						entry.groupedRecords = make(map[uint32][]uint64)
+					}
+					entry.groupedRecords[ptr.FileID] = append(entry.groupedRecords[ptr.FileID], start)
+					entry.valueLogTallies[ptr.FileID] = tally
+					continue
+				}
+				result.recordLengthLookups++
+				hint := page.ValuePtrRecordLength(ptr)
+				recordLen, err := db.valueLogRecordLengthForRewriteInSet(ptr, snap.state.ValueLogSet)
+				if err != nil {
+					return err
+				}
+				if hint == 0 {
+					result.counters.PhysicalBytesRead += valuelog.HeaderSize
+				}
+				tally.liveBytes += int64(recordLen)
+			}
+			entry.valueLogTallies[ptr.FileID] = tally
+		}
+		return nil
+	}
+
+	scanOuterLeaf := func(ptr page.LeafLogPtr, entry *memoEntry) error {
+		data, usedDst, state, err := snap.reader.ReadLeafLogPageUnsafeToWithState(ptr, leafScratch[:0])
+		if err != nil {
+			return err
+		}
+		if len(data) != page.PageSize {
+			return fmt.Errorf("maintenance reachability: invalid outer leaf size %d for file=%d offset=%d", len(data), ptr.FileID, ptr.Offset)
+		}
+		result.counters.PhysicalBytesRead += uint64(len(data))
+		n := node.NewNodeView(data)
+		if snap.reader.ReadChecksumEnabled() && !(state.PageChecksumVerified && state.RecordChecksumVerified) {
+			if !n.VerifyChecksum() {
+				return fmt.Errorf("maintenance reachability: checksum mismatch on outer leaf file=%d offset=%d", ptr.FileID, ptr.Offset)
+			}
+			if state.RecordChecksumVerified && state.CacheEntryPresent {
+				snap.reader.MarkLeafLogPageChecksumVerified(ptr)
+			}
+		}
+		if n.Type() != page.PageTypeLeaf {
+			return fmt.Errorf("maintenance reachability: invalid outer leaf page type %d for file=%d offset=%d", n.Type(), ptr.FileID, ptr.Offset)
+		}
+		if err := scanLeafValues(n, entry); err != nil {
+			return err
+		}
+		if usedDst {
+			leafScratch = data[:0]
+		} else {
+			leafScratch = leafScratch[:0]
+		}
+		return nil
+	}
+
+	var walk func(uint64, int, bool) (leafGenerationSubtreeStats, error)
+	walk = func(pageID uint64, depth int, valueLogProjection bool) (leafGenerationSubtreeStats, error) {
+		if entry, ok := memo[pageID]; ok {
+			if valueLogProjection && !entry.valueLogComplete {
+				return nil, fmt.Errorf("maintenance reachability: value-log projection reached protected-only memo page %d", pageID)
+			}
+			result.counters.MemoHits++
+			return entry.leafTotals, nil
+		}
+		if leafCacheOnly {
+			if stats, ok := db.loadLeafGenerationSubtreeStats(pageID); ok {
+				result.counters.MemoHits++
+				memo[pageID] = memoEntry{leafTotals: stats}
+				return stats, nil
+			}
+		}
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+		if collectLeaf {
+			runLeafGenerationSubtreeCacheMissHook(pageID)
+		}
+		data, err := snap.idx.pager.Get(pageID)
+		if err != nil {
+			return nil, err
+		}
+		result.counters.PagesVisited++
+		result.counters.PhysicalBytesRead += uint64(len(data))
+		n := node.NewNodeView(data)
+		if verifyAlways || !snap.idx.pager.IsVerified(pageID) {
+			if !n.VerifyChecksum() {
+				return nil, fmt.Errorf("maintenance reachability: checksum mismatch on page %d", pageID)
+			}
+			if !verifyAlways {
+				snap.idx.pager.MarkVerified(pageID)
+			}
+		}
+
+		entry := memoEntry{valueLogComplete: valueLogProjection}
+		switch n.Type() {
+		case page.PageTypeLeaf:
+			if valueLogProjection {
+				if err := scanLeafValues(n, &entry); err != nil {
+					return nil, err
+				}
+			}
+		case page.PageTypeInternal:
+			for len(childStacks) <= depth {
+				childStacks = append(childStacks, nil)
+			}
+			children := childStacks[depth][:0]
+			err := n.WalkInternalChildren(&children, func(ptr page.LeafLogPtr) error {
+				if leafScan != nil {
+					result.leafFrameProjections++
+					var visitErr error
+					entry.leafTotals, visitErr = db.scanLeafGenerationPtrTotals(leafScan, entry.leafTotals, ptr)
+					if visitErr != nil {
+						return visitErr
+					}
+				}
+				if valueLogProjection {
+					return scanOuterLeaf(ptr, &entry)
+				}
+				return nil
+			})
+			if err != nil {
+				return nil, err
+			}
+			entry.children = append(entry.children, children...)
+			childStacks[depth] = children[:0]
+			for _, childID := range children {
+				childTotals, err := walk(childID, depth+1, valueLogProjection)
+				if err != nil {
+					return nil, err
+				}
+				entry.leafTotals = mergeLeafGenerationTotals(entry.leafTotals, childTotals)
+			}
+		default:
+			return nil, fmt.Errorf("maintenance reachability: invalid page type %d on page %d", n.Type(), pageID)
+		}
+		memo[pageID] = entry
+		if collectLeaf && !verifyAlways {
+			db.storeLeafGenerationSubtreeStats(pageID, entry.leafTotals)
+		}
+		return entry.leafTotals, nil
+	}
+
+	var projectValueLog func(uint64) error
+	projectValueLog = func(pageID uint64) error {
+		entry, ok := memo[pageID]
+		if !ok || !entry.valueLogComplete {
+			return fmt.Errorf("maintenance reachability: missing value-log projection for page %d", pageID)
+		}
+		for fileID, local := range entry.valueLogTallies {
+			tally := segmentTallies[fileID]
+			tally.references += local.references
+			tally.liveBytes += local.liveBytes
+			tally.pointers += local.pointers
+			segmentTallies[fileID] = tally
+			result.counters.PointerProjections += local.pointers
+		}
+		if collectLive {
+			for fileID, starts := range entry.groupedRecords {
+				lengths := groupedRecordLengths[fileID]
+				for _, start := range starts {
+					recordLen, ok := lengths[start]
+					if !ok || recordLen == 0 {
+						return fmt.Errorf("maintenance reachability: missing grouped record length for file=%d start=%d", fileID, start)
+					}
+					if recordLen < 0 {
+						result.counters.GroupedRecordDedupeHits++
+						continue
+					}
+					lengths[start] = -recordLen
+					tally := segmentTallies[fileID]
+					tally.liveBytes += recordLen
+					segmentTallies[fileID] = tally
+				}
+			}
+		}
+		for _, childID := range entry.children {
+			if err := projectValueLog(childID); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+
+	for _, root := range roots {
+		stats, err := walk(root.rootID, 0, root.valueLogProjection)
+		if err != nil {
+			return result, err
+		}
+		if collectLeaf {
+			result.leafGenerationLive.Generations = mergeLeafGenerationTotals(result.leafGenerationLive.Generations, stats)
+		}
+		if root.valueLogProjection && !directValueLogProjection {
+			if err := projectValueLog(root.rootID); err != nil {
+				return result, err
+			}
+		}
+	}
+	for fileID, tally := range segmentTallies {
+		if collectRefs && tally.references != 0 {
+			result.valueLogRefCounts[fileID] = tally.references
+			result.valueLogReferencedSegments[fileID] = struct{}{}
+		}
+		if collectLive {
+			result.valueLogLiveBytesBySegment[fileID] = tally.liveBytes
+		}
+	}
+	result.counters.SharedScans = 1
+	return result, nil
+}

--- a/TreeDB/db/maintenance_reachability_test.go
+++ b/TreeDB/db/maintenance_reachability_test.go
@@ -131,6 +131,44 @@ func TestMaintenanceReachabilityCollectorSelectionSkipsUnusedWork(t *testing.T) 
 	}
 }
 
+func TestMaintenanceReachabilityLeafSubtreeCachePolicy(t *testing.T) {
+	db, _ := openLeafGenerationGCTestDB(t)
+	writeLeafGenerationKeys(t, db, "cache", 1024, 'c')
+	snap := db.AcquireSnapshot()
+	if snap == nil {
+		t.Fatal("AcquireSnapshot returned nil")
+	}
+	defer closeNoErr(t, snap)
+
+	scan := func(disable bool) maintenanceReachabilityResult {
+		t.Helper()
+		got, err := db.maintenanceReachabilityScan(context.Background(), snap, maintenanceReachabilityScanOptions{
+			Collectors:              maintenanceReachabilityLeafGenerationTotals,
+			DisableLeafSubtreeCache: disable,
+		})
+		if err != nil {
+			t.Fatalf("maintenanceReachabilityScan disable=%v: %v", disable, err)
+		}
+		return got
+	}
+
+	db.clearLeafGenerationReachabilityCaches()
+	if first := scan(false); first.counters.PagesVisited == 0 {
+		t.Fatalf("cold cached scan visited no pages: %+v", first.counters)
+	}
+	if second := scan(false); second.counters.PagesVisited != 0 || second.counters.MemoHits == 0 {
+		t.Fatalf("warm cached scan did not reuse root subtree: %+v", second.counters)
+	}
+
+	db.clearLeafGenerationReachabilityCaches()
+	if first := scan(true); first.counters.PagesVisited == 0 {
+		t.Fatalf("first uncached scan visited no pages: %+v", first.counters)
+	}
+	if second := scan(true); second.counters.PagesVisited == 0 {
+		t.Fatalf("disabled cache unexpectedly reused subtree: %+v", second.counters)
+	}
+}
+
 func BenchmarkMaintenanceReachability(b *testing.B) {
 	db := openCompactStorageAuditBenchmarkFixture(b, 4096, 256)
 	ctx := context.Background()

--- a/TreeDB/db/maintenance_reachability_test.go
+++ b/TreeDB/db/maintenance_reachability_test.go
@@ -1,0 +1,192 @@
+package db
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"reflect"
+	"testing"
+
+	"github.com/snissn/gomap/TreeDB/page"
+)
+
+func TestMaintenanceReachabilityCollectorsSharePageWalkAndMatchLegacy(t *testing.T) {
+	db, leafLog := openLeafGenerationGCTestDB(t)
+
+	grouped := appendPointersInNewSegment(t, db.dir, 0, 1, 410_000, 1, func(int) []byte {
+		return bytes.Repeat([]byte("maintenance-reachability-grouped|"), 32)
+	})[0]
+	if err := db.RefreshValueLogSet(); err != nil {
+		t.Fatalf("RefreshValueLogSet: %v", err)
+	}
+
+	writeLeafGenerationKeys(t, db, "base", 1024, 'a')
+	b := db.NewBatch().(*Batch)
+	recordLen := page.ValuePtrRecordLength(grouped)
+	for i := 0; i < 3; i++ {
+		ptr := grouped
+		ptr.Length = page.ValuePtrMarkGrouped(recordLen, uint8(i))
+		if err := b.SetPointer([]byte(fmt.Sprintf("grouped/%d", i)), ptr); err != nil {
+			t.Fatalf("SetPointer grouped %d: %v", i, err)
+		}
+	}
+	if err := b.Set([]byte("inline"), []byte("value")); err != nil {
+		t.Fatalf("Set inline: %v", err)
+	}
+	if err := b.WriteSync(); err != nil {
+		t.Fatalf("WriteSync: %v", err)
+	}
+	closeNoErr(t, b)
+	if err := leafLog.rotateLeaf(); err != nil {
+		t.Fatalf("rotateLeaf: %v", err)
+	}
+	writeLeafGenerationKeys(t, db, "current", 1, 'z')
+
+	wantRefs, _, err := db.scanValueLogRefCounts(context.Background())
+	if err != nil {
+		t.Fatalf("legacy ref counts: %v", err)
+	}
+	wantLive, err := db.estimateValueLogLiveBytesBySegment(context.Background())
+	if err != nil {
+		t.Fatalf("legacy live bytes: %v", err)
+	}
+	snap := db.AcquireSnapshot()
+	if snap == nil {
+		t.Fatal("AcquireSnapshot returned nil")
+	}
+	defer closeNoErr(t, snap)
+	wantLeaf, err := db.scanLeafGenerationLiveStats(context.Background(), snap)
+	if err != nil {
+		t.Fatalf("legacy leaf-generation totals: %v", err)
+	}
+
+	got, err := db.maintenanceReachabilityScan(context.Background(), snap, maintenanceReachabilityScanOptions{
+		Collectors: maintenanceReachabilityValueLogRefCounts |
+			maintenanceReachabilityValueLogLiveBytes |
+			maintenanceReachabilityLeafGenerationTotals,
+	})
+	if err != nil {
+		t.Fatalf("maintenanceReachabilityScan: %v", err)
+	}
+	if !reflect.DeepEqual(got.valueLogRefCounts, wantRefs) {
+		t.Fatalf("ref counts mismatch: shared=%v legacy=%v", got.valueLogRefCounts, wantRefs)
+	}
+	if !reflect.DeepEqual(got.valueLogLiveBytesBySegment, wantLive) {
+		t.Fatalf("live bytes mismatch: shared=%v legacy=%v", got.valueLogLiveBytesBySegment, wantLive)
+	}
+	if !reflect.DeepEqual(got.leafGenerationLive, wantLeaf) {
+		t.Fatalf("leaf-generation totals mismatch: shared=%v legacy=%v", got.leafGenerationLive, wantLeaf)
+	}
+	if got.valueLogRefCounts[grouped.FileID] != 3 {
+		t.Fatalf("grouped ref count=%d want 3", got.valueLogRefCounts[grouped.FileID])
+	}
+	if got.valueLogLiveBytesBySegment[grouped.FileID] != int64(recordLen) {
+		t.Fatalf("grouped live bytes=%d want one record=%d", got.valueLogLiveBytesBySegment[grouped.FileID], recordLen)
+	}
+	if got.counters.SharedScans != 1 || got.counters.PagesVisited == 0 {
+		t.Fatalf("shared traversal counters=%+v", got.counters)
+	}
+}
+
+func TestMaintenanceReachabilityCollectorSelectionSkipsUnusedWork(t *testing.T) {
+	db, _ := openLeafGenerationGCTestDB(t)
+	ptr := appendPointersInNewSegment(t, db.dir, 0, 1, 420_000, 1, func(int) []byte {
+		return bytes.Repeat([]byte("maintenance-reachability-selection|"), 32)
+	})[0]
+	if err := db.RefreshValueLogSet(); err != nil {
+		t.Fatalf("RefreshValueLogSet: %v", err)
+	}
+	b := db.NewBatch().(*Batch)
+	if err := b.SetPointer([]byte("pointer"), ptr); err != nil {
+		t.Fatalf("SetPointer: %v", err)
+	}
+	if err := b.WriteSync(); err != nil {
+		t.Fatalf("WriteSync: %v", err)
+	}
+	closeNoErr(t, b)
+	writeLeafGenerationKeys(t, db, "leaf", 512, 'l')
+
+	snap := db.AcquireSnapshot()
+	if snap == nil {
+		t.Fatal("AcquireSnapshot returned nil")
+	}
+	defer closeNoErr(t, snap)
+	got, err := db.maintenanceReachabilityScan(context.Background(), snap, maintenanceReachabilityScanOptions{
+		Collectors: maintenanceReachabilityValueLogRefCounts,
+	})
+	if err != nil {
+		t.Fatalf("maintenanceReachabilityScan ref-only: %v", err)
+	}
+	if got.valueLogRefCounts[ptr.FileID] != 1 {
+		t.Fatalf("ref count=%d want 1", got.valueLogRefCounts[ptr.FileID])
+	}
+	if got.valueLogLiveBytesBySegment != nil {
+		t.Fatalf("live-byte collector unexpectedly initialized: %v", got.valueLogLiveBytesBySegment)
+	}
+	if got.leafGenerationLive.Generations != nil {
+		t.Fatalf("leaf collector unexpectedly initialized: %v", got.leafGenerationLive)
+	}
+	if got.recordLengthLookups != 0 || got.leafFrameProjections != 0 {
+		t.Fatalf("unused collector work: record lengths=%d leaf frames=%d", got.recordLengthLookups, got.leafFrameProjections)
+	}
+}
+
+func BenchmarkMaintenanceReachability(b *testing.B) {
+	db := openCompactStorageAuditBenchmarkFixture(b, 4096, 256)
+	ctx := context.Background()
+
+	b.Run("legacy_ref_counts", func(b *testing.B) {
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			if _, _, err := db.scanValueLogRefCounts(ctx); err != nil {
+				b.Fatalf("scanValueLogRefCounts: %v", err)
+			}
+		}
+	})
+	b.Run("shared_ref_counts", func(b *testing.B) {
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			snap := db.AcquireSnapshot()
+			if snap == nil {
+				b.Fatal("AcquireSnapshot returned nil")
+			}
+			_, err := db.maintenanceReachabilityScan(ctx, snap, maintenanceReachabilityScanOptions{
+				Collectors: maintenanceReachabilityValueLogRefCounts,
+			})
+			if closeErr := snap.Close(); closeErr != nil {
+				b.Fatalf("close snapshot: %v", closeErr)
+			}
+			if err != nil {
+				b.Fatalf("maintenanceReachabilityScan: %v", err)
+			}
+		}
+	})
+	b.Run("legacy_all_collectors", func(b *testing.B) {
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			in, err := db.acquireCompactStorageAuditInput(CompactStorageOptions{})
+			if err != nil {
+				b.Fatalf("acquireCompactStorageAuditInput: %v", err)
+			}
+			_, err = db.scanCompactStorageAuditLegacy(ctx, in)
+			in.close()
+			if err != nil {
+				b.Fatalf("scanCompactStorageAuditLegacy: %v", err)
+			}
+		}
+	})
+	b.Run("shared_all_collectors", func(b *testing.B) {
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			in, err := db.acquireCompactStorageAuditInput(CompactStorageOptions{})
+			if err != nil {
+				b.Fatalf("acquireCompactStorageAuditInput: %v", err)
+			}
+			_, err = db.scanCompactStorageAudit(ctx, in)
+			in.close()
+			if err != nil {
+				b.Fatalf("scanCompactStorageAudit: %v", err)
+			}
+		}
+	})
+}


### PR DESCRIPTION
## Summary

First staged migration for #3644.

- extracts the PL-03 page-granular walk into `maintenanceReachabilityScan`
- adds bit-selected collectors for exact value-log ref counts, grouped-deduped live bytes, and leaf-generation totals
- preserves maintenance-root/collection-root expansion, protected user/system roots, checksum behavior, subtree memoization, cache policy, and grouped leaf-frame accounting
- migrates CompactStorage audit onto the shared scanner without changing its protected-basis acquisition, cache key, revalidation/retry, tracker publication, or deletion fences
- retains `scanCompactStorageAuditLegacy` temporarily for direct staged equivalence and rollback until standalone consumers migrate

## TDD and correctness

Added before implementation:

- `TestMaintenanceReachabilityCollectorsSharePageWalkAndMatchLegacy`
- `TestMaintenanceReachabilityCollectorSelectionSkipsUnusedWork`
- `TestMaintenanceReachabilityLeafSubtreeCachePolicy`

Existing CompactStorage audit tests continue to cover grouped aliases, collection roots, protected ordinary/system roots, protected-root cache identity, memo reuse, retry/revalidation, and unchanged public plans.

Exact-head validation for `a200b8d450f26bb688540013c9369ac43e3de1ab`:

```text
GOWORK=off GOMEMLIMIT=4GiB GOMAXPROCS=2 go test -p 1 ./TreeDB/db -count=1
ok github.com/snissn/gomap/TreeDB/db 284.498s

GOWORK=off GOMEMLIMIT=4GiB GOMAXPROCS=2 go test -p 1 ./TreeDB/db ./TreeDB/collections -run 'TestMaintenanceReachability|TestValueLogGC|TestValueLogRewrite|TestLeafGeneration|TestColumnAssetGC' -count=1
ok github.com/snissn/gomap/TreeDB/db 15.119s
ok github.com/snissn/gomap/TreeDB/collections 2.900s
```

## Performance evidence

Command:

```text
GOWORK=off GOMEMLIMIT=4GiB GOMAXPROCS=2 go test -p 1 ./TreeDB/db -run '^$' -bench '^BenchmarkMaintenanceReachability$' -benchmem -benchtime=300ms -count=8
```

Exact-head paired benchstat:

| Path | Time | Bytes | Allocations |
| --- | ---: | ---: | ---: |
| ref-only shared vs dedicated legacy | -48.73%, p=0.000 | +385.04% (14.8 KiB vs 3.1 KiB) | -55.00% (18 vs 40) |
| all collectors shared vs PL-03 legacy | no significant change, p=0.105 | +0.10% | unchanged (167) |

The unused-collector time gate passes comfortably: selecting ref counts alone performs zero record-length lookups and zero leaf-frame projections and is materially faster than the dedicated iterator scanner. The higher ref-only transient byte count is the page-walk memo; allocations and wall time both improve.

## Staging

This PR migrates only CompactStorage. Follow-up PRs will migrate the standalone ref-count, live-byte, and leaf-generation wrappers one at a time, retain their existing tracker/cache/refresh contracts, and remove the legacy scanners only after equivalence tests pass.

Part of #3644
