### PR TITLE
fix(treedb): lock selected shard precheck during iterator rotation

### DIFF
--- a/TreeDB/caching/db.go
+++ b/TreeDB/caching/db.go
@@ -33671,24 +33671,26 @@ func (b *Batch) canApplySmallSelectedSortedShard(shardCounts []int, allowBatchAr
 			continue
 		}
 		shard := &b.db.mutableShards[i]
-		useSteal, _ := cachedBatchWriteUseSteal(b.db, shard.mem)
+		// Iterator rotation replaces shard.mem while holding db.mu then shard.mu.
+		// This precheck takes only shard.mu, releases it before returning, and the
+		// apply phase below locks the shard and rechecks the selected interface.
+		shard.mu.Lock()
+		mem := shard.mem
+		useSteal, _ := cachedBatchWriteUseSteal(b.db, mem)
 		useSteal = allowBatchArenaBorrow && useSteal
-		if useSteal {
-			return false
-		}
-		if allowStableViewValueBorrow {
-			if _, ok := shard.mem.(memtable.CopySelectedSortedBatchApplier); !ok {
-				return false
+		eligible := false
+		if !useSteal {
+			switch {
+			case allowStableViewValueBorrow:
+				_, eligible = mem.(memtable.CopySelectedSortedBatchApplier)
+			case !allowBatchArenaBorrow:
+				_, eligible = mem.(memtable.CopySelectedSortedBatchValueCopier)
+			default:
+				_, eligible = mem.(memtable.CopySelectedSortedBatchApplier)
 			}
-			continue
 		}
-		if !allowBatchArenaBorrow {
-			if _, ok := shard.mem.(memtable.CopySelectedSortedBatchValueCopier); !ok {
-				return false
-			}
-			continue
-		}
-		if _, ok := shard.mem.(memtable.CopySelectedSortedBatchApplier); !ok {
+		shard.mu.Unlock()
+		if !eligible {
 			return false
 		}
 	}

--- a/TreeDB/caching/selected_sorted_rotation_race_test.go
+++ b/TreeDB/caching/selected_sorted_rotation_race_test.go
@@ -1,0 +1,93 @@
+package caching
+
+import (
+	"fmt"
+	"runtime"
+	"sync"
+	"testing"
+)
+
+func TestSmallSelectedSortedBatchRaceWithIteratorRotation(t *testing.T) {
+	db, err := Open(t.TempDir(), NewMockBackend(), Options{
+		DisableWAL:     true,
+		AllowUnsafe:    true,
+		FlushThreshold: 1 << 30,
+		MemtableMode:   "append_only",
+		MemtableShards: 1,
+	})
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	const iterations = 2000
+	start := make(chan struct{})
+	errCh := make(chan error, 2)
+	var workers sync.WaitGroup
+	workers.Add(2)
+	go func() {
+		defer workers.Done()
+		<-start
+		for i := 0; i < iterations; i++ {
+			key := []byte(fmt.Sprintf("key-%02d", i%64))
+			value := []byte(fmt.Sprintf("value-%04d", i))
+			batch := db.NewBatchWithSize(1)
+			if err := batch.Set(key, value); err != nil {
+				_ = batch.Close()
+				errCh <- fmt.Errorf("batch set %d: %w", i, err)
+				return
+			}
+			if err := batch.Write(); err != nil {
+				_ = batch.Close()
+				errCh <- fmt.Errorf("batch write %d: %w", i, err)
+				return
+			}
+			if err := batch.Close(); err != nil {
+				errCh <- fmt.Errorf("batch close %d: %w", i, err)
+				return
+			}
+			runtime.Gosched()
+		}
+	}()
+	go func() {
+		defer workers.Done()
+		<-start
+		for i := 0; i < iterations; i++ {
+			it, err := db.Iterator(nil, nil)
+			if err != nil {
+				errCh <- fmt.Errorf("iterator %d: %w", i, err)
+				return
+			}
+			for it.Valid() {
+				_ = it.Key()
+				_ = it.Value()
+				it.Next()
+			}
+			iterErr := it.Error()
+			closeErr := it.Close()
+			if iterErr != nil || closeErr != nil {
+				errCh <- fmt.Errorf("iterator %d drain=%v close=%v", i, iterErr, closeErr)
+				return
+			}
+			runtime.Gosched()
+		}
+	}()
+	close(start)
+	workers.Wait()
+	close(errCh)
+	for err := range errCh {
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	finalKey := []byte(fmt.Sprintf("key-%02d", (iterations-1)%64))
+	want := fmt.Sprintf("value-%04d", iterations-1)
+	got, err := db.Get(finalKey)
+	if err != nil {
+		t.Fatalf("Get final key %q: %v", finalKey, err)
+	}
+	if string(got) != want {
+		t.Fatalf("Get final key %q = %q, want %q", finalKey, got, want)
+	}
+}


### PR DESCRIPTION
## Summary

- lock each selected mutable shard while reading `shard.mem` during the small selected-sorted eligibility precheck
- release `shard.mu` before returning and preserve the apply phase's locked interface recheck
- add a one-shard append-only regression that races repeated one-entry sorted batch writes with iterator-driven rotation, closes every batch, drains every iterator, and verifies the final committed value

Closes #3707.
Discovered while completing #3673.

## Correctness and lock order

Iterator rotation replaces `shard.mem` while holding `db.mu` and then `shard.mu`. The repaired precheck takes only `shard.mu`; it does not acquire `db.mu`, so it does not invert the existing order. The apply phase still locks the shard and rechecks the selected interface before applying.

No persistent format, WAL, or durability behavior changes.

## Race proof

Exact unpatched base: `e94013508e7fad1d9fb89034ec8dfd6d88c7e6e2`

```text
GOWORK=off go test -race ./TreeDB/caching -run '^TestSmallSelectedSortedBatchRaceWithIteratorRotation$' -count=1
```

The new regression immediately reports the intended race: the write in `rotateMutableShardsLocked` at `db.go:26619` conflicts with the read in `canApplySmallSelectedSortedShard` at `db.go:33674`.

Exact fixed head: `c87fdd5b28a1e558a6168387655133b493246215`

```text
GOWORK=off go test -race ./TreeDB/caching -run '^TestSmallSelectedSortedBatchRaceWithIteratorRotation$' -count=20
ok github.com/snissn/gomap/TreeDB/caching 5.728s
```

## Validation

```text
GOWORK=off go test -race ./TreeDB/caching -count=1
ok github.com/snissn/gomap/TreeDB/caching 73.461s

GOWORK=off go test -race ./TreeDB/mvcc/... -run 'TestPublicSurfaceConformance|TestGetAtConcurrentReaders|TestPruneConcurrentSnapshotReaders|TestPruneAfterSnapshotCaptureDoesNotBlockForegroundOperations|TestFloorAdvanceRaceNeverServesPrunedHistoricalRead' -count=3
ok github.com/snissn/gomap/TreeDB/mvcc 2.724s

GOWORK=off go vet ./TreeDB/...

GOWORK=off go test ./TreeDB/... -count=1
# all TreeDB packages passed; longest package:
ok github.com/snissn/gomap/TreeDB/db 292.418s
```

## Performance smoke

Existing one-entry direct commit benchmark, serialized with `GOMAXPROCS=1`:

```text
GOMAXPROCS=1 GOWORK=off go test ./TreeDB/mvcc -run '^$' -bench '^BenchmarkCommitAt/DirectTreeDB/1$' -benchmem -benchtime=750ms -count=10
```

- base median: approximately 3,983 ns/op
- fixed median: approximately 3,943 ns/op
- both: 9 allocs/op and approximately 7.4 KiB/op

No material regression observed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when iterators and batch writes run concurrently during memory rotation.
  * Prevented inconsistent eligibility checks that could affect batch processing.

* **Tests**
  * Added coverage for concurrent batch updates and iterator operations, including validation of final stored values and iterator completion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->