### PR TITLE
perf(treedb): reduce sparse leaf-pack apply cost

### DIFF
--- a/TreeDB/db/leaf_generation_pack.go
+++ b/TreeDB/db/leaf_generation_pack.go
@@ -63,6 +63,49 @@ type LeafGenerationPackOptions struct {
 	ProtectedSystemRootIDs     []uint64
 }
 
+// LeafGenerationPackApplyStageStats attributes copy and publication wall time.
+// DirectorySyncTimeNanos is diagnostic operation wall and may overlap page
+// relocation/sync; DirectorySyncWaitTimeNanos is the non-overlapping portion
+// charged to the exclusive publication path.
+type LeafGenerationPackApplyStageStats struct {
+	SetupTimeNanos             int64
+	TreeRewriteTimeNanos       int64
+	LeafSyncTimeNanos          int64
+	CopyCloseTimeNanos         int64
+	RevalidateTimeNanos        int64
+	PromotionTimeNanos         int64
+	RelocationTimeNanos        int64
+	PageSyncTimeNanos          int64
+	DirectorySyncTimeNanos     int64
+	DirectorySyncWaitTimeNanos int64
+	RegistrationTimeNanos      int64
+	CollectionPublishTimeNanos int64
+	FinalizeTimeNanos          int64
+	PostWorkTimeNanos          int64
+	CleanupTimeNanos           int64
+}
+
+func (s *LeafGenerationPackApplyStageStats) add(other LeafGenerationPackApplyStageStats) {
+	if s == nil {
+		return
+	}
+	s.SetupTimeNanos += other.SetupTimeNanos
+	s.TreeRewriteTimeNanos += other.TreeRewriteTimeNanos
+	s.LeafSyncTimeNanos += other.LeafSyncTimeNanos
+	s.CopyCloseTimeNanos += other.CopyCloseTimeNanos
+	s.RevalidateTimeNanos += other.RevalidateTimeNanos
+	s.PromotionTimeNanos += other.PromotionTimeNanos
+	s.RelocationTimeNanos += other.RelocationTimeNanos
+	s.PageSyncTimeNanos += other.PageSyncTimeNanos
+	s.DirectorySyncTimeNanos += other.DirectorySyncTimeNanos
+	s.DirectorySyncWaitTimeNanos += other.DirectorySyncWaitTimeNanos
+	s.RegistrationTimeNanos += other.RegistrationTimeNanos
+	s.CollectionPublishTimeNanos += other.CollectionPublishTimeNanos
+	s.FinalizeTimeNanos += other.FinalizeTimeNanos
+	s.PostWorkTimeNanos += other.PostWorkTimeNanos
+	s.CleanupTimeNanos += other.CleanupTimeNanos
+}
+
 type LeafGenerationPackStats struct {
 	GenerationsRequested            int
 	GenerationsMatched              int
@@ -91,6 +134,8 @@ type LeafGenerationPackStats struct {
 	PublishHoldNanos                int64
 	PrivatePagesAllocated           int
 	PrivatePagesDiscarded           int
+	ApplyStages                     LeafGenerationPackApplyStageStats
+	RetryApplyStages                LeafGenerationPackApplyStageStats
 	WallTimeNanos                   int64
 }
 
@@ -255,6 +300,7 @@ func (db *DB) leafGenerationPackLocked(ctx context.Context, opts LeafGenerationP
 	const maxCopyAttempts = 2
 	for attempt := 1; attempt <= maxCopyAttempts; attempt++ {
 		stats.CopyAttempts++
+		attemptStarted := time.Now()
 		stagingDir, err := os.MkdirTemp(layout.leafVLogDir, ".leaf-pack-copy-")
 		if err != nil {
 			return stats, err
@@ -266,6 +312,7 @@ func (db *DB) leafGenerationPackLocked(ctx context.Context, opts LeafGenerationP
 		}
 		writer := newRewriteWriter(layout.valueVLogDir, 0, 0, 0)
 		writer.ConfigureLeafLog(privateLeafDir, rewriteLeafLogLaneID, leafStartSeq)
+		writer.configureLeafStaging()
 		writer.setLeafPageLogSeqAllocator(seqAlloc)
 		writer.setLeafPageLogRIDAllocator(ridAlloc)
 		writer.blockCompression = blockCompression
@@ -281,13 +328,18 @@ func (db *DB) leafGenerationPackLocked(ctx context.Context, opts LeafGenerationP
 			protectedRootIDs:       opts.ProtectedRootIDs,
 			protectedSystemRootIDs: opts.ProtectedSystemRootIDs,
 		}
+		rewriteStarted := time.Now()
 		copied, copiedBytes, rewriteErr := db.rewriteLeafRefsOnline(ctx, writer, ridAlloc, sourceValueIDs, nil, 0, 0, false, 0, opts.Sync, normalizeLeafGenerationPackLeafFrameK(opts.LeafFrameK), attempt, &rewriteStats)
+		rewriteStats.ApplyStages.SetupTimeNanos += rewriteStarted.Sub(attemptStarted).Nanoseconds()
+		cleanupStarted := time.Now()
 		closeErr := writer.Close()
 		removeErr := removeLeafGenerationPackStagingDirFn(stagingDir)
+		rewriteStats.ApplyStages.CleanupTimeNanos += time.Since(cleanupStarted).Nanoseconds()
 		stats.CopyTimeNanos += rewriteStats.CopyTimeNanos
 		stats.PublishWaitNanos += rewriteStats.PublishWaitNanos
 		stats.PublishHoldNanos += rewriteStats.PublishHoldNanos
 		stats.PrivatePagesAllocated += rewriteStats.PrivatePages
+		stats.ApplyStages.add(rewriteStats.ApplyStages)
 		if carry != nil {
 			carry.sourceStateKey = rewriteStats.sourceStateKey
 			carry.publishedState = rewriteStats.publishedState
@@ -299,6 +351,7 @@ func (db *DB) leafGenerationPackLocked(ctx context.Context, opts LeafGenerationP
 			stats.CopyAborts++
 			stats.RetryCopyTimeNanos += rewriteStats.CopyTimeNanos
 			stats.PrivatePagesDiscarded += rewriteStats.PrivatePages
+			stats.RetryApplyStages.add(rewriteStats.ApplyStages)
 			if closeErr != nil || removeErr != nil {
 				return stats, errors.Join(rewriteErr, closeErr, removeErr)
 			}

--- a/TreeDB/db/leaf_generation_pack_concurrency_test.go
+++ b/TreeDB/db/leaf_generation_pack_concurrency_test.go
@@ -189,6 +189,12 @@ func TestLeafGenerationPack_ChangedOverlappingRootDiscardsCopyAndRetries(t *test
 		if result.stats.CopyAborts != 1 || result.stats.PrivatePagesDiscarded == 0 {
 			t.Fatalf("stale copy cleanup stats=%+v", result.stats)
 		}
+		if result.stats.RetryApplyStages.TreeRewriteTimeNanos <= 0 || result.stats.RetryApplyStages.LeafSyncTimeNanos <= 0 {
+			t.Fatalf("discarded attempt stages were not accounted separately: %+v", result.stats)
+		}
+		if result.stats.RetryApplyStages.TreeRewriteTimeNanos >= result.stats.ApplyStages.TreeRewriteTimeNanos {
+			t.Fatalf("aggregate stages do not include successful retry: %+v", result.stats)
+		}
 	case <-time.After(15 * time.Second):
 		t.Fatal("pack did not finish after overlapping write")
 	}

--- a/TreeDB/db/leaf_generation_pack_rewrite.go
+++ b/TreeDB/db/leaf_generation_pack_rewrite.go
@@ -1543,11 +1543,11 @@ func (db *DB) rewriteLeafRefsOnline(ctx context.Context, writer *rewriteWriter, 
 	if len(createdSegments) > 0 {
 		dirSyncCh = make(chan leafGenerationPackDirectorySyncResult, 1)
 		leafVLogDir := resolveStorageLayout(db.dir).leafVLogDir
-		go func() {
-			started := time.Now()
+		started := time.Now()
+		go func(started time.Time) {
 			err := syncDirFn(leafVLogDir)
 			dirSyncCh <- leafGenerationPackDirectorySyncResult{err: err, timeNanos: time.Since(started).Nanoseconds()}
-		}()
+		}(started)
 	}
 
 	var leafManifest *leafGenerationManifest

--- a/TreeDB/db/leaf_generation_pack_rewrite.go
+++ b/TreeDB/db/leaf_generation_pack_rewrite.go
@@ -197,6 +197,7 @@ type leafRefRewriteRunStats struct {
 	PublishHoldNanos                       int64
 	PrivatePages                           int
 	PublishConflict                        bool
+	ApplyStages                            LeafGenerationPackApplyStageStats
 	trackCarry                             bool
 	trackSourceLiveMoved                   bool
 	protectedRootIDs                       []uint64
@@ -1153,6 +1154,7 @@ func promoteLeafGenerationPackSegments(created []rewriteCreatedSegment, leafDir 
 }
 
 func (db *DB) rewriteLeafRefsOnline(ctx context.Context, writer *rewriteWriter, ridAlloc *rewriteRIDAllocator, sourceIDs map[uint32]struct{}, sourceChunks map[valueLogChunkKey]ValueLogRewritePlanChunk, sourceChunkBytes int64, singleSourceID uint32, hasSingleSourceID bool, maxCopiedBytes int64, _ bool, leafFrameK int, attempt int, runStats *leafRefRewriteRunStats) (copied int, copiedBytes int64, err error) {
+	applyStarted := time.Now()
 	if db == nil {
 		return 0, 0, fmt.Errorf("missing db")
 	}
@@ -1243,6 +1245,9 @@ func (db *DB) rewriteLeafRefsOnline(ctx context.Context, writer *rewriteWriter, 
 		}
 	}
 
+	if runStats != nil {
+		runStats.ApplyStages.SetupTimeNanos += time.Since(applyStarted).Nanoseconds()
+	}
 	copyStarted := time.Now()
 	leafCtx := &leafRefRewriteCtx{
 		ctx:                  ctx,
@@ -1356,6 +1361,7 @@ func (db *DB) rewriteLeafRefsOnline(ctx context.Context, writer *rewriteWriter, 
 	}
 	if !sysChanged && !userChanged {
 		if runStats != nil {
+			runStats.ApplyStages.TreeRewriteTimeNanos += time.Since(copyStarted).Nanoseconds()
 			runStats.CopyTimeNanos = time.Since(copyStarted).Nanoseconds()
 		}
 		return 0, 0, nil
@@ -1375,13 +1381,21 @@ func (db *DB) rewriteLeafRefsOnline(ctx context.Context, writer *rewriteWriter, 
 		CreatedFileIDs: append([]uint32(nil), createdIDs...),
 		PrivatePageIDs: append([]uint64(nil), privatePages...),
 	})
+	if runStats != nil {
+		runStats.ApplyStages.TreeRewriteTimeNanos += time.Since(copyStarted).Nanoseconds()
+	}
 
 	// Pack publication is always durable. Copy fsync remains outside writeMu;
 	// Sync=false is retained only for source compatibility with the pre-alpha
 	// API and no longer weakens the root/segment publication contract.
+	leafSyncStarted := time.Now()
 	if err := writer.Sync(); err != nil {
 		return 0, 0, fmt.Errorf("vlog-rewrite: sync rewritten leaf refs: %w", err)
 	}
+	if runStats != nil {
+		runStats.ApplyStages.LeafSyncTimeNanos += time.Since(leafSyncStarted).Nanoseconds()
+	}
+	copyCloseStarted := time.Now()
 	// The private index pages live only in memory and are never a publication
 	// candidate. Their reconstructed live-pager pages are synchronized before the
 	// alternate meta page.
@@ -1401,6 +1415,7 @@ func (db *DB) rewriteLeafRefsOnline(ctx context.Context, writer *rewriteWriter, 
 		return 0, 0, fmt.Errorf("vlog-rewrite: close copied leaf refs: %w", err)
 	}
 	if runStats != nil {
+		runStats.ApplyStages.CopyCloseTimeNanos += time.Since(copyCloseStarted).Nanoseconds()
 		runStats.CopyTimeNanos = time.Since(copyStarted).Nanoseconds()
 	}
 
@@ -1424,6 +1439,7 @@ func (db *DB) rewriteLeafRefsOnline(ctx context.Context, writer *rewriteWriter, 
 	if !db.leafGenerationPackCopyBasisMatches(basis) {
 		if runStats != nil {
 			runStats.PublishConflict = true
+			runStats.ApplyStages.RevalidateTimeNanos += time.Since(publishStarted).Nanoseconds()
 		}
 		unlockPublish()
 		return 0, 0, errLeafGenerationPackPublishConflict
@@ -1452,6 +1468,7 @@ func (db *DB) rewriteLeafRefsOnline(ctx context.Context, writer *rewriteWriter, 
 	if !db.leafGenerationPackCopyBasisMatches(basis) {
 		if runStats != nil {
 			runStats.PublishConflict = true
+			runStats.ApplyStages.RevalidateTimeNanos += time.Since(publishStarted).Nanoseconds()
 		}
 		unlockPublish()
 		return 0, 0, errLeafGenerationPackPublishConflict
@@ -1466,19 +1483,31 @@ func (db *DB) rewriteLeafRefsOnline(ctx context.Context, writer *rewriteWriter, 
 		return 0, 0, fmt.Errorf("vlog-rewrite: promotion failpoint: %w", err)
 	}
 
+	if runStats != nil {
+		runStats.ApplyStages.RevalidateTimeNanos += time.Since(publishStarted).Nanoseconds()
+	}
+	promotionStarted := time.Now()
 	promotedSegments, promoteErr := promoteLeafGenerationPackSegments(createdSegments, resolveStorageLayout(db.dir).leafVLogDir)
+	if runStats != nil {
+		runStats.ApplyStages.PromotionTimeNanos += time.Since(promotionStarted).Nanoseconds()
+	}
 	createdSegments = promotedSegments
 	var (
 		publishAlloc *leafGenerationPackPublishAllocator
-		dirSyncCh    chan error
+		dirSyncCh    chan leafGenerationPackDirectorySyncResult
 	)
 	waitDirectorySync := func() error {
 		if dirSyncCh == nil {
 			return nil
 		}
-		err := <-dirSyncCh
+		waitStarted := time.Now()
+		result := <-dirSyncCh
 		dirSyncCh = nil
-		return err
+		if runStats != nil {
+			runStats.ApplyStages.DirectorySyncTimeNanos += result.timeNanos
+			runStats.ApplyStages.DirectorySyncWaitTimeNanos += time.Since(waitStarted).Nanoseconds()
+		}
+		return result.err
 	}
 	cleanupCreatedSegments := func(baseErr error) (int, int64, error) {
 		if syncErr := waitDirectorySync(); syncErr != nil {
@@ -1512,9 +1541,13 @@ func (db *DB) rewriteLeafRefsOnline(ctx context.Context, writer *rewriteWriter, 
 		return cleanupAndUnlock(fmt.Errorf("vlog-rewrite: promoted leaf directory failpoint: %w", err))
 	}
 	if len(createdSegments) > 0 {
-		dirSyncCh = make(chan error, 1)
+		dirSyncCh = make(chan leafGenerationPackDirectorySyncResult, 1)
 		leafVLogDir := resolveStorageLayout(db.dir).leafVLogDir
-		go func() { dirSyncCh <- syncDirFn(leafVLogDir) }()
+		go func() {
+			started := time.Now()
+			err := syncDirFn(leafVLogDir)
+			dirSyncCh <- leafGenerationPackDirectorySyncResult{err: err, timeNanos: time.Since(started).Nanoseconds()}
+		}()
 	}
 
 	var leafManifest *leafGenerationManifest
@@ -1550,6 +1583,9 @@ func (db *DB) rewriteLeafRefsOnline(ctx context.Context, writer *rewriteWriter, 
 		return cleanupAndUnlock(fmt.Errorf("vlog-rewrite: publish system root: %w", err))
 	}
 	relocateDuration := time.Since(relocateStarted)
+	if runStats != nil {
+		runStats.ApplyStages.RelocationTimeNanos += relocateDuration.Nanoseconds()
+	}
 	publishRetired := leafGenerationPackCommittedRetired(leafCtx.retired)
 	// The target-directory and index-page durability fences are independent and
 	// can run concurrently. Both complete before registration or meta write.
@@ -1558,6 +1594,9 @@ func (db *DB) rewriteLeafRefsOnline(ctx context.Context, writer *rewriteWriter, 
 		return cleanupAndUnlock(fmt.Errorf("vlog-rewrite: sync published index pages: %w", err))
 	}
 	pageSyncDuration := time.Since(pageSyncStarted)
+	if runStats != nil {
+		runStats.ApplyStages.PageSyncTimeNanos += pageSyncDuration.Nanoseconds()
+	}
 	dirWaitStarted := time.Now()
 	if err := waitDirectorySync(); err != nil {
 		return cleanupAndUnlock(fmt.Errorf("vlog-rewrite: sync promoted leaf directory: %w", err))
@@ -1586,7 +1625,12 @@ func (db *DB) rewriteLeafRefsOnline(ctx context.Context, writer *rewriteWriter, 
 	if err := runLeafGenerationPackPublishHook(publishEvent); err != nil {
 		return cleanupAndUnlock(fmt.Errorf("vlog-rewrite: post-registration failpoint: %w", err))
 	}
+	registerDuration := time.Since(registerStarted)
+	if runStats != nil {
+		runStats.ApplyStages.RegistrationTimeNanos += registerDuration.Nanoseconds()
+	}
 
+	collectionPublishStarted := time.Now()
 	if len(publishCollectionReplacements) > 0 {
 		if db.leafPageLog == nil {
 			return cleanupAndUnlock(errors.New("vlog-rewrite: collection root publication requires leaf page log"))
@@ -1614,18 +1658,23 @@ func (db *DB) rewriteLeafRefsOnline(ctx context.Context, writer *rewriteWriter, 
 			return cleanupAndUnlock(fmt.Errorf("vlog-rewrite: sync published collection index pages: %w", err))
 		}
 	}
+	if runStats != nil {
+		runStats.ApplyStages.CollectionPublishTimeNanos += time.Since(collectionPublishStarted).Nanoseconds()
+	}
 	publishEvent.Phase = leafGenerationPackBeforeMetaWrite
 	if err := runLeafGenerationPackPublishHook(publishEvent); err != nil {
 		return cleanupAndUnlock(fmt.Errorf("vlog-rewrite: meta write failpoint: %w", err))
 	}
 
-	registerDuration := time.Since(registerStarted)
 	finalizeStarted := time.Now()
 	post, finalizeErr := db.finalizeCommitLockedWithOptions(publishedRoot, publishedSysRoot, publishRetired, true, adaptive.Metrics{}, createdIDs, len(publishCollectionReplacements) > 0, nil, leafManifest, leafManifestRawFileIDs, finalizeCommitOptions{
 		skipPrePublishFlush: true,
 		syncMetaPageOnly:    true,
 	})
 	finalizeDuration := time.Since(finalizeStarted)
+	if runStats != nil {
+		runStats.ApplyStages.FinalizeTimeNanos += finalizeDuration.Nanoseconds()
+	}
 	if finalizeErr != nil {
 		if !finalizeCommitErrorAllowsCreatedSegmentCleanup(finalizeErr) {
 			// The alternate meta page was written and its durability outcome is
@@ -1648,6 +1697,15 @@ func (db *DB) rewriteLeafRefsOnline(ctx context.Context, writer *rewriteWriter, 
 	}
 	commitTimingPrintf("treedb: leaf_pack_publish relocate=%s page_sync=%s dir_wait=%s register=%s finalize=%s total=%s\n", relocateDuration, pageSyncDuration, dirWaitDuration, registerDuration, finalizeDuration, time.Since(publishStarted))
 	unlockPublish()
+	postWorkStarted := time.Now()
 	db.finalizeCommitPostWork(post)
+	if runStats != nil {
+		runStats.ApplyStages.PostWorkTimeNanos += time.Since(postWorkStarted).Nanoseconds()
+	}
 	return leafCtx.copied, leafCtx.copiedBytes, nil
+}
+
+type leafGenerationPackDirectorySyncResult struct {
+	err       error
+	timeNanos int64
 }

--- a/TreeDB/db/leaf_generation_pack_stage_stats_test.go
+++ b/TreeDB/db/leaf_generation_pack_stage_stats_test.go
@@ -1,0 +1,76 @@
+package db
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+)
+
+func TestLeafGenerationPack_ApplyStageAccounting(t *testing.T) {
+	db, leafLog, _ := openLeafGenerationPackTestDB(t)
+	candidate := prepareLeafGenerationPackTestCandidate(t, db, leafLog, 1024)
+
+	stats, err := db.LeafGenerationPack(context.Background(), LeafGenerationPackOptions{
+		GenerationIDs: []uint64{candidate.generation.GenerationID},
+		Force:         true,
+	})
+	if err != nil {
+		t.Fatalf("LeafGenerationPack: %v", err)
+	}
+	stages := stats.ApplyStages
+	if stages.TreeRewriteTimeNanos <= 0 || stages.LeafSyncTimeNanos <= 0 {
+		t.Fatalf("copy stage timings were not populated: %+v", stages)
+	}
+	if stages.PageSyncTimeNanos <= 0 || stages.FinalizeTimeNanos <= 0 {
+		t.Fatalf("publish stage timings were not populated: %+v", stages)
+	}
+	copyAttributed := stages.TreeRewriteTimeNanos + stages.LeafSyncTimeNanos + stages.CopyCloseTimeNanos
+	if copyAttributed > stats.CopyTimeNanos {
+		t.Fatalf("copy stages=%d exceed copy wall=%d: %+v", copyAttributed, stats.CopyTimeNanos, stages)
+	}
+	publishAttributed := stages.RevalidateTimeNanos + stages.PromotionTimeNanos + stages.RelocationTimeNanos +
+		stages.PageSyncTimeNanos + stages.DirectorySyncWaitTimeNanos + stages.RegistrationTimeNanos +
+		stages.CollectionPublishTimeNanos + stages.FinalizeTimeNanos
+	if publishAttributed > stats.PublishHoldNanos {
+		t.Fatalf("exclusive publish stages=%d exceed publish hold=%d: %+v", publishAttributed, stats.PublishHoldNanos, stages)
+	}
+	if stages.DirectorySyncWaitTimeNanos > stages.DirectorySyncTimeNanos {
+		t.Fatalf("directory sync wait=%d exceeds operation wall=%d", stages.DirectorySyncWaitTimeNanos, stages.DirectorySyncTimeNanos)
+	}
+	if stats.RetryApplyStages != (LeafGenerationPackApplyStageStats{}) {
+		t.Fatalf("successful first attempt reported retry stages: %+v", stats.RetryApplyStages)
+	}
+}
+
+func TestLeafGenerationPackStats_JSONTimingFieldsRemainAdditive(t *testing.T) {
+	const legacy = `{"CopyTimeNanos":11,"RetryCopyTimeNanos":12,"PublishWaitNanos":13,"PublishHoldNanos":14}`
+	var decoded LeafGenerationPackStats
+	if err := json.Unmarshal([]byte(legacy), &decoded); err != nil {
+		t.Fatalf("Unmarshal legacy stats: %v", err)
+	}
+	if decoded.CopyTimeNanos != 11 || decoded.RetryCopyTimeNanos != 12 || decoded.PublishWaitNanos != 13 || decoded.PublishHoldNanos != 14 {
+		t.Fatalf("legacy timing fields changed: %+v", decoded)
+	}
+
+	decoded.ApplyStages.TreeRewriteTimeNanos = 15
+	encoded, err := json.Marshal(decoded)
+	if err != nil {
+		t.Fatalf("Marshal stats: %v", err)
+	}
+	var fields map[string]json.RawMessage
+	if err := json.Unmarshal(encoded, &fields); err != nil {
+		t.Fatalf("Unmarshal encoded stats: %v", err)
+	}
+	for _, name := range []string{
+		"CopyTimeNanos",
+		"RetryCopyTimeNanos",
+		"PublishWaitNanos",
+		"PublishHoldNanos",
+		"ApplyStages",
+		"RetryApplyStages",
+	} {
+		if _, ok := fields[name]; !ok {
+			t.Fatalf("encoded stats missing %q: %s", name, encoded)
+		}
+	}
+}

--- a/TreeDB/db/leaf_generation_pack_stage_stats_test.go
+++ b/TreeDB/db/leaf_generation_pack_stage_stats_test.go
@@ -18,19 +18,19 @@ func TestLeafGenerationPack_ApplyStageAccounting(t *testing.T) {
 		t.Fatalf("LeafGenerationPack: %v", err)
 	}
 	stages := stats.ApplyStages
-	if stages.TreeRewriteTimeNanos <= 0 || stages.LeafSyncTimeNanos <= 0 {
+	copyAttributed := stages.TreeRewriteTimeNanos + stages.LeafSyncTimeNanos + stages.CopyCloseTimeNanos
+	if copyAttributed <= 0 {
 		t.Fatalf("copy stage timings were not populated: %+v", stages)
 	}
-	if stages.PageSyncTimeNanos <= 0 || stages.FinalizeTimeNanos <= 0 {
-		t.Fatalf("publish stage timings were not populated: %+v", stages)
-	}
-	copyAttributed := stages.TreeRewriteTimeNanos + stages.LeafSyncTimeNanos + stages.CopyCloseTimeNanos
 	if copyAttributed > stats.CopyTimeNanos {
 		t.Fatalf("copy stages=%d exceed copy wall=%d: %+v", copyAttributed, stats.CopyTimeNanos, stages)
 	}
 	publishAttributed := stages.RevalidateTimeNanos + stages.PromotionTimeNanos + stages.RelocationTimeNanos +
 		stages.PageSyncTimeNanos + stages.DirectorySyncWaitTimeNanos + stages.RegistrationTimeNanos +
 		stages.CollectionPublishTimeNanos + stages.FinalizeTimeNanos
+	if publishAttributed <= 0 {
+		t.Fatalf("publish stage timings were not populated: %+v", stages)
+	}
 	if publishAttributed > stats.PublishHoldNanos {
 		t.Fatalf("exclusive publish stages=%d exceed publish hold=%d: %+v", publishAttributed, stats.PublishHoldNanos, stages)
 	}

--- a/TreeDB/db/vlog_rewrite.go
+++ b/TreeDB/db/vlog_rewrite.go
@@ -3356,6 +3356,7 @@ type rewriteWriter struct {
 	currentFileID     uint32
 	leafCurrentPath   string
 	leafCurrentFileID uint32
+	leafStaging       bool
 	lastLeafRecordLen uint32
 	// blockCompression enables per-frame block compression for dictID=0 append
 	// paths (used by online rewrite). Offline rewrites use AppendRawRecord and do
@@ -3441,6 +3442,12 @@ func (w *rewriteWriter) ConfigureLeafLog(leafDir string, lane, startSeq uint32) 
 	w.leafSeq = startSeq
 }
 
+func (w *rewriteWriter) configureLeafStaging() {
+	if w != nil {
+		w.leafStaging = true
+	}
+}
+
 func (w *rewriteWriter) setLeafPageLogSeqAllocator(seqAlloc *leafLogSeqAllocator) {
 	if w == nil {
 		return
@@ -3483,6 +3490,7 @@ func (w *rewriteWriter) cloneLeafPageLogLane(seqAlloc *leafLogSeqAllocator, ridA
 	clone := newRewriteWriter(w.walDir, w.lane, 0, w.maxSize)
 	clone.leafDir = w.leafDir
 	clone.leafLane = w.leafLane
+	clone.leafStaging = w.leafStaging
 	clone.leafSeqAllocator = seqAlloc
 	clone.ridAlloc = ridAlloc
 	clone.blockCompression = w.blockCompression
@@ -4118,7 +4126,12 @@ func (w *rewriteWriter) rotateLeaf() error {
 	}
 	path := filepath.Join(w.leafDir, fmt.Sprintf("value-l%d-%06d.log", w.leafLane, nextSeq))
 	if w.leafW == nil {
-		writer, err := valuelog.NewWriter(path, fileID)
+		var writer *valuelog.Writer
+		if w.leafStaging {
+			writer, err = valuelog.NewStagingWriter(path, fileID)
+		} else {
+			writer, err = valuelog.NewWriter(path, fileID)
+		}
 		if err != nil {
 			return err
 		}

--- a/TreeDB/internal/valuelog/sync_staging_file_linux.go
+++ b/TreeDB/internal/valuelog/sync_staging_file_linux.go
@@ -1,0 +1,25 @@
+//go:build linux
+
+package valuelog
+
+import (
+	"os"
+	"runtime"
+
+	"golang.org/x/sys/unix"
+)
+
+func syncStagingFileData(file *os.File) error {
+	fd := int(file.Fd())
+	for {
+		err := unix.Fdatasync(fd)
+		runtime.KeepAlive(file)
+		if err == unix.EINTR {
+			continue
+		}
+		if err == unix.ENOSYS || err == unix.EINVAL {
+			return file.Sync()
+		}
+		return err
+	}
+}

--- a/TreeDB/internal/valuelog/sync_staging_file_other.go
+++ b/TreeDB/internal/valuelog/sync_staging_file_other.go
@@ -1,0 +1,9 @@
+//go:build !linux
+
+package valuelog
+
+import "os"
+
+func syncStagingFileData(file *os.File) error {
+	return file.Sync()
+}

--- a/TreeDB/internal/valuelog/valuelog_test.go
+++ b/TreeDB/internal/valuelog/valuelog_test.go
@@ -172,6 +172,33 @@ func TestWriterRotateToWithSyncFalseSkipsRotateSync(t *testing.T) {
 	}
 }
 
+func TestNewStagingWriterSkipsDirectorySync(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "staging.log")
+
+	original := syncDirFn
+	dirSyncs := 0
+	syncDirFn = func(string) error {
+		dirSyncs++
+		return nil
+	}
+	t.Cleanup(func() { syncDirFn = original })
+
+	writer, err := NewStagingWriter(path, page.ValueLogFileID(1))
+	if err != nil {
+		t.Fatalf("NewStagingWriter: %v", err)
+	}
+	if err := writer.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	if dirSyncs != 0 {
+		t.Fatalf("staging directory syncs=%d want 0", dirSyncs)
+	}
+	if _, err := os.Stat(path); err != nil {
+		t.Fatalf("staging file: %v", err)
+	}
+}
+
 func TestValueLogAppendRead(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "value-000001.log")

--- a/TreeDB/internal/valuelog/writer.go
+++ b/TreeDB/internal/valuelog/writer.go
@@ -554,17 +554,31 @@ func shouldUseEncodeAllParts(records []Record, rawPayloadBytes int) bool {
 }
 
 func NewWriter(path string, fileID uint32) (*Writer, error) {
+	return newFileWriter(path, fileID, true, func(file *os.File) error { return file.Sync() })
+}
+
+// NewStagingWriter creates a writer for an unreferenced temporary file whose
+// caller owns later promotion. It skips syncing the disposable source
+// directory; callers must sync the file, rename it into its durable namespace,
+// and sync the destination directory before publishing a reference.
+func NewStagingWriter(path string, fileID uint32) (*Writer, error) {
+	return newFileWriter(path, fileID, false, syncStagingFileData)
+}
+
+func newFileWriter(path string, fileID uint32, syncDirectory bool, syncFn func(*os.File) error) (*Writer, error) {
 	f, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0600)
 	if err != nil {
 		return nil, err
 	}
 	w := &Writer{
 		f:      f,
-		syncFn: func(file *os.File) error { return file.Sync() },
+		syncFn: syncFn,
 	}
-	if err := w.syncDirectory(path); err != nil {
-		_ = f.Close()
-		return nil, err
+	if syncDirectory {
+		if err := w.syncDirectory(path); err != nil {
+			_ = f.Close()
+			return nil, err
+		}
 	}
 	info, err := f.Stat()
 	if err != nil {

--- a/TreeDB/pager/pager.go
+++ b/TreeDB/pager/pager.go
@@ -48,12 +48,15 @@ type Pager struct {
 	atomicChunks atomic.Pointer[chunkList] // Lock-free view for Get
 	chunkSize    int64
 	numPages     atomic.Uint64 // The number of pages logically allocated
-	dirtyChunks  map[int]struct{}
-	mu           sync.RWMutex
-	allocMu      sync.Mutex
-	path         string
-	readOnly     bool
-	memoryOnly   bool
+	// durableFileSize is the file length covered by a completed file-wide
+	// durability fence. Sparse range durability is restricted to this prefix.
+	durableFileSize atomic.Int64
+	dirtyChunks     map[int]struct{}
+	mu              sync.RWMutex
+	allocMu         sync.Mutex
+	path            string
+	readOnly        bool
+	memoryOnly      bool
 	// pageIDBase gives private overlay pagers a disjoint logical ID namespace.
 	// IDs below the base are read through fallback and are never writable here.
 	pageIDBase   uint64
@@ -155,6 +158,7 @@ func OpenWithOptions(path string, chunkSize int64, opts OpenOptions) (*Pager, er
 	}
 
 	size := info.Size()
+	durableSize := size
 
 	p := &Pager{
 		file:           f,
@@ -165,6 +169,7 @@ func OpenWithOptions(path string, chunkSize int64, opts OpenOptions) (*Pager, er
 		prefetchOnRead: opts.PrefetchOnRead,
 	}
 	p.syncConcurrency.Store(1)
+	p.durableFileSize.Store(durableSize)
 
 	if size > 0 {
 		// Align size to chunk size if needed
@@ -833,6 +838,8 @@ func (p *Pager) syncDirtyChunks(syncFile bool, firstChunk int) error {
 	if syncErr == nil && syncFile {
 		if err := p.file.Sync(); err != nil {
 			syncErr = err
+		} else {
+			p.durableFileSize.Store(int64(len(p.chunks)) * p.chunkSize)
 		}
 	}
 	p.mu.RUnlock()
@@ -947,10 +954,13 @@ func (p *Pager) SyncPages(pageIDs []uint64) error {
 		p.mu.RUnlock()
 		return err
 	}
-	handled, err := syncPageRangesFn(p.file, p.chunks, ranges, p.chunkSize)
-	if err != nil {
-		p.mu.RUnlock()
-		return err
+	handled := false
+	if syncPageRangesWithinDurableFileSize(ranges, p.chunkSize, p.durableFileSize.Load()) {
+		handled, err = syncPageRangesFn(p.file, p.chunks, ranges, p.chunkSize)
+		if err != nil {
+			p.mu.RUnlock()
+			return err
+		}
 	}
 	if !handled && mappedRangeSyncRequired() {
 		for _, r := range ranges {
@@ -963,6 +973,9 @@ func (p *Pager) SyncPages(pageIDs []uint64) error {
 	}
 	if !handled {
 		err = syncPageFile(p.file)
+		if err == nil {
+			p.durableFileSize.Store(int64(len(p.chunks)) * p.chunkSize)
+		}
 	}
 	p.mu.RUnlock()
 	return err

--- a/TreeDB/pager/pager.go
+++ b/TreeDB/pager/pager.go
@@ -916,10 +916,11 @@ func planSyncPageRanges(pageIDs []uint64, pageIDBase, pageCount uint64, chunkSiz
 
 // SyncPages durably synchronizes the named pages. Platforms that require an
 // explicit mapped-view flush receive granularity-aligned ranges before the
-// final os.File.Sync; Linux relies on fsync's file-wide modified-page-cache
-// contract. This method never promises that only the named bytes reach stable
-// storage and deliberately leaves dirtyChunks unchanged so ordinary commit
-// bookkeeping remains exact.
+// final file data-sync boundary. Linux fdatasync includes file-size metadata
+// needed to retrieve appended pages; other platforms retain os.File.Sync.
+// This method never promises that only the named bytes reach stable storage
+// and deliberately leaves dirtyChunks unchanged so ordinary commit bookkeeping
+// remains exact.
 func (p *Pager) SyncPages(pageIDs []uint64) error {
 	if p.readOnly {
 		return ErrReadOnly
@@ -946,7 +947,12 @@ func (p *Pager) SyncPages(pageIDs []uint64) error {
 		p.mu.RUnlock()
 		return err
 	}
-	if mappedRangeSyncRequired() {
+	handled, err := syncPageRangesFn(p.file, p.chunks, ranges, p.chunkSize)
+	if err != nil {
+		p.mu.RUnlock()
+		return err
+	}
+	if !handled && mappedRangeSyncRequired() {
 		for _, r := range ranges {
 			err := msyncFile(p.chunks[r.chunk][r.start:r.end])
 			if err != nil {
@@ -955,7 +961,9 @@ func (p *Pager) SyncPages(pageIDs []uint64) error {
 			}
 		}
 	}
-	err = p.file.Sync()
+	if !handled {
+		err = syncPageFile(p.file)
+	}
 	p.mu.RUnlock()
 	return err
 }

--- a/TreeDB/pager/sync_page_file.go
+++ b/TreeDB/pager/sync_page_file.go
@@ -1,0 +1,12 @@
+package pager
+
+import "os"
+
+var syncPageFileFn = syncPageFileData
+
+func syncPageFile(file *os.File) error {
+	if file == nil {
+		return nil
+	}
+	return syncPageFileFn(file)
+}

--- a/TreeDB/pager/sync_page_file_linux.go
+++ b/TreeDB/pager/sync_page_file_linux.go
@@ -1,0 +1,25 @@
+//go:build linux
+
+package pager
+
+import (
+	"os"
+	"runtime"
+
+	"golang.org/x/sys/unix"
+)
+
+func syncPageFileData(file *os.File) error {
+	fd := int(file.Fd())
+	for {
+		err := unix.Fdatasync(fd)
+		runtime.KeepAlive(file)
+		if err == unix.EINTR {
+			continue
+		}
+		if err == unix.ENOSYS || err == unix.EINVAL {
+			return file.Sync()
+		}
+		return err
+	}
+}

--- a/TreeDB/pager/sync_page_file_other.go
+++ b/TreeDB/pager/sync_page_file_other.go
@@ -1,0 +1,9 @@
+//go:build !linux
+
+package pager
+
+import "os"
+
+func syncPageFileData(file *os.File) error {
+	return file.Sync()
+}

--- a/TreeDB/pager/sync_page_ranges.go
+++ b/TreeDB/pager/sync_page_ranges.go
@@ -1,0 +1,25 @@
+package pager
+
+const (
+	maxDurableRangeWrites = 32
+	maxDurableRangeBytes  = 256 << 10
+)
+
+var syncPageRangesFn = syncPageRangesData
+
+func useDurableRangeWrites(ranges []syncPageRange) bool {
+	if len(ranges) == 0 || len(ranges) > maxDurableRangeWrites {
+		return false
+	}
+	totalBytes := 0
+	for _, r := range ranges {
+		if r.end < r.start {
+			return false
+		}
+		totalBytes += r.end - r.start
+		if totalBytes > maxDurableRangeBytes {
+			return false
+		}
+	}
+	return true
+}

--- a/TreeDB/pager/sync_page_ranges.go
+++ b/TreeDB/pager/sync_page_ranges.go
@@ -7,6 +7,22 @@ const (
 
 var syncPageRangesFn = syncPageRangesData
 
+func syncPageRangesWithinDurableFileSize(ranges []syncPageRange, chunkSize, durableFileSize int64) bool {
+	if chunkSize <= 0 || durableFileSize <= 0 || len(ranges) == 0 {
+		return false
+	}
+	for _, r := range ranges {
+		if r.chunk < 0 || r.start < 0 || r.end < r.start {
+			return false
+		}
+		end := int64(r.chunk)*chunkSize + int64(r.end)
+		if end > durableFileSize {
+			return false
+		}
+	}
+	return true
+}
+
 func useDurableRangeWrites(ranges []syncPageRange) bool {
 	if len(ranges) == 0 || len(ranges) > maxDurableRangeWrites {
 		return false

--- a/TreeDB/pager/sync_page_ranges_linux.go
+++ b/TreeDB/pager/sync_page_ranges_linux.go
@@ -1,0 +1,45 @@
+//go:build linux
+
+package pager
+
+import (
+	"errors"
+	"os"
+	"runtime"
+
+	"golang.org/x/sys/unix"
+)
+
+func syncPageRangesData(file *os.File, chunks [][]byte, ranges []syncPageRange, chunkSize int64) (bool, error) {
+	if file == nil {
+		return true, nil
+	}
+	if !useDurableRangeWrites(ranges) {
+		return false, nil
+	}
+	fd := int(file.Fd())
+	for _, r := range ranges {
+		buf := chunks[r.chunk][r.start:r.end]
+		offset := int64(r.chunk)*chunkSize + int64(r.start)
+		for len(buf) > 0 {
+			n, err := unix.Pwritev2(fd, [][]byte{buf}, offset, unix.RWF_DSYNC)
+			runtime.KeepAlive(file)
+			runtime.KeepAlive(chunks)
+			if err == unix.EINTR {
+				continue
+			}
+			if errors.Is(err, unix.ENOSYS) || errors.Is(err, unix.EINVAL) || errors.Is(err, unix.EOPNOTSUPP) {
+				return false, nil
+			}
+			if err != nil {
+				return true, err
+			}
+			if n <= 0 {
+				return true, unix.EIO
+			}
+			buf = buf[n:]
+			offset += int64(n)
+		}
+	}
+	return true, nil
+}

--- a/TreeDB/pager/sync_page_ranges_other.go
+++ b/TreeDB/pager/sync_page_ranges_other.go
@@ -1,0 +1,9 @@
+//go:build !linux
+
+package pager
+
+import "os"
+
+func syncPageRangesData(_ *os.File, _ [][]byte, _ []syncPageRange, _ int64) (bool, error) {
+	return false, nil
+}

--- a/TreeDB/pager/sync_pages_test.go
+++ b/TreeDB/pager/sync_pages_test.go
@@ -41,6 +41,7 @@ func TestSyncPagesUsesDataDurabilityBoundary(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Alloc: %v", err)
 	}
+	p.durableFileSize.Store(int64(len(p.chunks)) * p.chunkSize)
 	if err := p.Write(id, bytes.Repeat([]byte{0x2a}, page.PageSize)); err != nil {
 		t.Fatalf("Write: %v", err)
 	}
@@ -75,11 +76,62 @@ func TestSyncPagesFallsBackWhenRangeDurabilityIsUnavailable(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Alloc: %v", err)
 	}
+	p.durableFileSize.Store(int64(len(p.chunks)) * p.chunkSize)
 	if err := p.SyncPages([]uint64{id}); err != nil {
 		t.Fatalf("SyncPages: %v", err)
 	}
 	if fileCalls != 1 {
 		t.Fatalf("fallback durability calls=%d want 1", fileCalls)
+	}
+}
+
+func TestSyncPagesFallsBackUntilFileGrowthIsDurable(t *testing.T) {
+	originalRanges := syncPageRangesFn
+	originalFile := syncPageFileFn
+	rangeCalls := 0
+	fileCalls := 0
+	syncPageRangesFn = func(*os.File, [][]byte, []syncPageRange, int64) (bool, error) {
+		rangeCalls++
+		return true, nil
+	}
+	syncPageFileFn = func(*os.File) error {
+		fileCalls++
+		return nil
+	}
+	t.Cleanup(func() {
+		syncPageRangesFn = originalRanges
+		syncPageFileFn = originalFile
+	})
+
+	chunkSize := int64(2 * page.PageSize)
+	if granularity := mmapOffsetGranularity(); chunkSize%granularity != 0 {
+		chunkSize = ((chunkSize + granularity - 1) / granularity) * granularity
+	}
+	p, err := Open(filepath.Join(t.TempDir(), "growth.db"), chunkSize)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer func() { _ = p.Close() }()
+	first, err := p.Alloc(1)
+	if err != nil {
+		t.Fatalf("Alloc first: %v", err)
+	}
+	if err := p.SyncPages([]uint64{first}); err != nil {
+		t.Fatalf("SyncPages growth: %v", err)
+	}
+	if rangeCalls != 0 || fileCalls != 1 {
+		t.Fatalf("growth range/file durability calls=%d/%d want 0/1", rangeCalls, fileCalls)
+	}
+
+	second, err := p.Alloc(1)
+	if err != nil {
+		t.Fatalf("Alloc second: %v", err)
+	}
+	if err := p.SyncPages([]uint64{second}); err != nil {
+		t.Fatalf("SyncPages durable capacity: %v", err)
+	}
+	if rangeCalls != 1 || fileCalls != 1 {
+		t.Fatalf("steady-state range/file durability calls=%d/%d want 1/1", rangeCalls, fileCalls)
 	}
 }
 
@@ -225,6 +277,10 @@ func TestSyncPagesPersistsNonzeroPageWithinAllocationGranularity(t *testing.T) {
 	if err != nil {
 		_ = p.Close()
 		t.Fatalf("Alloc: %v", err)
+	}
+	if err := p.Sync(); err != nil {
+		_ = p.Close()
+		t.Fatalf("Sync allocated file size: %v", err)
 	}
 	want := bytes.Repeat([]byte{0x5d}, page.PageSize)
 	if err := p.Write(start+1, want); err != nil {

--- a/TreeDB/pager/sync_pages_test.go
+++ b/TreeDB/pager/sync_pages_test.go
@@ -10,6 +10,12 @@ import (
 	"github.com/snissn/gomap/TreeDB/page"
 )
 
+func syncPagesTestChunkSize(minPages int) int64 {
+	size := int64(minPages * page.PageSize)
+	size = alignUp(size, int64(os.Getpagesize()))
+	return alignUp(size, mmapOffsetGranularity())
+}
+
 func TestSyncPagesUsesDataDurabilityBoundary(t *testing.T) {
 	originalRanges := syncPageRangesFn
 	originalFile := syncPageFileFn
@@ -32,7 +38,7 @@ func TestSyncPagesUsesDataDurabilityBoundary(t *testing.T) {
 	})
 
 	dir := t.TempDir()
-	p, err := Open(filepath.Join(dir, "data-sync.db"), int64(page.PageSize))
+	p, err := Open(filepath.Join(dir, "data-sync.db"), syncPagesTestChunkSize(1))
 	if err != nil {
 		t.Fatalf("Open: %v", err)
 	}
@@ -67,7 +73,7 @@ func TestSyncPagesFallsBackWhenRangeDurabilityIsUnavailable(t *testing.T) {
 		syncPageFileFn = originalFile
 	})
 
-	p, err := Open(filepath.Join(t.TempDir(), "fallback.db"), int64(page.PageSize))
+	p, err := Open(filepath.Join(t.TempDir(), "fallback.db"), syncPagesTestChunkSize(1))
 	if err != nil {
 		t.Fatalf("Open: %v", err)
 	}
@@ -103,10 +109,7 @@ func TestSyncPagesFallsBackUntilFileGrowthIsDurable(t *testing.T) {
 		syncPageFileFn = originalFile
 	})
 
-	chunkSize := int64(2 * page.PageSize)
-	if granularity := mmapOffsetGranularity(); chunkSize%granularity != 0 {
-		chunkSize = ((chunkSize + granularity - 1) / granularity) * granularity
-	}
+	chunkSize := syncPagesTestChunkSize(2)
 	p, err := Open(filepath.Join(t.TempDir(), "growth.db"), chunkSize)
 	if err != nil {
 		t.Fatalf("Open: %v", err)

--- a/TreeDB/pager/sync_pages_test.go
+++ b/TreeDB/pager/sync_pages_test.go
@@ -3,11 +3,102 @@ package pager
 import (
 	"bytes"
 	"errors"
+	"os"
 	"path/filepath"
 	"testing"
 
 	"github.com/snissn/gomap/TreeDB/page"
 )
+
+func TestSyncPagesUsesDataDurabilityBoundary(t *testing.T) {
+	originalRanges := syncPageRangesFn
+	originalFile := syncPageFileFn
+	rangeCalls := 0
+	fileCalls := 0
+	syncPageRangesFn = func(file *os.File, chunks [][]byte, ranges []syncPageRange, chunkSize int64) (bool, error) {
+		if file == nil || len(chunks) == 0 || len(ranges) == 0 || chunkSize <= 0 {
+			t.Fatalf("invalid range durability input: file=%v chunks=%d ranges=%d chunk_size=%d", file, len(chunks), len(ranges), chunkSize)
+		}
+		rangeCalls++
+		return true, nil
+	}
+	syncPageFileFn = func(file *os.File) error {
+		fileCalls++
+		return originalFile(file)
+	}
+	t.Cleanup(func() {
+		syncPageRangesFn = originalRanges
+		syncPageFileFn = originalFile
+	})
+
+	dir := t.TempDir()
+	p, err := Open(filepath.Join(dir, "data-sync.db"), int64(page.PageSize))
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer func() { _ = p.Close() }()
+	id, err := p.Alloc(1)
+	if err != nil {
+		t.Fatalf("Alloc: %v", err)
+	}
+	if err := p.Write(id, bytes.Repeat([]byte{0x2a}, page.PageSize)); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	if err := p.SyncPages([]uint64{id}); err != nil {
+		t.Fatalf("SyncPages: %v", err)
+	}
+	if rangeCalls != 1 || fileCalls != 0 {
+		t.Fatalf("range/file durability calls=%d/%d want 1/0", rangeCalls, fileCalls)
+	}
+}
+
+func TestSyncPagesFallsBackWhenRangeDurabilityIsUnavailable(t *testing.T) {
+	originalRanges := syncPageRangesFn
+	originalFile := syncPageFileFn
+	fileCalls := 0
+	syncPageRangesFn = func(*os.File, [][]byte, []syncPageRange, int64) (bool, error) { return false, nil }
+	syncPageFileFn = func(*os.File) error {
+		fileCalls++
+		return nil
+	}
+	t.Cleanup(func() {
+		syncPageRangesFn = originalRanges
+		syncPageFileFn = originalFile
+	})
+
+	p, err := Open(filepath.Join(t.TempDir(), "fallback.db"), int64(page.PageSize))
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer func() { _ = p.Close() }()
+	id, err := p.Alloc(1)
+	if err != nil {
+		t.Fatalf("Alloc: %v", err)
+	}
+	if err := p.SyncPages([]uint64{id}); err != nil {
+		t.Fatalf("SyncPages: %v", err)
+	}
+	if fileCalls != 1 {
+		t.Fatalf("fallback durability calls=%d want 1", fileCalls)
+	}
+}
+
+func TestUseDurableRangeWritesBoundsSparseDurabilityWork(t *testing.T) {
+	unit := syncPageRange{chunk: 0, start: 0, end: page.PageSize}
+	if !useDurableRangeWrites([]syncPageRange{unit}) {
+		t.Fatal("single-page publication should use range durability")
+	}
+	tooMany := make([]syncPageRange, maxDurableRangeWrites+1)
+	for i := range tooMany {
+		tooMany[i] = unit
+	}
+	if useDurableRangeWrites(tooMany) {
+		t.Fatalf("%d ranges should use the file durability fallback", len(tooMany))
+	}
+	if useDurableRangeWrites([]syncPageRange{{chunk: 0, start: 0, end: maxDurableRangeBytes + 1}}) {
+		t.Fatal("oversized range should use the file durability fallback")
+	}
+}
 
 func TestPlanSyncPageRangesAlignsTo64KiBAllocationGranularity(t *testing.T) {
 	const (


### PR DESCRIPTION
Closes #3666.
Parent: #3630.

## Summary

- add additive structured leaf-pack apply-stage counters, including separate discarded-retry accounting while preserving the existing coarse timing fields and JSON shape
- make private leaf-log staging explicit: sync the staging file without syncing its disposable source directory, then retain the existing rename plus destination-directory durability fence before publication
- use bounded Linux `pwritev2(..., RWF_DSYNC)` durability for small sparse page sets, with a single `fdatasync` fallback for newly grown capacity or publications over 32 ranges or 256 KiB; non-Linux retains `os.File.Sync`
- preserve copy outside `writeMu`, exact basis revalidation, full abort/retry, fail-closed publication, durable `Sync=false`, and the existing meta-page ordering

## Root cause and attribution

The pinned baseline profiles showed an I/O-bound path rather than metadata CPU or lock contention:

- baseline apply: 83.64 ms/op
- tree rewrite: 20.04 ms/op
- leaf-file sync: 19.69 ms/op
- published-page sync: 21.90 ms/op
- finalize/meta durability: 20.40 ms/op
- CPU profile: 70 ms sampled over 1.41 s; syscall work was the largest flat entry (20 ms)
- mutex profile: zero sampled delay; block profile was dominated by background-loop waits

A final structured-counter run assigned 87.325 ms of 87.402 ms apply wall to non-overlapping named stages (99.91%). A syscall trace confirmed the sparse path executes `pwritev2` with `RWF_DSYNC`. An initial unbounded range implementation regressed the 739-page PL-01 fixture, so the final implementation bounds range durability and falls back to one file fence for larger publications.

## Performance

Exact base: `851d8e89c1e38fd1af6edc682ebe1722852d4215`  
Exact head: `d9273f1525eb04998f93b0c1b11f54e33342d99e`  
Benchmark source SHA-256 on both revisions: `96c767caffeedfe244be6a935016b37d8c84b7d849c39360dfa14e593b7afb3d`

Fixture: three sparse sealed leaf generations, four bounded `CompactStorage` pack phases, setup outside the timer. Six base/head pairs were interleaved with alternating order on CPU 2, `GOMAXPROCS=1`, Intel i5-11400F.

```sh
taskset -c 2 env GOWORK=off GOMEMLIMIT=4GiB GOMAXPROCS=1 \
  ./db.test -test.run '^$' \
  -test.bench '^BenchmarkCompactStorageLeafPackMultiPass$' \
  -test.benchtime=10x -test.count=1 -test.benchmem
```

| Metric | Base median | Head median | Delta |
| --- | ---: | ---: | ---: |
| pack apply | 81.18 ms/op (12.318 ops/s) | 47.59 ms/op (21.013 ops/s) | **-41.38%**, p=0.002 |
| total wall | 137.6 ms/op (7.267 ops/s) | 111.8 ms/op (8.945 ops/s) | directional improvement, p=0.132 |
| pack copy | 39.07 ms/op | 19.50 ms/op | -50.09%, p=0.002 |
| publish hold | 40.87 ms/op | 27.02 ms/op | -33.88%, p=0.002 |
| B/op | 3.680 MiB | 3.680 MiB | unchanged, p=0.699 |
| allocs/op | 4.017k | 4.010k | -0.17%, p=0.002 |
| live scans / pack passes | 3 / 4 | 3 / 4 | unchanged |

PL-01 large-pack regression check (one 1x invocation, 1,048,576-key fixture):

| Metric | PL-01 reference | This head | Result |
| --- | ---: | ---: | --- |
| idle pack wall | 607.7 ms | 609.7 ms | no regression |
| idle publish hold | 24.41 ms | 13.01 ms | no regression |
| contended foreground p95 | idle 2.271 ms | pack 2.396 ms | 1.05x, <=2x gate |
| contended foreground p99 | idle 4.248 ms | pack 4.102 ms | 0.97x, <=2x gate |

## Tests

Exact head `d9273f152`:

```sh
GOWORK=off GOMEMLIMIT=4GiB GOMAXPROCS=2 go test -p 1 ./TreeDB/db \
  -run '^TestLeafGenerationPack_ApplyStageAccounting$' -count=20
GOWORK=off GOMEMLIMIT=4GiB GOMAXPROCS=2 go test -race -p 1 ./TreeDB/db \
  -run '^TestLeafGenerationPack_ApplyStageAccounting$' -count=3
GOWORK=off GOOS=darwin GOARCH=amd64 go test -c -o /tmp/gomap-3666-db-darwin-final.test ./TreeDB/db
GOWORK=off GOOS=windows GOARCH=amd64 go test -c -o /tmp/gomap-3666-db-windows-final.test.exe ./TreeDB/db
```

Runtime-equivalent parent `4dafed395` (the final commit only relaxes a test assertion for optional or sub-clock-resolution stages):

```sh
GOWORK=off GOMEMLIMIT=4GiB GOMAXPROCS=2 go test -p 1 ./TreeDB/db \
  -run 'TestLeafGenerationPack|TestCompactStorage.*LeafPack|TestCompactStorageExhaustiveDefaultWriteProducedLeafPointersSurviveReopenGC' -count=1
GOWORK=off GOMEMLIMIT=4GiB GOMAXPROCS=2 go test -race -p 1 ./TreeDB/db \
  -run 'TestLeafGenerationPack_(Retry|Copy|Changed|Private|Source|SyncFalse)' -count=3
GOWORK=off GOMEMLIMIT=4GiB GOMAXPROCS=2 go test -count=10 ./TreeDB/pager
GOWORK=off GOMEMLIMIT=4GiB GOMAXPROCS=2 go test -race -count=3 ./TreeDB/pager
GOWORK=off GOMEMLIMIT=4GiB GOMAXPROCS=2 go vet ./TreeDB/db ./TreeDB/pager ./TreeDB/internal/valuelog
GOWORK=off GOOS=darwin GOARCH=amd64 go test -c -o /tmp/gomap-3666-pager-darwin.test ./TreeDB/pager
GOWORK=off GOOS=windows GOARCH=amd64 go test -c -o /tmp/gomap-3666-pager-windows.test.exe ./TreeDB/pager
```

Additional code-equivalent validation before the test-only portability commit (the rebase added only `TreeDB/caching` changes from main):

```sh
GOWORK=off GOMEMLIMIT=4GiB GOMAXPROCS=2 go test -p 1 ./TreeDB/db -count=1  # 335.590s
GOWORK=off GOMEMLIMIT=4GiB GOMAXPROCS=2 go test -race -p 1 ./TreeDB/pager ./TreeDB/internal/valuelog -count=1
GOWORK=off GOMEMLIMIT=4GiB GOMAXPROCS=2 go vet ./TreeDB/db ./TreeDB/pager ./TreeDB/internal/valuelog
GOWORK=off GOMEMLIMIT=4GiB GOMAXPROCS=2 GOOS=darwin GOARCH=amd64 go test -p 1 -c ./TreeDB/db
GOWORK=off GOMEMLIMIT=4GiB GOMAXPROCS=2 GOOS=windows GOARCH=amd64 go test -p 1 -c ./TreeDB/db
```

The focused inventory includes retry exhaustion, concurrent foreground writes, source pinning, `Sync=false` durability, promotion/directory-sync/registration/meta-write/meta-sync failure seams, checkpoint/close/reopen, leaf GC, and persistent value-log pointers.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added detailed stage timing metrics for leaf-generation operations, including retries, rewrites, synchronization, publishing, and cleanup.
  * Improved durability handling for page and staging files, with optimized synchronization on Linux and compatible fallbacks on other platforms.
  * Added safer durable range writes with automatic fallback when the platform or workload does not support them.

* **Bug Fixes**
  * Improved handling of synchronization boundaries and publish retries to help preserve data durability and provide more accurate operation diagnostics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
