### PR TITLE
db: migrate value-log live-byte scan to shared reachability

### DIFF
--- a/TreeDB/db/compact_storage_audit_test.go
+++ b/TreeDB/db/compact_storage_audit_test.go
@@ -211,7 +211,7 @@ func TestCompactStorageAudit_ValueLogCollectorsMatchLegacyGroupedAliases(t *test
 	if err != nil {
 		t.Fatalf("legacy refs: %v", err)
 	}
-	wantLive, err := db.estimateValueLogLiveBytesBySegment(context.Background())
+	wantLive, err := db.estimateValueLogLiveBytesBySegmentLegacy(context.Background())
 	if err != nil {
 		t.Fatalf("legacy live bytes: %v", err)
 	}
@@ -313,7 +313,7 @@ func TestCompactStorageAudit_ProtectedRootsOnlyExtendLeafProjection(t *testing.T
 	if err != nil {
 		t.Fatalf("legacy refs: %v", err)
 	}
-	wantLive, err := db.estimateValueLogLiveBytesBySegment(context.Background())
+	wantLive, err := db.estimateValueLogLiveBytesBySegmentLegacy(context.Background())
 	if err != nil {
 		t.Fatalf("legacy live bytes: %v", err)
 	}
@@ -476,7 +476,7 @@ func TestCompactStorageAudit_ProtectedPagerRootsMatchLegacyWithMemoReuse(t *test
 	if err != nil {
 		t.Fatalf("legacy refs: %v", err)
 	}
-	wantLive, err := db.estimateValueLogLiveBytesBySegment(context.Background())
+	wantLive, err := db.estimateValueLogLiveBytesBySegmentLegacy(context.Background())
 	if err != nil {
 		t.Fatalf("legacy live bytes: %v", err)
 	}

--- a/TreeDB/db/maintenance_reachability_test.go
+++ b/TreeDB/db/maintenance_reachability_test.go
@@ -46,7 +46,7 @@ func TestMaintenanceReachabilityCollectorsSharePageWalkAndMatchLegacy(t *testing
 	if err != nil {
 		t.Fatalf("legacy ref counts: %v", err)
 	}
-	wantLive, err := db.estimateValueLogLiveBytesBySegment(context.Background())
+	wantLive, err := db.estimateValueLogLiveBytesBySegmentLegacy(context.Background())
 	if err != nil {
 		t.Fatalf("legacy live bytes: %v", err)
 	}
@@ -175,6 +175,127 @@ func TestScanValueLogRefCountsUsesSharedCollectorAndMatchesLegacy(t *testing.T) 
 	}
 }
 
+func clearRewritePlanLiveBytesCacheForTest(db *DB) {
+	db.rewritePlanLiveBytesMu.Lock()
+	db.rewritePlanLiveBytesCache = valueLogRewriteLiveBytesCache{}
+	db.rewritePlanLiveBytesMu.Unlock()
+}
+
+func TestEstimateValueLogLiveBytesBySegmentUsesSharedCollectorAndMatchesLegacy(t *testing.T) {
+	db, _ := openLeafGenerationGCTestDB(t)
+	grouped := appendPointersInNewSegment(t, db.dir, 0, 1, 440_000, 1, func(int) []byte {
+		return bytes.Repeat([]byte("maintenance-reachability-live-migration|"), 32)
+	})[0]
+	if err := db.RefreshValueLogSet(); err != nil {
+		t.Fatalf("RefreshValueLogSet: %v", err)
+	}
+	b := db.NewBatch().(*Batch)
+	recordLen := page.ValuePtrRecordLength(grouped)
+	for i := 0; i < 3; i++ {
+		ptr := grouped
+		ptr.Length = page.ValuePtrMarkGrouped(recordLen, uint8(i))
+		if err := b.SetPointer([]byte(fmt.Sprintf("grouped-live/%d", i)), ptr); err != nil {
+			t.Fatalf("SetPointer grouped %d: %v", i, err)
+		}
+	}
+	if err := b.WriteSync(); err != nil {
+		t.Fatalf("WriteSync: %v", err)
+	}
+	closeNoErr(t, b)
+	ctx := context.Background()
+
+	clearRewritePlanLiveBytesCacheForTest(db)
+	want, err := db.estimateValueLogLiveBytesBySegmentLegacy(ctx)
+	if err != nil {
+		t.Fatalf("legacy estimateValueLogLiveBytesBySegment: %v", err)
+	}
+	if len(want) == 0 {
+		t.Fatal("legacy live-byte fixture produced no value-log references")
+	}
+	if got := want[grouped.FileID]; got != int64(recordLen) {
+		t.Fatalf("legacy grouped live bytes=%d want one record=%d", got, recordLen)
+	}
+
+	clearRewritePlanLiveBytesCacheForTest(db)
+	var hookCalls int
+	restore := registerRewritePlanLiveEstimateHook(func() { hookCalls++ })
+	defer restore()
+	got, err := db.estimateValueLogLiveBytesBySegment(ctx)
+	if err != nil {
+		t.Fatalf("estimateValueLogLiveBytesBySegment: %v", err)
+	}
+	if hookCalls != 1 {
+		t.Fatalf("uncached live-estimate hook calls=%d want 1", hookCalls)
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("live bytes mismatch: shared=%v legacy=%v", got, want)
+	}
+	if _, err := db.estimateValueLogLiveBytesBySegment(ctx); err != nil {
+		t.Fatalf("cached estimateValueLogLiveBytesBySegment: %v", err)
+	}
+	if hookCalls != 1 {
+		t.Fatalf("cached live estimate reran scanner: hook calls=%d want 1", hookCalls)
+	}
+}
+
+func TestEstimateValueLogLiveBytesBySegmentRefreshesOnceOnMissingSnapshotFile(t *testing.T) {
+	dir := t.TempDir()
+	db, err := Open(Options{
+		Dir:                        dir,
+		Durability:                 DurabilityWALOffRelaxed,
+		DisableBackgroundPrune:     true,
+		IndexOuterLeavesInValueLog: true,
+		LeafPrefixCompression:      true,
+		IndexColumnarLeaves:        true,
+		IndexPackedValuePtr:        true,
+		LeafPageReadCacheEntries:   -1,
+	})
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	leafLog := newRewriteWriter(ValueLogDirPath(dir), 0, 0, 64<<20)
+	leafLog.ConfigureLeafLog(LeafLogDirPath(dir), rewriteLeafLogLaneID, 0)
+	db.SetLeafPageLog(leafLog)
+	t.Cleanup(func() { closeNoErr(t, leafLog) })
+	t.Cleanup(func() { closeNoErr(t, db) })
+	ptr := appendPointersInNewSegment(t, db.dir, 0, 1, 450_000, 1, func(int) []byte {
+		return bytes.Repeat([]byte("maintenance-reachability-live-refresh|"), 32)
+	})[0]
+	if err := db.RefreshValueLogSet(); err != nil {
+		t.Fatalf("RefreshValueLogSet: %v", err)
+	}
+	b := db.NewBatch().(*Batch)
+	if err := b.SetPointer([]byte("refresh-pointer"), ptr); err != nil {
+		t.Fatalf("SetPointer: %v", err)
+	}
+	if err := b.WriteSync(); err != nil {
+		t.Fatalf("WriteSync: %v", err)
+	}
+	closeNoErr(t, b)
+	writeLeafGenerationKeys(t, db, "refresh-outer-leaf", 1024, 'r')
+
+	clearRewritePlanLiveBytesCacheForTest(db)
+	forceStalePublishedValueLogSetForReadRetryTest(t, db)
+	refreshBefore := db.valueLogManager.RefreshScanCount()
+	var hookCalls int
+	restore := registerRewritePlanLiveEstimateHook(func() { hookCalls++ })
+	defer restore()
+
+	got, err := db.estimateValueLogLiveBytesBySegment(context.Background())
+	if err != nil {
+		t.Fatalf("estimateValueLogLiveBytesBySegment after stale set: %v", err)
+	}
+	if gotRefreshes := db.valueLogManager.RefreshScanCount() - refreshBefore; gotRefreshes != 1 {
+		t.Fatalf("refresh scans=%d want 1", gotRefreshes)
+	}
+	if hookCalls != 2 {
+		t.Fatalf("uncached live-estimate hook calls=%d want initial attempt plus retry", hookCalls)
+	}
+	if want := int64(page.ValuePtrRecordLength(ptr)); got[ptr.FileID] != want {
+		t.Fatalf("live bytes for refreshed segment=%d want %d", got[ptr.FileID], want)
+	}
+}
+
 func TestMaintenanceReachabilityLeafSubtreeCachePolicy(t *testing.T) {
 	db, _ := openLeafGenerationGCTestDB(t)
 	writeLeafGenerationKeys(t, db, "cache", 1024, 'c')
@@ -240,6 +361,28 @@ func BenchmarkMaintenanceReachability(b *testing.B) {
 			}
 			if err != nil {
 				b.Fatalf("maintenanceReachabilityScan: %v", err)
+			}
+		}
+	})
+	b.Run("legacy_live_bytes", func(b *testing.B) {
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			b.StopTimer()
+			clearRewritePlanLiveBytesCacheForTest(db)
+			b.StartTimer()
+			if _, err := db.estimateValueLogLiveBytesBySegmentLegacy(ctx); err != nil {
+				b.Fatalf("estimateValueLogLiveBytesBySegmentLegacy: %v", err)
+			}
+		}
+	})
+	b.Run("shared_live_bytes", func(b *testing.B) {
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			b.StopTimer()
+			clearRewritePlanLiveBytesCacheForTest(db)
+			b.StartTimer()
+			if _, err := db.estimateValueLogLiveBytesBySegment(ctx); err != nil {
+				b.Fatalf("estimateValueLogLiveBytesBySegment: %v", err)
 			}
 		}
 	})

--- a/TreeDB/db/vlog_rewrite.go
+++ b/TreeDB/db/vlog_rewrite.go
@@ -1179,6 +1179,50 @@ func (db *DB) estimateValueLogLiveBytesBySegment(ctx context.Context) (_ map[uin
 			}
 		}
 		runRewritePlanLiveEstimateHook()
+		result, err := db.maintenanceReachabilityScan(ctx, snap, maintenanceReachabilityScanOptions{
+			Collectors: maintenanceReachabilityValueLogLiveBytes,
+		})
+		if err != nil {
+			return nil, err
+		}
+		liveByID := result.valueLogLiveBytesBySegment
+		if cacheable {
+			db.storeCachedValueLogLiveBytes(cacheKey, liveByID)
+		}
+		return liveByID, nil
+	}
+
+	liveByID, err := estimate()
+	if err != nil && errors.Is(err, valuelog.ErrFileNotFound) {
+		// Refresh/re-publish value-log set once when live-byte estimation races
+		// segment registration (for example, new outer-leaf segments).
+		if refreshErr := db.RefreshValueLogSet(); refreshErr != nil {
+			return nil, refreshErr
+		}
+		return estimate()
+	}
+	return liveByID, err
+}
+
+func (db *DB) estimateValueLogLiveBytesBySegmentLegacy(ctx context.Context) (_ map[uint32]int64, err error) {
+	estimate := func() (_ map[uint32]int64, err error) {
+		if ctx == nil {
+			ctx = context.Background()
+		}
+
+		snap := db.AcquireSnapshot()
+		if snap == nil || snap.state == nil || snap.idx == nil {
+			closeRewriteSnapshot(&err, snap)
+			return nil, fmt.Errorf("missing snapshot state")
+		}
+		defer closeRewriteSnapshot(&err, snap)
+		cacheKey, cacheable := rewritePlanLiveBytesKeyForState(snap.state)
+		if cacheable {
+			if liveByID, ok := db.loadCachedValueLogLiveBytes(cacheKey); ok {
+				return liveByID, nil
+			}
+		}
+		runRewritePlanLiveEstimateHook()
 		liveByID := make(map[uint32]int64)
 
 		// Pointer-projection iterators can return many keys pointing at the same


### PR DESCRIPTION
Part of #3644
Parent tracker: #3630
Depends on merged #3690.

## Summary

- migrate `estimateValueLogLiveBytesBySegment` to the live-byte-only shared page-granular maintenance reachability collector
- retain `estimateValueLogLiveBytesBySegmentLegacy` as the migration oracle until the final PL-14 cleanup stage
- preserve the existing commit/root/system-root cache key, immutable clone-and-publish cache, uncached hook, snapshot close-error joining, and one-refresh retry on `valuelog.ErrFileNotFound`
- keep grouped-record dedupe exact: three aliases to one grouped record contribute one physical record length

## TDD and correctness evidence

The migration test was added first and failed to compile because the explicit legacy oracle did not yet exist. Production code was then moved behind that oracle and the shared collector was wired into the existing wrapper.

New coverage:

- non-empty grouped fixture compares the shared wrapper exactly with the retained legacy scanner
- one uncached hook call is followed by a cache hit with no second scan
- a cache-disabled outer-leaf fixture publishes an intentionally stale value-log set, observes one failed attempt, performs exactly one manager refresh, retries once, and returns the exact live bytes for the referenced segment
- existing CompactStorage golden tests now continue to compare against the true legacy live-byte scanner

Exact-head local validation at `d55dfde352364979e348dc5cfdb1862e5669d69c`:

```text
GOWORK=off GOMEMLIMIT=4GiB GOMAXPROCS=2 go test -p 1 ./TreeDB/db -count=1
ok github.com/snissn/gomap/TreeDB/db 327.682s

GOWORK=off GOMEMLIMIT=4GiB GOMAXPROCS=2 go test -p 1 ./TreeDB/db ./TreeDB/collections -run 'TestMaintenanceReachability|TestEstimateValueLogLiveBytesBySegment|TestValueLogRewrite|TestValueLogGC|TestLeafGeneration|TestColumnAssetGC' -count=1
ok github.com/snissn/gomap/TreeDB/db 10.997s
ok github.com/snissn/gomap/TreeDB/collections 2.000s

GOWORK=off GOMEMLIMIT=4GiB GOMAXPROCS=2 go vet ./TreeDB/db ./TreeDB/collections
PASS
```

The branch was rebased after #3687 changed snapshot lifetime accounting; the exact-head runs above validate the wrapper against that final base.

## Performance gate

Command:

```text
GOWORK=off GOMEMLIMIT=4GiB GOMAXPROCS=2 go test ./TreeDB/db -run '^$' -bench 'BenchmarkMaintenanceReachability/(legacy_live_bytes|shared_live_bytes)$' -benchmem -count=8
```

Paired benchstat:

```text
                                legacy          shared          delta
sec/op                          563.0us         494.4us         -12.19% (p=0.000 n=8)
B/op                            377.3KiB        430.5KiB        +14.11% (p=0.000 n=8)
allocs/op                       76              85              +11.84% (p=0.000 n=8)
```

Latency passes the issue's <5% overhead gate with a 12.19% improvement. The shared page-granular scanner retains a structural page memo so multiple maintenance roots can reuse traversal and preserve future combined-collector behavior; that accounts for a bounded 53.2 KiB and nine allocations in this 4,096-record fixture. No unused record-length or leaf-frame collector runs, and the allocation tradeoff is explicit for review.

## Safety boundaries

- no rewrite thresholds or policy changes
- no GC deletion-fence changes
- no protected-root or collection-asset semantics changes
- legacy ref-count/live-byte/leaf scanners remain until the final staged cleanup PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved value-log live-byte estimation reliability when snapshot files are missing or stale.
  * Added a retry and refresh path to keep maintenance calculations accurate.

* **Performance**
  * Added benchmarking coverage for shared and legacy live-byte estimation paths.

* **Tests**
  * Expanded validation to ensure shared maintenance calculations match established results and correctly refresh cached estimates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->