### PR TITLE
TreeDB: admit writes after checkpoint frontier cut

### DIFF
--- a/TreeDB/caching/checkpoint_test.go
+++ b/TreeDB/caching/checkpoint_test.go
@@ -27,6 +27,26 @@ func countCommitLogFiles(entries []os.DirEntry) int {
 	return n
 }
 
+func awaitCheckpointTestSignal(t *testing.T, ch <-chan struct{}, what string) {
+	t.Helper()
+	select {
+	case <-ch:
+	case <-time.After(withRaceTimeout(2 * time.Second)):
+		t.Fatalf("timed out waiting for %s", what)
+	}
+}
+
+func awaitCheckpointWriterWaiters(t *testing.T, db *DB, want int64) {
+	t.Helper()
+	deadline := time.Now().Add(withRaceTimeout(2 * time.Second))
+	for db.writeWaitForCheckpointActive.Load() != want {
+		if time.Now().After(deadline) {
+			t.Fatalf("checkpoint writer waiters=%d, want %d", db.writeWaitForCheckpointActive.Load(), want)
+		}
+		time.Sleep(time.Millisecond)
+	}
+}
+
 func TestCachingDB_Checkpoint_TrimsWAL(t *testing.T) {
 	dir := t.TempDir()
 	backend := NewMockBackend()
@@ -91,6 +111,216 @@ func TestCachingDB_Checkpoint_TrimsWAL(t *testing.T) {
 	walFilesAfter := countCommitLogFiles(after)
 	if walFilesAfter != len(db.lanes) {
 		t.Fatalf("expected exactly %d WAL segments after checkpoint, got %d", len(db.lanes), walFilesAfter)
+	}
+}
+
+func TestCachingDB_CheckpointExternalCommandWALAdmitsAfterFrontierCut(t *testing.T) {
+	backend := NewMockBackend()
+	db, err := Open(t.TempDir(), backend, Options{
+		ExternalCommandWAL: true,
+		FlushThreshold:     1 << 30,
+		JournalLanes:       1,
+	})
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	// A command-WAL owner installs this hook to rotate the active segment and
+	// capture the LSN covered by the checkpoint. The latch hooks below expose all
+	// three state-machine boundaries without relying on scheduler sleeps.
+	db.SetCommandWALCheckpointCutoverHook(func() {})
+	writePoint := func(key, value string) error {
+		return db.SetAfterCommandWALAppend([]byte(key), []byte(value), func() error { return nil })
+	}
+	if err := writePoint("pre-cut", "pre-value"); err != nil {
+		t.Fatalf("seed pre-cut point: %v", err)
+	}
+
+	beforeCapture := make(chan struct{})
+	releaseCapture := make(chan struct{})
+	afterCapture := make(chan struct{})
+	releaseAfterCapture := make(chan struct{})
+	beforeDrain := make(chan struct{})
+	releaseDrain := make(chan struct{})
+	db.testBeforeCheckpointFrontierCapture = func() {
+		close(beforeCapture)
+		<-releaseCapture
+	}
+	db.testAfterCheckpointFrontierCapture = func() {
+		close(afterCapture)
+		<-releaseAfterCapture
+	}
+	db.testBeforeCheckpointFrontierDrain = func() {
+		close(beforeDrain)
+		<-releaseDrain
+	}
+
+	checkpointDone := make(chan error, 1)
+	go func() { checkpointDone <- db.Checkpoint() }()
+	awaitCheckpointTestSignal(t, beforeCapture, "pre-frontier capture latch")
+
+	cutoverWriteDone := make(chan error, 1)
+	go func() { cutoverWriteDone <- writePoint("during-cut", "during-value") }()
+	awaitCheckpointWriterWaiters(t, db, 1)
+	select {
+	case err := <-cutoverWriteDone:
+		t.Fatalf("write crossed the frontier cut before release: %v", err)
+	default:
+	}
+	close(releaseCapture)
+	awaitCheckpointTestSignal(t, afterCapture, "post-frontier capture latch")
+	if err := <-cutoverWriteDone; err != nil {
+		t.Fatalf("write waiting at frontier cut: %v", err)
+	}
+
+	if err := writePoint("after-cut", "after-value"); err != nil {
+		t.Fatalf("post-frontier point write: %v", err)
+	}
+	close(releaseAfterCapture)
+	awaitCheckpointTestSignal(t, beforeDrain, "pre-frontier drain latch")
+
+	writeBatch := func(syncWrite bool, key, value string) error {
+		batch := db.NewBatch()
+		defer func() { _ = batch.Close() }()
+		if err := batch.Set([]byte(key), []byte(value)); err != nil {
+			return err
+		}
+		return batch.WriteAfterCommandWALAppend(syncWrite, func() error { return nil })
+	}
+	if err := writeBatch(false, "drain-write", "drain-value"); err != nil {
+		t.Fatalf("post-frontier Write: %v", err)
+	}
+	if err := writeBatch(true, "drain-writesync", "drain-sync-value"); err != nil {
+		t.Fatalf("post-frontier WriteSync: %v", err)
+	}
+	select {
+	case err := <-checkpointDone:
+		t.Fatalf("checkpoint completed while frontier drain was latched: %v", err)
+	default:
+	}
+	close(releaseDrain)
+	if err := <-checkpointDone; err != nil {
+		t.Fatalf("Checkpoint: %v", err)
+	}
+
+	got, err := backend.Get([]byte("pre-cut"))
+	if err != nil || !bytes.Equal(got, []byte("pre-value")) {
+		t.Fatalf("backend pre-cut value=(%q, %v), want pre-value", got, err)
+	}
+	for _, key := range []string{"during-cut", "after-cut", "drain-write", "drain-writesync"} {
+		got, err := backend.Get([]byte(key))
+		if err != nil {
+			t.Fatalf("backend Get(%q): %v", key, err)
+		}
+		if got != nil {
+			t.Fatalf("active checkpoint included post-frontier key %q=%q", key, got)
+		}
+		if got, err = db.Get([]byte(key)); err != nil || got == nil {
+			t.Fatalf("cached Get(%q)=(%q, %v), want post-frontier value", key, got, err)
+		}
+	}
+
+	stats := db.Stats()
+	if got := requireStatUint64(t, stats, "treedb.cache.write.wait.frontier_cutover.count_total"); got != 1 {
+		t.Fatalf("frontier_cutover waits=%d, want 1", got)
+	}
+	if got := requireStatUint64(t, stats, "treedb.cache.write.wait.checkpoint_drain.count_total"); got != 0 {
+		t.Fatalf("checkpoint_drain waits=%d, want 0", got)
+	}
+	if got := requireStatUint64(t, stats, "treedb.cache.write.post_frontier_admission.count_total"); got != 4 {
+		t.Fatalf("post-frontier admissions=%d, want 4", got)
+	}
+
+	// A successful checkpoint remains a strict boundary: only a later checkpoint
+	// may publish the post-cut generation to the backend.
+	db.testBeforeCheckpointFrontierCapture = nil
+	db.testAfterCheckpointFrontierCapture = nil
+	db.testBeforeCheckpointFrontierDrain = nil
+	if err := db.Checkpoint(); err != nil {
+		t.Fatalf("second Checkpoint: %v", err)
+	}
+	for _, key := range []string{"during-cut", "after-cut", "drain-write", "drain-writesync"} {
+		if got, err := backend.Get([]byte(key)); err != nil || got == nil {
+			t.Fatalf("backend Get(%q) after second checkpoint=(%q, %v), want value", key, got, err)
+		}
+	}
+}
+
+func TestCachingDB_CheckpointDrainRetainsWriterGateWithoutCommandWALCutover(t *testing.T) {
+	tests := []struct {
+		name  string
+		opts  Options
+		write func(*DB, string, string) error
+	}{
+		{
+			name: "cached_redo_wal",
+			opts: Options{FlushThreshold: 1 << 30, JournalLanes: 1},
+			write: func(db *DB, key, value string) error {
+				return db.Set([]byte(key), []byte(value))
+			},
+		},
+		{
+			name: "external_command_wal_without_cutover_hook",
+			opts: Options{ExternalCommandWAL: true, FlushThreshold: 1 << 30, JournalLanes: 1},
+			write: func(db *DB, key, value string) error {
+				return db.SetAfterCommandWALAppend([]byte(key), []byte(value), func() error { return nil })
+			},
+		},
+		{
+			name: "unsafe_wal_off",
+			opts: Options{DisableWAL: true, AllowUnsafe: true, FlushThreshold: 1 << 30, JournalLanes: 1},
+			write: func(db *DB, key, value string) error {
+				return db.Set([]byte(key), []byte(value))
+			},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			db, err := Open(t.TempDir(), NewMockBackend(), tc.opts)
+			if err != nil {
+				t.Fatalf("Open: %v", err)
+			}
+			defer func() { _ = db.Close() }()
+			if err := tc.write(db, "pre-cut", "pre-value"); err != nil {
+				t.Fatalf("seed: %v", err)
+			}
+
+			beforeDrain := make(chan struct{})
+			releaseDrain := make(chan struct{})
+			db.testBeforeCheckpointFrontierDrain = func() {
+				close(beforeDrain)
+				<-releaseDrain
+			}
+			checkpointDone := make(chan error, 1)
+			go func() { checkpointDone <- db.Checkpoint() }()
+			awaitCheckpointTestSignal(t, beforeDrain, "checkpoint drain latch")
+
+			writeDone := make(chan error, 1)
+			go func() { writeDone <- tc.write(db, "during-drain", "during-value") }()
+			awaitCheckpointWriterWaiters(t, db, 1)
+			select {
+			case err := <-writeDone:
+				t.Fatalf("write bypassed checkpoint drain without a safe command-WAL cut: %v", err)
+			default:
+			}
+			close(releaseDrain)
+			if err := <-checkpointDone; err != nil {
+				t.Fatalf("Checkpoint: %v", err)
+			}
+			if err := <-writeDone; err != nil {
+				t.Fatalf("write after checkpoint: %v", err)
+			}
+			db.testBeforeCheckpointFrontierDrain = nil
+
+			stats := db.Stats()
+			if got := requireStatUint64(t, stats, "treedb.cache.write.wait.checkpoint_drain.count_total"); got != 1 {
+				t.Fatalf("checkpoint_drain waits=%d, want 1", got)
+			}
+			if got := requireStatUint64(t, stats, "treedb.cache.write.post_frontier_admission.count_total"); got != 0 {
+				t.Fatalf("post-frontier admissions=%d, want 0", got)
+			}
+		})
 	}
 }
 
@@ -264,6 +494,10 @@ func TestCachingDB_ExclusiveWriteWithFlushMuHeldReleasesFlushMuWhileWaiting(t *t
 	case <-done:
 	case <-time.After(2 * time.Second):
 		t.Fatalf("exclusive writer with flushMu held did not resume after maintenance")
+	}
+	stats := db.Stats()
+	if got := requireStatUint64(t, stats, "treedb.cache.write.wait.maintenance.count_total"); got != 1 {
+		t.Fatalf("maintenance waits=%d, want 1", got)
 	}
 }
 

--- a/TreeDB/caching/db.go
+++ b/TreeDB/caching/db.go
@@ -8443,11 +8443,18 @@ type DB struct {
 	// Commit workers removed; backend commits are synchronous.
 	journalOwner *commitlog.JournalOwner
 
-	checkpointMu      sync.Mutex
-	checkpointCond    *sync.Cond
-	checkpointing     atomic.Bool
-	maintenanceActive atomic.Bool
-	maintenancePhase  atomic.Uint32
+	checkpointMu   sync.Mutex
+	checkpointCond *sync.Cond
+	checkpointing  atomic.Bool
+	// checkpointWriteCutoverActive is the short writer-stop phase inside an
+	// active checkpoint. checkpointing remains true until the captured frontier,
+	// durability metadata, and cleanup complete. Post-frontier admission is
+	// enabled separately only after an installed command-WAL cutover hook runs;
+	// cached redo-WAL and unsafe WAL-off modes keep waiting through the full drain.
+	checkpointWriteCutoverActive    atomic.Bool
+	checkpointPostFrontierAdmission atomic.Bool
+	maintenanceActive               atomic.Bool
+	maintenancePhase                atomic.Uint32
 
 	// Level 0 (Memory)
 	mutableShards                 []memShard
@@ -8849,6 +8856,10 @@ type DB struct {
 	writeWaitForCheckpointMaxNs                                  atomic.Uint64
 	writeWaitForCheckpointLastNs                                 atomic.Uint64
 	writeWaitForCheckpointSamples                                atomic.Uint64
+	writeWaitFrontierCutover                                     writeWaitReasonStats
+	writeWaitCheckpointDrain                                     writeWaitReasonStats
+	writeWaitMaintenance                                         writeWaitReasonStats
+	writePostFrontierAdmissions                                  atomic.Uint64
 	checkpointDebtMemtablesLast                                  atomic.Uint64
 	checkpointDebtMemtablesMax                                   atomic.Uint64
 	checkpointDebtBytesLast                                      atomic.Uint64
@@ -9475,14 +9486,17 @@ type DB struct {
 	publishWatermarkLastBacklogBytes int64
 	publishWatermarkLastUnixNano     int64
 	// testing hooks
-	testOnVlogFlush                    func(laneID int)
-	testOnVlogSync                     func(laneID int)
-	testBeforeVlogUnlock               func(laneID int)
-	testRetainedPruneScanHook          func(context.Context, string) error
-	testRetainedPruneQuietWaitExitHook func(retainedPruneQuietWaitResult)
-	testSkipRetainedPrune              bool
-	testSkipVlogCheckpointKick         bool
-	testSkipCheckpointAutoVacuum       bool
+	testOnVlogFlush                     func(laneID int)
+	testOnVlogSync                      func(laneID int)
+	testBeforeVlogUnlock                func(laneID int)
+	testBeforeCheckpointFrontierCapture func()
+	testAfterCheckpointFrontierCapture  func()
+	testBeforeCheckpointFrontierDrain   func()
+	testRetainedPruneScanHook           func(context.Context, string) error
+	testRetainedPruneQuietWaitExitHook  func(retainedPruneQuietWaitResult)
+	testSkipRetainedPrune               bool
+	testSkipVlogCheckpointKick          bool
+	testSkipCheckpointAutoVacuum        bool
 }
 
 const (
@@ -22740,11 +22754,45 @@ func (db *DB) waitForCheckpoint() {
 	db.checkpointMu.Unlock()
 }
 
+func (db *DB) writeAdmissionWaitReason() writeWaitReason {
+	if db == nil {
+		return writeWaitReasonNone
+	}
+	if db.maintenanceActive.Load() {
+		return writeWaitReasonMaintenance
+	}
+	if !db.checkpointing.Load() {
+		return writeWaitReasonNone
+	}
+	if db.checkpointWriteCutoverActive.Load() {
+		return writeWaitReasonFrontierCutover
+	}
+	// The installed command-WAL cutover hook captures an explicit LSN cut and
+	// rotates its active segment while writeMu is held. Once that cut completes,
+	// later commands are recoverable from the fresh command-WAL generation and
+	// cannot be covered or cleaned by the active checkpoint. Configuring external
+	// command WAL without the hook is not enough: retain the legacy full-drain
+	// writer stop unless this checkpoint actually established that ownership.
+	if db.checkpointPostFrontierAdmission.Load() {
+		return writeWaitReasonNone
+	}
+	return writeWaitReasonCheckpointDrain
+}
+
+func (db *DB) observePostFrontierWriteAdmission() {
+	if db == nil || !db.checkpointPostFrontierAdmission.Load() || db.maintenanceActive.Load() {
+		return
+	}
+	if db.checkpointing.Load() && !db.checkpointWriteCutoverActive.Load() {
+		db.writePostFrontierAdmissions.Add(1)
+	}
+}
+
 func (db *DB) waitForCheckpointForWrite() {
 	if db == nil {
 		return
 	}
-	if !db.checkpointing.Load() && !db.maintenanceActive.Load() {
+	if db.writeAdmissionWaitReason() == writeWaitReasonNone {
 		return
 	}
 	db.waitForCheckpointForWriteSince(time.Now())
@@ -22754,15 +22802,27 @@ func (db *DB) waitForCheckpointForWriteSince(start time.Time) {
 	if db == nil {
 		return
 	}
+	if start.IsZero() {
+		start = time.Now()
+	}
 	db.checkpointMu.Lock()
-	if !db.checkpointing.Load() && !db.maintenanceActive.Load() {
+	reason := db.writeAdmissionWaitReason()
+	if reason == writeWaitReasonNone {
 		db.checkpointMu.Unlock()
 		return
 	}
 	db.writeWaitForCheckpointActive.Add(1)
 	defer addAtomicInt64FloorZero(&db.writeWaitForCheckpointActive, -1)
-	for db.checkpointing.Load() || db.maintenanceActive.Load() {
+	phaseStart := start
+	for reason != writeWaitReasonNone {
 		db.checkpointCond.Wait()
+		now := time.Now()
+		nextReason := db.writeAdmissionWaitReason()
+		if nextReason != reason {
+			db.observeWriteWaitReason(reason, now.Sub(phaseStart))
+			phaseStart = now
+			reason = nextReason
+		}
 	}
 	db.checkpointMu.Unlock()
 	db.observeWriteWaitForCheckpoint(time.Since(start))
@@ -22770,26 +22830,29 @@ func (db *DB) waitForCheckpointForWriteSince(start time.Time) {
 
 func (db *DB) beginDirectWrite() error {
 	for {
-		preWaitActive := db.checkpointing.Load() || db.maintenanceActive.Load()
+		preWaitReason := db.writeAdmissionWaitReason()
 		var start time.Time
-		if preWaitActive {
+		if preWaitReason != writeWaitReasonNone {
 			start = time.Now()
 		}
 		db.writeMu.RLock()
 		if db.closing.Load() {
 			db.writeMu.RUnlock()
-			if preWaitActive {
+			if preWaitReason != writeWaitReasonNone {
+				db.observeWriteWaitReason(preWaitReason, time.Since(start))
 				db.observeWriteWaitForCheckpoint(time.Since(start))
 			}
 			return backenddb.ErrClosed
 		}
-		if !db.checkpointing.Load() && !db.maintenanceActive.Load() {
-			if preWaitActive {
+		if db.writeAdmissionWaitReason() == writeWaitReasonNone {
+			if preWaitReason != writeWaitReasonNone {
+				db.observeWriteWaitReason(preWaitReason, time.Since(start))
 				db.observeWriteWaitForCheckpoint(time.Since(start))
 			}
+			db.observePostFrontierWriteAdmission()
 			return nil
 		}
-		if !preWaitActive {
+		if preWaitReason == writeWaitReasonNone {
 			start = time.Now()
 		}
 		db.writeMu.RUnlock()
@@ -22799,26 +22862,29 @@ func (db *DB) beginDirectWrite() error {
 
 func (db *DB) beginDirectWriteWithFlushMuHeld() error {
 	for {
-		preWaitActive := db.checkpointing.Load() || db.maintenanceActive.Load()
+		preWaitReason := db.writeAdmissionWaitReason()
 		var start time.Time
-		if preWaitActive {
+		if preWaitReason != writeWaitReasonNone {
 			start = time.Now()
 		}
 		db.writeMu.RLock()
 		if db.closing.Load() {
 			db.writeMu.RUnlock()
-			if preWaitActive {
+			if preWaitReason != writeWaitReasonNone {
+				db.observeWriteWaitReason(preWaitReason, time.Since(start))
 				db.observeWriteWaitForCheckpoint(time.Since(start))
 			}
 			return backenddb.ErrClosed
 		}
-		if !db.checkpointing.Load() && !db.maintenanceActive.Load() {
-			if preWaitActive {
+		if db.writeAdmissionWaitReason() == writeWaitReasonNone {
+			if preWaitReason != writeWaitReasonNone {
+				db.observeWriteWaitReason(preWaitReason, time.Since(start))
 				db.observeWriteWaitForCheckpoint(time.Since(start))
 			}
+			db.observePostFrontierWriteAdmission()
 			return nil
 		}
-		if !preWaitActive {
+		if preWaitReason == writeWaitReasonNone {
 			start = time.Now()
 		}
 		db.writeMu.RUnlock()
@@ -22830,19 +22896,21 @@ func (db *DB) beginDirectWriteWithFlushMuHeld() error {
 
 func (db *DB) beginExclusiveWrite() {
 	for {
-		preWaitActive := db.checkpointing.Load() || db.maintenanceActive.Load()
+		preWaitReason := db.writeAdmissionWaitReason()
 		var start time.Time
-		if preWaitActive {
+		if preWaitReason != writeWaitReasonNone {
 			start = time.Now()
 		}
 		db.writeMu.Lock()
-		if !db.checkpointing.Load() && !db.maintenanceActive.Load() {
-			if preWaitActive {
+		if db.writeAdmissionWaitReason() == writeWaitReasonNone {
+			if preWaitReason != writeWaitReasonNone {
+				db.observeWriteWaitReason(preWaitReason, time.Since(start))
 				db.observeWriteWaitForCheckpoint(time.Since(start))
 			}
+			db.observePostFrontierWriteAdmission()
 			return
 		}
-		if !preWaitActive {
+		if preWaitReason == writeWaitReasonNone {
 			start = time.Now()
 		}
 		db.writeMu.Unlock()
@@ -22852,19 +22920,21 @@ func (db *DB) beginExclusiveWrite() {
 
 func (db *DB) beginExclusiveWriteWithFlushMuHeld() {
 	for {
-		preWaitActive := db.checkpointing.Load() || db.maintenanceActive.Load()
+		preWaitReason := db.writeAdmissionWaitReason()
 		var start time.Time
-		if preWaitActive {
+		if preWaitReason != writeWaitReasonNone {
 			start = time.Now()
 		}
 		db.writeMu.Lock()
-		if !db.checkpointing.Load() && !db.maintenanceActive.Load() {
-			if preWaitActive {
+		if db.writeAdmissionWaitReason() == writeWaitReasonNone {
+			if preWaitReason != writeWaitReasonNone {
+				db.observeWriteWaitReason(preWaitReason, time.Since(start))
 				db.observeWriteWaitForCheckpoint(time.Since(start))
 			}
+			db.observePostFrontierWriteAdmission()
 			return
 		}
-		if !preWaitActive {
+		if preWaitReason == writeWaitReasonNone {
 			start = time.Now()
 		}
 		db.writeMu.Unlock()
@@ -23602,6 +23672,8 @@ func (db *DB) Checkpoint() error {
 	for {
 		db.checkpointMu.Lock()
 		if !db.checkpointing.Load() {
+			db.checkpointPostFrontierAdmission.Store(false)
+			db.checkpointWriteCutoverActive.Store(true)
 			db.checkpointing.Store(true) // Set flag only after acquiring flushMu
 			db.checkpointMu.Unlock()
 			break
@@ -23620,10 +23692,19 @@ func (db *DB) Checkpoint() error {
 
 	defer func() { // This defer runs when db.Checkpoint() returns
 		db.checkpointMu.Lock()
+		db.checkpointPostFrontierAdmission.Store(false)
+		db.checkpointWriteCutoverActive.Store(false)
 		db.checkpointing.Store(false)
 		db.checkpointCond.Broadcast()
 		db.checkpointMu.Unlock()
 	}()
+	endWriteCutover := func() {
+		db.checkpointMu.Lock()
+		if db.checkpointWriteCutoverActive.Swap(false) {
+			db.checkpointCond.Broadcast()
+		}
+		db.checkpointMu.Unlock()
+	}
 
 	db.writeMu.Lock()
 	cutoverStart := time.Now()
@@ -23632,6 +23713,9 @@ func (db *DB) Checkpoint() error {
 		db.writeMu.Unlock()
 		db.recordCheckpointCutover(d)
 		db.checkpointStageCutover.record(d)
+	}
+	if hook := db.testBeforeCheckpointFrontierCapture; hook != nil {
+		hook()
 	}
 
 	// Rotate mutable into the flush queue and ensure future writes land in a fresh
@@ -23653,6 +23737,7 @@ func (db *DB) Checkpoint() error {
 		if err := db.rotateMutableShardsLocked(db.checkpointRotateCapacity(), false); err != nil {
 			db.mu.Unlock()
 			releaseWriteMu()
+			endWriteCutover()
 			return err
 		}
 		hasQueue = len(db.queue) > 0
@@ -23660,6 +23745,7 @@ func (db *DB) Checkpoint() error {
 	} else if !hasQueue && !hasDirtyVLog && !hasLiveWAL && db.loadCommandWALCheckpointPublishHook() == nil {
 		db.mu.Unlock()
 		releaseWriteMu()
+		endWriteCutover()
 		db.checkpointNoopSkips.Add(1)
 		if err := db.maybeVacuumSparseIndexOnCheckpoint(); err != nil {
 			return err
@@ -23674,9 +23760,15 @@ func (db *DB) Checkpoint() error {
 		// can re-check recently rewritten active sources.
 		forceVLogRotate := db.vlogGenerationCheckpointKickPending.Load()
 		if !forceVLogRotate {
-			db.snapshotCommandWALCheckpointCutover()
+			if db.snapshotCommandWALCheckpointCutover() && db.externalCommandWAL {
+				db.checkpointPostFrontierAdmission.Store(true)
+			}
 			db.mu.Unlock()
 			releaseWriteMu()
+			endWriteCutover()
+			if hook := db.testAfterCheckpointFrontierCapture; hook != nil {
+				hook()
+			}
 			if publishHook := db.loadCommandWALCheckpointPublishHook(); publishHook != nil {
 				commandWALAppliedLSN, commandWALRanges, err := publishHook(!db.relaxedSync)
 				if err != nil {
@@ -23703,13 +23795,16 @@ func (db *DB) Checkpoint() error {
 	if frontier.missingQueueID {
 		db.mu.Unlock()
 		releaseWriteMu()
+		endWriteCutover()
 		return errors.New("cachingdb: checkpoint frontier missing stable queue id")
 	}
 	db.observeCheckpointFrontierCapture(frontier)
 	walDir := db.dir
 	preRotateWALPaths := db.currentWALPaths()
 	ridBeforeWALRotate := db.nextRID.Load()
-	db.snapshotCommandWALCheckpointCutover()
+	if db.snapshotCommandWALCheckpointCutover() && db.externalCommandWAL {
+		db.checkpointPostFrontierAdmission.Store(true)
+	}
 	db.mu.Unlock()
 	rotateLaneIDs := make([]int, 0, len(db.lanes))
 	for i := range db.lanes {
@@ -23723,6 +23818,10 @@ func (db *DB) Checkpoint() error {
 		}
 	}
 	releaseWriteMu()
+	endWriteCutover()
+	if hook := db.testAfterCheckpointFrontierCapture; hook != nil {
+		hook()
+	}
 
 	walRotateStart := time.Now()
 	errCh := make(chan error, len(rotateLaneIDs))
@@ -23776,6 +23875,9 @@ func (db *DB) Checkpoint() error {
 	}
 
 	// Flush all queued memtables with backend sync.
+	if hook := db.testBeforeCheckpointFrontierDrain; hook != nil {
+		hook()
+	}
 	leafLogAppendWaitBefore := db.flushApplyLeafLogAppendWaitNs.Load()
 	reducerPublishBefore := db.backendFlushApplyReducerPublishNs()
 	flushAllStart := time.Now()
@@ -24056,12 +24158,13 @@ func (db *DB) loadStatsHook() func(map[string]string) {
 	return box.fn
 }
 
-func (db *DB) snapshotCommandWALCheckpointCutover() {
+func (db *DB) snapshotCommandWALCheckpointCutover() bool {
 	cutoverHook := db.loadCommandWALCheckpointCutoverHook()
 	if cutoverHook == nil {
-		return
+		return false
 	}
 	cutoverHook()
+	return true
 }
 
 func (db *DB) cleanupCommandWALCheckpoint(sync bool) error {
@@ -29669,6 +29772,10 @@ func (db *DB) Stats() map[string]string {
 	stats["treedb.cache.mutable_flush_threshold_base_bytes"] = fmt.Sprintf("%d", mutableThresholdBase)
 	stats["treedb.cache.mutable_flush_threshold_effective_bytes"] = fmt.Sprintf("%d", db.mutableFlushThreshold())
 	stats["treedb.cache.checkpoint.runs"] = fmt.Sprintf("%d", db.checkpointRuns.Load())
+	stats["treedb.cache.checkpoint.active"] = fmt.Sprintf("%t", db.checkpointing.Load())
+	stats["treedb.cache.checkpoint.write_cutover.active"] = fmt.Sprintf("%t", db.checkpointWriteCutoverActive.Load())
+	stats["treedb.cache.checkpoint.post_frontier_admission_enabled"] = fmt.Sprintf("%t", db.externalCommandWAL && db.loadCommandWALCheckpointCutoverHook() != nil)
+	stats["treedb.cache.checkpoint.post_frontier_admission.active"] = fmt.Sprintf("%t", db.checkpointPostFrontierAdmission.Load())
 	stats["treedb.cache.checkpoint.total_ms"] = fmt.Sprintf("%.3f", float64(db.checkpointTotalNs.Load())/float64(time.Millisecond))
 	stats["treedb.cache.checkpoint.max_ms"] = fmt.Sprintf("%.3f", float64(db.checkpointMaxNs.Load())/float64(time.Millisecond))
 	stats["treedb.cache.checkpoint.flushmu_wait_total_ms"] = fmt.Sprintf("%.3f", float64(db.checkpointFlushMuWaitNs.Load())/float64(time.Millisecond))

--- a/TreeDB/caching/db.go
+++ b/TreeDB/caching/db.go
@@ -22828,6 +22828,51 @@ func (db *DB) waitForCheckpointForWriteSince(start time.Time) {
 	db.observeWriteWaitForCheckpoint(time.Since(start))
 }
 
+// rangeSpanWriteAdmissionWaitReason keeps command-WAL range-span publication
+// behind the full checkpoint drain. Range-span writers take flushMu before
+// appending their command frame, so they cannot use the point-write
+// post-frontier lane while an older checkpoint still owns that mutex.
+func (db *DB) rangeSpanWriteAdmissionWaitReason() writeWaitReason {
+	if db == nil {
+		return writeWaitReasonNone
+	}
+	if db.maintenanceActive.Load() {
+		return writeWaitReasonMaintenance
+	}
+	if db.checkpointing.Load() {
+		return writeWaitReasonCheckpointDrain
+	}
+	return writeWaitReasonNone
+}
+
+func (db *DB) waitForRangeSpanCheckpointDrain() {
+	if db == nil || db.rangeSpanWriteAdmissionWaitReason() == writeWaitReasonNone {
+		return
+	}
+	start := time.Now()
+	db.checkpointMu.Lock()
+	reason := db.rangeSpanWriteAdmissionWaitReason()
+	if reason == writeWaitReasonNone {
+		db.checkpointMu.Unlock()
+		return
+	}
+	db.writeWaitForCheckpointActive.Add(1)
+	defer addAtomicInt64FloorZero(&db.writeWaitForCheckpointActive, -1)
+	phaseStart := start
+	for reason != writeWaitReasonNone {
+		db.checkpointCond.Wait()
+		now := time.Now()
+		nextReason := db.rangeSpanWriteAdmissionWaitReason()
+		if nextReason != reason {
+			db.observeWriteWaitReason(reason, now.Sub(phaseStart))
+			phaseStart = now
+			reason = nextReason
+		}
+	}
+	db.checkpointMu.Unlock()
+	db.observeWriteWaitForCheckpoint(time.Since(start))
+}
+
 func (db *DB) beginDirectWrite() error {
 	for {
 		preWaitReason := db.writeAdmissionWaitReason()
@@ -23592,7 +23637,10 @@ func (db *DB) observePublishWatermarkLagDrift(backlogBytes int64, now time.Time)
 // Checkpoint forces a durable backend boundary and trims the WAL so long-running
 // cached-mode runs do not accumulate unbounded `wal/` growth.
 //
-// It blocks writers while it:
+// It blocks all writers through the frontier cut. With an external command-WAL
+// cutover hook, point writers can then enter the fresh post-frontier generation;
+// range-span writers remain blocked through the full drain because they require
+// flushMu for atomic command append and span publication. The checkpoint:
 //   - rotates the current mutable memtable (if non-empty),
 //   - rotates to a fresh WAL segment,
 //   - flushes all queued memtables with backend sync,
@@ -25344,6 +25392,7 @@ func (db *DB) publishCommandWALRangeSpanLayer(start, end []byte, appendCommand f
 	if appendCommand == nil {
 		return fmt.Errorf("cachingdb: missing command wal append callback")
 	}
+	db.waitForRangeSpanCheckpointDrain()
 	db.flushMu.Lock()
 	defer db.flushMu.Unlock()
 	db.beginExclusiveWriteWithFlushMuHeld()
@@ -35204,6 +35253,7 @@ func (b *Batch) writeRangeSpanBatch(sync bool, ranges []batch.DeleteRange) (err 
 		}
 	}()
 
+	b.db.waitForRangeSpanCheckpointDrain()
 	b.db.flushMu.Lock()
 	defer b.db.flushMu.Unlock()
 	b.db.beginExclusiveWriteWithFlushMuHeld()

--- a/TreeDB/caching/flush_apply_stats.go
+++ b/TreeDB/caching/flush_apply_stats.go
@@ -268,6 +268,111 @@ func (db *DB) observeCheckpointActiveBackgroundFlushWait(wait time.Duration) {
 	updateAtomicMaxUint64(&db.checkpointActiveBackgroundFlushWaitMaxNs, ns)
 }
 
+type writeWaitReason uint8
+
+const (
+	writeWaitReasonNone writeWaitReason = iota
+	writeWaitReasonFrontierCutover
+	writeWaitReasonCheckpointDrain
+	writeWaitReasonMaintenance
+)
+
+type writeWaitReasonStats struct {
+	totalNs atomic.Uint64
+	maxNs   atomic.Uint64
+	lastNs  atomic.Uint64
+	samples atomic.Uint64
+	buckets [10]atomic.Uint64
+}
+
+var writeWaitLatencyBuckets = [...]struct {
+	upperNs uint64
+	label   string
+}{
+	{upperNs: uint64((10 * time.Microsecond).Nanoseconds()), label: "10us"},
+	{upperNs: uint64((100 * time.Microsecond).Nanoseconds()), label: "100us"},
+	{upperNs: uint64(time.Millisecond.Nanoseconds()), label: "1ms"},
+	{upperNs: uint64((10 * time.Millisecond).Nanoseconds()), label: "10ms"},
+	{upperNs: uint64((50 * time.Millisecond).Nanoseconds()), label: "50ms"},
+	{upperNs: uint64((100 * time.Millisecond).Nanoseconds()), label: "100ms"},
+	{upperNs: uint64((250 * time.Millisecond).Nanoseconds()), label: "250ms"},
+	{upperNs: uint64(time.Second.Nanoseconds()), label: "1s"},
+	{upperNs: uint64((5 * time.Second).Nanoseconds()), label: "5s"},
+	{upperNs: ^uint64(0), label: "inf"},
+}
+
+func (s *writeWaitReasonStats) observe(wait time.Duration) {
+	if s == nil {
+		return
+	}
+	ns := uint64(1)
+	if wait > 0 && wait.Nanoseconds() > 0 {
+		ns = uint64(wait.Nanoseconds())
+	}
+	s.totalNs.Add(ns)
+	s.lastNs.Store(ns)
+	s.samples.Add(1)
+	updateAtomicMaxUint64(&s.maxNs, ns)
+	for i := range writeWaitLatencyBuckets {
+		if ns <= writeWaitLatencyBuckets[i].upperNs {
+			s.buckets[i].Add(1)
+			break
+		}
+	}
+}
+
+func writeWaitQuantileUpperNs(s *writeWaitReasonStats, percentile uint64) uint64 {
+	if s == nil || percentile == 0 {
+		return 0
+	}
+	total := s.samples.Load()
+	if total == 0 {
+		return 0
+	}
+	target := (total*percentile + 99) / 100
+	var cumulative uint64
+	for i := range writeWaitLatencyBuckets {
+		cumulative += s.buckets[i].Load()
+		if cumulative >= target {
+			return writeWaitLatencyBuckets[i].upperNs
+		}
+	}
+	return ^uint64(0)
+}
+
+func appendWriteWaitReasonStats(stats map[string]string, reason string, s *writeWaitReasonStats) {
+	if stats == nil || reason == "" || s == nil {
+		return
+	}
+	prefix := "treedb.cache.write.wait." + reason
+	stats[prefix+".ns_total"] = fmt.Sprintf("%d", s.totalNs.Load())
+	stats[prefix+".ns_max"] = fmt.Sprintf("%d", s.maxNs.Load())
+	stats[prefix+".ns_last"] = fmt.Sprintf("%d", s.lastNs.Load())
+	stats[prefix+".count_total"] = fmt.Sprintf("%d", s.samples.Load())
+	var cumulative uint64
+	for i := range writeWaitLatencyBuckets {
+		cumulative += s.buckets[i].Load()
+		stats[prefix+".bucket_le_"+writeWaitLatencyBuckets[i].label+".count_total"] = fmt.Sprintf("%d", cumulative)
+	}
+	stats[prefix+".p50_upper_ns"] = fmt.Sprintf("%d", writeWaitQuantileUpperNs(s, 50))
+	stats[prefix+".p95_upper_ns"] = fmt.Sprintf("%d", writeWaitQuantileUpperNs(s, 95))
+	stats[prefix+".p99_upper_ns"] = fmt.Sprintf("%d", writeWaitQuantileUpperNs(s, 99))
+}
+
+func (db *DB) observeWriteWaitReason(reason writeWaitReason, wait time.Duration) {
+	if db == nil || reason == writeWaitReasonNone {
+		return
+	}
+	switch reason {
+	case writeWaitReasonFrontierCutover:
+		db.writeWaitFrontierCutover.observe(wait)
+	case writeWaitReasonCheckpointDrain:
+		db.writeWaitCheckpointDrain.observe(wait)
+	case writeWaitReasonMaintenance:
+		db.writeWaitMaintenance.observe(wait)
+	}
+}
+
 func (db *DB) observeWriteWaitForCheckpoint(wait time.Duration) {
 	if db == nil {
 		return
@@ -294,6 +399,10 @@ func (db *DB) appendWriteWaitForCheckpointStats(stats map[string]string) {
 	stats["treedb.cache.write.wait_for_checkpoint.ns_last"] = fmt.Sprintf("%d", db.writeWaitForCheckpointLastNs.Load())
 	stats["treedb.cache.write.wait_for_checkpoint.count_total"] = fmt.Sprintf("%d", db.writeWaitForCheckpointSamples.Load())
 	stats["treedb.cache.write.wait_for_checkpoint.active"] = fmt.Sprintf("%d", db.writeWaitForCheckpointActive.Load())
+	appendWriteWaitReasonStats(stats, "frontier_cutover", &db.writeWaitFrontierCutover)
+	appendWriteWaitReasonStats(stats, "checkpoint_drain", &db.writeWaitCheckpointDrain)
+	appendWriteWaitReasonStats(stats, "maintenance", &db.writeWaitMaintenance)
+	stats["treedb.cache.write.post_frontier_admission.count_total"] = fmt.Sprintf("%d", db.writePostFrontierAdmissions.Load())
 }
 
 const flushCoordinatorProgressWait = 10 * time.Millisecond

--- a/TreeDB/caching/flush_apply_stats.go
+++ b/TreeDB/caching/flush_apply_stats.go
@@ -311,7 +311,6 @@ func (s *writeWaitReasonStats) observe(wait time.Duration) {
 	}
 	s.totalNs.Add(ns)
 	s.lastNs.Store(ns)
-	s.samples.Add(1)
 	updateAtomicMaxUint64(&s.maxNs, ns)
 	for i := range writeWaitLatencyBuckets {
 		if ns <= writeWaitLatencyBuckets[i].upperNs {
@@ -319,6 +318,10 @@ func (s *writeWaitReasonStats) observe(wait time.Duration) {
 			break
 		}
 	}
+	// Publish the sample only after its bucket is visible. Stats readers use the
+	// sample count as the quantile target, so the reverse order can transiently
+	// produce an incomplete cumulative histogram and an artificial +Inf result.
+	s.samples.Add(1)
 }
 
 func writeWaitQuantileUpperNs(s *writeWaitReasonStats, percentile uint64) uint64 {

--- a/TreeDB/caching/flush_apply_stats_test.go
+++ b/TreeDB/caching/flush_apply_stats_test.go
@@ -209,6 +209,9 @@ func TestWriteWaitForCheckpointStatsIncrement(t *testing.T) {
 	if got := requireStatUint64(t, stats, "treedb.cache.write.wait_for_checkpoint.active"); got != 0 {
 		t.Fatalf("wait_for_checkpoint.active=%d, want 0 (stats=%#v)", got, stats)
 	}
+	if got := requireStatUint64(t, stats, "treedb.cache.write.wait.checkpoint_drain.count_total"); got != 1 {
+		t.Fatalf("checkpoint_drain.count_total=%d, want 1 (stats=%#v)", got, stats)
+	}
 	for _, key := range []string{
 		"treedb.cache.write.wait_for_checkpoint.ns_total",
 		"treedb.cache.write.wait_for_checkpoint.ns_max",
@@ -218,6 +221,44 @@ func TestWriteWaitForCheckpointStatsIncrement(t *testing.T) {
 			t.Fatalf("%s=0, want >0 (stats=%#v)", key, stats)
 		}
 	}
+}
+
+func TestWriteWaitReasonStatsDistribution(t *testing.T) {
+	db := &DB{}
+	for _, wait := range []time.Duration{
+		5 * time.Microsecond,
+		75 * time.Microsecond,
+		2 * time.Millisecond,
+		75 * time.Millisecond,
+		2 * time.Second,
+	} {
+		db.observeWriteWaitReason(writeWaitReasonFrontierCutover, wait)
+	}
+	db.observeWriteWaitReason(writeWaitReasonCheckpointDrain, 250*time.Millisecond)
+	db.observeWriteWaitReason(writeWaitReasonMaintenance, 0)
+
+	stats := map[string]string{}
+	db.appendWriteWaitForCheckpointStats(stats)
+	assertStat := func(key string, want uint64) {
+		t.Helper()
+		if got := requireStatUint64(t, stats, key); got != want {
+			t.Fatalf("%s=%d, want %d", key, got, want)
+		}
+	}
+	assertStat("treedb.cache.write.wait.frontier_cutover.count_total", 5)
+	assertStat("treedb.cache.write.wait.frontier_cutover.bucket_le_10us.count_total", 1)
+	assertStat("treedb.cache.write.wait.frontier_cutover.bucket_le_100us.count_total", 2)
+	assertStat("treedb.cache.write.wait.frontier_cutover.bucket_le_1ms.count_total", 2)
+	assertStat("treedb.cache.write.wait.frontier_cutover.bucket_le_10ms.count_total", 3)
+	assertStat("treedb.cache.write.wait.frontier_cutover.bucket_le_100ms.count_total", 4)
+	assertStat("treedb.cache.write.wait.frontier_cutover.bucket_le_5s.count_total", 5)
+	assertStat("treedb.cache.write.wait.frontier_cutover.bucket_le_inf.count_total", 5)
+	assertStat("treedb.cache.write.wait.frontier_cutover.p50_upper_ns", uint64((10 * time.Millisecond).Nanoseconds()))
+	assertStat("treedb.cache.write.wait.frontier_cutover.p95_upper_ns", uint64((5 * time.Second).Nanoseconds()))
+	assertStat("treedb.cache.write.wait.frontier_cutover.p99_upper_ns", uint64((5 * time.Second).Nanoseconds()))
+	assertStat("treedb.cache.write.wait.checkpoint_drain.count_total", 1)
+	assertStat("treedb.cache.write.wait.maintenance.count_total", 1)
+	assertStat("treedb.cache.write.wait.maintenance.ns_total", 1)
 }
 
 func TestObserveWriteWaitForCheckpointPreservesZeroDurationSample(t *testing.T) {

--- a/TreeDB/caching/flush_apply_stats_test.go
+++ b/TreeDB/caching/flush_apply_stats_test.go
@@ -261,6 +261,77 @@ func TestWriteWaitReasonStatsDistribution(t *testing.T) {
 	assertStat("treedb.cache.write.wait.maintenance.ns_total", 1)
 }
 
+func TestWriteWaitReasonStatsConcurrentSnapshotsNeverPublishIncompleteHistogram(t *testing.T) {
+	var reasonStats writeWaitReasonStats
+	const (
+		writers          = 8
+		samplesPerWriter = 25_000
+	)
+
+	start := make(chan struct{})
+	done := make(chan struct{})
+	var wg sync.WaitGroup
+	for worker := 0; worker < writers; worker++ {
+		wg.Add(1)
+		go func(worker int) {
+			defer wg.Done()
+			<-start
+			for sample := 0; sample < samplesPerWriter; sample++ {
+				reasonStats.observe(time.Duration((worker+sample)%9+1) * time.Microsecond)
+			}
+		}(worker)
+	}
+	go func() {
+		wg.Wait()
+		close(done)
+	}()
+	close(start)
+
+	var consistencyErr error
+	finished := false
+	for !finished && consistencyErr == nil {
+		stats := map[string]string{}
+		appendWriteWaitReasonStats(stats, "checkpoint_drain", &reasonStats)
+		count := requireStatUint64(t, stats, "treedb.cache.write.wait.checkpoint_drain.count_total")
+		bucketTotal := requireStatUint64(t, stats, "treedb.cache.write.wait.checkpoint_drain.bucket_le_inf.count_total")
+		if bucketTotal < count {
+			consistencyErr = fmt.Errorf("published samples=%d before histogram total=%d", count, bucketTotal)
+			break
+		}
+		if count > 0 {
+			for _, percentile := range []string{"p50", "p95", "p99"} {
+				key := "treedb.cache.write.wait.checkpoint_drain." + percentile + "_upper_ns"
+				if got := requireStatUint64(t, stats, key); got == ^uint64(0) {
+					consistencyErr = fmt.Errorf("%s reported +Inf with samples=%d histogram_total=%d", key, count, bucketTotal)
+					break
+				}
+			}
+		}
+		select {
+		case <-done:
+			finished = true
+		default:
+			runtime.Gosched()
+		}
+	}
+	if !finished {
+		<-done
+	}
+	if consistencyErr != nil {
+		t.Fatal(consistencyErr)
+	}
+
+	stats := map[string]string{}
+	appendWriteWaitReasonStats(stats, "checkpoint_drain", &reasonStats)
+	want := uint64(writers * samplesPerWriter)
+	if got := requireStatUint64(t, stats, "treedb.cache.write.wait.checkpoint_drain.count_total"); got != want {
+		t.Fatalf("final samples=%d, want %d", got, want)
+	}
+	if got := requireStatUint64(t, stats, "treedb.cache.write.wait.checkpoint_drain.bucket_le_inf.count_total"); got != want {
+		t.Fatalf("final histogram total=%d, want %d", got, want)
+	}
+}
+
 func TestObserveWriteWaitForCheckpointPreservesZeroDurationSample(t *testing.T) {
 	db := &DB{}
 	db.observeWriteWaitForCheckpoint(0)

--- a/TreeDB/command_wal_public_test.go
+++ b/TreeDB/command_wal_public_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"sort"
 	"strconv"
@@ -3328,6 +3329,111 @@ func BenchmarkPublicCommandWALDurableTinyBatchWriteSync(b *testing.B) {
 	}
 }
 
+func BenchmarkPublicCommandWALCheckpointOverlapWriteSync(b *testing.B) {
+	opts := commandWALDurabilityProofOptions(b.TempDir())
+	opts.FlushThreshold = 64 << 10
+	db, err := Open(opts)
+	if err != nil {
+		b.Fatalf("Open: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+	defer db.cached.SetCommandWALCheckpointPublishHook(db.preparePublicCommandWALPendingPublish)
+
+	// Seed one pre-cut command so every measured checkpoint has a real mutable
+	// frontier and an AppliedCommandLSN publication boundary. Each measured
+	// write then becomes the next iteration's pre-cut command.
+	if err := db.SetSync([]byte("tx-index/overlap/seed"), []byte("value")); err != nil {
+		b.Fatalf("seed SetSync: %v", err)
+	}
+
+	const checkpointDwell = 20 * time.Millisecond
+	before := db.Stats()
+	latencies := make([]time.Duration, 0, b.N)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		publishReached := make(chan struct{})
+		releasePublish := make(chan struct{})
+		var publishOnce sync.Once
+		db.cached.SetCommandWALCheckpointPublishHook(func(sync bool) (uint64, []backenddb.CommandWALLSNRange, error) {
+			publishOnce.Do(func() { close(publishReached) })
+			<-releasePublish
+			return db.preparePublicCommandWALPendingPublish(sync)
+		})
+
+		checkpointDone := make(chan error, 1)
+		go func() { checkpointDone <- db.cached.Checkpoint() }()
+		if err := waitForPublicCommandWALCheckpointPhase(publishReached, "benchmark checkpoint publish hook"); err != nil {
+			b.Fatal(err)
+		}
+
+		batch := db.NewBatchWithSize(1)
+		var keyBuf [64]byte
+		key := append(keyBuf[:0], "tx-index/overlap/"...)
+		key = strconv.AppendInt(key, int64(i), 10)
+		if err := batch.Set(key, []byte("value")); err != nil {
+			_ = batch.Close()
+			close(releasePublish)
+			b.Fatalf("batch Set: %v", err)
+		}
+
+		releaseTimer := time.AfterFunc(checkpointDwell, func() { close(releasePublish) })
+		writeStart := time.Now()
+		writeErr := batch.WriteSync()
+		latencies = append(latencies, time.Since(writeStart))
+		if writeErr != nil {
+			_ = batch.Close()
+			if releaseTimer.Stop() {
+				close(releasePublish)
+			}
+			b.Fatalf("batch WriteSync: %v", writeErr)
+		}
+		if err := batch.Close(); err != nil {
+			if releaseTimer.Stop() {
+				close(releasePublish)
+			}
+			b.Fatalf("batch Close: %v", err)
+		}
+		if err := <-checkpointDone; err != nil {
+			b.Fatalf("Checkpoint: %v", err)
+		}
+		_ = releaseTimer.Stop()
+	}
+	b.StopTimer()
+
+	after := db.Stats()
+	reportWriteSyncLatencyDistribution(b, latencies)
+	b.ReportMetric(float64(checkpointDwell.Nanoseconds()), "checkpoint_dwell_ns")
+	for _, key := range []string{
+		"treedb.cache.write.wait_for_checkpoint.count_total",
+		"treedb.cache.write.wait_for_checkpoint.ns_total",
+		"treedb.cache.write.wait.frontier_cutover.count_total",
+		"treedb.cache.write.wait.frontier_cutover.ns_total",
+		"treedb.cache.write.wait.checkpoint_drain.count_total",
+		"treedb.cache.write.wait.checkpoint_drain.ns_total",
+		"treedb.cache.write.wait.maintenance.count_total",
+		"treedb.cache.write.wait.maintenance.ns_total",
+		"treedb.cache.write.post_frontier_admission.count_total",
+	} {
+		beforeValue, beforeOK := benchmarkOptionalStatUint64(before, key)
+		afterValue, afterOK := benchmarkOptionalStatUint64(after, key)
+		if !beforeOK || !afterOK {
+			continue
+		}
+		name := strings.TrimPrefix(key, "treedb.cache.")
+		b.ReportMetric(float64(afterValue-beforeValue)/float64(b.N), name+"/op")
+	}
+}
+
+func benchmarkOptionalStatUint64(stats map[string]string, key string) (uint64, bool) {
+	raw, ok := stats[key]
+	if !ok || raw == "" {
+		return 0, false
+	}
+	value, err := strconv.ParseUint(raw, 10, 64)
+	return value, err == nil
+}
+
 func BenchmarkPublicCommandWALTinyBatchWriteSyncPhaseStatsOverhead(b *testing.B) {
 	for _, durability := range []struct {
 		name string
@@ -3419,7 +3525,7 @@ func TestPublicCommandWALDurableTinyBatchWriteSyncShapes(t *testing.T) {
 	}
 }
 
-func TestPublicCommandWALAutoCheckpointOverlapDrainsFrontier(t *testing.T) {
+func TestPublicCommandWALAutoCheckpointOverlapAdmitsPostFrontierWrites(t *testing.T) {
 	opts := commandWALDurabilityProofOptions(t.TempDir())
 	opts.BackgroundCheckpointInterval = time.Hour // Starts the existing loop; the test triggers its pass explicitly.
 	opts.FlushThreshold = 64 << 10
@@ -3511,26 +3617,34 @@ func TestPublicCommandWALAutoCheckpointOverlapDrainsFrontier(t *testing.T) {
 			writeResults <- writeResult{index: index, err: writeErr}
 		}(i, batch)
 	}
-	if err := waitForPublicCommandWALActiveCheckpointWriters(db, len(overlapBatches)); err != nil {
-		t.Fatal(err)
-	}
-	releaseCheckpointPublishOnce.Do(func() { close(releaseCheckpointPublish) })
-	if err := waitForPublicCommandWALCheckpointPhase(checkpointComplete, "checkpoint cleanup hook"); err != nil {
-		t.Fatal(err)
-	}
+	// The publish hook is after the command-LSN/mutable frontier cut and before
+	// the checkpoint can complete. Post-cut Write and WriteSync calls must finish
+	// in the fresh command-WAL/mutable generation while this old frontier remains
+	// latched.
 	writeCompletionTimer := time.NewTimer(publicCommandWALCheckpointTestTimeout)
 	defer writeCompletionTimer.Stop()
-	for i := 0; i < 16; i++ {
+	for i := 0; i < len(overlapBatches); i++ {
 		select {
 		case result := <-writeResults:
 			if result.err != nil {
 				t.Fatalf("overlap Write(%d): %v", result.index, result.err)
 			}
+		case <-checkpointComplete:
+			t.Fatalf("checkpoint completed before publish latch released after %d/%d overlap writes", i, len(overlapBatches))
 		case <-writeCompletionTimer.C:
-			t.Fatalf("timed out waiting for overlap write completion %d/16", i+1)
+			t.Fatalf("timed out waiting for post-frontier write completion %d/%d", i+1, len(overlapBatches))
 		}
 	}
 	writeCompletionTimer.Stop()
+	select {
+	case <-checkpointComplete:
+		t.Fatal("checkpoint completed while publish hook remained latched")
+	default:
+	}
+	releaseCheckpointPublishOnce.Do(func() { close(releaseCheckpointPublish) })
+	if err := waitForPublicCommandWALCheckpointPhase(checkpointComplete, "checkpoint cleanup hook"); err != nil {
+		t.Fatal(err)
+	}
 
 	wantAutoCheckpointCount := statMapUint64(t, before, "treedb.cache.auto_checkpoint.count") + 1
 	if err := waitForPublicCommandWALAutoCheckpointCount(db, wantAutoCheckpointCount); err != nil {
@@ -3547,10 +3661,9 @@ func TestPublicCommandWALAutoCheckpointOverlapDrainsFrontier(t *testing.T) {
 	if got := statMapUint64(t, after, "treedb.cache.checkpoint.frontier.drained_units_last"); got == 0 {
 		t.Fatal("checkpoint frontier drained no units")
 	}
-	requirePublicStatDelta(t, before, after, "treedb.cache.write.wait_for_checkpoint.count_total", 16)
-	if got := statMapUint64(t, after, "treedb.cache.write.wait_for_checkpoint.ns_total") - statMapUint64(t, before, "treedb.cache.write.wait_for_checkpoint.ns_total"); got == 0 {
-		t.Fatal("overlap writes recorded no checkpoint wait time")
-	}
+	requirePublicStatDelta(t, before, after, "treedb.cache.write.wait_for_checkpoint.count_total", 0)
+	requirePublicStatDelta(t, before, after, "treedb.cache.write.post_frontier_admission.count_total", 16)
+	requirePublicStatDelta(t, before, after, "treedb.cache.write.wait.checkpoint_drain.count_total", 0)
 	requirePublicStatDelta(t, before, after, "treedb.public.batch.write.calls_total", 8)
 	requirePublicStatDelta(t, before, after, "treedb.public.batch.write_sync.calls_total", 8)
 	requirePublicStatDelta(t, before, after, "treedb.command_wal.append.count_total", 16)
@@ -3558,6 +3671,229 @@ func TestPublicCommandWALAutoCheckpointOverlapDrainsFrontier(t *testing.T) {
 	// the eight durable overlap writes.
 	requirePublicStatDelta(t, before, after, "treedb.command_wal.sync.count_total", 9)
 	requirePublicStatDelta(t, before, after, "treedb.public.checkpoint.calls_total", 0)
+}
+
+func TestPublicCommandWALCheckpointPostFrontierAdmissionPropagatesPublishError(t *testing.T) {
+	db, err := Open(commandWALDurabilityProofOptions(t.TempDir()))
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+	if err := db.SetSync([]byte("publish-error/pre-cut"), []byte("pre-value")); err != nil {
+		t.Fatalf("pre-cut SetSync: %v", err)
+	}
+
+	publishErr := errors.New("forced checkpoint publish failure")
+	publishEntered := make(chan struct{})
+	releasePublish := make(chan struct{})
+	var publishOnce sync.Once
+	db.cached.SetCommandWALCheckpointPublishHook(func(bool) (uint64, []backenddb.CommandWALLSNRange, error) {
+		publishOnce.Do(func() { close(publishEntered) })
+		if err := waitForPublicCommandWALCheckpointPhase(releasePublish, "publish-error release"); err != nil {
+			return 0, nil, err
+		}
+		return 0, nil, publishErr
+	})
+	checkpointDone := make(chan error, 1)
+	go func() { checkpointDone <- db.Checkpoint() }()
+	if err := waitForPublicCommandWALCheckpointPhase(publishEntered, "publish-error hook"); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.SetSync([]byte("publish-error/post-cut"), []byte("post-value")); err != nil {
+		t.Fatalf("post-cut SetSync: %v", err)
+	}
+	close(releasePublish)
+	if err := <-checkpointDone; !errors.Is(err, publishErr) {
+		t.Fatalf("Checkpoint error=%v, want %v", err, publishErr)
+	}
+	if first, last := db.publicCommandWALPendingRange(); first != 1 || last != 2 {
+		t.Fatalf("pending command-WAL range after failed publish=(%d,%d), want (1,2)", first, last)
+	}
+	requireRawKVValue(t, db, []byte("publish-error/pre-cut"), []byte("pre-value"))
+	requireRawKVValue(t, db, []byte("publish-error/post-cut"), []byte("post-value"))
+	if got := db.cached.Stats()["treedb.cache.checkpoint.active"]; got != "false" {
+		t.Fatalf("checkpoint active after error=%q, want false", got)
+	}
+
+	// Restore the public owner hooks and prove the failed checkpoint left both
+	// command generations available for a later strict boundary.
+	db.cached.SetCommandWALCheckpointPublishHook(db.preparePublicCommandWALPendingPublish)
+	db.cached.SetCommandWALCheckpointCleanupHook(db.cleanupPublicCommandWALCheckpoint)
+	if err := db.Checkpoint(); err != nil {
+		t.Fatalf("retry Checkpoint: %v", err)
+	}
+	if got := db.backend.State().AppliedCommandLSN; got != 2 {
+		t.Fatalf("AppliedCommandLSN after retry=%d, want 2", got)
+	}
+}
+
+func TestPublicCommandWALCheckpointDefaultCutoverAdmitsPostFrontierWriteSync(t *testing.T) {
+	db, err := Open(commandWALDurabilityProofOptions(t.TempDir()))
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+	if err := db.SetSync([]byte("default-cutover/pre"), []byte("pre-value")); err != nil {
+		t.Fatalf("pre-cut SetSync: %v", err)
+	}
+
+	publishEntered := make(chan struct{})
+	releasePublish := make(chan struct{})
+	var publishOnce sync.Once
+	db.cached.SetCommandWALCheckpointPublishHook(func(syncWrite bool) (uint64, []backenddb.CommandWALLSNRange, error) {
+		publishOnce.Do(func() { close(publishEntered) })
+		if err := waitForPublicCommandWALCheckpointPhase(releasePublish, "default cutover publish release"); err != nil {
+			return 0, nil, err
+		}
+		return db.preparePublicCommandWALPendingPublish(syncWrite)
+	})
+	before := db.Stats()
+	checkpointDone := make(chan error, 1)
+	go func() { checkpointDone <- db.cached.Checkpoint() }()
+	if err := waitForPublicCommandWALCheckpointPhase(publishEntered, "default cutover publish hook"); err != nil {
+		t.Fatal(err)
+	}
+	if got := db.cached.Stats()["treedb.cache.checkpoint.post_frontier_admission.active"]; got != "true" {
+		t.Fatalf("post-frontier admission active=%q, want true", got)
+	}
+	if err := db.SetSync([]byte("default-cutover/post"), []byte("post-value")); err != nil {
+		t.Fatalf("post-cut SetSync: %v", err)
+	}
+	close(releasePublish)
+	if err := <-checkpointDone; err != nil {
+		t.Fatalf("Checkpoint: %v", err)
+	}
+	after := db.Stats()
+	requirePublicStatDelta(t, before, after, "treedb.cache.write.post_frontier_admission.count_total", 1)
+}
+
+func TestHelperPublicCommandWALCheckpointPostFrontierCrashWriter(t *testing.T) {
+	if os.Getenv("TREEDB_CHECKPOINT_FRONTIER_CRASH_HELPER") != "1" {
+		t.Skip("helper")
+	}
+	dir := os.Getenv("TREEDB_CHECKPOINT_FRONTIER_CRASH_DIR")
+	if dir == "" {
+		t.Fatal("missing TREEDB_CHECKPOINT_FRONTIER_CRASH_DIR")
+	}
+
+	opts := commandWALDurabilityProofOptions(dir)
+	opts.ValueLog.PointerThreshold = 1
+	opts.ValueLog.ForcePointers = true
+	db, err := Open(opts)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	preValue := bytes.Repeat([]byte("a"), 64<<10)
+	postValue := bytes.Repeat([]byte("b"), 64<<10)
+	if err := db.SetSync([]byte("frontier/pre-cut"), preValue); err != nil {
+		t.Fatalf("pre-cut SetSync: %v", err)
+	}
+	segmentsBefore := publicCommandWALSegmentNames(t, dir)
+	if len(segmentsBefore) == 0 {
+		t.Fatal("missing pre-cut command-WAL segment")
+	}
+
+	publishEntered := make(chan struct{})
+	releasePublish := make(chan struct{})
+	cleanupComplete := make(chan struct{})
+	var publishOnce, cleanupOnce sync.Once
+	db.cached.SetCommandWALCheckpointCutoverHook(db.snapshotPublicCommandWALCheckpointCutover)
+	db.cached.SetCommandWALCheckpointPublishHook(func(syncWrite bool) (uint64, []backenddb.CommandWALLSNRange, error) {
+		publishOnce.Do(func() { close(publishEntered) })
+		if err := waitForPublicCommandWALCheckpointPhase(releasePublish, "crash helper publish release"); err != nil {
+			return 0, nil, err
+		}
+		return db.preparePublicCommandWALPendingPublish(syncWrite)
+	})
+	db.cached.SetCommandWALCheckpointCleanupHook(func(syncWrite bool) error {
+		err := db.cleanupPublicCommandWALCheckpoint(syncWrite)
+		if err == nil {
+			cleanupOnce.Do(func() { close(cleanupComplete) })
+		}
+		return err
+	})
+
+	checkpointDone := make(chan error, 1)
+	go func() { checkpointDone <- db.Checkpoint() }()
+	if err := waitForPublicCommandWALCheckpointPhase(publishEntered, "crash helper checkpoint publish"); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.SetSync([]byte("frontier/post-cut"), postValue); err != nil {
+		t.Fatalf("post-cut SetSync while checkpoint publish latched: %v", err)
+	}
+	select {
+	case err := <-checkpointDone:
+		t.Fatalf("checkpoint completed while publish remained latched: %v", err)
+	default:
+	}
+	close(releasePublish)
+	if err := <-checkpointDone; err != nil {
+		t.Fatalf("Checkpoint: %v", err)
+	}
+	if err := waitForPublicCommandWALCheckpointPhase(cleanupComplete, "crash helper checkpoint cleanup"); err != nil {
+		t.Fatal(err)
+	}
+	if got := db.backend.State().AppliedCommandLSN; got != 1 {
+		t.Fatalf("AppliedCommandLSN=%d, want pre-cut LSN 1", got)
+	}
+	if first, last := db.publicCommandWALPendingRange(); first != 2 || last != 2 {
+		t.Fatalf("pending command-WAL range=(%d,%d), want post-cut range (2,2)", first, last)
+	}
+	segmentsAfter := publicCommandWALSegmentNames(t, dir)
+	if len(segmentsAfter) == 0 {
+		t.Fatalf("checkpoint cleanup removed the post-cut command-WAL generation; before=%v", segmentsBefore)
+	}
+	beforeSet := make(map[string]struct{}, len(segmentsBefore))
+	for _, name := range segmentsBefore {
+		beforeSet[name] = struct{}{}
+	}
+	for _, name := range segmentsAfter {
+		if _, covered := beforeSet[name]; covered {
+			t.Fatalf("checkpoint cleanup retained covered segment %s; before=%v after=%v", name, segmentsBefore, segmentsAfter)
+		}
+	}
+
+	// Simulate a process crash after cleanup without the close-time checkpoint.
+	// The only durable owner of the post-cut generation is its fresh command-WAL
+	// segment (plus the synced value-log external reference).
+	os.Exit(0)
+}
+
+func TestPublicCommandWALCheckpointPostFrontierGenerationSurvivesCrashReopen(t *testing.T) {
+	dir := t.TempDir()
+	exe, err := os.Executable()
+	if err != nil {
+		t.Fatalf("os.Executable: %v", err)
+	}
+	cmd := exec.Command(exe, "-test.run=^TestHelperPublicCommandWALCheckpointPostFrontierCrashWriter$", "-test.v")
+	cmd.Env = append(os.Environ(),
+		"TREEDB_CHECKPOINT_FRONTIER_CRASH_HELPER=1",
+		"TREEDB_CHECKPOINT_FRONTIER_CRASH_DIR="+dir,
+	)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("frontier crash helper failed: %v\n%s", err, out)
+	}
+
+	opts := commandWALDurabilityProofOptions(dir)
+	opts.ValueLog.PointerThreshold = 1
+	opts.ValueLog.ForcePointers = true
+	reopen, err := Open(opts)
+	if err != nil {
+		t.Fatalf("reopen after post-frontier crash: %v", err)
+	}
+	defer func() { _ = reopen.Close() }()
+	preValue := bytes.Repeat([]byte("a"), 64<<10)
+	postValue := bytes.Repeat([]byte("b"), 64<<10)
+	requireRawKVValue(t, reopen, []byte("frontier/pre-cut"), preValue)
+	requireRawKVValue(t, reopen, []byte("frontier/post-cut"), postValue)
+	if got := reopen.backend.State().AppliedCommandLSN; got < 2 {
+		t.Fatalf("reopened AppliedCommandLSN=%d, want post-cut LSN 2 replayed", got)
+	}
+	if _, err := reopen.ValueLogGC(context.Background(), ValueLogGCOptions{}); err != nil {
+		t.Fatalf("ValueLogGC after post-frontier replay: %v", err)
+	}
+	requireRawKVValue(t, reopen, []byte("frontier/pre-cut"), preValue)
+	requireRawKVValue(t, reopen, []byte("frontier/post-cut"), postValue)
 }
 
 // triggerAutoCheckpointForTest is test-only coordination for an already-running
@@ -3576,31 +3912,6 @@ func waitForPublicCommandWALCheckpointPhase(ch <-chan struct{}, phase string) er
 		return nil
 	case <-timer.C:
 		return fmt.Errorf("timed out waiting for %s", phase)
-	}
-}
-
-func waitForPublicCommandWALActiveCheckpointWriters(db *DB, want int) error {
-	timer := time.NewTimer(publicCommandWALCheckpointTestTimeout)
-	defer timer.Stop()
-	ticker := time.NewTicker(time.Millisecond)
-	defer ticker.Stop()
-	for {
-		stats := db.cached.Stats()
-		got, err := strconv.Atoi(stats["treedb.cache.write.wait_for_checkpoint.active"])
-		if err != nil {
-			return fmt.Errorf("parse active checkpoint writers %q: %w", stats["treedb.cache.write.wait_for_checkpoint.active"], err)
-		}
-		if got == want {
-			return nil
-		}
-		if got > want {
-			return fmt.Errorf("active checkpoint writers=%d, want %d", got, want)
-		}
-		select {
-		case <-ticker.C:
-		case <-timer.C:
-			return fmt.Errorf("timed out waiting for active checkpoint writers=%d (last=%d)", want, got)
-		}
 	}
 }
 

--- a/TreeDB/command_wal_public_test.go
+++ b/TreeDB/command_wal_public_test.go
@@ -3673,6 +3673,107 @@ func TestPublicCommandWALAutoCheckpointOverlapAdmitsPostFrontierWrites(t *testin
 	requirePublicStatDelta(t, before, after, "treedb.public.checkpoint.calls_total", 0)
 }
 
+func TestPublicCommandWALCheckpointPostFrontierRangeWritesWaitForDrain(t *testing.T) {
+	tests := []struct {
+		name  string
+		write func(*DB) error
+	}{
+		{
+			name: "delete_range",
+			write: func(db *DB) error {
+				return db.DeleteRange([]byte("range/"), []byte("range0"))
+			},
+		},
+		{
+			name: "pure_range_batch",
+			write: func(db *DB) error {
+				b := db.NewBatch()
+				if err := b.DeleteRange([]byte("range/"), []byte("range0")); err != nil {
+					_ = b.Close()
+					return err
+				}
+				err := b.WriteSync()
+				if closeErr := b.Close(); err == nil {
+					err = closeErr
+				}
+				return err
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			db, err := Open(commandWALDurabilityProofOptions(t.TempDir()))
+			if err != nil {
+				t.Fatalf("Open: %v", err)
+			}
+			defer func() { _ = db.Close() }()
+
+			for _, key := range []string{"range/a", "range/b", "outside"} {
+				if err := db.SetSync([]byte(key), []byte("value")); err != nil {
+					t.Fatalf("seed SetSync(%q): %v", key, err)
+				}
+			}
+
+			publishEntered := make(chan struct{})
+			releasePublish := make(chan struct{})
+			var publishOnce, releaseOnce sync.Once
+			defer releaseOnce.Do(func() { close(releasePublish) })
+			db.cached.SetCommandWALCheckpointPublishHook(func(syncWrite bool) (uint64, []backenddb.CommandWALLSNRange, error) {
+				publishOnce.Do(func() { close(publishEntered) })
+				if err := waitForPublicCommandWALCheckpointPhase(releasePublish, "range checkpoint publish release"); err != nil {
+					return 0, nil, err
+				}
+				return db.preparePublicCommandWALPendingPublish(syncWrite)
+			})
+
+			before := db.Stats()
+			checkpointDone := make(chan error, 1)
+			go func() { checkpointDone <- db.cached.Checkpoint() }()
+			if err := waitForPublicCommandWALCheckpointPhase(publishEntered, "range checkpoint publish hook"); err != nil {
+				t.Fatal(err)
+			}
+			if got := db.cached.Stats()["treedb.cache.checkpoint.post_frontier_admission.active"]; got != "true" {
+				t.Fatalf("post-frontier admission active=%q, want true", got)
+			}
+
+			writeDone := make(chan error, 1)
+			go func() { writeDone <- tc.write(db) }()
+			if err := waitForPublicCommandWALCheckpointWriterWaiters(db, 1); err != nil {
+				t.Fatal(err)
+			}
+			blocked := db.Stats()
+			requirePublicStatDelta(t, before, blocked, "treedb.command_wal.append.count_total", 0)
+			requirePublicStatDelta(t, before, blocked, "treedb.cache.write.post_frontier_admission.count_total", 0)
+			select {
+			case err := <-writeDone:
+				t.Fatalf("range write completed while checkpoint publish remained latched: %v", err)
+			default:
+			}
+
+			releaseOnce.Do(func() { close(releasePublish) })
+			if err := <-checkpointDone; err != nil {
+				t.Fatalf("Checkpoint: %v", err)
+			}
+			if err := <-writeDone; err != nil {
+				t.Fatalf("range write after checkpoint drain: %v", err)
+			}
+
+			after := db.Stats()
+			requirePublicStatDelta(t, before, after, "treedb.cache.write.wait_for_checkpoint.count_total", 1)
+			requirePublicStatDelta(t, before, after, "treedb.cache.write.wait.checkpoint_drain.count_total", 1)
+			requirePublicStatDelta(t, before, after, "treedb.cache.write.post_frontier_admission.count_total", 0)
+			requirePublicStatDelta(t, before, after, "treedb.command_wal.append.count_total", 1)
+			for _, key := range []string{"range/a", "range/b"} {
+				if got, err := db.Get([]byte(key)); err != nil || got != nil {
+					t.Fatalf("Get(%q) after range write=(%q, %v), want missing", key, got, err)
+				}
+			}
+			requireRawKVValue(t, db, []byte("outside"), []byte("value"))
+		})
+	}
+}
+
 func TestPublicCommandWALCheckpointPostFrontierAdmissionPropagatesPublishError(t *testing.T) {
 	db, err := Open(commandWALDurabilityProofOptions(t.TempDir()))
 	if err != nil {
@@ -3936,6 +4037,28 @@ func waitForPublicCommandWALAutoCheckpointCount(db *DB, want uint64) error {
 		case <-ticker.C:
 		case <-timer.C:
 			return fmt.Errorf("timed out waiting for auto-checkpoint count=%d (last=%d)", want, got)
+		}
+	}
+}
+
+func waitForPublicCommandWALCheckpointWriterWaiters(db *DB, want uint64) error {
+	timer := time.NewTimer(publicCommandWALCheckpointTestTimeout)
+	defer timer.Stop()
+	ticker := time.NewTicker(time.Millisecond)
+	defer ticker.Stop()
+	for {
+		stats := db.Stats()
+		got, err := strconv.ParseUint(stats["treedb.cache.write.wait_for_checkpoint.active"], 10, 64)
+		if err != nil {
+			return fmt.Errorf("parse checkpoint writer waiters %q: %w", stats["treedb.cache.write.wait_for_checkpoint.active"], err)
+		}
+		if got == want {
+			return nil
+		}
+		select {
+		case <-ticker.C:
+		case <-timer.C:
+			return fmt.Errorf("timed out waiting for checkpoint writer waiters=%d (last=%d)", want, got)
 		}
 	}
 }

--- a/TreeDB/docs/spec/verification.md
+++ b/TreeDB/docs/spec/verification.md
@@ -1017,6 +1017,22 @@ command-WAL cached mode feeds total command-WAL segment bytes into the
 size-triggered auto-checkpoint loop while the legacy cached redo journal is
 disabled.
 
+Post-frontier admission evidence includes
+`TestCachingDB_CheckpointExternalCommandWALAdmitsAfterFrontierCut`, which latches
+the pre-cut, post-cut, and pre-drain phases and proves that only the captured
+frontier reaches the first backend boundary;
+`TestCachingDB_CheckpointDrainRetainsWriterGateWithoutCommandWALCutover`, which
+keeps cached redo-WAL, unsafe WAL-off, and hookless external-WAL modes blocked
+through the drain; and
+`TestPublicCommandWALAutoCheckpointOverlapAdmitsPostFrontierWrites`, which
+admits concurrent public `Write` and `WriteSync` calls while checkpoint publish
+remains latched. Publish-error retry and crash/reopen cleanup coverage live in
+`TestPublicCommandWALCheckpointPostFrontierAdmissionPropagatesPublishError` and
+`TestPublicCommandWALCheckpointPostFrontierGenerationSurvivesCrashReopen`; the
+latter forces value-log pointers, crashes after covered command-WAL cleanup,
+replays the fresh post-cut segment, and verifies both values again after
+`ValueLogGC`.
+
 ## 12. Collections Document Formats
 
 Invariant:

--- a/TreeDB/docs/spec/verification.md
+++ b/TreeDB/docs/spec/verification.md
@@ -1026,7 +1026,11 @@ keeps cached redo-WAL, unsafe WAL-off, and hookless external-WAL modes blocked
 through the drain; and
 `TestPublicCommandWALAutoCheckpointOverlapAdmitsPostFrontierWrites`, which
 admits concurrent public `Write` and `WriteSync` calls while checkpoint publish
-remains latched. Publish-error retry and crash/reopen cleanup coverage live in
+remains latched. `TestPublicCommandWALCheckpointPostFrontierRangeWritesWaitForDrain`
+proves that DB-level and pure-batch range spans instead wait for the full drain,
+append no command frame while checkpoint publish is latched, record one
+`checkpoint_drain` wait, and do not increment point-write admission.
+Publish-error retry and crash/reopen cleanup coverage live in
 `TestPublicCommandWALCheckpointPostFrontierAdmissionPropagatesPublishError` and
 `TestPublicCommandWALCheckpointPostFrontierGenerationSurvivesCrashReopen`; the
 latter forces value-log pointers, crashes after covered command-WAL cleanup,

--- a/TreeDB/docs/spec/write-path-and-durability.md
+++ b/TreeDB/docs/spec/write-path-and-durability.md
@@ -251,24 +251,51 @@ promise that every safe-to-delete WAL file was physically removed.
 
 `DB.Checkpoint()` in cached mode is a forced durability/cleanup boundary.
 
-Current behavior:
+Checkpoint ownership and writer admission are separate states:
+
+- `flushMu` serializes checkpoint/flush ownership. `checkpointMu` and its
+  condition variable serialize checkpoints and wake writers when an admission
+  phase changes. The `checkpointing` state remains active for the entire
+  operation.
+- `writeMu` is held only for the frontier cut. While it is held, checkpoint
+  rotates the non-empty mutable memtable into a stable queue, captures the
+  queue frontier, and invokes the command-WAL cutover hook. The hook snapshots
+  the maximum covered command LSN and rotates the active command-WAL segment.
+- Once that hook has run, command-WAL writes may enter the fresh mutable,
+  command-WAL, and value-log generation while the captured frontier drains.
+  Those post-cut writes remain visible in cached state but are not part of the
+  active checkpoint's backend publication or `AppliedCommandLSN` boundary.
+- Cached redo-WAL mode, unsafe WAL-off mode, and external command-WAL mode
+  without an installed cutover hook retain the full-checkpoint writer stop.
+  They do not have the command-LSN/segment ownership proof needed for safe
+  post-frontier admission. Maintenance also retains its full writer stop.
+
+The active checkpoint then:
 
 1. serialize with flush/checkpoint locks,
 2. rotate non-empty mutable memtable into queue,
-3. rotate WAL writers so future writes use fresh segments,
-4. flush queued memtables with sync intent,
-5. force backend boundary even if queue was empty,
-6. remove old WAL segments not currently active and not retained,
-7. run value-log retention checks and pruning.
+3. capture a stable queue/command-LSN frontier and rotate WAL ownership,
+4. reopen command-WAL admission into the fresh post-cut generation when the
+   cutover hook established that ownership,
+5. flush only the captured frontier with sync intent,
+6. publish roots and the covered `AppliedCommandLSN`,
+7. force a backend boundary even if the queue was empty,
+8. remove only WAL segments covered by that published boundary, and
+9. run value-log retention checks and pruning while preserving active,
+   retained, and command-WAL-protected references.
 
 In backend-only mode, checkpoint is implemented as an empty sync batch write.
 
-Under the user-command WAL target, `DB.Checkpoint()` is also a command-WAL
-boundary. That later gate must close admission for the checkpoint cut, wait for
-in-flight commands admitted before the cut, drain async publish and write
-domains, publish roots, advance durable `AppliedLSN`, create the backend
-durability boundary containing that `AppliedLSN`, and only then report a clean
-command WAL state or clean commit-log ranges. Root publication and `AppliedLSN`
+With user-command WAL, `DB.Checkpoint()` is also a command-WAL boundary. The
+short cutover gate closes admission for the checkpoint cut and waits for
+in-flight commands admitted before the cut. The checkpoint then drains its
+captured publish/write domains, publishes roots, advances durable `AppliedLSN`,
+creates the backend durability boundary containing that `AppliedLSN`, and only
+then reports a clean command WAL state or clean commit-log ranges. Reopening
+admission after the cut does not relax `Checkpoint()` completion: success still
+means the entire captured frontier, durability metadata, and covered-segment
+cleanup completed. A publish or cleanup failure is returned to the caller, and
+post-cut segments remain recovery-owned. Root publication and `AppliedLSN`
 advancement must be atomic with respect to meta/root recovery: after any crash,
 open must select either the old roots plus old `AppliedLSN` or the new roots
 plus new `AppliedLSN`, never a split state. A future
@@ -286,6 +313,16 @@ Under the user-command WAL target, `DB.Checkpoint()` success must cover command
 WAL. A checkpoint that cannot publish `AppliedLSN` covering pre-cut command
 frames must return an error or expose explicit command WAL debt through a new
 API; it must not return `nil` and call the command WAL state clean.
+
+Checkpoint/write coordination is observable without conflating unrelated
+causes. `treedb.cache.write.wait.<reason>.*` reports totals, maximum/last
+latency, count, fixed cumulative latency buckets, and p50/p95/p99 bucket upper
+bounds for `frontier_cutover`, `checkpoint_drain`, and `maintenance`.
+`treedb.cache.write.post_frontier_admission.count_total` counts writes admitted
+while an older command-WAL frontier remains active. The compatibility aggregate
+`treedb.cache.write.wait_for_checkpoint.*` remains available. Flush-lock and
+I/O ownership stay separate in `treedb.cache.checkpoint.flushmu_wait_*` and
+`treedb.cache.checkpoint.stage.<cutover|wal_rotate|value_log_flush|command_wal_publish|flush_all|backend_boundary|wal_cleanup>.*`.
 
 ## 7. Auto-Checkpoint Defaults (Cached Mode)
 

--- a/TreeDB/docs/spec/write-path-and-durability.md
+++ b/TreeDB/docs/spec/write-path-and-durability.md
@@ -261,10 +261,13 @@ Checkpoint ownership and writer admission are separate states:
   rotates the non-empty mutable memtable into a stable queue, captures the
   queue frontier, and invokes the command-WAL cutover hook. The hook snapshots
   the maximum covered command LSN and rotates the active command-WAL segment.
-- Once that hook has run, command-WAL writes may enter the fresh mutable,
+- Once that hook has run, command-WAL point writes may enter the fresh mutable,
   command-WAL, and value-log generation while the captured frontier drains.
   Those post-cut writes remain visible in cached state but are not part of the
   active checkpoint's backend publication or `AppliedCommandLSN` boundary.
+  Range-span writes remain gated through checkpoint drain because their atomic
+  command append and span-layer publication still require `flushMu`; their wait
+  is reported under `checkpoint_drain`, not as post-frontier admission.
 - Cached redo-WAL mode, unsafe WAL-off mode, and external command-WAL mode
   without an installed cutover hook retain the full-checkpoint writer stop.
   They do not have the command-LSN/segment ownership proof needed for safe
@@ -318,10 +321,11 @@ Checkpoint/write coordination is observable without conflating unrelated
 causes. `treedb.cache.write.wait.<reason>.*` reports totals, maximum/last
 latency, count, fixed cumulative latency buckets, and p50/p95/p99 bucket upper
 bounds for `frontier_cutover`, `checkpoint_drain`, and `maintenance`.
-`treedb.cache.write.post_frontier_admission.count_total` counts writes admitted
-while an older command-WAL frontier remains active. The compatibility aggregate
-`treedb.cache.write.wait_for_checkpoint.*` remains available. Flush-lock and
-I/O ownership stay separate in `treedb.cache.checkpoint.flushmu_wait_*` and
+`treedb.cache.write.post_frontier_admission.count_total` counts point writes
+admitted while an older command-WAL frontier remains active. The compatibility
+aggregate `treedb.cache.write.wait_for_checkpoint.*` remains available.
+Flush-lock and I/O ownership stay separate in
+`treedb.cache.checkpoint.flushmu_wait_*` and
 `treedb.cache.checkpoint.stage.<cutover|wal_rotate|value_log_flush|command_wal_publish|flush_all|backend_boundary|wal_cleanup>.*`.
 
 ## 7. Auto-Checkpoint Defaults (Cached Mode)


### PR DESCRIPTION
## Summary

- split full checkpoint ownership from the short command-WAL frontier cutover gate
- admit external command-WAL point writes into a fresh mutable/WAL generation after the cut, while keeping `Checkpoint()` strict through publish, durability, cleanup, and maintenance
- retain full-drain writer blocking for cached redo-WAL, unsafe WAL-off, hookless external-WAL, and maintenance paths
- retain full-drain blocking for range-span writes that require `flushMu`, with waits attributed to `checkpoint_drain`
- add deterministic phase latches, reason-specific latency distributions, post-frontier admission counters, crash/reopen/value-log coverage, and the overlap benchmark

## Safety boundary

The cutover hook runs under `writeMu`, snapshots the maximum covered command LSN, and rotates the active command-WAL segment. Post-cut point writes are therefore owned by a fresh segment/mutable generation and cannot be published or cleaned by the active checkpoint. Range-span `DeleteRange` and pure range batches stay behind the full checkpoint drain because their atomic command append/span publication requires `flushMu`; they are not counted as post-frontier admission. The checkpoint still publishes only its captured frontier and `AppliedCommandLSN`; errors remain synchronous, and post-cut segments remain recovery-owned.

## Validation

- focused caching admission/fallback/reason tests: 10x pass
- focused public command-WAL admission/error/crash/default-hook tests: 5x pass
- focused caching and public race runs: pass
- `GOWORK=off go test ./TreeDB/db ./TreeDB/caching ./TreeDB -count=1`: pass (329.304 s / 84.129 s / 66.047 s)
- forced-pointer crash after covered command-WAL cleanup: reopen replay and post-`ValueLogGC` reads pass
- exact review-fix head `1bce6208374fa3ffc0d5e2a7333a117b6173eb7f`: DB-level and pure-batch range latches pass 20x, concurrent histogram snapshots pass 10x, and the focused public/caching race run passes

Identical 5x overlap benchmark medians:

| Metric | M0 baseline | Candidate |
| --- | ---: | ---: |
| checkpoint wait | 48.140 ms/op, 1 wait/op | 0, 0 waits/op |
| `WriteSync` p50 | 54.171 ms | 6.335 ms |
| `WriteSync` p95 | 56.645 ms | 6.381 ms |
| `WriteSync` p99/max | 66.065 ms | 7.222 ms |
| benchmark wall | 62.391 ms/op | 57.112 ms/op |
| B/op | 399,530 | 386,802 |
| allocs/op | 309 | 316 |

The accepted Ironbird candidate row at measured revision `502e34477a591635f5b2589c69f3d500799ce359` exercised 68 tx-index point-write post-frontier admissions with zero frontier-cutover and zero checkpoint-drain wait. Async tx-index total was 40.935 ms/block, passing the 42 ms/block target. One 1.017 s maintenance wait remains separately attributed; it is not relabeled as checkpoint wait. The exact review-fix head only narrows range-span admission and fixes histogram publication order; no replacement Ironbird row is claimed.

Canonical commands, revisions, raw artifact paths, profile findings, and the gate table are recorded in [the #3655 evidence node](https://github.com/snissn/gomap/issues/3655#issuecomment-4941305639).

Parent: #3652

Closes #3655
