### PR TITLE
db: migrate value-log ref counts to shared reachability

### DIFF
--- a/TreeDB/db/maintenance_reachability_test.go
+++ b/TreeDB/db/maintenance_reachability_test.go
@@ -153,6 +153,9 @@ func TestScanValueLogRefCountsUsesSharedCollectorAndMatchesLegacy(t *testing.T) 
 	if err != nil {
 		t.Fatalf("legacy scanValueLogRefCounts: %v", err)
 	}
+	if len(want) == 0 {
+		t.Fatal("legacy ref-count fixture produced no value-log references")
+	}
 	var hookCalls int
 	restore := registerScanValueLogRefCountsHook(func() { hookCalls++ })
 	defer restore()

--- a/TreeDB/db/maintenance_reachability_test.go
+++ b/TreeDB/db/maintenance_reachability_test.go
@@ -42,7 +42,7 @@ func TestMaintenanceReachabilityCollectorsSharePageWalkAndMatchLegacy(t *testing
 	}
 	writeLeafGenerationKeys(t, db, "current", 1, 'z')
 
-	wantRefs, _, err := db.scanValueLogRefCounts(context.Background())
+	wantRefs, _, err := db.scanValueLogRefCountsLegacy(context.Background())
 	if err != nil {
 		t.Fatalf("legacy ref counts: %v", err)
 	}
@@ -131,6 +131,47 @@ func TestMaintenanceReachabilityCollectorSelectionSkipsUnusedWork(t *testing.T) 
 	}
 }
 
+func TestScanValueLogRefCountsUsesSharedCollectorAndMatchesLegacy(t *testing.T) {
+	db, _ := openLeafGenerationGCTestDB(t)
+	ptr := appendPointersInNewSegment(t, db.dir, 0, 1, 430_000, 1, func(int) []byte {
+		return bytes.Repeat([]byte("maintenance-reachability-ref-migration|"), 32)
+	})[0]
+	if err := db.RefreshValueLogSet(); err != nil {
+		t.Fatalf("RefreshValueLogSet: %v", err)
+	}
+	b := db.NewBatch().(*Batch)
+	if err := b.SetPointer([]byte("pointer"), ptr); err != nil {
+		t.Fatalf("SetPointer: %v", err)
+	}
+	if err := b.WriteSync(); err != nil {
+		t.Fatalf("WriteSync: %v", err)
+	}
+	closeNoErr(t, b)
+	ctx := context.Background()
+
+	want, wantSeq, err := db.scanValueLogRefCountsLegacy(ctx)
+	if err != nil {
+		t.Fatalf("legacy scanValueLogRefCounts: %v", err)
+	}
+	var hookCalls int
+	restore := registerScanValueLogRefCountsHook(func() { hookCalls++ })
+	defer restore()
+
+	got, gotSeq, err := db.scanValueLogRefCounts(ctx)
+	if err != nil {
+		t.Fatalf("scanValueLogRefCounts: %v", err)
+	}
+	if hookCalls != 1 {
+		t.Fatalf("scan hook calls=%d want 1", hookCalls)
+	}
+	if gotSeq != wantSeq {
+		t.Fatalf("commit sequence=%d want %d", gotSeq, wantSeq)
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("ref counts mismatch: shared=%v legacy=%v", got, want)
+	}
+}
+
 func TestMaintenanceReachabilityLeafSubtreeCachePolicy(t *testing.T) {
 	db, _ := openLeafGenerationGCTestDB(t)
 	writeLeafGenerationKeys(t, db, "cache", 1024, 'c')
@@ -176,8 +217,8 @@ func BenchmarkMaintenanceReachability(b *testing.B) {
 	b.Run("legacy_ref_counts", func(b *testing.B) {
 		b.ReportAllocs()
 		for i := 0; i < b.N; i++ {
-			if _, _, err := db.scanValueLogRefCounts(ctx); err != nil {
-				b.Fatalf("scanValueLogRefCounts: %v", err)
+			if _, _, err := db.scanValueLogRefCountsLegacy(ctx); err != nil {
+				b.Fatalf("scanValueLogRefCountsLegacy: %v", err)
 			}
 		}
 	})

--- a/TreeDB/db/vlog_gc_incremental.go
+++ b/TreeDB/db/vlog_gc_incremental.go
@@ -630,6 +630,31 @@ func (db *DB) scanValueLogRefCounts(ctx context.Context) (map[uint32]uint64, uin
 		return nil, 0, fmt.Errorf("missing db state")
 	}
 	commitSeq := snap.state.CommitSeq
+	result, err := db.maintenanceReachabilityScan(ctx, snap, maintenanceReachabilityScanOptions{
+		Collectors: maintenanceReachabilityValueLogRefCounts,
+	})
+	if err != nil {
+		_ = snap.Close()
+		return nil, 0, err
+	}
+	if err := snap.Close(); err != nil {
+		return nil, 0, err
+	}
+	return result.valueLogRefCounts, commitSeq, nil
+}
+
+func (db *DB) scanValueLogRefCountsLegacy(ctx context.Context) (map[uint32]uint64, uint64, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	snap := db.AcquireSnapshot()
+	if snap == nil || snap.idx == nil || snap.state == nil {
+		if snap != nil {
+			_ = snap.Close()
+		}
+		return nil, 0, fmt.Errorf("missing db state")
+	}
+	commitSeq := snap.state.CommitSeq
 	counts := make(map[uint32]uint64)
 
 	roots, err := maintenanceRootsForSnapshot(snap)


### PR DESCRIPTION
## Summary

- route `scanValueLogRefCounts` through the page-granular maintenance reachability scanner with only the exact per-pointer ref-count collector enabled
- preserve the wrapper's hook, pinned snapshot ownership, commit-sequence result, close/error behavior, tracker fallback/retry callers, and GC deletion fences
- retain the pointer-projection iterator for pending-appender exact pointer matching and retain the old ref-count walk temporarily as a test-only migration oracle

Part of #3644. Depends on merged #3689.

## TDD and equivalence

- added `TestScanValueLogRefCountsUsesSharedCollectorAndMatchesLegacy` before the implementation; it initially failed because the migration oracle did not exist
- the migration test verifies exact map equality, commit-sequence equality, and one hook call
- the mixed shared-scanner fixture now compares ref counts against the dedicated legacy implementation, including exact per-pointer grouped-record accounting
- existing incremental tracker parity, publish-during-full-scan, post-scan deletion-fence, protected-root, and value-log GC tests continue to exercise the unchanged callers

## Exact-head validation

```text
GOWORK=off GOMEMLIMIT=4GiB GOMAXPROCS=2 go test -p 1 ./TreeDB/db -count=1
ok github.com/snissn/gomap/TreeDB/db 251.196s

GOWORK=off GOMEMLIMIT=4GiB GOMAXPROCS=2 go test -p 1 ./TreeDB/db ./TreeDB/collections -run 'TestMaintenanceReachability|TestValueLogGC|TestValueLogRewrite|TestLeafGeneration|TestColumnAssetGC' -count=1
[pending command output at PR creation; will be posted as an exact-head comment]

GOWORK=off GOMEMLIMIT=4GiB GOMAXPROCS=2 go vet ./TreeDB/db
PASS
```

## Performance gate

Eight-sample direct comparison on the same exact code:

| scanner | median time | bytes/op | allocs/op |
| --- | ---: | ---: | ---: |
| dedicated legacy ref scan | 175.3 us | 3.056 KiB | 40 |
| shared ref-only collector | 90.37 us | 14.82 KiB | 18 |

The migrated path is about 48% faster and reduces allocations by 55%. The additional bytes are the bounded page memo used by the shared traversal; record-length lookups and leaf-frame projections remain zero for ref-only selection. This is well inside the issue's `<5%` unused-collector overhead gate.

## Remaining #3644 work

- migrate live-byte/rewrite estimation while preserving grouped-record dedupe, cache keys, immutable cached maps, and one refresh/retry on missing files
- migrate leaf-generation totals while preserving protected-root cache keys and subtree memoization
- remove migration-oracle scanners after all consumer equivalence tests pass


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved value-log reference counting during maintenance reachability scans.
  * Preserved commit sequence and reference-count results while using the shared scan process.
  * Improved snapshot cleanup and error handling during scanning.

* **Tests**
  * Added coverage verifying shared scanning is invoked once and matches legacy results.
  * Updated benchmarks and validation tests to compare against the legacy implementation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->