### PR TITLE
treedb: audit durable write sync barriers

### DIFF
--- a/TreeDB/caching/db.go
+++ b/TreeDB/caching/db.go
@@ -8649,6 +8649,10 @@ type DB struct {
 	valueLogSyncPathWaitNs    [valueLogSyncPathCount]atomic.Uint64
 	valueLogSyncPathErrors    [valueLogSyncPathCount]atomic.Uint64
 
+	valueLogRotatedFileSyncCalls  atomic.Uint64
+	valueLogRotatedFileSyncNs     atomic.Uint64
+	valueLogRotatedFileSyncErrors atomic.Uint64
+
 	// Legacy flags removed from public options; retained internally for code paths.
 	disableValueLog            bool
 	splitValueLog              bool
@@ -9539,6 +9543,7 @@ type DB struct {
 	// testing hooks
 	testOnVlogFlush                     func(laneID int)
 	testOnVlogSync                      func(laneID int)
+	testSyncRotatedValueLogFile         func(*os.File) error
 	testBeforeVlogUnlock                func(laneID int)
 	testBeforeCheckpointFrontierCapture func()
 	testAfterCheckpointFrontierCapture  func()
@@ -29877,6 +29882,15 @@ func (db *DB) Stats() map[string]string {
 	stats["treedb.cache.value_log.sync.ns_total"] = fmt.Sprintf("%d", valueLogSyncNs)
 	stats["treedb.cache.value_log.sync.wait_ns_total"] = fmt.Sprintf("%d", valueLogSyncWaitNs)
 	stats["treedb.cache.value_log.sync.errors_total"] = fmt.Sprintf("%d", valueLogSyncErrors)
+	rotatedSyncCalls := db.valueLogRotatedFileSyncCalls.Load()
+	rotatedSyncNs := db.valueLogRotatedFileSyncNs.Load()
+	rotatedSyncErrors := db.valueLogRotatedFileSyncErrors.Load()
+	valueLogFileSyncCalls += rotatedSyncCalls
+	valueLogFileSyncNs += rotatedSyncNs
+	valueLogFileSyncErrors += rotatedSyncErrors
+	stats["treedb.cache.value_log.file_sync.rotated_segment.calls_total"] = fmt.Sprintf("%d", rotatedSyncCalls)
+	stats["treedb.cache.value_log.file_sync.rotated_segment.ns_total"] = fmt.Sprintf("%d", rotatedSyncNs)
+	stats["treedb.cache.value_log.file_sync.rotated_segment.errors_total"] = fmt.Sprintf("%d", rotatedSyncErrors)
 	stats["treedb.cache.value_log.file_sync.calls_total"] = fmt.Sprintf("%d", valueLogFileSyncCalls)
 	stats["treedb.cache.value_log.file_sync.ns_total"] = fmt.Sprintf("%d", valueLogFileSyncNs)
 	stats["treedb.cache.value_log.file_sync.errors_total"] = fmt.Sprintf("%d", valueLogFileSyncErrors)

--- a/TreeDB/caching/db.go
+++ b/TreeDB/caching/db.go
@@ -2548,7 +2548,48 @@ func (db *DB) markLaneValueLogBoundary(l *lane, totalBytes int64, flushedBoundar
 	l.vlogSyncPending.Store(true)
 }
 
-func (db *DB) flushPendingValueLogLanes(sync bool) error {
+type valueLogSyncPath uint8
+
+const (
+	valueLogSyncPathMaterialization valueLogSyncPath = iota
+	valueLogSyncPathExternalRef
+	valueLogSyncPathPendingBarrier
+	valueLogSyncPathCheckpoint
+	valueLogSyncPathCount
+)
+
+func (p valueLogSyncPath) statName() string {
+	switch p {
+	case valueLogSyncPathMaterialization:
+		return "materialization"
+	case valueLogSyncPathExternalRef:
+		return "external_ref"
+	case valueLogSyncPathPendingBarrier:
+		return "pending_barrier"
+	case valueLogSyncPathCheckpoint:
+		return "checkpoint"
+	default:
+		return "unknown"
+	}
+}
+
+func (db *DB) observeValueLogSync(path valueLogSyncPath, waited, elapsed time.Duration, err error) {
+	if db == nil || path >= valueLogSyncPathCount {
+		return
+	}
+	db.valueLogSyncPathCalls[path].Add(1)
+	if ns := elapsed.Nanoseconds(); ns > 0 {
+		db.valueLogSyncPathNs[path].Add(uint64(ns))
+	}
+	if ns := waited.Nanoseconds(); ns > 0 {
+		db.valueLogSyncPathWaitNs[path].Add(uint64(ns))
+	}
+	if err != nil {
+		db.valueLogSyncPathErrors[path].Add(1)
+	}
+}
+
+func (db *DB) flushPendingValueLogLanes(sync bool, syncPath valueLogSyncPath) error {
 	if db == nil || !db.splitValueLogEnabled() {
 		return nil
 	}
@@ -2558,13 +2599,17 @@ func (db *DB) flushPendingValueLogLanes(sync bool) error {
 		if !l.vlogDirty.Load() && !(actualSync && l.vlogSyncPending.Load()) {
 			continue
 		}
+		waitStart := time.Now()
 		l.vlogMu.Lock()
+		waited := time.Since(waitStart)
 		w := l.vlog
 		var err error
 		syncBoundary := actualSync && l.vlogSyncPending.Load()
 		if w != nil {
 			if syncBoundary {
+				start := time.Now()
 				err = w.Sync()
+				db.observeValueLogSync(syncPath, waited, time.Since(start), err)
 			} else {
 				err = w.Flush()
 			}
@@ -2587,7 +2632,7 @@ func (db *DB) flushPendingValueLogLanes(sync bool) error {
 func (db *DB) checkpointFlushValueLogLanes() error {
 	// Checkpoint is a durability boundary for cached mode. Ensure any buffered
 	// value-log bytes are visible before publishing pointers durably to the backend.
-	return db.flushPendingValueLogLanes(true)
+	return db.flushPendingValueLogLanes(true, valueLogSyncPathCheckpoint)
 }
 
 func (db *DB) syncDirBestEffort(dir string) {
@@ -4955,10 +5000,12 @@ func (db *DB) syncValueLogLane(l *lane) error {
 		}
 		start := time.Now()
 		err := w.Sync()
+		elapsed := time.Since(start)
+		db.observeValueLogSync(valueLogSyncPathExternalRef, waited, elapsed, err)
 		if db.testOnVlogSync != nil {
 			db.testOnVlogSync(int(l.id))
 		}
-		db.debugVlogTiming("vlog_sync", int(l.id), "vlogMu", waited, time.Since(start))
+		db.debugVlogTiming("vlog_sync", int(l.id), "vlogMu", waited, elapsed)
 		if err == nil {
 			l.vlogDirty.Store(false)
 			l.vlogSyncPending.Store(false)
@@ -8597,6 +8644,10 @@ type DB struct {
 	walAckMu                  sync.Mutex
 	walErr                    error
 	nextRID                   atomic.Uint64
+	valueLogSyncPathCalls     [valueLogSyncPathCount]atomic.Uint64
+	valueLogSyncPathNs        [valueLogSyncPathCount]atomic.Uint64
+	valueLogSyncPathWaitNs    [valueLogSyncPathCount]atomic.Uint64
+	valueLogSyncPathErrors    [valueLogSyncPathCount]atomic.Uint64
 
 	// Legacy flags removed from public options; retained internally for code paths.
 	disableValueLog            bool
@@ -15592,21 +15643,29 @@ func (db *DB) flushVlogRequests(l *lane, requests []vlogWriteRequest) {
 	}
 
 	var (
-		ptrs        []page.ValuePtr
-		startSize   int64
-		totalBytes  int64
-		framesTotal int
-		framesTried int
-		framesKept  int
-		retainPath  string
-		probeKept   bool
-		dictRaw     int
-		dictStored  int
-		dictRecords int
-		err         error
+		ptrs         []page.ValuePtr
+		startSize    int64
+		totalBytes   int64
+		framesTotal  int
+		framesTried  int
+		framesKept   int
+		retainPath   string
+		probeKept    bool
+		dictRaw      int
+		dictStored   int
+		dictRecords  int
+		err          error
+		syncLockWait time.Duration
 	)
 
+	syncLockWaitStart := time.Time{}
+	if needSync {
+		syncLockWaitStart = time.Now()
+	}
 	l.vlogMu.Lock()
+	if needSync {
+		syncLockWait = time.Since(syncLockWaitStart)
+	}
 	if err := db.ensureValueLogWriterMuHeld(l); err != nil {
 		l.vlogMu.Unlock()
 		for i := range requests {
@@ -15976,7 +16035,9 @@ func (db *DB) flushVlogRequests(l *lane, requests []vlogWriteRequest) {
 	if err == nil {
 		switch {
 		case needSync:
+			start := time.Now()
 			err = w.Sync()
+			db.observeValueLogSync(valueLogSyncPathMaterialization, syncLockWait, time.Since(start), err)
 		case needFlush:
 			err = w.Flush()
 		default:
@@ -16635,6 +16696,7 @@ func (db *DB) appendValueLog(l *lane, dictID uint64, dict []byte, records []valu
 	appendWallStart := time.Time{}
 	appendWait := time.Duration(0)
 	appendHold := time.Duration(0)
+	syncLockWait := time.Duration(0)
 	if leafLogAppend {
 		appendWallStart = time.Now()
 	}
@@ -16898,13 +16960,21 @@ func (db *DB) appendValueLog(l *lane, dictID uint64, dict []byte, records []valu
 	}
 
 	lockWaitStart := time.Time{}
-	if leafLogAppend {
+	if leafLogAppend || durability == journalDurabilitySync {
 		lockWaitStart = time.Now()
 	}
 	l.vlogMu.Lock()
 	lockHoldStart := time.Time{}
+	if leafLogAppend || durability == journalDurabilitySync {
+		waited := time.Since(lockWaitStart)
+		if leafLogAppend {
+			appendWait += waited
+		}
+		if durability == journalDurabilitySync {
+			syncLockWait += waited
+		}
+	}
 	if leafLogAppend {
-		appendWait += time.Since(lockWaitStart)
 		lockHoldStart = time.Now()
 	}
 	if err := db.ensureValueLogWriterMuHeld(l); err != nil {
@@ -17118,12 +17188,20 @@ func (db *DB) appendValueLog(l *lane, dictID uint64, dict []byte, records []valu
 				l.vlogMu.Unlock()
 				runtime.Gosched()
 				relockWaitStart := time.Time{}
-				if leafLogAppend {
+				if leafLogAppend || durability == journalDurabilitySync {
 					relockWaitStart = time.Now()
 				}
 				l.vlogMu.Lock()
+				if leafLogAppend || durability == journalDurabilitySync {
+					waited := time.Since(relockWaitStart)
+					if leafLogAppend {
+						appendWait += waited
+					}
+					if durability == journalDurabilitySync {
+						syncLockWait += waited
+					}
+				}
 				if leafLogAppend {
-					appendWait += time.Since(relockWaitStart)
 					lockHoldStart = time.Now()
 				}
 				w = l.vlog
@@ -17242,7 +17320,9 @@ func (db *DB) appendValueLog(l *lane, dictID uint64, dict []byte, records []valu
 			err = w.Flush()
 			flushedBoundary = err == nil
 		case journalDurabilitySync:
+			start := time.Now()
 			err = w.Sync()
+			db.observeValueLogSync(valueLogSyncPathMaterialization, syncLockWait, time.Since(start), err)
 			syncedBoundary = err == nil
 		default:
 			if db.shouldFlushDeferredValueLog(finalWriteMode, records) {
@@ -17442,6 +17522,7 @@ func (db *DB) appendValueLogOneInternal(l *lane, dictID uint64, dict []byte, rid
 	appendWallStart := time.Time{}
 	appendWait := time.Duration(0)
 	appendHold := time.Duration(0)
+	syncLockWait := time.Duration(0)
 	if leafLogAppend {
 		appendWallStart = time.Now()
 	}
@@ -17798,13 +17879,21 @@ func (db *DB) appendValueLogOneInternal(l *lane, dictID uint64, dict []byte, rid
 	}
 
 	lockWaitStart := time.Time{}
-	if leafLogAppend {
+	if leafLogAppend || durability == journalDurabilitySync {
 		lockWaitStart = time.Now()
 	}
 	l.vlogMu.Lock()
 	lockHoldStart := time.Time{}
+	if leafLogAppend || durability == journalDurabilitySync {
+		waited := time.Since(lockWaitStart)
+		if leafLogAppend {
+			appendWait += waited
+		}
+		if durability == journalDurabilitySync {
+			syncLockWait += waited
+		}
+	}
 	if leafLogAppend {
-		appendWait += time.Since(lockWaitStart)
 		lockHoldStart = time.Now()
 	}
 	if err := db.ensureValueLogWriterMuHeld(l); err != nil {
@@ -17943,7 +18032,9 @@ func (db *DB) appendValueLogOneInternal(l *lane, dictID uint64, dict []byte, rid
 			err = w.Flush()
 			flushedBoundary = err == nil
 		case journalDurabilitySync:
+			start := time.Now()
 			err = w.Sync()
+			db.observeValueLogSync(valueLogSyncPathMaterialization, syncLockWait, time.Since(start), err)
 			syncedBoundary = err == nil
 		default:
 			if db.shouldFlushDeferredValueLogValue(finalWriteMode, value) {
@@ -29624,6 +29715,12 @@ func (db *DB) Stats() map[string]string {
 	var rawWriteSyscalls uint64
 	var rawWriteBytes uint64
 	var rawWriteCalls uint64
+	var valueLogFileSyncCalls uint64
+	var valueLogFileSyncNs uint64
+	var valueLogFileSyncErrors uint64
+	var valueLogDirectorySyncCalls uint64
+	var valueLogDirectorySyncNs uint64
+	var valueLogDirectorySyncErrors uint64
 	var vlogShapeSegmentsTotal int64
 	var vlogShapeBytesTotal int64
 	var vlogShapeL0Segments int64
@@ -29722,6 +29819,17 @@ func (db *DB) Stats() map[string]string {
 			rawWriteBytes += snap.Bytes
 			rawWriteCalls += snap.Calls
 		}
+		if snapper, ok := any(vlogWriter).(interface {
+			DurabilityStats() valuelog.DurabilityStats
+		}); ok {
+			snap := snapper.DurabilityStats()
+			valueLogFileSyncCalls += snap.FileSyncCalls
+			valueLogFileSyncNs += snap.FileSyncNs
+			valueLogFileSyncErrors += snap.FileSyncErrors
+			valueLogDirectorySyncCalls += snap.DirectorySyncCalls
+			valueLogDirectorySyncNs += snap.DirectorySyncNs
+			valueLogDirectorySyncErrors += snap.DirectorySyncErrors
+		}
 
 		laneLagP99 := estimateVlogQueueLagPercentile(lagSnap.Buckets, lagSnap.Count, 0.99)
 		laneLagP999 := estimateVlogQueueLagPercentile(lagSnap.Buckets, lagSnap.Count, 0.999)
@@ -29749,6 +29857,32 @@ func (db *DB) Stats() map[string]string {
 		stats["treedb.cache.vlog_shape.l0.segments_total"] = "0"
 		stats["treedb.cache.vlog_shape.l0.bytes_total"] = "0"
 	}
+	var valueLogSyncCalls, valueLogSyncNs, valueLogSyncWaitNs, valueLogSyncErrors uint64
+	for path := valueLogSyncPathMaterialization; path < valueLogSyncPathCount; path++ {
+		calls := db.valueLogSyncPathCalls[path].Load()
+		ns := db.valueLogSyncPathNs[path].Load()
+		waitNs := db.valueLogSyncPathWaitNs[path].Load()
+		errors := db.valueLogSyncPathErrors[path].Load()
+		valueLogSyncCalls += calls
+		valueLogSyncNs += ns
+		valueLogSyncWaitNs += waitNs
+		valueLogSyncErrors += errors
+		name := path.statName()
+		stats["treedb.cache.value_log.sync."+name+".calls_total"] = fmt.Sprintf("%d", calls)
+		stats["treedb.cache.value_log.sync."+name+".ns_total"] = fmt.Sprintf("%d", ns)
+		stats["treedb.cache.value_log.sync."+name+".wait_ns_total"] = fmt.Sprintf("%d", waitNs)
+		stats["treedb.cache.value_log.sync."+name+".errors_total"] = fmt.Sprintf("%d", errors)
+	}
+	stats["treedb.cache.value_log.sync.calls_total"] = fmt.Sprintf("%d", valueLogSyncCalls)
+	stats["treedb.cache.value_log.sync.ns_total"] = fmt.Sprintf("%d", valueLogSyncNs)
+	stats["treedb.cache.value_log.sync.wait_ns_total"] = fmt.Sprintf("%d", valueLogSyncWaitNs)
+	stats["treedb.cache.value_log.sync.errors_total"] = fmt.Sprintf("%d", valueLogSyncErrors)
+	stats["treedb.cache.value_log.file_sync.calls_total"] = fmt.Sprintf("%d", valueLogFileSyncCalls)
+	stats["treedb.cache.value_log.file_sync.ns_total"] = fmt.Sprintf("%d", valueLogFileSyncNs)
+	stats["treedb.cache.value_log.file_sync.errors_total"] = fmt.Sprintf("%d", valueLogFileSyncErrors)
+	stats["treedb.cache.value_log.directory_sync.calls_total"] = fmt.Sprintf("%d", valueLogDirectorySyncCalls)
+	stats["treedb.cache.value_log.directory_sync.ns_total"] = fmt.Sprintf("%d", valueLogDirectorySyncNs)
+	stats["treedb.cache.value_log.directory_sync.errors_total"] = fmt.Sprintf("%d", valueLogDirectorySyncErrors)
 
 	stats["treedb.cache.queue_len"] = fmt.Sprintf("%d", queueLen)
 	stats["treedb.cache.flush_apply.coordinator.active"] = fmt.Sprintf("%d", db.flushCoordinatorActive.Load())

--- a/TreeDB/caching/value_log_appender.go
+++ b/TreeDB/caching/value_log_appender.go
@@ -85,7 +85,7 @@ func (a *cachingValueLogAppender) FlushValueLogExternalRefs(fileIDs []uint32, sy
 		return errWALUnavailable
 	}
 	if len(fileIDs) == 0 {
-		return a.db.flushPendingValueLogLanes(sync)
+		return a.db.flushPendingValueLogLanes(sync, valueLogSyncPathPendingBarrier)
 	}
 	seenLanes := make(map[*lane]struct{}, len(fileIDs))
 	activeFileIDs := make(map[uint32]struct{}, len(fileIDs))

--- a/TreeDB/caching/value_log_appender.go
+++ b/TreeDB/caching/value_log_appender.go
@@ -3,6 +3,7 @@ package caching
 import (
 	"fmt"
 	"os"
+	"time"
 
 	backenddb "github.com/snissn/gomap/TreeDB/db"
 	"github.com/snissn/gomap/TreeDB/internal/valuelog"
@@ -134,10 +135,14 @@ func (a *cachingValueLogAppender) FlushValueLogExternalRefs(fileIDs []uint32, sy
 	return nil
 }
 
-func (a *cachingValueLogAppender) syncValueLogExternalRefSegment(fileID uint32) error {
+func (a *cachingValueLogAppender) syncValueLogExternalRefSegment(fileID uint32) (retErr error) {
 	if a == nil || a.db == nil || fileID == 0 {
 		return errWALUnavailable
 	}
+	start := time.Now()
+	defer func() {
+		a.db.observeValueLogSync(valueLogSyncPathExternalRef, 0, time.Since(start), retErr)
+	}()
 	path := valuelog.SegmentPath(a.db.valueLogDir, fileID)
 	if l := a.db.valueLogLaneForFileID(fileID); l != nil {
 		dir := a.db.valueLogDirForLane(l)
@@ -150,7 +155,31 @@ func (a *cachingValueLogAppender) syncValueLogExternalRefSegment(fileID uint32) 
 		return err
 	}
 	defer func() { _ = f.Close() }()
-	return f.Sync()
+	return a.db.syncRotatedValueLogFile(f)
+}
+
+func (db *DB) syncRotatedValueLogFile(f *os.File) error {
+	if db == nil || f == nil {
+		return errWALUnavailable
+	}
+	// Rotated segments no longer have an active writer whose DurabilityStats can
+	// own this direct file-sync observation. Keep this telemetry DB-owned so the
+	// aggregate can add it to active-writer stats exactly once.
+	start := time.Now()
+	var err error
+	if db.testSyncRotatedValueLogFile != nil {
+		err = db.testSyncRotatedValueLogFile(f)
+	} else {
+		err = f.Sync()
+	}
+	db.valueLogRotatedFileSyncCalls.Add(1)
+	if ns := time.Since(start).Nanoseconds(); ns > 0 {
+		db.valueLogRotatedFileSyncNs.Add(uint64(ns))
+	}
+	if err != nil {
+		db.valueLogRotatedFileSyncErrors.Add(1)
+	}
+	return err
 }
 
 func cachingValueLogSegmentForLane(l *lane) (string, uint32, bool) {

--- a/TreeDB/caching/value_log_appender_test.go
+++ b/TreeDB/caching/value_log_appender_test.go
@@ -175,10 +175,19 @@ func TestCachingValueLogExternalRefFlusherAccountsForRotatedCommandFrameSegment(
 		"treedb.cache.value_log.file_sync.rotated_segment.ns_total",
 		"treedb.cache.value_log.file_sync.ns_total",
 	} {
-		got := requireStatUint64(t, after, key) - requireStatUint64(t, before, key)
-		if got == 0 {
-			t.Fatalf("%s delta=0, want observed time", key)
+		beforeNs := requireStatUint64(t, before, key)
+		afterNs := requireStatUint64(t, after, key)
+		// A completed file sync can fit inside one timer tick on Windows. Calls
+		// and errors above are the exact accounting boundary; elapsed counters
+		// are cumulative and may legitimately have a zero delta.
+		if afterNs < beforeNs {
+			t.Fatalf("%s decreased from %d to %d", key, beforeNs, afterNs)
 		}
+	}
+	if aggregate, rotated :=
+		requireStatUint64(t, after, "treedb.cache.value_log.file_sync.ns_total"),
+		requireStatUint64(t, after, "treedb.cache.value_log.file_sync.rotated_segment.ns_total"); aggregate < rotated {
+		t.Fatalf("aggregate file-sync ns=%d, want >= rotated-segment ns=%d", aggregate, rotated)
 	}
 }
 

--- a/TreeDB/caching/value_log_appender_test.go
+++ b/TreeDB/caching/value_log_appender_test.go
@@ -1,10 +1,13 @@
 package caching
 
 import (
+	"bytes"
 	"errors"
 	"os"
 	"testing"
 
+	batchpkg "github.com/snissn/gomap/TreeDB/batch"
+	backenddb "github.com/snissn/gomap/TreeDB/db"
 	"github.com/snissn/gomap/TreeDB/internal/valuelog"
 )
 
@@ -34,11 +37,148 @@ func TestCachingValueLogExternalRefFlusherSyncsRotatedSegments(t *testing.T) {
 	if err := appender.FlushValueLogExternalRefs([]uint32{oldFileID}, true); !errors.Is(err, os.ErrNotExist) {
 		t.Fatalf("FlushValueLogExternalRefs missing rotated segment error=%v, want os.ErrNotExist", err)
 	}
+	if got := db.valueLogSyncPathCalls[valueLogSyncPathExternalRef].Load(); got != 1 {
+		t.Fatalf("logical external-ref calls after open failure=%d, want 1", got)
+	}
+	if got := db.valueLogSyncPathErrors[valueLogSyncPathExternalRef].Load(); got != 1 {
+		t.Fatalf("logical external-ref errors after open failure=%d, want 1", got)
+	}
+	if got := db.valueLogRotatedFileSyncCalls.Load(); got != 0 {
+		t.Fatalf("rotated file-sync calls after open failure=%d, want 0", got)
+	}
 	if err := os.WriteFile(valuelog.SegmentPath(dir, oldFileID), []byte("old segment"), 0o644); err != nil {
 		t.Fatalf("write old segment: %v", err)
 	}
+	injected := errors.New("injected rotated sync failure")
+	db.testSyncRotatedValueLogFile = func(*os.File) error { return injected }
+	if err := appender.FlushValueLogExternalRefs([]uint32{oldFileID}, true); !errors.Is(err, injected) {
+		t.Fatalf("FlushValueLogExternalRefs injected rotated sync error=%v, want %v", err, injected)
+	}
+	if got := db.valueLogSyncPathCalls[valueLogSyncPathExternalRef].Load(); got != 2 {
+		t.Fatalf("logical external-ref calls after sync failure=%d, want 2", got)
+	}
+	if got := db.valueLogSyncPathErrors[valueLogSyncPathExternalRef].Load(); got != 2 {
+		t.Fatalf("logical external-ref errors after sync failure=%d, want 2", got)
+	}
+	if got := db.valueLogRotatedFileSyncCalls.Load(); got != 1 {
+		t.Fatalf("rotated file-sync calls after sync failure=%d, want 1", got)
+	}
+	if got := db.valueLogRotatedFileSyncErrors.Load(); got != 1 {
+		t.Fatalf("rotated file-sync errors after sync failure=%d, want 1", got)
+	}
+	db.testSyncRotatedValueLogFile = nil
 	if err := appender.FlushValueLogExternalRefs([]uint32{oldFileID, currentFileID, oldFileID}, true); err != nil {
 		t.Fatalf("FlushValueLogExternalRefs rotated segment: %v", err)
+	}
+	if got := db.valueLogSyncPathCalls[valueLogSyncPathExternalRef].Load(); got != 3 {
+		t.Fatalf("logical external-ref calls after successful deduplicated sync=%d, want 3", got)
+	}
+	if got := db.valueLogSyncPathErrors[valueLogSyncPathExternalRef].Load(); got != 2 {
+		t.Fatalf("logical external-ref errors after successful deduplicated sync=%d, want 2", got)
+	}
+	if got := db.valueLogRotatedFileSyncCalls.Load(); got != 2 {
+		t.Fatalf("rotated file-sync calls after successful deduplicated sync=%d, want 2", got)
+	}
+	if got := db.valueLogRotatedFileSyncErrors.Load(); got != 1 {
+		t.Fatalf("rotated file-sync errors after successful deduplicated sync=%d, want 1", got)
+	}
+	if got := db.valueLogSyncPathWaitNs[valueLogSyncPathExternalRef].Load(); got != 0 {
+		t.Fatalf("logical rotated external-ref wait ns=%d, want 0 without an active writer", got)
+	}
+	if got := db.valueLogSyncPathNs[valueLogSyncPathExternalRef].Load(); got == 0 {
+		t.Fatal("logical rotated external-ref ns=0, want observed time")
+	}
+	if got := db.valueLogRotatedFileSyncNs.Load(); got == 0 {
+		t.Fatal("rotated file-sync ns=0, want observed time")
+	}
+}
+
+func TestCachingValueLogExternalRefFlusherAccountsForRotatedCommandFrameSegment(t *testing.T) {
+	dir := t.TempDir()
+	backend, err := backenddb.Open(backenddb.Options{
+		Dir:                    dir,
+		Durability:             backenddb.DurabilityDurable,
+		CommandWAL:             true,
+		DisableBackgroundPrune: true,
+		ValueLog: backenddb.ValueLogOptions{
+			PointerThreshold: 1,
+			ForcePointers:    true,
+		},
+	})
+	if err != nil {
+		t.Fatalf("backend Open: %v", err)
+	}
+	db, err := Open(dir, backend, Options{
+		ExternalCommandWAL:       true,
+		FlushThreshold:           1 << 30,
+		JournalLanes:             1,
+		ValueLogPointerThreshold: 1,
+		ForceValueLogPointers:    true,
+	})
+	if err != nil {
+		_ = backend.Close()
+		t.Fatalf("cache Open: %v", err)
+	}
+	defer func() {
+		_ = db.Close()
+		_ = backend.Close()
+	}()
+
+	ptrs, err := backend.AppendValueLogValues([][]byte{bytes.Repeat([]byte("v"), 2048)})
+	if err != nil {
+		t.Fatalf("AppendValueLogValues: %v", err)
+	}
+	if len(ptrs) != 1 || ptrs[0].FileID == 0 {
+		t.Fatalf("AppendValueLogValues pointers=%v, want one value-log pointer", ptrs)
+	}
+	referencedFileID := ptrs[0].FileID
+	if err := db.rotateValueLogLocked(&db.lanes[0]); err != nil {
+		t.Fatalf("rotateValueLogLocked: %v", err)
+	}
+	_, activeFileID, ok := cachingValueLogSegmentForLane(&db.lanes[0])
+	if !ok || activeFileID == 0 || activeFileID == referencedFileID {
+		t.Fatalf("active file ID after rotation=(%d,%t), want nonzero and different from referenced %d", activeFileID, ok, referencedFileID)
+	}
+
+	before := db.Stats()
+	lsn, err := backend.AppendRawKVCommandWALOrderedEntries([]batchpkg.Entry{{
+		Type:     batchpkg.OpPut,
+		Key:      []byte("rotated-command-ref"),
+		ValuePtr: ptrs[0],
+		IsPtr:    true,
+	}}, true)
+	if err != nil {
+		t.Fatalf("AppendRawKVCommandWALOrderedEntries: %v", err)
+	}
+	if lsn == 0 {
+		t.Fatal("AppendRawKVCommandWALOrderedEntries LSN=0, want an appended command frame")
+	}
+	after := db.Stats()
+
+	for key, want := range map[string]uint64{
+		"treedb.command_wal.append.count_total":                         1,
+		"treedb.command_wal.file_sync.calls_total":                      1,
+		"treedb.cache.value_log.sync.external_ref.calls_total":          2,
+		"treedb.cache.value_log.sync.external_ref.errors_total":         0,
+		"treedb.cache.value_log.file_sync.rotated_segment.calls_total":  1,
+		"treedb.cache.value_log.file_sync.rotated_segment.errors_total": 0,
+		"treedb.cache.value_log.file_sync.calls_total":                  2,
+		"treedb.cache.value_log.file_sync.errors_total":                 0,
+	} {
+		got := requireStatUint64(t, after, key) - requireStatUint64(t, before, key)
+		if got != want {
+			t.Fatalf("%s delta=%d, want %d (referenced=%d active=%d)", key, got, want, referencedFileID, activeFileID)
+		}
+	}
+	for _, key := range []string{
+		"treedb.cache.value_log.sync.external_ref.ns_total",
+		"treedb.cache.value_log.file_sync.rotated_segment.ns_total",
+		"treedb.cache.value_log.file_sync.ns_total",
+	} {
+		got := requireStatUint64(t, after, key) - requireStatUint64(t, before, key)
+		if got == 0 {
+			t.Fatalf("%s delta=0, want observed time", key)
+		}
 	}
 }
 

--- a/TreeDB/command_wal_public_test.go
+++ b/TreeDB/command_wal_public_test.go
@@ -3632,10 +3632,12 @@ func benchmarkPublicCommandWALBatchWithSetView(b *testing.B, db *DB, prefix stri
 
 func publicCommandWALDurableShapeExpectedCounters(shape string, forcedPointers bool) map[string]uint64 {
 	want := map[string]uint64{
-		"treedb.command_wal.write.errors_total":         0,
-		"treedb.command_wal.file_sync.errors_total":     0,
-		"treedb.cache.value_log.sync.errors_total":      0,
-		"treedb.cache.value_log.file_sync.errors_total": 0,
+		"treedb.command_wal.write.errors_total":                         0,
+		"treedb.command_wal.file_sync.errors_total":                     0,
+		"treedb.cache.value_log.sync.errors_total":                      0,
+		"treedb.cache.value_log.file_sync.errors_total":                 0,
+		"treedb.cache.value_log.file_sync.rotated_segment.calls_total":  0,
+		"treedb.cache.value_log.file_sync.rotated_segment.errors_total": 0,
 	}
 	var appendCalls, flushCalls, syncCalls, writeSyscalls, fileSyncCalls uint64
 	var batchWriteCalls, batchWriteSyncCalls, barrierSyncCalls uint64
@@ -4484,6 +4486,8 @@ func reportCommandWALBenchmarkDeltas(b *testing.B, before, after map[string]stri
 		"treedb.cache.value_log.sync.pending_barrier.wait_ns_total",
 		"treedb.cache.value_log.file_sync.calls_total",
 		"treedb.cache.value_log.file_sync.ns_total",
+		"treedb.cache.value_log.file_sync.rotated_segment.calls_total",
+		"treedb.cache.value_log.file_sync.rotated_segment.ns_total",
 		"treedb.public.batch.write_sync.phase.wall.ns_total",
 		"treedb.public.batch.write_sync.phase.checkpoint_gate.ns_total",
 		"treedb.public.batch.write_sync.phase.preflight_materialization.ns_total",

--- a/TreeDB/command_wal_public_test.go
+++ b/TreeDB/command_wal_public_test.go
@@ -772,7 +772,7 @@ func TestPublicCommandWALBatchWriteSyncPhaseStatsLabelRelaxedFlush(t *testing.T)
 	requirePublicBatchWriteSyncPhasePartitions(t, stats)
 }
 
-func TestPublicCommandWALBatchWriteSyncPhaseStatsLabelExternalRefOrdering(t *testing.T) {
+func TestPublicCommandWALBatchWriteSyncExternalRefOrderingPhaseStats(t *testing.T) {
 	opts := commandWALDurabilityProofOptions(t.TempDir())
 	opts.PublicBatchWriteSyncPhaseStats = true
 	opts.ValueLog.PointerThreshold = 1
@@ -782,6 +782,7 @@ func TestPublicCommandWALBatchWriteSyncPhaseStatsLabelExternalRefOrdering(t *tes
 		t.Fatalf("Open command WAL: %v", err)
 	}
 	defer func() { _ = db.Close() }()
+	before := db.Stats()
 
 	b := db.NewBatch()
 	if err := b.Set([]byte("external-ref"), bytes.Repeat([]byte("v"), 2048)); err != nil {
@@ -801,7 +802,214 @@ func TestPublicCommandWALBatchWriteSyncPhaseStatsLabelExternalRefOrdering(t *tes
 	if got := statMapUint64(t, stats, prefix+"command_external_ref_ordering.calls_total"); got != 1 {
 		t.Fatalf("phase external-ref ordering calls=%d, want 1 (stats=%#v)", got, stats)
 	}
+	requirePublicStatDelta(t, before, stats, "treedb.command_wal.sync.count_total", 1)
+	requirePublicStatDelta(t, before, stats, "treedb.command_wal.write.syscalls_total", 1)
+	requirePublicStatDelta(t, before, stats, "treedb.command_wal.file_sync.calls_total", 1)
+	requirePublicStatDelta(t, before, stats, "treedb.cache.value_log.sync.calls_total", 2)
+	requirePublicStatDelta(t, before, stats, "treedb.cache.value_log.sync.materialization.calls_total", 1)
+	requirePublicStatDelta(t, before, stats, "treedb.cache.value_log.sync.external_ref.calls_total", 1)
+	requirePublicStatDelta(t, before, stats, "treedb.cache.value_log.file_sync.calls_total", 2)
 	requirePublicBatchWriteSyncPhasePartitions(t, stats)
+}
+
+func TestPublicCommandWALStateShapedDurabilityLedger(t *testing.T) {
+	db, err := Open(commandWALDurabilityProofOptions(t.TempDir()))
+	if err != nil {
+		t.Fatalf("Open command WAL: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	before := db.Stats()
+	if err := db.Set([]byte("state/unsynced"), []byte("u")); err != nil {
+		t.Fatalf("Set: %v", err)
+	}
+	if err := db.SetSync([]byte("state/synced"), []byte("s")); err != nil {
+		t.Fatalf("SetSync: %v", err)
+	}
+	b, ok := db.NewBatch().(*commandWALPublicBatch)
+	if !ok {
+		t.Fatalf("NewBatch type=%T, want *commandWALPublicBatch", db.NewBatch())
+	}
+	if err := b.SetView([]byte("state/batch"), []byte("b")); err != nil {
+		_ = b.Close()
+		t.Fatalf("batch SetView: %v", err)
+	}
+	if err := b.WriteSync(); err != nil {
+		_ = b.Close()
+		t.Fatalf("batch WriteSync: %v", err)
+	}
+	if err := b.Close(); err != nil {
+		t.Fatalf("batch Close: %v", err)
+	}
+	after := db.Stats()
+
+	for key, want := range map[string]uint64{
+		"treedb.command_wal.append.count_total":            3,
+		"treedb.command_wal.append.point.count_total":      2,
+		"treedb.command_wal.append.entry_scan.count_total": 1,
+		"treedb.command_wal.flush.count_total":             1,
+		"treedb.command_wal.flush.point.count_total":       1,
+		"treedb.command_wal.sync.count_total":              2,
+		"treedb.command_wal.sync.point.count_total":        1,
+		"treedb.command_wal.sync.entry_scan.count_total":   1,
+		"treedb.command_wal.sync.barrier.count_total":      0,
+		"treedb.command_wal.write.syscalls_total":          3,
+		"treedb.command_wal.write.errors_total":            0,
+		"treedb.command_wal.file_sync.calls_total":         2,
+		"treedb.command_wal.file_sync.errors_total":        0,
+		"treedb.public.batch.write_sync.calls_total":       1,
+		"treedb.cache.value_log.sync.calls_total":          0,
+		"treedb.cache.value_log.file_sync.calls_total":     0,
+	} {
+		requirePublicStatDelta(t, before, after, key, want)
+	}
+	for key, value := range map[string]string{
+		"state/unsynced": "u",
+		"state/synced":   "s",
+		"state/batch":    "b",
+	} {
+		requireRawKVValue(t, db, []byte(key), []byte(value))
+	}
+}
+
+func TestPublicCommandWALPointerEmptyWriteSyncSweepsPriorUnsyncedWrite(t *testing.T) {
+	dir := t.TempDir()
+	opts := commandWALDurabilityProofOptions(dir)
+	opts.ValueLog.PointerThreshold = 1
+	opts.ValueLog.ForcePointers = true
+	db, err := Open(opts)
+	if err != nil {
+		t.Fatalf("Open command WAL: %v", err)
+	}
+
+	before := db.Stats()
+	want := bytes.Repeat([]byte("p"), 2048)
+	dirty := db.NewBatch()
+	if err := dirty.Set([]byte("pointer/prior"), want); err != nil {
+		_ = dirty.Close()
+		_ = db.Close()
+		t.Fatalf("dirty Set: %v", err)
+	}
+	if err := dirty.Write(); err != nil {
+		_ = dirty.Close()
+		_ = db.Close()
+		t.Fatalf("dirty Write: %v", err)
+	}
+	if err := dirty.Close(); err != nil {
+		_ = db.Close()
+		t.Fatalf("dirty Close: %v", err)
+	}
+	empty := db.NewBatch()
+	if err := empty.WriteSync(); err != nil {
+		_ = empty.Close()
+		_ = db.Close()
+		t.Fatalf("empty WriteSync: %v", err)
+	}
+	if err := empty.Close(); err != nil {
+		_ = db.Close()
+		t.Fatalf("empty Close: %v", err)
+	}
+	after := db.Stats()
+	for key, wantDelta := range map[string]uint64{
+		"treedb.command_wal.append.count_total":                   1,
+		"treedb.command_wal.flush.count_total":                    1,
+		"treedb.command_wal.sync.count_total":                     1,
+		"treedb.command_wal.sync.barrier.count_total":             1,
+		"treedb.command_wal.write.syscalls_total":                 1,
+		"treedb.command_wal.file_sync.calls_total":                1,
+		"treedb.cache.value_log.sync.calls_total":                 1,
+		"treedb.cache.value_log.sync.pending_barrier.calls_total": 1,
+		"treedb.cache.value_log.file_sync.calls_total":            1,
+		"treedb.public.batch.write.calls_total":                   1,
+		"treedb.public.batch.write_sync.calls_total":              1,
+	} {
+		requirePublicStatDelta(t, before, after, key, wantDelta)
+	}
+	requireRawKVValue(t, db, []byte("pointer/prior"), want)
+	if err := db.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	reopen, err := Open(opts)
+	if err != nil {
+		t.Fatalf("reopen: %v", err)
+	}
+	defer func() { _ = reopen.Close() }()
+	requireRawKVValue(t, reopen, []byte("pointer/prior"), want)
+}
+
+func TestPublicCommandWALWriteThenDirtyWriteSyncDurabilityLedger(t *testing.T) {
+	for _, tc := range []struct {
+		name           string
+		forcedPointers bool
+	}{
+		{name: "inline"},
+		{name: "forced_pointer", forcedPointers: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			opts := commandWALDurabilityProofOptions(dir)
+			value := []byte("inline-value")
+			if tc.forcedPointers {
+				opts.ValueLog.PointerThreshold = 1
+				opts.ValueLog.ForcePointers = true
+				value = bytes.Repeat([]byte("p"), 2048)
+			}
+			db, err := Open(opts)
+			if err != nil {
+				t.Fatalf("Open command WAL: %v", err)
+			}
+
+			before := db.Stats()
+			prior := db.NewBatch()
+			if err := prior.Set([]byte("prior"), value); err != nil {
+				_ = prior.Close()
+				_ = db.Close()
+				t.Fatalf("prior Set: %v", err)
+			}
+			if err := prior.Write(); err != nil {
+				_ = prior.Close()
+				_ = db.Close()
+				t.Fatalf("prior Write: %v", err)
+			}
+			if err := prior.Close(); err != nil {
+				_ = db.Close()
+				t.Fatalf("prior Close: %v", err)
+			}
+
+			durable := db.NewBatch()
+			if err := durable.Set([]byte("durable"), value); err != nil {
+				_ = durable.Close()
+				_ = db.Close()
+				t.Fatalf("durable Set: %v", err)
+			}
+			if err := durable.WriteSync(); err != nil {
+				_ = durable.Close()
+				_ = db.Close()
+				t.Fatalf("durable WriteSync: %v", err)
+			}
+			if err := durable.Close(); err != nil {
+				_ = db.Close()
+				t.Fatalf("durable Close: %v", err)
+			}
+
+			after := db.Stats()
+			for key, want := range publicCommandWALDurableShapeExpectedCounters("write_then_dirty_write_sync", tc.forcedPointers) {
+				requirePublicStatDelta(t, before, after, key, want)
+			}
+			if err := db.Close(); err != nil {
+				t.Fatalf("Close: %v", err)
+			}
+
+			reopen, err := Open(opts)
+			if err != nil {
+				t.Fatalf("reopen: %v", err)
+			}
+			defer func() { _ = reopen.Close() }()
+			requireRawKVValue(t, reopen, []byte("prior"), value)
+			requireRawKVValue(t, reopen, []byte("durable"), value)
+		})
+	}
 }
 
 func TestPublicCommandWALDurableSyncBoundaryMatrixDoesNotCheckpoint(t *testing.T) {
@@ -3267,66 +3475,214 @@ func TestPublicCommandWALDurableTinyBatchWriteSyncByteAccounting(t *testing.T) {
 }
 
 func BenchmarkPublicCommandWALDurableTinyBatchWriteSync(b *testing.B) {
-	for _, batchSize := range []int{1, 8, 32} {
-		b.Run(fmt.Sprintf("ops=%d", batchSize), func(b *testing.B) {
-			db, err := Open(commandWALDurabilityProofOptions(b.TempDir()))
-			if err != nil {
-				b.Fatalf("Open: %v", err)
-			}
-			defer func() { _ = db.Close() }()
-
-			value := []byte("public-command-wal-value")
-			before := db.Stats()
-			latencies := make([]time.Duration, 0, b.N)
-			b.ReportAllocs()
-			b.ResetTimer()
-			for i := 0; i < b.N; i++ {
-				batch := db.NewBatchWithSize(batchSize)
-				for j := 0; j < batchSize; j++ {
-					var keyBuf [32]byte
-					key := strconv.AppendInt(keyBuf[:0], int64(i*batchSize+j), 10)
-					if err := batch.Set(key, value); err != nil {
-						_ = batch.Close()
-						b.Fatalf("batch Set(%d): %v", j, err)
-					}
-				}
-				start := time.Now()
-				if err := batch.WriteSync(); err != nil {
-					_ = batch.Close()
-					b.Fatalf("batch WriteSync: %v", err)
-				}
-				latencies = append(latencies, time.Since(start))
-				if err := batch.Close(); err != nil {
-					b.Fatalf("batch Close: %v", err)
-				}
-			}
-			b.StopTimer()
-			totalWrites := b.N * batchSize
-			totalBatchBytes := publicCommandWALSequentialDecimalKeyBytes(totalWrites) +
-				uint64(totalWrites)*uint64(len(value))
-
-			after := db.Stats()
-			requireBenchmarkStatDelta(b, before, after, "treedb.command_wal.append.count_total", uint64(b.N))
-			requireBenchmarkStatDelta(b, before, after, "treedb.command_wal.append.payload.count_total", uint64(b.N))
-			requireBenchmarkStatDelta(b, before, after, "treedb.command_wal.flush.count_total", 0)
-			requireBenchmarkStatDelta(b, before, after, "treedb.command_wal.sync.count_total", uint64(b.N))
-			requireBenchmarkStatDelta(b, before, after, "treedb.public.batch.write_sync.calls_total", uint64(b.N))
-			requireBenchmarkStatDelta(b, before, after, "treedb.public.checkpoint.calls_total", 0)
-			if got := statMapUint64B(b, after, "treedb.cache.checkpoint.runs"); got != 0 {
-				b.Fatalf("checkpoint.runs=%d, want 0 for isolated WriteSync baseline", got)
-			}
-
-			elapsed := b.Elapsed()
-			if elapsed > 0 {
-				b.ReportMetric(float64(b.N)/elapsed.Seconds(), "batches/s")
-				b.ReportMetric(float64(b.N*batchSize)/elapsed.Seconds(), "writes/s")
-			}
-			b.ReportMetric(float64(batchSize), "writes/batch")
-			b.ReportMetric(float64(totalBatchBytes)/float64(b.N), "bytes/batch")
-			reportWriteSyncLatencyDistribution(b, latencies)
-			reportCommandWALBenchmarkDeltas(b, before, after, uint64(b.N))
-		})
+	type shape struct {
+		name      string
+		batchSize int
 	}
+	shapes := []shape{
+		{name: "dirty_batch", batchSize: 1},
+		{name: "dirty_batch", batchSize: 8},
+		{name: "dirty_batch", batchSize: 32},
+		{name: "write_then_dirty_write_sync", batchSize: 1},
+		{name: "empty_write_sync_after_write", batchSize: 1},
+		{name: "state_point_point_sync_batch_sync", batchSize: 1},
+	}
+	for _, placement := range []struct {
+		name           string
+		forcedPointers bool
+	}{
+		{name: "inline"},
+		{name: "forced_pointer", forcedPointers: true},
+	} {
+		for _, benchmarkShape := range shapes {
+			name := fmt.Sprintf("placement=%s/shape=%s/ops=%d", placement.name, benchmarkShape.name, benchmarkShape.batchSize)
+			b.Run(name, func(b *testing.B) {
+				benchmarkPublicCommandWALDurableShape(b, placement.forcedPointers, benchmarkShape.name, benchmarkShape.batchSize)
+			})
+		}
+	}
+}
+
+func benchmarkPublicCommandWALDurableShape(b *testing.B, forcedPointers bool, shape string, batchSize int) {
+	opts := commandWALDurabilityProofOptions(b.TempDir())
+	opts.PublicBatchWriteSyncPhaseStats = true
+	if forcedPointers {
+		opts.ValueLog.PointerThreshold = 1
+		opts.ValueLog.ForcePointers = true
+	}
+	db, err := Open(opts)
+	if err != nil {
+		b.Fatalf("Open: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	value := []byte("public-command-wal-value")
+	if forcedPointers {
+		value = bytes.Repeat([]byte("p"), 2048)
+	}
+	before := db.Stats()
+	latencyCapacity := b.N
+	if shape == "state_point_point_sync_batch_sync" {
+		latencyCapacity *= 2
+	}
+	latencies := make([]time.Duration, 0, latencyCapacity)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		base := i * max(batchSize, 1)
+		switch shape {
+		case "dirty_batch":
+			latencies = append(latencies, benchmarkPublicCommandWALBatch(b, db, "dirty/", base, batchSize, value, true))
+		case "write_then_dirty_write_sync":
+			_ = benchmarkPublicCommandWALBatch(b, db, "prior/", base, 1, value, false)
+			latencies = append(latencies, benchmarkPublicCommandWALBatch(b, db, "dirty/", base, 1, value, true))
+		case "empty_write_sync_after_write":
+			_ = benchmarkPublicCommandWALBatch(b, db, "prior/", base, 1, value, false)
+			latencies = append(latencies, benchmarkPublicCommandWALBatch(b, db, "empty/", base, 0, value, true))
+		case "state_point_point_sync_batch_sync":
+			var keyBuf [64]byte
+			key := strconv.AppendInt(append(keyBuf[:0], "state/unsynced/"...), int64(base), 10)
+			if err := db.Set(key, value); err != nil {
+				b.Fatalf("state Set: %v", err)
+			}
+			key = strconv.AppendInt(append(keyBuf[:0], "state/synced/"...), int64(base), 10)
+			start := time.Now()
+			if err := db.SetSync(key, value); err != nil {
+				b.Fatalf("state SetSync: %v", err)
+			}
+			latencies = append(latencies, time.Since(start))
+			latencies = append(latencies, benchmarkPublicCommandWALBatchWithSetView(b, db, "state/batch/", base, value))
+		default:
+			b.Fatalf("unknown durable shape %q", shape)
+		}
+	}
+	b.StopTimer()
+
+	perIteration := publicCommandWALDurableShapeExpectedCounters(shape, forcedPointers)
+	after := db.Stats()
+	for key, want := range perIteration {
+		requireBenchmarkStatDelta(b, before, after, key, want*uint64(b.N))
+	}
+	requireBenchmarkStatDelta(b, before, after, "treedb.public.checkpoint.calls_total", 0)
+	if got := statMapUint64B(b, after, "treedb.cache.checkpoint.runs"); got != 0 {
+		b.Fatalf("checkpoint.runs=%d, want 0 for isolated durable shape", got)
+	}
+
+	elapsed := b.Elapsed()
+	if elapsed > 0 {
+		b.ReportMetric(float64(b.N)/elapsed.Seconds(), "iterations/s")
+	}
+	b.ReportMetric(float64(batchSize), "batch_keys/iteration")
+	reportWriteSyncLatencyDistribution(b, latencies)
+	reportCommandWALBenchmarkDeltas(b, before, after, uint64(b.N))
+}
+
+func benchmarkPublicCommandWALBatch(b *testing.B, db *DB, prefix string, base, count int, value []byte, syncWrite bool) time.Duration {
+	b.Helper()
+	batch := db.NewBatchWithSize(max(count, 1))
+	for j := 0; j < count; j++ {
+		var keyBuf [64]byte
+		key := strconv.AppendInt(append(keyBuf[:0], prefix...), int64(base+j), 10)
+		if err := batch.Set(key, value); err != nil {
+			_ = batch.Close()
+			b.Fatalf("batch Set(%d): %v", j, err)
+		}
+	}
+	start := time.Now()
+	var err error
+	if syncWrite {
+		err = batch.WriteSync()
+	} else {
+		err = batch.Write()
+	}
+	elapsed := time.Since(start)
+	if err != nil {
+		_ = batch.Close()
+		b.Fatalf("batch write (sync=%t): %v", syncWrite, err)
+	}
+	if err := batch.Close(); err != nil {
+		b.Fatalf("batch Close: %v", err)
+	}
+	return elapsed
+}
+
+func benchmarkPublicCommandWALBatchWithSetView(b *testing.B, db *DB, prefix string, base int, value []byte) time.Duration {
+	b.Helper()
+	batch, ok := db.NewBatchWithSize(1).(*commandWALPublicBatch)
+	if !ok {
+		b.Fatalf("NewBatchWithSize type=%T, want *commandWALPublicBatch", db.NewBatchWithSize(1))
+	}
+	var keyBuf [64]byte
+	key := strconv.AppendInt(append(keyBuf[:0], prefix...), int64(base), 10)
+	if err := batch.SetView(key, value); err != nil {
+		_ = batch.Close()
+		b.Fatalf("batch SetView: %v", err)
+	}
+	start := time.Now()
+	if err := batch.WriteSync(); err != nil {
+		_ = batch.Close()
+		b.Fatalf("batch WriteSync: %v", err)
+	}
+	elapsed := time.Since(start)
+	if err := batch.Close(); err != nil {
+		b.Fatalf("batch Close: %v", err)
+	}
+	return elapsed
+}
+
+func publicCommandWALDurableShapeExpectedCounters(shape string, forcedPointers bool) map[string]uint64 {
+	want := map[string]uint64{
+		"treedb.command_wal.write.errors_total":         0,
+		"treedb.command_wal.file_sync.errors_total":     0,
+		"treedb.cache.value_log.sync.errors_total":      0,
+		"treedb.cache.value_log.file_sync.errors_total": 0,
+	}
+	var appendCalls, flushCalls, syncCalls, writeSyscalls, fileSyncCalls uint64
+	var batchWriteCalls, batchWriteSyncCalls, barrierSyncCalls uint64
+	var valueLogMaterializationSyncs, valueLogExternalRefSyncs, valueLogPendingBarrierSyncs uint64
+	switch shape {
+	case "dirty_batch":
+		appendCalls, syncCalls, writeSyscalls, fileSyncCalls = 1, 1, 1, 1
+		batchWriteSyncCalls = 1
+		if forcedPointers {
+			valueLogMaterializationSyncs, valueLogExternalRefSyncs = 1, 1
+		}
+	case "write_then_dirty_write_sync":
+		appendCalls, flushCalls, syncCalls, writeSyscalls, fileSyncCalls = 2, 1, 1, 2, 1
+		batchWriteCalls, batchWriteSyncCalls = 1, 1
+		if forcedPointers {
+			valueLogMaterializationSyncs, valueLogExternalRefSyncs = 1, 1
+		}
+	case "empty_write_sync_after_write":
+		appendCalls, flushCalls, syncCalls, writeSyscalls, fileSyncCalls = 1, 1, 1, 1, 1
+		batchWriteCalls, batchWriteSyncCalls, barrierSyncCalls = 1, 1, 1
+		if forcedPointers {
+			valueLogPendingBarrierSyncs = 1
+		}
+	case "state_point_point_sync_batch_sync":
+		appendCalls, flushCalls, syncCalls, writeSyscalls, fileSyncCalls = 3, 1, 2, 3, 2
+		batchWriteSyncCalls = 1
+		if forcedPointers {
+			// Public point commands remain inline command-WAL inputs. The batch
+			// materialization is the state-shaped external-value boundary.
+			valueLogMaterializationSyncs, valueLogExternalRefSyncs = 1, 1
+		}
+	}
+	valueLogSyncs := valueLogMaterializationSyncs + valueLogExternalRefSyncs + valueLogPendingBarrierSyncs
+	want["treedb.command_wal.append.count_total"] = appendCalls
+	want["treedb.command_wal.flush.count_total"] = flushCalls
+	want["treedb.command_wal.sync.count_total"] = syncCalls
+	want["treedb.command_wal.sync.barrier.count_total"] = barrierSyncCalls
+	want["treedb.command_wal.write.syscalls_total"] = writeSyscalls
+	want["treedb.command_wal.file_sync.calls_total"] = fileSyncCalls
+	want["treedb.public.batch.write.calls_total"] = batchWriteCalls
+	want["treedb.public.batch.write_sync.calls_total"] = batchWriteSyncCalls
+	want["treedb.cache.value_log.sync.calls_total"] = valueLogSyncs
+	want["treedb.cache.value_log.sync.materialization.calls_total"] = valueLogMaterializationSyncs
+	want["treedb.cache.value_log.sync.external_ref.calls_total"] = valueLogExternalRefSyncs
+	want["treedb.cache.value_log.sync.pending_barrier.calls_total"] = valueLogPendingBarrierSyncs
+	want["treedb.cache.value_log.file_sync.calls_total"] = valueLogSyncs
+	return want
 }
 
 func BenchmarkPublicCommandWALCheckpointOverlapWriteSync(b *testing.B) {
@@ -4098,15 +4454,46 @@ func reportWriteSyncLatencyDistribution(b *testing.B, samples []time.Duration) {
 	}
 }
 
-func reportCommandWALBenchmarkDeltas(b *testing.B, before, after map[string]string, batches uint64) {
+func reportCommandWALBenchmarkDeltas(b *testing.B, before, after map[string]string, operations uint64) {
 	b.Helper()
 	for _, key := range []string{
 		"treedb.command_wal.append.count_total",
 		"treedb.command_wal.flush.count_total",
 		"treedb.command_wal.sync.count_total",
+		"treedb.command_wal.write.syscalls_total",
+		"treedb.command_wal.write.bytes_total",
+		"treedb.command_wal.write.ns_total",
+		"treedb.command_wal.file_sync.calls_total",
+		"treedb.command_wal.file_sync.ns_total",
+		"treedb.command_wal.directory_sync.calls_total",
+		"treedb.command_wal.directory_sync.ns_total",
 		"treedb.command_wal.append.ns_total",
 		"treedb.command_wal.flush.ns_total",
 		"treedb.command_wal.sync.ns_total",
+		"treedb.cache.value_log.sync.calls_total",
+		"treedb.cache.value_log.sync.ns_total",
+		"treedb.cache.value_log.sync.wait_ns_total",
+		"treedb.cache.value_log.sync.materialization.calls_total",
+		"treedb.cache.value_log.sync.materialization.ns_total",
+		"treedb.cache.value_log.sync.materialization.wait_ns_total",
+		"treedb.cache.value_log.sync.external_ref.calls_total",
+		"treedb.cache.value_log.sync.external_ref.ns_total",
+		"treedb.cache.value_log.sync.external_ref.wait_ns_total",
+		"treedb.cache.value_log.sync.pending_barrier.calls_total",
+		"treedb.cache.value_log.sync.pending_barrier.ns_total",
+		"treedb.cache.value_log.sync.pending_barrier.wait_ns_total",
+		"treedb.cache.value_log.file_sync.calls_total",
+		"treedb.cache.value_log.file_sync.ns_total",
+		"treedb.public.batch.write_sync.phase.wall.ns_total",
+		"treedb.public.batch.write_sync.phase.checkpoint_gate.ns_total",
+		"treedb.public.batch.write_sync.phase.preflight_materialization.ns_total",
+		"treedb.public.batch.write_sync.phase.command_callback.ns_total",
+		"treedb.public.batch.write_sync.phase.memtable_publication_reset.ns_total",
+		"treedb.public.batch.write_sync.phase.residual.ns_total",
+		"treedb.public.batch.write_sync.phase.command_external_ref_ordering.ns_total",
+		"treedb.public.batch.write_sync.phase.command_append.ns_total",
+		"treedb.public.batch.write_sync.phase.command_sync.ns_total",
+		"treedb.public.batch.write_sync.phase.command_empty_barrier.ns_total",
 		"treedb.cache.checkpoint.runs",
 		"treedb.cache.checkpoint.barrier_wait_ns_total",
 		"treedb.cache.checkpoint.stage.cutover.total_ns",
@@ -4118,12 +4505,9 @@ func reportCommandWALBenchmarkDeltas(b *testing.B, before, after map[string]stri
 		"treedb.cache.checkpoint.stage.wal_cleanup.total_ns",
 	} {
 		delta := statMapUint64B(b, after, key) - statMapUint64B(b, before, key)
-		name := strings.TrimPrefix(strings.TrimSuffix(key, "_total"), "treedb.command_wal.")
-		b.ReportMetric(float64(delta)/float64(batches), name+"/batch")
+		name := strings.TrimPrefix(strings.TrimSuffix(key, "_total"), "treedb.")
+		b.ReportMetric(float64(delta)/float64(operations), name+"/op")
 	}
-	// Kernel syscall counts and kernel-only syscall time are intentionally not
-	// claimed here: these in-process timers cover TreeDB stages, while the
-	// coordinator-owned profile capture is the evidence source for syscalls.
 }
 
 func assertPublicCommandWALFramesB(b *testing.B, db *DB, minFrames uint64) {

--- a/TreeDB/command_wal_public_test.go
+++ b/TreeDB/command_wal_public_test.go
@@ -4165,6 +4165,12 @@ func TestPublicCommandWALCheckpointPostFrontierAdmissionPropagatesPublishError(t
 	if err := <-checkpointDone; !errors.Is(err, publishErr) {
 		t.Fatalf("Checkpoint error=%v, want %v", err, publishErr)
 	}
+	// SetSync publishes into the cache before a background flush finishes its
+	// backend commit post-work. Drain serializes with that flush so the Stats
+	// snapshot below cannot overlap leaf-generation finalization.
+	if err := db.cached.Drain(); err != nil {
+		t.Fatalf("Drain after failed checkpoint: %v", err)
+	}
 	if first, last := db.publicCommandWALPendingRange(); first != 1 || last != 2 {
 		t.Fatalf("pending command-WAL range after failed publish=(%d,%d), want (1,2)", first, last)
 	}

--- a/TreeDB/db/command_wal_raw.go
+++ b/TreeDB/db/command_wal_raw.go
@@ -228,6 +228,10 @@ func (db *DB) FlushCommandWALBarrier(sync bool) error {
 }
 
 func (db *DB) flushCommandWAL(sync bool, observe bool) error {
+	return db.flushCommandWALForPath(sync, observe, commandWALAppendStatsBarrier)
+}
+
+func (db *DB) flushCommandWALForPath(sync bool, observe bool, path commandWALAppendStatsPath) error {
 	if db == nil || !db.commandWAL || db.commandJournal == nil {
 		return nil
 	}
@@ -249,7 +253,7 @@ func (db *DB) flushCommandWAL(sync bool, observe bool) error {
 		err = errTestCommandWALFlushFailpoint
 	}
 	if observe {
-		db.observeCommandWALFlush(actualSync, time.Since(start))
+		db.observeCommandWALFlush(path, actualSync, time.Since(start))
 	}
 	if err != nil {
 		db.commandWALFlushPoisoned.Store(true)
@@ -265,7 +269,7 @@ func (db *DB) finishCommandWALAppendFlush(path commandWALAppendStatsPath, actual
 		if err == nil && db.testFailCommandWALFlush.Load() {
 			err = errTestCommandWALFlushFailpoint
 		}
-		db.observeCommandWALFlush(actualSync, timing.Flush)
+		db.observeCommandWALFlush(path, actualSync, timing.Flush)
 	}
 	if err != nil {
 		if lsn != 0 {
@@ -1518,7 +1522,7 @@ func (db *DB) appendCommandWALIntentWithTiming(intent *commandWALBatchIntent, sy
 		requestTiming.Sync = actualSync
 		flushStart = time.Now()
 	}
-	flushErr := db.FlushCommandWAL(sync)
+	flushErr := db.flushCommandWALForPath(sync, true, appendPath)
 	if requestTiming != nil {
 		requestTiming.Flush = time.Since(flushStart)
 	}

--- a/TreeDB/db/command_wal_raw_test.go
+++ b/TreeDB/db/command_wal_raw_test.go
@@ -76,7 +76,9 @@ func TestFlushCommandWALBarrierOrdersExternalRefsBeforeCommandWAL(t *testing.T) 
 	externalErr := errors.New("external value-log sync failed")
 	appender := &commandWALBarrierTestAppender{externalErr: externalErr}
 	d.SetValueLogAppender(appender)
-	before := commandWALTestStatUint64(t, d.Stats(), "treedb.command_wal.sync.count_total")
+	beforeStats := d.Stats()
+	before := commandWALTestStatUint64(t, beforeStats, "treedb.command_wal.sync.count_total")
+	beforeFileSyncs := commandWALTestStatUint64(t, beforeStats, "treedb.command_wal.file_sync.calls_total")
 	if err := d.FlushCommandWALBarrier(true); !errors.Is(err, externalErr) {
 		t.Fatalf("FlushCommandWALBarrier error=%v, want %v", err, externalErr)
 	}
@@ -86,6 +88,9 @@ func TestFlushCommandWALBarrierOrdersExternalRefsBeforeCommandWAL(t *testing.T) 
 	if got := commandWALTestStatUint64(t, d.Stats(), "treedb.command_wal.sync.count_total"); got != before {
 		t.Fatalf("command WAL sync count=%d, want %d when external barrier fails", got, before)
 	}
+	if got := commandWALTestStatUint64(t, d.Stats(), "treedb.command_wal.file_sync.calls_total"); got != beforeFileSyncs {
+		t.Fatalf("command WAL file sync calls=%d, want %d when external barrier fails", got, beforeFileSyncs)
+	}
 
 	appender.externalErr = nil
 	if err := d.FlushCommandWALBarrier(true); err != nil {
@@ -93,6 +98,9 @@ func TestFlushCommandWALBarrierOrdersExternalRefsBeforeCommandWAL(t *testing.T) 
 	}
 	if got := commandWALTestStatUint64(t, d.Stats(), "treedb.command_wal.sync.count_total"); got != before+1 {
 		t.Fatalf("command WAL sync count=%d, want %d", got, before+1)
+	}
+	if got := commandWALTestStatUint64(t, d.Stats(), "treedb.command_wal.file_sync.calls_total"); got != beforeFileSyncs+1 {
+		t.Fatalf("command WAL file sync calls=%d, want %d", got, beforeFileSyncs+1)
 	}
 }
 

--- a/TreeDB/db/command_wal_recovery_test.go
+++ b/TreeDB/db/command_wal_recovery_test.go
@@ -105,6 +105,7 @@ func TestCommandWALCrashAfterFrameBeforeRootPublishRecovers(t *testing.T) {
 	dir := t.TempDir()
 	enableCommandWALFormat(t, dir)
 	db := openCommandWALDB(t, dir)
+	beforeFileSyncs := commandWALTestStatUint64(t, db.Stats(), "treedb.command_wal.file_sync.calls_total")
 	db.testFailFinalizeCommit.Store(true)
 	b := db.NewBatch()
 	if err := b.Set([]byte("k"), []byte("v")); err != nil {
@@ -113,6 +114,9 @@ func TestCommandWALCrashAfterFrameBeforeRootPublishRecovers(t *testing.T) {
 	err := b.WriteSync()
 	if !errors.Is(err, errTestFinalizeCommitFailpoint) {
 		t.Fatalf("WriteSync error=%v, want failpoint", err)
+	}
+	if got := commandWALTestStatUint64(t, db.Stats(), "treedb.command_wal.file_sync.calls_total"); got != beforeFileSyncs+1 {
+		t.Fatalf("command WAL file sync calls=%d, want %d before publication failpoint", got, beforeFileSyncs+1)
 	}
 	_ = b.Close()
 	if err := db.Close(); err != nil {

--- a/TreeDB/db/command_wal_stats.go
+++ b/TreeDB/db/command_wal_stats.go
@@ -29,7 +29,29 @@ const (
 	commandWALAppendStatsPayload
 	commandWALAppendStatsEntryScan
 	commandWALAppendStatsIntent
+	// commandWALAppendStatsBarrier is not an append path. It attributes a
+	// FlushCommandWAL call that has no frame append in the same operation, such
+	// as an empty public WriteSync or checkpoint publication boundary.
+	commandWALAppendStatsBarrier
+	commandWALStatsPathCount
 )
+
+func (p commandWALAppendStatsPath) statName() string {
+	switch p {
+	case commandWALAppendStatsPoint:
+		return "point"
+	case commandWALAppendStatsPayload:
+		return "payload"
+	case commandWALAppendStatsEntryScan:
+		return "entry_scan"
+	case commandWALAppendStatsIntent:
+		return "intent"
+	case commandWALAppendStatsBarrier:
+		return "barrier"
+	default:
+		return "unknown"
+	}
+}
 
 func writeCommandWALStats(stats map[string]string, db *DB) {
 	if stats == nil || db == nil {
@@ -111,6 +133,23 @@ func writeCommandWALStatsZeroCounters(stats map[string]string) {
 	stats["treedb.command_wal.flush.ns_total"] = "0"
 	stats["treedb.command_wal.sync.count_total"] = "0"
 	stats["treedb.command_wal.sync.ns_total"] = "0"
+	for path := commandWALAppendStatsPoint; path < commandWALStatsPathCount; path++ {
+		name := path.statName()
+		stats["treedb.command_wal.flush."+name+".count_total"] = "0"
+		stats["treedb.command_wal.flush."+name+".ns_total"] = "0"
+		stats["treedb.command_wal.sync."+name+".count_total"] = "0"
+		stats["treedb.command_wal.sync."+name+".ns_total"] = "0"
+	}
+	stats["treedb.command_wal.file_sync.calls_total"] = "0"
+	stats["treedb.command_wal.file_sync.ns_total"] = "0"
+	stats["treedb.command_wal.file_sync.errors_total"] = "0"
+	stats["treedb.command_wal.write.syscalls_total"] = "0"
+	stats["treedb.command_wal.write.bytes_total"] = "0"
+	stats["treedb.command_wal.write.ns_total"] = "0"
+	stats["treedb.command_wal.write.errors_total"] = "0"
+	stats["treedb.command_wal.directory_sync.calls_total"] = "0"
+	stats["treedb.command_wal.directory_sync.ns_total"] = "0"
+	stats["treedb.command_wal.directory_sync.errors_total"] = "0"
 	stats["treedb.command_wal.cleanup.scans"] = "0"
 	stats["treedb.command_wal.cleanup.scan.count_total"] = "0"
 	stats["treedb.command_wal.cleanup.scan.ns_total"] = "0"
@@ -160,6 +199,14 @@ func writeCommandWALLifecycleStats(stats map[string]string, db *DB) {
 	stats["treedb.command_wal.flush.ns_total"] = fmt.Sprintf("%d", db.commandWALFlushNs.Load())
 	stats["treedb.command_wal.sync.count_total"] = fmt.Sprintf("%d", db.commandWALSyncCount.Load())
 	stats["treedb.command_wal.sync.ns_total"] = fmt.Sprintf("%d", db.commandWALSyncNs.Load())
+	for path := commandWALAppendStatsPoint; path < commandWALStatsPathCount; path++ {
+		name := path.statName()
+		stats["treedb.command_wal.flush."+name+".count_total"] = fmt.Sprintf("%d", db.commandWALFlushPathCount[path].Load())
+		stats["treedb.command_wal.flush."+name+".ns_total"] = fmt.Sprintf("%d", db.commandWALFlushPathNs[path].Load())
+		stats["treedb.command_wal.sync."+name+".count_total"] = fmt.Sprintf("%d", db.commandWALSyncPathCount[path].Load())
+		stats["treedb.command_wal.sync."+name+".ns_total"] = fmt.Sprintf("%d", db.commandWALSyncPathNs[path].Load())
+	}
+	writeCommandWALDurabilityStats(stats, db)
 	stats["treedb.command_wal.cleanup.scans"] = fmt.Sprintf("%d", db.commandWALCleanupScans.Load())
 	stats["treedb.command_wal.cleanup.scan.count_total"] = fmt.Sprintf("%d", db.commandWALCleanupScans.Load())
 	stats["treedb.command_wal.cleanup.scan.ns_total"] = fmt.Sprintf("%d", db.commandWALCleanupScanNs.Load())
@@ -186,6 +233,23 @@ func writeCommandWALWriterBufferStats(stats map[string]string, db *DB) {
 	stats["treedb.command_wal.writer.command_buffer.dropped_bytes_total"] = fmt.Sprintf("%d", snap.CommandBufferDroppedBytes)
 	stats["treedb.command_wal.writer.pending_batch.length_bytes"] = fmt.Sprintf("%d", snap.PendingBatchLength)
 	stats["treedb.command_wal.writer.pending_batch.capacity_bytes"] = fmt.Sprintf("%d", snap.PendingBatchCapacity)
+}
+
+func writeCommandWALDurabilityStats(stats map[string]string, db *DB) {
+	if stats == nil || db == nil || db.commandJournal == nil {
+		return
+	}
+	snap := db.commandJournal.WriterDurabilityStats()
+	stats["treedb.command_wal.write.syscalls_total"] = fmt.Sprintf("%d", snap.WriteSyscalls)
+	stats["treedb.command_wal.write.bytes_total"] = fmt.Sprintf("%d", snap.WriteBytes)
+	stats["treedb.command_wal.write.ns_total"] = fmt.Sprintf("%d", snap.WriteNs)
+	stats["treedb.command_wal.write.errors_total"] = fmt.Sprintf("%d", snap.WriteErrors)
+	stats["treedb.command_wal.file_sync.calls_total"] = fmt.Sprintf("%d", snap.FileSyncCalls)
+	stats["treedb.command_wal.file_sync.ns_total"] = fmt.Sprintf("%d", snap.FileSyncNs)
+	stats["treedb.command_wal.file_sync.errors_total"] = fmt.Sprintf("%d", snap.FileSyncErrors)
+	stats["treedb.command_wal.directory_sync.calls_total"] = fmt.Sprintf("%d", snap.DirectorySyncCalls)
+	stats["treedb.command_wal.directory_sync.ns_total"] = fmt.Sprintf("%d", snap.DirectorySyncNs)
+	stats["treedb.command_wal.directory_sync.errors_total"] = fmt.Sprintf("%d", snap.DirectorySyncErrors)
 }
 
 func (db *DB) observeCommandWALAccepted(lsn uint64) {
@@ -237,21 +301,33 @@ func (db *DB) observeCommandWALAppend(path commandWALAppendStatsPath, elapsed ti
 	}
 }
 
-func (db *DB) observeCommandWALFlush(sync bool, elapsed time.Duration) {
+func (db *DB) observeCommandWALFlush(path commandWALAppendStatsPath, sync bool, elapsed time.Duration) {
 	if db == nil {
 		return
 	}
 	ns := commandWALDurationNs(elapsed)
 	if sync {
 		db.commandWALSyncCount.Add(1)
+		if path < commandWALStatsPathCount {
+			db.commandWALSyncPathCount[path].Add(1)
+		}
 		if ns > 0 {
 			db.commandWALSyncNs.Add(ns)
+			if path < commandWALStatsPathCount {
+				db.commandWALSyncPathNs[path].Add(ns)
+			}
 		}
 		return
 	}
 	db.commandWALFlushCount.Add(1)
+	if path < commandWALStatsPathCount {
+		db.commandWALFlushPathCount[path].Add(1)
+	}
 	if ns > 0 {
 		db.commandWALFlushNs.Add(ns)
+		if path < commandWALStatsPathCount {
+			db.commandWALFlushPathNs[path].Add(ns)
+		}
 	}
 }
 

--- a/TreeDB/db/command_wal_stats_test.go
+++ b/TreeDB/db/command_wal_stats_test.go
@@ -112,6 +112,7 @@ func TestCommandWALRuntimeStatsExposeAppendPaths(t *testing.T) {
 		"treedb.command_wal.append.entry_scan.count_total",
 		"treedb.command_wal.flush.count_total",
 		"treedb.command_wal.sync.count_total",
+		"treedb.command_wal.write.syscalls_total",
 	} {
 		if got := commandWALTestStatUint64(t, before, key); got != 0 {
 			t.Fatalf("%s before writes=%d, want 0 (stats=%#v)", key, got, before)
@@ -149,6 +150,14 @@ func TestCommandWALRuntimeStatsExposeAppendPaths(t *testing.T) {
 		"treedb.command_wal.append.intent.count_total":     0,
 		"treedb.command_wal.flush.count_total":             2,
 		"treedb.command_wal.sync.count_total":              1,
+		"treedb.command_wal.flush.point.count_total":       1,
+		"treedb.command_wal.flush.payload.count_total":     1,
+		"treedb.command_wal.sync.entry_scan.count_total":   1,
+		"treedb.command_wal.sync.barrier.count_total":      0,
+		"treedb.command_wal.write.syscalls_total":          3,
+		"treedb.command_wal.write.errors_total":            0,
+		"treedb.command_wal.file_sync.calls_total":         1,
+		"treedb.command_wal.file_sync.errors_total":        0,
 	} {
 		if got := commandWALTestStatUint64(t, stats, key); got != want {
 			t.Fatalf("%s=%d, want %d (stats=%#v)", key, got, want, stats)
@@ -158,6 +167,8 @@ func TestCommandWALRuntimeStatsExposeAppendPaths(t *testing.T) {
 		"treedb.command_wal.append.ns_total",
 		"treedb.command_wal.flush.ns_total",
 		"treedb.command_wal.sync.ns_total",
+		"treedb.command_wal.write.ns_total",
+		"treedb.command_wal.file_sync.ns_total",
 	} {
 		// Path-level count stats above prove the append/flush/sync paths ran.
 		// Short operations can report zero elapsed nanoseconds on platforms

--- a/TreeDB/db/db.go
+++ b/TreeDB/db/db.go
@@ -533,6 +533,10 @@ type DB struct {
 	commandWALFlushNs                atomic.Uint64
 	commandWALSyncCount              atomic.Uint64
 	commandWALSyncNs                 atomic.Uint64
+	commandWALFlushPathCount         [commandWALStatsPathCount]atomic.Uint64
+	commandWALFlushPathNs            [commandWALStatsPathCount]atomic.Uint64
+	commandWALSyncPathCount          [commandWALStatsPathCount]atomic.Uint64
+	commandWALSyncPathNs             [commandWALStatsPathCount]atomic.Uint64
 	commandWALCleanupScans           atomic.Uint64
 	commandWALCleanupScanNs          atomic.Uint64
 	commandWALCleanupScanBytes       atomic.Uint64

--- a/TreeDB/docs/spec/README.md
+++ b/TreeDB/docs/spec/README.md
@@ -99,6 +99,9 @@ Given pre-alpha status, this is a living spec that tracks implementation.
     production benchmark matrix, target envelope, and fail-closed rollout gates.
 - `TreeDB/docs/spec/write-path-and-durability.md`
   - write pipeline and durability semantics for all durability modes.
+- `TreeDB/docs/spec/command-wal-durable-write-contract.md`
+  - current cached command-WAL `Write`/`WriteSync` ordering, logical versus
+    physical sync counters, crash boundaries, and the M3 optimization guardrail.
 - `TreeDB/docs/spec/publication-readability-3245.md`
   - issue #3245 publication/readability map for collection catalog metadata and
     root descriptors, ordered/system-root publication, value-log pointer

--- a/TreeDB/docs/spec/command-wal-durable-write-contract.md
+++ b/TreeDB/docs/spec/command-wal-durable-write-contract.md
@@ -1,0 +1,186 @@
+# Command-WAL Durable Write Contract
+
+Status: current behavior and measurement contract for issue #3656 (M2).
+
+This document defines the durability boundary used by cached public raw-KV
+operations in `ProfileCommandWALDurable`. It distinguishes a logical public
+operation, a logical writer flush or sync, an actual file-sync hook, and the
+Linux syscall reached by that hook. It does not authorize an optimization or a
+weaker durability mode.
+
+## Durable return boundary
+
+For `SetSync`, `DeleteSync`, and a dirty `Batch.WriteSync`, a nil return means:
+
+1. any value-log records referenced by the command frame have passed a file
+   sync boundary;
+2. the complete typed command-WAL frame has been written and the command-WAL
+   file has passed a later file sync boundary; and
+3. the mutation has been published to the cached memtable before the call
+   returns.
+
+The durable bytes are the external value-log records, including their RIDs and
+record integrity fields, followed by the complete command envelope and payload
+needed to replay the logical mutation. The boundary does not require a backend
+root publication or `Checkpoint()`. Until a later checkpoint publishes roots
+and `AppliedCommandLSN`, open-time recovery replays complete frames above the
+durable applied-LSN prefix through the normal command executor.
+
+An error after the command-WAL file sync is commit-ambiguous. The open handle is
+poisoned and must be reopened; recovery may apply the durable frame. An error
+while ordering external value-log references occurs before the command frame
+sync and must not advance that command durability boundary.
+
+`DurabilityWALOnRelaxed` retains the same ordering but replaces file-sync
+guarantees with flush-to-kernel boundaries. Nothing in this document upgrades a
+relaxed operation to power-loss durability.
+
+## Current ordered paths
+
+### Inline dirty `WriteSync`
+
+```text
+public Batch.WriteSync
+  -> cached preflight / inline entry preparation
+  -> append one RawKVBatch command frame
+  -> flush command writer buffers
+  -> command-WAL file Sync
+  -> publish entries to cached memtables and reset the batch
+  -> return nil
+```
+
+There is one logical command-WAL sync and one actual command-WAL file-sync hook
+for this operation when no segment rotation occurs. Directory sync is a segment
+creation/rotation concern, not a per-operation durability barrier.
+
+### Pointer-backed dirty `WriteSync`
+
+```text
+public Batch.WriteSync
+  -> append external records to the selected persistent value-log lane
+  -> value-log materialization Sync
+  -> acquire the command publish/barrier ordering lock
+  -> value-log external-reference Sync for referenced lane/file IDs
+  -> encode RID references and append one RawKVBatch command frame
+  -> flush command writer buffers
+  -> command-WAL file Sync
+  -> publish pointers to cached memtables and reset the batch
+  -> return nil
+```
+
+Current code therefore performs two actual value-log file-sync hooks for a
+forced-pointer dirty `WriteSync`: `materialization`, then `external_ref`. This
+is measured behavior, not a required count in the public contract. M2 leaves it
+unchanged. A later M3 may coalesce the second sync only if it proves that the
+exact referenced bytes were covered by the first successful sync, no writer or
+rotation can intervene, the external-reference lookup is readable, and the
+command-WAL sync remains strictly later. The measured ceiling is at most the
+second value-log file-sync time; it is not the sum of both syncs and is not a
+throughput claim.
+
+### `Write` followed by `WriteSync`
+
+```text
+unsynced Write                         following WriteSync
+---------------                       -------------------
+append/flush external bytes, if any   materialize its external bytes, if any
+append/flush command frame      --->  order/sync required value-log lanes
+publish to memtable                    append its command frame
+return                                 command-WAL file Sync
+                                       publish to memtable
+                                       return nil
+```
+
+File sync applies to the file contents preceding the boundary, not only the
+latest logical frame. Consequently, the later command-WAL sync also covers
+earlier flushed command frames in that segment. For pointer values, the later
+operation covers earlier external bytes only when its value-log sync covers the
+same pending lane/file. Callers that need a database-wide barrier independent of
+the next dirty batch use an empty `WriteSync`.
+
+### Empty `WriteSync` after unsynced writes
+
+An empty public `Batch.WriteSync` appends no frame. It takes the command publish
+barrier, syncs every pending dirty value-log lane, and then performs one
+command-WAL barrier sync. It therefore establishes the durable boundary for
+preceding flushed writes without manufacturing an LSN or publishing a backend
+root.
+
+## Logical observations versus physical calls
+
+The stats below are cumulative. Reports must delta them over the same active
+window.
+
+| Layer | Counters | Meaning |
+| --- | --- | --- |
+| public operation | `treedb.public.batch.write{,_sync}.*`, `treedb.public.point.*` | caller-visible operations and wall time |
+| frame append | `treedb.command_wal.append.{point,payload,entry_scan,intent}.*` | one typed frame accepted by an append route; not a syscall count |
+| writer boundary | `treedb.command_wal.flush.<path>.*`, `treedb.command_wal.sync.<path>.*` | logical command-writer Flush or durable Sync calls; `barrier` has no associated frame |
+| command writes | `treedb.command_wal.write.{syscalls,bytes,ns,errors}_total` | actual underlying `write`/`writev` calls made by the command writer |
+| command file sync | `treedb.command_wal.file_sync.{calls,ns,errors}_total` | calls at the injected production hook, which is `os.File.Sync` |
+| directory sync | `treedb.command_wal.directory_sync.{calls,ns,errors}_total` | parent-directory sync on segment creation/rotation |
+| value-log logical sync | `treedb.cache.value_log.sync.<path>.{calls,ns,wait_ns,errors}_total` | `materialization`, `external_ref`, `pending_barrier`, or `checkpoint` sync, including lane-lock wait separately |
+| value-log file sync | `treedb.cache.value_log.file_sync.{calls,ns,errors}_total` | actual value-log writer file-sync hook calls |
+| request partition | `treedb.public.batch.write_sync.phase.*` | exclusive top-level wall partition plus nested command subphases; enabled only by the diagnostic option |
+
+`Flush` means buffered bytes were passed to the kernel and is not an fsync
+promise. `Sync` is a logical durable-mode request. `file_sync.calls_total` is
+the physical hook count. On Linux M2 validates that production `os.File.Sync`
+calls appear as `fsync(2)` with `strace`; consumers must not assume a specific
+syscall name on other Go versions or operating systems.
+
+The request phase top-level partition is exclusive:
+`checkpoint_gate + preflight_materialization + command_callback +
+memtable_publication_reset + residual = wall` (subject only to integer
+nanosecond rounding). Command preparation, external-reference ordering, append,
+flush/sync, and pending-LSN bookkeeping are nested inside `command_callback` and
+must not be added to the top-level fields a second time.
+
+## Explaining the accepted state-shaped interval
+
+The accepted M0 `state.db` interval is a point/point-sync/batch-sync mix per
+block, plus checkpoint barriers:
+
+```text
+3,595 appends
+  = 1,199 entry_scan batch WriteSync frames
+  + 1,198 point SetSync/WriteSync frames
+  + 1,198 point Set/Write frames
+
+2,408 logical command-WAL sync observations
+  = 1,199 entry_scan batch WriteSync syncs
+  + 1,198 point syncs
+  + 11 checkpoint/publish barrier syncs
+```
+
+The 1,198 unsynced point writes account for logical command-WAL flush
+observations, not sync observations. There is not a duplicate command-WAL sync
+inside each public batch `WriteSync`: the state workload contains two distinct
+durable public operations per block. The accepted `application.db` window uses
+the same implementation primitive but a different operation mix; its 1,212
+sync observations do not show the extra per-block point-sync family present in
+`state.db`.
+
+## Recovery and failure proofs
+
+The verification matrix requires all of the following:
+
+- external-reference ordering failure leaves the command-WAL file-sync count
+  unchanged;
+- a frame synced before a publication failure is replayed after reopen;
+- inline and forced-pointer public writes survive reopen;
+- an empty barrier after a prior unsynced pointer write syncs the pending
+  value-log bytes before the command WAL;
+- deterministic hooks agree with Linux syscall tracing for write and file-sync
+  counts; and
+- observer state remains race-safe.
+
+## M3 ownership
+
+M2 records costs but makes no performance change. The only currently proven
+redundancy candidate is the second value-log sync in the pointer-backed dirty
+`WriteSync` path. Any M3 proposal must report the measured second-sync ceiling,
+preserve the no-intervening-writer/rotation and external-reference durability
+invariants above, and re-run crash/reopen plus syscall-count gates. Command-WAL
+sync removal, async acknowledgement, relaxed durability, and per-write backend
+checkpointing are outside that optimization boundary.

--- a/TreeDB/docs/spec/command-wal-durable-write-contract.md
+++ b/TreeDB/docs/spec/command-wal-durable-write-contract.md
@@ -78,6 +78,17 @@ command-WAL sync remains strictly later. The measured ceiling is at most the
 second value-log file-sync time; it is not the sum of both syncs and is not a
 throughput claim.
 
+When a command frame references a rotated, non-current value-log segment, the
+current implementation first flushes and syncs the referenced lane's active
+writer, then opens and syncs each distinct referenced old segment directly.
+Each operation is a logical `external_ref` observation. The active-writer call
+records its lane-lock wait; the direct old-segment call has zero lock wait and
+records the direct request time. Failure to open an old segment is a logical error
+without a physical file-sync attempt. A reached direct sync hook is both a
+logical observation and a physical rotated-segment attempt. This is measured
+ordering, not a required sync count, and it makes segment rotation an explicit
+exclusion in any M3 coalescing proof.
+
 ### `Write` followed by `WriteSync`
 
 ```text
@@ -119,8 +130,9 @@ window.
 | command writes | `treedb.command_wal.write.{syscalls,bytes,ns,errors}_total` | actual underlying `write`/`writev` calls made by the command writer |
 | command file sync | `treedb.command_wal.file_sync.{calls,ns,errors}_total` | calls at the injected production hook, which is `os.File.Sync` |
 | directory sync | `treedb.command_wal.directory_sync.{calls,ns,errors}_total` | parent-directory sync on segment creation/rotation |
-| value-log logical sync | `treedb.cache.value_log.sync.<path>.{calls,ns,wait_ns,errors}_total` | `materialization`, `external_ref`, `pending_barrier`, or `checkpoint` sync, including lane-lock wait separately |
-| value-log file sync | `treedb.cache.value_log.file_sync.{calls,ns,errors}_total` | actual value-log writer file-sync hook calls |
+| value-log logical sync | `treedb.cache.value_log.sync.<path>.{calls,ns,wait_ns,errors}_total` | `materialization`, `external_ref`, `pending_barrier`, or `checkpoint` sync, including lane-lock wait separately; rotated-segment `external_ref` observations report zero wait |
+| value-log file sync | `treedb.cache.value_log.file_sync.{calls,ns,errors}_total` | actual active-writer file-sync hooks plus direct rotated-segment hooks, each counted once |
+| rotated value-log file sync | `treedb.cache.value_log.file_sync.rotated_segment.{calls,ns,errors}_total` | direct non-current segment sync-hook attempts; this is a subset of aggregate value-log file syncs |
 | request partition | `treedb.public.batch.write_sync.phase.*` | exclusive top-level wall partition plus nested command subphases; enabled only by the diagnostic option |
 
 `Flush` means buffered bytes were passed to the kernel and is not an fsync

--- a/TreeDB/docs/spec/verification.md
+++ b/TreeDB/docs/spec/verification.md
@@ -146,6 +146,9 @@ Coverage:
   - `TestPublicCommandWALPointerEmptyWriteSyncSweepsPriorUnsyncedWrite`
   - `TestPublicCommandWALWriteThenDirtyWriteSyncDurabilityLedger`
   - `BenchmarkPublicCommandWALDurableTinyBatchWriteSync`
+- `TreeDB/caching/value_log_appender_test.go`:
+  - `TestCachingValueLogExternalRefFlusherSyncsRotatedSegments`
+  - `TestCachingValueLogExternalRefFlusherAccountsForRotatedCommandFrameSegment`
 - `TreeDB/internal/commitlog/commitlog_test.go` and
   `TreeDB/internal/valuelog/valuelog_test.go`:
   deterministic file/directory sync-hook count and rotation tests.

--- a/TreeDB/docs/spec/verification.md
+++ b/TreeDB/docs/spec/verification.md
@@ -125,6 +125,31 @@ Coverage:
 - `TreeDB/db/api_test.go`:
   - `TestValuePlacement_PerDomainThreshold_DefaultFallback`
 
+### 6.1 Command-WAL durable-write ordering and syscall ledger
+
+Invariant:
+- external value-log bytes pass their required durability boundary before the
+  command frame; the complete command frame passes the command-WAL file-sync
+  boundary before cached publication; and an empty `WriteSync` covers pending
+  value-log lanes before its command-WAL barrier.
+- logical append/flush/sync counters remain distinguishable from actual writer
+  `write`/`writev`, file-sync, and directory-sync hook counts.
+
+Coverage:
+- `TreeDB/db/command_wal_raw_test.go`:
+  - `TestFlushCommandWALBarrierOrdersExternalRefsBeforeCommandWAL`
+- `TreeDB/db/command_wal_recovery_test.go`:
+  - `TestCommandWALCrashAfterFrameBeforeRootPublishRecovers`
+- `TreeDB/command_wal_public_test.go`:
+  - `TestPublicCommandWALStateShapedDurabilityLedger`
+  - `TestPublicCommandWALBatchWriteSyncExternalRefOrderingPhaseStats`
+  - `TestPublicCommandWALPointerEmptyWriteSyncSweepsPriorUnsyncedWrite`
+  - `TestPublicCommandWALWriteThenDirtyWriteSyncDurabilityLedger`
+  - `BenchmarkPublicCommandWALDurableTinyBatchWriteSync`
+- `TreeDB/internal/commitlog/commitlog_test.go` and
+  `TreeDB/internal/valuelog/valuelog_test.go`:
+  deterministic file/directory sync-hook count and rotation tests.
+
 ## 7. Maintenance/Compaction Behavior
 
 Invariant:

--- a/TreeDB/internal/commitlog/commitlog_test.go
+++ b/TreeDB/internal/commitlog/commitlog_test.go
@@ -701,6 +701,14 @@ func TestWriterRotateToWithSyncSkipsDirSyncWhenRelaxed(t *testing.T) {
 		t.Fatalf("new writer: %v", err)
 	}
 	defer func() { _ = writer.Close() }()
+	if got := writer.DurabilityStats().DirectorySyncCalls; got != 1 {
+		t.Fatalf("initial directory sync calls=%d, want 1", got)
+	}
+	fileSyncs := 0
+	writer.syncFn = func(*os.File) error {
+		fileSyncs++
+		return nil
+	}
 	calls = 0
 	if err := writer.RotateToWithSync(path1, false); err != nil {
 		t.Fatalf("relaxed RotateToWithSync: %v", err)
@@ -708,11 +716,20 @@ func TestWriterRotateToWithSyncSkipsDirSyncWhenRelaxed(t *testing.T) {
 	if calls != 0 {
 		t.Fatalf("relaxed RotateToWithSync syncDir calls=%d, want 0", calls)
 	}
+	if got := writer.DurabilityStats(); got.FileSyncCalls != 0 || got.DirectorySyncCalls != 1 {
+		t.Fatalf("durability stats after relaxed rotate=%+v, want file=0 directory=1", got)
+	}
 	if err := writer.RotateToWithSync(path2, true); err != nil {
 		t.Fatalf("strict RotateToWithSync: %v", err)
 	}
 	if calls != 1 {
 		t.Fatalf("strict RotateToWithSync syncDir calls=%d, want 1", calls)
+	}
+	if fileSyncs != 1 {
+		t.Fatalf("strict RotateToWithSync file sync calls=%d, want 1", fileSyncs)
+	}
+	if got := writer.DurabilityStats(); got.FileSyncCalls != 1 || got.DirectorySyncCalls != 2 || got.FileSyncErrors != 0 || got.DirectorySyncErrors != 0 {
+		t.Fatalf("durability stats after strict rotate=%+v, want file=1 directory=2 and no errors", got)
 	}
 }
 

--- a/TreeDB/internal/commitlog/commitlog_test.go
+++ b/TreeDB/internal/commitlog/commitlog_test.go
@@ -733,6 +733,36 @@ func TestWriterRotateToWithSyncSkipsDirSyncWhenRelaxed(t *testing.T) {
 	}
 }
 
+func TestWriterSyncFallsBackToFileSyncWhenHookNil(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "commit.log")
+	writer, err := NewWriter(path)
+	if err != nil {
+		t.Fatalf("new writer: %v", err)
+	}
+	defer func() { _ = writer.Close() }()
+
+	if err := writer.AppendBatch([]Record{{
+		Op:    OpSetInline,
+		Key:   []byte("key"),
+		Value: []byte("value"),
+		Seq:   1,
+	}}); err != nil {
+		t.Fatalf("append: %v", err)
+	}
+	writer.syncFn = nil
+	before := writer.DurabilityStats()
+	if err := writer.Sync(); err != nil {
+		t.Fatalf("sync with nil hook: %v", err)
+	}
+	after := writer.DurabilityStats()
+	if got := after.FileSyncCalls - before.FileSyncCalls; got != 1 {
+		t.Fatalf("file sync call delta=%d, want 1", got)
+	}
+	if got := after.FileSyncErrors - before.FileSyncErrors; got != 0 {
+		t.Fatalf("file sync error delta=%d, want 0", got)
+	}
+}
+
 func TestCommitLogWriteReadBatchCompressed(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "commit.log")

--- a/TreeDB/internal/commitlog/journal_owner.go
+++ b/TreeDB/internal/commitlog/journal_owner.go
@@ -552,6 +552,22 @@ func (j *CommandJournal) WriterBufferStats() WriterBufferStats {
 	return j.writer.BufferStats()
 }
 
+// WriterDurabilityStats reports cumulative file and directory sync hook calls
+// for the active writer, including calls made while rotating prior segments.
+// The writer object is reused across rotations, so the snapshot is journal
+// lifetime cumulative.
+func (j *CommandJournal) WriterDurabilityStats() DurabilityStats {
+	if j == nil {
+		return DurabilityStats{}
+	}
+	j.mu.Lock()
+	defer j.mu.Unlock()
+	if j.writer == nil {
+		return DurabilityStats{}
+	}
+	return j.writer.DurabilityStats()
+}
+
 // ActiveSegmentSnapshot reports the active segment path and accepted bytes under
 // one journal lock acquisition.
 func (j *CommandJournal) ActiveSegmentSnapshot() (path string, bytes int64) {

--- a/TreeDB/internal/commitlog/writer.go
+++ b/TreeDB/internal/commitlog/writer.go
@@ -273,11 +273,16 @@ func (w *Writer) writev(parts [][]byte) error {
 }
 
 func (w *Writer) syncFile() error {
-	if w == nil || w.f == nil || w.syncFn == nil {
+	if w == nil || w.f == nil {
 		return nil
 	}
 	start := time.Now()
-	err := w.syncFn(w.f)
+	var err error
+	if w.syncFn != nil {
+		err = w.syncFn(w.f)
+	} else {
+		err = w.f.Sync()
+	}
 	w.fileSyncCalls.Add(1)
 	if ns := time.Since(start).Nanoseconds(); ns > 0 {
 		w.fileSyncNs.Add(uint64(ns))

--- a/TreeDB/internal/commitlog/writer.go
+++ b/TreeDB/internal/commitlog/writer.go
@@ -9,6 +9,8 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"sync/atomic"
+	"time"
 
 	"github.com/snissn/compress/zstd"
 	"github.com/snissn/gomap/TreeDB/internal/crc"
@@ -90,6 +92,7 @@ func sameNonEmptyBytesData(a, b []byte) bool {
 type Writer struct {
 	f                      *os.File
 	bw                     *bufio.Writer
+	fileSink               writerFileSink
 	scratch                []byte
 	encScratch             []byte
 	commandBuf             []byte
@@ -108,6 +111,33 @@ type Writer struct {
 	compress               bool
 	enc                    *zstd.Encoder
 	syncFn                 func(*os.File) error
+	fileSyncCalls          atomic.Uint64
+	fileSyncNs             atomic.Uint64
+	fileSyncErrors         atomic.Uint64
+	directorySyncCalls     atomic.Uint64
+	directorySyncNs        atomic.Uint64
+	directorySyncErrors    atomic.Uint64
+	writeSyscalls          atomic.Uint64
+	writeBytes             atomic.Uint64
+	writeNs                atomic.Uint64
+	writeErrors            atomic.Uint64
+}
+
+type writerFileSink struct {
+	owner *Writer
+	file  *os.File
+}
+
+func (s *writerFileSink) Write(p []byte) (int, error) {
+	if s == nil || s.file == nil {
+		return 0, os.ErrInvalid
+	}
+	start := time.Now()
+	n, err := s.file.Write(p)
+	if s.owner != nil {
+		s.owner.observeWriteSyscalls(1, uint64(max(n, 0)), time.Since(start), err)
+	}
+	return n, err
 }
 
 type WriterBufferStats struct {
@@ -122,6 +152,24 @@ type WriterBufferStats struct {
 	CommandBufferDroppedBytes   uint64
 	PendingBatchLength          int
 	PendingBatchCapacity        int
+}
+
+// DurabilityStats reports underlying writer calls plus injected durability
+// boundaries. The production hooks are os.File.Sync for FileSync and a parent
+// directory os.File.Sync for DirectorySync. Keeping sync counters at the hook
+// boundary makes tests deterministic while Linux strace can validate the
+// production write/writev and sync mappings.
+type DurabilityStats struct {
+	WriteSyscalls       uint64
+	WriteBytes          uint64
+	WriteNs             uint64
+	WriteErrors         uint64
+	FileSyncCalls       uint64
+	FileSyncNs          uint64
+	FileSyncErrors      uint64
+	DirectorySyncCalls  uint64
+	DirectorySyncNs     uint64
+	DirectorySyncErrors uint64
 }
 
 func (w *Writer) ActiveBytes() int64 {
@@ -145,7 +193,12 @@ func NewWriterWithOptions(path string, opts Options) (*Writer, error) {
 	if err != nil {
 		return nil, err
 	}
-	if err := syncDirFn(path); err != nil {
+	w := &Writer{
+		f:      f,
+		syncFn: func(file *os.File) error { return file.Sync() },
+	}
+	w.fileSink = writerFileSink{owner: w, file: f}
+	if err := w.syncDirectory(path); err != nil {
 		_ = f.Close()
 		return nil, err
 	}
@@ -164,17 +217,91 @@ func NewWriterWithOptions(path string, opts Options) (*Writer, error) {
 		commandBufLimit = opts.DeferredCommandBufferSize
 	}
 	commandBufRetain := normalizeCommandBufferRetainSize(opts.DeferredCommandBufferRetainSize, commandBufLimit)
-	return &Writer{
-		f:                f,
-		bw:               bufio.NewWriterSize(f, normalizeBufferSize(opts.BufferSize)),
-		commandBuf:       commandBuf,
-		commandBufLimit:  commandBufLimit,
-		commandBufRetain: commandBufRetain,
-		size:             info.Size(),
-		maxSegmentSize:   normalizeMaxSegmentSize(opts.MaxSegmentSize),
-		compress:         opts.Compress,
-		syncFn:           func(file *os.File) error { return file.Sync() },
-	}, nil
+	w.bw = bufio.NewWriterSize(&w.fileSink, normalizeBufferSize(opts.BufferSize))
+	w.commandBuf = commandBuf
+	w.commandBufLimit = commandBufLimit
+	w.commandBufRetain = commandBufRetain
+	w.size = info.Size()
+	w.maxSegmentSize = normalizeMaxSegmentSize(opts.MaxSegmentSize)
+	w.compress = opts.Compress
+	return w, nil
+}
+
+// DurabilityStats returns a lock-free cumulative snapshot. Writer callers
+// already serialize mutations; atomics keep diagnostic snapshots race-safe.
+func (w *Writer) DurabilityStats() DurabilityStats {
+	if w == nil {
+		return DurabilityStats{}
+	}
+	return DurabilityStats{
+		WriteSyscalls:       w.writeSyscalls.Load(),
+		WriteBytes:          w.writeBytes.Load(),
+		WriteNs:             w.writeNs.Load(),
+		WriteErrors:         w.writeErrors.Load(),
+		FileSyncCalls:       w.fileSyncCalls.Load(),
+		FileSyncNs:          w.fileSyncNs.Load(),
+		FileSyncErrors:      w.fileSyncErrors.Load(),
+		DirectorySyncCalls:  w.directorySyncCalls.Load(),
+		DirectorySyncNs:     w.directorySyncNs.Load(),
+		DirectorySyncErrors: w.directorySyncErrors.Load(),
+	}
+}
+
+func (w *Writer) observeWriteSyscalls(calls, bytes uint64, elapsed time.Duration, err error) {
+	if w == nil {
+		return
+	}
+	if calls > 0 {
+		w.writeSyscalls.Add(calls)
+	}
+	if bytes > 0 {
+		w.writeBytes.Add(bytes)
+	}
+	if ns := elapsed.Nanoseconds(); calls > 0 && ns > 0 {
+		w.writeNs.Add(uint64(ns))
+	}
+	if err != nil {
+		w.writeErrors.Add(1)
+	}
+}
+
+func (w *Writer) writev(parts [][]byte) error {
+	start := time.Now()
+	stats, err := writevFull(w.f, parts)
+	w.observeWriteSyscalls(stats.syscalls, stats.bytes, time.Since(start), err)
+	return err
+}
+
+func (w *Writer) syncFile() error {
+	if w == nil || w.f == nil || w.syncFn == nil {
+		return nil
+	}
+	start := time.Now()
+	err := w.syncFn(w.f)
+	w.fileSyncCalls.Add(1)
+	if ns := time.Since(start).Nanoseconds(); ns > 0 {
+		w.fileSyncNs.Add(uint64(ns))
+	}
+	if err != nil {
+		w.fileSyncErrors.Add(1)
+	}
+	return err
+}
+
+func (w *Writer) syncDirectory(path string) error {
+	if w == nil {
+		return syncDirFn(path)
+	}
+	start := time.Now()
+	err := syncDirFn(path)
+	w.directorySyncCalls.Add(1)
+	if ns := time.Since(start).Nanoseconds(); ns > 0 {
+		w.directorySyncNs.Add(uint64(ns))
+	}
+	if err != nil {
+		w.directorySyncErrors.Add(1)
+	}
+	return err
 }
 
 func normalizeCommandBufferRetainSize(retain, limit int) int {
@@ -350,7 +477,7 @@ func (w *Writer) RotateToWithSync(path string, syncCurrent bool) error {
 			return err
 		}
 		if syncCurrent {
-			if err := syncDirFn(path); err != nil {
+			if err := w.syncDirectory(path); err != nil {
 				_ = f.Close()
 				return err
 			}
@@ -361,7 +488,8 @@ func (w *Writer) RotateToWithSync(path string, syncCurrent bool) error {
 			return err
 		}
 		w.f = f
-		w.bw.Reset(f)
+		w.fileSink.file = f
+		w.bw.Reset(&w.fileSink)
 		w.size = info.Size()
 		w.scratch = w.scratch[:0]
 		return nil
@@ -378,8 +506,8 @@ func (w *Writer) RotateToWithSync(path string, syncCurrent bool) error {
 	if err := w.bw.Flush(); err != nil {
 		return err
 	}
-	if syncCurrent && w.syncFn != nil {
-		if err := w.syncFn(w.f); err != nil {
+	if syncCurrent {
+		if err := w.syncFile(); err != nil {
 			return err
 		}
 	}
@@ -394,7 +522,7 @@ func (w *Writer) RotateToWithSync(path string, syncCurrent bool) error {
 		return err
 	}
 	if syncCurrent {
-		if err := syncDirFn(path); err != nil {
+		if err := w.syncDirectory(path); err != nil {
 			_ = f.Close()
 			return err
 		}
@@ -402,7 +530,8 @@ func (w *Writer) RotateToWithSync(path string, syncCurrent bool) error {
 
 	old := w.f
 	w.f = f
-	w.bw.Reset(f)
+	w.fileSink.file = f
+	w.bw.Reset(&w.fileSink)
 	w.size = info.Size()
 	w.scratch = w.scratch[:0]
 	if err := old.Close(); err != nil {
@@ -1073,7 +1202,7 @@ func (w *Writer) appendRawKVBatchPayloadCommandDirect(lsn, baseAppliedLSN uint64
 			return err
 		}
 		parts := [2][]byte{prefix[:], payload}
-		if err := writevFull(w.f, parts[:]); err != nil {
+		if err := w.writev(parts[:]); err != nil {
 			return w.poisonCommandBuffer(err)
 		}
 		w.size += int64(segmentHeaderSize + size)
@@ -1113,7 +1242,7 @@ func (w *Writer) appendRawKVBatchPayloadScanCommandDirect(lsn, baseAppliedLSN ui
 	if err := w.bw.Flush(); err != nil {
 		return err
 	}
-	if err := writeFull(w.f, prefix[:]); err != nil {
+	if err := w.writeFull(prefix[:]); err != nil {
 		return w.poisonCommandBuffer(err)
 	}
 	scratch := w.scratch[:0]
@@ -1124,7 +1253,7 @@ func (w *Writer) appendRawKVBatchPayloadScanCommandDirect(lsn, baseAppliedLSN ui
 		if len(scratch) == 0 {
 			return nil
 		}
-		if err := writeFull(w.f, scratch); err != nil {
+		if err := w.writeFull(scratch); err != nil {
 			return err
 		}
 		scratch = scratch[:0]
@@ -1178,7 +1307,7 @@ func (w *Writer) appendCommandPayloadDirectTrusted(lsn, baseAppliedLSN uint64, k
 			return err
 		}
 		parts := [2][]byte{prefix[:], payload}
-		if err := writevFull(w.f, parts[:]); err != nil {
+		if err := w.writev(parts[:]); err != nil {
 			return w.poisonCommandBuffer(err)
 		}
 		w.size += int64(segmentHeaderSize + size)
@@ -1257,9 +1386,9 @@ func (w *Writer) commandBufferLimit() int {
 	return w.commandBufLimit
 }
 
-func writeFull(f *os.File, p []byte) error {
+func (w *Writer) writeFull(p []byte) error {
 	for len(p) > 0 {
-		n, err := f.Write(p)
+		n, err := w.fileSink.Write(p)
 		if err != nil {
 			return err
 		}
@@ -1306,7 +1435,7 @@ func (w *Writer) flushBufferedCommandFrames() error {
 		return w.poisonCommandBuffer(err)
 	}
 	flushed := len(w.commandBuf)
-	if err := writeFull(w.f, w.commandBuf); err != nil {
+	if err := w.writeFull(w.commandBuf); err != nil {
 		return w.poisonCommandBuffer(err)
 	}
 	w.size += int64(flushed)
@@ -1396,10 +1525,10 @@ func (w *Writer) writeSegment(payload []byte) error {
 			return err
 		}
 		if length&segmentFlagCompressed != 0 {
-			if err := writevFull(w.f, [][]byte{header, rawLenPrefix, stored}); err != nil {
+			if err := w.writev([][]byte{header, rawLenPrefix, stored}); err != nil {
 				return err
 			}
-		} else if err := writevFull(w.f, [][]byte{header, stored}); err != nil {
+		} else if err := w.writev([][]byte{header, stored}); err != nil {
 			return err
 		}
 		w.size += int64(segmentHeaderSize) + int64(storedLen)
@@ -1447,7 +1576,7 @@ func (w *Writer) writeRawSegmentWithChecksumNoPending(payload []byte, wantCRC ui
 		if err := w.bw.Flush(); err != nil {
 			return err
 		}
-		if err := writevFull(w.f, [][]byte{header, payload}); err != nil {
+		if err := w.writev([][]byte{header, payload}); err != nil {
 			return err
 		}
 		w.size += int64(segmentHeaderSize) + int64(storedLen)
@@ -1524,10 +1653,7 @@ func (w *Writer) Sync() error {
 	if err := w.bw.Flush(); err != nil {
 		return err
 	}
-	if w.syncFn != nil {
-		return w.syncFn(w.f)
-	}
-	return nil
+	return w.syncFile()
 }
 
 func (w *Writer) Close() error {

--- a/TreeDB/internal/commitlog/writer_writev_stub.go
+++ b/TreeDB/internal/commitlog/writer_writev_stub.go
@@ -4,11 +4,28 @@ package commitlog
 
 import "os"
 
-func writevFull(f *os.File, parts [][]byte) error {
+type writevStats struct {
+	syscalls uint64
+	bytes    uint64
+}
+
+func writevFull(f *os.File, parts [][]byte) (writevStats, error) {
+	var stats writevStats
 	for _, p := range parts {
-		if err := writeFull(f, p); err != nil {
-			return err
+		for len(p) > 0 {
+			stats.syscalls++
+			n, err := f.Write(p)
+			if n > 0 {
+				stats.bytes += uint64(n)
+				p = p[n:]
+			}
+			if err != nil {
+				return stats, err
+			}
+			if n <= 0 {
+				return stats, os.ErrInvalid
+			}
 		}
 	}
-	return nil
+	return stats, nil
 }

--- a/TreeDB/internal/commitlog/writer_writev_unix.go
+++ b/TreeDB/internal/commitlog/writer_writev_unix.go
@@ -9,27 +9,35 @@ import (
 	"golang.org/x/sys/unix"
 )
 
-func writevFull(f *os.File, parts [][]byte) error {
+type writevStats struct {
+	syscalls uint64
+	bytes    uint64
+}
+
+func writevFull(f *os.File, parts [][]byte) (writevStats, error) {
+	var stats writevStats
 	if f == nil {
-		return errors.New("commitlog: nil file")
+		return stats, errors.New("commitlog: nil file")
 	}
 	for len(parts) > 0 {
 		for len(parts) > 0 && len(parts[0]) == 0 {
 			parts = parts[1:]
 		}
 		if len(parts) == 0 {
-			return nil
+			return stats, nil
 		}
+		stats.syscalls++
 		n, err := unix.Writev(int(f.Fd()), parts)
 		if err != nil {
 			if err == unix.EINTR || err == unix.EAGAIN {
 				continue
 			}
-			return err
+			return stats, err
 		}
 		if n <= 0 {
-			return errors.New("commitlog: short writev")
+			return stats, errors.New("commitlog: short writev")
 		}
+		stats.bytes += uint64(n)
 		written := n
 		for written > 0 && len(parts) > 0 {
 			if written >= len(parts[0]) {
@@ -41,5 +49,5 @@ func writevFull(f *os.File, parts [][]byte) error {
 			written = 0
 		}
 	}
-	return nil
+	return stats, nil
 }

--- a/TreeDB/internal/valuelog/valuelog_test.go
+++ b/TreeDB/internal/valuelog/valuelog_test.go
@@ -121,6 +121,9 @@ func TestWriterRotateToWithSyncFalseSkipsRotateSync(t *testing.T) {
 			t.Fatalf("Close: %v", err)
 		}
 	}()
+	if got := writer.DurabilityStats().DirectorySyncCalls; got != 1 {
+		t.Fatalf("initial directory sync calls=%d want 1", got)
+	}
 
 	var fileSyncs int
 	writer.syncFn = func(*os.File) error {
@@ -141,6 +144,9 @@ func TestWriterRotateToWithSyncFalseSkipsRotateSync(t *testing.T) {
 	if dirSyncs != 0 {
 		t.Fatalf("dirSyncs after relaxed rotate=%d want 0", dirSyncs)
 	}
+	if got := writer.DurabilityStats(); got.FileSyncCalls != 0 || got.DirectorySyncCalls != 1 {
+		t.Fatalf("durability stats after relaxed rotate=%+v want file=0 directory=1", got)
+	}
 
 	if err := writer.Sync(); err != nil {
 		t.Fatalf("Sync: %v", err)
@@ -160,6 +166,9 @@ func TestWriterRotateToWithSyncFalseSkipsRotateSync(t *testing.T) {
 	}
 	if dirSyncs != 1 {
 		t.Fatalf("dirSyncs after synced rotate=%d want 1", dirSyncs)
+	}
+	if got := writer.DurabilityStats(); got.FileSyncCalls != 2 || got.DirectorySyncCalls != 2 || got.FileSyncErrors != 0 || got.DirectorySyncErrors != 0 {
+		t.Fatalf("durability stats after sync and rotate=%+v want file=2 directory=2 and no errors", got)
 	}
 }
 

--- a/TreeDB/internal/valuelog/writer.go
+++ b/TreeDB/internal/valuelog/writer.go
@@ -87,6 +87,12 @@ type Writer struct {
 	noBenefit              uint8
 	skipRemain             uint16
 	syncFn                 func(*os.File) error
+	fileSyncCalls          atomic.Uint64
+	fileSyncNs             atomic.Uint64
+	fileSyncErrors         atomic.Uint64
+	directorySyncCalls     atomic.Uint64
+	directorySyncNs        atomic.Uint64
+	directorySyncErrors    atomic.Uint64
 	clock                  Clock
 	encodeCostModel        EncodeCostModel
 	encodeSampleStride     uint64
@@ -94,6 +100,71 @@ type Writer struct {
 	keepIoNsPerStoredByte  float64
 	keepEncodeNsPerRawByte float64
 	keepSafetyMargin       float64
+}
+
+// DurabilityStats reports calls to the writer's injected durability
+// boundaries. Production file and directory hooks call os.File.Sync; tests may
+// replace the hooks to count the same boundaries deterministically.
+type DurabilityStats struct {
+	FileSyncCalls       uint64
+	FileSyncNs          uint64
+	FileSyncErrors      uint64
+	DirectorySyncCalls  uint64
+	DirectorySyncNs     uint64
+	DirectorySyncErrors uint64
+}
+
+// DurabilityStats returns a lock-free cumulative snapshot. The writer object
+// is reused across value-log segment rotations.
+func (w *Writer) DurabilityStats() DurabilityStats {
+	if w == nil {
+		return DurabilityStats{}
+	}
+	return DurabilityStats{
+		FileSyncCalls:       w.fileSyncCalls.Load(),
+		FileSyncNs:          w.fileSyncNs.Load(),
+		FileSyncErrors:      w.fileSyncErrors.Load(),
+		DirectorySyncCalls:  w.directorySyncCalls.Load(),
+		DirectorySyncNs:     w.directorySyncNs.Load(),
+		DirectorySyncErrors: w.directorySyncErrors.Load(),
+	}
+}
+
+func (w *Writer) syncFile() error {
+	if w == nil || w.f == nil {
+		return nil
+	}
+	start := time.Now()
+	var err error
+	if w.syncFn != nil {
+		err = w.syncFn(w.f)
+	} else {
+		err = w.f.Sync()
+	}
+	w.fileSyncCalls.Add(1)
+	if ns := time.Since(start).Nanoseconds(); ns > 0 {
+		w.fileSyncNs.Add(uint64(ns))
+	}
+	if err != nil {
+		w.fileSyncErrors.Add(1)
+	}
+	return err
+}
+
+func (w *Writer) syncDirectory(path string) error {
+	if w == nil {
+		return syncDirFn(path)
+	}
+	start := time.Now()
+	err := syncDirFn(path)
+	w.directorySyncCalls.Add(1)
+	if ns := time.Since(start).Nanoseconds(); ns > 0 {
+		w.directorySyncNs.Add(uint64(ns))
+	}
+	if err != nil {
+		w.directorySyncErrors.Add(1)
+	}
+	return err
 }
 
 var errEncodedTooLarge = errors.New("valuelog: encoded payload too large")
@@ -487,7 +558,11 @@ func NewWriter(path string, fileID uint32) (*Writer, error) {
 	if err != nil {
 		return nil, err
 	}
-	if err := syncDirFn(path); err != nil {
+	w := &Writer{
+		f:      f,
+		syncFn: func(file *os.File) error { return file.Sync() },
+	}
+	if err := w.syncDirectory(path); err != nil {
 		_ = f.Close()
 		return nil, err
 	}
@@ -496,23 +571,21 @@ func NewWriter(path string, fileID uint32) (*Writer, error) {
 		_ = f.Close()
 		return nil, err
 	}
-	return &Writer{
-		f: f,
-		// File-backed writers use direct writes and append buffers; bufio is only
-		// needed for sink-backed writers (tests/benchmarks).
-		bw:                    nil,
-		size:                  info.Size(),
-		fileID:                fileID,
-		appendMax:             defaultBufferSize,
-		rawWritevMinAvgBytes:  defaultRawWritevMinAvgBytes,
-		rawWritevMinBatchRecs: defaultRawWritevMinBatchRecords,
-		prefixBuf:             make([]byte, 0, FrameHeaderSize+(MaxFrameK*8)+((MaxFrameK+1)*4)),
-		dictFrameEncodeLevel:  zstd.SpeedFastest,
-		blockCodec:            BlockCodecSnappy,
-		syncFn:                func(file *os.File) error { return file.Sync() },
-		clock:                 RealClock{},
-		keepSafetyMargin:      DefaultKeepSafetyMargin,
-	}, nil
+	w.f = f
+	// File-backed writers use direct writes and append buffers; bufio is only
+	// needed for sink-backed writers (tests/benchmarks).
+	w.bw = nil
+	w.size = info.Size()
+	w.fileID = fileID
+	w.appendMax = defaultBufferSize
+	w.rawWritevMinAvgBytes = defaultRawWritevMinAvgBytes
+	w.rawWritevMinBatchRecs = defaultRawWritevMinBatchRecords
+	w.prefixBuf = make([]byte, 0, FrameHeaderSize+(MaxFrameK*8)+((MaxFrameK+1)*4))
+	w.dictFrameEncodeLevel = zstd.SpeedFastest
+	w.blockCodec = BlockCodecSnappy
+	w.clock = RealClock{}
+	w.keepSafetyMargin = DefaultKeepSafetyMargin
+	return w, nil
 }
 
 func newWriterWithSink(sink io.Writer, fileID uint32) *Writer {
@@ -803,7 +876,7 @@ func (w *Writer) RotateToWithSync(path string, fileID uint32, syncCurrent bool) 
 			return err
 		}
 		if syncCurrent {
-			if err := syncDirFn(path); err != nil {
+			if err := w.syncDirectory(path); err != nil {
 				_ = f.Close()
 				return err
 			}
@@ -827,8 +900,8 @@ func (w *Writer) RotateToWithSync(path string, fileID uint32, syncCurrent bool) 
 	if err := w.flushNoTrim(); err != nil {
 		return err
 	}
-	if syncCurrent && w.syncFn != nil {
-		if err := w.syncFn(w.f); err != nil {
+	if syncCurrent {
+		if err := w.syncFile(); err != nil {
 			return err
 		}
 	}
@@ -843,7 +916,7 @@ func (w *Writer) RotateToWithSync(path string, fileID uint32, syncCurrent bool) 
 		return err
 	}
 	if syncCurrent {
-		if err := syncDirFn(path); err != nil {
+		if err := w.syncDirectory(path); err != nil {
 			_ = f.Close()
 			return err
 		}
@@ -2319,15 +2392,7 @@ func (w *Writer) Sync() error {
 	if err := w.flushNoTrim(); err != nil {
 		return err
 	}
-	if w.syncFn != nil {
-		if err := w.syncFn(w.f); err != nil {
-			return err
-		}
-		w.trimTransientScratchBuffers()
-		w.releaseIdleAppendBuf()
-		return nil
-	}
-	if err := w.f.Sync(); err != nil {
+	if err := w.syncFile(); err != nil {
 		return err
 	}
 	w.trimTransientScratchBuffers()

--- a/docs/TREEDB_IRONBIRD_ATTRIBUTION.md
+++ b/docs/TREEDB_IRONBIRD_ATTRIBUTION.md
@@ -115,6 +115,9 @@ families that Ironbird should preserve when present:
 
 - command-WAL append, flush, sync, live coverage, and cleanup:
   `treedb.command_wal.*`;
+- command-WAL physical write/file-sync/directory-sync calls and time:
+  `treedb.command_wal.write.*`, `treedb.command_wal.file_sync.*`, and
+  `treedb.command_wal.directory_sync.*`;
 - cached command-WAL durability mode and checkpoint publication split:
   `treedb.cache.command_wal.*`;
 - foreground write wait-for-checkpoint totals:
@@ -132,6 +135,7 @@ families that Ironbird should preserve when present:
   `treedb.cache.queue_laneid_misses`;
 - value-log generation, GC, rewrite, mmap, read, template, buffer, and cache
   telemetry: `treedb.cache.vlog_generation.*`, `treedb.cache.vlog_mmap.*`,
+  `treedb.cache.value_log.sync.*`, `treedb.cache.value_log.file_sync.*`,
   selected `treedb.cache.vlog_read.*_total`,
   selected `treedb.cache.vlog_template.*_total`,
   selected `treedb.cache.vlog_template_def_cache.{hits,misses}`,

--- a/docs/benchmarks/treedb_durable_write_m2_ledger_2026-07-10.md
+++ b/docs/benchmarks/treedb_durable_write_m2_ledger_2026-07-10.md
@@ -27,6 +27,10 @@ durability boundary and does not claim a throughput improvement.
   value-log sync. Its focused ceiling is 1.35-1.46 ms per affected batch. It
   is not safe to remove without proving byte coverage and exclusion of an
   intervening writer or rotation.
+- A rotated external reference is a distinct case: the current lane writer is
+  synced first and each referenced non-current segment is then synced directly.
+  M2 now attributes those direct attempts to both logical `external_ref` and
+  aggregate physical value-log counters without changing the ordering.
 
 The normative byte and ordering contract is in
 `TreeDB/docs/spec/command-wal-durable-write-contract.md`.
@@ -57,6 +61,8 @@ Primary artifacts:
 | `block.pprof`, `mutex.pprof`, `trace.out` | blocking, mutex, and runtime trace evidence |
 | `*_top.txt`, `trace_sync_top.txt` | text profile summaries |
 | `strace.log`, `strace_active_window.txt` | production Linux syscall validation |
+| `rotated_segment_test.txt`, `rotated_segment_strace.log`, `rotated_segment_strace_fsync.txt` | rotated command-reference counter and syscall reconciliation |
+| `rotated_segment_focused_count10.txt`, `rotated_segment_race.txt`, `rotated_segment_public_regression.txt` | focused repeat, race, and public-ledger regressions |
 | `perf_stat.txt`, `perf_benchmark.txt` | hardware/runtime counter sample |
 | `environment.txt` | commit, Go, kernel, filesystem, device, and capacity |
 
@@ -118,7 +124,18 @@ The command-write byte mean can be fractional because key lengths cross a
 decimal digit boundary during the 20-iteration samples. Logical sync-path
 counts and actual file-sync-hook counts agree for every isolated row. Segment
 creation/rotation directory syncs are outside the delta window and remain
-separate counters.
+separate counters. None of the 12 measured active windows rotated a referenced
+value-log segment, so the ledger values above are unchanged by the follow-up
+counter fix and `file_sync.rotated_segment.calls_total` is zero for those rows.
+
+The deterministic rotated-reference regression constructs a real command
+frame whose value pointer names a deliberately rotated non-current segment. Its
+delta is two logical `external_ref` calls and two aggregate value-log file-sync
+attempts: one through the active lane writer and one direct old-segment sync.
+The rotated-segment subcounter is exactly one. An injected direct-sync failure
+increments both logical and physical error counters, while a segment-open
+failure increments only the logical error counter because no file-sync hook was
+reached.
 
 ## Latency, publication, and residual ledger
 
@@ -166,6 +183,12 @@ charged to the five measured public operations.
 This validates both the production mapping and the deterministic hook tests.
 It also proves that the two pointer value-log sync observations are two
 physical syscalls on this host.
+
+The rotated-reference follow-up retains a separate path-specific Linux trace.
+It verifies that the direct production hook for the deliberately old segment
+also maps to `fsync(2)`; the in-process regression supplies the exact active
+window reconciliation because test setup, rotation, and close add unrelated
+directory and checkpoint calls to the whole-process trace.
 
 ## State and application interval reconciliation
 

--- a/docs/benchmarks/treedb_durable_write_m2_ledger_2026-07-10.md
+++ b/docs/benchmarks/treedb_durable_write_m2_ledger_2026-07-10.md
@@ -1,0 +1,255 @@
+# TreeDB Durable-Write M2 Barrier Ledger (2026-07-10)
+
+Issue: [#3656](https://github.com/snissn/gomap/issues/3656)  
+Parent: [#3652](https://github.com/snissn/gomap/issues/3652)  
+Base commit: `3e5543145e2f4fd0762b6bdeb1bbcbcb42599f6c`
+
+This is an instrumentation and contract result. It does not change a
+durability boundary and does not claim a throughput improvement.
+
+## Result
+
+- A dirty inline public `WriteSync` performs one command-frame append, one
+  command-writer sync, one command-file `fsync`, and no value-log sync.
+- A dirty forced-pointer public `WriteSync` currently performs two value-log
+  file `fsync` calls (`materialization`, then `external_ref`) before one
+  command-WAL write and one later command-file `fsync`.
+- An unsynced `Write` contributes an append, kernel write, and logical flush.
+  A following sync boundary covers the earlier command bytes already flushed
+  to that file. An empty `WriteSync` also sweeps pending value-log lanes first.
+- The state-shaped interval has two distinct durable operations per block. It
+  does not perform two command-file syncs inside one batch `WriteSync`.
+- Named top-level phases cover 99.923% or more of every focused `WriteSync`
+  shape below. The matching state active-window phase sample covers 99.982%.
+- The only measured M3 redundancy candidate is the second pointer-path
+  value-log sync. Its focused ceiling is 1.35-1.46 ms per affected batch. It
+  is not safe to remove without proving byte coverage and exclusion of an
+  intervening writer or rotation.
+
+The normative byte and ordering contract is in
+`TreeDB/docs/spec/command-wal-durable-write-contract.md`.
+
+## Environment and artifacts
+
+The focused artifacts are in:
+
+```text
+/mnt/fast4tb/gomap-3656-m2-evidence-20260710
+```
+
+The benchmark binary reports Go 1.26.0, Linux/amd64. Trace decoding used the
+matching Go 1.26.3 tool. The worktree is on `/dev/nvme1n1p1`, an ext4
+filesystem mounted `rw,noatime` at `/mnt/fast4tb` on a Samsung SSD 990 PRO 4TB.
+The host CPU is an Intel Core i5-11400F.
+
+Primary artifacts:
+
+| Artifact | Purpose |
+| --- | --- |
+| `benchmark_count3.txt` | all 12 shapes, 20 iterations, three runs |
+| `benchmark_summary.tsv` | arithmetic means used in the tables below |
+| `benchmark_wait_summary.tsv` | value-log lane-lock wait ledger |
+| `phase_stats_overhead{,_benchstat}.txt` | diagnostic option disabled/enabled comparison |
+| `always_on_overhead*.txt` | same-Go base/current default-path comparison |
+| `profile_benchmark.txt`, `cpu.pprof`, `allocs.pprof` | CPU and allocation evidence |
+| `block.pprof`, `mutex.pprof`, `trace.out` | blocking, mutex, and runtime trace evidence |
+| `*_top.txt`, `trace_sync_top.txt` | text profile summaries |
+| `strace.log`, `strace_active_window.txt` | production Linux syscall validation |
+| `perf_stat.txt`, `perf_benchmark.txt` | hardware/runtime counter sample |
+| `environment.txt` | commit, Go, kernel, filesystem, device, and capacity |
+
+Reproduction commands:
+
+```sh
+GOWORK=off go test -c ./TreeDB \
+  -o /mnt/fast4tb/gomap-3656-m2-evidence-20260710/TreeDB.test
+
+./TreeDB.test -test.run='^$' \
+  -test.bench='^BenchmarkPublicCommandWALDurableTinyBatchWriteSync$' \
+  -test.benchtime=20x -test.count=3
+
+./TreeDB.test -test.run='^$' \
+  -test.bench='^BenchmarkPublicCommandWALDurableTinyBatchWriteSync/placement=forced_pointer/shape=dirty_batch/ops=1$' \
+  -test.benchtime=100x -test.count=1 \
+  -test.cpuprofile=cpu.pprof -test.memprofile=allocs.pprof \
+  -test.blockprofile=block.pprof -test.mutexprofile=mutex.pprof \
+  -test.trace=trace.out
+
+strace -f -yy -tt -T \
+  -e trace=write,writev,fsync,fdatasync,openat,close \
+  -o strace.log ./TreeDB.test -test.run='^$' \
+  -test.bench='^BenchmarkPublicCommandWALDurableTinyBatchWriteSync/placement=forced_pointer/shape=dirty_batch/ops=1$' \
+  -test.benchtime=5x -test.count=1
+
+perf stat -d -o perf_stat.txt -- ./TreeDB.test -test.run='^$' \
+  -test.bench='^BenchmarkPublicCommandWALDurableTinyBatchWriteSync/placement=forced_pointer/shape=dirty_batch/ops=1$' \
+  -test.benchtime=100x -test.count=1
+```
+
+## Barrier ledger
+
+The rows are means of three runs at exactly 20 iterations. `D1`, `D8`, and
+`D32` are dirty batches of that many keys; `W->DWS` is an unsynced dirty batch
+followed by a dirty `WriteSync`; `W->EWS` is an unsynced dirty batch followed
+by an empty `WriteSync`; and `state` is `Set`, `SetSync`, then batch
+`WriteSync`. Times are hook wall time in milliseconds per iteration.
+
+`M`, `E`, and `P` mean value-log `materialization`, `external_ref`, and
+`pending_barrier` logical sync paths respectively.
+
+| Placement | Shape | Appends | command writes / bytes | Flush | Sync | command fsync / ms | value paths | value fsync / ms |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: | --- | ---: |
+| inline | D1 | 1 | 1 / 134.5 | 0 | 1 | 1 / 7.816 | - | 0 / 0 |
+| inline | D8 | 1 | 1 / 480.5 | 0 | 1 | 1 / 10.493 | - | 0 / 0 |
+| inline | D32 | 1 | 1 / 1,680 | 0 | 1 | 1 / 6.551 | - | 0 / 0 |
+| inline | W->DWS | 2 | 2 / 269 | 1 | 1 | 1 / 6.570 | - | 0 / 0 |
+| inline | W->EWS | 1 | 1 / 134.5 | 1 | 1 | 1 / 6.565 | - | 0 / 0 |
+| inline | state | 3 | 3 / 425.5 | 1 | 2 | 2 / 13.184 | - | 0 / 0 |
+| pointer | D1 | 1 | 1 / 118.5 | 0 | 1 | 1 / 6.760 | M + E | 2 / 7.869 |
+| pointer | D8 | 1 | 1 / 352.5 | 0 | 1 | 1 / 6.756 | M + E | 2 / 7.759 |
+| pointer | D32 | 1 | 1 / 1,168 | 0 | 1 | 1 / 6.467 | M + E | 2 / 8.055 |
+| pointer | W->DWS | 2 | 2 / 237 | 1 | 1 | 1 / 6.559 | M + E | 2 / 8.249 |
+| pointer | W->EWS | 1 | 1 / 118.5 | 1 | 1 | 1 / 2.636 | P | 1 / 6.516 |
+| pointer | state | 3 | 3 / 4,458 | 1 | 2 | 2 / 14.205 | M + E | 2 / 8.406 |
+
+The command-write byte mean can be fractional because key lengths cross a
+decimal digit boundary during the 20-iteration samples. Logical sync-path
+counts and actual file-sync-hook counts agree for every isolated row. Segment
+creation/rotation directory syncs are outside the delta window and remain
+separate counters.
+
+## Latency, publication, and residual ledger
+
+`iter` includes the entire named operation mix. `WS wall` is the exclusive
+batch-`WriteSync` phase wall, so it excludes the preceding `Write` in the two
+arrow shapes and excludes the state row's point `Set`/`SetSync`. The state
+latency distribution contains both durable point and durable batch samples.
+
+| Placement | Shape | iter ms | B/op | allocs/op | WS wall ms | preflight ms | callback ms | publish us | residual us | p50 ms | p95 ms | named % |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| inline | D1 | 7.876 | 5,710 | 21.0 | 7.862 | 0.005 | 7.835 | 17.260 | 3.839 | 6.844 | 12.026 | 99.951 |
+| inline | D8 | 10.575 | 9,170 | 35.0 | 10.562 | 0.005 | 10.531 | 22.682 | 3.541 | 11.076 | 12.060 | 99.966 |
+| inline | D32 | 6.645 | 16,148 | 60.3 | 6.623 | 0.005 | 6.587 | 27.343 | 3.823 | 6.434 | 7.434 | 99.942 |
+| inline | W->DWS | 6.648 | 10,711 | 36.0 | 6.602 | 0.004 | 6.579 | 14.070 | 5.105 | 6.375 | 7.253 | 99.923 |
+| inline | W->EWS | 6.625 | 7,239 | 20.0 | 6.572 | 0 | 6.568 | 0 | 3.570 | 6.354 | 7.236 | 99.946 |
+| inline | state | 13.312 | 33,811 | 38.3 | 6.484 | 0.007 | 6.455 | 18.498 | 3.984 | 6.398 | 7.271 | 99.939 |
+| pointer | D1 | 15.122 | 7,143 | 37.0 | 15.106 | 6.848 | 8.231 | 23.617 | 3.755 | 15.093 | 17.224 | 99.975 |
+| pointer | D8 | 15.047 | 10,807 | 51.3 | 15.027 | 6.806 | 8.189 | 27.925 | 3.677 | 15.091 | 15.752 | 99.976 |
+| pointer | D32 | 15.073 | 19,476 | 78.0 | 15.048 | 7.044 | 7.972 | 28.471 | 3.396 | 15.062 | 15.315 | 99.977 |
+| pointer | W->DWS | 15.277 | 12,498 | 65.7 | 14.888 | 6.808 | 8.060 | 17.723 | 2.993 | 14.993 | 16.868 | 99.980 |
+| pointer | W->EWS | 9.601 | 8,386 | 36.0 | 9.161 | 0 | 9.158 | 0 | 3.510 | 9.440 | 9.940 | 99.962 |
+| pointer | state | 23.154 | 8,675 | 42.3 | 15.709 | 7.053 | 8.635 | 16.898 | 3.565 | 9.421 | 20.776 | 99.977 |
+
+The measured value-log lane-lock wait is 159 ns/op or less in every row. The
+mutex profile contains only 230 microseconds total delay in the 100-operation
+profile, so there is no material local lock target in this focused path.
+
+## Linux syscall validation
+
+Go's production file hook is `os.File.Sync`. On this Linux/Go build it maps to
+`fsync(2)`. The five-iteration measured window in `strace_active_window.txt`
+contains exactly:
+
+| Operation | Writes | fsync calls | strace fsync total | in-process hook total |
+| --- | ---: | ---: | ---: | ---: |
+| value-log file | 5 | 10 | 37.639 ms | 37.934 ms |
+| command-WAL file | 5 | 5 | 28.496 ms | 28.601 ms |
+
+The sequence repeats as value write, value materialization `fsync`, value
+external-reference `fsync`, command write, command `fsync`. The trace also
+contains benchmark warmup, open, close, checkpoint, rotation, and directory
+sync activity outside the timestamped active window; those calls must not be
+charged to the five measured public operations.
+
+This validates both the production mapping and the deterministic hook tests.
+It also proves that the two pointer value-log sync observations are two
+physical syscalls on this host.
+
+## State and application interval reconciliation
+
+The accepted state interval is explained without a duplicate sync inside one
+batch call:
+
+```text
+3,595 appends
+  = 1,199 entry-scan batch WriteSync frames
+  + 1,198 point SetSync frames
+  + 1,198 point Set frames
+
+2,408 logical command-WAL sync observations
+  = 1,199 batch WriteSync syncs
+  + 1,198 point SetSync syncs
+  + 11 checkpoint/publication barrier syncs
+```
+
+The 1,198 unsynced point writes account for 1,198 logical flush observations.
+The benchmark's state row reproduces the per-block ratio exactly: three
+appends, three command writes, one flush, two syncs, and two command-file
+syncs. The aggregate application interval uses the same primitives but a
+different operation mix: its 1,212 sync observations do not contain the extra
+per-block point-sync family seen in state.
+
+The original accepted interval predates the exclusive phase counters, so those
+phase durations cannot be assigned retroactively. A matching M0 state active
+window captured 1,187 batch `WriteSync` operations and the exclusive partition:
+
+| Named top-level phase | Total |
+| --- | ---: |
+| checkpoint gate | 0.2282 s |
+| preflight/materialization | 8.5386 s |
+| command callback | 16.6293 s |
+| cached publication/reset | 0.0276 s |
+| residual | 0.00458 s |
+| wall | 25.4283 s |
+
+The first four named categories account for 99.982% of that matching active
+window. Nested inside the callback, value-log external ordering contributes
+8.2433 s and command sync contributes 8.3452 s; they are not added again to
+the exclusive top-level sum. Sampling boundaries and the different 1,187-call
+representative count are stated explicitly rather than splicing these timings
+into the older 1,199-call accepted window.
+
+## Profiles and default overhead
+
+The 100-operation forced-pointer profile is I/O-bound. `perf stat` reports
+90.37 ms task-clock over 1.197 s elapsed (0.075 CPUs) and 3,980 context
+switches. The CPU profile sampled only 70 ms over 1.74 s. Block/trace profiles
+are dominated by background goroutines waiting on channels, and the allocation
+profile includes DB open/close setup; per-operation `B/op` and `allocs/op` are
+therefore taken from the benchmark ledger above.
+
+The existing diagnostic phase option remains disabled by default. At 100
+iterations and five runs, the durable median was 6.611 ms/op disabled versus
+6.613 ms/op enabled (no significant timing difference, `p=0.841`). Enabling
+the detailed diagnostic partition increased 4,845 B/op and 13 allocs/op to
+about 5,037 B/op and 18 allocs/op. The always-on M2 observations are atomic
+counters plus clocks only at actual write/sync boundaries; they do not enable
+the allocation-bearing detailed phase collector.
+
+A same-Go 1.25 base/current comparison with diagnostics disabled found no
+significant default-path change. The adjacent accepted durable reruns measured
+6.491 ms/op at the base and 6.512 ms/op in M2 (`p=0.620`, seven samples), with
+the same 13 allocs/op and statistically unchanged bytes. The relaxed 10,000x
+comparison measured 4.857 versus 5.842 microseconds/op (`p=0.128`, seven
+samples), with identical 12 allocs/op and bytes. An earlier non-interleaved
+durable pair was rejected because a rerun showed its large difference tracked
+device-time ordering rather than the branch; both raw and accepted rerun
+artifacts are retained.
+
+## M3 ranking and guardrail
+
+Only one candidate is supported by the evidence:
+
+1. Coalesce the second pointer-path `external_ref` value-log sync when, and
+   only when, the implementation can prove that the successful materialization
+   sync covered every referenced byte, that no writer or segment rotation can
+   intervene, and that reference lookup/readability remains valid before the
+   later command-WAL sync. The measured ceiling is 1.35-1.46 ms per affected
+   batch, roughly 9-10% of the focused pointer batch wall. The macro effect is
+   unknown and is zero for inline values and the required pending-lane empty
+   barrier.
+
+There is no evidence for removing the command-WAL sync, making acknowledgement
+asynchronous, weakening the durable profile, or checkpointing the backend per
+write. Materialization sync, command sync, and the empty pending-lane barrier
+all carry distinct correctness obligations.

--- a/docs/benchmarks/treedb_durable_write_m2_ledger_2026-07-10.md
+++ b/docs/benchmarks/treedb_durable_write_m2_ledger_2026-07-10.md
@@ -1,7 +1,9 @@
 # TreeDB Durable-Write M2 Barrier Ledger (2026-07-10)
 
-Issue: [#3656](https://github.com/snissn/gomap/issues/3656)  
-Parent: [#3652](https://github.com/snissn/gomap/issues/3652)  
+Issue: [#3656](https://github.com/snissn/gomap/issues/3656)
+
+Parent: [#3652](https://github.com/snissn/gomap/issues/3652)
+
 Base commit: `3e5543145e2f4fd0762b6bdeb1bbcbcb42599f6c`
 
 This is an instrumentation and contract result. It does not change a

--- a/docs/contracts/DURABILITY.md
+++ b/docs/contracts/DURABILITY.md
@@ -36,6 +36,11 @@ the persistent value log, then eventually flushes to the backend.
   On recovery, either the entire batch is applied or none of it is.
 - None of these `*Sync` calls need a backend `Checkpoint()` or `treedb.commit_seq`
   advance per write. The backend root is published later by flush/checkpoint.
+- The exact inline, pointer-backed, `Write`-then-`WriteSync`, and empty-barrier
+  ordering is normative in
+  `TreeDB/docs/spec/command-wal-durable-write-contract.md`. In particular,
+  external value-log bytes are synced before the command frame, and cached
+  publication occurs only after the command-WAL sync succeeds.
 
 Crash recovery:
 - On open, command-WAL segments in `Dir/maindb/wal/` are replayed through the


### PR DESCRIPTION
## Summary

- define the exact inline, pointer-backed, Write-to-WriteSync, empty-barrier, publication, and recovery ordering contract
- distinguish logical append/flush/sync observations from physical command writes, file syncs, directory syncs, value-log sync paths, and lane-lock wait
- extend the durable tiny-write benchmark across 12 placement/operation shapes with exact counter assertions and phase/latency ledgers
- add crash/reopen and deterministic hook coverage without changing durability behavior

Closes #3656
Parent: #3652
Depends on the merged M1 base from #3655 / PR #3692.

## Findings

The accepted state interval is explained by distinct operations:

- 3,595 appends = 1,199 batch WriteSync + 1,198 point SetSync + 1,198 point Set
- 2,408 logical syncs = 1,199 batch + 1,198 point + 11 checkpoint/publication barriers

A single dirty batch WriteSync issues one command-file sync. Forced-pointer batches currently issue two physical value-log syncs before it: materialization and external-reference ordering. Linux strace confirms the five-operation active window exactly: 5 value writes, 10 value-log fsync calls, 5 command writes, and 5 command-WAL fsync calls.

M2 deliberately leaves that behavior unchanged. The only supported M3 candidate is coalescing the second value-log sync under the byte-coverage/no-intervening-writer-or-rotation invariant. Its measured focused ceiling is 1.35-1.46 ms per affected batch; there is no macro throughput claim.

## Evidence

- focused named phase attribution: at least 99.923% across all 12 shapes
- matching state active-window attribution: 99.982%, with nested overlap and sampling limits stated
- full ledger and exact commands: `docs/benchmarks/treedb_durable_write_m2_ledger_2026-07-10.md`
- normative contract: `TreeDB/docs/spec/command-wal-durable-write-contract.md`
- host artifacts: `/mnt/fast4tb/gomap-3656-m2-evidence-20260710`
- same-toolchain base/current default-path comparison: no significant timing, byte, or allocation regression in accepted reruns

## Validation

- `GOWORK=off go test ./TreeDB/... -count=1`
- focused race suite covering new observers, barriers, crash points, and reopen paths
- Windows cross-compilation of commit-log and value-log writer packages
- all 12 benchmark shapes at `20x`, `count=3`
- CPU, allocation, block, mutex, trace, perf, strace, and TreeDB-counter captures

No review has been requested and this PR has not been merged.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added detailed durability and synchronization metrics for cached value logs and command-WAL operations.
  * Added per-path timing, wait, error, write, file-sync, and directory-sync statistics.
  * Empty `WriteSync` operations now act as barriers for previously unsynchronized writes.

* **Documentation**
  * Added durable-write specifications, verification guidance, contract details, and benchmark reporting.

* **Tests**
  * Expanded durability, recovery, ordering, persistence, and synchronization coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->