### PR TITLE
treedb: coalesce covered value-log sync

### DIFF
--- a/TreeDB/caching/db.go
+++ b/TreeDB/caching/db.go
@@ -2589,6 +2589,32 @@ func (db *DB) observeValueLogSync(path valueLogSyncPath, waited, elapsed time.Du
 	}
 }
 
+// recordValueLogMaterializationSyncCoverageMuHeld records the append-only
+// writer boundary covered by a successful materialization sync. Callers hold
+// l.vlogMu; reuse additionally requires the lane's sync reservation to remain
+// held until the command-WAL external-reference ordering step.
+func (db *DB) recordValueLogMaterializationSyncCoverageMuHeld(l *lane, w valueWriter) {
+	if l == nil {
+		return
+	}
+	l.vlogMaterializationSyncValid = false
+	if db == nil || w == nil || l.id < 0 || l.vlogSeq <= 0 {
+		return
+	}
+	fileID, err := valuelog.EncodeFileID(uint32(l.id), uint32(l.vlogSeq))
+	if err != nil {
+		return
+	}
+	size := w.Size()
+	if size < 0 {
+		return
+	}
+	l.vlogMaterializationSyncFileID = fileID
+	l.vlogMaterializationSyncSeq = l.vlogSeq
+	l.vlogMaterializationSyncSize = size
+	l.vlogMaterializationSyncValid = true
+}
+
 func (db *DB) flushPendingValueLogLanes(sync bool, syncPath valueLogSyncPath) error {
 	if db == nil || !db.splitValueLogEnabled() {
 		return nil
@@ -16042,6 +16068,9 @@ func (db *DB) flushVlogRequests(l *lane, requests []vlogWriteRequest) {
 		case needSync:
 			start := time.Now()
 			err = w.Sync()
+			if err == nil {
+				db.recordValueLogMaterializationSyncCoverageMuHeld(l, w)
+			}
 			db.observeValueLogSync(valueLogSyncPathMaterialization, syncLockWait, time.Since(start), err)
 		case needFlush:
 			err = w.Flush()
@@ -17327,6 +17356,9 @@ func (db *DB) appendValueLog(l *lane, dictID uint64, dict []byte, records []valu
 		case journalDurabilitySync:
 			start := time.Now()
 			err = w.Sync()
+			if err == nil {
+				db.recordValueLogMaterializationSyncCoverageMuHeld(l, w)
+			}
 			db.observeValueLogSync(valueLogSyncPathMaterialization, syncLockWait, time.Since(start), err)
 			syncedBoundary = err == nil
 		default:
@@ -18039,6 +18071,9 @@ func (db *DB) appendValueLogOneInternal(l *lane, dictID uint64, dict []byte, rid
 		case journalDurabilitySync:
 			start := time.Now()
 			err = w.Sync()
+			if err == nil {
+				db.recordValueLogMaterializationSyncCoverageMuHeld(l, w)
+			}
 			db.observeValueLogSync(valueLogSyncPathMaterialization, syncLockWait, time.Since(start), err)
 			syncedBoundary = err == nil
 		default:

--- a/TreeDB/caching/lane.go
+++ b/TreeDB/caching/lane.go
@@ -88,12 +88,19 @@ type lane struct {
 	vlogQueueDriftCurrentNs        uint64
 	vlogDirty                      atomic.Bool
 	vlogSyncPending                atomic.Bool
-	backendReadDirtySeq            atomic.Uint64
-	backendReadFlushedSeq          atomic.Uint64
-	vlogLiveBytes                  atomic.Int64
-	vlogClosedBytes                atomic.Int64
-	vlogClosedSizes                map[string]int64
-	vlogCreatedSegments            []laneValueLogSegment
+	// The materialization-sync certificate is protected by vlogMu. It is only
+	// reusable while this lane's sync reservation remains held and the active
+	// append-only writer still has the same file and size.
+	vlogMaterializationSyncValid  bool
+	vlogMaterializationSyncFileID uint32
+	vlogMaterializationSyncSeq    int
+	vlogMaterializationSyncSize   int64
+	backendReadDirtySeq           atomic.Uint64
+	backendReadFlushedSeq         atomic.Uint64
+	vlogLiveBytes                 atomic.Int64
+	vlogClosedBytes               atomic.Int64
+	vlogClosedSizes               map[string]int64
+	vlogCreatedSegments           []laneValueLogSegment
 
 	// Observability counters for diagnosing pathological lane shapes (e.g. huge l0).
 	// These are incremented on segment rotation and allow distinguishing useful

--- a/TreeDB/caching/value_log_appender.go
+++ b/TreeDB/caching/value_log_appender.go
@@ -100,17 +100,13 @@ func (a *cachingValueLogAppender) FlushValueLogExternalRefs(fileIDs []uint32, sy
 		}
 		if _, ok := seenLanes[l]; !ok {
 			seenLanes[l] = struct{}{}
-			if err := a.db.flushValueLogLane(l); err != nil {
+			activeFileID, err := a.db.flushValueLogLaneForExternalRefFileIDs(l, fileIDs, sync)
+			if err != nil {
 				return err
 			}
-			if sync && !a.db.relaxedSync {
-				if err := a.db.syncValueLogLane(l); err != nil {
-					return err
-				}
+			if activeFileID != 0 {
+				activeFileIDs[activeFileID] = struct{}{}
 			}
-		}
-		if _, activeFileID, ok := cachingValueLogSegmentForLane(l); ok {
-			activeFileIDs[activeFileID] = struct{}{}
 		}
 	}
 	if !sync {
@@ -133,6 +129,104 @@ func (a *cachingValueLogAppender) FlushValueLogExternalRefs(fileIDs []uint32, sy
 		}
 	}
 	return nil
+}
+
+func (db *DB) flushValueLogLaneForExternalRefFileIDs(l *lane, fileIDs []uint32, sync bool) (uint32, error) {
+	if db == nil || l == nil {
+		return 0, errWALUnavailable
+	}
+	if !db.splitValueLogEnabled() {
+		if err := db.flushValueLogLane(l); err != nil {
+			return 0, err
+		}
+		if sync && !db.relaxedSync {
+			if err := db.syncValueLogLane(l); err != nil {
+				return 0, err
+			}
+		}
+		_, activeFileID, _ := cachingValueLogSegmentForLane(l)
+		return activeFileID, nil
+	}
+	waitStart := time.Now()
+	l.vlogMu.Lock()
+	waited := time.Since(waitStart)
+	defer l.vlogMu.Unlock()
+
+	var activeFileID uint32
+	if l.vlogPath != "" && l.vlogSeq > 0 {
+		if fileID, err := valuelog.EncodeFileID(uint32(l.id), uint32(l.vlogSeq)); err == nil {
+			activeFileID = fileID
+		}
+	}
+	w := l.vlog
+	if w == nil {
+		// A path/sequence without an active writer is not an active durability
+		// owner. Return no active ID so the caller directly syncs the segment.
+		return 0, nil
+	}
+	if l.vlogDirty.Load() || valueWriterPendingBytes(w) > 0 {
+		start := time.Now()
+		err := w.Flush()
+		if db.testOnVlogFlush != nil {
+			db.testOnVlogFlush(int(l.id))
+		}
+		db.debugVlogTiming("vlog_flush", int(l.id), "vlogMu", waited, time.Since(start))
+		if err != nil {
+			return activeFileID, err
+		}
+		l.vlogDirty.Store(false)
+		if db.relaxedSync {
+			l.vlogSyncPending.Store(false)
+		}
+		l.backendReadFlushedSeq.Store(l.backendReadDirtySeq.Load())
+	}
+	if !sync || db.relaxedSync {
+		return activeFileID, nil
+	}
+	if db.valueLogMaterializationSyncCoversFileIDMuHeld(l, w, activeFileID, fileIDs) {
+		return activeFileID, nil
+	}
+	start := time.Now()
+	err := w.Sync()
+	elapsed := time.Since(start)
+	db.observeValueLogSync(valueLogSyncPathExternalRef, waited, elapsed, err)
+	if db.testOnVlogSync != nil {
+		db.testOnVlogSync(int(l.id))
+	}
+	db.debugVlogTiming("vlog_sync", int(l.id), "vlogMu", waited, elapsed)
+	if err == nil {
+		l.vlogDirty.Store(false)
+		l.vlogSyncPending.Store(false)
+		l.backendReadFlushedSeq.Store(l.backendReadDirtySeq.Load())
+	}
+	return activeFileID, err
+}
+
+func valueWriterPendingBytes(w valueWriter) int {
+	if pending, ok := w.(interface{ PendingBytes() int }); ok {
+		return pending.PendingBytes()
+	}
+	return 0
+}
+
+func (db *DB) valueLogMaterializationSyncCoversFileIDMuHeld(l *lane, w valueWriter, activeFileID uint32, fileIDs []uint32) bool {
+	// Durable batch writes retain l.syncing from value materialization through
+	// command-WAL external-reference ordering. A successful materialization
+	// sync therefore covers the whole append-only active file at the recorded
+	// boundary. Reuse is safe only while the writer identity (file/sequence) and
+	// size remain unchanged; every uncertainty falls back to another sync.
+	if db == nil || l == nil || w == nil || activeFileID == 0 || !l.syncing.Load() ||
+		!l.vlogMaterializationSyncValid || l.vlogMaterializationSyncFileID != activeFileID ||
+		l.vlogMaterializationSyncSeq != l.vlogSeq || l.vlogMaterializationSyncSize < 0 ||
+		w.Size() != l.vlogMaterializationSyncSize {
+		return false
+	}
+	for _, fileID := range fileIDs {
+		if fileID == activeFileID {
+			return true
+		}
+	}
+	return false
 }
 
 func (a *cachingValueLogAppender) syncValueLogExternalRefSegment(fileID uint32) (retErr error) {

--- a/TreeDB/caching/value_log_appender_test.go
+++ b/TreeDB/caching/value_log_appender_test.go
@@ -11,6 +11,127 @@ import (
 	"github.com/snissn/gomap/TreeDB/internal/valuelog"
 )
 
+func TestCachingValueLogExternalRefSyncCoalescingGuards(t *testing.T) {
+	type setupResult struct {
+		db       *DB
+		lane     *lane
+		writer   *vlogDirtyOrderWriter
+		appender *cachingValueLogAppender
+		fileID   uint32
+	}
+	setup := func(t *testing.T) setupResult {
+		t.Helper()
+		db := &DB{
+			closeCh:       make(chan struct{}),
+			splitValueLog: true,
+			valueLogDir:   t.TempDir(),
+			lanes:         make([]lane, 1),
+		}
+		l := &db.lanes[0]
+		l.id = 0
+		l.vlogSeq = 1
+		fileID, err := valuelog.EncodeFileID(0, 1)
+		if err != nil {
+			t.Fatalf("EncodeFileID: %v", err)
+		}
+		l.vlogPath = valuelog.SegmentPath(db.valueLogDir, fileID)
+		w := &vlogDirtyOrderWriter{}
+		l.vlog = w
+		l.syncing.Store(true)
+		ptrs, err := db.appendValueLog(l, 0, nil, []valuelog.Record{{RID: 1, Value: []byte("covered")}}, journalDurabilitySync)
+		if err != nil {
+			t.Fatalf("appendValueLog materialization sync: %v", err)
+		}
+		if len(ptrs) != 1 {
+			putValueLogPtrs(ptrs)
+			t.Fatalf("appendValueLog pointers=%d, want 1", len(ptrs))
+		}
+		putValueLogPtrs(ptrs)
+		return setupResult{
+			db:       db,
+			lane:     l,
+			writer:   w,
+			appender: &cachingValueLogAppender{db: db, lane: l},
+			fileID:   fileID,
+		}
+	}
+
+	t.Run("same_reserved_segment_and_unchanged_writer", func(t *testing.T) {
+		got := setup(t)
+		if err := got.appender.FlushValueLogExternalRefs([]uint32{got.fileID}, true); err != nil {
+			t.Fatalf("FlushValueLogExternalRefs: %v", err)
+		}
+		if syncs := got.writer.syncs.Load(); syncs != 1 {
+			t.Fatalf("writer syncs=%d, want only the materialization sync", syncs)
+		}
+		if calls := got.db.valueLogSyncPathCalls[valueLogSyncPathExternalRef].Load(); calls != 0 {
+			t.Fatalf("external-ref sync calls=%d, want 0", calls)
+		}
+	})
+
+	for _, tc := range []struct {
+		name   string
+		mutate func(*setupResult)
+	}{
+		{
+			name: "intervening_writer_growth",
+			mutate: func(got *setupResult) {
+				got.lane.vlogMu.Lock()
+				got.writer.size++
+				got.lane.vlogMu.Unlock()
+			},
+		},
+		{
+			name: "sync_reservation_released",
+			mutate: func(got *setupResult) {
+				got.lane.syncing.Store(false)
+			},
+		},
+		{
+			name: "segment_rotated",
+			mutate: func(got *setupResult) {
+				got.lane.vlogMu.Lock()
+				got.lane.vlogSeq = 2
+				fileID, err := valuelog.EncodeFileID(0, 2)
+				if err != nil {
+					got.lane.vlogMu.Unlock()
+					t.Fatalf("EncodeFileID rotated: %v", err)
+				}
+				got.lane.vlogPath = valuelog.SegmentPath(got.db.valueLogDir, fileID)
+				got.fileID = fileID
+				got.lane.vlogMu.Unlock()
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got := setup(t)
+			tc.mutate(&got)
+			if err := got.appender.FlushValueLogExternalRefs([]uint32{got.fileID}, true); err != nil {
+				t.Fatalf("FlushValueLogExternalRefs: %v", err)
+			}
+			if syncs := got.writer.syncs.Load(); syncs != 2 {
+				t.Fatalf("writer syncs=%d, want materialization plus conservative external-ref sync", syncs)
+			}
+			if calls := got.db.valueLogSyncPathCalls[valueLogSyncPathExternalRef].Load(); calls != 1 {
+				t.Fatalf("external-ref sync calls=%d, want 1", calls)
+			}
+		})
+	}
+
+	t.Run("fallback_sync_failure_propagates", func(t *testing.T) {
+		got := setup(t)
+		injected := errors.New("injected conservative external-ref sync failure")
+		got.lane.syncing.Store(false)
+		got.writer.syncErr = injected
+		if err := got.appender.FlushValueLogExternalRefs([]uint32{got.fileID}, true); !errors.Is(err, injected) {
+			t.Fatalf("FlushValueLogExternalRefs error=%v, want %v", err, injected)
+		}
+		if calls := got.db.valueLogSyncPathErrors[valueLogSyncPathExternalRef].Load(); calls != 1 {
+			t.Fatalf("external-ref sync errors=%d, want 1", calls)
+		}
+	})
+}
+
 func TestCachingValueLogExternalRefFlusherSyncsRotatedSegments(t *testing.T) {
 	dir := t.TempDir()
 	oldFileID, err := valuelog.EncodeFileID(0, 1)
@@ -31,20 +152,26 @@ func TestCachingValueLogExternalRefFlusherSyncsRotatedSegments(t *testing.T) {
 	db.lanes[0].vlogPath = valuelog.SegmentPath(dir, currentFileID)
 	appender := &cachingValueLogAppender{db: db, lane: &db.lanes[0]}
 
+	if err := os.WriteFile(valuelog.SegmentPath(dir, currentFileID), []byte("current segment"), 0o644); err != nil {
+		t.Fatalf("write current segment: %v", err)
+	}
 	if err := appender.FlushValueLogExternalRefs([]uint32{currentFileID}, true); err != nil {
 		t.Fatalf("FlushValueLogExternalRefs current segment: %v", err)
+	}
+	if got := db.valueLogRotatedFileSyncCalls.Load(); got != 1 {
+		t.Fatalf("direct file-sync calls for nil active writer=%d, want 1", got)
 	}
 	if err := appender.FlushValueLogExternalRefs([]uint32{oldFileID}, true); !errors.Is(err, os.ErrNotExist) {
 		t.Fatalf("FlushValueLogExternalRefs missing rotated segment error=%v, want os.ErrNotExist", err)
 	}
-	if got := db.valueLogSyncPathCalls[valueLogSyncPathExternalRef].Load(); got != 1 {
-		t.Fatalf("logical external-ref calls after open failure=%d, want 1", got)
+	if got := db.valueLogSyncPathCalls[valueLogSyncPathExternalRef].Load(); got != 2 {
+		t.Fatalf("logical external-ref calls after open failure=%d, want 2", got)
 	}
 	if got := db.valueLogSyncPathErrors[valueLogSyncPathExternalRef].Load(); got != 1 {
 		t.Fatalf("logical external-ref errors after open failure=%d, want 1", got)
 	}
-	if got := db.valueLogRotatedFileSyncCalls.Load(); got != 0 {
-		t.Fatalf("rotated file-sync calls after open failure=%d, want 0", got)
+	if got := db.valueLogRotatedFileSyncCalls.Load(); got != 1 {
+		t.Fatalf("rotated file-sync calls after open failure=%d, want 1", got)
 	}
 	if err := os.WriteFile(valuelog.SegmentPath(dir, oldFileID), []byte("old segment"), 0o644); err != nil {
 		t.Fatalf("write old segment: %v", err)
@@ -54,14 +181,14 @@ func TestCachingValueLogExternalRefFlusherSyncsRotatedSegments(t *testing.T) {
 	if err := appender.FlushValueLogExternalRefs([]uint32{oldFileID}, true); !errors.Is(err, injected) {
 		t.Fatalf("FlushValueLogExternalRefs injected rotated sync error=%v, want %v", err, injected)
 	}
-	if got := db.valueLogSyncPathCalls[valueLogSyncPathExternalRef].Load(); got != 2 {
-		t.Fatalf("logical external-ref calls after sync failure=%d, want 2", got)
+	if got := db.valueLogSyncPathCalls[valueLogSyncPathExternalRef].Load(); got != 3 {
+		t.Fatalf("logical external-ref calls after sync failure=%d, want 3", got)
 	}
 	if got := db.valueLogSyncPathErrors[valueLogSyncPathExternalRef].Load(); got != 2 {
 		t.Fatalf("logical external-ref errors after sync failure=%d, want 2", got)
 	}
-	if got := db.valueLogRotatedFileSyncCalls.Load(); got != 1 {
-		t.Fatalf("rotated file-sync calls after sync failure=%d, want 1", got)
+	if got := db.valueLogRotatedFileSyncCalls.Load(); got != 2 {
+		t.Fatalf("rotated file-sync calls after sync failure=%d, want 2", got)
 	}
 	if got := db.valueLogRotatedFileSyncErrors.Load(); got != 1 {
 		t.Fatalf("rotated file-sync errors after sync failure=%d, want 1", got)
@@ -70,14 +197,14 @@ func TestCachingValueLogExternalRefFlusherSyncsRotatedSegments(t *testing.T) {
 	if err := appender.FlushValueLogExternalRefs([]uint32{oldFileID, currentFileID, oldFileID}, true); err != nil {
 		t.Fatalf("FlushValueLogExternalRefs rotated segment: %v", err)
 	}
-	if got := db.valueLogSyncPathCalls[valueLogSyncPathExternalRef].Load(); got != 3 {
-		t.Fatalf("logical external-ref calls after successful deduplicated sync=%d, want 3", got)
+	if got := db.valueLogSyncPathCalls[valueLogSyncPathExternalRef].Load(); got != 5 {
+		t.Fatalf("logical external-ref calls after successful deduplicated sync=%d, want 5", got)
 	}
 	if got := db.valueLogSyncPathErrors[valueLogSyncPathExternalRef].Load(); got != 2 {
 		t.Fatalf("logical external-ref errors after successful deduplicated sync=%d, want 2", got)
 	}
-	if got := db.valueLogRotatedFileSyncCalls.Load(); got != 2 {
-		t.Fatalf("rotated file-sync calls after successful deduplicated sync=%d, want 2", got)
+	if got := db.valueLogRotatedFileSyncCalls.Load(); got != 4 {
+		t.Fatalf("rotated file-sync calls after successful deduplicated sync=%d, want 4", got)
 	}
 	if got := db.valueLogRotatedFileSyncErrors.Load(); got != 1 {
 		t.Fatalf("rotated file-sync errors after successful deduplicated sync=%d, want 1", got)

--- a/TreeDB/caching/vlog_dirty_order_test.go
+++ b/TreeDB/caching/vlog_dirty_order_test.go
@@ -16,6 +16,7 @@ type vlogDirtyOrderWriter struct {
 	size    int64
 	flushes atomic.Int64
 	syncs   atomic.Int64
+	syncErr error
 }
 
 var _ valueWriter = (*vlogDirtyOrderWriter)(nil)
@@ -68,7 +69,7 @@ func (w *vlogDirtyOrderWriter) Flush() error {
 }
 func (w *vlogDirtyOrderWriter) Sync() error {
 	w.syncs.Add(1)
-	return nil
+	return w.syncErr
 }
 func (w *vlogDirtyOrderWriter) Close() error { return nil }
 

--- a/TreeDB/command_wal_public_test.go
+++ b/TreeDB/command_wal_public_test.go
@@ -805,10 +805,10 @@ func TestPublicCommandWALBatchWriteSyncExternalRefOrderingPhaseStats(t *testing.
 	requirePublicStatDelta(t, before, stats, "treedb.command_wal.sync.count_total", 1)
 	requirePublicStatDelta(t, before, stats, "treedb.command_wal.write.syscalls_total", 1)
 	requirePublicStatDelta(t, before, stats, "treedb.command_wal.file_sync.calls_total", 1)
-	requirePublicStatDelta(t, before, stats, "treedb.cache.value_log.sync.calls_total", 2)
+	requirePublicStatDelta(t, before, stats, "treedb.cache.value_log.sync.calls_total", 1)
 	requirePublicStatDelta(t, before, stats, "treedb.cache.value_log.sync.materialization.calls_total", 1)
-	requirePublicStatDelta(t, before, stats, "treedb.cache.value_log.sync.external_ref.calls_total", 1)
-	requirePublicStatDelta(t, before, stats, "treedb.cache.value_log.file_sync.calls_total", 2)
+	requirePublicStatDelta(t, before, stats, "treedb.cache.value_log.sync.external_ref.calls_total", 0)
+	requirePublicStatDelta(t, before, stats, "treedb.cache.value_log.file_sync.calls_total", 1)
 	requirePublicBatchWriteSyncPhasePartitions(t, stats)
 }
 
@@ -3647,13 +3647,13 @@ func publicCommandWALDurableShapeExpectedCounters(shape string, forcedPointers b
 		appendCalls, syncCalls, writeSyscalls, fileSyncCalls = 1, 1, 1, 1
 		batchWriteSyncCalls = 1
 		if forcedPointers {
-			valueLogMaterializationSyncs, valueLogExternalRefSyncs = 1, 1
+			valueLogMaterializationSyncs = 1
 		}
 	case "write_then_dirty_write_sync":
 		appendCalls, flushCalls, syncCalls, writeSyscalls, fileSyncCalls = 2, 1, 1, 2, 1
 		batchWriteCalls, batchWriteSyncCalls = 1, 1
 		if forcedPointers {
-			valueLogMaterializationSyncs, valueLogExternalRefSyncs = 1, 1
+			valueLogMaterializationSyncs = 1
 		}
 	case "empty_write_sync_after_write":
 		appendCalls, flushCalls, syncCalls, writeSyscalls, fileSyncCalls = 1, 1, 1, 1, 1
@@ -3667,7 +3667,7 @@ func publicCommandWALDurableShapeExpectedCounters(shape string, forcedPointers b
 		if forcedPointers {
 			// Public point commands remain inline command-WAL inputs. The batch
 			// materialization is the state-shaped external-value boundary.
-			valueLogMaterializationSyncs, valueLogExternalRefSyncs = 1, 1
+			valueLogMaterializationSyncs = 1
 		}
 	}
 	valueLogSyncs := valueLogMaterializationSyncs + valueLogExternalRefSyncs + valueLogPendingBarrierSyncs

--- a/TreeDB/db/command_wal_raw_test.go
+++ b/TreeDB/db/command_wal_raw_test.go
@@ -532,6 +532,42 @@ func TestAppendRawKVCommandWALOrderedEntryScanFlushesFreshValueLogPointer(t *tes
 	}
 }
 
+func TestAppendRawKVCommandWALOrderedEntriesRejectsMalformedValueLogPointerBeforeDurability(t *testing.T) {
+	d, err := Open(Options{Dir: t.TempDir(), CommandWAL: true, DisableBackgroundPrune: true})
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer func() { _ = d.Close() }()
+	appender := &commandWALBarrierTestAppender{}
+	d.SetValueLogAppender(appender)
+
+	before := d.Stats()
+	_, err = d.AppendRawKVCommandWALOrderedEntries([]batchpkg.Entry{{
+		Type:  batchpkg.OpPut,
+		Key:   []byte("malformed-pointer"),
+		IsPtr: true,
+		ValuePtr: page.ValuePtr{
+			FileID: page.ValueLogFileID(1),
+			Length: 0,
+		},
+	}}, true)
+	if err == nil || !strings.Contains(err.Error(), "invalid value-log pointer") {
+		t.Fatalf("AppendRawKVCommandWALOrderedEntries error=%v, want invalid value-log pointer", err)
+	}
+	for _, key := range []string{
+		"treedb.command_wal.append.count_total",
+		"treedb.command_wal.file_sync.calls_total",
+	} {
+		got := commandWALTestStatUint64(t, d.Stats(), key) - commandWALTestStatUint64(t, before, key)
+		if got != 0 {
+			t.Fatalf("%s delta=%d, want 0 after pointer validation failure", key, got)
+		}
+	}
+	if appender.externalFlushes != 0 {
+		t.Fatalf("external-reference flushes=%d, want 0 after pointer validation failure", appender.externalFlushes)
+	}
+}
+
 func TestRawKVOrderedEntriesIntentOwnsPayloadBytes(t *testing.T) {
 	dir := t.TempDir()
 	d, err := Open(Options{Dir: dir, CommandWAL: true, DisableBackgroundPrune: true})

--- a/TreeDB/docs/spec/command-wal-durable-write-contract.md
+++ b/TreeDB/docs/spec/command-wal-durable-write-contract.md
@@ -1,6 +1,8 @@
 # Command-WAL Durable Write Contract
 
-Status: current behavior and measurement contract for issue #3656 (M2).
+Status: current behavior and measurement contract for issue #3657 (M3
+candidate). The candidate preserves this contract but does not meet the issue's
+latency exit gate.
 
 This document defines the durability boundary used by cached public raw-KV
 operations in `ProfileCommandWALDurable`. It distinguishes a logical public
@@ -59,8 +61,11 @@ creation/rotation concern, not a per-operation durability barrier.
 public Batch.WriteSync
   -> append external records to the selected persistent value-log lane
   -> value-log materialization Sync
+  -> retain that lane's durable-write reservation
   -> acquire the command publish/barrier ordering lock
-  -> value-log external-reference Sync for referenced lane/file IDs
+  -> validate/read each pointer RID
+  -> verify the active lane still has the certified file, sequence, and size
+  -> reuse the materialization Sync for that unchanged active segment
   -> encode RID references and append one RawKVBatch command frame
   -> flush command writer buffers
   -> command-WAL file Sync
@@ -68,19 +73,28 @@ public Batch.WriteSync
   -> return nil
 ```
 
-Current code therefore performs two actual value-log file-sync hooks for a
-forced-pointer dirty `WriteSync`: `materialization`, then `external_ref`. This
-is measured behavior, not a required count in the public contract. M2 leaves it
-unchanged. A later M3 may coalesce the second sync only if it proves that the
-exact referenced bytes were covered by the first successful sync, no writer or
-rotation can intervene, the external-reference lookup is readable, and the
-command-WAL sync remains strictly later. The measured ceiling is at most the
-second value-log file-sync time; it is not the sum of both syncs and is not a
-throughput claim.
+For an unchanged active segment, current code therefore performs one actual
+value-log file-sync hook for a forced-pointer dirty `WriteSync`, attributed to
+`materialization`; the logical `external_ref` sync and its duplicate physical
+file sync are coalesced. The successful materialization sync records a
+certificate containing the active file ID, lane sequence, and writer size while
+holding `vlogMu`. The durable batch retains `lane.syncing` until
+external-reference ordering. Reuse requires that reservation plus an exact
+file/sequence/size match under the same lock. The value log is append-only, so
+the certificate covers every referenced byte in that unchanged file at or
+below the recorded boundary. Pointer validation and RID lookup complete before
+external-reference ordering can append or sync a command frame. The later
+command-WAL sync remains mandatory.
+
+Every uncertainty falls back to the original external-reference sync: writer
+growth, rotation, reservation release, missing active writer, a failed
+materialization sync, or a referenced file different from the certified active
+file. Malformed or unreadable pointers fail before command-WAL durability.
 
 When a command frame references a rotated, non-current value-log segment, the
-current implementation first flushes and syncs the referenced lane's active
-writer, then opens and syncs each distinct referenced old segment directly.
+current implementation first flushes and, unless its own active reference is
+certified, syncs the referenced lane's active writer, then opens and syncs each
+distinct referenced old segment directly.
 Each operation is a logical `external_ref` observation. The active-writer call
 records its lane-lock wait; the direct old-segment call has zero lock wait and
 records the direct request time. Failure to open an old segment is a logical error
@@ -137,7 +151,7 @@ window.
 
 `Flush` means buffered bytes were passed to the kernel and is not an fsync
 promise. `Sync` is a logical durable-mode request. `file_sync.calls_total` is
-the physical hook count. On Linux M2 validates that production `os.File.Sync`
+the physical hook count. On Linux M2 and M3 validate that production `os.File.Sync`
 calls appear as `fsync(2)` with `strace`; consumers must not assume a specific
 syscall name on other Go versions or operating systems.
 
@@ -179,6 +193,8 @@ The verification matrix requires all of the following:
 
 - external-reference ordering failure leaves the command-WAL file-sync count
   unchanged;
+- a malformed value-log pointer is rejected before any external-reference or
+  command-WAL sync;
 - a frame synced before a publication failure is replayed after reopen;
 - inline and forced-pointer public writes survive reopen;
 - an empty barrier after a prior unsynced pointer write syncs the pending
@@ -187,12 +203,19 @@ The verification matrix requires all of the following:
   counts; and
 - observer state remains race-safe.
 
-## M3 ownership
+## M3 result and remaining ownership
 
-M2 records costs but makes no performance change. The only currently proven
-redundancy candidate is the second value-log sync in the pointer-backed dirty
-`WriteSync` path. Any M3 proposal must report the measured second-sync ceiling,
-preserve the no-intervening-writer/rotation and external-reference durability
-invariants above, and re-run crash/reopen plus syscall-count gates. Command-WAL
-sync removal, async acknowledgement, relaxed durability, and per-write backend
-checkpointing are outside that optimization boundary.
+M3 removes the only redundancy proven by M2: the second value-log sync in the
+unchanged active-segment pointer path. Deterministic counters and Linux syscall
+tracing show one value-log sync rather than two, while rotation, writer growth,
+missing-writer, released-reservation, and error fallbacks retain conservative
+ordering. Crash/reopen, race, and full repository tests pass.
+
+The identical focused benchmark does not demonstrate the required latency
+improvement: the canonical alternating comparison is statistically
+inconclusive and has a +3.0% geomean. The remaining power-loss-durable floor is
+one value-log materialization sync followed by one command-WAL sync. Therefore
+this candidate is a partial mechanism result and a no-go for #3657's latency
+gate, not completion of that issue. Command-WAL sync removal, async
+acknowledgement, relaxed durability, and per-write backend checkpointing remain
+outside the optimization boundary.

--- a/TreeDB/recovery_spec_test.go
+++ b/TreeDB/recovery_spec_test.go
@@ -217,6 +217,8 @@ func TestHelperTreeDBCommandWALDurableUncheckpointedWriter(t *testing.T) {
 	opts.WriterFlushMaxMemtables = 0
 	opts.WriterFlushMaxDuration = 0
 	opts.ValueLog.Generational.Policy = treedb.ValueLogGenerationOff
+	opts.ValueLog.PointerThreshold = 1
+	opts.ValueLog.ForcePointers = true
 
 	db, err := treedb.Open(opts)
 	if err != nil {

--- a/docs/benchmarks/treedb_durable_write_m3_sync_coalescing_2026-07-10.md
+++ b/docs/benchmarks/treedb_durable_write_m3_sync_coalescing_2026-07-10.md
@@ -1,0 +1,171 @@
+# TreeDB Durable-Write M3 Sync Coalescing (2026-07-10)
+
+Issue: [#3657](https://github.com/snissn/gomap/issues/3657)
+
+Parent: [#3652](https://github.com/snissn/gomap/issues/3652)
+
+Base commit: `851d8e89c1e38fd1af6edc682ebe1722852d4215`
+
+This candidate removes one proven duplicate value-log file sync without
+weakening the durable return boundary. It is a partial mechanism win and a
+latency-gate no-go: #3657 remains open because the required 20% focused
+improvement and 16 ms state target are not demonstrated.
+
+## Result
+
+- A forced-pointer dirty `WriteSync` on an unchanged active value-log segment
+  now performs one materialization file sync instead of a materialization sync
+  followed by a duplicate external-reference sync.
+- The later command-WAL file sync is unchanged. The irreducible ordered floor
+  remains one value-log file sync followed by one command-WAL file sync.
+- The canonical alternating comparison changes physical value-log syncs from
+  2 to 1 and logical external-reference syncs from 1 to 0 in every sample.
+- Wall time does not move reliably: the two focused rows are statistically
+  unchanged and their geomean is 3.0% slower. This is far short of the issue's
+  required 20% improvement.
+- Allocations are unchanged. Crash/reopen, failure fallback, race, focused
+  package, and full repository tests pass.
+
+M2 measured the removable second-sync ceiling at only 1.35-1.46 ms per affected
+batch. A 20% reduction from a roughly 19.5 ms focused geomean would require
+about 3.9 ms. The measured candidate confirms that this lane cannot by itself
+meet the M3 gate on this host.
+
+## Safety proof
+
+The materialization file sync runs while holding the lane's `vlogMu`. After a
+successful sync, the lane records a certificate containing the active value-log
+file ID, lane sequence, and writer size. The durable batch retains its
+`lane.syncing` reservation from value materialization through command-WAL
+external-reference ordering.
+
+At external-reference ordering, reuse is allowed only while holding the same
+`vlogMu` and only when all of these remain true:
+
+1. the durable-write reservation is still held;
+2. the materialization sync succeeded;
+3. the active file ID and sequence match the certificate;
+4. the append-only writer size is unchanged; and
+5. the command actually references that active file ID.
+
+Because the active value log is append-only, the successful sync covers every
+referenced record at or below the certified size. Intent construction validates
+each pointer and reads its RID before the external-reference barrier may append
+or sync the command frame. A malformed or unreadable pointer therefore fails
+before command-WAL durability.
+
+All uncertain cases retain the conservative path:
+
+| Case | Result |
+| --- | --- |
+| exact certified active file, sequence, size, and reservation | reuse materialization sync |
+| active writer grew | external-reference sync |
+| reservation released | external-reference sync |
+| segment rotated or file ID differs | active fallback plus direct sync of each referenced old segment |
+| no active writer | direct sync of the referenced segment |
+| failed materialization sync | error; no certificate |
+| fallback sync failure | error propagated before command-WAL durability |
+| empty barrier | unchanged pending-lane sweep, then command-WAL barrier |
+
+The normative ordering contract is in
+`TreeDB/docs/spec/command-wal-durable-write-contract.md`.
+
+## Focused benchmark
+
+Artifacts are under:
+
+```text
+/mnt/fast4tb/gomap-3657-m3-evidence-20260710
+```
+
+The accepted focused comparison used separately compiled base and candidate
+binaries, one CPU (`taskset -c 5`), warmups excluded, and the alternating
+schedule `A B B A A B B A A B B A A B B A`. Each reported sample ran exactly
+20 operations; there are eight samples per side.
+
+```sh
+taskset -c 5 ./TreeDB.test -test.run='^$' \
+  -test.bench='^BenchmarkPublicCommandWALDurableTinyBatchWriteSync$/^placement=forced_pointer$/^shape=(dirty_batch|state_point_point_sync_batch_sync)$/^ops=1$' \
+  -test.benchtime=20x -test.count=1
+```
+
+| Shape | M2 base | M3 candidate | Comparison | Required |
+| --- | ---: | ---: | --- | ---: |
+| dirty batch | 16.93 ms/op +/-38% | 16.44 ms/op +/-86% | -2.9%, `p=0.721`, n=8 | at least -20% |
+| state-shaped | 22.36 ms/op +/-68% | 24.44 ms/op +/-64% | +9.3%, `p=0.878`, n=8 | at least -20% and <=16 ms |
+| geomean | 19.46 ms/op | 20.04 ms/op | +3.0% | at least -20% |
+
+The host's durable syscall latency is highly variable, but the deterministic
+mechanism counters are exact:
+
+| Counter | M2 base | M3 candidate |
+| --- | ---: | ---: |
+| value-log file sync calls/op | 2 | 1 |
+| logical value-log sync calls/op | 2 | 1 |
+| materialization sync calls/op | 1 | 1 |
+| external-reference sync calls/op | 1 | 0 |
+
+Allocation results are neutral: dirty-batch is 36 allocs/op and 6.151 KiB/op
+on both sides; state-shaped is 39 allocs/op with 6.972 KiB base and 6.969 KiB
+candidate. The candidate did not select allocation as an optimization lane.
+
+An adjacent all-shape five-sample pair is retained as
+`comparison_adjacent.txt` for counter and allocation reconciliation, but is
+excluded from wall-time conclusions: unrelated inline rows moved by +50% to
++70%, while pointer rows ranged from about -40% to +91%. The pinned alternating
+comparison above is the canonical latency evidence.
+
+## Profiles and Linux syscall validation
+
+The 100-operation CPU profile contains only 60 ms of samples over 3.03 s
+(1.98%), confirming an I/O-bound path. Allocation, block, mutex, and trace
+profiles do not identify a local M3 target: the allocation profile includes
+open/close setup, blocking is dominated by background channel waits, and total
+mutex delay is under 1 ms.
+
+The five-operation Linux trace uses the production `os.File.Sync` path. Its
+measured active window contains exactly five active value-log `fsync` calls and
+five later command-WAL `fsync` calls, alternating once per operation. There is
+no duplicate external-reference value-log `fsync`. The in-process row agrees:
+one materialization sync, zero external-reference syncs, one aggregate
+value-log file sync, and one command-WAL file sync per operation.
+
+Primary artifacts:
+
+| Artifact | Purpose |
+| --- | --- |
+| `focused_abba8_core5_comparison.txt` | canonical alternating comparison |
+| `baseline/focused_abba8_core5.txt` | eight M2 base samples |
+| `candidate/focused_abba8_core5.txt` | eight M3 samples |
+| `comparison_adjacent.txt` | excluded noisy all-shape pair; counters only |
+| `candidate/profile/{cpu,allocs,block,mutex}.pprof` | focused profiles |
+| `candidate/profile/trace.out` | runtime trace |
+| `candidate/profile/strace.log` | Linux syscall trace |
+| `candidate/profile/strace_benchmark.txt` | in-process syscall ledger |
+
+## Verification
+
+The following completed successfully with `GOWORK=off`:
+
+```sh
+go test ./TreeDB/caching ./TreeDB/db ./TreeDB \
+  -run 'TestCachingValueLogExternalRefSyncCoalescingGuards|TestCachingValueLogExternalRefFlusherSyncsRotatedSegments|TestFlushCommandWALBarrierOrdersExternalRefsBeforeCommandWAL|TestPublicCommandWALBatchWriteSyncExternalRefOrderingPhaseStats' -count=1
+
+go test ./TreeDB \
+  -run '^TestCrashRecovery_CommandWALDurableSyncedUncheckpointedFramesReplay$' -count=1
+
+go test -race ./TreeDB/caching ./TreeDB \
+  -run 'TestCachingValueLogExternalRefSyncCoalescingGuards|TestCachingValueLogExternalRefFlusherSyncsRotatedSegments|TestPublicCommandWALBatchWriteSyncExternalRefOrderingPhaseStats' -count=1
+
+go test ./TreeDB/db ./TreeDB/caching ./TreeDB -count=1
+go test ./... -count=1
+```
+
+The full repository run passed; notable package durations were 406.987 s for
+`TreeDB/db` and 190.534 s for `TreeDB/collections`.
+
+## Ironbird diagnostic
+
+The required candidate-pinned diagnostic row is recorded in this report before
+PR handoff. It is diagnostic only: one row cannot establish the parent issue's
+paired throughput gate.

--- a/docs/benchmarks/treedb_durable_write_m3_sync_coalescing_2026-07-10.md
+++ b/docs/benchmarks/treedb_durable_write_m3_sync_coalescing_2026-07-10.md
@@ -6,6 +6,8 @@ Parent: [#3652](https://github.com/snissn/gomap/issues/3652)
 
 Base commit: `851d8e89c1e38fd1af6edc682ebe1722852d4215`
 
+Candidate mechanism commit: `b8f9625fc4965fad9a912437176334f3c7632ef6`
+
 This candidate removes one proven duplicate value-log file sync without
 weakening the durable return boundary. It is a partial mechanism win and a
 latency-gate no-go: #3657 remains open because the required 20% focused
@@ -159,6 +161,10 @@ go test -race ./TreeDB/caching ./TreeDB \
 
 go test ./TreeDB/db ./TreeDB/caching ./TreeDB -count=1
 go test ./... -count=1
+
+go test ./TreeDB/db \
+  -run '^TestAppendRawKVCommandWALOrderedEntriesRejectsMalformedValueLogPointerBeforeDurability$' \
+  -count=1
 ```
 
 The full repository run passed; notable package durations were 406.987 s for
@@ -166,6 +172,62 @@ The full repository run passed; notable package durations were 406.987 s for
 
 ## Ironbird diagnostic
 
-The required candidate-pinned diagnostic row is recorded in this report before
-PR handoff. It is diagnostic only: one row cannot establish the parent issue's
-paired throughput gate.
+The required candidate-pinned production-shape diagnostic completed without a
+runner or result error. The scenario dependency manifest resolves the exact
+candidate source:
+
+```text
+github.com/snissn/gomap@v0.6.2-0.20260711055505-b8f9625fc496
+=> b8f9625fc4965fad9a912437176334f3c7632ef6
+```
+
+The backend verifier observed TreeDB for both app and node databases and the
+`kv` transaction indexer, matching the requested configuration. The run used
+one validator, no non-validator nodes, 100,000 preseeded accounts, 5,000 active
+wallets, 500 requested transactions per block, and 450 requested blocks:
+
+```sh
+/mnt/fast4tb/bin/ironbird-local-report-runner-3657 \
+  -scenario simapp-treedb-all \
+  -validators 1 -nodes 0 -wallets 5000 \
+  -preseed-profile accounts -preseed-accounts 100000 \
+  -cosmos-txs 500 -cosmos-blocks 450 \
+  -tx-indexer kv \
+  -load-window-min-duration 5m \
+  -load-window-target-fraction 0.995 \
+  -stop-catalyst-after-load-window \
+  -app-debug-vars -raw-tx-audit=false \
+  -out /mnt/fast4tb/ironbird-gomap-3657-m3-20260710T2005HST/accepted/result.json
+```
+
+| Signal | Result |
+| --- | ---: |
+| intended transactions | 225,000 |
+| accepted target at 99.5% | 223,875 |
+| included and successful | 223,997 (99.55422% of intended) |
+| accepted load window | 331.580154797 s |
+| accepted throughput | 675.544047976 tx/s |
+| backend verification | valid |
+| runner/result errors | 0 |
+
+Whole-scenario TreeDB stat deltas give these public batch `WriteSync` rows:
+
+| Store | Calls | Total | Mean | Checkpoint barrier wait |
+| --- | ---: | ---: | ---: | ---: |
+| `application.db` | 1,313 | 18.973057 s | 14.450157 ms | 900.581200 ms |
+| `state.db` | 1,313 | 18.511351 s | 14.098515 ms | 0.002928 ms |
+| `blockstore.db` | 2,626 | 25.622918 s | 9.757395 ms | not selected |
+
+The application and state means are below the issue's absolute production-row
+ceilings of 17 ms and 16 ms, respectively. This is not evidence that the M3
+mechanism caused those results: every production store records zero public
+preflight-materialization time and zero public external-reference-ordering
+calls. The optimized forced-pointer branch was therefore inactive in this row;
+the relevant public `WriteSync` values stayed inline.
+
+This single candidate row is diagnostic only. It is not a paired baseline and
+does not establish a throughput delta or the required 20% focused latency
+reduction. The canonical forced-pointer comparison remains the decision
+evidence: it proves the physical sync reduction but fails the latency gate and
+the focused 16 ms state target. The accepted Ironbird artifacts are under
+`/mnt/fast4tb/ironbird-gomap-3657-m3-20260710T2005HST/accepted`.


### PR DESCRIPTION
## Objective

Remove one proven duplicate active value-log file sync from forced-pointer durable command-WAL `WriteSync` while preserving the public operation's return-time durability contract.

This is a bounded mechanism win and a latency-gate no-go. It references #3657 but does not close it: the deterministic sync count improves, while the required 20% focused latency reduction is not demonstrated.

## Context

M2 showed that a dirty forced-pointer batch performed a materialization value-log sync and then repeated that sync during command-WAL external-reference ordering. The removable second sync measured only about 1.35-1.46 ms on this host, below the roughly 3.9 ms reduction needed for the issue's 20% gate.

This PR tests that ceiling directly. It coalesces only the exact covered boundary and retains the conservative sync path for growth, rotation, reservation loss, failed materialization, missing writers, and every other uncertain case.

Refs #3657

## Non-goals

- No relaxed durability or asynchronous return.
- No change to command-WAL publication ordering, empty-barrier semantics, or strict `Checkpoint()` semantics.
- No public API, option, on-disk format, or migration change.
- No allocator/compaction work and no claim that M3's latency gate is complete.
- No attribution of the unpaired Ironbird throughput row to this mechanism.

## Design

- A successful materialization sync records a lane-local certificate under `vlogMu`: active value-log file ID, lane sequence, and writer size.
- The durable operation retains its `lane.syncing` reservation through command-WAL external-reference ordering.
- After the external-reference flush, reuse is allowed only when the reservation is still held and the active file ID, sequence, and size exactly match the certificate.
- Exact coverage skips the duplicate active-writer sync. The later command-WAL file sync is unchanged, leaving the required ordered floor of one value-log fsync followed by one command-WAL fsync.
- Writer growth, reservation release, rotation, no active writer, or any mismatch uses the existing conservative path. Rotated referenced segments are still synced directly.
- Failed materialization produces no certificate and propagates before command-WAL durability.
- Intent construction validates pointer shape and RID readability before external-reference flushing, command append, or command fsync.
- Existing value-log sync and file-sync counters expose the physical and logical result.

The updated normative contract is in `TreeDB/docs/spec/command-wal-durable-write-contract.md`.

## Scope

- Includes: `TreeDB/caching` materialization certificate state, value-log external-reference ordering, guard/failure tests, public stats tests, raw command intent ordering tests, forced-pointer crash recovery coverage, contract documentation, and the benchmark report.
- Excludes: command-WAL format, value-log format, GC/rewrite, checkpoint implementation, public options/APIs, and unrelated durability or performance lanes.

## Correctness

Tests run with `GOWORK=off`:

```sh
go test ./TreeDB/caching ./TreeDB/db ./TreeDB \
  -run 'TestCachingValueLogExternalRefSyncCoalescingGuards|TestCachingValueLogExternalRefFlusherSyncsRotatedSegments|TestFlushCommandWALBarrierOrdersExternalRefsBeforeCommandWAL|TestPublicCommandWALBatchWriteSyncExternalRefOrderingPhaseStats' \
  -count=1

go test ./TreeDB \
  -run '^TestCrashRecovery_CommandWALDurableSyncedUncheckpointedFramesReplay$' \
  -count=1

go test ./TreeDB/db \
  -run '^TestAppendRawKVCommandWALOrderedEntriesRejectsMalformedValueLogPointerBeforeDurability$' \
  -count=1

go test -race ./TreeDB/caching ./TreeDB \
  -run 'TestCachingValueLogExternalRefSyncCoalescingGuards|TestCachingValueLogExternalRefFlusherSyncsRotatedSegments|TestPublicCommandWALBatchWriteSyncExternalRefOrderingPhaseStats' \
  -count=1

go test ./TreeDB/db ./TreeDB/caching ./TreeDB -count=1
go test ./... -count=1
```

The full repository run passed. Notable package durations were 406.987 s for `TreeDB/db` and 190.534 s for `TreeDB/collections`.

Covered edge cases include exact reuse, writer growth, released reservation, rotation, missing active writer, materialization failure, fallback sync failure, malformed pointers before any durability side effect, empty barriers, forced-pointer crash/reopen, and public counter reconciliation.

## Performance

Canonical comparison: separately compiled M2 base `851d8e89c` and candidate `b8f9625fc`, pinned to CPU 5, warmups excluded, alternating `A B B A A B B A A B B A A B B A`, eight samples per side, exactly 20 operations per sample.

```sh
taskset -c 5 ./TreeDB.test -test.run='^$' \
  -test.bench='^BenchmarkPublicCommandWALDurableTinyBatchWriteSync$/^placement=forced_pointer$/^shape=(dirty_batch|state_point_point_sync_batch_sync)$/^ops=1$' \
  -test.benchtime=20x -test.count=1
```

| Shape | M2 base | Candidate | Delta | Gate |
| --- | ---: | ---: | ---: | ---: |
| dirty batch | 16.93 ms/op +/-38% | 16.44 ms/op +/-86% | -2.9%, p=0.721 | at least -20% |
| state-shaped | 22.36 ms/op +/-68% | 24.44 ms/op +/-64% | +9.3%, p=0.878 | at least -20%; at most 16 ms |
| geomean | 19.46 ms/op | 20.04 ms/op | +3.0% | at least -20% |

Deterministic forced-pointer counters do show the intended mechanism:

| Counter | M2 base | Candidate |
| --- | ---: | ---: |
| physical value-log file syncs/op | 2 | 1 |
| logical value-log syncs/op | 2 | 1 |
| materialization syncs/op | 1 | 1 |
| external-reference syncs/op | 1 | 0 |

Allocations are unchanged: dirty is 36 allocs/op and 6.151 KiB/op on both sides; state-shaped is 39 allocs/op with 6.972 KiB base and 6.969 KiB candidate. A five-operation Linux trace contains exactly one value-log fsync followed by one command-WAL fsync per operation.

The candidate-pinned Ironbird diagnostic resolved `github.com/snissn/gomap@v0.6.2-0.20260711055505-b8f9625fc496` to full candidate SHA `b8f9625fc4965fad9a912437176334f3c7632ef6`. Backend verification passed and the accepted 331.580154797 s window included 223,997 successful transactions at 675.544047976 tx/s, with zero runner/result errors.

| Ironbird store | Calls | Mean | Absolute gate |
| --- | ---: | ---: | ---: |
| `application.db` | 1,313 | 14.450157 ms | at most 17 ms |
| `state.db` | 1,313 | 14.098515 ms | at most 16 ms |
| `blockstore.db` | 2,626 | 9.757395 ms | not selected |

Those absolute production-row ceilings pass, but the result is not attributable to this PR: every production store recorded zero public preflight-materialization time and zero public external-reference-ordering calls, so the optimized branch was inactive. The row is also unpaired and cannot establish a throughput delta.

Detailed commands, profiles, syscall evidence, counters, caveats, and the accepted diagnostic are recorded in `docs/benchmarks/treedb_durable_write_m3_sync_coalescing_2026-07-10.md`.

## Rollout / Toggle Plan

- Default setting: no new setting; exact certified coverage is reused automatically.
- Conservative fallback: any uncertainty executes the prior sync path.
- Disable quickly: revert the two commits in this PR; there is no format or API rollback concern.
- Observability: value-log logical sync, physical file-sync, command-WAL file-sync, and public phase counters distinguish reuse from fallback.

## Follow-ups

- Keep #3657 open: this lane does not satisfy the 20% focused latency gate or focused state target.
- Select another lane only from fresh wall/CPU/lock evidence; do not weaken the durability contract to manufacture a win.
- The issue-graph coordinator owns latest-head review, CI, and merge disposition for this bounded result.

### AI Review Loop

- Codex latest-head review: not requested in this handoff; coordinator owns the review gate.
- Copilot latest-head review: not requested.
- CodeRabbit latest-head review: not requested.
- Review comments/threads resolved or explicitly dismissed: none yet.
- Re-requested after final meaningful push: not applicable yet.

---

## Optimization PR Checklist (TreeDB)

### Scope

- [x] Single, clear objective.
- [x] Explicit include and exclude lists.
- [x] No unwanted feature reintroduction.

### Safety / Correctness

- [x] Written-versus-durable semantics documented for the touched `WriteSync` path.
- [x] No new mmap usage.
- [x] No new length fields or allocations from untrusted lengths.
- [x] Pointer validation fails before durability side effects.
- [x] Concurrency state and invariants are defined under `vlogMu` and the durable reservation.

### Tests

- [x] Deterministic regression tests cover the targeted duplicate sync and conservative fallbacks.
- [x] Tests use hooks/latches rather than timing sleeps.
- [x] Focused race coverage passed.
- [x] `go test ./... -count=1` passed.

### Benchmarks / Measurements

- [x] Relevant existing benchmark used unchanged before and after.
- [x] Alternating, pinned, eight-sample results and allocation counters reported.
- [x] CPU, alloc, block, mutex, trace, and syscall evidence captured.
- [x] No compression lane selected; incompressible comparison is not applicable.

### Docs / Rollout

- [x] Normative durable-write contract updated.
- [x] Benchmark and diagnostic report added.
- [x] No config, API, or on-disk format change.
- [x] Conservative fallback and revert path documented.
