### PR TITLE
TreeDB: close Dgraph MVCC readiness with conformance evidence

### DIFF
--- a/.github/scripts/check_mvcc_adapter_overhead_gate.py
+++ b/.github/scripts/check_mvcc_adapter_overhead_gate.py
@@ -129,7 +129,7 @@ def render(baseline_sha, candidate_sha, samples, max_regression, max_ratio, pass
     return "\n".join(lines)
 
 
-def synthetic(scale=1.0, adapter_ratio=1.5, bytes_delta=0.0, alloc_delta=0.0, runs=7):
+def synthetic(scale=1.0, adapter_ratio=1.5, bytes_delta=0.0, alloc_delta=0.0, runs=8):
     lines = []
     adapter_names = {adapter for _, _, adapter in PAIRS}
     for run in range(runs):
@@ -147,26 +147,26 @@ def self_test():
         base_path, head_path = Path(tmp) / "base", Path(tmp) / "head"
         base_path.write_text(synthetic(), encoding="utf-8")
         head_path.write_text(synthetic(scale=1.04), encoding="utf-8")
-        base, head = parse(base_path, 7), parse(head_path, 7)
+        base, head = parse(base_path, 8), parse(head_path, 8)
         assert evaluate(base, head, 5, 1, 64, 2)[0]
         head_path.write_text(synthetic(scale=1.06), encoding="utf-8")
-        assert not evaluate(base, parse(head_path, 7), 5, 1, 64, 2)[0]
+        assert not evaluate(base, parse(head_path, 8), 5, 1, 64, 2)[0]
         head_path.write_text(synthetic(bytes_delta=1.01), encoding="utf-8")
-        assert not evaluate(base, parse(head_path, 7), 5, 1, 64, 2)[0]
+        assert not evaluate(base, parse(head_path, 8), 5, 1, 64, 2)[0]
         head_path.write_text(synthetic(alloc_delta=1), encoding="utf-8")
-        assert not evaluate(base, parse(head_path, 7), 5, 1, 64, 2)[0]
+        assert not evaluate(base, parse(head_path, 8), 5, 1, 64, 2)[0]
         head_path.write_text(synthetic(adapter_ratio=2.01), encoding="utf-8")
-        assert not evaluate(base, parse(head_path, 7), 5, 1, 64, 2)[0]
-        head_path.write_text(synthetic(runs=6), encoding="utf-8")
+        assert not evaluate(base, parse(head_path, 8), 5, 1, 64, 2)[0]
+        head_path.write_text(synthetic(runs=7), encoding="utf-8")
         try:
-            parse(head_path, 7)
+            parse(head_path, 8)
         except ValueError:
             pass
         else:
             raise AssertionError("wrong sample count should fail")
         head_path.write_text(synthetic().replace(BENCHMARKS[0] + "-1", "ignored-1"), encoding="utf-8")
         try:
-            parse(head_path, 7)
+            parse(head_path, 8)
         except ValueError:
             pass
         else:
@@ -180,7 +180,7 @@ def main():
     parser.add_argument("--candidate")
     parser.add_argument("--baseline-sha")
     parser.add_argument("--candidate-sha")
-    parser.add_argument("--expected-samples", type=int, default=7)
+    parser.add_argument("--expected-samples", type=int, default=8)
     parser.add_argument("--max-regression-percent", type=float, default=5)
     parser.add_argument("--max-bytes-regression-percent", type=float, default=1)
     parser.add_argument("--max-bytes-regression-absolute", type=float, default=64)
@@ -196,13 +196,13 @@ def main():
     missing = [name for name in required if not getattr(args, name)]
     if missing:
         parser.error("missing required arguments: " + ", ".join(missing))
-    if args.expected_samples < 1 or min(
+    if args.expected_samples < 1 or args.expected_samples % 2 != 0 or min(
         args.max_regression_percent,
         args.max_bytes_regression_percent,
         args.max_bytes_regression_absolute,
         args.max_adapter_ratio,
     ) < 0:
-        parser.error("sample count must be positive and thresholds non-negative")
+        parser.error("sample count must be positive/even and thresholds non-negative")
     baseline = parse(Path(args.baseline), args.expected_samples)
     candidate = parse(Path(args.candidate), args.expected_samples)
     passed, results, ratios = evaluate(

--- a/.github/scripts/check_mvcc_adapter_overhead_gate.py
+++ b/.github/scripts/check_mvcc_adapter_overhead_gate.py
@@ -1,0 +1,228 @@
+#!/usr/bin/env python3
+"""Check MVCC adapter overhead and base/head regressions without dependencies."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import statistics
+import tempfile
+from pathlib import Path
+
+
+BENCHMARKS = (
+    "BenchmarkCommitAt/DirectTreeDB/1",
+    "BenchmarkCommitAt/MVCC/1",
+    "BenchmarkGetAt/DirectSeek/64",
+    "BenchmarkGetAt/MVCC/64",
+    "BenchmarkVersionIteration/Physical/keys=64/depth=32/reverse=false",
+    "BenchmarkVersionIteration/MVCC/keys=64/depth=32/reverse=false",
+)
+PAIRS = (
+    ("CommitAt", BENCHMARKS[0], BENCHMARKS[1]),
+    ("GetAt", BENCHMARKS[2], BENCHMARKS[3]),
+    ("VersionIteration", BENCHMARKS[4], BENCHMARKS[5]),
+)
+BENCH_RE = re.compile(
+    r"^(Benchmark.+?)(?:-\d+)?\s+\d+\s+([0-9.]+)\s+ns/op\s+(.*)$"
+)
+METRIC_RE = re.compile(r"([0-9.eE+-]+)\s+(B/op|allocs/op)(?:\s|$)")
+
+
+def parse(path: Path, expected: int) -> dict[str, list[tuple[float, float, float]]]:
+    rows = {name: [] for name in BENCHMARKS}
+    for line in path.read_text(encoding="utf-8", errors="replace").splitlines():
+        match = BENCH_RE.match(line.strip())
+        if match is None:
+            continue
+        name, ns, tail = match.groups()
+        if name in rows:
+            metrics = {unit: float(value) for value, unit in METRIC_RE.findall(tail)}
+            missing = {"B/op", "allocs/op"} - set(metrics)
+            if missing:
+                raise ValueError(f"{path}: {name}: missing metrics {sorted(missing)}")
+            rows[name].append((float(ns), metrics["B/op"], metrics["allocs/op"]))
+    for name, samples in rows.items():
+        if len(samples) != expected:
+            raise ValueError(f"{path}: expected {expected} samples for {name}, got {len(samples)}")
+    return rows
+
+
+def medians(rows: dict[str, list[tuple[float, float, float]]]) -> dict[str, tuple[float, float, float]]:
+    return {
+        name: tuple(statistics.median(sample[index] for sample in samples) for index in range(3))
+        for name, samples in rows.items()
+    }
+
+
+def evaluate(
+    baseline_rows,
+    candidate_rows,
+    max_regression: float,
+    max_bytes_percent: float,
+    max_bytes_absolute: float,
+    max_ratio: float,
+):
+    baseline = medians(baseline_rows)
+    candidate = medians(candidate_rows)
+    results = []
+    passed = True
+    for name in BENCHMARKS:
+        base_ns, base_bytes, base_allocs = baseline[name]
+        head_ns, head_bytes, head_allocs = candidate[name]
+        delta = (head_ns / base_ns - 1) * 100
+        bytes_tolerance = min(base_bytes * max_bytes_percent / 100, max_bytes_absolute)
+        row_pass = (
+            delta <= max_regression
+            and head_bytes - base_bytes <= bytes_tolerance
+            and head_allocs <= base_allocs
+        )
+        passed &= row_pass
+        results.append(
+            {
+                "benchmark": name,
+                "baseline": {"ns_per_op": base_ns, "bytes_per_op": base_bytes, "allocs_per_op": base_allocs},
+                "candidate": {"ns_per_op": head_ns, "bytes_per_op": head_bytes, "allocs_per_op": head_allocs},
+                "ns_delta_percent": delta,
+                "bytes_tolerance": bytes_tolerance,
+                "pass": row_pass,
+            }
+        )
+    ratios = []
+    for label, direct, adapter in PAIRS:
+        base_ratio = baseline[adapter][0] / baseline[direct][0]
+        head_ratio = candidate[adapter][0] / candidate[direct][0]
+        ratio_pass = head_ratio <= max_ratio
+        passed &= ratio_pass
+        ratios.append(
+            {"pair": label, "baseline_ratio": base_ratio, "candidate_ratio": head_ratio, "pass": ratio_pass}
+        )
+    return passed, results, ratios
+
+
+def render(baseline_sha, candidate_sha, samples, max_regression, max_ratio, passed, results, ratios):
+    lines = [
+        "## TreeDB MVCC adapter-overhead gate", "",
+        f"- result: **{'PASS' if passed else 'FAIL'}**",
+        f"- baseline: `{baseline_sha}`", f"- candidate: `{candidate_sha}`",
+        f"- samples: {samples} per revision, alternating sequential order",
+        f"- base/head timing threshold: +{max_regression:g}%",
+        f"- candidate MVCC/direct ratio threshold: {max_ratio:g}x", "",
+        "| Benchmark | Base ns/op | Head ns/op | Delta | Base B/op | Head B/op | Base allocs/op | Head allocs/op | Result |",
+        "| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | --- |",
+    ]
+    for row in results:
+        base, head = row["baseline"], row["candidate"]
+        lines.append(
+            f"| {row['benchmark']} | {base['ns_per_op']:.3f} | {head['ns_per_op']:.3f} | "
+            f"{row['ns_delta_percent']:+.2f}% | {base['bytes_per_op']:.3f} | {head['bytes_per_op']:.3f} | "
+            f"{base['allocs_per_op']:.3f} | {head['allocs_per_op']:.3f} | {'PASS' if row['pass'] else 'FAIL'} |"
+        )
+    lines.extend(["", "| Pair | Base ratio | Head ratio | Result |", "| --- | ---: | ---: | --- |"])
+    for row in ratios:
+        lines.append(
+            f"| {row['pair']} | {row['baseline_ratio']:.3f}x | {row['candidate_ratio']:.3f}x | "
+            f"{'PASS' if row['pass'] else 'FAIL'} |"
+        )
+    lines.append("")
+    return "\n".join(lines)
+
+
+def synthetic(scale=1.0, adapter_ratio=1.5, bytes_delta=0.0, alloc_delta=0.0, runs=7):
+    lines = []
+    adapter_names = {adapter for _, _, adapter in PAIRS}
+    for run in range(runs):
+        for index, name in enumerate(BENCHMARKS):
+            ns = (1000 + index + run) * scale * (adapter_ratio if name in adapter_names else 1)
+            lines.append(
+                f"{name}-1 10 {ns} ns/op 7 custom_metric/op "
+                f"{100 + bytes_delta} B/op {2 + alloc_delta} allocs/op"
+            )
+    return "\n".join(lines) + "\n"
+
+
+def self_test():
+    with tempfile.TemporaryDirectory() as tmp:
+        base_path, head_path = Path(tmp) / "base", Path(tmp) / "head"
+        base_path.write_text(synthetic(), encoding="utf-8")
+        head_path.write_text(synthetic(scale=1.04), encoding="utf-8")
+        base, head = parse(base_path, 7), parse(head_path, 7)
+        assert evaluate(base, head, 5, 1, 64, 2)[0]
+        head_path.write_text(synthetic(scale=1.06), encoding="utf-8")
+        assert not evaluate(base, parse(head_path, 7), 5, 1, 64, 2)[0]
+        head_path.write_text(synthetic(bytes_delta=1.01), encoding="utf-8")
+        assert not evaluate(base, parse(head_path, 7), 5, 1, 64, 2)[0]
+        head_path.write_text(synthetic(alloc_delta=1), encoding="utf-8")
+        assert not evaluate(base, parse(head_path, 7), 5, 1, 64, 2)[0]
+        head_path.write_text(synthetic(adapter_ratio=2.01), encoding="utf-8")
+        assert not evaluate(base, parse(head_path, 7), 5, 1, 64, 2)[0]
+        head_path.write_text(synthetic(runs=6), encoding="utf-8")
+        try:
+            parse(head_path, 7)
+        except ValueError:
+            pass
+        else:
+            raise AssertionError("wrong sample count should fail")
+        head_path.write_text(synthetic().replace(BENCHMARKS[0] + "-1", "ignored-1"), encoding="utf-8")
+        try:
+            parse(head_path, 7)
+        except ValueError:
+            pass
+        else:
+            raise AssertionError("missing row should fail")
+    print("check_mvcc_adapter_overhead_gate.py self-test: PASS")
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--baseline")
+    parser.add_argument("--candidate")
+    parser.add_argument("--baseline-sha")
+    parser.add_argument("--candidate-sha")
+    parser.add_argument("--expected-samples", type=int, default=7)
+    parser.add_argument("--max-regression-percent", type=float, default=5)
+    parser.add_argument("--max-bytes-regression-percent", type=float, default=1)
+    parser.add_argument("--max-bytes-regression-absolute", type=float, default=64)
+    parser.add_argument("--max-adapter-ratio", type=float, default=2)
+    parser.add_argument("--json-output")
+    parser.add_argument("--markdown-output")
+    parser.add_argument("--self-test", action="store_true")
+    args = parser.parse_args()
+    if args.self_test:
+        self_test()
+        return 0
+    required = ("baseline", "candidate", "baseline_sha", "candidate_sha", "json_output", "markdown_output")
+    missing = [name for name in required if not getattr(args, name)]
+    if missing:
+        parser.error("missing required arguments: " + ", ".join(missing))
+    if args.expected_samples < 1 or min(
+        args.max_regression_percent,
+        args.max_bytes_regression_percent,
+        args.max_bytes_regression_absolute,
+        args.max_adapter_ratio,
+    ) < 0:
+        parser.error("sample count must be positive and thresholds non-negative")
+    baseline = parse(Path(args.baseline), args.expected_samples)
+    candidate = parse(Path(args.candidate), args.expected_samples)
+    passed, results, ratios = evaluate(
+        baseline, candidate, args.max_regression_percent,
+        args.max_bytes_regression_percent, args.max_bytes_regression_absolute,
+        args.max_adapter_ratio,
+    )
+    payload = {
+        "pass": passed, "baseline_sha": args.baseline_sha, "candidate_sha": args.candidate_sha,
+        "expected_samples": args.expected_samples, "results": results, "ratios": ratios,
+    }
+    Path(args.json_output).write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    markdown = render(
+        args.baseline_sha, args.candidate_sha, args.expected_samples,
+        args.max_regression_percent, args.max_adapter_ratio, passed, results, ratios,
+    )
+    Path(args.markdown_output).write_text(markdown, encoding="utf-8")
+    print(markdown, end="")
+    return 0 if passed else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/scripts/check_mvcc_adapter_overhead_gate.py
+++ b/.github/scripts/check_mvcc_adapter_overhead_gate.py
@@ -106,7 +106,7 @@ def render(baseline_sha, candidate_sha, samples, max_regression, max_ratio, pass
         "## TreeDB MVCC adapter-overhead gate", "",
         f"- result: **{'PASS' if passed else 'FAIL'}**",
         f"- baseline: `{baseline_sha}`", f"- candidate: `{candidate_sha}`",
-        f"- samples: {samples} per revision, alternating sequential order",
+        f"- samples: {samples} per revision, benchmark-group-paired alternating AB/BA order",
         f"- base/head timing threshold: +{max_regression:g}%",
         f"- candidate MVCC/direct ratio threshold: {max_ratio:g}x", "",
         "| Benchmark | Base ns/op | Head ns/op | Delta | Base B/op | Head B/op | Base allocs/op | Head allocs/op | Result |",

--- a/.github/scripts/check_mvcc_adapter_overhead_gate.py
+++ b/.github/scripts/check_mvcc_adapter_overhead_gate.py
@@ -32,13 +32,21 @@ METRIC_RE = re.compile(r"([0-9.eE+-]+)\s+(B/op|allocs/op)(?:\s|$)")
 
 def parse(path: Path, expected: int) -> dict[str, list[tuple[float, float, float]]]:
     rows = {name: [] for name in BENCHMARKS}
-    for line in path.read_text(encoding="utf-8", errors="replace").splitlines():
+    for line_number, line in enumerate(
+        path.read_text(encoding="utf-8", errors="replace").splitlines(), 1
+    ):
         match = BENCH_RE.match(line.strip())
         if match is None:
             continue
         name, ns, tail = match.groups()
         if name in rows:
-            metrics = {unit: float(value) for value, unit in METRIC_RE.findall(tail)}
+            metrics = {}
+            for value, unit in METRIC_RE.findall(tail):
+                if unit in metrics:
+                    raise ValueError(
+                        f"{path}:{line_number}: {name}: duplicate metric unit {unit}"
+                    )
+                metrics[unit] = float(value)
             missing = {"B/op", "allocs/op"} - set(metrics)
             if missing:
                 raise ValueError(f"{path}: {name}: missing metrics {sorted(missing)}")
@@ -103,7 +111,7 @@ def evaluate(
 
 def render(baseline_sha, candidate_sha, samples, max_regression, max_ratio, passed, results, ratios):
     lines = [
-        "## TreeDB MVCC adapter-overhead gate", "",
+        "# TreeDB MVCC adapter-overhead gate", "",
         f"- result: **{'PASS' if passed else 'FAIL'}**",
         f"- baseline: `{baseline_sha}`", f"- candidate: `{candidate_sha}`",
         f"- samples: {samples} per revision, benchmark-group-paired alternating AB/BA order",
@@ -171,6 +179,16 @@ def self_test():
             pass
         else:
             raise AssertionError("missing row should fail")
+        head_path.write_text(
+            synthetic().replace("100.0 B/op", "100.0 B/op 101.0 B/op", 1),
+            encoding="utf-8",
+        )
+        try:
+            parse(head_path, 8)
+        except ValueError:
+            pass
+        else:
+            raise AssertionError("duplicate metric unit should fail")
     print("check_mvcc_adapter_overhead_gate.py self-test: PASS")
 
 

--- a/.github/scripts/check_mvcc_raw_path_gate.py
+++ b/.github/scripts/check_mvcc_raw_path_gate.py
@@ -1,11 +1,14 @@
 #!/usr/bin/env python3
-"""Check paired TreeDB raw-path benchmark medians without third-party modules."""
+"""Check paired TreeDB raw-path medians and benchmark-binary equivalence."""
 
 from __future__ import annotations
 
 import argparse
+import hashlib
 import json
+import os
 import re
+import stat
 import statistics
 import tempfile
 from dataclasses import dataclass
@@ -19,6 +22,14 @@ BENCHMARKS = (
     "BenchmarkRepeatedIterator",
     "BenchmarkPublicCommandWALDurableTinyBatchWriteSync/placement=inline/shape=dirty_batch/ops=1",
 )
+BINARY_PACKAGE_BY_BENCHMARK = {
+    "BenchmarkGetVersioned": "db",
+    "BenchmarkConditionalTxnBaselineBatchWrite": "db",
+    "BenchmarkSnapshotIteratorSeekNext/keys=1024/snapshot_seek": "treedb",
+    "BenchmarkRepeatedIterator": "caching",
+    "BenchmarkPublicCommandWALDurableTinyBatchWriteSync/placement=inline/shape=dirty_batch/ops=1": "treedb",
+}
+BINARY_PACKAGES = ("db", "caching", "treedb")
 BENCH_RE = re.compile(
     r"^(Benchmark.+?)(?:-\d+)?\s+\d+\s+([0-9.]+)\s+ns/op\s+(.*)$"
 )
@@ -30,6 +41,53 @@ class Sample:
     ns_per_op: float
     bytes_per_op: float
     allocs_per_op: float
+
+
+def sha256_file(path: Path) -> tuple[str, tuple[int, int]]:
+    if path.is_symlink():
+        raise ValueError(f"benchmark binary evidence must not be a symlink: {path}")
+    digest = hashlib.sha256()
+    try:
+        with path.open("rb") as source:
+            metadata = os.fstat(source.fileno())
+            if not stat.S_ISREG(metadata.st_mode):
+                raise ValueError(
+                    f"benchmark binary evidence must be a regular file: {path}"
+                )
+            for chunk in iter(lambda: source.read(1024 * 1024), b""):
+                digest.update(chunk)
+    except OSError as error:
+        raise ValueError(f"missing benchmark binary evidence: {path}: {error}") from error
+    return digest.hexdigest(), (metadata.st_dev, metadata.st_ino)
+
+
+def compute_binary_digests(
+    binary_paths: dict[str, dict[str, Path]],
+) -> dict[str, dict[str, str]]:
+    if set(binary_paths) != set(BINARY_PACKAGES):
+        raise ValueError("binary path mapping must contain exactly db, caching, and treedb")
+    digests: dict[str, dict[str, str]] = {}
+    identities: set[tuple[int, int]] = set()
+    for package in BINARY_PACKAGES:
+        revisions = binary_paths[package]
+        if set(revisions) != {"baseline", "candidate"}:
+            raise ValueError(
+                f"binary path mapping for {package} must contain exactly baseline and candidate"
+            )
+        digests[package] = {}
+        for revision in ("baseline", "candidate"):
+            path = revisions[revision]
+            expected_name = f"{revision}-{package}.test"
+            if path.name != expected_name:
+                raise ValueError(
+                    f"{revision} {package} binary must be named {expected_name}: {path}"
+                )
+            digest, identity = sha256_file(path)
+            if identity in identities:
+                raise ValueError(f"benchmark binary paths must identify six files: {path}")
+            identities.add(identity)
+            digests[package][revision] = digest
+    return digests
 
 
 def parse_benchmarks(path: Path, expected_samples: int) -> dict[str, list[Sample]]:
@@ -107,10 +165,39 @@ def evaluate(
                 "timing_pass": timing_pass,
                 "bytes_pass": bytes_pass,
                 "allocs_pass": allocs_pass,
-                "pass": row_pass,
+                "measurement_pass": row_pass,
             }
         )
     return passed, results
+
+
+def annotate_binary_equivalence(
+    results: list[dict[str, object]],
+    binary_digests: dict[str, dict[str, str]],
+) -> tuple[bool, list[dict[str, object]]]:
+    annotated: list[dict[str, object]] = []
+    all_equivalent = True
+    for result in results:
+        benchmark = result["benchmark"]
+        assert isinstance(benchmark, str)
+        package = BINARY_PACKAGE_BY_BENCHMARK[benchmark]
+        package_digests = binary_digests[package]
+        equivalent = package_digests["baseline"] == package_digests["candidate"]
+        all_equivalent = all_equivalent and equivalent
+        annotated.append(
+            {
+                **result,
+                "binary_package": package,
+                "binary_equivalent": equivalent,
+            }
+        )
+    return all_equivalent, annotated
+
+
+def acceptance_verdict(measurement_pass: bool, all_equivalent: bool) -> str:
+    if all_equivalent:
+        return "EQUIVALENT"
+    return "PASS" if measurement_pass else "FAIL"
 
 
 def render_markdown(
@@ -120,13 +207,16 @@ def render_markdown(
     max_regression_percent: float,
     max_bytes_regression_percent: float,
     max_bytes_regression_absolute: float,
-    passed: bool,
+    measurement_pass: bool,
+    verdict: str,
+    binary_digests: dict[str, dict[str, str]],
     results: list[dict[str, object]],
 ) -> str:
     lines = [
         "## TreeDB MVCC raw-path gate",
         "",
-        f"- result: **{'PASS' if passed else 'FAIL'}**",
+        f"- verdict: **{verdict}**",
+        f"- measured threshold observation: **{'PASS' if measurement_pass else 'FAIL'}**",
         f"- baseline: `{baseline_sha}`",
         f"- candidate: `{candidate_sha}`",
         f"- samples: {expected_samples} per revision, benchmark-group-paired alternating AB/BA order",
@@ -135,20 +225,51 @@ def render_markdown(
         "- B/op jitter threshold: candidate median may increase by at most the smaller of "
         f"{max_bytes_regression_percent:g}% or {max_bytes_regression_absolute:g} B; "
         "zero-B baselines remain strict",
-        "",
-        "| Benchmark | Base ns/op | Head ns/op | Delta | Base B/op | Head B/op | B tolerance | Base allocs/op | Head allocs/op | Result |",
-        "| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | --- |",
     ]
+    if verdict == "EQUIVALENT":
+        lines.extend(
+            [
+                "- equivalence acceptance: every row-producing base/head benchmark binary "
+                "is byte-identical, so the measured delta is retained but is not "
+                "attributable to the candidate revision",
+            ]
+        )
+    lines.extend(
+        [
+            "",
+            "| Package | Baseline SHA-256 | Candidate SHA-256 | Relation |",
+            "| --- | --- | --- | --- |",
+        ]
+    )
+    for package in BINARY_PACKAGES:
+        base_digest = binary_digests[package]["baseline"]
+        candidate_digest = binary_digests[package]["candidate"]
+        relation = "EQUIVALENT" if base_digest == candidate_digest else "DIFFERENT"
+        lines.append(
+            f"| {package} | `{base_digest}` | `{candidate_digest}` | {relation} |"
+        )
+    lines.extend(
+        [
+            "",
+            "| Benchmark | Binary | Base ns/op | Head ns/op | Delta | Base B/op | Head B/op | B tolerance | Base allocs/op | Head allocs/op | Measured |",
+            "| --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | --- |",
+        ]
+    )
     for row in results:
         base = row["baseline"]
         head = row["candidate"]
         assert isinstance(base, dict)
         assert isinstance(head, dict)
         lines.append(
-            "| {benchmark} | {base_ns:.3f} | {head_ns:.3f} | {delta:+.2f}% | "
+            "| {benchmark} | {binary} | {base_ns:.3f} | {head_ns:.3f} | {delta:+.2f}% | "
             "{base_bytes:.3f} | {head_bytes:.3f} | {bytes_tolerance:.3f} | {base_allocs:.3f} | "
             "{head_allocs:.3f} | {status} |".format(
                 benchmark=row["benchmark"],
+                binary=(
+                    f"{row['binary_package']} EQUIVALENT"
+                    if row["binary_equivalent"]
+                    else f"{row['binary_package']} DIFFERENT"
+                ),
                 base_ns=base["ns_per_op"],
                 head_ns=head["ns_per_op"],
                 delta=row["ns_delta_percent"],
@@ -157,7 +278,7 @@ def render_markdown(
                 bytes_tolerance=row["bytes_tolerance"],
                 base_allocs=base["allocs_per_op"],
                 head_allocs=head["allocs_per_op"],
-                status="PASS" if row["pass"] else "FAIL",
+                status="PASS" if row["measurement_pass"] else "FAIL",
             )
         )
     lines.append("")
@@ -169,7 +290,7 @@ def synthetic_log(
     bytes_base: float = 128.0,
     bytes_delta: float = 0.0,
     alloc_delta: float = 0.0,
-    runs: int = 7,
+    runs: int = 8,
 ) -> str:
     lines: list[str] = []
     for index in range(runs):
@@ -192,20 +313,20 @@ def self_test() -> None:
         candidate_path = root / "candidate.txt"
         baseline_path.write_text(synthetic_log(), encoding="utf-8")
         candidate_path.write_text(synthetic_log(ns_scale=1.04), encoding="utf-8")
-        baseline = parse_benchmarks(baseline_path, 7)
-        candidate = parse_benchmarks(candidate_path, 7)
+        baseline = parse_benchmarks(baseline_path, 8)
+        candidate = parse_benchmarks(candidate_path, 8)
         passed, _ = evaluate(baseline, candidate, 5.0, 1.0, 64.0)
         if not passed:
             raise AssertionError("4% timing change should pass")
 
         candidate_path.write_text(synthetic_log(ns_scale=1.06), encoding="utf-8")
-        candidate = parse_benchmarks(candidate_path, 7)
+        candidate = parse_benchmarks(candidate_path, 8)
         passed, _ = evaluate(baseline, candidate, 5.0, 1.0, 64.0)
         if passed:
             raise AssertionError("6% timing regression should fail")
 
         candidate_path.write_text(synthetic_log(alloc_delta=1.0), encoding="utf-8")
-        candidate = parse_benchmarks(candidate_path, 7)
+        candidate = parse_benchmarks(candidate_path, 8)
         passed, _ = evaluate(baseline, candidate, 5.0, 1.0, 64.0)
         if passed:
             raise AssertionError("allocation regression should fail")
@@ -214,8 +335,8 @@ def self_test() -> None:
         candidate_path.write_text(
             synthetic_log(bytes_base=100.0, bytes_delta=1.0), encoding="utf-8"
         )
-        baseline = parse_benchmarks(baseline_path, 7)
-        candidate = parse_benchmarks(candidate_path, 7)
+        baseline = parse_benchmarks(baseline_path, 8)
+        candidate = parse_benchmarks(candidate_path, 8)
         passed, _ = evaluate(baseline, candidate, 5.0, 1.0, 64.0)
         if not passed:
             raise AssertionError("B/op increase at the 1% boundary should pass")
@@ -223,7 +344,7 @@ def self_test() -> None:
         candidate_path.write_text(
             synthetic_log(bytes_base=100.0, bytes_delta=1.001), encoding="utf-8"
         )
-        candidate = parse_benchmarks(candidate_path, 7)
+        candidate = parse_benchmarks(candidate_path, 8)
         passed, _ = evaluate(baseline, candidate, 5.0, 1.0, 64.0)
         if passed:
             raise AssertionError("B/op increase above the 1% boundary should fail")
@@ -232,8 +353,8 @@ def self_test() -> None:
         candidate_path.write_text(
             synthetic_log(bytes_base=10000.0, bytes_delta=64.0), encoding="utf-8"
         )
-        baseline = parse_benchmarks(baseline_path, 7)
-        candidate = parse_benchmarks(candidate_path, 7)
+        baseline = parse_benchmarks(baseline_path, 8)
+        candidate = parse_benchmarks(candidate_path, 8)
         passed, _ = evaluate(baseline, candidate, 5.0, 1.0, 64.0)
         if not passed:
             raise AssertionError("B/op increase at the 64 B boundary should pass")
@@ -241,14 +362,14 @@ def self_test() -> None:
         candidate_path.write_text(
             synthetic_log(bytes_base=10000.0, bytes_delta=64.001), encoding="utf-8"
         )
-        candidate = parse_benchmarks(candidate_path, 7)
+        candidate = parse_benchmarks(candidate_path, 8)
         passed, _ = evaluate(baseline, candidate, 5.0, 1.0, 64.0)
         if passed:
             raise AssertionError("B/op increase above the 64 B boundary should fail")
 
-        candidate_path.write_text(synthetic_log(runs=6), encoding="utf-8")
+        candidate_path.write_text(synthetic_log(runs=7), encoding="utf-8")
         try:
-            parse_benchmarks(candidate_path, 7)
+            parse_benchmarks(candidate_path, 8)
         except ValueError:
             pass
         else:
@@ -259,7 +380,7 @@ def self_test() -> None:
             encoding="utf-8",
         )
         try:
-            parse_benchmarks(candidate_path, 7)
+            parse_benchmarks(candidate_path, 8)
         except ValueError:
             pass
         else:
@@ -273,7 +394,10 @@ def main() -> int:
     parser.add_argument("--candidate")
     parser.add_argument("--baseline-sha")
     parser.add_argument("--candidate-sha")
-    parser.add_argument("--expected-samples", type=int, default=7)
+    for package in BINARY_PACKAGES:
+        parser.add_argument(f"--baseline-{package}-binary")
+        parser.add_argument(f"--candidate-{package}-binary")
+    parser.add_argument("--expected-samples", type=int, default=8)
     parser.add_argument("--max-regression-percent", type=float, default=5.0)
     parser.add_argument("--max-bytes-regression-percent", type=float, default=1.0)
     parser.add_argument("--max-bytes-regression-absolute", type=float, default=64.0)
@@ -302,21 +426,44 @@ def main() -> int:
         "json_output",
         "markdown_output",
     )
+    required += tuple(
+        f"{revision}_{package}_binary"
+        for package in BINARY_PACKAGES
+        for revision in ("baseline", "candidate")
+    )
     missing = [name for name in required if getattr(args, name) in (None, "")]
     if missing:
         parser.error("missing required arguments: " + ", ".join(missing))
+    if args.expected_samples <= 0 or args.expected_samples % 2 != 0:
+        parser.error("--expected-samples must be a positive even integer")
 
     baseline = parse_benchmarks(Path(args.baseline), args.expected_samples)
     candidate = parse_benchmarks(Path(args.candidate), args.expected_samples)
-    passed, results = evaluate(
+    binary_digests = compute_binary_digests(
+        {
+            package: {
+                revision: Path(getattr(args, f"{revision}_{package}_binary"))
+                for revision in ("baseline", "candidate")
+            }
+            for package in BINARY_PACKAGES
+        }
+    )
+    measurement_pass, results = evaluate(
         baseline,
         candidate,
         args.max_regression_percent,
         args.max_bytes_regression_percent,
         args.max_bytes_regression_absolute,
     )
+    all_equivalent, results = annotate_binary_equivalence(results, binary_digests)
+    verdict = acceptance_verdict(measurement_pass, all_equivalent)
+    accepted = verdict in {"PASS", "EQUIVALENT"}
     payload = {
-        "pass": passed,
+        "accepted": accepted,
+        "verdict": verdict,
+        "measurement_pass": measurement_pass,
+        "all_row_binaries_equivalent": all_equivalent,
+        "binary_digests": binary_digests,
         "baseline_sha": args.baseline_sha,
         "candidate_sha": args.candidate_sha,
         "expected_samples": args.expected_samples,
@@ -335,12 +482,14 @@ def main() -> int:
         args.max_regression_percent,
         args.max_bytes_regression_percent,
         args.max_bytes_regression_absolute,
-        passed,
+        measurement_pass,
+        verdict,
+        binary_digests,
         results,
     )
     Path(args.markdown_output).write_text(markdown, encoding="utf-8")
     print(markdown, end="")
-    return 0 if passed else 1
+    return 0 if accepted else 1
 
 
 if __name__ == "__main__":

--- a/.github/scripts/check_mvcc_raw_path_gate.py
+++ b/.github/scripts/check_mvcc_raw_path_gate.py
@@ -129,7 +129,7 @@ def render_markdown(
         f"- result: **{'PASS' if passed else 'FAIL'}**",
         f"- baseline: `{baseline_sha}`",
         f"- candidate: `{candidate_sha}`",
-        f"- samples: {expected_samples} per revision, alternating sequential order",
+        f"- samples: {expected_samples} per revision, benchmark-group-paired alternating AB/BA order",
         f"- timing threshold: candidate median <= baseline median + {max_regression_percent:g}%",
         "- allocs/op threshold: candidate median must not increase",
         "- B/op jitter threshold: candidate median may increase by at most the smaller of "

--- a/.github/scripts/check_mvcc_raw_path_gate.py
+++ b/.github/scripts/check_mvcc_raw_path_gate.py
@@ -92,14 +92,22 @@ def compute_binary_digests(
 
 def parse_benchmarks(path: Path, expected_samples: int) -> dict[str, list[Sample]]:
     samples = {name: [] for name in BENCHMARKS}
-    for line in path.read_text(encoding="utf-8", errors="replace").splitlines():
+    for line_number, line in enumerate(
+        path.read_text(encoding="utf-8", errors="replace").splitlines(), 1
+    ):
         match = BENCH_RE.match(line.strip())
         if match is None:
             continue
         name, ns_per_op, tail = match.groups()
         if name not in samples:
             continue
-        metrics = {unit: float(value) for value, unit in METRIC_RE.findall(tail)}
+        metrics = {}
+        for value, unit in METRIC_RE.findall(tail):
+            if unit in metrics:
+                raise ValueError(
+                    f"{path}:{line_number}: {name}: duplicate metric unit {unit}"
+                )
+            metrics[unit] = float(value)
         missing = {"B/op", "allocs/op"} - set(metrics)
         if missing:
             raise ValueError(f"{path}: {name}: missing metrics {sorted(missing)}")
@@ -385,6 +393,18 @@ def self_test() -> None:
             pass
         else:
             raise AssertionError("missing required row should fail")
+        candidate_path.write_text(
+            synthetic_log().replace(
+                "128.000 B/op", "128.000 B/op 129.000 B/op", 1
+            ),
+            encoding="utf-8",
+        )
+        try:
+            parse_benchmarks(candidate_path, 8)
+        except ValueError:
+            pass
+        else:
+            raise AssertionError("duplicate metric unit should fail")
     print("check_mvcc_raw_path_gate.py self-test: PASS")
 
 

--- a/.github/scripts/check_mvcc_raw_path_gate.py
+++ b/.github/scripts/check_mvcc_raw_path_gate.py
@@ -195,9 +195,9 @@ def annotate_binary_equivalence(
 
 
 def acceptance_verdict(measurement_pass: bool, all_equivalent: bool) -> str:
-    if all_equivalent:
-        return "EQUIVALENT"
-    return "PASS" if measurement_pass else "FAIL"
+    if measurement_pass:
+        return "PASS"
+    return "EQUIVALENT" if all_equivalent else "FAIL"
 
 
 def render_markdown(
@@ -460,6 +460,7 @@ def main() -> int:
     accepted = verdict in {"PASS", "EQUIVALENT"}
     payload = {
         "accepted": accepted,
+        "no_attributable_regression": accepted,
         "verdict": verdict,
         "measurement_pass": measurement_pass,
         "all_row_binaries_equivalent": all_equivalent,

--- a/.github/scripts/check_mvcc_raw_path_gate.py
+++ b/.github/scripts/check_mvcc_raw_path_gate.py
@@ -15,12 +15,14 @@ from pathlib import Path
 BENCHMARKS = (
     "BenchmarkGetVersioned",
     "BenchmarkConditionalTxnBaselineBatchWrite",
+    "BenchmarkSnapshotIteratorSeekNext/keys=1024/snapshot_seek",
+    "BenchmarkRepeatedIterator",
+    "BenchmarkPublicCommandWALDurableTinyBatchWriteSync/placement=inline/shape=dirty_batch/ops=1",
 )
 BENCH_RE = re.compile(
-    r"^(Benchmark(?:GetVersioned|ConditionalTxnBaselineBatchWrite))(?:-\d+)?\s+"
-    r"\d+\s+([0-9.]+)\s+ns/op\s+([0-9.]+)\s+B/op\s+"
-    r"([0-9.]+)\s+allocs/op\s*$"
+    r"^(Benchmark.+?)(?:-\d+)?\s+\d+\s+([0-9.]+)\s+ns/op\s+(.*)$"
 )
+METRIC_RE = re.compile(r"([0-9.eE+-]+)\s+(B/op|allocs/op)(?:\s|$)")
 
 
 @dataclass(frozen=True)
@@ -36,9 +38,15 @@ def parse_benchmarks(path: Path, expected_samples: int) -> dict[str, list[Sample
         match = BENCH_RE.match(line.strip())
         if match is None:
             continue
-        name, ns_per_op, bytes_per_op, allocs_per_op = match.groups()
+        name, ns_per_op, tail = match.groups()
+        if name not in samples:
+            continue
+        metrics = {unit: float(value) for value, unit in METRIC_RE.findall(tail)}
+        missing = {"B/op", "allocs/op"} - set(metrics)
+        if missing:
+            raise ValueError(f"{path}: {name}: missing metrics {sorted(missing)}")
         samples[name].append(
-            Sample(float(ns_per_op), float(bytes_per_op), float(allocs_per_op))
+            Sample(float(ns_per_op), metrics["B/op"], metrics["allocs/op"])
         )
 
     for name, rows in samples.items():
@@ -161,15 +169,17 @@ def synthetic_log(
     bytes_base: float = 128.0,
     bytes_delta: float = 0.0,
     alloc_delta: float = 0.0,
+    runs: int = 7,
 ) -> str:
     lines: list[str] = []
-    for index in range(7):
+    for index in range(runs):
         for bench_index, name in enumerate(BENCHMARKS):
             ns_per_op = (1000.0 + bench_index * 9000.0 + index) * ns_scale
             bytes_per_op = bytes_base + bench_index * bytes_base + bytes_delta
             allocs_per_op = 2.0 + bench_index + alloc_delta
             lines.append(
                 f"{name}-1 1000 {ns_per_op:.3f} ns/op "
+                f"7.000 custom_metric/op "
                 f"{bytes_per_op:.3f} B/op {allocs_per_op:.3f} allocs/op"
             )
     return "\n".join(lines) + "\n"
@@ -236,13 +246,24 @@ def self_test() -> None:
         if passed:
             raise AssertionError("B/op increase above the 64 B boundary should fail")
 
-        candidate_path.write_text("", encoding="utf-8")
+        candidate_path.write_text(synthetic_log(runs=6), encoding="utf-8")
         try:
             parse_benchmarks(candidate_path, 7)
         except ValueError:
             pass
         else:
-            raise AssertionError("missing benchmark rows should fail")
+            raise AssertionError("wrong sample count should fail")
+
+        candidate_path.write_text(
+            synthetic_log().replace(BENCHMARKS[0] + "-1", "IgnoredBenchmark-1"),
+            encoding="utf-8",
+        )
+        try:
+            parse_benchmarks(candidate_path, 7)
+        except ValueError:
+            pass
+        else:
+            raise AssertionError("missing required row should fail")
     print("check_mvcc_raw_path_gate.py self-test: PASS")
 
 

--- a/.github/scripts/summarize_mvcc_closeout.py
+++ b/.github/scripts/summarize_mvcc_closeout.py
@@ -51,9 +51,10 @@ def parse_resources(path: Path) -> dict[str, float]:
     if not rss or not user or not system:
         raise ValueError(f"{path}: incomplete /usr/bin/time evidence")
     return {
+        "invocations": float(len(rss)),
         "max_rss_kib": float(max(rss)),
-        "median_user_seconds": statistics.median(user),
-        "median_system_seconds": statistics.median(system),
+        "total_user_seconds": sum(user),
+        "total_system_seconds": sum(system),
     }
 
 
@@ -75,9 +76,10 @@ def render_markdown(
         "",
         f"- candidate: `{candidate_sha}`",
         f"- samples: {expected}",
+        f"- measured benchmark invocations: {resources['invocations']:.0f}",
         f"- maximum benchmark-process RSS: {resources['max_rss_kib']:.0f} KiB",
-        f"- median process CPU: user {resources['median_user_seconds']:.2f}s, "
-        f"system {resources['median_system_seconds']:.2f}s",
+        f"- aggregate process CPU: user {resources['total_user_seconds']:.2f}s, "
+        f"system {resources['total_system_seconds']:.2f}s",
         "- durability classes are separate rows; relaxed rows are not durability-equivalent to durable sync",
         "",
         "| Benchmark | ns/op | Throughput | B/op | allocs/op | storage bytes/op | durable bytes/op |",

--- a/.github/scripts/summarize_mvcc_closeout.py
+++ b/.github/scripts/summarize_mvcc_closeout.py
@@ -19,6 +19,39 @@ RSS_RE = re.compile(r"Maximum resident set size \(kbytes\):\s+(\d+)")
 USER_RE = re.compile(r"User time \(seconds\):\s+([0-9.]+)")
 SYSTEM_RE = re.compile(r"System time \(seconds\):\s+([0-9.]+)")
 
+PROFILES = ("durable_sync", "wal_on_relaxed", "wal_off_relaxed")
+EXPECTED_BENCHMARKS = frozenset(
+    name
+    for profile in PROFILES
+    for name in (
+        f"BenchmarkDgraphMVCCCloseout/CommitAt/{profile}/batch=1",
+        f"BenchmarkDgraphMVCCCloseout/CommitAt/{profile}/batch=32",
+        f"BenchmarkDgraphMVCCCloseout/GetAt/{profile}/depth=1",
+        f"BenchmarkDgraphMVCCCloseout/GetAt/{profile}/depth=64",
+        f"BenchmarkDgraphMVCCCloseout/AllVersions/{profile}/keys=64/depth=1",
+        f"BenchmarkDgraphMVCCCloseout/AllVersions/{profile}/keys=64/depth=32",
+        f"BenchmarkDgraphMVCCCloseout/Prune/{profile}/keys=64/depth=16/floor=4",
+        f"BenchmarkDgraphMVCCCloseout/Prune/{profile}/keys=64/depth=16/floor=12",
+    )
+)
+
+
+def required_metrics(name: str) -> set[str]:
+    required = {"ns/op", "B/op", "allocs/op"}
+    if "/CommitAt/" in name:
+        required.update(("mutations/s", "storage_bytes/op"))
+    elif "/GetAt/" in name:
+        required.add("lookups/s")
+    elif "/AllVersions/" in name:
+        required.add("versions/s")
+    elif "/Prune/" in name:
+        required.update(
+            ("pruned_versions/s", "storage_bytes/op", "delete_write_amplification")
+        )
+    if "/durable_sync/" in name and ("/CommitAt/" in name or "/Prune/" in name):
+        required.add("durable_footprint_bytes/op")
+    return required
+
 
 def parse_benchmarks(path: Path, expected: int) -> dict[str, dict[str, float]]:
     samples: dict[str, list[dict[str, float]]] = {}
@@ -32,10 +65,20 @@ def parse_benchmarks(path: Path, expected: int) -> dict[str, dict[str, float]]:
         samples.setdefault(name, []).append(metrics)
     if not samples:
         raise ValueError(f"{path}: no closeout benchmarks found")
+    names = set(samples)
+    if names != EXPECTED_BENCHMARKS:
+        missing = sorted(EXPECTED_BENCHMARKS - names)
+        extra = sorted(names - EXPECTED_BENCHMARKS)
+        raise ValueError(f"{path}: benchmark set mismatch; missing={missing}; extra={extra}")
     medians: dict[str, dict[str, float]] = {}
     for name, rows in samples.items():
         if len(rows) != expected:
             raise ValueError(f"{path}: {name}: expected {expected} samples, got {len(rows)}")
+        required = required_metrics(name)
+        for index, row in enumerate(rows, 1):
+            missing = sorted(required - set(row))
+            if missing:
+                raise ValueError(f"{path}: {name}: sample {index} missing metrics {missing}")
         units = set.intersection(*(set(row) for row in rows))
         medians[name] = {
             unit: statistics.median(row[unit] for row in rows) for unit in sorted(units)
@@ -43,13 +86,18 @@ def parse_benchmarks(path: Path, expected: int) -> dict[str, dict[str, float]]:
     return medians
 
 
-def parse_resources(path: Path) -> dict[str, float]:
+def parse_resources(path: Path, expected_samples: int) -> dict[str, float]:
     text = path.read_text(encoding="utf-8", errors="replace")
     rss = [int(value) for value in RSS_RE.findall(text)]
     user = [float(value) for value in USER_RE.findall(text)]
     system = [float(value) for value in SYSTEM_RE.findall(text)]
-    if not rss or not user or not system:
-        raise ValueError(f"{path}: incomplete /usr/bin/time evidence")
+    expected_invocations = expected_samples * 2
+    counts = (len(rss), len(user), len(system))
+    if counts != (expected_invocations,) * 3:
+        raise ValueError(
+            f"{path}: expected {expected_invocations} complete /usr/bin/time "
+            f"invocations, got rss/user/system={counts}"
+        )
     return {
         "invocations": float(len(rss)),
         "max_rss_kib": float(max(rss)),
@@ -63,6 +111,11 @@ def throughput(metrics: dict[str, float]) -> tuple[float, str]:
         if unit in metrics:
             return metrics[unit], unit
     return 0.0, "-"
+
+
+def metric_text(metrics: dict[str, float], unit: str) -> str:
+    value = metrics.get(unit)
+    return "-" if value is None else f"{value:.3f}"
 
 
 def render_markdown(
@@ -82,7 +135,7 @@ def render_markdown(
         f"system {resources['total_system_seconds']:.2f}s",
         "- durability classes are separate rows; relaxed rows are not durability-equivalent to durable sync",
         "",
-        "| Benchmark | ns/op | Throughput | B/op | allocs/op | storage bytes/op | durable bytes/op | delete write amp |",
+        "| Benchmark | ns/op | Throughput | B/op | allocs/op | storage bytes/op | durable footprint bytes/op | delete write amp |",
         "| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |",
     ]
     for name in sorted(medians):
@@ -91,10 +144,10 @@ def render_markdown(
         rate_text = f"{rate:.3f} {unit}" if unit != "-" else "-"
         lines.append(
             f"| `{name}` | {metrics['ns/op']:.3f} | {rate_text} | "
-            f"{metrics.get('B/op', 0):.3f} | {metrics.get('allocs/op', 0):.3f} | "
-            f"{metrics.get('storage_bytes/op', 0):.3f} | "
-            f"{metrics.get('durable_bytes/op', 0):.3f} | "
-            f"{metrics.get('delete_write_amplification', 0):.3f} |"
+            f"{metric_text(metrics, 'B/op')} | {metric_text(metrics, 'allocs/op')} | "
+            f"{metric_text(metrics, 'storage_bytes/op')} | "
+            f"{metric_text(metrics, 'durable_footprint_bytes/op')} | "
+            f"{metric_text(metrics, 'delete_write_amplification')} |"
         )
     lines.append("")
     return "\n".join(lines)
@@ -111,7 +164,7 @@ def main() -> None:
     args = parser.parse_args()
 
     medians = parse_benchmarks(args.bench, args.expected_samples)
-    resources = parse_resources(args.resources)
+    resources = parse_resources(args.resources, args.expected_samples)
     payload = {
         "schema": "treedb-dgraph-mvcc-closeout-v1",
         "candidate_sha": args.candidate_sha,

--- a/.github/scripts/summarize_mvcc_closeout.py
+++ b/.github/scripts/summarize_mvcc_closeout.py
@@ -15,9 +15,37 @@ BENCH_RE = re.compile(
     r"([0-9.]+)\s+ns/op\s+(.*)$"
 )
 METRIC_RE = re.compile(r"([0-9.eE+-]+)\s+([^\s]+)")
-RSS_RE = re.compile(r"Maximum resident set size \(kbytes\):\s+(\d+)")
-USER_RE = re.compile(r"User time \(seconds\):\s+([0-9.]+)")
-SYSTEM_RE = re.compile(r"System time \(seconds\):\s+([0-9.]+)")
+RESOURCE_DELIMITER_RE = re.compile(
+    r"--- sample=(\d+) group=(regular|prune) benchtime=([^\s]+) ---"
+)
+RESOURCE_FIELDS = (
+    ("command", re.compile(r'Command being timed:\s+".+"')),
+    ("user", re.compile(r"User time \(seconds\):\s+([0-9.]+)")),
+    ("system", re.compile(r"System time \(seconds\):\s+([0-9.]+)")),
+    ("cpu", re.compile(r"Percent of CPU this job got:\s+\d+%")),
+    (
+        "elapsed",
+        re.compile(r"Elapsed \(wall clock\) time \(h:mm:ss or m:ss\):\s+[0-9:.]+"),
+    ),
+    ("average_shared_text", re.compile(r"Average shared text size \(kbytes\):\s+\d+")),
+    ("average_unshared_data", re.compile(r"Average unshared data size \(kbytes\):\s+\d+")),
+    ("average_stack", re.compile(r"Average stack size \(kbytes\):\s+\d+")),
+    ("average_total", re.compile(r"Average total size \(kbytes\):\s+\d+")),
+    ("rss", re.compile(r"Maximum resident set size \(kbytes\):\s+(\d+)")),
+    ("average_rss", re.compile(r"Average resident set size \(kbytes\):\s+\d+")),
+    ("major_faults", re.compile(r"Major \(requiring I/O\) page faults:\s+\d+")),
+    ("minor_faults", re.compile(r"Minor \(reclaiming a frame\) page faults:\s+\d+")),
+    ("voluntary_switches", re.compile(r"Voluntary context switches:\s+\d+")),
+    ("involuntary_switches", re.compile(r"Involuntary context switches:\s+\d+")),
+    ("swaps", re.compile(r"Swaps:\s+\d+")),
+    ("filesystem_inputs", re.compile(r"File system inputs:\s+\d+")),
+    ("filesystem_outputs", re.compile(r"File system outputs:\s+\d+")),
+    ("socket_sent", re.compile(r"Socket messages sent:\s+\d+")),
+    ("socket_received", re.compile(r"Socket messages received:\s+\d+")),
+    ("signals", re.compile(r"Signals delivered:\s+\d+")),
+    ("page_size", re.compile(r"Page size \(bytes\):\s+\d+")),
+    ("exit_status", re.compile(r"Exit status:\s+(\d+)")),
+)
 
 PROFILES = ("durable_sync", "wal_on_relaxed", "wal_off_relaxed")
 EXPECTED_BENCHMARKS = frozenset(
@@ -55,13 +83,20 @@ def required_metrics(name: str) -> set[str]:
 
 def parse_benchmarks(path: Path, expected: int) -> dict[str, dict[str, float]]:
     samples: dict[str, list[dict[str, float]]] = {}
-    for line in path.read_text(encoding="utf-8", errors="replace").splitlines():
+    for line_number, line in enumerate(
+        path.read_text(encoding="utf-8", errors="replace").splitlines(), 1
+    ):
         match = BENCH_RE.match(line.strip())
         if match is None:
             continue
         name, ns_per_op, tail = match.groups()
-        metrics = {unit: float(value) for value, unit in METRIC_RE.findall(tail)}
-        metrics["ns/op"] = float(ns_per_op)
+        metrics = {"ns/op": float(ns_per_op)}
+        for value, unit in METRIC_RE.findall(tail):
+            if unit in metrics:
+                raise ValueError(
+                    f"{path}:{line_number}: {name}: duplicate metric unit {unit}"
+                )
+            metrics[unit] = float(value)
         samples.setdefault(name, []).append(metrics)
     if not samples:
         raise ValueError(f"{path}: no closeout benchmarks found")
@@ -87,19 +122,55 @@ def parse_benchmarks(path: Path, expected: int) -> dict[str, dict[str, float]]:
 
 
 def parse_resources(path: Path, expected_samples: int) -> dict[str, float]:
-    text = path.read_text(encoding="utf-8", errors="replace")
-    rss = [int(value) for value in RSS_RE.findall(text)]
-    user = [float(value) for value in USER_RE.findall(text)]
-    system = [float(value) for value in SYSTEM_RE.findall(text)]
-    expected_invocations = expected_samples * 2
-    counts = (len(rss), len(user), len(system))
-    if counts != (expected_invocations,) * 3:
-        raise ValueError(
-            f"{path}: expected {expected_invocations} complete /usr/bin/time "
-            f"invocations, got rss/user/system={counts}"
-        )
+    lines = [
+        line.strip()
+        for line in path.read_text(encoding="utf-8", errors="replace").splitlines()
+        if line.strip()
+    ]
+    cursor = 0
+    records: list[dict[str, str]] = []
+    for sample in range(1, expected_samples + 1):
+        for group in ("regular", "prune"):
+            if cursor >= len(lines):
+                raise ValueError(f"{path}: missing resource record for sample={sample} group={group}")
+            delimiter = RESOURCE_DELIMITER_RE.fullmatch(lines[cursor])
+            if delimiter is None or (int(delimiter.group(1)), delimiter.group(2)) != (
+                sample,
+                group,
+            ):
+                raise ValueError(
+                    f"{path}: expected resource delimiter for sample={sample} "
+                    f"group={group}, got {lines[cursor]!r}"
+                )
+            cursor += 1
+            record: dict[str, str] = {}
+            for field, pattern in RESOURCE_FIELDS:
+                if cursor >= len(lines):
+                    raise ValueError(
+                        f"{path}: sample={sample} group={group}: missing {field} field"
+                    )
+                match = pattern.fullmatch(lines[cursor])
+                if match is None:
+                    raise ValueError(
+                        f"{path}: sample={sample} group={group}: expected {field} "
+                        f"field, got {lines[cursor]!r}"
+                    )
+                if match.lastindex:
+                    record[field] = match.group(1)
+                cursor += 1
+            if record["exit_status"] != "0":
+                raise ValueError(
+                    f"{path}: sample={sample} group={group}: /usr/bin/time "
+                    f"exit status {record['exit_status']}"
+                )
+            records.append(record)
+    if cursor != len(lines):
+        raise ValueError(f"{path}: unexpected extra resource content {lines[cursor]!r}")
+    rss = [int(record["rss"]) for record in records]
+    user = [float(record["user"]) for record in records]
+    system = [float(record["system"]) for record in records]
     return {
-        "invocations": float(len(rss)),
+        "invocations": float(len(records)),
         "max_rss_kib": float(max(rss)),
         "total_user_seconds": sum(user),
         "total_system_seconds": sum(system),

--- a/.github/scripts/summarize_mvcc_closeout.py
+++ b/.github/scripts/summarize_mvcc_closeout.py
@@ -82,8 +82,8 @@ def render_markdown(
         f"system {resources['total_system_seconds']:.2f}s",
         "- durability classes are separate rows; relaxed rows are not durability-equivalent to durable sync",
         "",
-        "| Benchmark | ns/op | Throughput | B/op | allocs/op | storage bytes/op | durable bytes/op |",
-        "| --- | ---: | ---: | ---: | ---: | ---: | ---: |",
+        "| Benchmark | ns/op | Throughput | B/op | allocs/op | storage bytes/op | durable bytes/op | delete write amp |",
+        "| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |",
     ]
     for name in sorted(medians):
         metrics = medians[name]
@@ -93,7 +93,8 @@ def render_markdown(
             f"| `{name}` | {metrics['ns/op']:.3f} | {rate_text} | "
             f"{metrics.get('B/op', 0):.3f} | {metrics.get('allocs/op', 0):.3f} | "
             f"{metrics.get('storage_bytes/op', 0):.3f} | "
-            f"{metrics.get('durable_bytes/op', 0):.3f} |"
+            f"{metrics.get('durable_bytes/op', 0):.3f} | "
+            f"{metrics.get('delete_write_amplification', 0):.3f} |"
         )
     lines.append("")
     return "\n".join(lines)

--- a/.github/scripts/summarize_mvcc_closeout.py
+++ b/.github/scripts/summarize_mvcc_closeout.py
@@ -1,0 +1,127 @@
+#!/usr/bin/env python3
+"""Summarize the pinned TreeDB MVCC closeout benchmark matrix."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import statistics
+from pathlib import Path
+
+
+BENCH_RE = re.compile(
+    r"^(BenchmarkDgraphMVCCCloseout/.+?)(?:-\d+)?\s+\d+\s+"
+    r"([0-9.]+)\s+ns/op\s+(.*)$"
+)
+METRIC_RE = re.compile(r"([0-9.eE+-]+)\s+([^\s]+)")
+RSS_RE = re.compile(r"Maximum resident set size \(kbytes\):\s+(\d+)")
+USER_RE = re.compile(r"User time \(seconds\):\s+([0-9.]+)")
+SYSTEM_RE = re.compile(r"System time \(seconds\):\s+([0-9.]+)")
+
+
+def parse_benchmarks(path: Path, expected: int) -> dict[str, dict[str, float]]:
+    samples: dict[str, list[dict[str, float]]] = {}
+    for line in path.read_text(encoding="utf-8", errors="replace").splitlines():
+        match = BENCH_RE.match(line.strip())
+        if match is None:
+            continue
+        name, ns_per_op, tail = match.groups()
+        metrics = {unit: float(value) for value, unit in METRIC_RE.findall(tail)}
+        metrics["ns/op"] = float(ns_per_op)
+        samples.setdefault(name, []).append(metrics)
+    if not samples:
+        raise ValueError(f"{path}: no closeout benchmarks found")
+    medians: dict[str, dict[str, float]] = {}
+    for name, rows in samples.items():
+        if len(rows) != expected:
+            raise ValueError(f"{path}: {name}: expected {expected} samples, got {len(rows)}")
+        units = set.intersection(*(set(row) for row in rows))
+        medians[name] = {
+            unit: statistics.median(row[unit] for row in rows) for unit in sorted(units)
+        }
+    return medians
+
+
+def parse_resources(path: Path) -> dict[str, float]:
+    text = path.read_text(encoding="utf-8", errors="replace")
+    rss = [int(value) for value in RSS_RE.findall(text)]
+    user = [float(value) for value in USER_RE.findall(text)]
+    system = [float(value) for value in SYSTEM_RE.findall(text)]
+    if not rss or not user or not system:
+        raise ValueError(f"{path}: incomplete /usr/bin/time evidence")
+    return {
+        "max_rss_kib": float(max(rss)),
+        "median_user_seconds": statistics.median(user),
+        "median_system_seconds": statistics.median(system),
+    }
+
+
+def throughput(metrics: dict[str, float]) -> tuple[float, str]:
+    for unit in ("mutations/s", "lookups/s", "versions/s", "pruned_versions/s"):
+        if unit in metrics:
+            return metrics[unit], unit
+    return 0.0, "-"
+
+
+def render_markdown(
+    candidate_sha: str,
+    expected: int,
+    medians: dict[str, dict[str, float]],
+    resources: dict[str, float],
+) -> str:
+    lines = [
+        "## TreeDB Dgraph MVCC closeout matrix",
+        "",
+        f"- candidate: `{candidate_sha}`",
+        f"- samples: {expected}",
+        f"- maximum benchmark-process RSS: {resources['max_rss_kib']:.0f} KiB",
+        f"- median process CPU: user {resources['median_user_seconds']:.2f}s, "
+        f"system {resources['median_system_seconds']:.2f}s",
+        "- durability classes are separate rows; relaxed rows are not durability-equivalent to durable sync",
+        "",
+        "| Benchmark | ns/op | Throughput | B/op | allocs/op | storage bytes/op | durable bytes/op |",
+        "| --- | ---: | ---: | ---: | ---: | ---: | ---: |",
+    ]
+    for name in sorted(medians):
+        metrics = medians[name]
+        rate, unit = throughput(metrics)
+        rate_text = f"{rate:.3f} {unit}" if unit != "-" else "-"
+        lines.append(
+            f"| `{name}` | {metrics['ns/op']:.3f} | {rate_text} | "
+            f"{metrics.get('B/op', 0):.3f} | {metrics.get('allocs/op', 0):.3f} | "
+            f"{metrics.get('storage_bytes/op', 0):.3f} | "
+            f"{metrics.get('durable_bytes/op', 0):.3f} |"
+        )
+    lines.append("")
+    return "\n".join(lines)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--bench", type=Path, required=True)
+    parser.add_argument("--resources", type=Path, required=True)
+    parser.add_argument("--candidate-sha", required=True)
+    parser.add_argument("--expected-samples", type=int, required=True)
+    parser.add_argument("--json-output", type=Path, required=True)
+    parser.add_argument("--markdown-output", type=Path, required=True)
+    args = parser.parse_args()
+
+    medians = parse_benchmarks(args.bench, args.expected_samples)
+    resources = parse_resources(args.resources)
+    payload = {
+        "schema": "treedb-dgraph-mvcc-closeout-v1",
+        "candidate_sha": args.candidate_sha,
+        "samples": args.expected_samples,
+        "resources": resources,
+        "benchmarks": medians,
+    }
+    args.json_output.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    args.markdown_output.write_text(
+        render_markdown(args.candidate_sha, args.expected_samples, medians, resources),
+        encoding="utf-8",
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/scripts/test_mvcc_benchmark_pairing.py
+++ b/.github/scripts/test_mvcc_benchmark_pairing.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python3
+"""Structural tests for the base/head benchmark-group pairing contract."""
+
+from pathlib import Path
+import re
+import unittest
+
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def normalized(path: Path) -> str:
+    return re.sub(r"\s+", " ", path.read_text(encoding="utf-8"))
+
+
+def assert_in_order(test: unittest.TestCase, source: str, fragments: list[str]) -> None:
+    position = 0
+    for fragment in fragments:
+        found = source.find(fragment, position)
+        test.assertNotEqual(found, -1, f"missing or out of order: {fragment}")
+        position = found + len(fragment)
+
+
+class BenchmarkPairingTests(unittest.TestCase):
+    def test_raw_gate_pairs_each_individual_group(self) -> None:
+        source = normalized(ROOT / "scripts" / "mvcc_raw_path_gate.sh")
+        self.assertNotIn("run_revision()", source)
+        self.assertIn("GET_VERSIONED_BENCH_REGEX='^BenchmarkGetVersioned$'", source)
+        self.assertIn(
+            "BATCH_WRITE_BENCH_REGEX='^BenchmarkConditionalTxnBaselineBatchWrite$'",
+            source,
+        )
+        assert_in_order(
+            self,
+            source,
+            [
+                'run_pair "$sample" get_versioned',
+                'run_pair "$sample" batch_write',
+                'run_pair "$sample" snapshot_seek',
+                'run_pair "$sample" repeated_iterator',
+                'run_pair "$sample" durable_sync',
+            ],
+        )
+
+    def test_raw_gate_pair_order_is_abba_by_sample(self) -> None:
+        source = normalized(ROOT / "scripts" / "mvcc_raw_path_gate.sh")
+        assert_in_order(
+            self,
+            source,
+            [
+                'if ((sample % 2 == 1)); then run_sample baseline',
+                'run_sample candidate',
+                'else run_sample candidate',
+                'run_sample baseline',
+            ],
+        )
+
+    def test_adapter_gate_pairs_each_group(self) -> None:
+        source = normalized(ROOT / "scripts" / "mvcc_adapter_overhead_gate.sh")
+        self.assertNotIn("run_revision()", source)
+        assert_in_order(
+            self,
+            source,
+            [
+                'run_pair "$sample" "$BASELINE_BIN" "$CANDIDATE_BIN" "$COMMIT_REGEX"',
+                'run_pair "$sample" "$BASELINE_BIN" "$CANDIDATE_BIN" "$GET_REGEX"',
+                'run_pair "$sample" "$BASELINE_BIN" "$CANDIDATE_BIN" "$ITER_REGEX"',
+            ],
+        )
+
+    def test_adapter_gate_pair_order_is_abba_by_sample(self) -> None:
+        source = normalized(ROOT / "scripts" / "mvcc_adapter_overhead_gate.sh")
+        assert_in_order(
+            self,
+            source,
+            [
+                'if ((sample % 2 == 1)); then run_group baseline',
+                'run_group candidate',
+                'else run_group candidate',
+                'run_group baseline',
+            ],
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/scripts/test_mvcc_benchmark_pairing.py
+++ b/.github/scripts/test_mvcc_benchmark_pairing.py
@@ -98,6 +98,23 @@ class BenchmarkPairingTests(unittest.TestCase):
                 self.assertIn("if ((RUNS % 2 != 0)); then", source)
                 self.assertIn("RUNS must be even to balance AB/BA sample order", source)
 
+    def test_closeout_prune_stops_timer_before_all_setup(self) -> None:
+        source = normalized(ROOT / "TreeDB" / "mvcc" / "closeout_bench_test.go")
+        body = source.split("func benchmarkCloseoutPrune", 1)[1].split(
+            "func openCloseoutBench", 1
+        )[0]
+        self.assertRegex(body, r"^\(b .*\) \{ b\.StopTimer\(\) var total")
+        assert_in_order(
+            self,
+            body,
+            [
+                "b.StopTimer()",
+                "parentDir := b.TempDir()",
+                "b.StartTimer() stats, err := store.PruneVersions",
+                "b.StopTimer() if err := db.Close()",
+            ],
+        )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/.github/scripts/test_mvcc_benchmark_pairing.py
+++ b/.github/scripts/test_mvcc_benchmark_pairing.py
@@ -30,6 +30,15 @@ class BenchmarkPairingTests(unittest.TestCase):
             "BATCH_WRITE_BENCH_REGEX='^BenchmarkConditionalTxnBaselineBatchWrite$'",
             source,
         )
+        for package in ("DB", "CACHING", "TREEDB"):
+            self.assertIn(
+                f'--baseline-{package.lower()}-binary "$BASELINE_{package}_BIN"',
+                source,
+            )
+            self.assertIn(
+                f'--candidate-{package.lower()}-binary "$CANDIDATE_{package}_BIN"',
+                source,
+            )
         assert_in_order(
             self,
             source,
@@ -80,6 +89,14 @@ class BenchmarkPairingTests(unittest.TestCase):
                 'run_group baseline',
             ],
         )
+
+    def test_raw_and_adapter_require_balanced_even_sample_counts(self) -> None:
+        for name in ("mvcc_raw_path_gate.sh", "mvcc_adapter_overhead_gate.sh"):
+            source = normalized(ROOT / "scripts" / name)
+            with self.subTest(script=name):
+                self.assertIn('RUNS="${RUNS:-8}"', source)
+                self.assertIn("if ((RUNS % 2 != 0)); then", source)
+                self.assertIn("RUNS must be even to balance AB/BA sample order", source)
 
 
 if __name__ == "__main__":

--- a/.github/scripts/test_mvcc_candidate_checkout_guard.py
+++ b/.github/scripts/test_mvcc_candidate_checkout_guard.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python3
+"""Tests the fail-closed guard used by all live-checkout MVCC measurements."""
+
+from __future__ import annotations
+
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+GUARD = ROOT / "scripts" / "mvcc_candidate_checkout_guard.sh"
+MEASUREMENT_SCRIPTS = (
+    ROOT / "scripts" / "mvcc_raw_path_gate.sh",
+    ROOT / "scripts" / "mvcc_adapter_overhead_gate.sh",
+    ROOT / "scripts" / "mvcc_closeout_matrix.sh",
+)
+
+
+class CandidateCheckoutGuardTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.tmp = tempfile.TemporaryDirectory()
+        self.repo = Path(self.tmp.name)
+        self.git("init", "-q")
+        self.git("config", "user.email", "mvcctest@example.invalid")
+        self.git("config", "user.name", "MVCC Test")
+        (self.repo / ".gitignore").write_text("artifacts/\n", encoding="utf-8")
+        (self.repo / "tracked.txt").write_text("clean\n", encoding="utf-8")
+        self.git("add", ".gitignore", "tracked.txt")
+        self.git("commit", "-qm", "fixture")
+        self.sha = self.git("rev-parse", "HEAD").stdout.strip()
+
+    def tearDown(self) -> None:
+        self.tmp.cleanup()
+
+    def git(self, *args: str) -> subprocess.CompletedProcess[str]:
+        return subprocess.run(
+            ("git", "-C", str(self.repo), *args),
+            check=True,
+            text=True,
+            capture_output=True,
+        )
+
+    def guard(self, sha: str | None = None) -> subprocess.CompletedProcess[str]:
+        return subprocess.run(
+            (str(GUARD), str(self.repo), self.sha if sha is None else sha),
+            check=False,
+            text=True,
+            capture_output=True,
+        )
+
+    def test_clean_checkout_passes(self) -> None:
+        self.assertEqual(self.guard().returncode, 0)
+
+    def test_ignored_artifacts_do_not_block(self) -> None:
+        artifact = self.repo / "artifacts" / "summary.json"
+        artifact.parent.mkdir()
+        artifact.write_text("{}\n", encoding="utf-8")
+        self.assertEqual(self.guard().returncode, 0)
+
+    def test_tracked_edit_fails_closed(self) -> None:
+        (self.repo / "tracked.txt").write_text("dirty\n", encoding="utf-8")
+        result = self.guard()
+        self.assertEqual(result.returncode, 2)
+        self.assertIn("candidate worktree is dirty", result.stderr)
+        self.assertIn("tracked.txt", result.stderr)
+
+    def test_untracked_file_fails_closed(self) -> None:
+        (self.repo / "untracked.txt").write_text("dirty\n", encoding="utf-8")
+        result = self.guard()
+        self.assertEqual(result.returncode, 2)
+        self.assertIn("?? untracked.txt", result.stderr)
+
+    def test_sha_mismatch_fails_before_measurement(self) -> None:
+        result = self.guard("0" * 40)
+        self.assertEqual(result.returncode, 2)
+        self.assertIn("candidate mismatch", result.stderr)
+
+    def test_all_live_checkout_scripts_guard_before_output_cleanup(self) -> None:
+        invocation = '"$ROOT/scripts/mvcc_candidate_checkout_guard.sh" "$ROOT" "$CANDIDATE_SHA"'
+        for script in MEASUREMENT_SCRIPTS:
+            text = script.read_text(encoding="utf-8")
+            with self.subTest(script=script.name):
+                self.assertEqual(text.count(invocation), 1)
+                self.assertLess(text.index(invocation), text.index('rm -rf "$OUT_DIR"'))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/scripts/test_mvcc_raw_path_equivalence.py
+++ b/.github/scripts/test_mvcc_raw_path_equivalence.py
@@ -65,6 +65,23 @@ class RawPathEquivalenceTests(unittest.TestCase):
             CHECKER.acceptance_verdict(False, all_equivalent), "EQUIVALENT"
         )
 
+    def test_verdict_truth_table(self) -> None:
+        cases = (
+            (True, True, "PASS"),
+            (True, False, "PASS"),
+            (False, True, "EQUIVALENT"),
+            (False, False, "FAIL"),
+        )
+        for measurement_pass, all_equivalent, expected in cases:
+            with self.subTest(
+                measurement_pass=measurement_pass,
+                all_equivalent=all_equivalent,
+            ):
+                self.assertEqual(
+                    CHECKER.acceptance_verdict(measurement_pass, all_equivalent),
+                    expected,
+                )
+
     def test_different_package_digests_use_measured_pass(self) -> None:
         parsed = CHECKER.compute_binary_digests(self.binary_paths(set()))
         all_equivalent, _ = CHECKER.annotate_binary_equivalence(
@@ -152,6 +169,7 @@ class RawPathEquivalenceTests(unittest.TestCase):
         payload = json.loads(json_output.read_text(encoding="utf-8"))
         self.assertEqual(payload["verdict"], "EQUIVALENT")
         self.assertTrue(payload["accepted"])
+        self.assertTrue(payload["no_attributable_regression"])
         self.assertFalse(payload["measurement_pass"])
         self.assertFalse(payload["results"][0]["measurement_pass"])
         self.assertNotIn("pass", payload)

--- a/.github/scripts/test_mvcc_raw_path_equivalence.py
+++ b/.github/scripts/test_mvcc_raw_path_equivalence.py
@@ -1,0 +1,164 @@
+#!/usr/bin/env python3
+"""Tests fail-closed binary equivalence acceptance for the MVCC raw gate."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+CHECKER_PATH = ROOT / ".github" / "scripts" / "check_mvcc_raw_path_gate.py"
+SPEC = importlib.util.spec_from_file_location("check_mvcc_raw_path_gate", CHECKER_PATH)
+assert SPEC is not None and SPEC.loader is not None
+CHECKER = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = CHECKER
+SPEC.loader.exec_module(CHECKER)
+
+
+class RawPathEquivalenceTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.tmp = tempfile.TemporaryDirectory()
+        self.root = Path(self.tmp.name)
+
+    def tearDown(self) -> None:
+        self.tmp.cleanup()
+
+    def results(self, passed: bool) -> list[dict[str, object]]:
+        return [
+            {"benchmark": benchmark, "measurement_pass": passed}
+            for benchmark in CHECKER.BENCHMARKS
+        ]
+
+    def binary_paths(
+        self, equivalent_packages: set[str]
+    ) -> dict[str, dict[str, Path]]:
+        paths: dict[str, dict[str, Path]] = {}
+        for package in CHECKER.BINARY_PACKAGES:
+            baseline = self.root / f"baseline-{package}.test"
+            candidate = self.root / f"candidate-{package}.test"
+            baseline.write_bytes(f"{package}-baseline".encode())
+            candidate.write_bytes(
+                baseline.read_bytes()
+                if package in equivalent_packages
+                else f"{package}-candidate".encode()
+            )
+            paths[package] = {"baseline": baseline, "candidate": candidate}
+        return paths
+
+    def test_identical_package_digests_accept_equivalent_despite_failed_measurement(self) -> None:
+        parsed = CHECKER.compute_binary_digests(
+            self.binary_paths(set(CHECKER.BINARY_PACKAGES))
+        )
+        all_equivalent, rows = CHECKER.annotate_binary_equivalence(
+            self.results(False), parsed
+        )
+        self.assertTrue(all_equivalent)
+        self.assertTrue(all(row["binary_equivalent"] for row in rows))
+        self.assertFalse(all(row["measurement_pass"] for row in rows))
+        self.assertEqual(
+            CHECKER.acceptance_verdict(False, all_equivalent), "EQUIVALENT"
+        )
+
+    def test_different_package_digests_use_measured_pass(self) -> None:
+        parsed = CHECKER.compute_binary_digests(self.binary_paths(set()))
+        all_equivalent, _ = CHECKER.annotate_binary_equivalence(
+            self.results(True), parsed
+        )
+        self.assertFalse(all_equivalent)
+        self.assertEqual(CHECKER.acceptance_verdict(True, all_equivalent), "PASS")
+
+    def test_mixed_digests_cannot_mask_failed_measurement(self) -> None:
+        parsed = CHECKER.compute_binary_digests(
+            self.binary_paths({"db", "treedb"})
+        )
+        all_equivalent, rows = CHECKER.annotate_binary_equivalence(
+            self.results(False), parsed
+        )
+        self.assertFalse(all_equivalent)
+        self.assertTrue(rows[0]["binary_equivalent"])
+        self.assertFalse(rows[3]["binary_equivalent"])
+        self.assertEqual(CHECKER.acceptance_verdict(False, all_equivalent), "FAIL")
+
+    def test_malformed_or_missing_binary_evidence_fails_closed(self) -> None:
+        valid = self.binary_paths(set(CHECKER.BINARY_PACKAGES))
+        duplicate = self.root / "duplicate" / "candidate-db.test"
+        duplicate.parent.mkdir()
+        duplicate.symlink_to(valid["db"]["baseline"])
+        cases = {
+            "missing package": {key: value for key, value in valid.items() if key != "db"},
+            "unexpected package": {**valid, "other": valid["db"]},
+            "missing revision": {
+                **valid,
+                "db": {"baseline": valid["db"]["baseline"]},
+            },
+            "missing file": {
+                **valid,
+                "db": {
+                    **valid["db"],
+                    "candidate": self.root / "missing" / "candidate-db.test",
+                },
+            },
+            "symlinked duplicate": {
+                **valid,
+                "db": {**valid["db"], "candidate": duplicate},
+            },
+        }
+        for name, paths in cases.items():
+            with self.subTest(name=name), self.assertRaises(ValueError):
+                CHECKER.compute_binary_digests(paths)
+
+    def test_cli_emits_distinct_equivalent_verdict_and_failed_observation(self) -> None:
+        baseline_log = self.root / "baseline.txt"
+        candidate_log = self.root / "candidate.txt"
+        baseline_log.write_text(CHECKER.synthetic_log(), encoding="utf-8")
+        candidate_log.write_text(
+            CHECKER.synthetic_log(ns_scale=1.20), encoding="utf-8"
+        )
+        paths = self.binary_paths(set(CHECKER.BINARY_PACKAGES))
+        json_output = self.root / "summary.json"
+        markdown_output = self.root / "summary.md"
+        command = [
+            sys.executable,
+            str(CHECKER_PATH),
+            "--baseline",
+            str(baseline_log),
+            "--candidate",
+            str(candidate_log),
+            "--baseline-sha",
+            "a" * 40,
+            "--candidate-sha",
+            "b" * 40,
+            "--json-output",
+            str(json_output),
+            "--markdown-output",
+            str(markdown_output),
+        ]
+        for package in CHECKER.BINARY_PACKAGES:
+            for revision in ("baseline", "candidate"):
+                command.extend(
+                    [
+                        f"--{revision}-{package}-binary",
+                        str(paths[package][revision]),
+                    ]
+                )
+        completed = subprocess.run(command, text=True, capture_output=True, check=False)
+        self.assertEqual(completed.returncode, 0, completed.stderr)
+        payload = json.loads(json_output.read_text(encoding="utf-8"))
+        self.assertEqual(payload["verdict"], "EQUIVALENT")
+        self.assertTrue(payload["accepted"])
+        self.assertFalse(payload["measurement_pass"])
+        self.assertFalse(payload["results"][0]["measurement_pass"])
+        self.assertNotIn("pass", payload)
+        markdown = markdown_output.read_text(encoding="utf-8")
+        self.assertIn("- verdict: **EQUIVALENT**", markdown)
+        self.assertIn("- measured threshold observation: **FAIL**", markdown)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/scripts/test_summarize_mvcc_closeout.py
+++ b/.github/scripts/test_summarize_mvcc_closeout.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python3
+"""Unit tests for the exact MVCC closeout evidence contract."""
+
+from __future__ import annotations
+
+import importlib.util
+import tempfile
+import unittest
+from pathlib import Path
+
+
+MODULE_PATH = Path(__file__).with_name("summarize_mvcc_closeout.py")
+SPEC = importlib.util.spec_from_file_location("summarize_mvcc_closeout", MODULE_PATH)
+assert SPEC is not None and SPEC.loader is not None
+closeout = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(closeout)
+
+
+def benchmark_line(name: str, omit: str | None = None) -> str:
+    metrics = {"B/op": 32, "allocs/op": 1}
+    if "/CommitAt/" in name:
+        metrics.update({"mutations/s": 10, "storage_bytes/op": 20})
+    elif "/GetAt/" in name:
+        metrics["lookups/s"] = 10
+    elif "/AllVersions/" in name:
+        metrics["versions/s"] = 10
+    else:
+        metrics.update(
+            {
+                "pruned_versions/s": 10,
+                "storage_bytes/op": 20,
+                "delete_write_amplification": 1.25,
+            }
+        )
+    if "/durable_sync/" in name and ("/CommitAt/" in name or "/Prune/" in name):
+        metrics["durable_footprint_bytes/op"] = 20
+    metrics.pop(omit, None)
+    tail = " ".join(f"{value} {unit}" for unit, value in metrics.items())
+    return f"{name}-1 1 100 ns/op {tail}"
+
+
+class CloseoutSummaryTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.tmp = tempfile.TemporaryDirectory()
+        self.root = Path(self.tmp.name)
+
+    def tearDown(self) -> None:
+        self.tmp.cleanup()
+
+    def write_bench(self, names=None, runs: int = 2, omit: str | None = None) -> Path:
+        names = sorted(closeout.EXPECTED_BENCHMARKS if names is None else names)
+        path = self.root / "bench.txt"
+        path.write_text(
+            "\n".join(benchmark_line(name, omit) for _ in range(runs) for name in names)
+            + "\n",
+            encoding="utf-8",
+        )
+        return path
+
+    def write_resources(self, invocations: int) -> Path:
+        path = self.root / "resources.txt"
+        row = (
+            "Maximum resident set size (kbytes): 123\n"
+            "User time (seconds): 1.5\n"
+            "System time (seconds): 0.5\n"
+        )
+        path.write_text(row * invocations, encoding="utf-8")
+        return path
+
+    def test_success_and_absent_rendering(self) -> None:
+        medians = closeout.parse_benchmarks(self.write_bench(), 2)
+        resources = closeout.parse_resources(self.write_resources(4), 2)
+        markdown = closeout.render_markdown("abc", 2, medians, resources)
+        relaxed_get = next(
+            line for line in markdown.splitlines() if "/GetAt/wal_on_relaxed/" in line
+        )
+        self.assertIn(" | - | - | - |", relaxed_get)
+
+    def test_missing_required_row_rejected(self) -> None:
+        names = set(closeout.EXPECTED_BENCHMARKS)
+        names.remove(next(iter(names)))
+        with self.assertRaises(ValueError):
+            closeout.parse_benchmarks(self.write_bench(names), 2)
+
+    def test_missing_durability_class_rejected(self) -> None:
+        names = {name for name in closeout.EXPECTED_BENCHMARKS if "/wal_on_relaxed/" not in name}
+        with self.assertRaises(ValueError):
+            closeout.parse_benchmarks(self.write_bench(names), 2)
+
+    def test_missing_group_rejected(self) -> None:
+        names = {name for name in closeout.EXPECTED_BENCHMARKS if "/Prune/" not in name}
+        with self.assertRaises(ValueError):
+            closeout.parse_benchmarks(self.write_bench(names), 2)
+
+    def test_missing_required_metric_rejected(self) -> None:
+        with self.assertRaises(ValueError):
+            closeout.parse_benchmarks(self.write_bench(omit="allocs/op"), 2)
+
+    def test_wrong_sample_count_rejected(self) -> None:
+        with self.assertRaises(ValueError):
+            closeout.parse_benchmarks(self.write_bench(runs=1), 2)
+
+    def test_wrong_resource_count_rejected(self) -> None:
+        with self.assertRaises(ValueError):
+            closeout.parse_resources(self.write_resources(3), 2)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/scripts/test_summarize_mvcc_closeout.py
+++ b/.github/scripts/test_summarize_mvcc_closeout.py
@@ -57,19 +57,74 @@ class CloseoutSummaryTest(unittest.TestCase):
         )
         return path
 
-    def write_resources(self, invocations: int) -> Path:
-        path = self.root / "resources.txt"
-        row = (
-            "Maximum resident set size (kbytes): 123\n"
+    @staticmethod
+    def resource_record(sample: int, group: str) -> str:
+        benchtime = "750ms" if group == "regular" else "1x"
+        return (
+            f"--- sample={sample} group={group} benchtime={benchtime} ---\n"
+            'Command being timed: "benchmark command"\n'
             "User time (seconds): 1.5\n"
             "System time (seconds): 0.5\n"
+            "Percent of CPU this job got: 75%\n"
+            "Elapsed (wall clock) time (h:mm:ss or m:ss): 0:02.00\n"
+            "Average shared text size (kbytes): 0\n"
+            "Average unshared data size (kbytes): 0\n"
+            "Average stack size (kbytes): 0\n"
+            "Average total size (kbytes): 0\n"
+            "Maximum resident set size (kbytes): 123\n"
+            "Average resident set size (kbytes): 0\n"
+            "Major (requiring I/O) page faults: 0\n"
+            "Minor (reclaiming a frame) page faults: 1\n"
+            "Voluntary context switches: 2\n"
+            "Involuntary context switches: 3\n"
+            "Swaps: 0\n"
+            "File system inputs: 0\n"
+            "File system outputs: 4\n"
+            "Socket messages sent: 0\n"
+            "Socket messages received: 0\n"
+            "Signals delivered: 0\n"
+            "Page size (bytes): 4096\n"
+            "Exit status: 0\n"
         )
-        path.write_text(row * invocations, encoding="utf-8")
+
+    def write_resources(self, samples: int) -> Path:
+        path = self.root / "resources.txt"
+        path.write_text(
+            "".join(
+                self.resource_record(sample, group)
+                for sample in range(1, samples + 1)
+                for group in ("regular", "prune")
+            ),
+            encoding="utf-8",
+        )
         return path
 
     def test_success_and_absent_rendering(self) -> None:
         medians = closeout.parse_benchmarks(self.write_bench(), 2)
-        resources = closeout.parse_resources(self.write_resources(4), 2)
+        resources = closeout.parse_resources(self.write_resources(2), 2)
+        durable_commit = medians[
+            "BenchmarkDgraphMVCCCloseout/CommitAt/durable_sync/batch=1"
+        ]
+        self.assertEqual(
+            durable_commit,
+            {
+                "B/op": 32.0,
+                "allocs/op": 1.0,
+                "durable_footprint_bytes/op": 20.0,
+                "mutations/s": 10.0,
+                "ns/op": 100.0,
+                "storage_bytes/op": 20.0,
+            },
+        )
+        self.assertEqual(
+            resources,
+            {
+                "invocations": 4.0,
+                "max_rss_kib": 123.0,
+                "total_user_seconds": 6.0,
+                "total_system_seconds": 2.0,
+            },
+        )
         markdown = closeout.render_markdown("abc", 2, medians, resources)
         relaxed_get = next(
             line for line in markdown.splitlines() if "/GetAt/wal_on_relaxed/" in line
@@ -96,13 +151,84 @@ class CloseoutSummaryTest(unittest.TestCase):
         with self.assertRaises(ValueError):
             closeout.parse_benchmarks(self.write_bench(omit="allocs/op"), 2)
 
+    def test_duplicate_required_metric_rejected(self) -> None:
+        path = self.write_bench()
+        path.write_text(
+            path.read_text(encoding="utf-8").replace(
+                "32 B/op", "32 B/op 64 B/op", 1
+            ),
+            encoding="utf-8",
+        )
+        with self.assertRaisesRegex(ValueError, "duplicate metric unit B/op"):
+            closeout.parse_benchmarks(path, 2)
+
     def test_wrong_sample_count_rejected(self) -> None:
         with self.assertRaises(ValueError):
             closeout.parse_benchmarks(self.write_bench(runs=1), 2)
 
     def test_wrong_resource_count_rejected(self) -> None:
         with self.assertRaises(ValueError):
-            closeout.parse_resources(self.write_resources(3), 2)
+            closeout.parse_resources(self.write_resources(1), 2)
+
+    def test_missing_resource_field_rejected(self) -> None:
+        path = self.write_resources(2)
+        path.write_text(
+            path.read_text(encoding="utf-8").replace(
+                "Page size (bytes): 4096\n", "", 1
+            ),
+            encoding="utf-8",
+        )
+        with self.assertRaises(ValueError):
+            closeout.parse_resources(path, 2)
+
+    def test_extra_resource_field_rejected(self) -> None:
+        path = self.write_resources(2)
+        path.write_text(
+            path.read_text(encoding="utf-8").replace(
+                "Exit status: 0\n", "Exit status: 0\nUnexpected field: 1\n", 1
+            ),
+            encoding="utf-8",
+        )
+        with self.assertRaises(ValueError):
+            closeout.parse_resources(path, 2)
+
+    def test_malformed_resource_field_rejected(self) -> None:
+        path = self.write_resources(2)
+        path.write_text(
+            path.read_text(encoding="utf-8").replace(
+                "System time (seconds): 0.5",
+                "System time (seconds): malformed",
+                1,
+            ),
+            encoding="utf-8",
+        )
+        with self.assertRaises(ValueError):
+            closeout.parse_resources(path, 2)
+
+    def test_interleaved_resource_record_rejected(self) -> None:
+        path = self.write_resources(2)
+        path.write_text(
+            path.read_text(encoding="utf-8").replace(
+                "Maximum resident set size (kbytes): 123",
+                "--- sample=1 group=prune benchtime=1x ---\n"
+                "Maximum resident set size (kbytes): 123",
+                1,
+            ),
+            encoding="utf-8",
+        )
+        with self.assertRaises(ValueError):
+            closeout.parse_resources(path, 2)
+
+    def test_nonzero_resource_exit_rejected(self) -> None:
+        path = self.write_resources(2)
+        path.write_text(
+            path.read_text(encoding="utf-8").replace(
+                "Exit status: 0", "Exit status: 1", 1
+            ),
+            encoding="utf-8",
+        )
+        with self.assertRaisesRegex(ValueError, "exit status 1"):
+            closeout.parse_resources(path, 2)
 
 
 if __name__ == "__main__":

--- a/.github/workflows/treedb-tests.yml
+++ b/.github/workflows/treedb-tests.yml
@@ -12,6 +12,8 @@ jobs:
     name: mvcc raw-path gate (linux)
     runs-on: ubuntu-24.04
     timeout-minutes: 15
+    env:
+      MVCC_GATE_PATH_RE: '^((TreeDB/((mvcc|internal/mvcckey|db|caching)/|[^/]+\.go$))|scripts/mvcc_(raw_path|adapter_overhead)_gate\.sh$|\.github/scripts/(check_mvcc_(raw_path|adapter_overhead)_gate|test_mvcc_(raw_path_equivalence|benchmark_pairing))\.py$|\.github/workflows/treedb-tests\.yml$)'
     steps:
       - name: Resolve open PR and relevant paths
         id: scope
@@ -39,7 +41,7 @@ jobs:
             "/repos/${REPOSITORY}/pulls/${pr_number}/files?per_page=100" \
             --jq '.[].filename' > "$RUNNER_TEMP/pr-files.txt"
           cat "$RUNNER_TEMP/pr-files.txt"
-          if grep -Eq '^((TreeDB/(mvcc|internal/mvcckey|db)/)|scripts/mvcc_(raw_path|adapter_overhead)_gate\.sh$|\.github/scripts/(check_mvcc_(raw_path|adapter_overhead)_gate|test_mvcc_(raw_path_equivalence|benchmark_pairing))\.py$|\.github/workflows/treedb-tests\.yml$)' \
+          if grep -Eq "$MVCC_GATE_PATH_RE" \
             "$RUNNER_TEMP/pr-files.txt"; then
             echo "run=true" >> "$GITHUB_OUTPUT"
           else
@@ -74,6 +76,20 @@ jobs:
           python3 .github/scripts/check_mvcc_adapter_overhead_gate.py --self-test
           python3 .github/scripts/test_mvcc_raw_path_equivalence.py
           python3 .github/scripts/test_mvcc_benchmark_pairing.py
+          for path in \
+            TreeDB/snapshot_seek_iterator_bench_test.go \
+            TreeDB/command_wal_public_test.go \
+            TreeDB/caching/bench_test.go \
+            TreeDB/bg_vacuum.go; do
+            if ! grep -Eq "$MVCC_GATE_PATH_RE" <<< "$path"; then
+              echo "MVCC gate path scope unexpectedly excludes: $path" >&2
+              exit 1
+            fi
+          done
+          if grep -Eq "$MVCC_GATE_PATH_RE" <<< 'TreeDB/docs/spec/native-ann-vector-index.md'; then
+            echo "MVCC gate path scope unexpectedly includes TreeDB docs" >&2
+            exit 1
+          fi
 
       - name: Compare exact base and head
         if: steps.scope.outputs.run == 'true'

--- a/.github/workflows/treedb-tests.yml
+++ b/.github/workflows/treedb-tests.yml
@@ -71,8 +71,13 @@ jobs:
         env:
           PYTHONDONTWRITEBYTECODE: "1"
         run: |
-          bash -n scripts/mvcc_raw_path_gate.sh scripts/mvcc_adapter_overhead_gate.sh \
-            scripts/mvcc_closeout_matrix.sh scripts/mvcc_candidate_checkout_guard.sh
+          for script in \
+            scripts/mvcc_raw_path_gate.sh \
+            scripts/mvcc_adapter_overhead_gate.sh \
+            scripts/mvcc_closeout_matrix.sh \
+            scripts/mvcc_candidate_checkout_guard.sh; do
+            bash -n "$script"
+          done
           python3 .github/scripts/check_mvcc_raw_path_gate.py --self-test
           python3 .github/scripts/check_mvcc_adapter_overhead_gate.py --self-test
           python3 .github/scripts/test_mvcc_raw_path_equivalence.py
@@ -89,6 +94,8 @@ jobs:
             TreeDB/pager/madvise_linux.go \
             TreeDB/internal/valuelog/autotune_options.go \
             TreeDB/docs/spec/native-ann-vector-index.md \
+            scripts/mvcc_raw_path_gate.sh \
+            scripts/mvcc_adapter_overhead_gate.sh \
             scripts/mvcc_closeout_matrix.sh \
             scripts/mvcc_candidate_checkout_guard.sh \
             .github/scripts/summarize_mvcc_closeout.py \

--- a/.github/workflows/treedb-tests.yml
+++ b/.github/workflows/treedb-tests.yml
@@ -39,7 +39,7 @@ jobs:
             "/repos/${REPOSITORY}/pulls/${pr_number}/files?per_page=100" \
             --jq '.[].filename' > "$RUNNER_TEMP/pr-files.txt"
           cat "$RUNNER_TEMP/pr-files.txt"
-          if grep -Eq '^((TreeDB/(mvcc|internal/mvcckey|db)/)|scripts/mvcc_raw_path_gate\.sh$|\.github/scripts/check_mvcc_raw_path_gate\.py$|\.github/workflows/treedb-tests\.yml$)' \
+          if grep -Eq '^((TreeDB/(mvcc|internal/mvcckey|db)/)|scripts/mvcc_(raw_path|adapter_overhead)_gate\.sh$|\.github/scripts/(check_mvcc_(raw_path|adapter_overhead)_gate|test_mvcc_(raw_path_equivalence|benchmark_pairing))\.py$|\.github/workflows/treedb-tests\.yml$)' \
             "$RUNNER_TEMP/pr-files.txt"; then
             echo "run=true" >> "$GITHUB_OUTPUT"
           else
@@ -67,15 +67,18 @@ jobs:
       - name: Gate self-checks
         if: steps.scope.outputs.run == 'true'
         run: |
-          bash -n scripts/mvcc_raw_path_gate.sh
+          bash -n scripts/mvcc_raw_path_gate.sh scripts/mvcc_adapter_overhead_gate.sh
           python3 .github/scripts/check_mvcc_raw_path_gate.py --self-test
+          python3 .github/scripts/check_mvcc_adapter_overhead_gate.py --self-test
+          python3 .github/scripts/test_mvcc_raw_path_equivalence.py
+          python3 .github/scripts/test_mvcc_benchmark_pairing.py
 
       - name: Compare exact base and head
         if: steps.scope.outputs.run == 'true'
         env:
           BASELINE_HASH: ${{ steps.scope.outputs.base_sha }}
           CANDIDATE_HASH: ${{ steps.scope.outputs.head_sha }}
-          RUNS: "7"
+          RUNS: "8"
           BENCHTIME: 2s
           CPUSET: "0"
           MAX_REGRESSION_PERCENT: "5"

--- a/.github/workflows/treedb-tests.yml
+++ b/.github/workflows/treedb-tests.yml
@@ -66,6 +66,8 @@ jobs:
 
       - name: Gate self-checks
         if: steps.scope.outputs.run == 'true'
+        env:
+          PYTHONDONTWRITEBYTECODE: "1"
         run: |
           bash -n scripts/mvcc_raw_path_gate.sh scripts/mvcc_adapter_overhead_gate.sh
           python3 .github/scripts/check_mvcc_raw_path_gate.py --self-test
@@ -86,7 +88,14 @@ jobs:
           MAX_BYTES_REGRESSION_ABSOLUTE: "64"
           SCRIPT_GOWORK: "off"
           OUT_DIR: ${{ runner.temp }}/mvcc-raw-path-gate
-        run: ./scripts/mvcc_raw_path_gate.sh
+        run: |
+          status=$(git status --porcelain --untracked-files=normal)
+          if [[ -n "$status" ]]; then
+            echo "candidate checkout became dirty before the raw-path gate:" >&2
+            printf '%s\n' "$status" >&2
+            exit 2
+          fi
+          ./scripts/mvcc_raw_path_gate.sh
 
       - name: Add benchmark summary
         if: always() && steps.scope.outputs.run == 'true'

--- a/.github/workflows/treedb-tests.yml
+++ b/.github/workflows/treedb-tests.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-24.04
     timeout-minutes: 15
     env:
-      MVCC_GATE_PATH_RE: '^((TreeDB/((mvcc|internal/mvcckey|db|caching)/|[^/]+\.go$))|scripts/mvcc_(raw_path|adapter_overhead)_gate\.sh$|\.github/scripts/(check_mvcc_(raw_path|adapter_overhead)_gate|test_mvcc_(raw_path_equivalence|benchmark_pairing))\.py$|\.github/workflows/treedb-tests\.yml$)'
+      MVCC_GATE_PATH_RE: '^((TreeDB/((mvcc|internal/mvcckey|db|caching)/|[^/]+\.go$))|scripts/mvcc_(raw_path_gate|adapter_overhead_gate|closeout_matrix|candidate_checkout_guard)\.sh$|\.github/scripts/(check_mvcc_(raw_path|adapter_overhead)_gate|summarize_mvcc_closeout|test_(mvcc_(raw_path_equivalence|benchmark_pairing|candidate_checkout_guard)|summarize_mvcc_closeout))\.py$|\.github/workflows/treedb-tests\.yml$)'
     steps:
       - name: Resolve open PR and relevant paths
         id: scope
@@ -71,16 +71,24 @@ jobs:
         env:
           PYTHONDONTWRITEBYTECODE: "1"
         run: |
-          bash -n scripts/mvcc_raw_path_gate.sh scripts/mvcc_adapter_overhead_gate.sh
+          bash -n scripts/mvcc_raw_path_gate.sh scripts/mvcc_adapter_overhead_gate.sh \
+            scripts/mvcc_closeout_matrix.sh scripts/mvcc_candidate_checkout_guard.sh
           python3 .github/scripts/check_mvcc_raw_path_gate.py --self-test
           python3 .github/scripts/check_mvcc_adapter_overhead_gate.py --self-test
           python3 .github/scripts/test_mvcc_raw_path_equivalence.py
           python3 .github/scripts/test_mvcc_benchmark_pairing.py
+          python3 .github/scripts/test_summarize_mvcc_closeout.py
+          python3 .github/scripts/test_mvcc_candidate_checkout_guard.py
           for path in \
             TreeDB/snapshot_seek_iterator_bench_test.go \
             TreeDB/command_wal_public_test.go \
             TreeDB/caching/bench_test.go \
-            TreeDB/bg_vacuum.go; do
+            TreeDB/bg_vacuum.go \
+            scripts/mvcc_closeout_matrix.sh \
+            scripts/mvcc_candidate_checkout_guard.sh \
+            .github/scripts/summarize_mvcc_closeout.py \
+            .github/scripts/test_summarize_mvcc_closeout.py \
+            .github/scripts/test_mvcc_candidate_checkout_guard.py; do
             if ! grep -Eq "$MVCC_GATE_PATH_RE" <<< "$path"; then
               echo "MVCC gate path scope unexpectedly excludes: $path" >&2
               exit 1

--- a/.github/workflows/treedb-tests.yml
+++ b/.github/workflows/treedb-tests.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-24.04
     timeout-minutes: 15
     env:
-      MVCC_GATE_PATH_RE: '^((TreeDB/((mvcc|internal/mvcckey|db|caching)/|[^/]+\.go$))|scripts/mvcc_(raw_path_gate|adapter_overhead_gate|closeout_matrix|candidate_checkout_guard)\.sh$|\.github/scripts/(check_mvcc_(raw_path|adapter_overhead)_gate|summarize_mvcc_closeout|test_(mvcc_(raw_path_equivalence|benchmark_pairing|candidate_checkout_guard)|summarize_mvcc_closeout))\.py$|\.github/workflows/treedb-tests\.yml$)'
+      MVCC_GATE_PATH_RE: '^((TreeDB/)|scripts/mvcc_(raw_path_gate|adapter_overhead_gate|closeout_matrix|candidate_checkout_guard)\.sh$|\.github/scripts/(check_mvcc_(raw_path|adapter_overhead)_gate|summarize_mvcc_closeout|test_(mvcc_(raw_path_equivalence|benchmark_pairing|candidate_checkout_guard)|summarize_mvcc_closeout))\.py$|\.github/workflows/treedb-tests\.yml$)'
     steps:
       - name: Resolve open PR and relevant paths
         id: scope
@@ -84,6 +84,11 @@ jobs:
             TreeDB/command_wal_public_test.go \
             TreeDB/caching/bench_test.go \
             TreeDB/bg_vacuum.go \
+            TreeDB/node/leaf_prefix_v2.go \
+            TreeDB/page/freelist.go \
+            TreeDB/pager/madvise_linux.go \
+            TreeDB/internal/valuelog/autotune_options.go \
+            TreeDB/docs/spec/native-ann-vector-index.md \
             scripts/mvcc_closeout_matrix.sh \
             scripts/mvcc_candidate_checkout_guard.sh \
             .github/scripts/summarize_mvcc_closeout.py \
@@ -94,10 +99,6 @@ jobs:
               exit 1
             fi
           done
-          if grep -Eq "$MVCC_GATE_PATH_RE" <<< 'TreeDB/docs/spec/native-ann-vector-index.md'; then
-            echo "MVCC gate path scope unexpectedly includes TreeDB docs" >&2
-            exit 1
-          fi
 
       - name: Compare exact base and head
         if: steps.scope.outputs.run == 'true'

--- a/TreeDB/docs/spec/README.md
+++ b/TreeDB/docs/spec/README.md
@@ -78,6 +78,10 @@ Given pre-alpha status, this is a living spec that tracks implementation.
   - downstream adapter closeout for native `EntryRevision` cache tokens,
     conditional transaction conflict mapping, command-WAL/fail-closed surfaces,
     and unsupported Badger-style feature errors.
+- `TreeDB/docs/spec/dgraph-mvcc-readiness-3673.md`
+  - reusable external-MVCC conformance harness, exact supported/unsupported
+    Dgraph Alpha boundary, merged-main module-pin policy, correctness matrix,
+    and pinned raw/MVCC performance evidence for issue #3673.
 - `TreeDB/docs/spec/concurrency-paradigms.md`
   - complete concurrency mechanism inventory, lock/worker topology, and option/flag matrix for perf/refactor audits.
 - `TreeDB/docs/spec/storage-format.md`

--- a/TreeDB/docs/spec/artifacts/dgraph-mvcc-closeout/README.md
+++ b/TreeDB/docs/spec/artifacts/dgraph-mvcc-closeout/README.md
@@ -1,14 +1,14 @@
 # Dgraph MVCC closeout evidence
 
 This directory contains the compact exact-target evidence for gomap #3673.
-The measured code target is
+The raw-path and adapter target is
 `dbea38e0e8ad0c7d1e0bb05ac564bd9b57dd747a`; the paired comparison base is
-`f9c9b2a37838909d0e669818cfa2840c0a8d5f85`. The final pull-request head is a
-post-measure validation, CI-wiring, and evidence descendant of the measured
-target. It does not change production MVCC code, benchmark definitions,
-benchmark harnesses, or the inputs used for these measurements. The committed
-summaries were regenerated and revalidated from the preserved raw inputs; no
-benchmark was rerun after the measured target.
+`f9c9b2a37838909d0e669818cfa2840c0a8d5f85`. The corrected closeout-matrix
+target is `103f9c5af85d8d6a5801119fc2247be3b9c87fad`, which stops the prune
+benchmark timer before all fixture setup. The final pull-request head is an
+evidence descendant of that correction and does not change production MVCC
+code. The raw-path and adapter benchmarks were not rerun; the closeout matrix
+was rerun exactly once after a fresh passing quiet audit.
 Dgraph must still pin the first merged-main descendant containing this PR, not
 the worker-branch commit.
 
@@ -18,8 +18,10 @@ the worker-branch commit.
 - CPU: 11th Gen Intel Core i5-11400F, 6 cores / 12 threads;
 - Go: `go1.26.0 linux/amd64`;
 - timing CPU: `0`, `GOMAXPROCS=1`, `GOWORK=off`;
-- final local preflight: exact clean target, 92.21% average idle, 0.38%
+- adapter preflight: exact clean `dbea38e0` target, 92.21% average idle, 0.38%
   iowait, no `simd`, and no competing benchmark/build/test job;
+- corrected-matrix preflight: exact clean `103f9c5af` target, 95.64% average
+  idle, 0.36% iowait, no `simd`, and no competing benchmark/build/test job;
 - the unrelated Ironbird durability campaign completed 15/15 accepted rows
   before the local adapter and matrix measurements started.
 
@@ -30,10 +32,13 @@ outside git at:
   `/mnt/fast4tb/gomap-3673-evidence/hosted-raw-dbea38e0`;
 - local adapter artifact:
   `/mnt/fast4tb/gomap-3673-evidence/adapter-dbea38e0`;
-- local closeout matrix:
+- superseded local closeout matrix, invalid for prune timing because fixture
+  setup entered the single timed sample:
   `/mnt/fast4tb/gomap-3673-evidence/closeout-matrix-dbea38e0`;
-- passing final quiet audit:
-  `/mnt/fast4tb/gomap-3673-evidence/quiet-window-dbea38e0-final`.
+- corrected local closeout matrix:
+  `/mnt/fast4tb/gomap-3673-evidence/closeout-matrix-103f9c5af`;
+- passing corrected-matrix quiet audit:
+  `/mnt/fast4tb/gomap-3673-evidence/quiet-window-103f9c5af`.
 
 Large raw logs, test binaries, and binary CPU profiles are deliberately not
 committed. The generated Markdown and JSON summaries in this directory are
@@ -95,17 +100,21 @@ keeps the exact samples and profiles available for follow-up. See
 
 ## Durability-matched closeout matrix: PASS
 
-The exact-target closeout matrix used five samples and `-benchtime=750ms` for
-regular rows; each prune row used one fresh fixture per sample. The summarizer
-completed successfully with all 24 benchmark rows, ten measured invocations,
-600,640 KiB maximum RSS, 109.07 seconds aggregate user CPU, and 7.49 seconds
-aggregate system CPU. Representative durable-sync medians were:
+The corrected exact-target closeout matrix used five samples and
+`-benchtime=750ms` for regular rows; each prune row used one fresh fixture per
+sample, with the benchmark timer stopped before the parent temporary directory
+and all fixture setup. Only `PruneVersions` is timed. The prior matrix is
+superseded because its single prune sample included pre-loop temporary-directory
+setup. The corrected summarizer completed successfully with all 24 benchmark
+rows, ten measured invocations, 611,264 KiB maximum RSS, 102.36 seconds
+aggregate user CPU, and 6.97 seconds aggregate system CPU. Representative
+durable-sync medians were:
 
-- commit: 152.5 mutations/s at batch 1 and 4,833 mutations/s at batch 32;
-- point read: 870,369 lookups/s at depth 1 and 567,989 lookups/s at depth 64;
-- all-version iteration: 2,996,840 versions/s at depth 1 and 3,582,446
+- commit: 149.5 mutations/s at batch 1 and 5,271 mutations/s at batch 32;
+- point read: 937,621 lookups/s at depth 1 and 670,037 lookups/s at depth 64;
+- all-version iteration: 3,485,151 versions/s at depth 1 and 4,119,271
   versions/s at depth 32;
-- prune: 14,400 pruned versions/s at floor 4 and 26,322/s at floor 12.
+- prune: 13,505 pruned versions/s at floor 4 and 25,211/s at floor 12.
 
 Prune delete write amplification was 0.8286 in every row. Durable-sync,
 WAL-on relaxed, and WAL-off relaxed results remain separate acknowledgement
@@ -126,7 +135,7 @@ CANDIDATE_HASH=dbea38e0e8ad0c7d1e0bb05ac564bd9b57dd747a \
 RUNS=8 BENCHTIME=2s PROFILE_BENCHTIME=1s CPUSET=0 GOWORK=off \
 OUT_DIR=/absolute/adapter ./scripts/mvcc_adapter_overhead_gate.sh
 
-CANDIDATE_HASH=dbea38e0e8ad0c7d1e0bb05ac564bd9b57dd747a \
+CANDIDATE_HASH=103f9c5af85d8d6a5801119fc2247be3b9c87fad \
 RUNS=5 BENCHTIME=750ms CPUSET=0 GOWORK=off \
 OUT_DIR=/absolute/matrix ./scripts/mvcc_closeout_matrix.sh
 ```

--- a/TreeDB/docs/spec/artifacts/dgraph-mvcc-closeout/README.md
+++ b/TreeDB/docs/spec/artifacts/dgraph-mvcc-closeout/README.md
@@ -1,104 +1,129 @@
 # Dgraph MVCC closeout evidence
 
-> [!CAUTION]
-> The committed summaries below are superseded by post-review code changes
-> after `5ea704c4892191c509aa76e4551148b77db018f0`. They remain historical
-> records of the first measurement only and MUST NOT be cited as exact-head
-> evidence. A clean-checkout exact-head rerun and replacement evidence commit
-> are required before this PR is merge-ready.
->
-> A later exact-`c6515de296bb89fa0ce4730a4df4561cab4b688a` raw-path run is
-> retained outside git at
-> `/mnt/fast4tb/gomap-3673-evidence/raw-path-c6515de`. It failed the point-read
-> timing row, but is not valid replacement evidence: the old harness separated
-> same-row base/head measurements with whole revision blocks, and its process
-> snapshots captured unexpected 65% and 80% CPU Ironbird analysis processes
-> during later candidate blocks. Preserve that failed run for audit; supersede
-> it only after the benchmark-group-paired harness change is reviewed and an
-> exact-new-head clean-window run is recorded.
-> Its measured `BenchmarkGetVersioned` median remains a FAIL observation
-> (+11.24%). All three recorded base/head package binaries were byte-identical,
-> which supports `EQUIVALENT` revision attribution rather than PASS: the
-> observation remains visible, while identical executable code means it is not
-> an attributable candidate regression. The historical seven-sample run itself
-> is not accepted by the current gate, which requires balanced even AB/BA pairs.
+This directory contains the compact exact-target evidence for gomap #3673.
+The measured code target is
+`dbea38e0e8ad0c7d1e0bb05ac564bd9b57dd747a`; the paired comparison base is
+`f9c9b2a37838909d0e669818cfa2840c0a8d5f85`. The final pull-request head is a
+docs-and-evidence-only descendant of the measured target. It does not change
+production MVCC code, benchmark definitions, or the benchmark harnesses.
+Dgraph must still pin the first merged-main descendant containing this PR, not
+the worker-branch commit.
 
-This directory indexes the compact, reproducible evidence for gomap #3673.
-The measured code commit is
-`2f0a687f048ece277ab039303f6e28a1a7906bcb`; the base commit for paired
-no-regression gates is
-`f9c9b2a37838909d0e669818cfa2840c0a8d5f85`. The following evidence-only
-commit changes no production or benchmark code. Dgraph must still pin the
-first merged-main descendant that contains the closeout PR, not this worker
-commit.
+## Host, method, and retained evidence
 
-## Host and correctness
-
-- host: `mikers-B560-DS3H-AC-Y1`, Linux `6.8.0-124-generic`;
+- local host: `mikers-B560-DS3H-AC-Y1`, Linux `6.8.0-124-generic`;
 - CPU: 11th Gen Intel Core i5-11400F, 6 cores / 12 threads;
 - Go: `go1.26.0 linux/amd64`;
 - timing CPU: `0`, `GOMAXPROCS=1`, `GOWORK=off`;
-- `go vet ./...` and `go test ./... -count=1`: PASS;
-- `go test -race ./TreeDB/mvcc/... -count=1`: PASS;
-- durable commit/prune crash tests, `-count=3`: PASS;
-- codec `FuzzRoundTrip` and `FuzzDecodeNeverPanics`, 10 seconds each: PASS.
+- final local preflight: exact clean target, 92.21% average idle, 0.38%
+  iowait, no `simd`, and no competing benchmark/build/test job;
+- the unrelated Ironbird durability campaign completed 15/15 accepted rows
+  before the local adapter and matrix measurements started.
 
-## Performance gates
+Raw logs, environment/process captures, checksums, and profiles are retained
+outside git at:
 
-The historical raw-path gate used seven revision-block-alternating samples per
-revision, `-benchtime=2s`, a 5% median timing ceiling, no allocation increase,
-and a `B/op` increase ceiling of the smaller of 1% or 64 bytes. Current harness
-code instead pairs every individual benchmark group immediately in alternating
-AB/BA order; these historical summaries predate that methodology correction:
+- hosted raw-path artifact:
+  `/mnt/fast4tb/gomap-3673-evidence/hosted-raw-dbea38e0`;
+- local adapter artifact:
+  `/mnt/fast4tb/gomap-3673-evidence/adapter-dbea38e0`;
+- local closeout matrix:
+  `/mnt/fast4tb/gomap-3673-evidence/closeout-matrix-dbea38e0`;
+- passing final quiet audit:
+  `/mnt/fast4tb/gomap-3673-evidence/quiet-window-dbea38e0-final`.
 
-```sh
-BASELINE_HASH=f9c9b2a37838909d0e669818cfa2840c0a8d5f85 \
-CANDIDATE_HASH=2f0a687f048ece277ab039303f6e28a1a7906bcb \
-RUNS=7 BENCHTIME=2s CPUSET=0 GOWORK=off \
-OUT_DIR=/mnt/fast4tb/gomap-3673-evidence/raw-path-2f0a687 \
-./scripts/mvcc_raw_path_gate.sh
-```
+Large raw logs, test binaries, and binary CPU profiles are deliberately not
+committed. The generated Markdown and JSON summaries in this directory are
+copied without changing their verdicts or samples.
 
-Result: PASS for raw point, batch, snapshot, iterator, and durable synced write
-rows. See [raw-path-summary.md](raw-path-summary.md) and its machine-readable
-companion `raw-path-summary.json`.
+## Raw-path gate: EQUIVALENT
 
-The adapter-overhead gate used the same samples and thresholds, plus a 2x
-candidate MVCC/direct ceiling. It always captured candidate MVCC CPU profiles:
+The hosted exact-target raw gate used eight benchmark-group-paired samples per
+revision, exactly four AB and four BA pairs, at `-benchtime=2s`. Its verdict is
+**EQUIVALENT**, with the measured threshold observation preserved as **FAIL**:
 
-```sh
-BASELINE_HASH=f9c9b2a37838909d0e669818cfa2840c0a8d5f85 \
-CANDIDATE_HASH=2f0a687f048ece277ab039303f6e28a1a7906bcb \
-RUNS=7 BENCHTIME=2s PROFILE_BENCHTIME=1s CPUSET=0 GOWORK=off \
-OUT_DIR=/mnt/fast4tb/gomap-3673-evidence/adapter-overhead-2f0a687 \
-./scripts/mvcc_adapter_overhead_gate.sh
-```
+- point read: +1.12%, PASS;
+- batch write: +0.36%, PASS;
+- snapshot seek: -0.47%, PASS;
+- repeated iterator: -1.76%, PASS;
+- durable synced write: +27.94%, measured FAIL.
 
-Result: PASS. Candidate MVCC/direct medians were 1.042x for commit, 1.119x for
-get, and 1.109x for all-version iteration. See
+Every row-producing base/head test binary was byte-identical: `db`, `caching`,
+and root `treedb`. The checker therefore accepts the result as EQUIVALENT—no
+observed delta can be attributed to candidate code—without relabeling the
+durable timing observation as PASS. See [raw-path-summary.md](raw-path-summary.md)
+and `raw-path-summary.json`.
+
+## Adapter-overhead gate: FAIL, scoped acceptance
+
+The local exact-target adapter gate used eight benchmark-group-paired samples
+per revision at `-benchtime=2s`, plus 1-second candidate profiles. Its gate
+verdict is **FAIL** and remains a FAIL in the committed generated summaries.
+Four base/head timing rows exceeded the 5% ceiling:
+
+- direct commit +9.77% and MVCC commit +7.03%;
+- physical all-version iteration +18.88% and MVCC iteration +13.41%.
+
+Direct and MVCC controls co-moved within each failing operation family. The
+candidate adapter/direct ratios all passed the independent 2x ceiling:
+0.936x commit, 1.008x get, and 1.121x iteration. Allocations were unchanged in
+all six rows, and bytes were flat within the gate tolerance. Point reads also
+remained within the revision threshold: +2.63% direct and +4.35% MVCC.
+
+The four revision-ceiling misses are accepted only for this restricted
+pre-alpha downstream benchmark closeout, not erased or promoted to a passing
+gate, because all of the following scoped evidence agrees:
+
+- the base-to-target production diff is test/conformance harness, benchmark,
+  documentation, scripts, and workflow code; it does not change TreeDB's
+  production read, commit, or iteration implementation;
+- direct and MVCC rows co-moved while all candidate adapter/direct ratios
+  passed, with a maximum of 1.121x;
+- allocations were unchanged and bytes remained flat;
+- the hosted raw-path production binaries were byte-identical and received an
+  EQUIVALENT verdict; and
+- the durability-matched closeout matrix completed successfully.
+
+This rationale does not establish a general performance guarantee. It accepts
+the measured closeout risk for the first restricted Dgraph Alpha benchmark and
+keeps the exact samples and profiles available for follow-up. See
 [adapter-overhead-summary.md](adapter-overhead-summary.md) and
 `adapter-overhead-summary.json`.
 
-## Durability-matched matrix
+## Durability-matched closeout matrix: PASS
 
-```sh
-CANDIDATE_HASH=2f0a687f048ece277ab039303f6e28a1a7906bcb \
-RUNS=5 BENCHTIME=750ms CPUSET=0 GOWORK=off \
-OUT_DIR=/mnt/fast4tb/gomap-3673-evidence/closeout-matrix-2f0a687 \
-./scripts/mvcc_closeout_matrix.sh
-```
+The exact-target closeout matrix used five samples and `-benchtime=750ms` for
+regular rows; each prune row used one fresh fixture per sample. The summarizer
+completed successfully with all 24 benchmark rows, ten measured invocations,
+600,640 KiB maximum RSS, 109.07 seconds aggregate user CPU, and 7.49 seconds
+aggregate system CPU. Representative durable-sync medians were:
 
-Result: all 24 exact benchmark rows and all required metrics were present for
-five samples in durable-sync, WAL-on relaxed, and WAL-off relaxed classes. The
-ten timed processes used 100.64 seconds user and 6.85 seconds system CPU in
-aggregate. Maximum RSS was 622,068 KiB for a duration-calibrated regular
-process. The five one-operation prune processes used 82,624-91,004 KiB, so the
-622 MiB headline must not be attributed to one prune fixture. Prune delete
-write amplification was 0.829 in every row. See
-[closeout-matrix-summary.md](closeout-matrix-summary.md) and
+- commit: 152.5 mutations/s at batch 1 and 4,833 mutations/s at batch 32;
+- point read: 870,369 lookups/s at depth 1 and 567,989 lookups/s at depth 64;
+- all-version iteration: 2,996,840 versions/s at depth 1 and 3,582,446
+  versions/s at depth 32;
+- prune: 14,400 pruned versions/s at floor 4 and 26,322/s at floor 12.
+
+Prune delete write amplification was 0.8286 in every row. Durable-sync,
+WAL-on relaxed, and WAL-off relaxed results remain separate acknowledgement
+classes; relaxed rows are not described as durability-equivalent to synced
+rows. See [closeout-matrix-summary.md](closeout-matrix-summary.md) and
 `closeout-matrix-summary.json`.
 
-The three `OUT_DIR` paths above contain the retained raw logs, environment and
-process snapshots, binary checksums, and profiles on the measurement host.
-Large raw logs, benchmark binaries, and binary CPU profiles are deliberately
-not committed.
+## Reproduction
+
+```sh
+BASELINE_HASH=f9c9b2a37838909d0e669818cfa2840c0a8d5f85 \
+CANDIDATE_HASH=dbea38e0e8ad0c7d1e0bb05ac564bd9b57dd747a \
+RUNS=8 BENCHTIME=2s CPUSET=0 GOWORK=off \
+OUT_DIR=/absolute/raw-path ./scripts/mvcc_raw_path_gate.sh
+
+BASELINE_HASH=f9c9b2a37838909d0e669818cfa2840c0a8d5f85 \
+CANDIDATE_HASH=dbea38e0e8ad0c7d1e0bb05ac564bd9b57dd747a \
+RUNS=8 BENCHTIME=2s PROFILE_BENCHTIME=1s CPUSET=0 GOWORK=off \
+OUT_DIR=/absolute/adapter ./scripts/mvcc_adapter_overhead_gate.sh
+
+CANDIDATE_HASH=dbea38e0e8ad0c7d1e0bb05ac564bd9b57dd747a \
+RUNS=5 BENCHTIME=750ms CPUSET=0 GOWORK=off \
+OUT_DIR=/absolute/matrix ./scripts/mvcc_closeout_matrix.sh
+```

--- a/TreeDB/docs/spec/artifacts/dgraph-mvcc-closeout/README.md
+++ b/TreeDB/docs/spec/artifacts/dgraph-mvcc-closeout/README.md
@@ -1,0 +1,7 @@
+# Dgraph MVCC closeout evidence
+
+This directory indexes the compact, reproducible evidence for gomap #3673.
+Exact code commit, host, commands, raw-artifact locations, raw-path result, and
+durability-matched matrix medians are added after the implementation commit is
+frozen and measured. Large raw logs and binary CPU profiles are deliberately
+not committed.

--- a/TreeDB/docs/spec/artifacts/dgraph-mvcc-closeout/README.md
+++ b/TreeDB/docs/spec/artifacts/dgraph-mvcc-closeout/README.md
@@ -1,5 +1,12 @@
 # Dgraph MVCC closeout evidence
 
+> [!CAUTION]
+> The committed summaries below are superseded by post-review code changes
+> after `5ea704c4892191c509aa76e4551148b77db018f0`. They remain historical
+> records of the first measurement only and MUST NOT be cited as exact-head
+> evidence. A clean-checkout exact-head rerun and replacement evidence commit
+> are required before this PR is merge-ready.
+
 This directory indexes the compact, reproducible evidence for gomap #3673.
 The measured code commit is
 `2f0a687f048ece277ab039303f6e28a1a7906bcb`; the base commit for paired

--- a/TreeDB/docs/spec/artifacts/dgraph-mvcc-closeout/README.md
+++ b/TreeDB/docs/spec/artifacts/dgraph-mvcc-closeout/README.md
@@ -4,8 +4,11 @@ This directory contains the compact exact-target evidence for gomap #3673.
 The measured code target is
 `dbea38e0e8ad0c7d1e0bb05ac564bd9b57dd747a`; the paired comparison base is
 `f9c9b2a37838909d0e669818cfa2840c0a8d5f85`. The final pull-request head is a
-docs-and-evidence-only descendant of the measured target. It does not change
-production MVCC code, benchmark definitions, or the benchmark harnesses.
+post-measure validation, CI-wiring, and evidence descendant of the measured
+target. It does not change production MVCC code, benchmark definitions,
+benchmark harnesses, or the inputs used for these measurements. The committed
+summaries were regenerated and revalidated from the preserved raw inputs; no
+benchmark was rerun after the measured target.
 Dgraph must still pin the first merged-main descendant containing this PR, not
 the worker-branch commit.
 

--- a/TreeDB/docs/spec/artifacts/dgraph-mvcc-closeout/README.md
+++ b/TreeDB/docs/spec/artifacts/dgraph-mvcc-closeout/README.md
@@ -1,7 +1,79 @@
 # Dgraph MVCC closeout evidence
 
 This directory indexes the compact, reproducible evidence for gomap #3673.
-Exact code commit, host, commands, raw-artifact locations, raw-path result, and
-durability-matched matrix medians are added after the implementation commit is
-frozen and measured. Large raw logs and binary CPU profiles are deliberately
+The measured code commit is
+`2f0a687f048ece277ab039303f6e28a1a7906bcb`; the base commit for paired
+no-regression gates is
+`f9c9b2a37838909d0e669818cfa2840c0a8d5f85`. The following evidence-only
+commit changes no production or benchmark code. Dgraph must still pin the
+first merged-main descendant that contains the closeout PR, not this worker
+commit.
+
+## Host and correctness
+
+- host: `mikers-B560-DS3H-AC-Y1`, Linux `6.8.0-124-generic`;
+- CPU: 11th Gen Intel Core i5-11400F, 6 cores / 12 threads;
+- Go: `go1.26.0 linux/amd64`;
+- timing CPU: `0`, `GOMAXPROCS=1`, `GOWORK=off`;
+- `go vet ./...` and `go test ./... -count=1`: PASS;
+- `go test -race ./TreeDB/mvcc/... -count=1`: PASS;
+- durable commit/prune crash tests, `-count=3`: PASS;
+- codec `FuzzRoundTrip` and `FuzzDecodeNeverPanics`, 10 seconds each: PASS.
+
+## Performance gates
+
+The raw-path gate used seven alternating sequential samples per revision,
+`-benchtime=2s`, a 5% median timing ceiling, no allocation increase, and a
+`B/op` increase ceiling of the smaller of 1% or 64 bytes:
+
+```sh
+BASELINE_HASH=f9c9b2a37838909d0e669818cfa2840c0a8d5f85 \
+CANDIDATE_HASH=2f0a687f048ece277ab039303f6e28a1a7906bcb \
+RUNS=7 BENCHTIME=2s CPUSET=0 GOWORK=off \
+OUT_DIR=/mnt/fast4tb/gomap-3673-evidence/raw-path-2f0a687 \
+./scripts/mvcc_raw_path_gate.sh
+```
+
+Result: PASS for raw point, batch, snapshot, iterator, and durable synced write
+rows. See [raw-path-summary.md](raw-path-summary.md) and its machine-readable
+companion `raw-path-summary.json`.
+
+The adapter-overhead gate used the same samples and thresholds, plus a 2x
+candidate MVCC/direct ceiling. It always captured candidate MVCC CPU profiles:
+
+```sh
+BASELINE_HASH=f9c9b2a37838909d0e669818cfa2840c0a8d5f85 \
+CANDIDATE_HASH=2f0a687f048ece277ab039303f6e28a1a7906bcb \
+RUNS=7 BENCHTIME=2s PROFILE_BENCHTIME=1s CPUSET=0 GOWORK=off \
+OUT_DIR=/mnt/fast4tb/gomap-3673-evidence/adapter-overhead-2f0a687 \
+./scripts/mvcc_adapter_overhead_gate.sh
+```
+
+Result: PASS. Candidate MVCC/direct medians were 1.042x for commit, 1.119x for
+get, and 1.109x for all-version iteration. See
+[adapter-overhead-summary.md](adapter-overhead-summary.md) and
+`adapter-overhead-summary.json`.
+
+## Durability-matched matrix
+
+```sh
+CANDIDATE_HASH=2f0a687f048ece277ab039303f6e28a1a7906bcb \
+RUNS=5 BENCHTIME=750ms CPUSET=0 GOWORK=off \
+OUT_DIR=/mnt/fast4tb/gomap-3673-evidence/closeout-matrix-2f0a687 \
+./scripts/mvcc_closeout_matrix.sh
+```
+
+Result: all 24 exact benchmark rows and all required metrics were present for
+five samples in durable-sync, WAL-on relaxed, and WAL-off relaxed classes. The
+ten timed processes used 100.64 seconds user and 6.85 seconds system CPU in
+aggregate. Maximum RSS was 622,068 KiB for a duration-calibrated regular
+process. The five one-operation prune processes used 82,624-91,004 KiB, so the
+622 MiB headline must not be attributed to one prune fixture. Prune delete
+write amplification was 0.829 in every row. See
+[closeout-matrix-summary.md](closeout-matrix-summary.md) and
+`closeout-matrix-summary.json`.
+
+The three `OUT_DIR` paths above contain the retained raw logs, environment and
+process snapshots, binary checksums, and profiles on the measurement host.
+Large raw logs, benchmark binaries, and binary CPU profiles are deliberately
 not committed.

--- a/TreeDB/docs/spec/artifacts/dgraph-mvcc-closeout/README.md
+++ b/TreeDB/docs/spec/artifacts/dgraph-mvcc-closeout/README.md
@@ -6,6 +6,16 @@
 > records of the first measurement only and MUST NOT be cited as exact-head
 > evidence. A clean-checkout exact-head rerun and replacement evidence commit
 > are required before this PR is merge-ready.
+>
+> A later exact-`c6515de296bb89fa0ce4730a4df4561cab4b688a` raw-path run is
+> retained outside git at
+> `/mnt/fast4tb/gomap-3673-evidence/raw-path-c6515de`. It failed the point-read
+> timing row, but is not valid replacement evidence: the old harness separated
+> same-row base/head measurements with whole revision blocks, and its process
+> snapshots captured unexpected 65% and 80% CPU Ironbird analysis processes
+> during later candidate blocks. Preserve that failed run for audit; supersede
+> it only after the benchmark-group-paired harness change is reviewed and an
+> exact-new-head clean-window run is recorded.
 
 This directory indexes the compact, reproducible evidence for gomap #3673.
 The measured code commit is
@@ -29,9 +39,11 @@ commit.
 
 ## Performance gates
 
-The raw-path gate used seven alternating sequential samples per revision,
-`-benchtime=2s`, a 5% median timing ceiling, no allocation increase, and a
-`B/op` increase ceiling of the smaller of 1% or 64 bytes:
+The historical raw-path gate used seven revision-block-alternating samples per
+revision, `-benchtime=2s`, a 5% median timing ceiling, no allocation increase,
+and a `B/op` increase ceiling of the smaller of 1% or 64 bytes. Current harness
+code instead pairs every individual benchmark group immediately in alternating
+AB/BA order; these historical summaries predate that methodology correction:
 
 ```sh
 BASELINE_HASH=f9c9b2a37838909d0e669818cfa2840c0a8d5f85 \

--- a/TreeDB/docs/spec/artifacts/dgraph-mvcc-closeout/README.md
+++ b/TreeDB/docs/spec/artifacts/dgraph-mvcc-closeout/README.md
@@ -16,6 +16,12 @@
 > during later candidate blocks. Preserve that failed run for audit; supersede
 > it only after the benchmark-group-paired harness change is reviewed and an
 > exact-new-head clean-window run is recorded.
+> Its measured `BenchmarkGetVersioned` median remains a FAIL observation
+> (+11.24%). All three recorded base/head package binaries were byte-identical,
+> which supports `EQUIVALENT` revision attribution rather than PASS: the
+> observation remains visible, while identical executable code means it is not
+> an attributable candidate regression. The historical seven-sample run itself
+> is not accepted by the current gate, which requires balanced even AB/BA pairs.
 
 This directory indexes the compact, reproducible evidence for gomap #3673.
 The measured code commit is

--- a/TreeDB/docs/spec/artifacts/dgraph-mvcc-closeout/adapter-overhead-summary.json
+++ b/TreeDB/docs/spec/artifacts/dgraph-mvcc-closeout/adapter-overhead-summary.json
@@ -1,0 +1,124 @@
+{
+  "baseline_sha": "f9c9b2a37838909d0e669818cfa2840c0a8d5f85",
+  "candidate_sha": "2f0a687f048ece277ab039303f6e28a1a7906bcb",
+  "expected_samples": 7,
+  "pass": true,
+  "ratios": [
+    {
+      "baseline_ratio": 1.0469572541587702,
+      "candidate_ratio": 1.0417633410672853,
+      "pair": "CommitAt",
+      "pass": true
+    },
+    {
+      "baseline_ratio": 1.1069669247009148,
+      "candidate_ratio": 1.119434628975265,
+      "pair": "GetAt",
+      "pass": true
+    },
+    {
+      "baseline_ratio": 1.0588019161168376,
+      "candidate_ratio": 1.1089710275358828,
+      "pair": "VersionIteration",
+      "pass": true
+    }
+  ],
+  "results": [
+    {
+      "baseline": {
+        "allocs_per_op": 8.0,
+        "bytes_per_op": 7556.0,
+        "ns_per_op": 4749.0
+      },
+      "benchmark": "BenchmarkCommitAt/DirectTreeDB/1",
+      "bytes_tolerance": 64.0,
+      "candidate": {
+        "allocs_per_op": 8.0,
+        "bytes_per_op": 7555.0,
+        "ns_per_op": 4741.0
+      },
+      "ns_delta_percent": -0.16845651716150822,
+      "pass": true
+    },
+    {
+      "baseline": {
+        "allocs_per_op": 9.0,
+        "bytes_per_op": 7567.0,
+        "ns_per_op": 4972.0
+      },
+      "benchmark": "BenchmarkCommitAt/MVCC/1",
+      "bytes_tolerance": 64.0,
+      "candidate": {
+        "allocs_per_op": 9.0,
+        "bytes_per_op": 7560.0,
+        "ns_per_op": 4939.0
+      },
+      "ns_delta_percent": -0.6637168141592875,
+      "pass": true
+    },
+    {
+      "baseline": {
+        "allocs_per_op": 15.0,
+        "bytes_per_op": 992.0,
+        "ns_per_op": 1421.0
+      },
+      "benchmark": "BenchmarkGetAt/DirectSeek/64",
+      "bytes_tolerance": 9.92,
+      "candidate": {
+        "allocs_per_op": 15.0,
+        "bytes_per_op": 992.0,
+        "ns_per_op": 1415.0
+      },
+      "ns_delta_percent": -0.4222378606615007,
+      "pass": true
+    },
+    {
+      "baseline": {
+        "allocs_per_op": 16.0,
+        "bytes_per_op": 1008.0,
+        "ns_per_op": 1573.0
+      },
+      "benchmark": "BenchmarkGetAt/MVCC/64",
+      "bytes_tolerance": 10.08,
+      "candidate": {
+        "allocs_per_op": 16.0,
+        "bytes_per_op": 1008.0,
+        "ns_per_op": 1584.0
+      },
+      "ns_delta_percent": 0.6993006993007089,
+      "pass": true
+    },
+    {
+      "baseline": {
+        "allocs_per_op": 4108.0,
+        "bytes_per_op": 50102.0,
+        "ns_per_op": 508946.0
+      },
+      "benchmark": "BenchmarkVersionIteration/Physical/keys=64/depth=32/reverse=false",
+      "bytes_tolerance": 64.0,
+      "candidate": {
+        "allocs_per_op": 4108.0,
+        "bytes_per_op": 50100.0,
+        "ns_per_op": 473346.0
+      },
+      "ns_delta_percent": -6.994848176427359,
+      "pass": true
+    },
+    {
+      "baseline": {
+        "allocs_per_op": 4118.0,
+        "bytes_per_op": 51831.0,
+        "ns_per_op": 538873.0
+      },
+      "benchmark": "BenchmarkVersionIteration/MVCC/keys=64/depth=32/reverse=false",
+      "bytes_tolerance": 64.0,
+      "candidate": {
+        "allocs_per_op": 4118.0,
+        "bytes_per_op": 51831.0,
+        "ns_per_op": 524927.0
+      },
+      "ns_delta_percent": -2.5879938315707007,
+      "pass": true
+    }
+  ]
+}

--- a/TreeDB/docs/spec/artifacts/dgraph-mvcc-closeout/adapter-overhead-summary.json
+++ b/TreeDB/docs/spec/artifacts/dgraph-mvcc-closeout/adapter-overhead-summary.json
@@ -1,24 +1,24 @@
 {
   "baseline_sha": "f9c9b2a37838909d0e669818cfa2840c0a8d5f85",
-  "candidate_sha": "2f0a687f048ece277ab039303f6e28a1a7906bcb",
-  "expected_samples": 7,
-  "pass": true,
+  "candidate_sha": "dbea38e0e8ad0c7d1e0bb05ac564bd9b57dd747a",
+  "expected_samples": 8,
+  "pass": false,
   "ratios": [
     {
-      "baseline_ratio": 1.0469572541587702,
-      "candidate_ratio": 1.0417633410672853,
+      "baseline_ratio": 0.9597239023696008,
+      "candidate_ratio": 0.9357578114870997,
       "pair": "CommitAt",
       "pass": true
     },
     {
-      "baseline_ratio": 1.1069669247009148,
-      "candidate_ratio": 1.119434628975265,
+      "baseline_ratio": 0.9917895129688374,
+      "candidate_ratio": 1.0083636363636364,
       "pair": "GetAt",
       "pass": true
     },
     {
-      "baseline_ratio": 1.0588019161168376,
-      "candidate_ratio": 1.1089710275358828,
+      "baseline_ratio": 1.175073560953478,
+      "candidate_ratio": 1.1209445770707982,
       "pair": "VersionIteration",
       "pass": true
     }
@@ -26,99 +26,99 @@
   "results": [
     {
       "baseline": {
-        "allocs_per_op": 8.0,
-        "bytes_per_op": 7556.0,
-        "ns_per_op": 4749.0
+        "allocs_per_op": 8.5,
+        "bytes_per_op": 7477.0,
+        "ns_per_op": 7026.5
       },
       "benchmark": "BenchmarkCommitAt/DirectTreeDB/1",
       "bytes_tolerance": 64.0,
       "candidate": {
-        "allocs_per_op": 8.0,
-        "bytes_per_op": 7555.0,
-        "ns_per_op": 4741.0
+        "allocs_per_op": 8.5,
+        "bytes_per_op": 7467.5,
+        "ns_per_op": 7713.0
       },
-      "ns_delta_percent": -0.16845651716150822,
-      "pass": true
+      "ns_delta_percent": 9.770155838610982,
+      "pass": false
     },
     {
       "baseline": {
         "allocs_per_op": 9.0,
-        "bytes_per_op": 7567.0,
-        "ns_per_op": 4972.0
+        "bytes_per_op": 7558.5,
+        "ns_per_op": 6743.5
       },
       "benchmark": "BenchmarkCommitAt/MVCC/1",
       "bytes_tolerance": 64.0,
       "candidate": {
         "allocs_per_op": 9.0,
-        "bytes_per_op": 7560.0,
-        "ns_per_op": 4939.0
+        "bytes_per_op": 7559.0,
+        "ns_per_op": 7217.5
       },
-      "ns_delta_percent": -0.6637168141592875,
-      "pass": true
+      "ns_delta_percent": 7.028990880106778,
+      "pass": false
     },
     {
       "baseline": {
         "allocs_per_op": 15.0,
         "bytes_per_op": 992.0,
-        "ns_per_op": 1421.0
+        "ns_per_op": 2679.5
       },
       "benchmark": "BenchmarkGetAt/DirectSeek/64",
       "bytes_tolerance": 9.92,
       "candidate": {
         "allocs_per_op": 15.0,
         "bytes_per_op": 992.0,
-        "ns_per_op": 1415.0
+        "ns_per_op": 2750.0
       },
-      "ns_delta_percent": -0.4222378606615007,
+      "ns_delta_percent": 2.631087889531636,
       "pass": true
     },
     {
       "baseline": {
         "allocs_per_op": 16.0,
         "bytes_per_op": 1008.0,
-        "ns_per_op": 1573.0
+        "ns_per_op": 2657.5
       },
       "benchmark": "BenchmarkGetAt/MVCC/64",
       "bytes_tolerance": 10.08,
       "candidate": {
         "allocs_per_op": 16.0,
         "bytes_per_op": 1008.0,
-        "ns_per_op": 1584.0
+        "ns_per_op": 2773.0
       },
-      "ns_delta_percent": 0.6993006993007089,
+      "ns_delta_percent": 4.346190028222008,
       "pass": true
     },
     {
       "baseline": {
         "allocs_per_op": 4108.0,
-        "bytes_per_op": 50102.0,
-        "ns_per_op": 508946.0
+        "bytes_per_op": 50114.0,
+        "ns_per_op": 828734.5
       },
       "benchmark": "BenchmarkVersionIteration/Physical/keys=64/depth=32/reverse=false",
       "bytes_tolerance": 64.0,
       "candidate": {
         "allocs_per_op": 4108.0,
-        "bytes_per_op": 50100.0,
-        "ns_per_op": 473346.0
+        "bytes_per_op": 50119.0,
+        "ns_per_op": 985224.0
       },
-      "ns_delta_percent": -6.994848176427359,
-      "pass": true
+      "ns_delta_percent": 18.882947433707663,
+      "pass": false
     },
     {
       "baseline": {
         "allocs_per_op": 4118.0,
-        "bytes_per_op": 51831.0,
-        "ns_per_op": 538873.0
+        "bytes_per_op": 51846.5,
+        "ns_per_op": 973824.0
       },
       "benchmark": "BenchmarkVersionIteration/MVCC/keys=64/depth=32/reverse=false",
       "bytes_tolerance": 64.0,
       "candidate": {
         "allocs_per_op": 4118.0,
-        "bytes_per_op": 51831.0,
-        "ns_per_op": 524927.0
+        "bytes_per_op": 51853.0,
+        "ns_per_op": 1104381.5
       },
-      "ns_delta_percent": -2.5879938315707007,
-      "pass": true
+      "ns_delta_percent": 13.406683343191371,
+      "pass": false
     }
   ]
 }

--- a/TreeDB/docs/spec/artifacts/dgraph-mvcc-closeout/adapter-overhead-summary.md
+++ b/TreeDB/docs/spec/artifacts/dgraph-mvcc-closeout/adapter-overhead-summary.md
@@ -1,0 +1,23 @@
+## TreeDB MVCC adapter-overhead gate
+
+- result: **PASS**
+- baseline: `f9c9b2a37838909d0e669818cfa2840c0a8d5f85`
+- candidate: `2f0a687f048ece277ab039303f6e28a1a7906bcb`
+- samples: 7 per revision, alternating sequential order
+- base/head timing threshold: +5%
+- candidate MVCC/direct ratio threshold: 2x
+
+| Benchmark | Base ns/op | Head ns/op | Delta | Base B/op | Head B/op | Base allocs/op | Head allocs/op | Result |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | --- |
+| BenchmarkCommitAt/DirectTreeDB/1 | 4749.000 | 4741.000 | -0.17% | 7556.000 | 7555.000 | 8.000 | 8.000 | PASS |
+| BenchmarkCommitAt/MVCC/1 | 4972.000 | 4939.000 | -0.66% | 7567.000 | 7560.000 | 9.000 | 9.000 | PASS |
+| BenchmarkGetAt/DirectSeek/64 | 1421.000 | 1415.000 | -0.42% | 992.000 | 992.000 | 15.000 | 15.000 | PASS |
+| BenchmarkGetAt/MVCC/64 | 1573.000 | 1584.000 | +0.70% | 1008.000 | 1008.000 | 16.000 | 16.000 | PASS |
+| BenchmarkVersionIteration/Physical/keys=64/depth=32/reverse=false | 508946.000 | 473346.000 | -6.99% | 50102.000 | 50100.000 | 4108.000 | 4108.000 | PASS |
+| BenchmarkVersionIteration/MVCC/keys=64/depth=32/reverse=false | 538873.000 | 524927.000 | -2.59% | 51831.000 | 51831.000 | 4118.000 | 4118.000 | PASS |
+
+| Pair | Base ratio | Head ratio | Result |
+| --- | ---: | ---: | --- |
+| CommitAt | 1.047x | 1.042x | PASS |
+| GetAt | 1.107x | 1.119x | PASS |
+| VersionIteration | 1.059x | 1.109x | PASS |

--- a/TreeDB/docs/spec/artifacts/dgraph-mvcc-closeout/adapter-overhead-summary.md
+++ b/TreeDB/docs/spec/artifacts/dgraph-mvcc-closeout/adapter-overhead-summary.md
@@ -1,23 +1,23 @@
 ## TreeDB MVCC adapter-overhead gate
 
-- result: **PASS**
+- result: **FAIL**
 - baseline: `f9c9b2a37838909d0e669818cfa2840c0a8d5f85`
-- candidate: `2f0a687f048ece277ab039303f6e28a1a7906bcb`
-- samples: 7 per revision, alternating sequential order
+- candidate: `dbea38e0e8ad0c7d1e0bb05ac564bd9b57dd747a`
+- samples: 8 per revision, benchmark-group-paired alternating AB/BA order
 - base/head timing threshold: +5%
 - candidate MVCC/direct ratio threshold: 2x
 
 | Benchmark | Base ns/op | Head ns/op | Delta | Base B/op | Head B/op | Base allocs/op | Head allocs/op | Result |
 | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | --- |
-| BenchmarkCommitAt/DirectTreeDB/1 | 4749.000 | 4741.000 | -0.17% | 7556.000 | 7555.000 | 8.000 | 8.000 | PASS |
-| BenchmarkCommitAt/MVCC/1 | 4972.000 | 4939.000 | -0.66% | 7567.000 | 7560.000 | 9.000 | 9.000 | PASS |
-| BenchmarkGetAt/DirectSeek/64 | 1421.000 | 1415.000 | -0.42% | 992.000 | 992.000 | 15.000 | 15.000 | PASS |
-| BenchmarkGetAt/MVCC/64 | 1573.000 | 1584.000 | +0.70% | 1008.000 | 1008.000 | 16.000 | 16.000 | PASS |
-| BenchmarkVersionIteration/Physical/keys=64/depth=32/reverse=false | 508946.000 | 473346.000 | -6.99% | 50102.000 | 50100.000 | 4108.000 | 4108.000 | PASS |
-| BenchmarkVersionIteration/MVCC/keys=64/depth=32/reverse=false | 538873.000 | 524927.000 | -2.59% | 51831.000 | 51831.000 | 4118.000 | 4118.000 | PASS |
+| BenchmarkCommitAt/DirectTreeDB/1 | 7026.500 | 7713.000 | +9.77% | 7477.000 | 7467.500 | 8.500 | 8.500 | FAIL |
+| BenchmarkCommitAt/MVCC/1 | 6743.500 | 7217.500 | +7.03% | 7558.500 | 7559.000 | 9.000 | 9.000 | FAIL |
+| BenchmarkGetAt/DirectSeek/64 | 2679.500 | 2750.000 | +2.63% | 992.000 | 992.000 | 15.000 | 15.000 | PASS |
+| BenchmarkGetAt/MVCC/64 | 2657.500 | 2773.000 | +4.35% | 1008.000 | 1008.000 | 16.000 | 16.000 | PASS |
+| BenchmarkVersionIteration/Physical/keys=64/depth=32/reverse=false | 828734.500 | 985224.000 | +18.88% | 50114.000 | 50119.000 | 4108.000 | 4108.000 | FAIL |
+| BenchmarkVersionIteration/MVCC/keys=64/depth=32/reverse=false | 973824.000 | 1104381.500 | +13.41% | 51846.500 | 51853.000 | 4118.000 | 4118.000 | FAIL |
 
 | Pair | Base ratio | Head ratio | Result |
 | --- | ---: | ---: | --- |
-| CommitAt | 1.047x | 1.042x | PASS |
-| GetAt | 1.107x | 1.119x | PASS |
-| VersionIteration | 1.059x | 1.109x | PASS |
+| CommitAt | 0.960x | 0.936x | PASS |
+| GetAt | 0.992x | 1.008x | PASS |
+| VersionIteration | 1.175x | 1.121x | PASS |

--- a/TreeDB/docs/spec/artifacts/dgraph-mvcc-closeout/adapter-overhead-summary.md
+++ b/TreeDB/docs/spec/artifacts/dgraph-mvcc-closeout/adapter-overhead-summary.md
@@ -1,4 +1,4 @@
-## TreeDB MVCC adapter-overhead gate
+# TreeDB MVCC adapter-overhead gate
 
 - result: **FAIL**
 - baseline: `f9c9b2a37838909d0e669818cfa2840c0a8d5f85`

--- a/TreeDB/docs/spec/artifacts/dgraph-mvcc-closeout/closeout-matrix-summary.json
+++ b/TreeDB/docs/spec/artifacts/dgraph-mvcc-closeout/closeout-matrix-summary.json
@@ -3,176 +3,176 @@
     "BenchmarkDgraphMVCCCloseout/AllVersions/durable_sync/keys=64/depth=1": {
       "B/op": 4195.0,
       "allocs/op": 150.0,
-      "ns/op": 21356.0,
-      "versions/s": 2996840.0
+      "ns/op": 18364.0,
+      "versions/s": 3485151.0
     },
     "BenchmarkDgraphMVCCCloseout/AllVersions/durable_sync/keys=64/depth=32": {
-      "B/op": 51918.0,
+      "B/op": 51915.0,
       "allocs/op": 4118.0,
-      "ns/op": 571677.0,
-      "versions/s": 3582446.0
+      "ns/op": 497176.0,
+      "versions/s": 4119271.0
     },
     "BenchmarkDgraphMVCCCloseout/AllVersions/wal_off_relaxed/keys=64/depth=1": {
       "B/op": 4192.0,
       "allocs/op": 150.0,
-      "ns/op": 22236.0,
-      "versions/s": 2878164.0
+      "ns/op": 18879.0,
+      "versions/s": 3390107.0
     },
     "BenchmarkDgraphMVCCCloseout/AllVersions/wal_off_relaxed/keys=64/depth=32": {
-      "B/op": 51834.0,
+      "B/op": 51833.0,
       "allocs/op": 4118.0,
-      "ns/op": 564869.0,
-      "versions/s": 3625628.0
+      "ns/op": 501606.0,
+      "versions/s": 4082893.0
     },
     "BenchmarkDgraphMVCCCloseout/AllVersions/wal_on_relaxed/keys=64/depth=1": {
       "B/op": 4195.0,
       "allocs/op": 150.0,
-      "ns/op": 21558.0,
-      "versions/s": 2968764.0
+      "ns/op": 18669.0,
+      "versions/s": 3428068.0
     },
     "BenchmarkDgraphMVCCCloseout/AllVersions/wal_on_relaxed/keys=64/depth=32": {
-      "B/op": 51920.0,
+      "B/op": 51918.0,
       "allocs/op": 4118.0,
-      "ns/op": 585307.0,
-      "versions/s": 3499021.0
+      "ns/op": 510273.0,
+      "versions/s": 4013546.0
     },
     "BenchmarkDgraphMVCCCloseout/CommitAt/durable_sync/batch=1": {
-      "B/op": 4689.0,
+      "B/op": 4652.0,
       "allocs/op": 14.0,
-      "durable_footprint_bytes/op": 1876.0,
-      "mutations/s": 152.5,
-      "ns/op": 6559316.0,
-      "storage_bytes/op": 1876.0
+      "durable_footprint_bytes/op": 1960.0,
+      "mutations/s": 149.5,
+      "ns/op": 6688579.0,
+      "storage_bytes/op": 1960.0
     },
     "BenchmarkDgraphMVCCCloseout/CommitAt/durable_sync/batch=32": {
-      "B/op": 16911.0,
+      "B/op": 16925.0,
       "allocs/op": 112.0,
-      "durable_footprint_bytes/op": 4522.0,
-      "mutations/s": 4833.0,
-      "ns/op": 6621481.0,
-      "storage_bytes/op": 4522.0
+      "durable_footprint_bytes/op": 4496.0,
+      "mutations/s": 5271.0,
+      "ns/op": 6071126.0,
+      "storage_bytes/op": 4496.0
     },
     "BenchmarkDgraphMVCCCloseout/CommitAt/wal_off_relaxed/batch=1": {
-      "B/op": 7485.0,
+      "B/op": 7494.0,
       "allocs/op": 9.0,
-      "mutations/s": 242359.0,
-      "ns/op": 4126.0,
-      "storage_bytes/op": 74.01
+      "mutations/s": 250407.0,
+      "ns/op": 3993.0,
+      "storage_bytes/op": 76.84
     },
     "BenchmarkDgraphMVCCCloseout/CommitAt/wal_off_relaxed/batch=32": {
-      "B/op": 27035.0,
+      "B/op": 26144.0,
       "allocs/op": 106.0,
-      "mutations/s": 712204.0,
-      "ns/op": 44931.0,
-      "storage_bytes/op": 2050.0
+      "mutations/s": 838950.0,
+      "ns/op": 38143.0,
+      "storage_bytes/op": 2054.0
     },
     "BenchmarkDgraphMVCCCloseout/CommitAt/wal_on_relaxed/batch=1": {
-      "B/op": 4267.0,
+      "B/op": 4252.0,
       "allocs/op": 13.0,
-      "mutations/s": 181928.0,
-      "ns/op": 5497.0,
-      "storage_bytes/op": 79.63
+      "mutations/s": 217744.0,
+      "ns/op": 4593.0,
+      "storage_bytes/op": 83.41
     },
     "BenchmarkDgraphMVCCCloseout/CommitAt/wal_on_relaxed/batch=32": {
-      "B/op": 20647.0,
+      "B/op": 20131.0,
       "allocs/op": 110.0,
-      "mutations/s": 720202.0,
-      "ns/op": 44432.0,
-      "storage_bytes/op": 2079.0
+      "mutations/s": 752181.0,
+      "ns/op": 42543.0,
+      "storage_bytes/op": 2085.0
     },
     "BenchmarkDgraphMVCCCloseout/GetAt/durable_sync/depth=1": {
-      "B/op": 628.0,
+      "B/op": 629.0,
       "allocs/op": 12.0,
-      "lookups/s": 870369.0,
-      "ns/op": 1149.0
+      "lookups/s": 937621.0,
+      "ns/op": 1067.0
     },
     "BenchmarkDgraphMVCCCloseout/GetAt/durable_sync/depth=64": {
       "B/op": 1008.0,
       "allocs/op": 16.0,
-      "lookups/s": 567989.0,
-      "ns/op": 1761.0
+      "lookups/s": 670037.0,
+      "ns/op": 1492.0
     },
     "BenchmarkDgraphMVCCCloseout/GetAt/wal_off_relaxed/depth=1": {
       "B/op": 628.0,
       "allocs/op": 12.0,
-      "lookups/s": 813744.0,
-      "ns/op": 1229.0
+      "lookups/s": 946058.0,
+      "ns/op": 1057.0
     },
     "BenchmarkDgraphMVCCCloseout/GetAt/wal_off_relaxed/depth=64": {
       "B/op": 1008.0,
       "allocs/op": 16.0,
-      "lookups/s": 591775.0,
-      "ns/op": 1690.0
+      "lookups/s": 678949.0,
+      "ns/op": 1473.0
     },
     "BenchmarkDgraphMVCCCloseout/GetAt/wal_on_relaxed/depth=1": {
       "B/op": 629.0,
       "allocs/op": 12.0,
-      "lookups/s": 829597.0,
-      "ns/op": 1205.0
+      "lookups/s": 962350.0,
+      "ns/op": 1039.0
     },
     "BenchmarkDgraphMVCCCloseout/GetAt/wal_on_relaxed/depth=64": {
       "B/op": 1008.0,
       "allocs/op": 16.0,
-      "lookups/s": 602691.0,
-      "ns/op": 1659.0
+      "lookups/s": 687875.0,
+      "ns/op": 1454.0
     },
     "BenchmarkDgraphMVCCCloseout/Prune/durable_sync/keys=64/depth=16/floor=12": {
-      "B/op": 247008.0,
-      "allocs/op": 199.0,
+      "B/op": 245568.0,
+      "allocs/op": 182.0,
       "delete_write_amplification": 0.8286,
       "durable_footprint_bytes/op": 524727.0,
-      "ns/op": 26745805.0,
-      "pruned_versions/s": 26322.0,
+      "ns/op": 27923914.0,
+      "pruned_versions/s": 25211.0,
       "storage_bytes/op": 524727.0
     },
     "BenchmarkDgraphMVCCCloseout/Prune/durable_sync/keys=64/depth=16/floor=4": {
-      "B/op": 270976.0,
-      "allocs/op": 159.0,
+      "B/op": 269456.0,
+      "allocs/op": 142.0,
       "delete_write_amplification": 0.8286,
       "durable_footprint_bytes/op": 524727.0,
-      "ns/op": 13333546.0,
-      "pruned_versions/s": 14400.0,
+      "ns/op": 14216940.0,
+      "pruned_versions/s": 13505.0,
       "storage_bytes/op": 524727.0
     },
     "BenchmarkDgraphMVCCCloseout/Prune/wal_off_relaxed/keys=64/depth=16/floor=12": {
-      "B/op": 168512.0,
-      "allocs/op": 170.0,
+      "B/op": 167120.0,
+      "allocs/op": 154.0,
       "delete_write_amplification": 0.8286,
-      "ns/op": 510644.0,
-      "pruned_versions/s": 1378651.0,
+      "ns/op": 415359.0,
+      "pruned_versions/s": 1694919.0,
       "storage_bytes/op": 524664.0
     },
     "BenchmarkDgraphMVCCCloseout/Prune/wal_off_relaxed/keys=64/depth=16/floor=4": {
-      "B/op": 131576.0,
-      "allocs/op": 138.0,
+      "B/op": 130184.0,
+      "allocs/op": 122.0,
       "delete_write_amplification": 0.8286,
-      "ns/op": 528876.0,
-      "pruned_versions/s": 363034.0,
+      "ns/op": 353285.0,
+      "pruned_versions/s": 543471.0,
       "storage_bytes/op": 524664.0
     },
     "BenchmarkDgraphMVCCCloseout/Prune/wal_on_relaxed/keys=64/depth=16/floor=12": {
-      "B/op": 241728.0,
-      "allocs/op": 182.0,
+      "B/op": 240336.0,
+      "allocs/op": 166.0,
       "delete_write_amplification": 0.8286,
-      "ns/op": 633169.0,
-      "pruned_versions/s": 1111867.0,
+      "ns/op": 568753.0,
+      "pruned_versions/s": 1237796.0,
       "storage_bytes/op": 524727.0
     },
     "BenchmarkDgraphMVCCCloseout/Prune/wal_on_relaxed/keys=64/depth=16/floor=4": {
-      "B/op": 134544.0,
-      "allocs/op": 140.0,
+      "B/op": 133152.0,
+      "allocs/op": 124.0,
       "delete_write_amplification": 0.8286,
-      "ns/op": 814680.0,
-      "pruned_versions/s": 235675.0,
+      "ns/op": 769070.0,
+      "pruned_versions/s": 249652.0,
       "storage_bytes/op": 524727.0
     }
   },
-  "candidate_sha": "dbea38e0e8ad0c7d1e0bb05ac564bd9b57dd747a",
+  "candidate_sha": "103f9c5af85d8d6a5801119fc2247be3b9c87fad",
   "resources": {
     "invocations": 10.0,
-    "max_rss_kib": 600640.0,
-    "total_system_seconds": 7.489999999999999,
-    "total_user_seconds": 109.07000000000002
+    "max_rss_kib": 611264.0,
+    "total_system_seconds": 6.97,
+    "total_user_seconds": 102.36
   },
   "samples": 5,
   "schema": "treedb-dgraph-mvcc-closeout-v1"

--- a/TreeDB/docs/spec/artifacts/dgraph-mvcc-closeout/closeout-matrix-summary.json
+++ b/TreeDB/docs/spec/artifacts/dgraph-mvcc-closeout/closeout-matrix-summary.json
@@ -1,0 +1,179 @@
+{
+  "benchmarks": {
+    "BenchmarkDgraphMVCCCloseout/AllVersions/durable_sync/keys=64/depth=1": {
+      "B/op": 4195.0,
+      "allocs/op": 150.0,
+      "ns/op": 19127.0,
+      "versions/s": 3346027.0
+    },
+    "BenchmarkDgraphMVCCCloseout/AllVersions/durable_sync/keys=64/depth=32": {
+      "B/op": 51918.0,
+      "allocs/op": 4118.0,
+      "ns/op": 510050.0,
+      "versions/s": 4015297.0
+    },
+    "BenchmarkDgraphMVCCCloseout/AllVersions/wal_off_relaxed/keys=64/depth=1": {
+      "B/op": 4192.0,
+      "allocs/op": 150.0,
+      "ns/op": 18778.0,
+      "versions/s": 3408185.0
+    },
+    "BenchmarkDgraphMVCCCloseout/AllVersions/wal_off_relaxed/keys=64/depth=32": {
+      "B/op": 51832.0,
+      "allocs/op": 4118.0,
+      "ns/op": 509352.0,
+      "versions/s": 4020796.0
+    },
+    "BenchmarkDgraphMVCCCloseout/AllVersions/wal_on_relaxed/keys=64/depth=1": {
+      "B/op": 4195.0,
+      "allocs/op": 150.0,
+      "ns/op": 18661.0,
+      "versions/s": 3429627.0
+    },
+    "BenchmarkDgraphMVCCCloseout/AllVersions/wal_on_relaxed/keys=64/depth=32": {
+      "B/op": 51908.0,
+      "allocs/op": 4118.0,
+      "ns/op": 510853.0,
+      "versions/s": 4008987.0
+    },
+    "BenchmarkDgraphMVCCCloseout/CommitAt/durable_sync/batch=1": {
+      "B/op": 4689.0,
+      "allocs/op": 14.0,
+      "durable_footprint_bytes/op": 1931.0,
+      "mutations/s": 152.7,
+      "ns/op": 6550372.0,
+      "storage_bytes/op": 1931.0
+    },
+    "BenchmarkDgraphMVCCCloseout/CommitAt/durable_sync/batch=32": {
+      "B/op": 16917.0,
+      "allocs/op": 112.0,
+      "durable_footprint_bytes/op": 5177.0,
+      "mutations/s": 6357.0,
+      "ns/op": 5034211.0,
+      "storage_bytes/op": 5177.0
+    },
+    "BenchmarkDgraphMVCCCloseout/CommitAt/wal_off_relaxed/batch=1": {
+      "B/op": 7503.0,
+      "allocs/op": 9.0,
+      "mutations/s": 246564.0,
+      "ns/op": 4056.0,
+      "storage_bytes/op": 77.52
+    },
+    "BenchmarkDgraphMVCCCloseout/CommitAt/wal_off_relaxed/batch=32": {
+      "B/op": 26843.0,
+      "allocs/op": 106.0,
+      "mutations/s": 795301.0,
+      "ns/op": 40236.0,
+      "storage_bytes/op": 2081.0
+    },
+    "BenchmarkDgraphMVCCCloseout/CommitAt/wal_on_relaxed/batch=1": {
+      "B/op": 4259.0,
+      "allocs/op": 13.0,
+      "mutations/s": 206731.0,
+      "ns/op": 4837.0,
+      "storage_bytes/op": 81.35
+    },
+    "BenchmarkDgraphMVCCCloseout/CommitAt/wal_on_relaxed/batch=32": {
+      "B/op": 20868.0,
+      "allocs/op": 110.0,
+      "mutations/s": 736250.0,
+      "ns/op": 43463.0,
+      "storage_bytes/op": 2065.0
+    },
+    "BenchmarkDgraphMVCCCloseout/GetAt/durable_sync/depth=1": {
+      "B/op": 629.0,
+      "allocs/op": 12.0,
+      "lookups/s": 882798.0,
+      "ns/op": 1133.0
+    },
+    "BenchmarkDgraphMVCCCloseout/GetAt/durable_sync/depth=64": {
+      "B/op": 1008.0,
+      "allocs/op": 16.0,
+      "lookups/s": 664880.0,
+      "ns/op": 1504.0
+    },
+    "BenchmarkDgraphMVCCCloseout/GetAt/wal_off_relaxed/depth=1": {
+      "B/op": 628.0,
+      "allocs/op": 12.0,
+      "lookups/s": 943589.0,
+      "ns/op": 1060.0
+    },
+    "BenchmarkDgraphMVCCCloseout/GetAt/wal_off_relaxed/depth=64": {
+      "B/op": 1008.0,
+      "allocs/op": 16.0,
+      "lookups/s": 679436.0,
+      "ns/op": 1472.0
+    },
+    "BenchmarkDgraphMVCCCloseout/GetAt/wal_on_relaxed/depth=1": {
+      "B/op": 629.0,
+      "allocs/op": 12.0,
+      "lookups/s": 935395.0,
+      "ns/op": 1069.0
+    },
+    "BenchmarkDgraphMVCCCloseout/GetAt/wal_on_relaxed/depth=64": {
+      "B/op": 1008.0,
+      "allocs/op": 16.0,
+      "lookups/s": 676921.0,
+      "ns/op": 1477.0
+    },
+    "BenchmarkDgraphMVCCCloseout/Prune/durable_sync/keys=64/depth=16/floor=12": {
+      "B/op": 246960.0,
+      "allocs/op": 198.0,
+      "delete_write_amplification": 0.8286,
+      "durable_footprint_bytes/op": 524727.0,
+      "ns/op": 26114625.0,
+      "pruned_versions/s": 26958.0,
+      "storage_bytes/op": 524727.0
+    },
+    "BenchmarkDgraphMVCCCloseout/Prune/durable_sync/keys=64/depth=16/floor=4": {
+      "B/op": 271024.0,
+      "allocs/op": 160.0,
+      "delete_write_amplification": 0.8286,
+      "durable_footprint_bytes/op": 524727.0,
+      "ns/op": 12983205.0,
+      "pruned_versions/s": 14788.0,
+      "storage_bytes/op": 524727.0
+    },
+    "BenchmarkDgraphMVCCCloseout/Prune/wal_off_relaxed/keys=64/depth=16/floor=12": {
+      "B/op": 168512.0,
+      "allocs/op": 170.0,
+      "delete_write_amplification": 0.8286,
+      "ns/op": 486220.0,
+      "pruned_versions/s": 1447904.0,
+      "storage_bytes/op": 524664.0
+    },
+    "BenchmarkDgraphMVCCCloseout/Prune/wal_off_relaxed/keys=64/depth=16/floor=4": {
+      "B/op": 131576.0,
+      "allocs/op": 138.0,
+      "delete_write_amplification": 0.8286,
+      "ns/op": 389759.0,
+      "pruned_versions/s": 492612.0,
+      "storage_bytes/op": 524664.0
+    },
+    "BenchmarkDgraphMVCCCloseout/Prune/wal_on_relaxed/keys=64/depth=16/floor=12": {
+      "B/op": 241728.0,
+      "allocs/op": 182.0,
+      "delete_write_amplification": 0.8286,
+      "ns/op": 612027.0,
+      "pruned_versions/s": 1150276.0,
+      "storage_bytes/op": 524727.0
+    },
+    "BenchmarkDgraphMVCCCloseout/Prune/wal_on_relaxed/keys=64/depth=16/floor=4": {
+      "B/op": 134544.0,
+      "allocs/op": 140.0,
+      "delete_write_amplification": 0.8286,
+      "ns/op": 841761.0,
+      "pruned_versions/s": 228093.0,
+      "storage_bytes/op": 524727.0
+    }
+  },
+  "candidate_sha": "2f0a687f048ece277ab039303f6e28a1a7906bcb",
+  "resources": {
+    "invocations": 10.0,
+    "max_rss_kib": 622068.0,
+    "total_system_seconds": 6.85,
+    "total_user_seconds": 100.64
+  },
+  "samples": 5,
+  "schema": "treedb-dgraph-mvcc-closeout-v1"
+}

--- a/TreeDB/docs/spec/artifacts/dgraph-mvcc-closeout/closeout-matrix-summary.json
+++ b/TreeDB/docs/spec/artifacts/dgraph-mvcc-closeout/closeout-matrix-summary.json
@@ -3,176 +3,176 @@
     "BenchmarkDgraphMVCCCloseout/AllVersions/durable_sync/keys=64/depth=1": {
       "B/op": 4195.0,
       "allocs/op": 150.0,
-      "ns/op": 19127.0,
-      "versions/s": 3346027.0
+      "ns/op": 21356.0,
+      "versions/s": 2996840.0
     },
     "BenchmarkDgraphMVCCCloseout/AllVersions/durable_sync/keys=64/depth=32": {
       "B/op": 51918.0,
       "allocs/op": 4118.0,
-      "ns/op": 510050.0,
-      "versions/s": 4015297.0
+      "ns/op": 571677.0,
+      "versions/s": 3582446.0
     },
     "BenchmarkDgraphMVCCCloseout/AllVersions/wal_off_relaxed/keys=64/depth=1": {
       "B/op": 4192.0,
       "allocs/op": 150.0,
-      "ns/op": 18778.0,
-      "versions/s": 3408185.0
+      "ns/op": 22236.0,
+      "versions/s": 2878164.0
     },
     "BenchmarkDgraphMVCCCloseout/AllVersions/wal_off_relaxed/keys=64/depth=32": {
-      "B/op": 51832.0,
+      "B/op": 51834.0,
       "allocs/op": 4118.0,
-      "ns/op": 509352.0,
-      "versions/s": 4020796.0
+      "ns/op": 564869.0,
+      "versions/s": 3625628.0
     },
     "BenchmarkDgraphMVCCCloseout/AllVersions/wal_on_relaxed/keys=64/depth=1": {
       "B/op": 4195.0,
       "allocs/op": 150.0,
-      "ns/op": 18661.0,
-      "versions/s": 3429627.0
+      "ns/op": 21558.0,
+      "versions/s": 2968764.0
     },
     "BenchmarkDgraphMVCCCloseout/AllVersions/wal_on_relaxed/keys=64/depth=32": {
-      "B/op": 51908.0,
+      "B/op": 51920.0,
       "allocs/op": 4118.0,
-      "ns/op": 510853.0,
-      "versions/s": 4008987.0
+      "ns/op": 585307.0,
+      "versions/s": 3499021.0
     },
     "BenchmarkDgraphMVCCCloseout/CommitAt/durable_sync/batch=1": {
       "B/op": 4689.0,
       "allocs/op": 14.0,
-      "durable_footprint_bytes/op": 1931.0,
-      "mutations/s": 152.7,
-      "ns/op": 6550372.0,
-      "storage_bytes/op": 1931.0
+      "durable_footprint_bytes/op": 1876.0,
+      "mutations/s": 152.5,
+      "ns/op": 6559316.0,
+      "storage_bytes/op": 1876.0
     },
     "BenchmarkDgraphMVCCCloseout/CommitAt/durable_sync/batch=32": {
-      "B/op": 16917.0,
+      "B/op": 16911.0,
       "allocs/op": 112.0,
-      "durable_footprint_bytes/op": 5177.0,
-      "mutations/s": 6357.0,
-      "ns/op": 5034211.0,
-      "storage_bytes/op": 5177.0
+      "durable_footprint_bytes/op": 4522.0,
+      "mutations/s": 4833.0,
+      "ns/op": 6621481.0,
+      "storage_bytes/op": 4522.0
     },
     "BenchmarkDgraphMVCCCloseout/CommitAt/wal_off_relaxed/batch=1": {
-      "B/op": 7503.0,
+      "B/op": 7485.0,
       "allocs/op": 9.0,
-      "mutations/s": 246564.0,
-      "ns/op": 4056.0,
-      "storage_bytes/op": 77.52
+      "mutations/s": 242359.0,
+      "ns/op": 4126.0,
+      "storage_bytes/op": 74.01
     },
     "BenchmarkDgraphMVCCCloseout/CommitAt/wal_off_relaxed/batch=32": {
-      "B/op": 26843.0,
+      "B/op": 27035.0,
       "allocs/op": 106.0,
-      "mutations/s": 795301.0,
-      "ns/op": 40236.0,
-      "storage_bytes/op": 2081.0
+      "mutations/s": 712204.0,
+      "ns/op": 44931.0,
+      "storage_bytes/op": 2050.0
     },
     "BenchmarkDgraphMVCCCloseout/CommitAt/wal_on_relaxed/batch=1": {
-      "B/op": 4259.0,
+      "B/op": 4267.0,
       "allocs/op": 13.0,
-      "mutations/s": 206731.0,
-      "ns/op": 4837.0,
-      "storage_bytes/op": 81.35
+      "mutations/s": 181928.0,
+      "ns/op": 5497.0,
+      "storage_bytes/op": 79.63
     },
     "BenchmarkDgraphMVCCCloseout/CommitAt/wal_on_relaxed/batch=32": {
-      "B/op": 20868.0,
+      "B/op": 20647.0,
       "allocs/op": 110.0,
-      "mutations/s": 736250.0,
-      "ns/op": 43463.0,
-      "storage_bytes/op": 2065.0
+      "mutations/s": 720202.0,
+      "ns/op": 44432.0,
+      "storage_bytes/op": 2079.0
     },
     "BenchmarkDgraphMVCCCloseout/GetAt/durable_sync/depth=1": {
-      "B/op": 629.0,
+      "B/op": 628.0,
       "allocs/op": 12.0,
-      "lookups/s": 882798.0,
-      "ns/op": 1133.0
+      "lookups/s": 870369.0,
+      "ns/op": 1149.0
     },
     "BenchmarkDgraphMVCCCloseout/GetAt/durable_sync/depth=64": {
       "B/op": 1008.0,
       "allocs/op": 16.0,
-      "lookups/s": 664880.0,
-      "ns/op": 1504.0
+      "lookups/s": 567989.0,
+      "ns/op": 1761.0
     },
     "BenchmarkDgraphMVCCCloseout/GetAt/wal_off_relaxed/depth=1": {
       "B/op": 628.0,
       "allocs/op": 12.0,
-      "lookups/s": 943589.0,
-      "ns/op": 1060.0
+      "lookups/s": 813744.0,
+      "ns/op": 1229.0
     },
     "BenchmarkDgraphMVCCCloseout/GetAt/wal_off_relaxed/depth=64": {
       "B/op": 1008.0,
       "allocs/op": 16.0,
-      "lookups/s": 679436.0,
-      "ns/op": 1472.0
+      "lookups/s": 591775.0,
+      "ns/op": 1690.0
     },
     "BenchmarkDgraphMVCCCloseout/GetAt/wal_on_relaxed/depth=1": {
       "B/op": 629.0,
       "allocs/op": 12.0,
-      "lookups/s": 935395.0,
-      "ns/op": 1069.0
+      "lookups/s": 829597.0,
+      "ns/op": 1205.0
     },
     "BenchmarkDgraphMVCCCloseout/GetAt/wal_on_relaxed/depth=64": {
       "B/op": 1008.0,
       "allocs/op": 16.0,
-      "lookups/s": 676921.0,
-      "ns/op": 1477.0
+      "lookups/s": 602691.0,
+      "ns/op": 1659.0
     },
     "BenchmarkDgraphMVCCCloseout/Prune/durable_sync/keys=64/depth=16/floor=12": {
-      "B/op": 246960.0,
-      "allocs/op": 198.0,
+      "B/op": 247008.0,
+      "allocs/op": 199.0,
       "delete_write_amplification": 0.8286,
       "durable_footprint_bytes/op": 524727.0,
-      "ns/op": 26114625.0,
-      "pruned_versions/s": 26958.0,
+      "ns/op": 26745805.0,
+      "pruned_versions/s": 26322.0,
       "storage_bytes/op": 524727.0
     },
     "BenchmarkDgraphMVCCCloseout/Prune/durable_sync/keys=64/depth=16/floor=4": {
-      "B/op": 271024.0,
-      "allocs/op": 160.0,
+      "B/op": 270976.0,
+      "allocs/op": 159.0,
       "delete_write_amplification": 0.8286,
       "durable_footprint_bytes/op": 524727.0,
-      "ns/op": 12983205.0,
-      "pruned_versions/s": 14788.0,
+      "ns/op": 13333546.0,
+      "pruned_versions/s": 14400.0,
       "storage_bytes/op": 524727.0
     },
     "BenchmarkDgraphMVCCCloseout/Prune/wal_off_relaxed/keys=64/depth=16/floor=12": {
       "B/op": 168512.0,
       "allocs/op": 170.0,
       "delete_write_amplification": 0.8286,
-      "ns/op": 486220.0,
-      "pruned_versions/s": 1447904.0,
+      "ns/op": 510644.0,
+      "pruned_versions/s": 1378651.0,
       "storage_bytes/op": 524664.0
     },
     "BenchmarkDgraphMVCCCloseout/Prune/wal_off_relaxed/keys=64/depth=16/floor=4": {
       "B/op": 131576.0,
       "allocs/op": 138.0,
       "delete_write_amplification": 0.8286,
-      "ns/op": 389759.0,
-      "pruned_versions/s": 492612.0,
+      "ns/op": 528876.0,
+      "pruned_versions/s": 363034.0,
       "storage_bytes/op": 524664.0
     },
     "BenchmarkDgraphMVCCCloseout/Prune/wal_on_relaxed/keys=64/depth=16/floor=12": {
       "B/op": 241728.0,
       "allocs/op": 182.0,
       "delete_write_amplification": 0.8286,
-      "ns/op": 612027.0,
-      "pruned_versions/s": 1150276.0,
+      "ns/op": 633169.0,
+      "pruned_versions/s": 1111867.0,
       "storage_bytes/op": 524727.0
     },
     "BenchmarkDgraphMVCCCloseout/Prune/wal_on_relaxed/keys=64/depth=16/floor=4": {
       "B/op": 134544.0,
       "allocs/op": 140.0,
       "delete_write_amplification": 0.8286,
-      "ns/op": 841761.0,
-      "pruned_versions/s": 228093.0,
+      "ns/op": 814680.0,
+      "pruned_versions/s": 235675.0,
       "storage_bytes/op": 524727.0
     }
   },
-  "candidate_sha": "2f0a687f048ece277ab039303f6e28a1a7906bcb",
+  "candidate_sha": "dbea38e0e8ad0c7d1e0bb05ac564bd9b57dd747a",
   "resources": {
     "invocations": 10.0,
-    "max_rss_kib": 622068.0,
-    "total_system_seconds": 6.85,
-    "total_user_seconds": 100.64
+    "max_rss_kib": 600640.0,
+    "total_system_seconds": 7.489999999999999,
+    "total_user_seconds": 109.07000000000002
   },
   "samples": 5,
   "schema": "treedb-dgraph-mvcc-closeout-v1"

--- a/TreeDB/docs/spec/artifacts/dgraph-mvcc-closeout/closeout-matrix-summary.md
+++ b/TreeDB/docs/spec/artifacts/dgraph-mvcc-closeout/closeout-matrix-summary.md
@@ -1,35 +1,35 @@
 ## TreeDB Dgraph MVCC closeout matrix
 
-- candidate: `2f0a687f048ece277ab039303f6e28a1a7906bcb`
+- candidate: `dbea38e0e8ad0c7d1e0bb05ac564bd9b57dd747a`
 - samples: 5
 - measured benchmark invocations: 10
-- maximum benchmark-process RSS: 622068 KiB
-- aggregate process CPU: user 100.64s, system 6.85s
+- maximum benchmark-process RSS: 600640 KiB
+- aggregate process CPU: user 109.07s, system 7.49s
 - durability classes are separate rows; relaxed rows are not durability-equivalent to durable sync
 
 | Benchmark | ns/op | Throughput | B/op | allocs/op | storage bytes/op | durable footprint bytes/op | delete write amp |
 | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
-| `BenchmarkDgraphMVCCCloseout/AllVersions/durable_sync/keys=64/depth=1` | 19127.000 | 3346027.000 versions/s | 4195.000 | 150.000 | - | - | - |
-| `BenchmarkDgraphMVCCCloseout/AllVersions/durable_sync/keys=64/depth=32` | 510050.000 | 4015297.000 versions/s | 51918.000 | 4118.000 | - | - | - |
-| `BenchmarkDgraphMVCCCloseout/AllVersions/wal_off_relaxed/keys=64/depth=1` | 18778.000 | 3408185.000 versions/s | 4192.000 | 150.000 | - | - | - |
-| `BenchmarkDgraphMVCCCloseout/AllVersions/wal_off_relaxed/keys=64/depth=32` | 509352.000 | 4020796.000 versions/s | 51832.000 | 4118.000 | - | - | - |
-| `BenchmarkDgraphMVCCCloseout/AllVersions/wal_on_relaxed/keys=64/depth=1` | 18661.000 | 3429627.000 versions/s | 4195.000 | 150.000 | - | - | - |
-| `BenchmarkDgraphMVCCCloseout/AllVersions/wal_on_relaxed/keys=64/depth=32` | 510853.000 | 4008987.000 versions/s | 51908.000 | 4118.000 | - | - | - |
-| `BenchmarkDgraphMVCCCloseout/CommitAt/durable_sync/batch=1` | 6550372.000 | 152.700 mutations/s | 4689.000 | 14.000 | 1931.000 | 1931.000 | - |
-| `BenchmarkDgraphMVCCCloseout/CommitAt/durable_sync/batch=32` | 5034211.000 | 6357.000 mutations/s | 16917.000 | 112.000 | 5177.000 | 5177.000 | - |
-| `BenchmarkDgraphMVCCCloseout/CommitAt/wal_off_relaxed/batch=1` | 4056.000 | 246564.000 mutations/s | 7503.000 | 9.000 | 77.520 | - | - |
-| `BenchmarkDgraphMVCCCloseout/CommitAt/wal_off_relaxed/batch=32` | 40236.000 | 795301.000 mutations/s | 26843.000 | 106.000 | 2081.000 | - | - |
-| `BenchmarkDgraphMVCCCloseout/CommitAt/wal_on_relaxed/batch=1` | 4837.000 | 206731.000 mutations/s | 4259.000 | 13.000 | 81.350 | - | - |
-| `BenchmarkDgraphMVCCCloseout/CommitAt/wal_on_relaxed/batch=32` | 43463.000 | 736250.000 mutations/s | 20868.000 | 110.000 | 2065.000 | - | - |
-| `BenchmarkDgraphMVCCCloseout/GetAt/durable_sync/depth=1` | 1133.000 | 882798.000 lookups/s | 629.000 | 12.000 | - | - | - |
-| `BenchmarkDgraphMVCCCloseout/GetAt/durable_sync/depth=64` | 1504.000 | 664880.000 lookups/s | 1008.000 | 16.000 | - | - | - |
-| `BenchmarkDgraphMVCCCloseout/GetAt/wal_off_relaxed/depth=1` | 1060.000 | 943589.000 lookups/s | 628.000 | 12.000 | - | - | - |
-| `BenchmarkDgraphMVCCCloseout/GetAt/wal_off_relaxed/depth=64` | 1472.000 | 679436.000 lookups/s | 1008.000 | 16.000 | - | - | - |
-| `BenchmarkDgraphMVCCCloseout/GetAt/wal_on_relaxed/depth=1` | 1069.000 | 935395.000 lookups/s | 629.000 | 12.000 | - | - | - |
-| `BenchmarkDgraphMVCCCloseout/GetAt/wal_on_relaxed/depth=64` | 1477.000 | 676921.000 lookups/s | 1008.000 | 16.000 | - | - | - |
-| `BenchmarkDgraphMVCCCloseout/Prune/durable_sync/keys=64/depth=16/floor=12` | 26114625.000 | 26958.000 pruned_versions/s | 246960.000 | 198.000 | 524727.000 | 524727.000 | 0.829 |
-| `BenchmarkDgraphMVCCCloseout/Prune/durable_sync/keys=64/depth=16/floor=4` | 12983205.000 | 14788.000 pruned_versions/s | 271024.000 | 160.000 | 524727.000 | 524727.000 | 0.829 |
-| `BenchmarkDgraphMVCCCloseout/Prune/wal_off_relaxed/keys=64/depth=16/floor=12` | 486220.000 | 1447904.000 pruned_versions/s | 168512.000 | 170.000 | 524664.000 | - | 0.829 |
-| `BenchmarkDgraphMVCCCloseout/Prune/wal_off_relaxed/keys=64/depth=16/floor=4` | 389759.000 | 492612.000 pruned_versions/s | 131576.000 | 138.000 | 524664.000 | - | 0.829 |
-| `BenchmarkDgraphMVCCCloseout/Prune/wal_on_relaxed/keys=64/depth=16/floor=12` | 612027.000 | 1150276.000 pruned_versions/s | 241728.000 | 182.000 | 524727.000 | - | 0.829 |
-| `BenchmarkDgraphMVCCCloseout/Prune/wal_on_relaxed/keys=64/depth=16/floor=4` | 841761.000 | 228093.000 pruned_versions/s | 134544.000 | 140.000 | 524727.000 | - | 0.829 |
+| `BenchmarkDgraphMVCCCloseout/AllVersions/durable_sync/keys=64/depth=1` | 21356.000 | 2996840.000 versions/s | 4195.000 | 150.000 | - | - | - |
+| `BenchmarkDgraphMVCCCloseout/AllVersions/durable_sync/keys=64/depth=32` | 571677.000 | 3582446.000 versions/s | 51918.000 | 4118.000 | - | - | - |
+| `BenchmarkDgraphMVCCCloseout/AllVersions/wal_off_relaxed/keys=64/depth=1` | 22236.000 | 2878164.000 versions/s | 4192.000 | 150.000 | - | - | - |
+| `BenchmarkDgraphMVCCCloseout/AllVersions/wal_off_relaxed/keys=64/depth=32` | 564869.000 | 3625628.000 versions/s | 51834.000 | 4118.000 | - | - | - |
+| `BenchmarkDgraphMVCCCloseout/AllVersions/wal_on_relaxed/keys=64/depth=1` | 21558.000 | 2968764.000 versions/s | 4195.000 | 150.000 | - | - | - |
+| `BenchmarkDgraphMVCCCloseout/AllVersions/wal_on_relaxed/keys=64/depth=32` | 585307.000 | 3499021.000 versions/s | 51920.000 | 4118.000 | - | - | - |
+| `BenchmarkDgraphMVCCCloseout/CommitAt/durable_sync/batch=1` | 6559316.000 | 152.500 mutations/s | 4689.000 | 14.000 | 1876.000 | 1876.000 | - |
+| `BenchmarkDgraphMVCCCloseout/CommitAt/durable_sync/batch=32` | 6621481.000 | 4833.000 mutations/s | 16911.000 | 112.000 | 4522.000 | 4522.000 | - |
+| `BenchmarkDgraphMVCCCloseout/CommitAt/wal_off_relaxed/batch=1` | 4126.000 | 242359.000 mutations/s | 7485.000 | 9.000 | 74.010 | - | - |
+| `BenchmarkDgraphMVCCCloseout/CommitAt/wal_off_relaxed/batch=32` | 44931.000 | 712204.000 mutations/s | 27035.000 | 106.000 | 2050.000 | - | - |
+| `BenchmarkDgraphMVCCCloseout/CommitAt/wal_on_relaxed/batch=1` | 5497.000 | 181928.000 mutations/s | 4267.000 | 13.000 | 79.630 | - | - |
+| `BenchmarkDgraphMVCCCloseout/CommitAt/wal_on_relaxed/batch=32` | 44432.000 | 720202.000 mutations/s | 20647.000 | 110.000 | 2079.000 | - | - |
+| `BenchmarkDgraphMVCCCloseout/GetAt/durable_sync/depth=1` | 1149.000 | 870369.000 lookups/s | 628.000 | 12.000 | - | - | - |
+| `BenchmarkDgraphMVCCCloseout/GetAt/durable_sync/depth=64` | 1761.000 | 567989.000 lookups/s | 1008.000 | 16.000 | - | - | - |
+| `BenchmarkDgraphMVCCCloseout/GetAt/wal_off_relaxed/depth=1` | 1229.000 | 813744.000 lookups/s | 628.000 | 12.000 | - | - | - |
+| `BenchmarkDgraphMVCCCloseout/GetAt/wal_off_relaxed/depth=64` | 1690.000 | 591775.000 lookups/s | 1008.000 | 16.000 | - | - | - |
+| `BenchmarkDgraphMVCCCloseout/GetAt/wal_on_relaxed/depth=1` | 1205.000 | 829597.000 lookups/s | 629.000 | 12.000 | - | - | - |
+| `BenchmarkDgraphMVCCCloseout/GetAt/wal_on_relaxed/depth=64` | 1659.000 | 602691.000 lookups/s | 1008.000 | 16.000 | - | - | - |
+| `BenchmarkDgraphMVCCCloseout/Prune/durable_sync/keys=64/depth=16/floor=12` | 26745805.000 | 26322.000 pruned_versions/s | 247008.000 | 199.000 | 524727.000 | 524727.000 | 0.829 |
+| `BenchmarkDgraphMVCCCloseout/Prune/durable_sync/keys=64/depth=16/floor=4` | 13333546.000 | 14400.000 pruned_versions/s | 270976.000 | 159.000 | 524727.000 | 524727.000 | 0.829 |
+| `BenchmarkDgraphMVCCCloseout/Prune/wal_off_relaxed/keys=64/depth=16/floor=12` | 510644.000 | 1378651.000 pruned_versions/s | 168512.000 | 170.000 | 524664.000 | - | 0.829 |
+| `BenchmarkDgraphMVCCCloseout/Prune/wal_off_relaxed/keys=64/depth=16/floor=4` | 528876.000 | 363034.000 pruned_versions/s | 131576.000 | 138.000 | 524664.000 | - | 0.829 |
+| `BenchmarkDgraphMVCCCloseout/Prune/wal_on_relaxed/keys=64/depth=16/floor=12` | 633169.000 | 1111867.000 pruned_versions/s | 241728.000 | 182.000 | 524727.000 | - | 0.829 |
+| `BenchmarkDgraphMVCCCloseout/Prune/wal_on_relaxed/keys=64/depth=16/floor=4` | 814680.000 | 235675.000 pruned_versions/s | 134544.000 | 140.000 | 524727.000 | - | 0.829 |

--- a/TreeDB/docs/spec/artifacts/dgraph-mvcc-closeout/closeout-matrix-summary.md
+++ b/TreeDB/docs/spec/artifacts/dgraph-mvcc-closeout/closeout-matrix-summary.md
@@ -1,35 +1,35 @@
 ## TreeDB Dgraph MVCC closeout matrix
 
-- candidate: `dbea38e0e8ad0c7d1e0bb05ac564bd9b57dd747a`
+- candidate: `103f9c5af85d8d6a5801119fc2247be3b9c87fad`
 - samples: 5
 - measured benchmark invocations: 10
-- maximum benchmark-process RSS: 600640 KiB
-- aggregate process CPU: user 109.07s, system 7.49s
+- maximum benchmark-process RSS: 611264 KiB
+- aggregate process CPU: user 102.36s, system 6.97s
 - durability classes are separate rows; relaxed rows are not durability-equivalent to durable sync
 
 | Benchmark | ns/op | Throughput | B/op | allocs/op | storage bytes/op | durable footprint bytes/op | delete write amp |
 | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
-| `BenchmarkDgraphMVCCCloseout/AllVersions/durable_sync/keys=64/depth=1` | 21356.000 | 2996840.000 versions/s | 4195.000 | 150.000 | - | - | - |
-| `BenchmarkDgraphMVCCCloseout/AllVersions/durable_sync/keys=64/depth=32` | 571677.000 | 3582446.000 versions/s | 51918.000 | 4118.000 | - | - | - |
-| `BenchmarkDgraphMVCCCloseout/AllVersions/wal_off_relaxed/keys=64/depth=1` | 22236.000 | 2878164.000 versions/s | 4192.000 | 150.000 | - | - | - |
-| `BenchmarkDgraphMVCCCloseout/AllVersions/wal_off_relaxed/keys=64/depth=32` | 564869.000 | 3625628.000 versions/s | 51834.000 | 4118.000 | - | - | - |
-| `BenchmarkDgraphMVCCCloseout/AllVersions/wal_on_relaxed/keys=64/depth=1` | 21558.000 | 2968764.000 versions/s | 4195.000 | 150.000 | - | - | - |
-| `BenchmarkDgraphMVCCCloseout/AllVersions/wal_on_relaxed/keys=64/depth=32` | 585307.000 | 3499021.000 versions/s | 51920.000 | 4118.000 | - | - | - |
-| `BenchmarkDgraphMVCCCloseout/CommitAt/durable_sync/batch=1` | 6559316.000 | 152.500 mutations/s | 4689.000 | 14.000 | 1876.000 | 1876.000 | - |
-| `BenchmarkDgraphMVCCCloseout/CommitAt/durable_sync/batch=32` | 6621481.000 | 4833.000 mutations/s | 16911.000 | 112.000 | 4522.000 | 4522.000 | - |
-| `BenchmarkDgraphMVCCCloseout/CommitAt/wal_off_relaxed/batch=1` | 4126.000 | 242359.000 mutations/s | 7485.000 | 9.000 | 74.010 | - | - |
-| `BenchmarkDgraphMVCCCloseout/CommitAt/wal_off_relaxed/batch=32` | 44931.000 | 712204.000 mutations/s | 27035.000 | 106.000 | 2050.000 | - | - |
-| `BenchmarkDgraphMVCCCloseout/CommitAt/wal_on_relaxed/batch=1` | 5497.000 | 181928.000 mutations/s | 4267.000 | 13.000 | 79.630 | - | - |
-| `BenchmarkDgraphMVCCCloseout/CommitAt/wal_on_relaxed/batch=32` | 44432.000 | 720202.000 mutations/s | 20647.000 | 110.000 | 2079.000 | - | - |
-| `BenchmarkDgraphMVCCCloseout/GetAt/durable_sync/depth=1` | 1149.000 | 870369.000 lookups/s | 628.000 | 12.000 | - | - | - |
-| `BenchmarkDgraphMVCCCloseout/GetAt/durable_sync/depth=64` | 1761.000 | 567989.000 lookups/s | 1008.000 | 16.000 | - | - | - |
-| `BenchmarkDgraphMVCCCloseout/GetAt/wal_off_relaxed/depth=1` | 1229.000 | 813744.000 lookups/s | 628.000 | 12.000 | - | - | - |
-| `BenchmarkDgraphMVCCCloseout/GetAt/wal_off_relaxed/depth=64` | 1690.000 | 591775.000 lookups/s | 1008.000 | 16.000 | - | - | - |
-| `BenchmarkDgraphMVCCCloseout/GetAt/wal_on_relaxed/depth=1` | 1205.000 | 829597.000 lookups/s | 629.000 | 12.000 | - | - | - |
-| `BenchmarkDgraphMVCCCloseout/GetAt/wal_on_relaxed/depth=64` | 1659.000 | 602691.000 lookups/s | 1008.000 | 16.000 | - | - | - |
-| `BenchmarkDgraphMVCCCloseout/Prune/durable_sync/keys=64/depth=16/floor=12` | 26745805.000 | 26322.000 pruned_versions/s | 247008.000 | 199.000 | 524727.000 | 524727.000 | 0.829 |
-| `BenchmarkDgraphMVCCCloseout/Prune/durable_sync/keys=64/depth=16/floor=4` | 13333546.000 | 14400.000 pruned_versions/s | 270976.000 | 159.000 | 524727.000 | 524727.000 | 0.829 |
-| `BenchmarkDgraphMVCCCloseout/Prune/wal_off_relaxed/keys=64/depth=16/floor=12` | 510644.000 | 1378651.000 pruned_versions/s | 168512.000 | 170.000 | 524664.000 | - | 0.829 |
-| `BenchmarkDgraphMVCCCloseout/Prune/wal_off_relaxed/keys=64/depth=16/floor=4` | 528876.000 | 363034.000 pruned_versions/s | 131576.000 | 138.000 | 524664.000 | - | 0.829 |
-| `BenchmarkDgraphMVCCCloseout/Prune/wal_on_relaxed/keys=64/depth=16/floor=12` | 633169.000 | 1111867.000 pruned_versions/s | 241728.000 | 182.000 | 524727.000 | - | 0.829 |
-| `BenchmarkDgraphMVCCCloseout/Prune/wal_on_relaxed/keys=64/depth=16/floor=4` | 814680.000 | 235675.000 pruned_versions/s | 134544.000 | 140.000 | 524727.000 | - | 0.829 |
+| `BenchmarkDgraphMVCCCloseout/AllVersions/durable_sync/keys=64/depth=1` | 18364.000 | 3485151.000 versions/s | 4195.000 | 150.000 | - | - | - |
+| `BenchmarkDgraphMVCCCloseout/AllVersions/durable_sync/keys=64/depth=32` | 497176.000 | 4119271.000 versions/s | 51915.000 | 4118.000 | - | - | - |
+| `BenchmarkDgraphMVCCCloseout/AllVersions/wal_off_relaxed/keys=64/depth=1` | 18879.000 | 3390107.000 versions/s | 4192.000 | 150.000 | - | - | - |
+| `BenchmarkDgraphMVCCCloseout/AllVersions/wal_off_relaxed/keys=64/depth=32` | 501606.000 | 4082893.000 versions/s | 51833.000 | 4118.000 | - | - | - |
+| `BenchmarkDgraphMVCCCloseout/AllVersions/wal_on_relaxed/keys=64/depth=1` | 18669.000 | 3428068.000 versions/s | 4195.000 | 150.000 | - | - | - |
+| `BenchmarkDgraphMVCCCloseout/AllVersions/wal_on_relaxed/keys=64/depth=32` | 510273.000 | 4013546.000 versions/s | 51918.000 | 4118.000 | - | - | - |
+| `BenchmarkDgraphMVCCCloseout/CommitAt/durable_sync/batch=1` | 6688579.000 | 149.500 mutations/s | 4652.000 | 14.000 | 1960.000 | 1960.000 | - |
+| `BenchmarkDgraphMVCCCloseout/CommitAt/durable_sync/batch=32` | 6071126.000 | 5271.000 mutations/s | 16925.000 | 112.000 | 4496.000 | 4496.000 | - |
+| `BenchmarkDgraphMVCCCloseout/CommitAt/wal_off_relaxed/batch=1` | 3993.000 | 250407.000 mutations/s | 7494.000 | 9.000 | 76.840 | - | - |
+| `BenchmarkDgraphMVCCCloseout/CommitAt/wal_off_relaxed/batch=32` | 38143.000 | 838950.000 mutations/s | 26144.000 | 106.000 | 2054.000 | - | - |
+| `BenchmarkDgraphMVCCCloseout/CommitAt/wal_on_relaxed/batch=1` | 4593.000 | 217744.000 mutations/s | 4252.000 | 13.000 | 83.410 | - | - |
+| `BenchmarkDgraphMVCCCloseout/CommitAt/wal_on_relaxed/batch=32` | 42543.000 | 752181.000 mutations/s | 20131.000 | 110.000 | 2085.000 | - | - |
+| `BenchmarkDgraphMVCCCloseout/GetAt/durable_sync/depth=1` | 1067.000 | 937621.000 lookups/s | 629.000 | 12.000 | - | - | - |
+| `BenchmarkDgraphMVCCCloseout/GetAt/durable_sync/depth=64` | 1492.000 | 670037.000 lookups/s | 1008.000 | 16.000 | - | - | - |
+| `BenchmarkDgraphMVCCCloseout/GetAt/wal_off_relaxed/depth=1` | 1057.000 | 946058.000 lookups/s | 628.000 | 12.000 | - | - | - |
+| `BenchmarkDgraphMVCCCloseout/GetAt/wal_off_relaxed/depth=64` | 1473.000 | 678949.000 lookups/s | 1008.000 | 16.000 | - | - | - |
+| `BenchmarkDgraphMVCCCloseout/GetAt/wal_on_relaxed/depth=1` | 1039.000 | 962350.000 lookups/s | 629.000 | 12.000 | - | - | - |
+| `BenchmarkDgraphMVCCCloseout/GetAt/wal_on_relaxed/depth=64` | 1454.000 | 687875.000 lookups/s | 1008.000 | 16.000 | - | - | - |
+| `BenchmarkDgraphMVCCCloseout/Prune/durable_sync/keys=64/depth=16/floor=12` | 27923914.000 | 25211.000 pruned_versions/s | 245568.000 | 182.000 | 524727.000 | 524727.000 | 0.829 |
+| `BenchmarkDgraphMVCCCloseout/Prune/durable_sync/keys=64/depth=16/floor=4` | 14216940.000 | 13505.000 pruned_versions/s | 269456.000 | 142.000 | 524727.000 | 524727.000 | 0.829 |
+| `BenchmarkDgraphMVCCCloseout/Prune/wal_off_relaxed/keys=64/depth=16/floor=12` | 415359.000 | 1694919.000 pruned_versions/s | 167120.000 | 154.000 | 524664.000 | - | 0.829 |
+| `BenchmarkDgraphMVCCCloseout/Prune/wal_off_relaxed/keys=64/depth=16/floor=4` | 353285.000 | 543471.000 pruned_versions/s | 130184.000 | 122.000 | 524664.000 | - | 0.829 |
+| `BenchmarkDgraphMVCCCloseout/Prune/wal_on_relaxed/keys=64/depth=16/floor=12` | 568753.000 | 1237796.000 pruned_versions/s | 240336.000 | 166.000 | 524727.000 | - | 0.829 |
+| `BenchmarkDgraphMVCCCloseout/Prune/wal_on_relaxed/keys=64/depth=16/floor=4` | 769070.000 | 249652.000 pruned_versions/s | 133152.000 | 124.000 | 524727.000 | - | 0.829 |

--- a/TreeDB/docs/spec/artifacts/dgraph-mvcc-closeout/closeout-matrix-summary.md
+++ b/TreeDB/docs/spec/artifacts/dgraph-mvcc-closeout/closeout-matrix-summary.md
@@ -1,0 +1,35 @@
+## TreeDB Dgraph MVCC closeout matrix
+
+- candidate: `2f0a687f048ece277ab039303f6e28a1a7906bcb`
+- samples: 5
+- measured benchmark invocations: 10
+- maximum benchmark-process RSS: 622068 KiB
+- aggregate process CPU: user 100.64s, system 6.85s
+- durability classes are separate rows; relaxed rows are not durability-equivalent to durable sync
+
+| Benchmark | ns/op | Throughput | B/op | allocs/op | storage bytes/op | durable footprint bytes/op | delete write amp |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| `BenchmarkDgraphMVCCCloseout/AllVersions/durable_sync/keys=64/depth=1` | 19127.000 | 3346027.000 versions/s | 4195.000 | 150.000 | - | - | - |
+| `BenchmarkDgraphMVCCCloseout/AllVersions/durable_sync/keys=64/depth=32` | 510050.000 | 4015297.000 versions/s | 51918.000 | 4118.000 | - | - | - |
+| `BenchmarkDgraphMVCCCloseout/AllVersions/wal_off_relaxed/keys=64/depth=1` | 18778.000 | 3408185.000 versions/s | 4192.000 | 150.000 | - | - | - |
+| `BenchmarkDgraphMVCCCloseout/AllVersions/wal_off_relaxed/keys=64/depth=32` | 509352.000 | 4020796.000 versions/s | 51832.000 | 4118.000 | - | - | - |
+| `BenchmarkDgraphMVCCCloseout/AllVersions/wal_on_relaxed/keys=64/depth=1` | 18661.000 | 3429627.000 versions/s | 4195.000 | 150.000 | - | - | - |
+| `BenchmarkDgraphMVCCCloseout/AllVersions/wal_on_relaxed/keys=64/depth=32` | 510853.000 | 4008987.000 versions/s | 51908.000 | 4118.000 | - | - | - |
+| `BenchmarkDgraphMVCCCloseout/CommitAt/durable_sync/batch=1` | 6550372.000 | 152.700 mutations/s | 4689.000 | 14.000 | 1931.000 | 1931.000 | - |
+| `BenchmarkDgraphMVCCCloseout/CommitAt/durable_sync/batch=32` | 5034211.000 | 6357.000 mutations/s | 16917.000 | 112.000 | 5177.000 | 5177.000 | - |
+| `BenchmarkDgraphMVCCCloseout/CommitAt/wal_off_relaxed/batch=1` | 4056.000 | 246564.000 mutations/s | 7503.000 | 9.000 | 77.520 | - | - |
+| `BenchmarkDgraphMVCCCloseout/CommitAt/wal_off_relaxed/batch=32` | 40236.000 | 795301.000 mutations/s | 26843.000 | 106.000 | 2081.000 | - | - |
+| `BenchmarkDgraphMVCCCloseout/CommitAt/wal_on_relaxed/batch=1` | 4837.000 | 206731.000 mutations/s | 4259.000 | 13.000 | 81.350 | - | - |
+| `BenchmarkDgraphMVCCCloseout/CommitAt/wal_on_relaxed/batch=32` | 43463.000 | 736250.000 mutations/s | 20868.000 | 110.000 | 2065.000 | - | - |
+| `BenchmarkDgraphMVCCCloseout/GetAt/durable_sync/depth=1` | 1133.000 | 882798.000 lookups/s | 629.000 | 12.000 | - | - | - |
+| `BenchmarkDgraphMVCCCloseout/GetAt/durable_sync/depth=64` | 1504.000 | 664880.000 lookups/s | 1008.000 | 16.000 | - | - | - |
+| `BenchmarkDgraphMVCCCloseout/GetAt/wal_off_relaxed/depth=1` | 1060.000 | 943589.000 lookups/s | 628.000 | 12.000 | - | - | - |
+| `BenchmarkDgraphMVCCCloseout/GetAt/wal_off_relaxed/depth=64` | 1472.000 | 679436.000 lookups/s | 1008.000 | 16.000 | - | - | - |
+| `BenchmarkDgraphMVCCCloseout/GetAt/wal_on_relaxed/depth=1` | 1069.000 | 935395.000 lookups/s | 629.000 | 12.000 | - | - | - |
+| `BenchmarkDgraphMVCCCloseout/GetAt/wal_on_relaxed/depth=64` | 1477.000 | 676921.000 lookups/s | 1008.000 | 16.000 | - | - | - |
+| `BenchmarkDgraphMVCCCloseout/Prune/durable_sync/keys=64/depth=16/floor=12` | 26114625.000 | 26958.000 pruned_versions/s | 246960.000 | 198.000 | 524727.000 | 524727.000 | 0.829 |
+| `BenchmarkDgraphMVCCCloseout/Prune/durable_sync/keys=64/depth=16/floor=4` | 12983205.000 | 14788.000 pruned_versions/s | 271024.000 | 160.000 | 524727.000 | 524727.000 | 0.829 |
+| `BenchmarkDgraphMVCCCloseout/Prune/wal_off_relaxed/keys=64/depth=16/floor=12` | 486220.000 | 1447904.000 pruned_versions/s | 168512.000 | 170.000 | 524664.000 | - | 0.829 |
+| `BenchmarkDgraphMVCCCloseout/Prune/wal_off_relaxed/keys=64/depth=16/floor=4` | 389759.000 | 492612.000 pruned_versions/s | 131576.000 | 138.000 | 524664.000 | - | 0.829 |
+| `BenchmarkDgraphMVCCCloseout/Prune/wal_on_relaxed/keys=64/depth=16/floor=12` | 612027.000 | 1150276.000 pruned_versions/s | 241728.000 | 182.000 | 524727.000 | - | 0.829 |
+| `BenchmarkDgraphMVCCCloseout/Prune/wal_on_relaxed/keys=64/depth=16/floor=4` | 841761.000 | 228093.000 pruned_versions/s | 134544.000 | 140.000 | 524727.000 | - | 0.829 |

--- a/TreeDB/docs/spec/artifacts/dgraph-mvcc-closeout/raw-path-summary.json
+++ b/TreeDB/docs/spec/artifacts/dgraph-mvcc-closeout/raw-path-summary.json
@@ -1,50 +1,71 @@
 {
+  "accepted": true,
+  "all_row_binaries_equivalent": true,
   "baseline_sha": "f9c9b2a37838909d0e669818cfa2840c0a8d5f85",
-  "candidate_sha": "2f0a687f048ece277ab039303f6e28a1a7906bcb",
-  "expected_samples": 7,
+  "binary_digests": {
+    "caching": {
+      "baseline": "3b4e906530b05cad58b68abd326f08946425c975664dbe40252339a26ba33b2f",
+      "candidate": "3b4e906530b05cad58b68abd326f08946425c975664dbe40252339a26ba33b2f"
+    },
+    "db": {
+      "baseline": "42e584b3fb32dec8c901966a2921fcd8fdd03c44da58881b20b1d5e5982651c3",
+      "candidate": "42e584b3fb32dec8c901966a2921fcd8fdd03c44da58881b20b1d5e5982651c3"
+    },
+    "treedb": {
+      "baseline": "1e9a6b4f060be007fa025a74b839b5a7e574268b2bf7ecf62efd1a3f5ed1548f",
+      "candidate": "1e9a6b4f060be007fa025a74b839b5a7e574268b2bf7ecf62efd1a3f5ed1548f"
+    }
+  },
+  "candidate_sha": "dbea38e0e8ad0c7d1e0bb05ac564bd9b57dd747a",
+  "expected_samples": 8,
   "max_bytes_regression_absolute": 64.0,
   "max_bytes_regression_percent": 1.0,
   "max_regression_percent": 5.0,
-  "pass": true,
+  "measurement_pass": false,
+  "no_attributable_regression": true,
   "results": [
     {
       "allocs_pass": true,
       "baseline": {
         "allocs_per_op": 1.0,
         "bytes_per_op": 480.0,
-        "ns_per_op": 803.0
+        "ns_per_op": 615.95
       },
       "benchmark": "BenchmarkGetVersioned",
+      "binary_equivalent": true,
+      "binary_package": "db",
       "bytes_delta": 0.0,
       "bytes_pass": true,
       "bytes_tolerance": 4.8,
       "candidate": {
         "allocs_per_op": 1.0,
         "bytes_per_op": 480.0,
-        "ns_per_op": 763.8
+        "ns_per_op": 622.85
       },
-      "ns_delta_percent": -4.881693648816943,
-      "pass": true,
+      "measurement_pass": true,
+      "ns_delta_percent": 1.1202207971426237,
       "timing_pass": true
     },
     {
       "allocs_pass": true,
       "baseline": {
         "allocs_per_op": 30.0,
-        "bytes_per_op": 13240.0,
-        "ns_per_op": 18515.0
+        "bytes_per_op": 13242.0,
+        "ns_per_op": 18772.5
       },
       "benchmark": "BenchmarkConditionalTxnBaselineBatchWrite",
-      "bytes_delta": -2.0,
+      "binary_equivalent": true,
+      "binary_package": "db",
+      "bytes_delta": -1.0,
       "bytes_pass": true,
       "bytes_tolerance": 64.0,
       "candidate": {
         "allocs_per_op": 30.0,
-        "bytes_per_op": 13238.0,
-        "ns_per_op": 18486.0
+        "bytes_per_op": 13241.0,
+        "ns_per_op": 18840.5
       },
-      "ns_delta_percent": -0.15662975965433645,
-      "pass": true,
+      "measurement_pass": true,
+      "ns_delta_percent": 0.36223198828073677,
       "timing_pass": true
     },
     {
@@ -52,19 +73,21 @@
       "baseline": {
         "allocs_per_op": 0.0,
         "bytes_per_op": 0.0,
-        "ns_per_op": 291.6
+        "ns_per_op": 279.2
       },
       "benchmark": "BenchmarkSnapshotIteratorSeekNext/keys=1024/snapshot_seek",
+      "binary_equivalent": true,
+      "binary_package": "treedb",
       "bytes_delta": 0.0,
       "bytes_pass": true,
       "bytes_tolerance": 0.0,
       "candidate": {
         "allocs_per_op": 0.0,
         "bytes_per_op": 0.0,
-        "ns_per_op": 293.4
+        "ns_per_op": 277.9
       },
-      "ns_delta_percent": 0.6172839506172645,
-      "pass": true,
+      "measurement_pass": true,
+      "ns_delta_percent": -0.46561604584527405,
       "timing_pass": true
     },
     {
@@ -72,40 +95,45 @@
       "baseline": {
         "allocs_per_op": 2.0,
         "bytes_per_op": 112.0,
-        "ns_per_op": 313.6
+        "ns_per_op": 227.15
       },
       "benchmark": "BenchmarkRepeatedIterator",
+      "binary_equivalent": true,
+      "binary_package": "caching",
       "bytes_delta": 0.0,
       "bytes_pass": true,
       "bytes_tolerance": 1.12,
       "candidate": {
         "allocs_per_op": 2.0,
         "bytes_per_op": 112.0,
-        "ns_per_op": 303.0
+        "ns_per_op": 223.14999999999998
       },
-      "ns_delta_percent": -3.380102040816335,
-      "pass": true,
+      "measurement_pass": true,
+      "ns_delta_percent": -1.7609509134932977,
       "timing_pass": true
     },
     {
       "allocs_pass": true,
       "baseline": {
         "allocs_per_op": 17.0,
-        "bytes_per_op": 4720.0,
-        "ns_per_op": 5454877.0
+        "bytes_per_op": 4560.0,
+        "ns_per_op": 383380.5
       },
       "benchmark": "BenchmarkPublicCommandWALDurableTinyBatchWriteSync/placement=inline/shape=dirty_batch/ops=1",
-      "bytes_delta": 11.0,
+      "binary_equivalent": true,
+      "binary_package": "treedb",
+      "bytes_delta": -2.5,
       "bytes_pass": true,
-      "bytes_tolerance": 47.2,
+      "bytes_tolerance": 45.6,
       "candidate": {
         "allocs_per_op": 17.0,
-        "bytes_per_op": 4731.0,
-        "ns_per_op": 5592783.0
+        "bytes_per_op": 4557.5,
+        "ns_per_op": 490497.0
       },
-      "ns_delta_percent": 2.5281229989237097,
-      "pass": true,
-      "timing_pass": true
+      "measurement_pass": false,
+      "ns_delta_percent": 27.939996948201596,
+      "timing_pass": false
     }
-  ]
+  ],
+  "verdict": "EQUIVALENT"
 }

--- a/TreeDB/docs/spec/artifacts/dgraph-mvcc-closeout/raw-path-summary.json
+++ b/TreeDB/docs/spec/artifacts/dgraph-mvcc-closeout/raw-path-summary.json
@@ -1,0 +1,111 @@
+{
+  "baseline_sha": "f9c9b2a37838909d0e669818cfa2840c0a8d5f85",
+  "candidate_sha": "2f0a687f048ece277ab039303f6e28a1a7906bcb",
+  "expected_samples": 7,
+  "max_bytes_regression_absolute": 64.0,
+  "max_bytes_regression_percent": 1.0,
+  "max_regression_percent": 5.0,
+  "pass": true,
+  "results": [
+    {
+      "allocs_pass": true,
+      "baseline": {
+        "allocs_per_op": 1.0,
+        "bytes_per_op": 480.0,
+        "ns_per_op": 803.0
+      },
+      "benchmark": "BenchmarkGetVersioned",
+      "bytes_delta": 0.0,
+      "bytes_pass": true,
+      "bytes_tolerance": 4.8,
+      "candidate": {
+        "allocs_per_op": 1.0,
+        "bytes_per_op": 480.0,
+        "ns_per_op": 763.8
+      },
+      "ns_delta_percent": -4.881693648816943,
+      "pass": true,
+      "timing_pass": true
+    },
+    {
+      "allocs_pass": true,
+      "baseline": {
+        "allocs_per_op": 30.0,
+        "bytes_per_op": 13240.0,
+        "ns_per_op": 18515.0
+      },
+      "benchmark": "BenchmarkConditionalTxnBaselineBatchWrite",
+      "bytes_delta": -2.0,
+      "bytes_pass": true,
+      "bytes_tolerance": 64.0,
+      "candidate": {
+        "allocs_per_op": 30.0,
+        "bytes_per_op": 13238.0,
+        "ns_per_op": 18486.0
+      },
+      "ns_delta_percent": -0.15662975965433645,
+      "pass": true,
+      "timing_pass": true
+    },
+    {
+      "allocs_pass": true,
+      "baseline": {
+        "allocs_per_op": 0.0,
+        "bytes_per_op": 0.0,
+        "ns_per_op": 291.6
+      },
+      "benchmark": "BenchmarkSnapshotIteratorSeekNext/keys=1024/snapshot_seek",
+      "bytes_delta": 0.0,
+      "bytes_pass": true,
+      "bytes_tolerance": 0.0,
+      "candidate": {
+        "allocs_per_op": 0.0,
+        "bytes_per_op": 0.0,
+        "ns_per_op": 293.4
+      },
+      "ns_delta_percent": 0.6172839506172645,
+      "pass": true,
+      "timing_pass": true
+    },
+    {
+      "allocs_pass": true,
+      "baseline": {
+        "allocs_per_op": 2.0,
+        "bytes_per_op": 112.0,
+        "ns_per_op": 313.6
+      },
+      "benchmark": "BenchmarkRepeatedIterator",
+      "bytes_delta": 0.0,
+      "bytes_pass": true,
+      "bytes_tolerance": 1.12,
+      "candidate": {
+        "allocs_per_op": 2.0,
+        "bytes_per_op": 112.0,
+        "ns_per_op": 303.0
+      },
+      "ns_delta_percent": -3.380102040816335,
+      "pass": true,
+      "timing_pass": true
+    },
+    {
+      "allocs_pass": true,
+      "baseline": {
+        "allocs_per_op": 17.0,
+        "bytes_per_op": 4720.0,
+        "ns_per_op": 5454877.0
+      },
+      "benchmark": "BenchmarkPublicCommandWALDurableTinyBatchWriteSync/placement=inline/shape=dirty_batch/ops=1",
+      "bytes_delta": 11.0,
+      "bytes_pass": true,
+      "bytes_tolerance": 47.2,
+      "candidate": {
+        "allocs_per_op": 17.0,
+        "bytes_per_op": 4731.0,
+        "ns_per_op": 5592783.0
+      },
+      "ns_delta_percent": 2.5281229989237097,
+      "pass": true,
+      "timing_pass": true
+    }
+  ]
+}

--- a/TreeDB/docs/spec/artifacts/dgraph-mvcc-closeout/raw-path-summary.md
+++ b/TreeDB/docs/spec/artifacts/dgraph-mvcc-closeout/raw-path-summary.md
@@ -1,0 +1,17 @@
+## TreeDB MVCC raw-path gate
+
+- result: **PASS**
+- baseline: `f9c9b2a37838909d0e669818cfa2840c0a8d5f85`
+- candidate: `2f0a687f048ece277ab039303f6e28a1a7906bcb`
+- samples: 7 per revision, alternating sequential order
+- timing threshold: candidate median <= baseline median + 5%
+- allocs/op threshold: candidate median must not increase
+- B/op jitter threshold: candidate median may increase by at most the smaller of 1% or 64 B; zero-B baselines remain strict
+
+| Benchmark | Base ns/op | Head ns/op | Delta | Base B/op | Head B/op | B tolerance | Base allocs/op | Head allocs/op | Result |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | --- |
+| BenchmarkGetVersioned | 803.000 | 763.800 | -4.88% | 480.000 | 480.000 | 4.800 | 1.000 | 1.000 | PASS |
+| BenchmarkConditionalTxnBaselineBatchWrite | 18515.000 | 18486.000 | -0.16% | 13240.000 | 13238.000 | 64.000 | 30.000 | 30.000 | PASS |
+| BenchmarkSnapshotIteratorSeekNext/keys=1024/snapshot_seek | 291.600 | 293.400 | +0.62% | 0.000 | 0.000 | 0.000 | 0.000 | 0.000 | PASS |
+| BenchmarkRepeatedIterator | 313.600 | 303.000 | -3.38% | 112.000 | 112.000 | 1.120 | 2.000 | 2.000 | PASS |
+| BenchmarkPublicCommandWALDurableTinyBatchWriteSync/placement=inline/shape=dirty_batch/ops=1 | 5454877.000 | 5592783.000 | +2.53% | 4720.000 | 4731.000 | 47.200 | 17.000 | 17.000 | PASS |

--- a/TreeDB/docs/spec/artifacts/dgraph-mvcc-closeout/raw-path-summary.md
+++ b/TreeDB/docs/spec/artifacts/dgraph-mvcc-closeout/raw-path-summary.md
@@ -1,17 +1,25 @@
 ## TreeDB MVCC raw-path gate
 
-- result: **PASS**
+- verdict: **EQUIVALENT**
+- measured threshold observation: **FAIL**
 - baseline: `f9c9b2a37838909d0e669818cfa2840c0a8d5f85`
-- candidate: `2f0a687f048ece277ab039303f6e28a1a7906bcb`
-- samples: 7 per revision, alternating sequential order
+- candidate: `dbea38e0e8ad0c7d1e0bb05ac564bd9b57dd747a`
+- samples: 8 per revision, benchmark-group-paired alternating AB/BA order
 - timing threshold: candidate median <= baseline median + 5%
 - allocs/op threshold: candidate median must not increase
 - B/op jitter threshold: candidate median may increase by at most the smaller of 1% or 64 B; zero-B baselines remain strict
+- equivalence acceptance: every row-producing base/head benchmark binary is byte-identical, so the measured delta is retained but is not attributable to the candidate revision
 
-| Benchmark | Base ns/op | Head ns/op | Delta | Base B/op | Head B/op | B tolerance | Base allocs/op | Head allocs/op | Result |
-| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | --- |
-| BenchmarkGetVersioned | 803.000 | 763.800 | -4.88% | 480.000 | 480.000 | 4.800 | 1.000 | 1.000 | PASS |
-| BenchmarkConditionalTxnBaselineBatchWrite | 18515.000 | 18486.000 | -0.16% | 13240.000 | 13238.000 | 64.000 | 30.000 | 30.000 | PASS |
-| BenchmarkSnapshotIteratorSeekNext/keys=1024/snapshot_seek | 291.600 | 293.400 | +0.62% | 0.000 | 0.000 | 0.000 | 0.000 | 0.000 | PASS |
-| BenchmarkRepeatedIterator | 313.600 | 303.000 | -3.38% | 112.000 | 112.000 | 1.120 | 2.000 | 2.000 | PASS |
-| BenchmarkPublicCommandWALDurableTinyBatchWriteSync/placement=inline/shape=dirty_batch/ops=1 | 5454877.000 | 5592783.000 | +2.53% | 4720.000 | 4731.000 | 47.200 | 17.000 | 17.000 | PASS |
+| Package | Baseline SHA-256 | Candidate SHA-256 | Relation |
+| --- | --- | --- | --- |
+| db | `42e584b3fb32dec8c901966a2921fcd8fdd03c44da58881b20b1d5e5982651c3` | `42e584b3fb32dec8c901966a2921fcd8fdd03c44da58881b20b1d5e5982651c3` | EQUIVALENT |
+| caching | `3b4e906530b05cad58b68abd326f08946425c975664dbe40252339a26ba33b2f` | `3b4e906530b05cad58b68abd326f08946425c975664dbe40252339a26ba33b2f` | EQUIVALENT |
+| treedb | `1e9a6b4f060be007fa025a74b839b5a7e574268b2bf7ecf62efd1a3f5ed1548f` | `1e9a6b4f060be007fa025a74b839b5a7e574268b2bf7ecf62efd1a3f5ed1548f` | EQUIVALENT |
+
+| Benchmark | Binary | Base ns/op | Head ns/op | Delta | Base B/op | Head B/op | B tolerance | Base allocs/op | Head allocs/op | Measured |
+| --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | --- |
+| BenchmarkGetVersioned | db EQUIVALENT | 615.950 | 622.850 | +1.12% | 480.000 | 480.000 | 4.800 | 1.000 | 1.000 | PASS |
+| BenchmarkConditionalTxnBaselineBatchWrite | db EQUIVALENT | 18772.500 | 18840.500 | +0.36% | 13242.000 | 13241.000 | 64.000 | 30.000 | 30.000 | PASS |
+| BenchmarkSnapshotIteratorSeekNext/keys=1024/snapshot_seek | treedb EQUIVALENT | 279.200 | 277.900 | -0.47% | 0.000 | 0.000 | 0.000 | 0.000 | 0.000 | PASS |
+| BenchmarkRepeatedIterator | caching EQUIVALENT | 227.150 | 223.150 | -1.76% | 112.000 | 112.000 | 1.120 | 2.000 | 2.000 | PASS |
+| BenchmarkPublicCommandWALDurableTinyBatchWriteSync/placement=inline/shape=dirty_batch/ops=1 | treedb EQUIVALENT | 383380.500 | 490497.000 | +27.94% | 4560.000 | 4557.500 | 45.600 | 17.000 | 17.000 | FAIL |

--- a/TreeDB/docs/spec/dgraph-mvcc-readiness-3673.md
+++ b/TreeDB/docs/spec/dgraph-mvcc-readiness-3673.md
@@ -134,6 +134,11 @@ Markdown medians. The matrix separates these acknowledgement classes:
 Each class covers `CommitAt` batches 1/32, `GetAt` depths 1/64, 64-key
 all-version scans at depths 1/32, and 64-key depth-16 pruning at floors 4/12.
 Go benchmark rows report latency, throughput, `B/op`, and `allocs/op`.
+Commit, get, and scan rows use duration calibration. Prune rows use exactly one
+fresh populated database per external sample (`-benchtime=1x`), because
+duration calibration would multiply excluded fixture setup and make process RSS
+describe fixture churn rather than the bounded pruning operation. Five external
+samples still provide five independent prune latency/throughput observations.
 `storage_bytes/op` is normalized final logical file footprint, including fixed
 TreeDB files and preallocation; `durable_bytes/op` is emitted only for the
 sync-acknowledged rows. It is storage-footprint context, not physical device

--- a/TreeDB/docs/spec/dgraph-mvcc-readiness-3673.md
+++ b/TreeDB/docs/spec/dgraph-mvcc-readiness-3673.md
@@ -1,0 +1,158 @@
+# Dgraph MVCC Readiness Closeout (#3673)
+
+Status: pre-alpha downstream contract for the first restricted Dgraph Alpha
+benchmark. This document closes gomap issue
+[#3673](https://github.com/snissn/gomap/issues/3673) and the TreeDB side of
+[#3668](https://github.com/snissn/gomap/issues/3668). The downstream tracker is
+[snissn/dgraph#16](https://github.com/snissn/dgraph/issues/16).
+
+TreeDB and its MVCC format remain pre-alpha. This closeout pins tested behavior
+for one Dgraph experiment; it is not a general compatibility or migration
+promise.
+
+## Intended Dgraph module pin
+
+Dgraph MUST pin the first `github.com/snissn/gomap` **merged-main commit that
+contains this closeout PR**, using the Go pseudo-version resolved for that exact
+commit. It MUST NOT pin a worker branch, a predecessor branch, or a floating
+`main`. The dependency chain through all #3668 children is present on main at
+`e94013508e7fad1d9fb89034ec8dfd6d88c7e6e2`; the final closeout merge commit is
+recorded in the Dgraph adapter PR when that descendant starts.
+
+The evidence below is collected on the closeout code commit named in
+`artifacts/dgraph-mvcc-closeout/README.md`. The final evidence-only commit may
+follow it without changing production MVCC code.
+
+## Reusable conformance surface
+
+`TreeDB/mvcc/mvcctest` is a downstream test package, not a production adapter.
+Its closure-based `Adapter` deliberately avoids requiring Dgraph types to
+implement TreeDB-specific interfaces. `mvcctest.FromStore` is the minimal
+TreeDB example. `mvcctest.Run` executes:
+
+- the committed `public_trace_v1.json` golden history;
+- durable close/reopen before and after floor advancement and pruning;
+- nil/empty-key duplicate handling, zero timestamps, durability rejection,
+  monotonic floors, and commit/read rejection at the floor;
+- a deterministic seed-3673 randomized point-read and all-version oracle over
+  empty, embedded-zero, and `0xff` logical keys;
+- concurrent point readers and writers while an older iterator retains its
+  pinned snapshot.
+
+`TreeDB/mvcc/conformance_external_test.go` invokes the suite from the external
+`mvcc_test` package, so package-private helpers cannot accidentally become part
+of the dependency. `TreeDB/mvcc/mvcctest/example_test.go` is a compiling example
+that imports only public TreeDB, MVCC, and harness APIs.
+
+The physical codec remains intentionally internal. Its exact v1 bytes and
+ordering are independently pinned by
+`TreeDB/internal/mvcckey/testdata/codec_v1_golden.json`; round-trip, malformed
+input, ordering, bound, and fuzz properties remain in the codec package.
+
+## Supported semantics for the restricted Alpha
+
+| Surface | Supported contract |
+| --- | --- |
+| Timestamp ownership | The caller supplies a nonzero `uint64`. One successful commit uses one timestamp for its full mutation batch. |
+| Atomic mutation batch | Puts and tombstones publish through one TreeDB batch. Duplicate logical keys in a batch are rejected; nil and empty keys are the same identity. |
+| Point visibility | `GetAt(k, ts)` returns the newest retained version at or below `ts`, distinguishing absent, present-empty, present-nonempty, and tombstone. |
+| Same key/timestamp | A later successful commit replaces the one physical version at the same logical key and timestamp. |
+| Logical keys | Arbitrary bytes, including empty, zero bytes, and `0xff`, within the codec envelope. |
+| All-version iteration | Snapshot-bound forward/reverse iteration, logical bounds, prefix, read-time ceiling, directional seek, explicit tombstones, owned returned bytes, and accounting. |
+| Discard floor | One durable monotonic global floor. Reads/scans at or below it fail; commits must be strictly above it. |
+| Pruning | Bounded, restartable value/tombstone pruning with pinned-reader safety and no value resurrection. `Skipped` is a subset of retained records. |
+| Durability | `CommitDurable` and durable floor/prune operations require `DurabilityDurable` and acknowledge through sync publication. Relaxed operations are atomic but not fsync acknowledgements. |
+| Reopen/crash | Durable commits and floor-first pruning survive reopen and abrupt child-process exit in the committed MVCC crash tests. |
+| Concurrency | Concurrent point readers, commits, snapshot iterators, pruning, and serialized floor advancement are race-tested. |
+| Ownership | Exactly one `mvcc.Store` owns one open TreeDB handle and reserved MVCC namespace. |
+| Errors | Validation, malformed-record, storage, floor, and durability failures remain distinguishable with `errors.Is`. Storage acknowledgement errors may be commit-ambiguous but never expose a partial batch. |
+
+## Unsupported or Dgraph-owned semantics
+
+These are not silently emulated by TreeDB MVCC:
+
+- encryption at rest or Badger encryption-key rotation;
+- TTL/expiry, leases, subscriptions, backup streams, bulk loaders, or managed
+  compaction scheduling;
+- Badger transaction objects, optimistic conflict detection, predicates,
+  compare-and-set, or conditional transaction semantics;
+- Dgraph posting-list metadata, namespace policy, rollup/split envelopes,
+  cache accounting, iterator prefetch/value callbacks, or Alpha lifecycle;
+- multiple `mvcc.Store` owners for one handle, raw writes in the reserved MVCC
+  namespace, or per-key discard floors;
+- stable cross-version on-disk migration or a public physical codec API.
+
+Dgraph owns any translation from its backend-neutral seam to this surface. A
+missing envelope is an explicit restricted-runtime capability error, not a
+reason to expand TreeDB's generic MVCC layer in this closeout.
+
+## Correctness evidence matrix
+
+| Contract | Committed evidence |
+| --- | --- |
+| Codec bytes/order/bounds | `TreeDB/internal/mvcckey/codec_golden_test.go`, `codec_test.go`, `codec_fuzz_test.go` |
+| Atomic commit and point histories | `TreeDB/mvcc/mvcc_test.go`, golden and randomized public harness cases |
+| Iteration, tombstones, seek, ownership | `TreeDB/mvcc/versions_test.go`, public golden trace |
+| Floor/reopen/prune/idempotence | `versions_test.go`, `mvcctest.Run/golden_reopen_floor_prune` |
+| Abrupt exit | `TestCommitAtDurableProcessCrashRecovery`, `TestPruneDurableProcessCrashAfterDeleteBatch` |
+| Reader/writer/prune concurrency | `TestGetAtConcurrentReaders`, `TestPruneConcurrentSnapshotReaders`, `TestPruneAfterSnapshotCaptureDoesNotBlockForegroundOperations`, public concurrency case |
+| Downstream public-only compilation | `TestPublicSurfaceConformance`, `ExampleFromStore` |
+
+Focused reproducible gates:
+
+```sh
+GOWORK=off go test ./TreeDB/internal/mvcckey ./TreeDB/mvcc/...
+GOWORK=off go test -race ./TreeDB/mvcc/... -run \
+  'TestPublicSurfaceConformance|TestGetAtConcurrentReaders|TestPruneConcurrentSnapshotReaders|TestPruneAfterSnapshotCaptureDoesNotBlockForegroundOperations|TestFloorAdvanceRaceNeverServesPrunedHistoricalRead'
+GOWORK=off go test ./TreeDB/mvcc -run \
+  'TestCommitAtDurableProcessCrashRecovery|TestPruneDurableProcessCrashAfterDeleteBatch'
+GOWORK=off go test ./TreeDB/internal/mvcckey -run '^$' \
+  -fuzz '^FuzzRoundTrip$' -fuzztime=10s
+GOWORK=off go test ./TreeDB/internal/mvcckey -run '^$' \
+  -fuzz '^FuzzDecodeNeverPanics$' -fuzztime=10s
+```
+
+The two codec fuzz targets are run separately because `go test -fuzz` accepts
+only one matching target per invocation.
+
+## Performance evidence and boundaries
+
+The raw-path no-regression gate remains `scripts/mvcc_raw_path_gate.sh`: it
+compiles identical base/head TreeDB/db benchmark binaries, alternates samples
+on one pinned CPU, and rejects a median timing regression over 5%, any
+allocation increase, or a material `B/op` increase.
+
+`scripts/mvcc_closeout_matrix.sh` captures the final downstream matrix at an
+exact checkout. It emits host/CPU/Go metadata, benchmark-binary checksum, raw
+samples, `/usr/bin/time -v` CPU/RSS evidence, a CPU profile/top, and JSON plus
+Markdown medians. The matrix separates these acknowledgement classes:
+
+- `durable_sync`: durable TreeDB plus `CommitDurable`/durable floor/prune;
+- `wal_on_relaxed`: WAL-on TreeDB plus `CommitRelaxed`/relaxed floor/prune;
+- `wal_off_relaxed`: WAL-off TreeDB plus relaxed operations.
+
+Each class covers `CommitAt` batches 1/32, `GetAt` depths 1/64, 64-key
+all-version scans at depths 1/32, and 64-key depth-16 pruning at floors 4/12.
+Go benchmark rows report latency, throughput, `B/op`, and `allocs/op`.
+`storage_bytes/op` is normalized final logical file footprint, including fixed
+TreeDB files and preallocation; `durable_bytes/op` is emitted only for the
+sync-acknowledged rows. It is storage-footprint context, not physical device
+write amplification. Prune's existing delete-write-amplification metric is
+reported separately.
+
+Reproduction:
+
+```sh
+OUT_DIR=/absolute/output/path \
+CANDIDATE_HASH=<exact-commit> RUNS=5 BENCHTIME=750ms CPUSET=0 \
+GOWORK=off ./scripts/mvcc_closeout_matrix.sh
+```
+
+The committed compact evidence index is
+`TreeDB/docs/spec/artifacts/dgraph-mvcc-closeout/README.md`. Raw local evidence
+is retained outside git and the exact-head CI raw-path artifact is attached to
+the pull request run; generated CPU profiles are not committed.
+
+Performance results compare only like-for-like rows. In particular, relaxed
+writes are never described as equivalent to synced writes, and one-iteration
+smokes are not used as stable throughput evidence.

--- a/TreeDB/docs/spec/dgraph-mvcc-readiness-3673.md
+++ b/TreeDB/docs/spec/dgraph-mvcc-readiness-3673.md
@@ -194,6 +194,34 @@ The committed compact evidence index is
 is retained outside git and the exact-head CI raw-path artifact is attached to
 the pull request run; generated CPU profiles are not committed.
 
+### Exact-target closeout outcome
+
+The measured code target is
+`dbea38e0e8ad0c7d1e0bb05ac564bd9b57dd747a`, compared with base
+`f9c9b2a37838909d0e669818cfa2840c0a8d5f85`. The final evidence commit is a
+docs-only descendant: it does not change the production MVCC implementation,
+benchmark definitions, or harnesses measured at `dbea38e0`.
+
+- The hosted raw-path verdict is **EQUIVALENT**, not PASS. Its durable-sync row
+  measured +27.94% and failed the timing threshold, while all three
+  row-producing base/head binary pairs were byte-identical. The other four
+  measured rows ranged from -1.76% to +1.12%.
+- The adapter-overhead gate verdict is **FAIL**. Direct/MVCC commit co-moved at
+  +9.77%/+7.03%, and physical/MVCC all-version iteration co-moved at
+  +18.88%/+13.41%. Get rows remained within the 5% revision ceiling.
+  Allocations were unchanged, bytes remained flat, and every candidate
+  adapter/direct ratio passed the 2x ceiling; the maximum was 1.121x.
+- The five-sample durability-matched closeout matrix completed successfully
+  with all 24 rows and required metrics present.
+
+The four adapter revision-ceiling misses are accepted only as a scoped risk for
+the first restricted pre-alpha Dgraph benchmark. They are not relabeled as a
+passing adapter gate. The acceptance is based on the non-production nature of
+the base-to-target diff, direct and MVCC co-movement, passing adapter/direct
+ratios, unchanged allocations, flat bytes, byte-identical hosted raw-path
+binaries, and the successful matrix. Exact samples and the full rationale are
+preserved in the compact evidence index.
+
 Performance results compare only like-for-like rows. In particular, relaxed
 writes are never described as equivalent to synced writes, and one-iteration
 smokes are not used as stable throughput evidence.

--- a/TreeDB/docs/spec/dgraph-mvcc-readiness-3673.md
+++ b/TreeDB/docs/spec/dgraph-mvcc-readiness-3673.md
@@ -130,15 +130,23 @@ compiles base/head benchmark binaries, pairs each individual benchmark group
 immediately in alternating AB/BA order on one pinned CPU, and covers point
 reads, batch writes, snapshot seek, iterator reuse, and durable synced writes.
 The point-read and batch-write rows use separate invocations so one row cannot
-delay the base/head pair for the other. It rejects a median timing regression
-over 5%, any allocation increase, or a material `B/op` increase.
+delay the base/head pair for the other. Eight samples provide exactly four AB
+and four BA pairs; odd sample counts are rejected. The gate rejects a median
+timing regression over 5%, any allocation increase, or a material `B/op`
+increase. A distinct `EQUIVALENT` acceptance is available only when the checker
+hashes all six actual test-binary paths and every row-producing base/head pair
+matches (`db`, `caching`, and `treedb`). `EQUIVALENT` preserves the measured
+PASS/FAIL medians and deltas but states that no observed difference can be
+attributed to the candidate code; mixed, missing, or malformed binary evidence
+fails closed and cannot produce equivalence acceptance.
 
 `scripts/mvcc_adapter_overhead_gate.sh` separately compares public MVCC commit,
 get, and all-version iteration rows with their direct TreeDB/physical controls.
 Each benchmark group is paired immediately in the same alternating AB/BA order.
-The gate applies the same base/head regression limits and rejects candidate
-MVCC overhead above 2x. Candidate MVCC CPU profiles and top reports are emitted
-for all three pairs on every run, including a failing run.
+The gate also requires an even sample count and defaults to eight. It applies
+the same base/head regression limits and rejects candidate MVCC overhead above
+2x. Candidate MVCC CPU profiles and top reports are emitted for all three pairs
+on every run, including a failing run.
 
 `scripts/mvcc_closeout_matrix.sh` captures the final downstream matrix at an
 exact checkout. It emits host/CPU/Go metadata, benchmark-binary checksum, raw

--- a/TreeDB/docs/spec/dgraph-mvcc-readiness-3673.md
+++ b/TreeDB/docs/spec/dgraph-mvcc-readiness-3673.md
@@ -126,16 +126,19 @@ only one matching target per invocation.
 ## Performance evidence and boundaries
 
 The raw-path no-regression gate remains `scripts/mvcc_raw_path_gate.sh`: it
-compiles identical base/head benchmark binaries, alternates samples on one
-pinned CPU, and covers point reads, batch writes, snapshot seek, iterator
-reuse, and durable synced writes. It rejects a median timing regression over
-5%, any allocation increase, or a material `B/op` increase.
+compiles base/head benchmark binaries, pairs each individual benchmark group
+immediately in alternating AB/BA order on one pinned CPU, and covers point
+reads, batch writes, snapshot seek, iterator reuse, and durable synced writes.
+The point-read and batch-write rows use separate invocations so one row cannot
+delay the base/head pair for the other. It rejects a median timing regression
+over 5%, any allocation increase, or a material `B/op` increase.
 
 `scripts/mvcc_adapter_overhead_gate.sh` separately compares public MVCC commit,
 get, and all-version iteration rows with their direct TreeDB/physical controls.
-It applies the same base/head regression limits and rejects candidate MVCC
-overhead above 2x. Candidate MVCC CPU profiles and top reports are emitted for
-all three pairs on every run, including a failing run.
+Each benchmark group is paired immediately in the same alternating AB/BA order.
+The gate applies the same base/head regression limits and rejects candidate
+MVCC overhead above 2x. Candidate MVCC CPU profiles and top reports are emitted
+for all three pairs on every run, including a failing run.
 
 `scripts/mvcc_closeout_matrix.sh` captures the final downstream matrix at an
 exact checkout. It emits host/CPU/Go metadata, benchmark-binary checksum, raw

--- a/TreeDB/docs/spec/dgraph-mvcc-readiness-3673.md
+++ b/TreeDB/docs/spec/dgraph-mvcc-readiness-3673.md
@@ -198,9 +198,12 @@ the pull request run; generated CPU profiles are not committed.
 
 The measured code target is
 `dbea38e0e8ad0c7d1e0bb05ac564bd9b57dd747a`, compared with base
-`f9c9b2a37838909d0e669818cfa2840c0a8d5f85`. The final evidence commit is a
-docs-only descendant: it does not change the production MVCC implementation,
-benchmark definitions, or harnesses measured at `dbea38e0`.
+`f9c9b2a37838909d0e669818cfa2840c0a8d5f85`. The final pull-request head is a
+post-measure validation, CI-wiring, and evidence descendant: it does not change
+the production MVCC implementation, benchmark definitions, benchmark
+harnesses, or measurement inputs used at `dbea38e0`. The summaries were
+regenerated and revalidated from the preserved raw inputs without rerunning
+the benchmarks.
 
 - The hosted raw-path verdict is **EQUIVALENT**, not PASS. Its durable-sync row
   measured +27.94% and failed the timing threshold, while all three

--- a/TreeDB/docs/spec/dgraph-mvcc-readiness-3673.md
+++ b/TreeDB/docs/spec/dgraph-mvcc-readiness-3673.md
@@ -42,6 +42,10 @@ TreeDB example. `mvcctest.Run` executes:
 - concurrent point readers and writers while an older iterator retains its
   pinned snapshot.
 
+Except for the durable reopen trace, the public suite runs each case against
+both WAL-on relaxed and WAL-off relaxed stores. The durable trace separately
+pins sync acknowledgement and reopen behavior.
+
 `TreeDB/mvcc/conformance_external_test.go` invokes the suite from the external
 `mvcc_test` package, so package-private helpers cannot accidentally become part
 of the dependency. `TreeDB/mvcc/mvcctest/example_test.go` is a compiling example
@@ -63,8 +67,8 @@ input, ordering, bound, and fuzz properties remain in the codec package.
 | Logical keys | Arbitrary bytes, including empty, zero bytes, and `0xff`, within the codec envelope. |
 | All-version iteration | Snapshot-bound forward/reverse iteration, logical bounds, prefix, read-time ceiling, directional seek, explicit tombstones, owned returned bytes, and accounting. |
 | Discard floor | One durable monotonic global floor. Reads/scans at or below it fail; commits must be strictly above it. |
-| Pruning | Bounded, restartable value/tombstone pruning with pinned-reader safety and no value resurrection. `Skipped` is a subset of retained records. |
-| Durability | `CommitDurable` and durable floor/prune operations require `DurabilityDurable` and acknowledge through sync publication. Relaxed operations are atomic but not fsync acknowledgements. |
+| Pruning | Bounded, restartable value/tombstone pruning with pinned-reader safety and no value resurrection. Each delete batch is atomic, but a full prune pass is not operation-atomic. `Skipped` is a subset of retained records. |
+| Durability | `CommitDurable` and durable floor/prune operations require `DurabilityDurable` and acknowledge through sync publication. Relaxed commits and floor advances retain operation-level atomicity but are not fsync acknowledgements. Relaxed pruning is restartable and batch-atomic, not operation-atomic across a full pass. |
 | Reopen/crash | Durable commits and floor-first pruning survive reopen and abrupt child-process exit in the committed MVCC crash tests. |
 | Concurrency | Concurrent point readers, commits, snapshot iterators, pruning, and serialized floor advancement are race-tested. |
 | Ownership | Exactly one `mvcc.Store` owns one open TreeDB handle and reserved MVCC namespace. |
@@ -121,9 +125,16 @@ only one matching target per invocation.
 ## Performance evidence and boundaries
 
 The raw-path no-regression gate remains `scripts/mvcc_raw_path_gate.sh`: it
-compiles identical base/head TreeDB/db benchmark binaries, alternates samples
-on one pinned CPU, and rejects a median timing regression over 5%, any
-allocation increase, or a material `B/op` increase.
+compiles identical base/head benchmark binaries, alternates samples on one
+pinned CPU, and covers point reads, batch writes, snapshot seek, iterator
+reuse, and durable synced writes. It rejects a median timing regression over
+5%, any allocation increase, or a material `B/op` increase.
+
+`scripts/mvcc_adapter_overhead_gate.sh` separately compares public MVCC commit,
+get, and all-version iteration rows with their direct TreeDB/physical controls.
+It applies the same base/head regression limits and rejects candidate MVCC
+overhead above 2x. Candidate MVCC CPU profiles and top reports are emitted for
+all three pairs on every run, including a failing run.
 
 `scripts/mvcc_closeout_matrix.sh` captures the final downstream matrix at an
 exact checkout. It emits host/CPU/Go metadata, benchmark-binary checksum, raw
@@ -143,10 +154,10 @@ duration calibration would multiply excluded fixture setup and make process RSS
 describe fixture churn rather than the bounded pruning operation. Five external
 samples still provide five independent prune latency/throughput observations.
 `storage_bytes/op` is normalized final logical file footprint, including fixed
-TreeDB files and preallocation; `durable_bytes/op` is emitted only for the
-sync-acknowledged rows. It is storage-footprint context, not physical device
-write amplification. Prune's existing delete-write-amplification metric is
-reported separately.
+TreeDB files and preallocation. `durable_footprint_bytes/op` is emitted only for
+the sync-acknowledged rows and remains final logical footprint; it does not
+measure bytes forced to the physical device. Prune's existing
+delete-write-amplification metric is reported separately.
 
 Reproduction:
 
@@ -154,6 +165,12 @@ Reproduction:
 OUT_DIR=/absolute/output/path \
 CANDIDATE_HASH=<exact-commit> RUNS=5 BENCHTIME=750ms CPUSET=0 \
 GOWORK=off ./scripts/mvcc_closeout_matrix.sh
+
+OUT_DIR=/absolute/raw-gate-path BASELINE_HASH=<base> CANDIDATE_HASH=<head> \
+GOWORK=off ./scripts/mvcc_raw_path_gate.sh
+
+OUT_DIR=/absolute/adapter-gate-path BASELINE_HASH=<base> CANDIDATE_HASH=<head> \
+GOWORK=off ./scripts/mvcc_adapter_overhead_gate.sh
 ```
 
 The committed compact evidence index is

--- a/TreeDB/docs/spec/dgraph-mvcc-readiness-3673.md
+++ b/TreeDB/docs/spec/dgraph-mvcc-readiness-3673.md
@@ -34,6 +34,9 @@ TreeDB example. `mvcctest.Run` executes:
 - durable close/reopen before and after floor advancement and pruning;
 - nil/empty-key duplicate handling, zero timestamps, durability rejection,
   monotonic floors, and commit/read rejection at the floor;
+- forward/reverse iterator order, logical bounds, prefix and read-time ceiling,
+  directional seek, exact accounting, and caller-owned entry bytes across
+  `Next`, `Seek`, and `Close`;
 - a deterministic seed-3673 randomized point-read and all-version oracle over
   empty, embedded-zero, and `0xff` logical keys;
 - concurrent point readers and writers while an older iterator retains its

--- a/TreeDB/docs/spec/dgraph-mvcc-readiness-3673.md
+++ b/TreeDB/docs/spec/dgraph-mvcc-readiness-3673.md
@@ -39,8 +39,9 @@ TreeDB example. `mvcctest.Run` executes:
   `Next`, `Seek`, and `Close`;
 - a deterministic seed-3673 randomized point-read and all-version oracle over
   empty, embedded-zero, and `0xff` logical keys;
-- concurrent point readers and writers while an older iterator retains its
-  pinned snapshot.
+- concurrent point readers and writers with an invocation/response barrier
+  proving one post-barrier Adapter read/commit call interval overlap, while an
+  older iterator retains its pinned snapshot.
 
 Except for the durable reopen trace, the public suite runs each case against
 both WAL-on relaxed and WAL-off relaxed stores. The durable trace separately

--- a/TreeDB/docs/spec/dgraph-mvcc-readiness-3673.md
+++ b/TreeDB/docs/spec/dgraph-mvcc-readiness-3673.md
@@ -169,6 +169,10 @@ fresh populated database per external sample (`-benchtime=1x`), because
 duration calibration would multiply excluded fixture setup and make process RSS
 describe fixture churn rather than the bounded pruning operation. Five external
 samples still provide five independent prune latency/throughput observations.
+The timer is stopped before the parent temporary directory and all other setup,
+then started only around `PruneVersions`; the earlier `dbea38e0` matrix is
+superseded because its single prune sample included pre-loop temporary-directory
+setup.
 `storage_bytes/op` is normalized final logical file footprint, including fixed
 TreeDB files and preallocation. `durable_footprint_bytes/op` is emitted only for
 the sync-acknowledged rows and remains final logical footprint; it does not
@@ -196,14 +200,15 @@ the pull request run; generated CPU profiles are not committed.
 
 ### Exact-target closeout outcome
 
-The measured code target is
+The raw-path and adapter code target is
 `dbea38e0e8ad0c7d1e0bb05ac564bd9b57dd747a`, compared with base
-`f9c9b2a37838909d0e669818cfa2840c0a8d5f85`. The final pull-request head is a
-post-measure validation, CI-wiring, and evidence descendant: it does not change
-the production MVCC implementation, benchmark definitions, benchmark
-harnesses, or measurement inputs used at `dbea38e0`. The summaries were
-regenerated and revalidated from the preserved raw inputs without rerunning
-the benchmarks.
+`f9c9b2a37838909d0e669818cfa2840c0a8d5f85`. The corrected closeout-matrix
+target is `103f9c5af85d8d6a5801119fc2247be3b9c87fad`, which changes only prune
+timer accounting and its structural guard relative to the previously measured
+matrix target. It does not change the production MVCC implementation. The raw
+and adapter gates were not rerun. After one passing 30-second quiet audit, the
+closeout matrix was rerun exactly once; its summaries were regenerated and
+revalidated from the preserved raw inputs.
 
 - The hosted raw-path verdict is **EQUIVALENT**, not PASS. Its durable-sync row
   measured +27.94% and failed the timing threshold, while all three
@@ -214,8 +219,10 @@ the benchmarks.
   +18.88%/+13.41%. Get rows remained within the 5% revision ceiling.
   Allocations were unchanged, bytes remained flat, and every candidate
   adapter/direct ratio passed the 2x ceiling; the maximum was 1.121x.
-- The five-sample durability-matched closeout matrix completed successfully
-  with all 24 rows and required metrics present.
+- The corrected five-sample durability-matched closeout matrix completed
+  successfully with all 24 rows and required metrics present. The prior matrix
+  is invalid for prune timing and is superseded, not combined with the
+  corrected samples.
 
 The four adapter revision-ceiling misses are accepted only as a scoped risk for
 the first restricted pre-alpha Dgraph benchmark. They are not relabeled as a

--- a/TreeDB/docs/spec/dgraph-mvcc-readiness-3673.md
+++ b/TreeDB/docs/spec/dgraph-mvcc-readiness-3673.md
@@ -139,6 +139,10 @@ matches (`db`, `caching`, and `treedb`). `EQUIVALENT` preserves the measured
 PASS/FAIL medians and deltas but states that no observed difference can be
 attributed to the candidate code; mixed, missing, or malformed binary evidence
 fails closed and cannot produce equivalence acceptance.
+The verdict truth table is `PASS` for a passing measurement, `EQUIVALENT` only
+for a failed measurement with all row binaries matching, and `FAIL` otherwise.
+Machine-readable `no_attributable_regression` is true exactly when the verdict
+is accepted (`PASS` or `EQUIVALENT`).
 
 `scripts/mvcc_adapter_overhead_gate.sh` separately compares public MVCC commit,
 get, and all-version iteration rows with their direct TreeDB/physical controls.

--- a/TreeDB/docs/spec/verification.md
+++ b/TreeDB/docs/spec/verification.md
@@ -381,6 +381,42 @@ is compared on the same base/head with ten samples; because the MVCC path is
 opt-in, its acceptable raw-path regression is at most 5% with no allocation
 increase.
 
+## 10.5 Dgraph MVCC Public Conformance and Closeout
+
+Invariants:
+
+- downstream conformance uses only exported `TreeDB`, `mvcc`, and `mvcctest`
+  APIs; Dgraph-specific envelopes do not become generic TreeDB contracts;
+- one committed golden public trace covers binary-key codec effects, atomic
+  commit/read-at, empty values, tombstones, all-version order, durable reopen,
+  discard floor, and pruning;
+- deterministic randomized and concurrent traces remain reproducible from
+  fixed seeds and bounded operation counts;
+- the Dgraph module pin is an exact merged-main gomap commit containing the
+  closeout, never a worker branch or floating main;
+- raw-path and MVCC evidence name the tested commit, host, Go toolchain,
+  commands, sample count, and artifact location; relaxed and durable rows are
+  never compared as equivalent acknowledgement classes.
+
+Coverage:
+
+- `TreeDB/mvcc/mvcctest` provides the closure-based downstream harness and
+  TreeDB adapter helper; `TreeDB/mvcc/conformance_external_test.go` proves the
+  suite from outside the implementation package and the harness example
+  compiles against the public surface.
+- `TreeDB/internal/mvcckey/testdata/codec_v1_golden.json` pins the internal
+  pre-alpha codec bytes and order independently from the public behavioral
+  trace; existing codec property/fuzz tests continue to cover larger domains.
+- Existing MVCC tests retain direct fault-injection and abrupt-child-exit
+  coverage that a generic in-process adapter factory cannot express.
+- `scripts/mvcc_raw_path_gate.sh` is the <=5% raw-path base/head gate.
+  `scripts/mvcc_closeout_matrix.sh` runs the pinned CommitAt, GetAt,
+  all-version, and pruning depth/durability matrix and captures CPU, peak RSS,
+  normalized storage footprint, `B/op`, and `allocs/op`.
+- `TreeDB/docs/spec/dgraph-mvcc-readiness-3673.md` is the supported/unsupported
+  capability and measurement-boundary closeout; its artifact index records the
+  exact measured commit and compact results.
+
 ## 11. Collections Native Fast Path
 
 Invariant:

--- a/TreeDB/docs/spec/verification.md
+++ b/TreeDB/docs/spec/verification.md
@@ -437,7 +437,13 @@ Coverage:
   trace; existing codec property/fuzz tests continue to cover larger domains.
 - Existing MVCC tests retain direct fault-injection and abrupt-child-exit
   coverage that a generic in-process adapter factory cannot express.
-- `scripts/mvcc_raw_path_gate.sh` is the <=5% raw-path base/head gate.
+- `scripts/mvcc_raw_path_gate.sh` is the <=5% raw-path base/head gate. Its
+  machine-readable verdict distinguishes measured `PASS`/`FAIL` from overall
+  `EQUIVALENT` acceptance. Equivalence requires checker-computed matching
+  SHA-256 digests from all six actual row-producing benchmark binaries; mixed,
+  missing, or malformed binary evidence cannot override a failed measurement.
+  Raw and adapter gates require balanced even AB/BA sample counts and default
+  to eight samples per revision.
   `scripts/mvcc_closeout_matrix.sh` runs the pinned CommitAt, GetAt,
   all-version, and pruning depth/durability matrix and captures CPU, peak RSS,
   normalized storage footprint, `B/op`, and `allocs/op`.

--- a/TreeDB/internal/mvcckey/codec_golden_test.go
+++ b/TreeDB/internal/mvcckey/codec_golden_test.go
@@ -1,0 +1,84 @@
+package mvcckey
+
+import (
+	"bytes"
+	"encoding/hex"
+	"encoding/json"
+	"os"
+	"sort"
+	"testing"
+)
+
+type codecGoldenCase struct {
+	Name        string `json:"name"`
+	LogicalHex  string `json:"logical_hex"`
+	Timestamp   uint64 `json:"timestamp"`
+	PhysicalHex string `json:"physical_hex"`
+}
+
+type codecGoldenFixture struct {
+	Schema        string            `json:"schema"`
+	Cases         []codecGoldenCase `json:"cases"`
+	PhysicalOrder []string          `json:"physical_order"`
+}
+
+func TestCodecV1GoldenFixture(t *testing.T) {
+	raw, err := os.ReadFile("testdata/codec_v1_golden.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	var fixture codecGoldenFixture
+	if err := json.Unmarshal(raw, &fixture); err != nil {
+		t.Fatal(err)
+	}
+	if fixture.Schema != "treedb-mvcc-key-codec-v1" {
+		t.Fatalf("schema=%q", fixture.Schema)
+	}
+	type encodedCase struct {
+		name     string
+		physical []byte
+	}
+	encoded := make([]encodedCase, 0, len(fixture.Cases))
+	for _, testCase := range fixture.Cases {
+		logical, err := hex.DecodeString(testCase.LogicalHex)
+		if err != nil {
+			t.Fatalf("%s logical: %v", testCase.Name, err)
+		}
+		wantPhysical, err := hex.DecodeString(testCase.PhysicalHex)
+		if err != nil {
+			t.Fatalf("%s physical: %v", testCase.Name, err)
+		}
+		gotPhysical, err := Encode(logical, testCase.Timestamp)
+		if err != nil {
+			t.Fatalf("%s Encode: %v", testCase.Name, err)
+		}
+		if !bytes.Equal(gotPhysical, wantPhysical) {
+			t.Fatalf("%s physical=%x want=%x", testCase.Name, gotPhysical, wantPhysical)
+		}
+		gotLogical, gotTimestamp, err := Decode(wantPhysical)
+		if err != nil || !bytes.Equal(gotLogical, logical) || gotTimestamp != testCase.Timestamp {
+			t.Fatalf("%s Decode=(%x,%d,%v) want=(%x,%d,nil)", testCase.Name, gotLogical, gotTimestamp, err, logical, testCase.Timestamp)
+		}
+		encoded = append(encoded, encodedCase{name: testCase.Name, physical: gotPhysical})
+	}
+	sort.Slice(encoded, func(i, j int) bool { return bytes.Compare(encoded[i].physical, encoded[j].physical) < 0 })
+	gotOrder := make([]string, len(encoded))
+	for i := range encoded {
+		gotOrder[i] = encoded[i].name
+	}
+	if !equalStrings(gotOrder, fixture.PhysicalOrder) {
+		t.Fatalf("physical order=%v want=%v", gotOrder, fixture.PhysicalOrder)
+	}
+}
+
+func equalStrings(left, right []string) bool {
+	if len(left) != len(right) {
+		return false
+	}
+	for i := range left {
+		if left[i] != right[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/TreeDB/internal/mvcckey/testdata/codec_v1_golden.json
+++ b/TreeDB/internal/mvcckey/testdata/codec_v1_golden.json
@@ -1,0 +1,42 @@
+{
+  "schema": "treedb-mvcc-key-codec-v1",
+  "cases": [
+    {
+      "name": "empty-oldest",
+      "logical_hex": "",
+      "timestamp": 1,
+      "physical_hex": "005444424d564343010000fffffffffffffffe"
+    },
+    {
+      "name": "embedded-zero-and-ff",
+      "logical_hex": "006100ff",
+      "timestamp": 42,
+      "physical_hex": "005444424d5643430100ff6100ffff0000ffffffffffffffd5"
+    },
+    {
+      "name": "a-zero-b-newest",
+      "logical_hex": "610062",
+      "timestamp": 18446744073709551615,
+      "physical_hex": "005444424d564343016100ff6200000000000000000000"
+    },
+    {
+      "name": "a-zero-b-oldest",
+      "logical_hex": "610062",
+      "timestamp": 1,
+      "physical_hex": "005444424d564343016100ff620000fffffffffffffffe"
+    },
+    {
+      "name": "ff-midpoint",
+      "logical_hex": "ff",
+      "timestamp": 9223372036854775808,
+      "physical_hex": "005444424d56434301ff00007fffffffffffffff"
+    }
+  ],
+  "physical_order": [
+    "empty-oldest",
+    "embedded-zero-and-ff",
+    "a-zero-b-newest",
+    "a-zero-b-oldest",
+    "ff-midpoint"
+  ]
+}

--- a/TreeDB/mvcc/closeout_bench_test.go
+++ b/TreeDB/mvcc/closeout_bench_test.go
@@ -3,6 +3,7 @@ package mvcc
 import (
 	"fmt"
 	"io/fs"
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -138,10 +139,16 @@ func benchmarkCloseoutAllVersions(b *testing.B, profile closeoutProfile, keys, d
 func benchmarkCloseoutPrune(b *testing.B, profile closeoutProfile, keys, depth, floor int) {
 	var total PruneStats
 	var storageBytes uint64
+	parentDir := b.TempDir()
 	b.ReportAllocs()
 	for i := 0; i < b.N; i++ {
 		b.StopTimer()
-		db, store, dir := openCloseoutBench(b, profile)
+		dir, err := os.MkdirTemp(parentDir, "prune-")
+		if err != nil {
+			b.Fatal(err)
+		}
+		db := openTestDB(b, dir, profile.durability)
+		store := New(db)
 		closeoutPrepareHistory(b, store, keys, depth, profile.mode)
 		if err := store.AdvanceDiscardFloor(uint64(floor), profile.mode); err != nil {
 			b.Fatal(err)
@@ -156,6 +163,9 @@ func benchmarkCloseoutPrune(b *testing.B, profile closeoutProfile, keys, depth, 
 			b.Fatal(err)
 		}
 		storageBytes += closeoutDirectoryBytes(b, dir)
+		if err := os.RemoveAll(dir); err != nil {
+			b.Fatal(err)
+		}
 		total.Visited += stats.Visited
 		total.Skipped += stats.Skipped
 		total.Retained += stats.Retained

--- a/TreeDB/mvcc/closeout_bench_test.go
+++ b/TreeDB/mvcc/closeout_bench_test.go
@@ -137,6 +137,7 @@ func benchmarkCloseoutAllVersions(b *testing.B, profile closeoutProfile, keys, d
 }
 
 func benchmarkCloseoutPrune(b *testing.B, profile closeoutProfile, keys, depth, floor int) {
+	b.StopTimer()
 	var total PruneStats
 	var storageBytes uint64
 	parentDir := b.TempDir()

--- a/TreeDB/mvcc/closeout_bench_test.go
+++ b/TreeDB/mvcc/closeout_bench_test.go
@@ -1,0 +1,221 @@
+package mvcc
+
+import (
+	"fmt"
+	"io/fs"
+	"path/filepath"
+	"testing"
+
+	treedb "github.com/snissn/gomap/TreeDB"
+)
+
+type closeoutProfile struct {
+	name       string
+	durability treedb.DurabilityMode
+	mode       CommitMode
+}
+
+var closeoutProfiles = []closeoutProfile{
+	{name: "durable_sync", durability: treedb.DurabilityDurable, mode: CommitDurable},
+	{name: "wal_on_relaxed", durability: treedb.DurabilityWALOnRelaxed, mode: CommitRelaxed},
+	{name: "wal_off_relaxed", durability: treedb.DurabilityWALOffRelaxed, mode: CommitRelaxed},
+}
+
+// BenchmarkDgraphMVCCCloseout is the pinned downstream-readiness matrix. Its
+// durability classes are intentionally separate sub-benchmarks: the relaxed
+// rows are not presented as equivalent to durable acknowledgement.
+func BenchmarkDgraphMVCCCloseout(b *testing.B) {
+	for _, profile := range closeoutProfiles {
+		profile := profile
+		for _, batchSize := range []int{1, 32} {
+			batchSize := batchSize
+			b.Run(fmt.Sprintf("CommitAt/%s/batch=%d", profile.name, batchSize), func(b *testing.B) {
+				benchmarkCloseoutCommitAt(b, profile, batchSize)
+			})
+		}
+		for _, depth := range []int{1, 64} {
+			depth := depth
+			b.Run(fmt.Sprintf("GetAt/%s/depth=%d", profile.name, depth), func(b *testing.B) {
+				benchmarkCloseoutGetAt(b, profile, depth)
+			})
+		}
+		for _, depth := range []int{1, 32} {
+			depth := depth
+			b.Run(fmt.Sprintf("AllVersions/%s/keys=64/depth=%d", profile.name, depth), func(b *testing.B) {
+				benchmarkCloseoutAllVersions(b, profile, 64, depth)
+			})
+		}
+		for _, floor := range []int{4, 12} {
+			floor := floor
+			b.Run(fmt.Sprintf("Prune/%s/keys=64/depth=16/floor=%d", profile.name, floor), func(b *testing.B) {
+				benchmarkCloseoutPrune(b, profile, 64, 16, floor)
+			})
+		}
+	}
+}
+
+func benchmarkCloseoutCommitAt(b *testing.B, profile closeoutProfile, batchSize int) {
+	db, store, dir := openCloseoutBench(b, profile)
+	mutations := make([]Mutation, batchSize)
+	for i := range mutations {
+		mutations[i] = Mutation{Key: []byte(fmt.Sprintf("key-%03d", i)), Value: []byte("value")}
+	}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if err := store.CommitAt(uint64(i+1), mutations, profile.mode); err != nil {
+			b.Fatal(err)
+		}
+	}
+	b.StopTimer()
+	if err := db.Close(); err != nil {
+		b.Fatal(err)
+	}
+	storageBytes := closeoutDirectoryBytes(b, dir)
+	b.ReportMetric(float64(batchSize*b.N)/b.Elapsed().Seconds(), "mutations/s")
+	b.ReportMetric(float64(storageBytes)/float64(max(b.N, 1)), "storage_bytes/op")
+	if profile.mode == CommitDurable {
+		b.ReportMetric(float64(storageBytes)/float64(max(b.N, 1)), "durable_bytes/op")
+	}
+}
+
+func benchmarkCloseoutGetAt(b *testing.B, profile closeoutProfile, depth int) {
+	db, store, _ := openCloseoutBench(b, profile)
+	key := []byte("benchmark-key")
+	for timestamp := 1; timestamp <= depth; timestamp++ {
+		if err := store.CommitAt(uint64(timestamp), []Mutation{{Key: key, Value: []byte("value")}}, profile.mode); err != nil {
+			b.Fatal(err)
+		}
+	}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		result, err := store.GetAt(key, uint64(depth+1))
+		if err != nil || result.State != Present || len(result.Value) == 0 {
+			b.Fatalf("GetAt result=%+v err=%v", result, err)
+		}
+	}
+	b.ReportMetric(float64(b.N)/b.Elapsed().Seconds(), "lookups/s")
+	b.StopTimer()
+	if err := db.Close(); err != nil {
+		b.Fatal(err)
+	}
+}
+
+func benchmarkCloseoutAllVersions(b *testing.B, profile closeoutProfile, keys, depth int) {
+	db, store, _ := openCloseoutBench(b, profile)
+	closeoutPrepareHistory(b, store, keys, depth, profile.mode)
+	versions := uint64(keys * depth)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		it, err := store.IterateVersions(VersionIteratorOptions{})
+		if err != nil {
+			b.Fatal(err)
+		}
+		var seen uint64
+		for it.Valid() {
+			entry := it.Entry()
+			if len(entry.Key) == 0 {
+				b.Fatal("empty benchmark key")
+			}
+			seen++
+			it.Next()
+		}
+		iterErr := it.Error()
+		closeErr := it.Close()
+		if iterErr != nil || closeErr != nil || seen != versions {
+			b.Fatalf("seen=%d iterErr=%v closeErr=%v", seen, iterErr, closeErr)
+		}
+	}
+	b.ReportMetric(float64(versions*uint64(b.N))/b.Elapsed().Seconds(), "versions/s")
+	b.StopTimer()
+	if err := db.Close(); err != nil {
+		b.Fatal(err)
+	}
+}
+
+func benchmarkCloseoutPrune(b *testing.B, profile closeoutProfile, keys, depth, floor int) {
+	var total PruneStats
+	var storageBytes uint64
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		b.StopTimer()
+		db, store, dir := openCloseoutBench(b, profile)
+		closeoutPrepareHistory(b, store, keys, depth, profile.mode)
+		if err := store.AdvanceDiscardFloor(uint64(floor), profile.mode); err != nil {
+			b.Fatal(err)
+		}
+		b.StartTimer()
+		stats, err := store.PruneVersions(PruneOptions{BatchSize: 256, Mode: profile.mode})
+		if err != nil {
+			b.Fatal(err)
+		}
+		b.StopTimer()
+		if err := db.Close(); err != nil {
+			b.Fatal(err)
+		}
+		storageBytes += closeoutDirectoryBytes(b, dir)
+		total.Visited += stats.Visited
+		total.Skipped += stats.Skipped
+		total.Retained += stats.Retained
+		total.Pruned += stats.Pruned
+		total.PrunedBytes += stats.PrunedBytes
+		total.DeleteWriteBytes += stats.DeleteWriteBytes
+		b.StartTimer()
+	}
+	b.StopTimer()
+	wantPruned := uint64(keys * (floor - 1) * b.N)
+	if total.Pruned != wantPruned || total.Visited != total.Retained+total.Pruned {
+		b.Fatalf("stats=%+v want pruned=%d", total, wantPruned)
+	}
+	b.ReportMetric(float64(total.Pruned)/b.Elapsed().Seconds(), "pruned_versions/s")
+	b.ReportMetric(float64(total.DeleteWriteBytes)/float64(max(total.PrunedBytes, 1)), "delete_write_amplification")
+	b.ReportMetric(float64(storageBytes)/float64(max(b.N, 1)), "storage_bytes/op")
+	if profile.mode == CommitDurable {
+		b.ReportMetric(float64(storageBytes)/float64(max(b.N, 1)), "durable_bytes/op")
+	}
+}
+
+func openCloseoutBench(b *testing.B, profile closeoutProfile) (*treedb.DB, *Store, string) {
+	b.Helper()
+	dir := b.TempDir()
+	db := openTestDB(b, dir, profile.durability)
+	return db, New(db), dir
+}
+
+func closeoutPrepareHistory(b *testing.B, store *Store, keys, depth int, mode CommitMode) {
+	b.Helper()
+	mutations := make([]Mutation, keys)
+	for key := range mutations {
+		mutations[key] = Mutation{Key: []byte(fmt.Sprintf("key-%06d", key)), Value: []byte("value")}
+	}
+	for timestamp := 1; timestamp <= depth; timestamp++ {
+		if err := store.CommitAt(uint64(timestamp), mutations, mode); err != nil {
+			b.Fatalf("prepare CommitAt(%d): %v", timestamp, err)
+		}
+	}
+}
+
+func closeoutDirectoryBytes(b *testing.B, root string) uint64 {
+	b.Helper()
+	var total uint64
+	err := filepath.WalkDir(root, func(path string, entry fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if entry.IsDir() {
+			return nil
+		}
+		info, err := entry.Info()
+		if err != nil {
+			return err
+		}
+		total += uint64(info.Size())
+		return nil
+	})
+	if err != nil {
+		b.Fatalf("measure %s: %v", root, err)
+	}
+	return total
+}

--- a/TreeDB/mvcc/closeout_bench_test.go
+++ b/TreeDB/mvcc/closeout_bench_test.go
@@ -76,7 +76,7 @@ func benchmarkCloseoutCommitAt(b *testing.B, profile closeoutProfile, batchSize 
 	b.ReportMetric(float64(batchSize*b.N)/b.Elapsed().Seconds(), "mutations/s")
 	b.ReportMetric(float64(storageBytes)/float64(max(b.N, 1)), "storage_bytes/op")
 	if profile.mode == CommitDurable {
-		b.ReportMetric(float64(storageBytes)/float64(max(b.N, 1)), "durable_bytes/op")
+		b.ReportMetric(float64(storageBytes)/float64(max(b.N, 1)), "durable_footprint_bytes/op")
 	}
 }
 
@@ -183,7 +183,7 @@ func benchmarkCloseoutPrune(b *testing.B, profile closeoutProfile, keys, depth, 
 	b.ReportMetric(float64(total.DeleteWriteBytes)/float64(max(total.PrunedBytes, 1)), "delete_write_amplification")
 	b.ReportMetric(float64(storageBytes)/float64(max(b.N, 1)), "storage_bytes/op")
 	if profile.mode == CommitDurable {
-		b.ReportMetric(float64(storageBytes)/float64(max(b.N, 1)), "durable_bytes/op")
+		b.ReportMetric(float64(storageBytes)/float64(max(b.N, 1)), "durable_footprint_bytes/op")
 	}
 }
 

--- a/TreeDB/mvcc/conformance_external_test.go
+++ b/TreeDB/mvcc/conformance_external_test.go
@@ -1,0 +1,39 @@
+package mvcc_test
+
+import (
+	"fmt"
+	"testing"
+
+	treedb "github.com/snissn/gomap/TreeDB"
+	"github.com/snissn/gomap/TreeDB/mvcc"
+	"github.com/snissn/gomap/TreeDB/mvcc/mvcctest"
+)
+
+func TestPublicSurfaceConformance(t *testing.T) {
+	mvcctest.Run(t, openConformanceAdapter)
+}
+
+func openConformanceAdapter(dir string, class mvcctest.DurabilityClass) (mvcctest.Adapter, error) {
+	var durability treedb.DurabilityMode
+	switch class {
+	case mvcctest.DurabilityDurable:
+		durability = treedb.DurabilityDurable
+	case mvcctest.DurabilityWALOnRelaxed:
+		durability = treedb.DurabilityWALOnRelaxed
+	case mvcctest.DurabilityWALOffRelaxed:
+		durability = treedb.DurabilityWALOffRelaxed
+	default:
+		return mvcctest.Adapter{}, fmt.Errorf("unsupported durability class %q", class)
+	}
+	db, err := treedb.Open(treedb.Options{
+		Dir:                          dir,
+		Durability:                   durability,
+		CommandWAL:                   durability != treedb.DurabilityWALOffRelaxed,
+		DisableSideStores:            true,
+		BackgroundCheckpointInterval: -1,
+	})
+	if err != nil {
+		return mvcctest.Adapter{}, err
+	}
+	return mvcctest.FromStore(mvcc.New(db), db.Close), nil
+}

--- a/TreeDB/mvcc/mvcctest/adapter.go
+++ b/TreeDB/mvcc/mvcctest/adapter.go
@@ -1,0 +1,101 @@
+// Package mvcctest provides a reusable conformance suite for adapters built on
+// TreeDB's public external-timestamp MVCC surface.
+//
+// The package deliberately models operations as function fields. Downstream
+// adapters can translate their own iterator and lifecycle types without making
+// those types implement a TreeDB-specific interface.
+package mvcctest
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/snissn/gomap/TreeDB/mvcc"
+)
+
+// DurabilityClass names the storage acknowledgement class requested by a
+// conformance test. OpenFunc maps it to the backend's concrete options.
+type DurabilityClass string
+
+const (
+	DurabilityDurable       DurabilityClass = "durable"
+	DurabilityWALOnRelaxed  DurabilityClass = "wal_on_relaxed"
+	DurabilityWALOffRelaxed DurabilityClass = "wal_off_relaxed"
+)
+
+// Iterator is the retained-version iterator surface consumed by the harness.
+type Iterator interface {
+	Valid() bool
+	Entry() mvcc.Version
+	Next()
+	Seek(logical []byte, timestamp uint64)
+	Stats() mvcc.VersionIteratorStats
+	Error() error
+	Close() error
+}
+
+// Adapter is the smallest public MVCC surface exercised by the conformance
+// suite. Close must close the owning database handle.
+type Adapter struct {
+	CommitAt            func(uint64, []mvcc.Mutation, mvcc.CommitMode) error
+	GetAt               func([]byte, uint64) (mvcc.Result, error)
+	IterateVersions     func(mvcc.VersionIteratorOptions) (Iterator, error)
+	DiscardFloor        func() (uint64, error)
+	AdvanceDiscardFloor func(uint64, mvcc.CommitMode) error
+	PruneVersions       func(mvcc.PruneOptions) (mvcc.PruneStats, error)
+	Close               func() error
+}
+
+// OpenFunc opens one adapter rooted at dir. A later call with the same dir is
+// a reopen and must observe the prior durable state.
+type OpenFunc func(dir string, durability DurabilityClass) (Adapter, error)
+
+// FromStore adapts an mvcc.Store plus its owning database close function.
+func FromStore(store *mvcc.Store, closeFn func() error) Adapter {
+	if store == nil {
+		return Adapter{Close: closeFn}
+	}
+	return Adapter{
+		CommitAt: store.CommitAt,
+		GetAt:    store.GetAt,
+		IterateVersions: func(options mvcc.VersionIteratorOptions) (Iterator, error) {
+			return store.IterateVersions(options)
+		},
+		DiscardFloor:        store.DiscardFloor,
+		AdvanceDiscardFloor: store.AdvanceDiscardFloor,
+		PruneVersions:       store.PruneVersions,
+		Close:               closeFn,
+	}
+}
+
+func (adapter Adapter) validate() error {
+	var missing []string
+	checks := []struct {
+		name string
+		ok   bool
+	}{
+		{"CommitAt", adapter.CommitAt != nil},
+		{"GetAt", adapter.GetAt != nil},
+		{"IterateVersions", adapter.IterateVersions != nil},
+		{"DiscardFloor", adapter.DiscardFloor != nil},
+		{"AdvanceDiscardFloor", adapter.AdvanceDiscardFloor != nil},
+		{"PruneVersions", adapter.PruneVersions != nil},
+		{"Close", adapter.Close != nil},
+	}
+	for _, check := range checks {
+		if !check.ok {
+			missing = append(missing, check.name)
+		}
+	}
+	if len(missing) != 0 {
+		return fmt.Errorf("mvcctest: incomplete adapter: %v", missing)
+	}
+	return nil
+}
+
+func closeAdapter(adapter Adapter) error {
+	if adapter.Close == nil {
+		return errors.New("mvcctest: adapter has no Close function")
+	}
+	return adapter.Close()
+}

--- a/TreeDB/mvcc/mvcctest/conformance.go
+++ b/TreeDB/mvcc/mvcctest/conformance.go
@@ -65,6 +65,7 @@ func Run(t *testing.T, open OpenFunc) {
 	}
 	t.Run("golden_reopen_floor_prune", func(t *testing.T) { runGolden(t, open) })
 	t.Run("validation_boundaries", func(t *testing.T) { runBoundaries(t, open) })
+	t.Run("iterator_options_seek_stats_ownership", func(t *testing.T) { runIteratorSurface(t, open) })
 	t.Run("randomized_oracle", func(t *testing.T) { runRandomized(t, open) })
 	t.Run("concurrent_snapshot_readers", func(t *testing.T) { runConcurrent(t, open) })
 }
@@ -158,6 +159,104 @@ func runBoundaries(t *testing.T, open OpenFunc) {
 	}
 	if err := adapter.CommitAt(5, []mvcc.Mutation{{Key: []byte("late")}}, mvcc.CommitRelaxed); !errors.Is(err, mvcc.ErrVersionBelowDiscardFloor) {
 		t.Fatalf("commit at floor err=%v", err)
+	}
+}
+
+func runIteratorSurface(t *testing.T, open OpenFunc) {
+	adapter := requireOpen(t, open, t.TempDir(), DurabilityWALOffRelaxed)
+	defer requireClose(t, adapter)
+	type mutationAt struct {
+		key       string
+		timestamp uint64
+		value     string
+		deleted   bool
+	}
+	for _, mutation := range []mutationAt{
+		{key: "a", timestamp: 10, value: "a10"},
+		{key: "a", timestamp: 20, deleted: true},
+		{key: "a", timestamp: 30, value: "a30"},
+		{key: "b", timestamp: 5, value: "b5"},
+		{key: "b", timestamp: 25, value: "b25"},
+		{key: "ba", timestamp: 15, value: "ba15"},
+		{key: "c", timestamp: 1, value: "c1"},
+	} {
+		err := adapter.CommitAt(mutation.timestamp, []mvcc.Mutation{{
+			Key: []byte(mutation.key), Value: []byte(mutation.value), Delete: mutation.deleted,
+		}}, mvcc.CommitRelaxed)
+		if err != nil {
+			t.Fatalf("CommitAt(%q,%d): %v", mutation.key, mutation.timestamp, err)
+		}
+	}
+
+	forward, err := adapter.IterateVersions(mvcc.VersionIteratorOptions{
+		LowerBound: []byte("a"), UpperBound: []byte("c"),
+	})
+	if err != nil {
+		t.Fatalf("forward bounded iterator: %v", err)
+	}
+	requireIteratorLabels(t, forward, []string{
+		"61@30:present:613330", "61@20:tombstone:", "61@10:present:613130",
+		"62@25:present:623235", "62@5:present:6235", "6261@15:present:62613135",
+	})
+
+	reverse, err := adapter.IterateVersions(mvcc.VersionIteratorOptions{
+		Prefix: []byte("b"), ReadTimestamp: 20, Reverse: true,
+	})
+	if err != nil {
+		t.Fatalf("reverse prefix iterator: %v", err)
+	}
+	stats := requireIteratorLabels(t, reverse, []string{
+		"6261@15:present:62613135", "62@5:present:6235",
+	})
+	if stats.Visited != 3 || stats.Skipped != 1 || stats.Retained != 2 || stats.Visited != stats.Skipped+stats.Retained {
+		t.Fatalf("reverse iterator stats=%+v", stats)
+	}
+
+	seek, err := adapter.IterateVersions(mvcc.VersionIteratorOptions{})
+	if err != nil {
+		t.Fatalf("forward seek iterator: %v", err)
+	}
+	seek.Seek([]byte("b"), 20)
+	if !seek.Valid() {
+		t.Fatalf("forward Seek invalid: %v", seek.Error())
+	}
+	owned := seek.Entry()
+	if string(owned.Key) != "b" || owned.Timestamp != 5 || string(owned.Value) != "b5" {
+		t.Fatalf("forward Seek entry=%+v", owned)
+	}
+	seek.Next()
+	if string(owned.Key) != "b" || owned.Timestamp != 5 || string(owned.Value) != "b5" {
+		t.Fatalf("Entry bytes changed after Next: %+v", owned)
+	}
+	seek.Seek([]byte("b"), 20)
+	mutableCopy := seek.Entry()
+	mutableCopy.Key[0], mutableCopy.Value[0] = 'x', 'x'
+	seek.Seek([]byte("b"), 20)
+	again := seek.Entry()
+	if string(again.Key) != "b" || again.Timestamp != 5 || string(again.Value) != "b5" {
+		t.Fatalf("Entry bytes were not caller-owned: %+v", again)
+	}
+	if err := seek.Close(); err != nil {
+		t.Fatalf("close forward seek iterator: %v", err)
+	}
+	if string(owned.Key) != "b" || owned.Timestamp != 5 || string(owned.Value) != "b5" {
+		t.Fatalf("Entry bytes changed after Close: %+v", owned)
+	}
+
+	reverseSeek, err := adapter.IterateVersions(mvcc.VersionIteratorOptions{Reverse: true})
+	if err != nil {
+		t.Fatalf("reverse seek iterator: %v", err)
+	}
+	reverseSeek.Seek([]byte("b"), 20)
+	if !reverseSeek.Valid() {
+		t.Fatalf("reverse Seek invalid: %v", reverseSeek.Error())
+	}
+	reverseEntry := reverseSeek.Entry()
+	if string(reverseEntry.Key) != "b" || reverseEntry.Timestamp != 25 || string(reverseEntry.Value) != "b25" {
+		t.Fatalf("reverse Seek entry=%+v", reverseEntry)
+	}
+	if err := reverseSeek.Close(); err != nil {
+		t.Fatalf("close reverse seek iterator: %v", err)
 	}
 }
 
@@ -257,7 +356,7 @@ func runConcurrent(t *testing.T, open OpenFunc) {
 			defer wg.Done()
 			for i := 0; i < 100; i++ {
 				got, err := adapter.GetAt([]byte("k"), 80)
-				if err != nil || (got.State != mvcc.Present && got.State != mvcc.Absent) {
+				if err != nil || got.State != mvcc.Present || got.Timestamp < 1 || got.Timestamp > 80 || string(got.Value) != fmt.Sprint(got.Timestamp) {
 					errCh <- fmt.Errorf("concurrent GetAt result=%+v err=%v", got, err)
 					return
 				}
@@ -339,12 +438,18 @@ func requireVersions(t testing.TB, adapter Adapter, want []string) {
 	if err != nil {
 		t.Fatalf("IterateVersions: %v", err)
 	}
+	requireIteratorLabels(t, it, want)
+}
+
+func requireIteratorLabels(t testing.TB, it Iterator, want []string) mvcc.VersionIteratorStats {
+	t.Helper()
 	var got []string
 	for it.Valid() {
 		entry := it.Entry()
 		got = append(got, versionLabel(entry.Key, entry.Timestamp, entry.State, entry.Value))
 		it.Next()
 	}
+	stats := it.Stats()
 	iterErr := it.Error()
 	closeErr := it.Close()
 	if iterErr != nil || closeErr != nil {
@@ -353,6 +458,7 @@ func requireVersions(t testing.TB, adapter Adapter, want []string) {
 	if fmt.Sprint(got) != fmt.Sprint(want) {
 		t.Fatalf("versions:\n got %v\nwant %v", got, want)
 	}
+	return stats
 }
 
 func oracleAt(versions []oracleVersion, timestamp uint64) oracleVersion {

--- a/TreeDB/mvcc/mvcctest/conformance.go
+++ b/TreeDB/mvcc/mvcctest/conformance.go
@@ -12,6 +12,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 
 	"github.com/snissn/gomap/TreeDB/mvcc"
@@ -343,8 +344,58 @@ func runConcurrent(t *testing.T, open OpenFunc, durability DurabilityClass) {
 		}
 	}()
 
+	// Prove one post-barrier read/commit overlap at the public Adapter call
+	// boundary. The wrappers make both invocations enter before either may call
+	// through and return, so this is independent of which goroutine the
+	// scheduler runs first and does not require backend-specific hooks.
+	originalCommitAt := adapter.CommitAt
+	originalGetAt := adapter.GetAt
+	proofCommitCall := make(chan struct{})
+	proofReadCall := make(chan struct{})
+	proofAbort := make(chan struct{})
+	var proofAbortOnce sync.Once
+	var proofEnabled atomic.Bool
+	var proofReadClaimed atomic.Bool
+	var proofCommitEntered atomic.Bool
+	var proofReadEntered atomic.Bool
+	abortProof := func() { proofAbortOnce.Do(func() { close(proofAbort) }) }
+	waitForProofPeer := func(peer <-chan struct{}) error {
+		select {
+		case <-peer:
+			return nil
+		case <-proofAbort:
+			return errors.New("mvcctest: concurrent overlap proof aborted")
+		}
+	}
+	adapter.CommitAt = func(timestamp uint64, mutations []mvcc.Mutation, mode mvcc.CommitMode) error {
+		if !proofEnabled.Load() || timestamp != 18 {
+			return originalCommitAt(timestamp, mutations, mode)
+		}
+		proofCommitEntered.Store(true)
+		close(proofCommitCall)
+		if err := waitForProofPeer(proofReadCall); err != nil {
+			return err
+		}
+		return originalCommitAt(timestamp, mutations, mode)
+	}
+	adapter.GetAt = func(key []byte, timestamp uint64) (mvcc.Result, error) {
+		if !proofEnabled.Load() || !proofReadClaimed.CompareAndSwap(false, true) {
+			return originalGetAt(key, timestamp)
+		}
+		proofReadEntered.Store(true)
+		close(proofReadCall)
+		if err := waitForProofPeer(proofCommitCall); err != nil {
+			return mvcc.Result{}, err
+		}
+		return originalGetAt(key, timestamp)
+	}
+
 	var wg sync.WaitGroup
 	errCh := make(chan error, 9)
+	reportError := func(err error) {
+		abortProof()
+		errCh <- err
+	}
 	start := make(chan struct{})
 	writerStarted := make(chan struct{})
 	overlap := make(chan struct{})
@@ -354,7 +405,7 @@ func runConcurrent(t *testing.T, open OpenFunc, durability DurabilityClass) {
 		defer wg.Done()
 		<-start
 		if err := adapter.CommitAt(17, []mvcc.Mutation{{Key: []byte("k"), Value: []byte("17")}}, mvcc.CommitRelaxed); err != nil {
-			errCh <- err
+			reportError(err)
 			close(writerStarted)
 			return
 		}
@@ -362,7 +413,7 @@ func runConcurrent(t *testing.T, open OpenFunc, durability DurabilityClass) {
 		<-overlap
 		for timestamp := uint64(18); timestamp <= 80; timestamp++ {
 			if err := adapter.CommitAt(timestamp, []mvcc.Mutation{{Key: []byte("k"), Value: []byte(fmt.Sprint(timestamp))}}, mvcc.CommitRelaxed); err != nil {
-				errCh <- err
+				reportError(err)
 				return
 			}
 		}
@@ -376,7 +427,7 @@ func runConcurrent(t *testing.T, open OpenFunc, durability DurabilityClass) {
 			for i := 0; i < 100; i++ {
 				got, err := adapter.GetAt([]byte("k"), 80)
 				if err != nil || got.State != mvcc.Present || got.Timestamp < 1 || got.Timestamp > 80 || string(got.Value) != fmt.Sprint(got.Timestamp) {
-					errCh <- fmt.Errorf("concurrent GetAt result=%+v err=%v", got, err)
+					reportError(fmt.Errorf("concurrent GetAt result=%+v err=%v", got, err))
 					return
 				}
 				if i == 0 {
@@ -388,20 +439,34 @@ func runConcurrent(t *testing.T, open OpenFunc, durability DurabilityClass) {
 	}
 	close(start)
 	<-writerStarted
+	var barrierErr error
 	for reader := 0; reader < 8; reader++ {
 		select {
 		case <-readerProgress:
 		case err := <-errCh:
-			t.Fatalf("reader failed before overlap barrier: %v", err)
+			barrierErr = fmt.Errorf("reader failed before overlap barrier: %w", err)
 		}
+		if barrierErr != nil {
+			break
+		}
+	}
+	if barrierErr == nil {
+		proofEnabled.Store(true)
 	}
 	close(overlap)
 	wg.Wait()
+	abortProof()
 	close(errCh)
+	if barrierErr != nil {
+		t.Fatal(barrierErr)
+	}
 	for err := range errCh {
 		if err != nil {
 			t.Fatal(err)
 		}
+	}
+	if !proofCommitEntered.Load() || !proofReadEntered.Load() {
+		t.Fatalf("post-barrier Adapter calls did not overlap: commit=%t read=%t", proofCommitEntered.Load(), proofReadEntered.Load())
 	}
 
 	var pinnedLabels []string

--- a/TreeDB/mvcc/mvcctest/conformance.go
+++ b/TreeDB/mvcc/mvcctest/conformance.go
@@ -64,10 +64,15 @@ func Run(t *testing.T, open OpenFunc) {
 		t.Fatal("mvcctest: nil OpenFunc")
 	}
 	t.Run("golden_reopen_floor_prune", func(t *testing.T) { runGolden(t, open) })
-	t.Run("validation_boundaries", func(t *testing.T) { runBoundaries(t, open) })
-	t.Run("iterator_options_seek_stats_ownership", func(t *testing.T) { runIteratorSurface(t, open) })
-	t.Run("randomized_oracle", func(t *testing.T) { runRandomized(t, open) })
-	t.Run("concurrent_snapshot_readers", func(t *testing.T) { runConcurrent(t, open) })
+	for _, durability := range []DurabilityClass{DurabilityWALOnRelaxed, DurabilityWALOffRelaxed} {
+		durability := durability
+		t.Run(string(durability), func(t *testing.T) {
+			t.Run("validation_boundaries", func(t *testing.T) { runBoundaries(t, open, durability) })
+			t.Run("iterator_options_seek_stats_ownership", func(t *testing.T) { runIteratorSurface(t, open, durability) })
+			t.Run("randomized_oracle", func(t *testing.T) { runRandomized(t, open, durability) })
+			t.Run("concurrent_snapshot_readers", func(t *testing.T) { runConcurrent(t, open, durability) })
+		})
+	}
 }
 
 func runGolden(t *testing.T, open OpenFunc) {
@@ -133,8 +138,8 @@ func runGolden(t *testing.T, open OpenFunc) {
 	requireClose(t, adapter)
 }
 
-func runBoundaries(t *testing.T, open OpenFunc) {
-	adapter := requireOpen(t, open, t.TempDir(), DurabilityWALOffRelaxed)
+func runBoundaries(t *testing.T, open OpenFunc, durability DurabilityClass) {
+	adapter := requireOpen(t, open, t.TempDir(), durability)
 	defer requireClose(t, adapter)
 	if err := adapter.CommitAt(0, []mvcc.Mutation{{Key: []byte("k")}}, mvcc.CommitRelaxed); !errors.Is(err, mvcc.ErrZeroTimestamp) {
 		t.Fatalf("zero timestamp err=%v", err)
@@ -162,8 +167,8 @@ func runBoundaries(t *testing.T, open OpenFunc) {
 	}
 }
 
-func runIteratorSurface(t *testing.T, open OpenFunc) {
-	adapter := requireOpen(t, open, t.TempDir(), DurabilityWALOffRelaxed)
+func runIteratorSurface(t *testing.T, open OpenFunc, durability DurabilityClass) {
+	adapter := requireOpen(t, open, t.TempDir(), durability)
 	defer requireClose(t, adapter)
 	type mutationAt struct {
 		key       string
@@ -266,8 +271,8 @@ type oracleVersion struct {
 	value     []byte
 }
 
-func runRandomized(t *testing.T, open OpenFunc) {
-	adapter := requireOpen(t, open, t.TempDir(), DurabilityWALOffRelaxed)
+func runRandomized(t *testing.T, open OpenFunc, durability DurabilityClass) {
+	adapter := requireOpen(t, open, t.TempDir(), durability)
 	defer requireClose(t, adapter)
 	rng := rand.New(rand.NewSource(3673))
 	keys := [][]byte{nil, {0}, {0, 'a'}, {'a'}, {'a', 0, 'b'}, {0xff}, {0xff, 0, 1}}
@@ -319,8 +324,8 @@ func runRandomized(t *testing.T, open OpenFunc) {
 	requireVersions(t, adapter, want)
 }
 
-func runConcurrent(t *testing.T, open OpenFunc) {
-	adapter := requireOpen(t, open, t.TempDir(), DurabilityWALOffRelaxed)
+func runConcurrent(t *testing.T, open OpenFunc, durability DurabilityClass) {
+	adapter := requireOpen(t, open, t.TempDir(), durability)
 	defer requireClose(t, adapter)
 	for timestamp := uint64(1); timestamp <= 16; timestamp++ {
 		if err := adapter.CommitAt(timestamp, []mvcc.Mutation{{Key: []byte("k"), Value: []byte(fmt.Sprint(timestamp))}}, mvcc.CommitRelaxed); err != nil {
@@ -340,10 +345,22 @@ func runConcurrent(t *testing.T, open OpenFunc) {
 
 	var wg sync.WaitGroup
 	errCh := make(chan error, 9)
+	start := make(chan struct{})
+	writerStarted := make(chan struct{})
+	overlap := make(chan struct{})
+	readerProgress := make(chan struct{}, 8)
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
-		for timestamp := uint64(17); timestamp <= 80; timestamp++ {
+		<-start
+		if err := adapter.CommitAt(17, []mvcc.Mutation{{Key: []byte("k"), Value: []byte("17")}}, mvcc.CommitRelaxed); err != nil {
+			errCh <- err
+			close(writerStarted)
+			return
+		}
+		close(writerStarted)
+		<-overlap
+		for timestamp := uint64(18); timestamp <= 80; timestamp++ {
 			if err := adapter.CommitAt(timestamp, []mvcc.Mutation{{Key: []byte("k"), Value: []byte(fmt.Sprint(timestamp))}}, mvcc.CommitRelaxed); err != nil {
 				errCh <- err
 				return
@@ -354,15 +371,31 @@ func runConcurrent(t *testing.T, open OpenFunc) {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
+			<-start
+			<-writerStarted
 			for i := 0; i < 100; i++ {
 				got, err := adapter.GetAt([]byte("k"), 80)
 				if err != nil || got.State != mvcc.Present || got.Timestamp < 1 || got.Timestamp > 80 || string(got.Value) != fmt.Sprint(got.Timestamp) {
 					errCh <- fmt.Errorf("concurrent GetAt result=%+v err=%v", got, err)
 					return
 				}
+				if i == 0 {
+					readerProgress <- struct{}{}
+					<-overlap
+				}
 			}
 		}()
 	}
+	close(start)
+	<-writerStarted
+	for reader := 0; reader < 8; reader++ {
+		select {
+		case <-readerProgress:
+		case err := <-errCh:
+			t.Fatalf("reader failed before overlap barrier: %v", err)
+		}
+	}
+	close(overlap)
 	wg.Wait()
 	close(errCh)
 	for err := range errCh {

--- a/TreeDB/mvcc/mvcctest/conformance.go
+++ b/TreeDB/mvcc/mvcctest/conformance.go
@@ -1,0 +1,415 @@
+package mvcctest
+
+import (
+	"bytes"
+	_ "embed"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"math/rand"
+	"sort"
+	"strconv"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/snissn/gomap/TreeDB/mvcc"
+)
+
+//go:embed testdata/public_trace_v1.json
+var goldenTraceJSON []byte
+
+type traceMutation struct {
+	KeyHex   string `json:"key_hex"`
+	ValueHex string `json:"value_hex"`
+	Delete   bool   `json:"delete"`
+}
+
+type traceCommit struct {
+	Timestamp uint64          `json:"timestamp"`
+	Mutations []traceMutation `json:"mutations"`
+}
+
+type traceRead struct {
+	KeyHex        string `json:"key_hex"`
+	ReadTimestamp uint64 `json:"read_timestamp"`
+	State         string `json:"state"`
+	Version       uint64 `json:"version"`
+	ValueHex      string `json:"value_hex"`
+}
+
+type tracePrune struct {
+	Visited  uint64 `json:"visited"`
+	Skipped  uint64 `json:"skipped"`
+	Retained uint64 `json:"retained"`
+	Pruned   uint64 `json:"pruned"`
+}
+
+type goldenTrace struct {
+	Schema              string        `json:"schema"`
+	Commits             []traceCommit `json:"commits"`
+	ReadsBeforeFloor    []traceRead   `json:"reads_before_floor"`
+	VersionsBeforeFloor []string      `json:"versions_before_floor"`
+	DiscardFloor        uint64        `json:"discard_floor"`
+	Prune               tracePrune    `json:"prune"`
+	ReadsAfterPrune     []traceRead   `json:"reads_after_prune"`
+	VersionsAfterPrune  []string      `json:"versions_after_prune"`
+}
+
+// Run executes the reusable public-surface conformance suite.
+func Run(t *testing.T, open OpenFunc) {
+	t.Helper()
+	if open == nil {
+		t.Fatal("mvcctest: nil OpenFunc")
+	}
+	t.Run("golden_reopen_floor_prune", func(t *testing.T) { runGolden(t, open) })
+	t.Run("validation_boundaries", func(t *testing.T) { runBoundaries(t, open) })
+	t.Run("randomized_oracle", func(t *testing.T) { runRandomized(t, open) })
+	t.Run("concurrent_snapshot_readers", func(t *testing.T) { runConcurrent(t, open) })
+}
+
+func runGolden(t *testing.T, open OpenFunc) {
+	var trace goldenTrace
+	if err := json.Unmarshal(goldenTraceJSON, &trace); err != nil {
+		t.Fatalf("decode golden trace: %v", err)
+	}
+	if trace.Schema != "treedb-mvcc-public-trace-v1" {
+		t.Fatalf("golden schema=%q", trace.Schema)
+	}
+	dir := t.TempDir()
+	adapter := requireOpen(t, open, dir, DurabilityDurable)
+	for _, commit := range trace.Commits {
+		mutations := make([]mvcc.Mutation, len(commit.Mutations))
+		for i, mutation := range commit.Mutations {
+			mutations[i] = mvcc.Mutation{
+				Key:    decodeHex(t, mutation.KeyHex),
+				Value:  decodeHex(t, mutation.ValueHex),
+				Delete: mutation.Delete,
+			}
+		}
+		if err := adapter.CommitAt(commit.Timestamp, mutations, mvcc.CommitDurable); err != nil {
+			t.Fatalf("CommitAt(%d): %v", commit.Timestamp, err)
+		}
+	}
+	requireReads(t, adapter, trace.ReadsBeforeFloor)
+	requireVersions(t, adapter, trace.VersionsBeforeFloor)
+	requireClose(t, adapter)
+
+	adapter = requireOpen(t, open, dir, DurabilityDurable)
+	requireReads(t, adapter, trace.ReadsBeforeFloor)
+	requireVersions(t, adapter, trace.VersionsBeforeFloor)
+	if err := adapter.AdvanceDiscardFloor(trace.DiscardFloor, mvcc.CommitDurable); err != nil {
+		t.Fatalf("AdvanceDiscardFloor: %v", err)
+	}
+	stats, err := adapter.PruneVersions(mvcc.PruneOptions{BatchSize: 2, Mode: mvcc.CommitDurable})
+	if err != nil {
+		t.Fatalf("PruneVersions: %v", err)
+	}
+	if stats.Visited != trace.Prune.Visited || stats.Skipped != trace.Prune.Skipped ||
+		stats.Retained != trace.Prune.Retained || stats.Pruned != trace.Prune.Pruned {
+		t.Fatalf("prune stats=%+v want=%+v", stats, trace.Prune)
+	}
+	if stats.Visited != stats.Retained+stats.Pruned || stats.Skipped > stats.Retained {
+		t.Fatalf("prune accounting=%+v", stats)
+	}
+	for _, timestamp := range []uint64{1, trace.DiscardFloor} {
+		if _, err := adapter.GetAt([]byte("any"), timestamp); !errors.Is(err, mvcc.ErrReadBeforeDiscardFloor) {
+			t.Fatalf("GetAt at/below floor timestamp=%d err=%v", timestamp, err)
+		}
+	}
+	requireReads(t, adapter, trace.ReadsAfterPrune)
+	requireVersions(t, adapter, trace.VersionsAfterPrune)
+	requireClose(t, adapter)
+
+	adapter = requireOpen(t, open, dir, DurabilityDurable)
+	floor, err := adapter.DiscardFloor()
+	if err != nil || floor != trace.DiscardFloor {
+		t.Fatalf("reopened floor=%d err=%v want=%d", floor, err, trace.DiscardFloor)
+	}
+	requireReads(t, adapter, trace.ReadsAfterPrune)
+	requireVersions(t, adapter, trace.VersionsAfterPrune)
+	requireClose(t, adapter)
+}
+
+func runBoundaries(t *testing.T, open OpenFunc) {
+	adapter := requireOpen(t, open, t.TempDir(), DurabilityWALOffRelaxed)
+	defer requireClose(t, adapter)
+	if err := adapter.CommitAt(0, []mvcc.Mutation{{Key: []byte("k")}}, mvcc.CommitRelaxed); !errors.Is(err, mvcc.ErrZeroTimestamp) {
+		t.Fatalf("zero timestamp err=%v", err)
+	}
+	if _, err := adapter.GetAt([]byte("k"), 0); !errors.Is(err, mvcc.ErrZeroTimestamp) {
+		t.Fatalf("zero read timestamp err=%v", err)
+	}
+	if err := adapter.CommitAt(1, []mvcc.Mutation{{Key: nil}, {Key: []byte{}}}, mvcc.CommitRelaxed); !errors.Is(err, mvcc.ErrDuplicateKey) {
+		t.Fatalf("nil/empty duplicate err=%v", err)
+	}
+	if err := adapter.CommitAt(1, []mvcc.Mutation{{Key: []byte("k")}}, mvcc.CommitDurable); !errors.Is(err, mvcc.ErrDurabilityUnavailable) {
+		t.Fatalf("durable-on-relaxed err=%v", err)
+	}
+	if err := adapter.CommitAt(5, []mvcc.Mutation{{Key: []byte("k"), Value: []byte("v")}}, mvcc.CommitRelaxed); err != nil {
+		t.Fatal(err)
+	}
+	if err := adapter.AdvanceDiscardFloor(5, mvcc.CommitRelaxed); err != nil {
+		t.Fatal(err)
+	}
+	if err := adapter.AdvanceDiscardFloor(4, mvcc.CommitRelaxed); !errors.Is(err, mvcc.ErrDiscardFloorRegression) {
+		t.Fatalf("floor regression err=%v", err)
+	}
+	if err := adapter.CommitAt(5, []mvcc.Mutation{{Key: []byte("late")}}, mvcc.CommitRelaxed); !errors.Is(err, mvcc.ErrVersionBelowDiscardFloor) {
+		t.Fatalf("commit at floor err=%v", err)
+	}
+}
+
+type oracleVersion struct {
+	timestamp uint64
+	state     mvcc.ReadState
+	value     []byte
+}
+
+func runRandomized(t *testing.T, open OpenFunc) {
+	adapter := requireOpen(t, open, t.TempDir(), DurabilityWALOffRelaxed)
+	defer requireClose(t, adapter)
+	rng := rand.New(rand.NewSource(3673))
+	keys := [][]byte{nil, {0}, {0, 'a'}, {'a'}, {'a', 0, 'b'}, {0xff}, {0xff, 0, 1}}
+	history := make(map[string][]oracleVersion, len(keys))
+	for step := 1; step <= 320; step++ {
+		key := keys[rng.Intn(len(keys))]
+		deleted := rng.Intn(5) == 0
+		value := []byte{byte(step), byte(step >> 8), byte(rng.Intn(256))}
+		if rng.Intn(9) == 0 {
+			value = []byte{}
+		}
+		if err := adapter.CommitAt(uint64(step), []mvcc.Mutation{{Key: key, Value: value, Delete: deleted}}, mvcc.CommitRelaxed); err != nil {
+			t.Fatalf("step %d CommitAt: %v", step, err)
+		}
+		state := mvcc.Present
+		if deleted {
+			state = mvcc.Tombstone
+			value = nil
+		}
+		history[string(key)] = append(history[string(key)], oracleVersion{timestamp: uint64(step), state: state, value: append([]byte(nil), value...)})
+		for probe := 0; probe < 3; probe++ {
+			probeKey := keys[rng.Intn(len(keys))]
+			readTimestamp := uint64(1 + rng.Intn(step))
+			want := oracleAt(history[string(probeKey)], readTimestamp)
+			got, err := adapter.GetAt(probeKey, readTimestamp)
+			if err != nil {
+				t.Fatalf("step %d GetAt(%x,%d): %v", step, probeKey, readTimestamp, err)
+			}
+			if got.State != want.state || got.Timestamp != want.timestamp || !bytes.Equal(got.Value, want.value) {
+				t.Fatalf("step %d GetAt(%x,%d)=%+v want=%+v", step, probeKey, readTimestamp, got, want)
+			}
+		}
+	}
+
+	want := make([]string, 0, 320)
+	for key, versions := range history {
+		for i := len(versions) - 1; i >= 0; i-- {
+			want = append(want, versionLabel([]byte(key), versions[i].timestamp, versions[i].state, versions[i].value))
+		}
+	}
+	sort.Slice(want, func(i, j int) bool {
+		leftKey, leftTimestamp := labelIdentity(want[i])
+		rightKey, rightTimestamp := labelIdentity(want[j])
+		if cmp := bytes.Compare(leftKey, rightKey); cmp != 0 {
+			return cmp < 0
+		}
+		return leftTimestamp > rightTimestamp
+	})
+	requireVersions(t, adapter, want)
+}
+
+func runConcurrent(t *testing.T, open OpenFunc) {
+	adapter := requireOpen(t, open, t.TempDir(), DurabilityWALOffRelaxed)
+	defer requireClose(t, adapter)
+	for timestamp := uint64(1); timestamp <= 16; timestamp++ {
+		if err := adapter.CommitAt(timestamp, []mvcc.Mutation{{Key: []byte("k"), Value: []byte(fmt.Sprint(timestamp))}}, mvcc.CommitRelaxed); err != nil {
+			t.Fatal(err)
+		}
+	}
+	pinned, err := adapter.IterateVersions(mvcc.VersionIteratorOptions{})
+	if err != nil {
+		t.Fatalf("open pinned iterator: %v", err)
+	}
+	pinnedClosed := false
+	defer func() {
+		if !pinnedClosed {
+			_ = pinned.Close()
+		}
+	}()
+
+	var wg sync.WaitGroup
+	errCh := make(chan error, 9)
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for timestamp := uint64(17); timestamp <= 80; timestamp++ {
+			if err := adapter.CommitAt(timestamp, []mvcc.Mutation{{Key: []byte("k"), Value: []byte(fmt.Sprint(timestamp))}}, mvcc.CommitRelaxed); err != nil {
+				errCh <- err
+				return
+			}
+		}
+	}()
+	for reader := 0; reader < 8; reader++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for i := 0; i < 100; i++ {
+				got, err := adapter.GetAt([]byte("k"), 80)
+				if err != nil || (got.State != mvcc.Present && got.State != mvcc.Absent) {
+					errCh <- fmt.Errorf("concurrent GetAt result=%+v err=%v", got, err)
+					return
+				}
+			}
+		}()
+	}
+	wg.Wait()
+	close(errCh)
+	for err := range errCh {
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	var pinnedLabels []string
+	for pinned.Valid() {
+		entry := pinned.Entry()
+		pinnedLabels = append(pinnedLabels, versionLabel(entry.Key, entry.Timestamp, entry.State, entry.Value))
+		pinned.Next()
+	}
+	if err := pinned.Error(); err != nil {
+		t.Fatalf("pinned iterator: %v", err)
+	}
+	if err := pinned.Close(); err != nil {
+		t.Fatalf("close pinned iterator: %v", err)
+	}
+	pinnedClosed = true
+	if len(pinnedLabels) != 16 {
+		t.Fatalf("pinned labels len=%d want=16", len(pinnedLabels))
+	}
+	if pinnedLabels[0] != "6b@16:present:3136" || pinnedLabels[15] != "6b@1:present:31" {
+		t.Fatalf("pinned labels len=%d first=%q last=%q", len(pinnedLabels), pinnedLabels[0], pinnedLabels[len(pinnedLabels)-1])
+	}
+	fresh, err := adapter.GetAt([]byte("k"), 80)
+	if err != nil || fresh.State != mvcc.Present || fresh.Timestamp != 80 || string(fresh.Value) != "80" {
+		t.Fatalf("fresh GetAt=%+v err=%v", fresh, err)
+	}
+}
+
+func requireOpen(t testing.TB, open OpenFunc, dir string, durability DurabilityClass) Adapter {
+	t.Helper()
+	adapter, err := open(dir, durability)
+	if err != nil {
+		t.Fatalf("open %s: %v", durability, err)
+	}
+	if err := adapter.validate(); err != nil {
+		_ = closeAdapter(adapter)
+		t.Fatal(err)
+	}
+	return adapter
+}
+
+func requireClose(t testing.TB, adapter Adapter) {
+	t.Helper()
+	if err := closeAdapter(adapter); err != nil {
+		t.Fatalf("close adapter: %v", err)
+	}
+}
+
+func requireReads(t testing.TB, adapter Adapter, reads []traceRead) {
+	t.Helper()
+	for _, read := range reads {
+		key := decodeHex(t, read.KeyHex)
+		wantState := parseState(t, read.State)
+		wantValue := decodeHex(t, read.ValueHex)
+		got, err := adapter.GetAt(key, read.ReadTimestamp)
+		if err != nil {
+			t.Fatalf("GetAt(%x,%d): %v", key, read.ReadTimestamp, err)
+		}
+		if got.State != wantState || got.Timestamp != read.Version || !bytes.Equal(got.Value, wantValue) {
+			t.Fatalf("GetAt(%x,%d)=%+v want state=%v timestamp=%d value=%x", key, read.ReadTimestamp, got, wantState, read.Version, wantValue)
+		}
+	}
+}
+
+func requireVersions(t testing.TB, adapter Adapter, want []string) {
+	t.Helper()
+	it, err := adapter.IterateVersions(mvcc.VersionIteratorOptions{})
+	if err != nil {
+		t.Fatalf("IterateVersions: %v", err)
+	}
+	var got []string
+	for it.Valid() {
+		entry := it.Entry()
+		got = append(got, versionLabel(entry.Key, entry.Timestamp, entry.State, entry.Value))
+		it.Next()
+	}
+	iterErr := it.Error()
+	closeErr := it.Close()
+	if iterErr != nil || closeErr != nil {
+		t.Fatalf("iterate versions err=%v close=%v", iterErr, closeErr)
+	}
+	if fmt.Sprint(got) != fmt.Sprint(want) {
+		t.Fatalf("versions:\n got %v\nwant %v", got, want)
+	}
+}
+
+func oracleAt(versions []oracleVersion, timestamp uint64) oracleVersion {
+	for i := len(versions) - 1; i >= 0; i-- {
+		if versions[i].timestamp <= timestamp {
+			return versions[i]
+		}
+	}
+	return oracleVersion{state: mvcc.Absent}
+}
+
+func versionLabel(key []byte, timestamp uint64, state mvcc.ReadState, value []byte) string {
+	return fmt.Sprintf("%x@%d:%s:%x", key, timestamp, stateLabel(state), value)
+}
+
+func labelIdentity(label string) ([]byte, uint64) {
+	at := strings.IndexByte(label, '@')
+	colon := strings.IndexByte(label[at+1:], ':') + at + 1
+	keyHex := label[:at]
+	timestamp, _ := strconv.ParseUint(label[at+1:colon], 10, 64)
+	key, _ := hex.DecodeString(keyHex)
+	return key, timestamp
+}
+
+func stateLabel(state mvcc.ReadState) string {
+	switch state {
+	case mvcc.Absent:
+		return "absent"
+	case mvcc.Present:
+		return "present"
+	case mvcc.Tombstone:
+		return "tombstone"
+	default:
+		return fmt.Sprintf("state(%d)", state)
+	}
+}
+
+func parseState(t testing.TB, label string) mvcc.ReadState {
+	t.Helper()
+	switch label {
+	case "absent":
+		return mvcc.Absent
+	case "present":
+		return mvcc.Present
+	case "tombstone":
+		return mvcc.Tombstone
+	default:
+		t.Fatalf("unknown state %q", label)
+		return mvcc.Absent
+	}
+}
+
+func decodeHex(t testing.TB, value string) []byte {
+	t.Helper()
+	decoded, err := hex.DecodeString(value)
+	if err != nil {
+		t.Fatalf("decode hex %q: %v", value, err)
+	}
+	return decoded
+}

--- a/TreeDB/mvcc/mvcctest/example_test.go
+++ b/TreeDB/mvcc/mvcctest/example_test.go
@@ -1,0 +1,39 @@
+package mvcctest_test
+
+import (
+	"fmt"
+	"os"
+
+	treedb "github.com/snissn/gomap/TreeDB"
+	"github.com/snissn/gomap/TreeDB/mvcc"
+	"github.com/snissn/gomap/TreeDB/mvcc/mvcctest"
+)
+
+func ExampleFromStore() {
+	dir, err := os.MkdirTemp("", "treedb-mvcctest-example-")
+	if err != nil {
+		panic(err)
+	}
+	defer os.RemoveAll(dir)
+	db, err := treedb.Open(treedb.Options{
+		Dir:                          dir,
+		Durability:                   treedb.DurabilityWALOffRelaxed,
+		DisableSideStores:            true,
+		BackgroundCheckpointInterval: -1,
+	})
+	if err != nil {
+		panic(err)
+	}
+	adapter := mvcctest.FromStore(mvcc.New(db), db.Close)
+	defer adapter.Close()
+
+	if err := adapter.CommitAt(7, []mvcc.Mutation{{Key: []byte("k"), Value: []byte("v")}}, mvcc.CommitRelaxed); err != nil {
+		panic(err)
+	}
+	result, err := adapter.GetAt([]byte("k"), 7)
+	if err != nil {
+		panic(err)
+	}
+	fmt.Printf("state=%d timestamp=%d value=%s\n", result.State, result.Timestamp, result.Value)
+	// Output: state=1 timestamp=7 value=v
+}

--- a/TreeDB/mvcc/mvcctest/testdata/public_trace_v1.json
+++ b/TreeDB/mvcc/mvcctest/testdata/public_trace_v1.json
@@ -1,0 +1,47 @@
+{
+  "schema": "treedb-mvcc-public-trace-v1",
+  "commits": [
+    {"timestamp": 10, "mutations": [{"key_hex": "610062", "value_hex": "74656e"}]},
+    {"timestamp": 15, "mutations": [{"key_hex": "", "value_hex": "656d707479"}]},
+    {"timestamp": 20, "mutations": [{"key_hex": "ff", "value_hex": "7477656e7479"}]},
+    {"timestamp": 30, "mutations": [{"key_hex": "610062", "value_hex": "746869727479"}]},
+    {"timestamp": 35, "mutations": [{"key_hex": "ff", "delete": true}]},
+    {"timestamp": 40, "mutations": [{"key_hex": "610062", "delete": true}]},
+    {"timestamp": 50, "mutations": [{"key_hex": "610062", "value_hex": ""}]}
+  ],
+  "reads_before_floor": [
+    {"key_hex": "610062", "read_timestamp": 9, "state": "absent", "version": 0, "value_hex": ""},
+    {"key_hex": "610062", "read_timestamp": 10, "state": "present", "version": 10, "value_hex": "74656e"},
+    {"key_hex": "610062", "read_timestamp": 39, "state": "present", "version": 30, "value_hex": "746869727479"},
+    {"key_hex": "610062", "read_timestamp": 40, "state": "tombstone", "version": 40, "value_hex": ""},
+    {"key_hex": "610062", "read_timestamp": 50, "state": "present", "version": 50, "value_hex": ""},
+    {"key_hex": "ff", "read_timestamp": 34, "state": "present", "version": 20, "value_hex": "7477656e7479"},
+    {"key_hex": "ff", "read_timestamp": 35, "state": "tombstone", "version": 35, "value_hex": ""}
+  ],
+  "versions_before_floor": [
+    "@15:present:656d707479",
+    "610062@50:present:",
+    "610062@40:tombstone:",
+    "610062@30:present:746869727479",
+    "610062@10:present:74656e",
+    "ff@35:tombstone:",
+    "ff@20:present:7477656e7479"
+  ],
+  "discard_floor": 30,
+  "prune": {"visited": 7, "skipped": 3, "retained": 6, "pruned": 1},
+  "reads_after_prune": [
+    {"key_hex": "610062", "read_timestamp": 31, "state": "present", "version": 30, "value_hex": "746869727479"},
+    {"key_hex": "610062", "read_timestamp": 40, "state": "tombstone", "version": 40, "value_hex": ""},
+    {"key_hex": "610062", "read_timestamp": 50, "state": "present", "version": 50, "value_hex": ""},
+    {"key_hex": "ff", "read_timestamp": 31, "state": "present", "version": 20, "value_hex": "7477656e7479"},
+    {"key_hex": "ff", "read_timestamp": 35, "state": "tombstone", "version": 35, "value_hex": ""}
+  ],
+  "versions_after_prune": [
+    "@15:present:656d707479",
+    "610062@50:present:",
+    "610062@40:tombstone:",
+    "610062@30:present:746869727479",
+    "ff@35:tombstone:",
+    "ff@20:present:7477656e7479"
+  ]
+}

--- a/scripts/mvcc_adapter_overhead_gate.sh
+++ b/scripts/mvcc_adapter_overhead_gate.sh
@@ -1,0 +1,139 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+cd "$ROOT"
+
+BASELINE_HASH="${BASELINE_HASH:?BASELINE_HASH is required}"
+CANDIDATE_HASH="${CANDIDATE_HASH:-HEAD}"
+RUNS="${RUNS:-7}"
+BENCHTIME="${BENCHTIME:-2s}"
+PROFILE_BENCHTIME="${PROFILE_BENCHTIME:-1s}"
+CPUSET="${CPUSET:-0}"
+MAX_REGRESSION_PERCENT="${MAX_REGRESSION_PERCENT:-5}"
+MAX_BYTES_REGRESSION_PERCENT="${MAX_BYTES_REGRESSION_PERCENT:-1}"
+MAX_BYTES_REGRESSION_ABSOLUTE="${MAX_BYTES_REGRESSION_ABSOLUTE:-64}"
+MAX_ADAPTER_RATIO="${MAX_ADAPTER_RATIO:-2}"
+SCRIPT_GOWORK="${SCRIPT_GOWORK:-off}"
+OUT_DIR="${OUT_DIR:-$ROOT/artifacts/mvcc_adapter_overhead_gate}"
+
+COMMIT_REGEX='^BenchmarkCommitAt/(DirectTreeDB|MVCC)/1$'
+GET_REGEX='^BenchmarkGetAt/(DirectSeek|MVCC)/64$'
+ITER_REGEX='^BenchmarkVersionIteration/(Physical|MVCC)/keys=64/depth=32/reverse=false$'
+
+if ! [[ "$RUNS" =~ ^[1-9][0-9]*$ ]]; then
+  echo "RUNS must be a positive integer" >&2
+  exit 2
+fi
+for value in "$BENCHTIME" "$PROFILE_BENCHTIME"; do
+  if ! [[ "$value" =~ ^[1-9][0-9]*(ms|s|x)$ ]]; then
+    echo "benchmark durations must be positive Go durations or iteration counts" >&2
+    exit 2
+  fi
+done
+for command in git go lscpu ps python3 realpath taskset sha256sum; do
+  command -v "$command" >/dev/null 2>&1 || { echo "missing required command: $command" >&2; exit 2; }
+done
+
+OUT_DIR=$(realpath -m "$OUT_DIR")
+if [[ -z "$OUT_DIR" || "$OUT_DIR" == "/" || "$OUT_DIR" == "$ROOT" ]]; then
+  echo "refusing unsafe OUT_DIR: $OUT_DIR" >&2
+  exit 2
+fi
+git cat-file -e "${BASELINE_HASH}^{commit}" >/dev/null 2>&1 || git fetch --no-tags origin "$BASELINE_HASH"
+BASELINE_SHA=$(git rev-parse "${BASELINE_HASH}^{commit}")
+CANDIDATE_SHA=$(git rev-parse "${CANDIDATE_HASH}^{commit}")
+CHECKED_OUT_SHA=$(git rev-parse "HEAD^{commit}")
+if [[ "$CHECKED_OUT_SHA" != "$CANDIDATE_SHA" ]]; then
+  echo "candidate mismatch: checkout=$CHECKED_OUT_SHA requested=$CANDIDATE_SHA" >&2
+  exit 2
+fi
+if [[ "$BASELINE_SHA" == "$CANDIDATE_SHA" ]]; then
+  echo "baseline and candidate resolve to the same commit" >&2
+  exit 2
+fi
+
+rm -rf "$OUT_DIR"
+mkdir -p "$OUT_DIR/profiles"
+TMP_ROOT=$(mktemp -d "${RUNNER_TEMP:-${TMPDIR:-/tmp}}/mvcc-adapter-gate.XXXXXX")
+BASELINE_WT="$TMP_ROOT/baseline"
+cleanup() {
+  git worktree remove --force "$BASELINE_WT" >/dev/null 2>&1 || true
+  rm -rf "$TMP_ROOT"
+}
+trap cleanup EXIT
+git worktree add --detach "$BASELINE_WT" "$BASELINE_SHA" >/dev/null
+
+BASELINE_BIN="$TMP_ROOT/baseline-mvcc.test"
+CANDIDATE_BIN="$TMP_ROOT/candidate-mvcc.test"
+env GOWORK="$SCRIPT_GOWORK" go test -c -trimpath -buildvcs=false -o "$CANDIDATE_BIN" ./TreeDB/mvcc
+(
+  cd "$BASELINE_WT"
+  env GOWORK="$SCRIPT_GOWORK" go test -c -trimpath -buildvcs=false -o "$BASELINE_BIN" ./TreeDB/mvcc
+)
+sha256sum "$BASELINE_BIN" "$CANDIDATE_BIN" >"$OUT_DIR/binary-sha256.txt"
+
+{
+  echo "baseline_sha=$BASELINE_SHA"
+  echo "candidate_sha=$CANDIDATE_SHA"
+  echo "runs=$RUNS"
+  echo "benchtime=$BENCHTIME"
+  echo "profile_benchtime=$PROFILE_BENCHTIME"
+  echo "cpuset=$CPUSET"
+  echo "gomaxprocs=1"
+  go version
+  go env GOOS GOARCH GOAMD64 GOROOT GOPATH
+  uname -a
+  lscpu
+} >"$OUT_DIR/environment.txt"
+: >"$OUT_DIR/baseline.txt"
+: >"$OUT_DIR/candidate.txt"
+: >"$OUT_DIR/processes.txt"
+
+run_group() {
+  local revision="$1" sample="$2" binary="$3" regex="$4" output="$5"
+  echo "--- revision=$revision sample=$sample regex=$regex ---" >>"$output"
+  taskset -c "$CPUSET" env GOMAXPROCS=1 "$binary" -test.run '^$' \
+    -test.bench "$regex" -test.benchmem -test.benchtime="$BENCHTIME" -test.count=1 >>"$output"
+}
+run_revision() {
+  local revision="$1" sample="$2" binary="$3" output="$4"
+  ps -eo pid,ppid,etime,%cpu,cmd --sort=-%cpu | head -20 >>"$OUT_DIR/processes.txt" || true
+  run_group "$revision" "$sample" "$binary" "$COMMIT_REGEX" "$output"
+  run_group "$revision" "$sample" "$binary" "$GET_REGEX" "$output"
+  run_group "$revision" "$sample" "$binary" "$ITER_REGEX" "$output"
+}
+for ((sample = 1; sample <= RUNS; sample++)); do
+  if ((sample % 2 == 1)); then
+    run_revision baseline "$sample" "$BASELINE_BIN" "$OUT_DIR/baseline.txt"
+    run_revision candidate "$sample" "$CANDIDATE_BIN" "$OUT_DIR/candidate.txt"
+  else
+    run_revision candidate "$sample" "$CANDIDATE_BIN" "$OUT_DIR/candidate.txt"
+    run_revision baseline "$sample" "$BASELINE_BIN" "$OUT_DIR/baseline.txt"
+  fi
+done
+
+profile_mvcc() {
+  local label="$1" regex="$2"
+  taskset -c "$CPUSET" env GOMAXPROCS=1 "$CANDIDATE_BIN" -test.run '^$' \
+    -test.bench "$regex" -test.benchtime="$PROFILE_BENCHTIME" -test.count=1 \
+    -test.cpuprofile="$OUT_DIR/profiles/$label.pprof" >/dev/null
+  go tool pprof -top -nodecount=30 "$CANDIDATE_BIN" "$OUT_DIR/profiles/$label.pprof" \
+    >"$OUT_DIR/profiles/${label}_top.txt"
+}
+# Profiles are intentionally captured before evaluation so a >2x failure always
+# includes actionable evidence rather than only a threshold message.
+profile_mvcc commit '^BenchmarkCommitAt/MVCC/1$'
+profile_mvcc get '^BenchmarkGetAt/MVCC/64$'
+profile_mvcc iteration '^BenchmarkVersionIteration/MVCC/keys=64/depth=32/reverse=false$'
+
+python3 .github/scripts/check_mvcc_adapter_overhead_gate.py \
+  --baseline "$OUT_DIR/baseline.txt" --candidate "$OUT_DIR/candidate.txt" \
+  --baseline-sha "$BASELINE_SHA" --candidate-sha "$CANDIDATE_SHA" \
+  --expected-samples "$RUNS" --max-regression-percent "$MAX_REGRESSION_PERCENT" \
+  --max-bytes-regression-percent "$MAX_BYTES_REGRESSION_PERCENT" \
+  --max-bytes-regression-absolute "$MAX_BYTES_REGRESSION_ABSOLUTE" \
+  --max-adapter-ratio "$MAX_ADAPTER_RATIO" \
+  --json-output "$OUT_DIR/summary.json" --markdown-output "$OUT_DIR/summary.md"
+
+echo "mvcc adapter-overhead gate artifacts: $OUT_DIR"

--- a/scripts/mvcc_adapter_overhead_gate.sh
+++ b/scripts/mvcc_adapter_overhead_gate.sh
@@ -6,7 +6,7 @@ cd "$ROOT"
 
 BASELINE_HASH="${BASELINE_HASH:?BASELINE_HASH is required}"
 CANDIDATE_HASH="${CANDIDATE_HASH:-HEAD}"
-RUNS="${RUNS:-7}"
+RUNS="${RUNS:-8}"
 BENCHTIME="${BENCHTIME:-2s}"
 PROFILE_BENCHTIME="${PROFILE_BENCHTIME:-1s}"
 CPUSET="${CPUSET:-0}"
@@ -23,6 +23,10 @@ ITER_REGEX='^BenchmarkVersionIteration/(Physical|MVCC)/keys=64/depth=32/reverse=
 
 if ! [[ "$RUNS" =~ ^[1-9][0-9]*$ ]]; then
   echo "RUNS must be a positive integer" >&2
+  exit 2
+fi
+if ((RUNS % 2 != 0)); then
+  echo "RUNS must be even to balance AB/BA sample order" >&2
   exit 2
 fi
 for value in "$BENCHTIME" "$PROFILE_BENCHTIME"; do

--- a/scripts/mvcc_adapter_overhead_gate.sh
+++ b/scripts/mvcc_adapter_overhead_gate.sh
@@ -89,24 +89,27 @@ sha256sum "$BASELINE_BIN" "$CANDIDATE_BIN" >"$OUT_DIR/binary-sha256.txt"
 run_group() {
   local revision="$1" sample="$2" binary="$3" regex="$4" output="$5"
   echo "--- revision=$revision sample=$sample regex=$regex ---" >>"$output"
+  {
+    echo "--- before revision=$revision sample=$sample regex=$regex at $(date -Iseconds) ---"
+    ps -eo pid,ppid,etime,%cpu,cmd --sort=-%cpu | head -20 || true
+  } >>"$OUT_DIR/processes.txt"
   taskset -c "$CPUSET" env GOMAXPROCS=1 "$binary" -test.run '^$' \
     -test.bench "$regex" -test.benchmem -test.benchtime="$BENCHTIME" -test.count=1 >>"$output"
 }
-run_revision() {
-  local revision="$1" sample="$2" binary="$3" output="$4"
-  ps -eo pid,ppid,etime,%cpu,cmd --sort=-%cpu | head -20 >>"$OUT_DIR/processes.txt" || true
-  run_group "$revision" "$sample" "$binary" "$COMMIT_REGEX" "$output"
-  run_group "$revision" "$sample" "$binary" "$GET_REGEX" "$output"
-  run_group "$revision" "$sample" "$binary" "$ITER_REGEX" "$output"
+run_pair() {
+  local sample="$1" baseline_binary="$2" candidate_binary="$3" regex="$4"
+  if ((sample % 2 == 1)); then
+    run_group baseline "$sample" "$baseline_binary" "$regex" "$OUT_DIR/baseline.txt"
+    run_group candidate "$sample" "$candidate_binary" "$regex" "$OUT_DIR/candidate.txt"
+  else
+    run_group candidate "$sample" "$candidate_binary" "$regex" "$OUT_DIR/candidate.txt"
+    run_group baseline "$sample" "$baseline_binary" "$regex" "$OUT_DIR/baseline.txt"
+  fi
 }
 for ((sample = 1; sample <= RUNS; sample++)); do
-  if ((sample % 2 == 1)); then
-    run_revision baseline "$sample" "$BASELINE_BIN" "$OUT_DIR/baseline.txt"
-    run_revision candidate "$sample" "$CANDIDATE_BIN" "$OUT_DIR/candidate.txt"
-  else
-    run_revision candidate "$sample" "$CANDIDATE_BIN" "$OUT_DIR/candidate.txt"
-    run_revision baseline "$sample" "$BASELINE_BIN" "$OUT_DIR/baseline.txt"
-  fi
+  run_pair "$sample" "$BASELINE_BIN" "$CANDIDATE_BIN" "$COMMIT_REGEX"
+  run_pair "$sample" "$BASELINE_BIN" "$CANDIDATE_BIN" "$GET_REGEX"
+  run_pair "$sample" "$BASELINE_BIN" "$CANDIDATE_BIN" "$ITER_REGEX"
 done
 
 profile_mvcc() {

--- a/scripts/mvcc_adapter_overhead_gate.sh
+++ b/scripts/mvcc_adapter_overhead_gate.sh
@@ -43,11 +43,7 @@ fi
 git cat-file -e "${BASELINE_HASH}^{commit}" >/dev/null 2>&1 || git fetch --no-tags origin "$BASELINE_HASH"
 BASELINE_SHA=$(git rev-parse "${BASELINE_HASH}^{commit}")
 CANDIDATE_SHA=$(git rev-parse "${CANDIDATE_HASH}^{commit}")
-CHECKED_OUT_SHA=$(git rev-parse "HEAD^{commit}")
-if [[ "$CHECKED_OUT_SHA" != "$CANDIDATE_SHA" ]]; then
-  echo "candidate mismatch: checkout=$CHECKED_OUT_SHA requested=$CANDIDATE_SHA" >&2
-  exit 2
-fi
+"$ROOT/scripts/mvcc_candidate_checkout_guard.sh" "$ROOT" "$CANDIDATE_SHA"
 if [[ "$BASELINE_SHA" == "$CANDIDATE_SHA" ]]; then
   echo "baseline and candidate resolve to the same commit" >&2
   exit 2

--- a/scripts/mvcc_candidate_checkout_guard.sh
+++ b/scripts/mvcc_candidate_checkout_guard.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="${1:?repository root is required}"
+CANDIDATE_SHA="${2:?candidate SHA is required}"
+
+CHECKED_OUT_SHA=$(git -C "$ROOT" rev-parse "HEAD^{commit}")
+if [[ "$CHECKED_OUT_SHA" != "$CANDIDATE_SHA" ]]; then
+  echo "candidate mismatch: checkout=$CHECKED_OUT_SHA requested=$CANDIDATE_SHA" >&2
+  exit 2
+fi
+
+# The candidate binaries are compiled from the live checkout. Fail closed when
+# tracked or ordinary untracked files could make those binaries differ from the
+# recorded SHA. Git status excludes ignored benchmark artifacts by default;
+# --untracked-files=normal still includes ordinary untracked source files.
+DIRTY_STATUS=$(git -C "$ROOT" status --porcelain --untracked-files=normal)
+if [[ -n "$DIRTY_STATUS" ]]; then
+  echo "candidate worktree is dirty; refusing to attribute live-checkout binaries to $CANDIDATE_SHA" >&2
+  echo "$DIRTY_STATUS" >&2
+  exit 2
+fi

--- a/scripts/mvcc_closeout_matrix.sh
+++ b/scripts/mvcc_closeout_matrix.sh
@@ -71,15 +71,28 @@ sha256sum "$BENCH_BIN" >"$OUT_DIR/binary-sha256.txt"
 : >"$OUT_DIR/bench.txt"
 : >"$OUT_DIR/resources.txt"
 
-for ((sample = 1; sample <= RUNS; sample++)); do
-  echo "--- sample=$sample ---" >>"$OUT_DIR/bench.txt"
+run_group() {
+  local sample="$1"
+  local group="$2"
+  local regex="$3"
+  local benchtime="$4"
+  echo "--- sample=$sample group=$group benchtime=$benchtime ---" >>"$OUT_DIR/bench.txt"
+  echo "--- sample=$sample group=$group benchtime=$benchtime ---" >>"$OUT_DIR/resources.txt"
   /usr/bin/time -v -a -o "$OUT_DIR/resources.txt" \
     taskset -c "$CPUSET" env GOMAXPROCS=1 "$BENCH_BIN" \
       -test.run '^$' \
-      -test.bench '^BenchmarkDgraphMVCCCloseout$' \
+      -test.bench "$regex" \
       -test.benchmem \
-      -test.benchtime="$BENCHTIME" \
+      -test.benchtime="$benchtime" \
       -test.count=1 >>"$OUT_DIR/bench.txt"
+}
+
+for ((sample = 1; sample <= RUNS; sample++)); do
+  run_group "$sample" regular '^BenchmarkDgraphMVCCCloseout/(CommitAt|GetAt|AllVersions)/' "$BENCHTIME"
+  # Prune requires a fresh populated database per operation. Keep exactly one
+  # fixture per external sample instead of allowing Go's duration calibration
+  # to multiply setup databases and distort process RSS.
+  run_group "$sample" prune '^BenchmarkDgraphMVCCCloseout/Prune/' '1x'
 done
 
 taskset -c "$CPUSET" env GOMAXPROCS=1 "$BENCH_BIN" \

--- a/scripts/mvcc_closeout_matrix.sh
+++ b/scripts/mvcc_closeout_matrix.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+cd "$ROOT"
+
+CANDIDATE_HASH="${CANDIDATE_HASH:-HEAD}"
+RUNS="${RUNS:-5}"
+BENCHTIME="${BENCHTIME:-750ms}"
+CPUSET="${CPUSET:-0}"
+SCRIPT_GOWORK="${SCRIPT_GOWORK:-off}"
+OUT_DIR="${OUT_DIR:-$ROOT/artifacts/mvcc_closeout_matrix}"
+
+if ! [[ "$RUNS" =~ ^[1-9][0-9]*$ ]]; then
+  echo "RUNS must be a positive integer" >&2
+  exit 2
+fi
+if ! [[ "$BENCHTIME" =~ ^[1-9][0-9]*(ms|s|x)$ ]]; then
+  echo "BENCHTIME must be a positive Go benchmark duration or iteration count" >&2
+  exit 2
+fi
+for command in git go lscpu python3 realpath taskset sha256sum; do
+  if ! command -v "$command" >/dev/null 2>&1; then
+    echo "missing required command: $command" >&2
+    exit 2
+  fi
+done
+if [[ ! -x /usr/bin/time ]]; then
+  echo "missing required command: /usr/bin/time" >&2
+  exit 2
+fi
+
+OUT_DIR=$(realpath -m "$OUT_DIR")
+if [[ -z "$OUT_DIR" || "$OUT_DIR" == "/" || "$OUT_DIR" == "$ROOT" ]]; then
+  echo "refusing unsafe OUT_DIR: $OUT_DIR" >&2
+  exit 2
+fi
+CANDIDATE_SHA=$(git rev-parse "${CANDIDATE_HASH}^{commit}")
+CHECKED_OUT_SHA=$(git rev-parse "HEAD^{commit}")
+if [[ "$CHECKED_OUT_SHA" != "$CANDIDATE_SHA" ]]; then
+  echo "candidate mismatch: checkout=$CHECKED_OUT_SHA requested=$CANDIDATE_SHA" >&2
+  exit 2
+fi
+
+rm -rf "$OUT_DIR"
+mkdir -p "$OUT_DIR"
+TMP_ROOT=$(mktemp -d "${RUNNER_TEMP:-${TMPDIR:-/tmp}}/mvcc-closeout.XXXXXX")
+cleanup() {
+  rm -rf "$TMP_ROOT"
+}
+trap cleanup EXIT
+BENCH_BIN="$TMP_ROOT/mvcc.test"
+
+{
+  echo "candidate_sha=$CANDIDATE_SHA"
+  echo "runs=$RUNS"
+  echo "benchtime=$BENCHTIME"
+  echo "cpuset=$CPUSET"
+  echo "gomaxprocs=1"
+  echo "github_runner_image=${ImageOS:-unknown} ${ImageVersion:-unknown}"
+  echo "runner_arch=${RUNNER_ARCH:-unknown}"
+  echo "runner_os=${RUNNER_OS:-unknown}"
+  go version
+  go env GOOS GOARCH GOAMD64 GOROOT GOPATH
+  uname -a
+  lscpu
+} >"$OUT_DIR/environment.txt"
+
+env GOWORK="$SCRIPT_GOWORK" go test -c -trimpath -buildvcs=false -o "$BENCH_BIN" ./TreeDB/mvcc
+sha256sum "$BENCH_BIN" >"$OUT_DIR/binary-sha256.txt"
+: >"$OUT_DIR/bench.txt"
+: >"$OUT_DIR/resources.txt"
+
+for ((sample = 1; sample <= RUNS; sample++)); do
+  echo "--- sample=$sample ---" >>"$OUT_DIR/bench.txt"
+  /usr/bin/time -v -a -o "$OUT_DIR/resources.txt" \
+    taskset -c "$CPUSET" env GOMAXPROCS=1 "$BENCH_BIN" \
+      -test.run '^$' \
+      -test.bench '^BenchmarkDgraphMVCCCloseout$' \
+      -test.benchmem \
+      -test.benchtime="$BENCHTIME" \
+      -test.count=1 >>"$OUT_DIR/bench.txt"
+done
+
+taskset -c "$CPUSET" env GOMAXPROCS=1 "$BENCH_BIN" \
+  -test.run '^$' \
+  -test.bench '^BenchmarkDgraphMVCCCloseout$' \
+  -test.benchtime=1x \
+  -test.cpuprofile="$OUT_DIR/cpu.pprof" >/dev/null
+go tool pprof -top -nodecount=30 "$BENCH_BIN" "$OUT_DIR/cpu.pprof" >"$OUT_DIR/cpu_top.txt"
+
+python3 .github/scripts/summarize_mvcc_closeout.py \
+  --bench "$OUT_DIR/bench.txt" \
+  --resources "$OUT_DIR/resources.txt" \
+  --candidate-sha "$CANDIDATE_SHA" \
+  --expected-samples "$RUNS" \
+  --json-output "$OUT_DIR/summary.json" \
+  --markdown-output "$OUT_DIR/summary.md"
+
+echo "MVCC closeout matrix artifacts: $OUT_DIR"

--- a/scripts/mvcc_closeout_matrix.sh
+++ b/scripts/mvcc_closeout_matrix.sh
@@ -36,11 +36,7 @@ if [[ -z "$OUT_DIR" || "$OUT_DIR" == "/" || "$OUT_DIR" == "$ROOT" ]]; then
   exit 2
 fi
 CANDIDATE_SHA=$(git rev-parse "${CANDIDATE_HASH}^{commit}")
-CHECKED_OUT_SHA=$(git rev-parse "HEAD^{commit}")
-if [[ "$CHECKED_OUT_SHA" != "$CANDIDATE_SHA" ]]; then
-  echo "candidate mismatch: checkout=$CHECKED_OUT_SHA requested=$CANDIDATE_SHA" >&2
-  exit 2
-fi
+"$ROOT/scripts/mvcc_candidate_checkout_guard.sh" "$ROOT" "$CANDIDATE_SHA"
 
 rm -rf "$OUT_DIR"
 mkdir -p "$OUT_DIR"

--- a/scripts/mvcc_raw_path_gate.sh
+++ b/scripts/mvcc_raw_path_gate.sh
@@ -14,7 +14,10 @@ MAX_BYTES_REGRESSION_PERCENT="${MAX_BYTES_REGRESSION_PERCENT:-1}"
 MAX_BYTES_REGRESSION_ABSOLUTE="${MAX_BYTES_REGRESSION_ABSOLUTE:-64}"
 SCRIPT_GOWORK="${SCRIPT_GOWORK:-off}"
 OUT_DIR="${OUT_DIR:-$ROOT/artifacts/mvcc_raw_path_gate}"
-BENCH_REGEX='^(BenchmarkGetVersioned|BenchmarkConditionalTxnBaselineBatchWrite)$'
+DB_BENCH_REGEX='^(BenchmarkGetVersioned|BenchmarkConditionalTxnBaselineBatchWrite)$'
+SNAPSHOT_BENCH_REGEX='^BenchmarkSnapshotIteratorSeekNext/keys=1024/snapshot_seek$'
+CACHING_BENCH_REGEX='^BenchmarkRepeatedIterator$'
+DURABILITY_BENCH_REGEX='^BenchmarkPublicCommandWALDurableTinyBatchWriteSync/placement=inline/shape=dirty_batch/ops=1$'
 
 if ! [[ "$RUNS" =~ ^[1-9][0-9]*$ ]]; then
   echo "RUNS must be a positive integer" >&2
@@ -69,8 +72,12 @@ BASELINE_LOG="$OUT_DIR/baseline.txt"
 CANDIDATE_LOG="$OUT_DIR/candidate.txt"
 SUMMARY_JSON="$OUT_DIR/summary.json"
 SUMMARY_MD="$OUT_DIR/summary.md"
-BASELINE_BIN="$TMP_ROOT/baseline.test"
-CANDIDATE_BIN="$TMP_ROOT/candidate.test"
+BASELINE_DB_BIN="$TMP_ROOT/baseline-db.test"
+BASELINE_CACHING_BIN="$TMP_ROOT/baseline-caching.test"
+BASELINE_TREEDB_BIN="$TMP_ROOT/baseline-treedb.test"
+CANDIDATE_DB_BIN="$TMP_ROOT/candidate-db.test"
+CANDIDATE_CACHING_BIN="$TMP_ROOT/candidate-caching.test"
+CANDIDATE_TREEDB_BIN="$TMP_ROOT/candidate-treedb.test"
 
 {
   echo "baseline_sha=$BASELINE_SHA"
@@ -91,15 +98,23 @@ CANDIDATE_BIN="$TMP_ROOT/candidate.test"
 } >"$ENVIRONMENT"
 
 env GOWORK="$SCRIPT_GOWORK" go test -c -trimpath -buildvcs=false \
-  -o "$CANDIDATE_BIN" ./TreeDB/db
+  -o "$CANDIDATE_DB_BIN" ./TreeDB/db
+env GOWORK="$SCRIPT_GOWORK" go test -c -trimpath -buildvcs=false \
+  -o "$CANDIDATE_CACHING_BIN" ./TreeDB/caching
+env GOWORK="$SCRIPT_GOWORK" go test -c -trimpath -buildvcs=false \
+  -o "$CANDIDATE_TREEDB_BIN" ./TreeDB
 (
   cd "$BASELINE_WT"
   env GOWORK="$SCRIPT_GOWORK" go test -c -trimpath -buildvcs=false \
-    -o "$BASELINE_BIN" ./TreeDB/db
+    -o "$BASELINE_DB_BIN" ./TreeDB/db
+  env GOWORK="$SCRIPT_GOWORK" go test -c -trimpath -buildvcs=false \
+    -o "$BASELINE_CACHING_BIN" ./TreeDB/caching
+  env GOWORK="$SCRIPT_GOWORK" go test -c -trimpath -buildvcs=false \
+    -o "$BASELINE_TREEDB_BIN" ./TreeDB
 )
 (
   cd "$TMP_ROOT"
-  sha256sum baseline.test candidate.test
+  sha256sum baseline-*.test candidate-*.test
 ) | tee "$OUT_DIR/binary-sha256.txt"
 
 : >"$BASELINE_LOG"
@@ -109,25 +124,40 @@ run_sample() {
   local revision="$1"
   local sample="$2"
   local binary="$3"
-  local output="$4"
+  local regex="$4"
+  local output="$5"
   {
     echo "--- before revision=$revision sample=$sample at $(date -Iseconds) ---"
     ps -eo pid,ppid,etime,%cpu,cmd --sort=-%cpu | head -20 || true
   } >>"$PROCESSES"
   taskset -c "$CPUSET" env GOMAXPROCS=1 "$binary" \
     -test.run '^$' \
-    -test.bench "$BENCH_REGEX" \
+    -test.bench "$regex" \
+    -test.benchmem \
     -test.benchtime="$BENCHTIME" \
     -test.count=1 >>"$output"
 }
 
+run_revision() {
+  local revision="$1"
+  local sample="$2"
+  local db_binary="$3"
+  local caching_binary="$4"
+  local treedb_binary="$5"
+  local output="$6"
+  run_sample "$revision" "$sample" "$db_binary" "$DB_BENCH_REGEX" "$output"
+  run_sample "$revision" "$sample" "$treedb_binary" "$SNAPSHOT_BENCH_REGEX" "$output"
+  run_sample "$revision" "$sample" "$caching_binary" "$CACHING_BENCH_REGEX" "$output"
+  run_sample "$revision" "$sample" "$treedb_binary" "$DURABILITY_BENCH_REGEX" "$output"
+}
+
 for ((sample = 1; sample <= RUNS; sample++)); do
   if ((sample % 2 == 1)); then
-    run_sample baseline "$sample" "$BASELINE_BIN" "$BASELINE_LOG"
-    run_sample candidate "$sample" "$CANDIDATE_BIN" "$CANDIDATE_LOG"
+    run_revision baseline "$sample" "$BASELINE_DB_BIN" "$BASELINE_CACHING_BIN" "$BASELINE_TREEDB_BIN" "$BASELINE_LOG"
+    run_revision candidate "$sample" "$CANDIDATE_DB_BIN" "$CANDIDATE_CACHING_BIN" "$CANDIDATE_TREEDB_BIN" "$CANDIDATE_LOG"
   else
-    run_sample candidate "$sample" "$CANDIDATE_BIN" "$CANDIDATE_LOG"
-    run_sample baseline "$sample" "$BASELINE_BIN" "$BASELINE_LOG"
+    run_revision candidate "$sample" "$CANDIDATE_DB_BIN" "$CANDIDATE_CACHING_BIN" "$CANDIDATE_TREEDB_BIN" "$CANDIDATE_LOG"
+    run_revision baseline "$sample" "$BASELINE_DB_BIN" "$BASELINE_CACHING_BIN" "$BASELINE_TREEDB_BIN" "$BASELINE_LOG"
   fi
 done
 

--- a/scripts/mvcc_raw_path_gate.sh
+++ b/scripts/mvcc_raw_path_gate.sh
@@ -14,7 +14,8 @@ MAX_BYTES_REGRESSION_PERCENT="${MAX_BYTES_REGRESSION_PERCENT:-1}"
 MAX_BYTES_REGRESSION_ABSOLUTE="${MAX_BYTES_REGRESSION_ABSOLUTE:-64}"
 SCRIPT_GOWORK="${SCRIPT_GOWORK:-off}"
 OUT_DIR="${OUT_DIR:-$ROOT/artifacts/mvcc_raw_path_gate}"
-DB_BENCH_REGEX='^(BenchmarkGetVersioned|BenchmarkConditionalTxnBaselineBatchWrite)$'
+GET_VERSIONED_BENCH_REGEX='^BenchmarkGetVersioned$'
+BATCH_WRITE_BENCH_REGEX='^BenchmarkConditionalTxnBaselineBatchWrite$'
 SNAPSHOT_BENCH_REGEX='^BenchmarkSnapshotIteratorSeekNext/keys=1024/snapshot_seek$'
 CACHING_BENCH_REGEX='^BenchmarkRepeatedIterator$'
 DURABILITY_BENCH_REGEX='^BenchmarkPublicCommandWALDurableTinyBatchWriteSync/placement=inline/shape=dirty_batch/ops=1$'
@@ -119,11 +120,12 @@ env GOWORK="$SCRIPT_GOWORK" go test -c -trimpath -buildvcs=false \
 run_sample() {
   local revision="$1"
   local sample="$2"
-  local binary="$3"
-  local regex="$4"
-  local output="$5"
+  local group="$3"
+  local binary="$4"
+  local regex="$5"
+  local output="$6"
   {
-    echo "--- before revision=$revision sample=$sample at $(date -Iseconds) ---"
+    echo "--- before revision=$revision sample=$sample group=$group at $(date -Iseconds) ---"
     ps -eo pid,ppid,etime,%cpu,cmd --sort=-%cpu | head -20 || true
   } >>"$PROCESSES"
   taskset -c "$CPUSET" env GOMAXPROCS=1 "$binary" \
@@ -134,27 +136,27 @@ run_sample() {
     -test.count=1 >>"$output"
 }
 
-run_revision() {
-  local revision="$1"
-  local sample="$2"
-  local db_binary="$3"
-  local caching_binary="$4"
-  local treedb_binary="$5"
-  local output="$6"
-  run_sample "$revision" "$sample" "$db_binary" "$DB_BENCH_REGEX" "$output"
-  run_sample "$revision" "$sample" "$treedb_binary" "$SNAPSHOT_BENCH_REGEX" "$output"
-  run_sample "$revision" "$sample" "$caching_binary" "$CACHING_BENCH_REGEX" "$output"
-  run_sample "$revision" "$sample" "$treedb_binary" "$DURABILITY_BENCH_REGEX" "$output"
+run_pair() {
+  local sample="$1"
+  local group="$2"
+  local baseline_binary="$3"
+  local candidate_binary="$4"
+  local regex="$5"
+  if ((sample % 2 == 1)); then
+    run_sample baseline "$sample" "$group" "$baseline_binary" "$regex" "$BASELINE_LOG"
+    run_sample candidate "$sample" "$group" "$candidate_binary" "$regex" "$CANDIDATE_LOG"
+  else
+    run_sample candidate "$sample" "$group" "$candidate_binary" "$regex" "$CANDIDATE_LOG"
+    run_sample baseline "$sample" "$group" "$baseline_binary" "$regex" "$BASELINE_LOG"
+  fi
 }
 
 for ((sample = 1; sample <= RUNS; sample++)); do
-  if ((sample % 2 == 1)); then
-    run_revision baseline "$sample" "$BASELINE_DB_BIN" "$BASELINE_CACHING_BIN" "$BASELINE_TREEDB_BIN" "$BASELINE_LOG"
-    run_revision candidate "$sample" "$CANDIDATE_DB_BIN" "$CANDIDATE_CACHING_BIN" "$CANDIDATE_TREEDB_BIN" "$CANDIDATE_LOG"
-  else
-    run_revision candidate "$sample" "$CANDIDATE_DB_BIN" "$CANDIDATE_CACHING_BIN" "$CANDIDATE_TREEDB_BIN" "$CANDIDATE_LOG"
-    run_revision baseline "$sample" "$BASELINE_DB_BIN" "$BASELINE_CACHING_BIN" "$BASELINE_TREEDB_BIN" "$BASELINE_LOG"
-  fi
+  run_pair "$sample" get_versioned "$BASELINE_DB_BIN" "$CANDIDATE_DB_BIN" "$GET_VERSIONED_BENCH_REGEX"
+  run_pair "$sample" batch_write "$BASELINE_DB_BIN" "$CANDIDATE_DB_BIN" "$BATCH_WRITE_BENCH_REGEX"
+  run_pair "$sample" snapshot_seek "$BASELINE_TREEDB_BIN" "$CANDIDATE_TREEDB_BIN" "$SNAPSHOT_BENCH_REGEX"
+  run_pair "$sample" repeated_iterator "$BASELINE_CACHING_BIN" "$CANDIDATE_CACHING_BIN" "$CACHING_BENCH_REGEX"
+  run_pair "$sample" durable_sync "$BASELINE_TREEDB_BIN" "$CANDIDATE_TREEDB_BIN" "$DURABILITY_BENCH_REGEX"
 done
 
 python3 .github/scripts/check_mvcc_raw_path_gate.py \

--- a/scripts/mvcc_raw_path_gate.sh
+++ b/scripts/mvcc_raw_path_gate.sh
@@ -6,7 +6,7 @@ cd "$ROOT"
 
 BASELINE_HASH="${BASELINE_HASH:?BASELINE_HASH is required}"
 CANDIDATE_HASH="${CANDIDATE_HASH:-HEAD}"
-RUNS="${RUNS:-7}"
+RUNS="${RUNS:-8}"
 BENCHTIME="${BENCHTIME:-2s}"
 CPUSET="${CPUSET:-0}"
 MAX_REGRESSION_PERCENT="${MAX_REGRESSION_PERCENT:-5}"
@@ -22,6 +22,10 @@ DURABILITY_BENCH_REGEX='^BenchmarkPublicCommandWALDurableTinyBatchWriteSync/plac
 
 if ! [[ "$RUNS" =~ ^[1-9][0-9]*$ ]]; then
   echo "RUNS must be a positive integer" >&2
+  exit 2
+fi
+if ((RUNS % 2 != 0)); then
+  echo "RUNS must be even to balance AB/BA sample order" >&2
   exit 2
 fi
 if ! [[ "$BENCHTIME" =~ ^[1-9][0-9]*(ms|s|x)$ ]]; then
@@ -159,11 +163,19 @@ for ((sample = 1; sample <= RUNS; sample++)); do
   run_pair "$sample" durable_sync "$BASELINE_TREEDB_BIN" "$CANDIDATE_TREEDB_BIN" "$DURABILITY_BENCH_REGEX"
 done
 
+# Hash the six actual benchmark executables while TMP_ROOT is still live. The
+# EXIT trap removes them only after the checker has emitted a verdict or error.
 python3 .github/scripts/check_mvcc_raw_path_gate.py \
   --baseline "$BASELINE_LOG" \
   --candidate "$CANDIDATE_LOG" \
   --baseline-sha "$BASELINE_SHA" \
   --candidate-sha "$CANDIDATE_SHA" \
+  --baseline-db-binary "$BASELINE_DB_BIN" \
+  --candidate-db-binary "$CANDIDATE_DB_BIN" \
+  --baseline-caching-binary "$BASELINE_CACHING_BIN" \
+  --candidate-caching-binary "$CANDIDATE_CACHING_BIN" \
+  --baseline-treedb-binary "$BASELINE_TREEDB_BIN" \
+  --candidate-treedb-binary "$CANDIDATE_TREEDB_BIN" \
   --expected-samples "$RUNS" \
   --max-regression-percent "$MAX_REGRESSION_PERCENT" \
   --max-bytes-regression-percent "$MAX_BYTES_REGRESSION_PERCENT" \

--- a/scripts/mvcc_raw_path_gate.sh
+++ b/scripts/mvcc_raw_path_gate.sh
@@ -45,11 +45,7 @@ if ! git cat-file -e "${BASELINE_HASH}^{commit}" >/dev/null 2>&1; then
 fi
 BASELINE_SHA=$(git rev-parse "${BASELINE_HASH}^{commit}")
 CANDIDATE_SHA=$(git rev-parse "${CANDIDATE_HASH}^{commit}")
-CHECKED_OUT_SHA=$(git rev-parse "HEAD^{commit}")
-if [[ "$CHECKED_OUT_SHA" != "$CANDIDATE_SHA" ]]; then
-  echo "candidate mismatch: checkout=$CHECKED_OUT_SHA requested=$CANDIDATE_SHA" >&2
-  exit 2
-fi
+"$ROOT/scripts/mvcc_candidate_checkout_guard.sh" "$ROOT" "$CANDIDATE_SHA"
 if [[ "$BASELINE_SHA" == "$CANDIDATE_SHA" ]]; then
   echo "baseline and candidate resolve to the same commit" >&2
   exit 2


### PR DESCRIPTION
Closes #3673. Part of #3668. Unblocks the TreeDB adapter/runtime work tracked by [snissn/dgraph#16](https://github.com/snissn/dgraph/issues/16).

## Dependency chain

This closeout is based on the merged issue stack:

- #3670 via #3685, merge `e84eeb5719dabb0e5c6e6d7e525a8c624fdf3cdf`
- #3671 via #3687, merge `cfd18421b4039abe4856255ae6dc29a8b173c464`
- #3672 via #3688, merge `8b847a222a6fda40d4a336ee4010314546ccb2c5`
- #3669 via #3693, merge `e94013508e7fad1d9fb89034ec8dfd6d88c7e6e2`

The paired validation base includes the caching race fix merged by #3708 at `f9c9b2a37838909d0e669818cfa2840c0a8d5f85`.

## What this closes out

- Adds a reusable public-only `TreeDB/mvcc/mvcctest` harness with committed golden, deterministic randomized, validation, iterator, ownership, and concurrent reader/writer coverage.
- Runs reusable conformance against WAL-on relaxed and WAL-off relaxed stores, with a separate durable reopen/floor/prune trace.
- Pins internal MVCC v1 codec bytes and ordering with committed fixtures and fuzz/property coverage.
- Adds a strict 24-row durability-separated closeout matrix, exact sample/resource validation, and profiles.
- Adds raw production-path and direct-vs-MVCC overhead gates with balanced benchmark-group AB/BA pairing.
- Documents the restricted Dgraph Alpha contract, unsupported behavior, durability semantics, reproduction, and exact evidence.

## Measurement targets versus final head

The authoritative raw-path and adapter target is `dbea38e0e8ad0c7d1e0bb05ac564bd9b57dd747a`. The corrected closeout-matrix target is `103f9c5af85d8d6a5801119fc2247be3b9c87fad`; it stops the prune timer before the parent temporary directory and all fixture setup. Final PR head `4a5b62b6c4c4bc202f1ed14b28d28f37335baeb9` is an evidence-only descendant of that correction and does not change production MVCC code.

The raw-path and adapter benchmarks were not rerun. After one fresh passing 30-second quiet audit, only the closeout matrix was rerun, exactly once. The prior `dbea38e0` matrix is preserved but superseded because its single `1x` prune sample included pre-loop `TempDir` setup.

The post-`dbea38e0` diff is limited to strict evidence validation and tests, CI relevance/self-check wiring, the prune timer-accounting fix and structural guard, and readiness/generated-evidence updates.

Dgraph must still pin the first merged-main descendant that contains this PR, not any worker-branch SHA.

## Supported boundary

The restricted Alpha may rely on caller-owned nonzero timestamps; atomic put/tombstone batches; exact-timestamp replacement; point reads at a timestamp; arbitrary byte keys; snapshot-bound forward/reverse all-version iteration with bounds, prefix, ceiling, seek, tombstones, owned bytes, and accounting; one monotonic global discard floor; bounded restartable pruning with pinned-reader safety; durable sync acknowledgment and crash/reopen behavior; and distinguishable validation/storage/durability errors.

Relaxed commits and floor advancement remain operation-atomic but are not fsync acknowledgments. Pruning is restartable and each delete batch is atomic; a complete prune pass is not operation-atomic.

## Unsupported / Dgraph-owned boundary

This does not provide encryption or key rotation; TTL/leases/subscriptions/backups/bulk loading; Badger transaction objects, conflicts, predicates, CAS, or conditional semantics; Dgraph posting-list envelopes, namespaces, rollups/splits, caches, prefetch callbacks, or Alpha lifecycle; multiple MVCC owners for one TreeDB handle; per-key discard floors; or a stable cross-version disk migration/public physical codec.

Missing Dgraph envelopes remain explicit restricted-runtime capability errors rather than implicit TreeDB emulation.

## Correctness and harness validation

The closeout stack preserves these passing checks:

- `go vet ./...`
- `go test ./... -count=1`
- `go test -race ./TreeDB/mvcc/... -count=1`
- durable commit/prune crash tests with `-count=3`
- `FuzzRoundTrip` and `FuzzDecodeNeverPanics`, 10 seconds each
- raw and adapter checker self-tests
- six raw-equivalence tests
- six benchmark-pairing tests
- six candidate-checkout-guard tests
- closeout summarizer tests, Python compilation, shell syntax, YAML parse, scope-regex probes, and diff checks
- `GOWORK=off go test ./TreeDB/docs/...` on the final validation/evidence head

The workflow scope conservatively includes all `TreeDB/**` paths, including docs and transitive packages used by the measured binaries, plus the gate harness, validator, guard, and workflow paths. This avoids false negatives when shared storage packages change.

## Exact performance evidence

### Hosted raw path: EQUIVALENT

Base `f9c9b2a...`, candidate `dbea38e0...`, eight samples per revision, benchmark-group-paired with exactly four AB and four BA pairs, `-benchtime=2s`.

Verdict: **EQUIVALENT**. Measured threshold observation: **FAIL**.

- point read: +1.12%, PASS
- batch write: +0.36%, PASS
- snapshot seek: -0.47%, PASS
- repeated iterator: -1.76%, PASS
- durable synced write: +27.94%, measured FAIL

All three row-producing base/head benchmark-binary pairs—`db`, `caching`, and root `treedb`—were byte-identical. The measured durable miss remains visible, but the checker accepts EQUIVALENT because no delta can be attributed to candidate code. It is not relabeled PASS.

Hosted artifact: `/mnt/fast4tb/gomap-3673-evidence/hosted-raw-dbea38e0`.

### Adapter overhead: FAIL with scoped acceptance

Base `f9c9b2a...`, candidate `dbea38e0...`, eight samples per revision, benchmark-group-paired AB/BA, `-benchtime=2s`, with 1-second candidate profiles.

Gate verdict: **FAIL**. Four rows exceeded the 5% revision ceiling:

- direct commit +9.77%
- MVCC commit +7.03%
- physical all-version iteration +18.88%
- MVCC all-version iteration +13.41%

Get rows passed at +2.63% direct and +4.35% MVCC. All candidate adapter/direct ratios passed the separate 2x limit:

- commit: 0.936x
- get: 1.008x
- all-version iteration: 1.121x

Allocations were unchanged in all six rows and bytes stayed flat within tolerance. Profiles/tops were captured for commit, get, and iteration.

The four revision-ceiling misses are accepted only as a scoped risk for the first restricted pre-alpha Dgraph benchmark. The adapter gate remains FAIL. The rationale is deliberately conjunctive:

- the base-to-target production diff is test/conformance harness, benchmark, docs, script, and workflow work, not changes to production read/commit/iteration implementations;
- direct and MVCC controls co-moved in both failing operation families;
- all three candidate adapter/direct ratios passed, maximum 1.121x;
- allocations were unchanged and bytes flat;
- hosted raw production binaries were byte-identical and received EQUIVALENT; and
- the durability-matched matrix completed successfully.

Local artifact: `/mnt/fast4tb/gomap-3673-evidence/adapter-dbea38e0`.

### Durability-matched closeout matrix: PASS

Corrected candidate `103f9c5af85d8d6a5801119fc2247be3b9c87fad`, five samples, `-benchtime=750ms` for regular rows and one fresh fixture per prune sample. The timer is stopped before all prune setup and started only around `PruneVersions`.

Result: **PASS**. All 24 rows and required metrics were present across durable-sync, WAL-on relaxed, and WAL-off relaxed classes. Ten measured invocations used 102.36s user / 6.97s system CPU; maximum RSS was 611,264 KiB. Durable-sync medians included:

- commit: 149.5 mutations/s batch 1; 5,271/s batch 32
- get: 937,621 lookups/s depth 1; 670,037/s depth 64
- all versions: 3,485,151 versions/s depth 1; 4,119,271/s depth 32
- prune: 13,505 pruned versions/s floor 4; 25,211/s floor 12

Prune delete write amplification was 0.8286 in every row. Relaxed rows are not presented as durability-equivalent to synced rows.

Corrected artifact: `/mnt/fast4tb/gomap-3673-evidence/closeout-matrix-103f9c5af`.

The prior artifact at `/mnt/fast4tb/gomap-3673-evidence/closeout-matrix-dbea38e0` is retained but invalid for prune timing and superseded; its samples are not combined with the replacement. The corrected run's sole preflight is retained at `/mnt/fast4tb/gomap-3673-evidence/quiet-window-103f9c5af`: exact clean target, 95.64% idle, 0.36% iowait, no `simd`, and no competing job.

## Committed compact evidence

- `TreeDB/docs/spec/artifacts/dgraph-mvcc-closeout/README.md`
- `raw-path-summary.{md,json}`
- `adapter-overhead-summary.{md,json}`
- `closeout-matrix-summary.{md,json}`

The raw-path and adapter summaries were revalidated from their retained exact-target inputs without rerunning those benchmarks. The corrected matrix summaries were regenerated and revalidated byte-for-byte from the sole replacement run. Large logs, benchmark binaries, and binary profiles remain host-local.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added MVCC public-surface conformance coverage (durability, discard/pruning, iteration, randomized, concurrent).
  * Added new benchmark gate automation for raw-path performance, adapter overhead, and MVCC closeout matrix runs.
  * Added automated evidence reporting (Markdown/JSON) with verdicts and binary-digest equivalence.
* **Documentation**
  * Added Dgraph MVCC readiness/verification specs and published closeout evidence artifacts.
* **Tests**
  * Added golden codec fixture and codec golden test, plus new unit tests guarding benchmark pairing and candidate checkout behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->