### PR TITLE
db: synchronize leaf-generation metrics

### DIFF
--- a/TreeDB/db/leaf_generation_stats.go
+++ b/TreeDB/db/leaf_generation_stats.go
@@ -43,9 +43,11 @@ func (db *DB) collectLeafGenerationMetrics(set *valuelog.Set, excludePinIDs []ui
 	}
 	m.enabled = true
 
-	db.writeMu.RLock()
+	// leafGenerationManifest is published under mu. Clone while holding the
+	// same lock so post-commit publication cannot race metrics collection.
+	db.mu.RLock()
 	manifest := db.leafGenerationManifest.clone()
-	db.writeMu.RUnlock()
+	db.mu.RUnlock()
 	if manifest == nil {
 		return m
 	}

--- a/TreeDB/db/leaf_generation_stats.go
+++ b/TreeDB/db/leaf_generation_stats.go
@@ -43,11 +43,14 @@ func (db *DB) collectLeafGenerationMetrics(set *valuelog.Set, excludePinIDs []ui
 	}
 	m.enabled = true
 
-	// leafGenerationManifest is published under mu. Clone while holding the
-	// same lock so post-commit publication cannot race metrics collection.
+	// Manifest publication is serialized by writeMu in maintenance paths and
+	// by mu in post-commit paths. Take both in the documented lock order while
+	// cloning so metrics collection is synchronized with either publisher.
+	db.writeMu.RLock()
 	db.mu.RLock()
 	manifest := db.leafGenerationManifest.clone()
 	db.mu.RUnlock()
+	db.writeMu.RUnlock()
 	if manifest == nil {
 		return m
 	}


### PR DESCRIPTION
Closes #3703.

## Summary

- clone the leaf-generation manifest while holding both publication lock domains
- acquire writeMu then mu in the documented lock order
- prevent both maintenance and post-commit manifest publication from racing Stats collection
- retain clone-before-walk behavior so metrics releases both locks before filesystem work

## Evidence at ca9dd160106a8cc748df57813f43c019c69a036c

- focused post-commit race test passed 100x
- GC lock-order, live-scan, publish, and plan tests passed under race 10x
- exact hosted root race partition passed locally in 121.149s
- hosted race-check shards passed in 6m06s and 13m32s
- all 28 hosted checks passed, including Linux, macOS, Windows, performance, MVCC raw-path, and snapshot-iterator gates
- Codex latest-head follow-up is clean; prior P2 thread is resolved; independent re-review is clean

The defect was exposed by PR #3693 hosted race job 86503415577; the changed reader/writer paths are independent of that PRs MVCC iterator and pruning diff.