### PR TITLE
treedb: dependency-closed root publication coordinator

### DIFF
--- a/TreeDB/batch/batch.go
+++ b/TreeDB/batch/batch.go
@@ -937,6 +937,28 @@ func (b *Batch) ByteSize() int {
 	return b.byteSize
 }
 
+// ValueLogPointerBytes returns a conservative byte total for value-log records
+// referenced by pointer puts in this batch. Grouped-record aliases may be
+// counted more than once intentionally: publication debt must never
+// under-account side-store bytes while durability is stalled.
+func (b *Batch) ValueLogPointerBytes() uint64 {
+	if b == nil || !b.hasValueLogPointers {
+		return 0
+	}
+	var total uint64
+	for _, entry := range b.entries {
+		if entry.Type != OpPut || !entry.IsPtr || !page.IsValueLogFileID(entry.ValuePtr.FileID) {
+			continue
+		}
+		length := uint64(page.ValuePtrRecordLength(entry.ValuePtr))
+		if length > ^uint64(0)-total {
+			return ^uint64(0)
+		}
+		total += length
+	}
+	return total
+}
+
 // HasValueLogPointers reports whether this batch contains any value-log
 // pointer operations.
 func (b *Batch) HasValueLogPointers() bool {

--- a/TreeDB/batch/batch.go
+++ b/TreeDB/batch/batch.go
@@ -937,18 +937,32 @@ func (b *Batch) ByteSize() int {
 	return b.byteSize
 }
 
-// ValueLogPointerBytes returns a conservative byte total for value-log records
-// referenced by pointer puts in this batch. Grouped-record aliases may be
-// counted more than once intentionally: publication debt must never
-// under-account side-store bytes while durability is stalled.
+// ValueLogPointerBytes returns the byte total for value-log records referenced
+// by pointer puts in this batch. Grouped pointers alias one physical record, so
+// aliases within the batch are counted once by their stable record identity.
 func (b *Batch) ValueLogPointerBytes() uint64 {
 	if b == nil || !b.hasValueLogPointers {
 		return 0
 	}
+	type groupedRecord struct {
+		fileID uint32
+		offset uint64
+	}
+	var groupedSeen map[groupedRecord]struct{}
 	var total uint64
 	for _, entry := range b.entries {
 		if entry.Type != OpPut || !entry.IsPtr || !page.IsValueLogFileID(entry.ValuePtr.FileID) {
 			continue
+		}
+		if page.ValuePtrIsGrouped(entry.ValuePtr) {
+			if groupedSeen == nil {
+				groupedSeen = make(map[groupedRecord]struct{})
+			}
+			identity := groupedRecord{fileID: entry.ValuePtr.FileID, offset: entry.ValuePtr.Offset}
+			if _, exists := groupedSeen[identity]; exists {
+				continue
+			}
+			groupedSeen[identity] = struct{}{}
 		}
 		length := uint64(page.ValuePtrRecordLength(entry.ValuePtr))
 		if length > ^uint64(0)-total {

--- a/TreeDB/batch/batch_test.go
+++ b/TreeDB/batch/batch_test.go
@@ -395,6 +395,39 @@ func TestTouchedValueLogSegments(t *testing.T) {
 	}
 }
 
+func TestValueLogPointerBytesCountsGroupedRecordOnce(t *testing.T) {
+	b := New(newMapValueReader(), page.DefaultInlineThreshold)
+	t.Cleanup(func() { _ = b.Close() })
+
+	const recordLen = uint32(8192)
+	fileID := page.ValueLogFileID(7)
+	for i := uint8(0); i < 8; i++ {
+		ptr := page.ValuePtr{
+			FileID: fileID,
+			Offset: 4096,
+			Length: page.ValuePtrMarkGrouped(recordLen, i),
+		}
+		if err := b.SetPointer([]byte{byte('a' + i)}, ptr); err != nil {
+			t.Fatalf("SetPointer alias %d: %v", i, err)
+		}
+	}
+	if got := b.ValueLogPointerBytes(); got != uint64(recordLen) {
+		t.Fatalf("ValueLogPointerBytes()=%d want %d", got, recordLen)
+	}
+
+	other := page.ValuePtr{
+		FileID: fileID,
+		Offset: 8192,
+		Length: page.ValuePtrMarkGrouped(recordLen, 0),
+	}
+	if err := b.SetPointer([]byte("z"), other); err != nil {
+		t.Fatalf("SetPointer distinct record: %v", err)
+	}
+	if got := b.ValueLogPointerBytes(); got != 2*uint64(recordLen) {
+		t.Fatalf("ValueLogPointerBytes()=%d want %d", got, 2*uint64(recordLen))
+	}
+}
+
 func TestSetPointerViewNoTouch_SkipsTouchedSegmentTracking(t *testing.T) {
 	b := New(newMapValueReader(), page.DefaultInlineThreshold)
 	t.Cleanup(func() { _ = b.Close() })

--- a/TreeDB/caching/db.go
+++ b/TreeDB/caching/db.go
@@ -2617,10 +2617,14 @@ func (db *DB) recordValueLogMaterializationSyncCoverageMuHeld(l *lane, w valueWr
 }
 
 func (db *DB) flushPendingValueLogLanes(sync bool, syncPath valueLogSyncPath) error {
+	return db.flushPendingValueLogLanesWithPolicy(sync, false, syncPath)
+}
+
+func (db *DB) flushPendingValueLogLanesWithPolicy(sync, forceDurable bool, syncPath valueLogSyncPath) error {
 	if db == nil || !db.splitValueLogEnabled() {
 		return nil
 	}
-	actualSync := sync && !db.relaxedSync
+	actualSync := sync && (forceDurable || !db.relaxedSync)
 	for i := range db.lanes {
 		l := &db.lanes[i]
 		if !l.vlogDirty.Load() && !(actualSync && l.vlogSyncPending.Load()) {
@@ -2643,7 +2647,7 @@ func (db *DB) flushPendingValueLogLanes(sync bool, syncPath valueLogSyncPath) er
 		}
 		if err == nil {
 			l.vlogDirty.Store(false)
-			if syncBoundary || db.relaxedSync {
+			if syncBoundary || (db.relaxedSync && !forceDurable) {
 				l.vlogSyncPending.Store(false)
 			}
 			l.backendReadFlushedSeq.Store(l.backendReadDirtySeq.Load())
@@ -23997,14 +24001,14 @@ func (db *DB) Checkpoint() error {
 				hook()
 			}
 			if publishHook := db.loadCommandWALCheckpointPublishHook(); publishHook != nil {
-				commandWALAppliedLSN, commandWALRanges, err := publishHook(!db.relaxedSync)
+				commandWALAppliedLSN, commandWALRanges, err := publishHook(true)
 				if err != nil {
 					return err
 				}
 				if _, err := db.publishCommandWALCheckpointApplied(commandWALAppliedLSN, commandWALRanges); err != nil {
 					return err
 				}
-				if err := db.cleanupCommandWALCheckpoint(!db.relaxedSync); err != nil {
+				if err := db.cleanupCommandWALCheckpoint(true); err != nil {
 					return err
 				}
 			}
@@ -24088,7 +24092,7 @@ func (db *DB) Checkpoint() error {
 	if publishHook := db.loadCommandWALCheckpointPublishHook(); publishHook != nil && db.canPiggybackCommandWALCheckpointPublish(true) {
 		var err error
 		commandWALPublishStart := time.Now()
-		commandWALAppliedLSN, commandWALRanges, err = publishHook(!db.relaxedSync)
+		commandWALAppliedLSN, commandWALRanges, err = publishHook(true)
 		recordCheckpointStageSince(&db.checkpointStageCommandWALPublish, commandWALPublishStart)
 		if err != nil {
 			return err
@@ -24176,7 +24180,7 @@ func (db *DB) Checkpoint() error {
 		if publishHook := db.loadCommandWALCheckpointPublishHook(); publishHook != nil {
 			var err error
 			commandWALPublishStart := time.Now()
-			commandWALAppliedLSN, commandWALRanges, err = publishHook(!db.relaxedSync)
+			commandWALAppliedLSN, commandWALRanges, err = publishHook(true)
 			recordCheckpointStageSince(&db.checkpointStageCommandWALPublish, commandWALPublishStart)
 			if err != nil {
 				return err
@@ -24202,7 +24206,7 @@ func (db *DB) Checkpoint() error {
 		}
 		segments = filtered
 	}
-	// New logic: perform sync write only if not relaxedSync
+	// Checkpoint is an explicit durable boundary in every configured write mode.
 	needsCommandWALPublish := commandWALAppliedLSN != 0 && !commandWALPublishCovered
 	var commitErr error
 	if nonEmptyBytes > 0 || needsCommandWALPublish {
@@ -24212,14 +24216,6 @@ func (db *DB) Checkpoint() error {
 			// non-command WAL segments observed above, so command-LSN publication and
 			// ordinary cached checkpoint proof are not mutually exclusive.
 			_, commitErr = db.publishCommandWALCheckpointApplied(commandWALAppliedLSN, commandWALRanges)
-		} else if db.relaxedSync {
-			backendBatch := db.backend.NewBatch()
-			// If relaxed sync, just write the batch without forcing sync
-			commitErr = backendBatch.Write()
-			cerr := backendBatch.Close()
-			if commitErr == nil {
-				commitErr = cerr
-			}
 		} else {
 			// Otherwise, force a backend durability boundary without publishing
 			// an artificial same-root commit.
@@ -24231,7 +24227,7 @@ func (db *DB) Checkpoint() error {
 		}
 	}
 	if commandWALAppliedLSN != 0 || commandWALPublishCovered {
-		if err := db.cleanupCommandWALCheckpoint(!db.relaxedSync); err != nil {
+		if err := db.cleanupCommandWALCheckpoint(true); err != nil {
 			return err
 		}
 	}
@@ -24314,12 +24310,7 @@ func (db *DB) publishCommandWALCheckpointApplied(appliedLSN uint64, ranges []bac
 		_ = backendBatch.Close()
 		return false, err
 	}
-	var err error
-	if db.relaxedSync {
-		err = backendBatch.Write()
-	} else {
-		err = backendBatch.WriteSync()
-	}
+	err := backendBatch.WriteSync()
 	cerr := backendBatch.Close()
 	if err == nil {
 		err = cerr
@@ -25115,21 +25106,9 @@ func (db *DB) syncBarrierAfterWrite(sync bool) error {
 		// - relaxed: flush-to-kernel (no fsync)
 		return nil
 	}
-	if db.relaxedSync {
-		if db.indexOuterLeavesInValueLog {
-			// ProfileFast-style workloads rely on WriteSync for immediate
-			// read-after-write visibility, not per-batch backend publication.
-			// Forcing a backend flush boundary on every sync write with WAL off and
-			// outer leaves in the value log turns live catch-up into thousands of
-			// tiny backend commits, which explodes page count and sparse internal
-			// nodes. Keep these writes visible in memory and let checkpoint/rotation
-			// establish the backend boundary.
-			return nil
-		}
-		// Journal disabled: enforce a backend flush boundary without fsync.
-		return db.flushAllMemtablesForSync(false)
-	}
-	// Journal disabled: enforce a durable backend boundary.
+	// With no redo journal, every explicit *Sync operation must wait for exact
+	// durable root coverage. The configured relaxed mode still governs ordinary
+	// writes; it cannot weaken an explicit sync request when no WAL exists.
 	return db.Checkpoint()
 }
 
@@ -27293,7 +27272,7 @@ func (db *DB) flushLoop() {
 }
 
 func (db *DB) flushSyncRequested(sync bool) bool {
-	return sync && !db.relaxedSync
+	return sync
 }
 
 func (db *DB) pickFlushLane() (int, bool) {

--- a/TreeDB/caching/leaf_page_log.go
+++ b/TreeDB/caching/leaf_page_log.go
@@ -16,6 +16,7 @@ type cachingLeafPageLog struct {
 }
 
 var _ backenddb.LeafPageLog = (*cachingLeafPageLog)(nil)
+var _ backenddb.LeafPageLogDurableSyncer = (*cachingLeafPageLog)(nil)
 var _ backenddb.LeafPageBatchLog = (*cachingLeafPageLog)(nil)
 var _ backenddb.LeafPageLogCompactStorageHandoff = (*cachingLeafPageLog)(nil)
 
@@ -502,6 +503,16 @@ func (l *cachingLeafPageLog) Sync() error {
 	}
 	if l.db.relaxedSync {
 		return nil
+	}
+	return l.db.syncValueLogLane(l.lane)
+}
+
+func (l *cachingLeafPageLog) SyncLeafPageLogDurable() error {
+	if l == nil || l.db == nil || l.lane == nil {
+		return errWALUnavailable
+	}
+	if err := l.db.flushValueLogLane(l.lane); err != nil {
+		return err
 	}
 	return l.db.syncValueLogLane(l.lane)
 }

--- a/TreeDB/caching/leaf_page_log_lanes.go
+++ b/TreeDB/caching/leaf_page_log_lanes.go
@@ -12,6 +12,7 @@ type cachingLeafPageLogGroup struct {
 }
 
 var _ backenddb.LeafPageLog = (*cachingLeafPageLogGroup)(nil)
+var _ backenddb.LeafPageLogDurableSyncer = (*cachingLeafPageLogGroup)(nil)
 var _ backenddb.LeafPageBatchLog = (*cachingLeafPageLogGroup)(nil)
 var _ backenddb.LeafPagePreparedLog = (*cachingLeafPageLogGroup)(nil)
 var _ backenddb.LeafPagePreparedBatchLog = (*cachingLeafPageLogGroup)(nil)
@@ -215,6 +216,10 @@ func (g *cachingLeafPageLogGroup) Flush() error {
 
 func (g *cachingLeafPageLogGroup) Sync() error {
 	return g.forEachLane(func(log *cachingLeafPageLog) error { return log.Sync() })
+}
+
+func (g *cachingLeafPageLogGroup) SyncLeafPageLogDurable() error {
+	return g.forEachLane(func(log *cachingLeafPageLog) error { return log.SyncLeafPageLogDurable() })
 }
 
 func (g *cachingLeafPageLogGroup) AdvanceCompactStorageLeafPageLogSeqAtLeast(seq uint32) error {

--- a/TreeDB/caching/leaf_page_log_test.go
+++ b/TreeDB/caching/leaf_page_log_test.go
@@ -131,6 +131,12 @@ func TestCachingLeafPageLog_SyncRespectsRelaxedSync(t *testing.T) {
 	if got := syncCalls.Load(); got != 0 {
 		t.Fatalf("sync calls=%d want 0", got)
 	}
+	if err := leafLog.SyncLeafPageLogDurable(); err != nil {
+		t.Fatalf("SyncLeafPageLogDurable: %v", err)
+	}
+	if got := syncCalls.Load(); got != 1 {
+		t.Fatalf("durable publication sync calls=%d want 1", got)
+	}
 }
 
 type leafRecordLengthNotifierBackendStub struct {

--- a/TreeDB/caching/value_log_appender.go
+++ b/TreeDB/caching/value_log_appender.go
@@ -18,6 +18,7 @@ type cachingValueLogAppender struct {
 
 var _ backenddb.ValueLogAppender = (*cachingValueLogAppender)(nil)
 var _ backenddb.ValueLogExternalRefFlusher = (*cachingValueLogAppender)(nil)
+var _ backenddb.ValueLogDurableExternalRefFlusher = (*cachingValueLogAppender)(nil)
 
 func newCachingValueLogAppender(db *DB, l *lane) backenddb.ValueLogAppender {
 	return &cachingValueLogAppender{db: db, lane: l}
@@ -112,11 +113,19 @@ func (a *cachingValueLogAppender) Sync() error {
 }
 
 func (a *cachingValueLogAppender) FlushValueLogExternalRefs(fileIDs []uint32, sync bool) error {
+	return a.flushValueLogExternalRefs(fileIDs, sync, false)
+}
+
+func (a *cachingValueLogAppender) SyncValueLogExternalRefsDurable(fileIDs []uint32) error {
+	return a.flushValueLogExternalRefs(fileIDs, true, true)
+}
+
+func (a *cachingValueLogAppender) flushValueLogExternalRefs(fileIDs []uint32, sync, forceDurable bool) error {
 	if a == nil || a.db == nil || a.lane == nil {
 		return errWALUnavailable
 	}
 	if len(fileIDs) == 0 {
-		return a.db.flushPendingValueLogLanes(sync, valueLogSyncPathPendingBarrier)
+		return a.db.flushPendingValueLogLanesWithPolicy(sync, forceDurable, valueLogSyncPathPendingBarrier)
 	}
 	seenLanes := make(map[*lane]struct{}, len(fileIDs))
 	activeFileIDs := make(map[uint32]struct{}, len(fileIDs))
@@ -130,7 +139,7 @@ func (a *cachingValueLogAppender) FlushValueLogExternalRefs(fileIDs []uint32, sy
 		}
 		if _, ok := seenLanes[l]; !ok {
 			seenLanes[l] = struct{}{}
-			activeFileID, err := a.db.flushValueLogLaneForExternalRefFileIDs(l, fileIDs, sync)
+			activeFileID, err := a.db.flushValueLogLaneForExternalRefFileIDs(l, fileIDs, sync, forceDurable)
 			if err != nil {
 				return err
 			}
@@ -161,7 +170,7 @@ func (a *cachingValueLogAppender) FlushValueLogExternalRefs(fileIDs []uint32, sy
 	return nil
 }
 
-func (db *DB) flushValueLogLaneForExternalRefFileIDs(l *lane, fileIDs []uint32, sync bool) (uint32, error) {
+func (db *DB) flushValueLogLaneForExternalRefFileIDs(l *lane, fileIDs []uint32, sync, forceDurable bool) (uint32, error) {
 	if db == nil || l == nil {
 		return 0, errWALUnavailable
 	}
@@ -169,7 +178,7 @@ func (db *DB) flushValueLogLaneForExternalRefFileIDs(l *lane, fileIDs []uint32, 
 		if err := db.flushValueLogLane(l); err != nil {
 			return 0, err
 		}
-		if sync && !db.relaxedSync {
+		if sync && (forceDurable || !db.relaxedSync) {
 			if err := db.syncValueLogLane(l); err != nil {
 				return 0, err
 			}
@@ -205,12 +214,12 @@ func (db *DB) flushValueLogLaneForExternalRefFileIDs(l *lane, fileIDs []uint32, 
 			return activeFileID, err
 		}
 		l.vlogDirty.Store(false)
-		if db.relaxedSync {
+		if db.relaxedSync && !forceDurable {
 			l.vlogSyncPending.Store(false)
 		}
 		l.backendReadFlushedSeq.Store(l.backendReadDirtySeq.Load())
 	}
-	if !sync || db.relaxedSync {
+	if !sync || (db.relaxedSync && !forceDurable) {
 		return activeFileID, nil
 	}
 	if db.valueLogMaterializationSyncCoversFileIDMuHeld(l, w, activeFileID, fileIDs) {

--- a/TreeDB/caching/value_log_appender_test.go
+++ b/TreeDB/caching/value_log_appender_test.go
@@ -132,6 +132,41 @@ func TestCachingValueLogExternalRefSyncCoalescingGuards(t *testing.T) {
 	})
 }
 
+func TestCachingValueLogPublicationDurabilityOverridesRelaxedSync(t *testing.T) {
+	db := &DB{
+		closeCh:       make(chan struct{}),
+		splitValueLog: true,
+		relaxedSync:   true,
+		valueLogDir:   t.TempDir(),
+		lanes:         make([]lane, 1),
+	}
+	l := &db.lanes[0]
+	l.id = 0
+	l.vlogSeq = 1
+	fileID, err := valuelog.EncodeFileID(0, 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	l.vlogPath = valuelog.SegmentPath(db.valueLogDir, fileID)
+	w := &vlogDirtyOrderWriter{size: 64}
+	l.vlog = w
+	l.vlogDirty.Store(true)
+	appender := &cachingValueLogAppender{db: db, lane: l}
+
+	if err := appender.FlushValueLogExternalRefs([]uint32{fileID}, true); err != nil {
+		t.Fatal(err)
+	}
+	if got := w.syncs.Load(); got != 0 {
+		t.Fatalf("foreground relaxed barrier synced %d times, want 0", got)
+	}
+	if err := appender.SyncValueLogExternalRefsDurable([]uint32{fileID}); err != nil {
+		t.Fatal(err)
+	}
+	if got := w.syncs.Load(); got != 1 {
+		t.Fatalf("publication durable barrier synced %d times, want 1", got)
+	}
+}
+
 func TestCachingValueLogExternalRefFlusherSyncsRotatedSegments(t *testing.T) {
 	dir := t.TempDir()
 	oldFileID, err := valuelog.EncodeFileID(0, 1)

--- a/TreeDB/collections/column_retained_vlog_placement_test.go
+++ b/TreeDB/collections/column_retained_vlog_placement_test.go
@@ -103,13 +103,17 @@ func TestColumnRetainedPayloadValueLogPlacementGCRewrite(t *testing.T) {
 		_ = d.Close()
 		t.Fatalf("ValueLogGC: %v", err)
 	}
-	if gcStats.SegmentsDeleted == 0 {
+	// The root-publication coordinator conservatively retains both alternating
+	// recovery closures until the publication-seal work lands. The old column
+	// part still physically names doc-a's record, so GC must keep that segment
+	// even though the current logical collection view contains a tombstone.
+	if gcStats.SegmentsDeleted != 0 || gcStats.SegmentsReferenced != 3 {
 		_ = d.Close()
-		t.Fatalf("ValueLogGC deleted no segments after deleting retained payload: %+v", gcStats)
+		t.Fatalf("ValueLogGC did not retain the complete recovery closure: %+v", gcStats)
 	}
-	if _, err := os.Stat(pathA); err == nil || !os.IsNotExist(err) {
+	if _, err := os.Stat(pathA); err != nil {
 		_ = d.Close()
-		t.Fatalf("stale retained payload segment %s stat err=%v, want removed", pathA, err)
+		t.Fatalf("recovery-protected retained payload segment %s stat err=%v", pathA, err)
 	}
 	if got, err := col.Get([]byte("doc-b")); err != nil {
 		_ = d.Close()

--- a/TreeDB/command_wal_public_test.go
+++ b/TreeDB/command_wal_public_test.go
@@ -2142,7 +2142,7 @@ func TestPublicCommandWALCheckpointHookUsesSyncIntent(t *testing.T) {
 		wantSync   bool
 	}{
 		{name: "durable", durability: DurabilityDurable, wantSync: true},
-		{name: "relaxed", durability: DurabilityWALOnRelaxed, wantSync: false},
+		{name: "relaxed", durability: DurabilityWALOnRelaxed, wantSync: true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -2171,6 +2171,7 @@ func TestPublicCommandWALCheckpointHookUsesSyncIntent(t *testing.T) {
 			if err := db.Checkpoint(); err != nil {
 				t.Fatalf("Checkpoint: %v", err)
 			}
+			db.cached.SetCommandWALCheckpointPublishHook(nil)
 			if !called {
 				t.Fatal("checkpoint publish hook was not called")
 			}

--- a/TreeDB/db/api.go
+++ b/TreeDB/db/api.go
@@ -91,9 +91,6 @@ func (db *DB) acquireSnapshotOrErr() (*Snapshot, error) {
 	if db == nil {
 		return nil, ErrClosed
 	}
-	if err := db.publicationPoisonedError(); err != nil {
-		return nil, err
-	}
 	snap := db.AcquireSnapshot()
 	if snap == nil {
 		return nil, ErrClosed
@@ -816,6 +813,26 @@ func (db *DB) Stats() map[string]string {
 	idx := snap.idx
 
 	stats["treedb.commit_seq"] = fmt.Sprintf("%d", state.CommitSeq)
+	publication := db.rootPublication.snapshot()
+	lagCommits := uint64(0)
+	if publication.visibleCommitSeq > publication.durableCommitSeq {
+		lagCommits = publication.visibleCommitSeq - publication.durableCommitSeq
+	}
+	stats["treedb.publication.visible_commit_seq"] = fmt.Sprintf("%d", publication.visibleCommitSeq)
+	stats["treedb.publication.durable_commit_seq"] = fmt.Sprintf("%d", publication.durableCommitSeq)
+	stats["treedb.publication.oldest_recoverable_commit_seq"] = fmt.Sprintf("%d", publication.oldestRecoverableCommitSeq)
+	stats["treedb.publication.durable_lag_commits"] = fmt.Sprintf("%d", lagCommits)
+	stats["treedb.publication.durable_lag_bytes"] = fmt.Sprintf("%d", publication.pendingBytes)
+	stats["treedb.publication.pending_candidates"] = fmt.Sprintf("%d", publication.pendingCandidates)
+	stats["treedb.publication.pending_bytes"] = fmt.Sprintf("%d", publication.pendingBytes)
+	stats["treedb.publication.candidates_coalesced_total"] = fmt.Sprintf("%d", publication.candidatesCoalesced)
+	stats["treedb.publication.dependency_syncs_total"] = fmt.Sprintf("%d", publication.dependencySyncs)
+	stats["treedb.publication.meta_syncs_total"] = fmt.Sprintf("%d", publication.metaSyncs)
+	stats["treedb.publication.stalls_total"] = fmt.Sprintf("%d", publication.publicationStalls)
+	stats["treedb.publication.poison_events_total"] = fmt.Sprintf("%d", publication.poisonEvents)
+	stats["treedb.publication.waiters_total"] = fmt.Sprintf("%d", publication.waiterCount)
+	stats["treedb.publication.waiter_latency_ns_total"] = fmt.Sprintf("%d", publication.waiterLatency.Nanoseconds())
+	stats["treedb.publication.waiter_latency_ns_max"] = fmt.Sprintf("%d", publication.waiterLatencyMax.Nanoseconds())
 	stats["treedb.root_page"] = fmt.Sprintf("%d", state.RootPageID)
 	stats["treedb.system_root_page"] = fmt.Sprintf("%d", state.SystemRootPageID)
 	stats["treedb.applied_command_lsn"] = fmt.Sprintf("%d", state.AppliedCommandLSN)

--- a/TreeDB/db/batch.go
+++ b/TreeDB/db/batch.go
@@ -16,6 +16,7 @@ type Batch struct {
 	batch                              *batch.Batch
 	physicalOnly                       bool
 	commandWALPublishIntent            *commandWALBatchIntent
+	publishedCommitSeq                 uint64
 	conditionalTxnID                   uint64
 	flushApplySpanNativeFallbackReason FlushSpanRunFallbackReason
 }
@@ -290,7 +291,18 @@ func (b *Batch) write(sync bool) error {
 			return err
 		}
 	}
-	return b.writeWithCommandWALIntent(sync, intent, maxEntryRevision)
+	err := b.writeWithCommandWALIntent(sync, intent, maxEntryRevision)
+	// Logical command-WAL batches may acknowledge once their command frame is
+	// durable. Physical batches (cached flush/checkpoint publication) have no
+	// replayable logical frame of their own, so WriteSync must wait for the exact
+	// root candidate even when the backend also has command WAL enabled.
+	if err != nil || !sync || (b.db.commandWAL && !b.physicalOnly) {
+		return err
+	}
+	if b.publishedCommitSeq == 0 || b.db.rootPublication == nil {
+		return ErrClosed
+	}
+	return b.db.rootPublication.waitDurable(b.publishedCommitSeq)
 }
 
 func (b *Batch) writeWithCommandWALIntent(sync bool, intent *commandWALBatchIntent, maxEntryRevision page.EntryRevision) error {
@@ -298,6 +310,7 @@ func (b *Batch) writeWithCommandWALIntent(sync bool, intent *commandWALBatchInte
 }
 
 func (b *Batch) writeWithCommandWALIntentPreflight(sync bool, intent *commandWALBatchIntent, maxEntryRevision page.EntryRevision, conditional *ConditionalTxn) error {
+	b.publishedCommitSeq = 0
 	// If a command frame is appended but root publication later returns an
 	// error, the durable frame is intentionally left for reopen recovery. Reuse
 	// the same intent across optimistic/serialized attempts so one user batch
@@ -317,6 +330,7 @@ func (b *Batch) writeWithCommandWALIntentPreflight(sync bool, intent *commandWAL
 
 func (b *Batch) writeOptimistic(sync bool, intent *commandWALBatchIntent, maxEntryRevision page.EntryRevision, conditional *ConditionalTxn) (bool, error) {
 	touchedValueLogSegments := b.batch.TouchedValueLogSegments()
+	sideStoreBytes := b.batch.ValueLogPointerBytes()
 	rawSpanPlan := b.rawSpanNativeBatchPlan()
 
 	b.db.writeMu.RLock()
@@ -330,13 +344,16 @@ func (b *Batch) writeOptimistic(sync bool, intent *commandWALBatchIntent, maxEnt
 		return false, fmt.Errorf("missing index")
 	}
 
-	b.db.mu.RLock()
-	rootID := b.db.meta.UserRootPageID
-	baseSeq := b.db.meta.CommitSeq
+	visible := b.db.state.Load()
+	if visible == nil {
+		b.db.writeMu.RUnlock()
+		return false, ErrClosed
+	}
+	rootID := visible.RootPageID
+	baseSeq := visible.CommitSeq
 	// Register this writer as a "reader" of the base state to prevent the
 	// pruner from reclaiming pages we are about to read during z.Apply.
 	regID := idx.registry.Register(baseSeq)
-	b.db.mu.RUnlock()
 
 	defer idx.registry.Unregister(regID)
 
@@ -403,9 +420,7 @@ func (b *Batch) writeOptimistic(sync bool, intent *commandWALBatchIntent, maxEnt
 			releaseValueLogRefDelta(vlogRefDelta)
 		}
 	}()
-	b.db.mu.RLock()
-	currentRoot := b.db.meta.UserRootPageID
-	b.db.mu.RUnlock()
+	currentRoot := b.db.state.Load().RootPageID
 	if currentRoot != rootID {
 		b.db.observeFlushApplyMismatch()
 		b.db.observeRawBatchSpanNativePublishFallback(rawSpanPlan, spanNativePublishSnapshot, FlushSpanRunFallbackRootMismatch)
@@ -450,10 +465,9 @@ func (b *Batch) writeOptimistic(sync bool, intent *commandWALBatchIntent, maxEnt
 	b.db.commitMu.Lock()
 	b.db.observeFlushApplyCommitWait(time.Since(commitWaitStart))
 	guardedPublishStart := time.Now()
-	b.db.mu.RLock()
-	currentRoot = b.db.meta.UserRootPageID
-	sysRoot := b.db.meta.SystemRootPageID
-	b.db.mu.RUnlock()
+	visible = b.db.state.Load()
+	currentRoot = visible.RootPageID
+	sysRoot := visible.SystemRootPageID
 	if currentRoot != rootID {
 		b.db.observeFlushApplyMismatch()
 		b.db.observeRawBatchSpanNativePublishFallback(rawSpanPlan, spanNativePublishSnapshot, FlushSpanRunFallbackRootMismatch)
@@ -484,7 +498,7 @@ func (b *Batch) writeOptimistic(sync bool, intent *commandWALBatchIntent, maxEnt
 
 	var post finalizeCommitPost
 	if intent == nil {
-		post, err = b.db.finalizeCommitLockedWithOptions(newRoot, sysRoot, retired, sync, metrics, touchedValueLogSegments, b.db.indexOuterLeavesInValueLog, vlogRefDelta, nil, nil, finalizeCommitOptions{skipPrePublishFlush: true, skipConditionalRootConflict: true, maxEntryRevision: maxEntryRevision})
+		post, err = b.db.finalizeCommitLockedWithOptions(newRoot, sysRoot, retired, sync, metrics, touchedValueLogSegments, b.db.indexOuterLeavesInValueLog, vlogRefDelta, nil, nil, finalizeCommitOptions{skipPrePublishFlush: true, dependenciesFlushed: true, skipConditionalRootConflict: true, maxEntryRevision: maxEntryRevision, publishPrepareGuard: publishPrepareGuard, touchedIndexPages: tracker.Pages(), sideStoreBytes: sideStoreBytes})
 	} else {
 		if _, err = b.db.appendRawKVCommandWALIntent(intent, sync); err != nil {
 			b.db.releasePendingValueLogAppendFileIDsFromBatch(b.batch)
@@ -501,8 +515,12 @@ func (b *Batch) writeOptimistic(sync bool, intent *commandWALBatchIntent, maxEnt
 		}
 		opts := commandWALFinalizeOptions(intent)
 		opts.skipPrePublishFlush = true
+		opts.dependenciesFlushed = true
 		opts.skipConditionalRootConflict = true
 		opts.maxEntryRevision = maxEntryRevision
+		opts.publishPrepareGuard = publishPrepareGuard
+		opts.touchedIndexPages = tracker.Pages()
+		opts.sideStoreBytes = sideStoreBytes
 		post, err = b.db.finalizeCommitLockedWithOptions(newRoot, sysRoot, retired, sync, metrics, touchedValueLogSegments, b.db.indexOuterLeavesInValueLog, vlogRefDelta, nil, nil, opts)
 		// Poison while still holding commitMu so that no concurrent writer can
 		// slip past the poison check in appendRawKVCommandWALIntent and publish a
@@ -526,6 +544,7 @@ func (b *Batch) writeOptimistic(sync bool, intent *commandWALBatchIntent, maxEnt
 		return false, err
 	}
 	b.db.observeFlushApplyInstalledOutput(metrics, len(retired))
+	b.publishedCommitSeq = post.commitSeq
 	vlogRefDelta = nil
 	b.db.invalidateLeafGenerationSubtreeStats(tracker.Pages())
 	b.db.finalizeCommitPostWork(post)
@@ -539,6 +558,7 @@ func (b *Batch) writeOptimistic(sync bool, intent *commandWALBatchIntent, maxEnt
 
 func (b *Batch) writeSerialized(sync bool, intent *commandWALBatchIntent, maxEntryRevision page.EntryRevision, conditional *ConditionalTxn) error {
 	touchedValueLogSegments := b.batch.TouchedValueLogSegments()
+	sideStoreBytes := b.batch.ValueLogPointerBytes()
 	rawSpanPlan := b.rawSpanNativeBatchPlan()
 
 	commitWaitStart := time.Now()
@@ -554,11 +574,13 @@ func (b *Batch) writeSerialized(sync bool, intent *commandWALBatchIntent, maxEnt
 		return fmt.Errorf("missing index")
 	}
 
-	b.db.mu.RLock()
-	rootID := b.db.meta.UserRootPageID
-	baseSeq := b.db.meta.CommitSeq
+	visible := b.db.state.Load()
+	if visible == nil {
+		return ErrClosed
+	}
+	rootID := visible.RootPageID
+	baseSeq := visible.CommitSeq
 	regID := idx.registry.Register(baseSeq)
-	b.db.mu.RUnlock()
 
 	defer idx.registry.Unregister(regID)
 	if conditional != nil {
@@ -617,18 +639,16 @@ func (b *Batch) writeSerialized(sync bool, intent *commandWALBatchIntent, maxEnt
 		}
 	}()
 
-	b.db.mu.Lock()
-	if b.db.meta.UserRootPageID != rootID {
+	visible = b.db.state.Load()
+	if visible.RootPageID != rootID {
 		// This should not happen if writeMu is held and we are the only writer.
 		b.db.releasePendingValueLogAppendFileIDsFromBatch(b.batch)
 		b.db.observeFlushApplyMismatch()
 		b.db.observeRawBatchSpanNativePublishFallback(rawSpanPlan, spanNativePublishSnapshot, FlushSpanRunFallbackRootMismatch)
 		b.db.observeFlushApplyAbandonedOutput(metrics, len(retired))
-		b.db.mu.Unlock()
 		return fmt.Errorf("concurrent modification detected during batch write")
 	}
-	sysRoot := b.db.meta.SystemRootPageID
-	b.db.mu.Unlock()
+	sysRoot := visible.SystemRootPageID
 
 	publishPrepareGuard, err := b.db.prepareFlushApplyPublish(sync)
 	if err != nil {
@@ -641,7 +661,7 @@ func (b *Batch) writeSerialized(sync bool, intent *commandWALBatchIntent, maxEnt
 	guardedPublishStart := time.Now()
 	var post finalizeCommitPost
 	if intent == nil {
-		post, err = b.db.finalizeCommitLockedWithOptions(newRoot, sysRoot, retired, sync, metrics, touchedValueLogSegments, b.db.indexOuterLeavesInValueLog, vlogRefDelta, nil, nil, finalizeCommitOptions{skipPrePublishFlush: true, skipConditionalRootConflict: true, maxEntryRevision: maxEntryRevision})
+		post, err = b.db.finalizeCommitLockedWithOptions(newRoot, sysRoot, retired, sync, metrics, touchedValueLogSegments, b.db.indexOuterLeavesInValueLog, vlogRefDelta, nil, nil, finalizeCommitOptions{skipPrePublishFlush: true, dependenciesFlushed: true, skipConditionalRootConflict: true, maxEntryRevision: maxEntryRevision, publishPrepareGuard: publishPrepareGuard, sideStoreBytes: sideStoreBytes})
 	} else {
 		// writeMu is released by the deferred unlock above even if the command
 		// journal append fails and poisons this open handle.
@@ -654,8 +674,11 @@ func (b *Batch) writeSerialized(sync bool, intent *commandWALBatchIntent, maxEnt
 		}
 		opts := commandWALFinalizeOptions(intent)
 		opts.skipPrePublishFlush = true
+		opts.dependenciesFlushed = true
 		opts.skipConditionalRootConflict = true
 		opts.maxEntryRevision = maxEntryRevision
+		opts.publishPrepareGuard = publishPrepareGuard
+		opts.sideStoreBytes = sideStoreBytes
 		post, err = b.db.finalizeCommitLockedWithOptions(newRoot, sysRoot, retired, sync, metrics, touchedValueLogSegments, b.db.indexOuterLeavesInValueLog, vlogRefDelta, nil, nil, opts)
 	}
 	b.db.observeFlushApplyGuardedPublish(time.Since(guardedPublishStart), err == nil)
@@ -672,6 +695,7 @@ func (b *Batch) writeSerialized(sync bool, intent *commandWALBatchIntent, maxEnt
 		b.db.conditionalRecordCommittedEntries(entries, ranges, b.conditionalTxnID, post.commitSeq)
 	}
 	b.db.observeFlushApplyInstalledOutput(metrics, len(retired))
+	b.publishedCommitSeq = post.commitSeq
 	vlogRefDelta = nil
 	b.db.finalizeCommitPostWork(post)
 	b.db.releasePendingValueLogAppendFileIDsFromBatch(b.batch)
@@ -710,6 +734,12 @@ func (b *Batch) writeConditional(sync bool, conditional *ConditionalTxn) error {
 	if err == nil && intent != nil && intent.lsn != 0 {
 		b.db.conditionalTxnCommandWALPayloads.Add(1)
 	}
+	if err == nil && sync && (!b.db.commandWAL || b.physicalOnly) {
+		if b.publishedCommitSeq == 0 || b.db.rootPublication == nil {
+			return ErrClosed
+		}
+		return b.db.rootPublication.waitDurable(b.publishedCommitSeq)
+	}
 	return err
 }
 
@@ -718,12 +748,14 @@ func (b *Batch) Close() error {
 		err := b.batch.Close()
 		b.batch = nil
 		b.commandWALPublishIntent = nil
+		b.publishedCommitSeq = 0
 		b.conditionalTxnID = 0
 		b.flushApplySpanNativeFallbackReason = FlushSpanRunFallbackUnknown
 		return err
 	}
 	b.batch = nil
 	b.commandWALPublishIntent = nil
+	b.publishedCommitSeq = 0
 	b.conditionalTxnID = 0
 	b.flushApplySpanNativeFallbackReason = FlushSpanRunFallbackUnknown
 	return nil
@@ -736,6 +768,7 @@ func (b *Batch) Reset() {
 	}
 	b.batch.Reset()
 	b.commandWALPublishIntent = nil
+	b.publishedCommitSeq = 0
 	b.conditionalTxnID = 0
 	b.flushApplySpanNativeFallbackReason = FlushSpanRunFallbackUnknown
 }

--- a/TreeDB/db/batch.go
+++ b/TreeDB/db/batch.go
@@ -498,7 +498,7 @@ func (b *Batch) writeOptimistic(sync bool, intent *commandWALBatchIntent, maxEnt
 
 	var post finalizeCommitPost
 	if intent == nil {
-		post, err = b.db.finalizeCommitLockedWithOptions(newRoot, sysRoot, retired, sync, metrics, touchedValueLogSegments, b.db.indexOuterLeavesInValueLog, vlogRefDelta, nil, nil, finalizeCommitOptions{skipPrePublishFlush: true, dependenciesFlushed: true, skipConditionalRootConflict: true, maxEntryRevision: maxEntryRevision, publishPrepareGuard: publishPrepareGuard, touchedIndexPages: tracker.Pages(), sideStoreBytes: sideStoreBytes})
+		post, err = b.db.finalizeCommitLockedWithOptions(newRoot, sysRoot, retired, sync, metrics, touchedValueLogSegments, b.db.indexOuterLeavesInValueLog, vlogRefDelta, nil, nil, finalizeCommitOptions{skipPrePublishFlush: true, dependenciesFlushed: true, skipConditionalRootConflict: true, maxEntryRevision: maxEntryRevision, publishPrepareGuard: publishPrepareGuard, touchedIndexPages: tracker.Pages(), touchedIndexPagesOwned: true, sideStoreBytes: sideStoreBytes})
 	} else {
 		if _, err = b.db.appendRawKVCommandWALIntent(intent, sync); err != nil {
 			b.db.releasePendingValueLogAppendFileIDsFromBatch(b.batch)
@@ -520,6 +520,7 @@ func (b *Batch) writeOptimistic(sync bool, intent *commandWALBatchIntent, maxEnt
 		opts.maxEntryRevision = maxEntryRevision
 		opts.publishPrepareGuard = publishPrepareGuard
 		opts.touchedIndexPages = tracker.Pages()
+		opts.touchedIndexPagesOwned = true
 		opts.sideStoreBytes = sideStoreBytes
 		post, err = b.db.finalizeCommitLockedWithOptions(newRoot, sysRoot, retired, sync, metrics, touchedValueLogSegments, b.db.indexOuterLeavesInValueLog, vlogRefDelta, nil, nil, opts)
 		// Poison while still holding commitMu so that no concurrent writer can

--- a/TreeDB/db/command_wal_publish.go
+++ b/TreeDB/db/command_wal_publish.go
@@ -36,6 +36,7 @@ type finalizeCommitOptions struct {
 	maxEntryRevision            page.EntryRevision
 	publishPrepareGuard         *finalizeCommitPrepareGuard
 	touchedIndexPages           []uint64
+	touchedIndexPagesOwned      bool
 	sideStoreBytes              uint64
 }
 

--- a/TreeDB/db/command_wal_publish.go
+++ b/TreeDB/db/command_wal_publish.go
@@ -30,19 +30,25 @@ type finalizeCommitOptions struct {
 	appliedCommandLSN           uint64
 	appliedRanges               []CommandWALLSNRange
 	skipPrePublishFlush         bool
+	dependenciesFlushed         bool
 	syncMetaPageOnly            bool
 	skipConditionalRootConflict bool
 	maxEntryRevision            page.EntryRevision
+	publishPrepareGuard         *finalizeCommitPrepareGuard
+	touchedIndexPages           []uint64
+	sideStoreBytes              uint64
 }
 
 func (db *DB) publishCommandWALRoots(newRootID uint64, sysRootID uint64, appliedLSN uint64, covered []CommandWALLSNRange, sync bool) error {
 	db.writeMu.Lock()
-	defer db.writeMu.Unlock()
 
-	db.mu.RLock()
-	baseSeq := db.meta.CommitSeq
-	rootsUnchanged := newRootID == db.meta.UserRootPageID && sysRootID == db.meta.SystemRootPageID
-	db.mu.RUnlock()
+	visible := db.state.Load()
+	if visible == nil {
+		db.writeMu.Unlock()
+		return ErrClosed
+	}
+	baseSeq := visible.CommitSeq
+	rootsUnchanged := newRootID == visible.RootPageID && sysRootID == visible.SystemRootPageID
 
 	var vlogRefDelta *valueLogRefDelta
 	if rootsUnchanged {
@@ -70,9 +76,15 @@ func (db *DB) publishCommandWALRoots(newRootID uint64, sysRootID uint64, applied
 		if vlogRefDelta != nil {
 			releaseValueLogRefDelta(vlogRefDelta)
 		}
+		db.writeMu.Unlock()
 		return err
 	}
 	db.finalizeCommitPostWork(post)
+	target := post.commitSeq
+	db.writeMu.Unlock()
+	if sync && db.rootPublication != nil {
+		return db.rootPublication.waitDurable(target)
+	}
 	return nil
 }
 

--- a/TreeDB/db/command_wal_publish_test.go
+++ b/TreeDB/db/command_wal_publish_test.go
@@ -937,7 +937,7 @@ func TestCommandWALCleanupDoesNotEmitAfterDeletionSyncOnSyncFailure(t *testing.T
 	writeCommandWALFrame(t, dir, 2, 2)
 
 	db := &DB{dir: dir, commandWAL: true, durability: DurabilityDurable}
-	db.state.Store(&DBState{AppliedCommandLSN: 1})
+	db.meta.AppliedCommandLSN = 1
 
 	originalSyncDir := syncDirFn
 	defer func() { syncDirFn = originalSyncDir }()
@@ -971,7 +971,7 @@ func TestCommandWALCleanupPartialUnlinkFailureRequiresRecoveryWithoutSync(t *tes
 	writeCommandWALFrame(t, dir, 3, 3)
 
 	db := &DB{dir: dir, commandWAL: true, durability: DurabilityDurable}
-	db.state.Store(&DBState{AppliedCommandLSN: 2})
+	db.meta.AppliedCommandLSN = 2
 
 	wantErr := errors.New("injected second-unlink cut")
 	var unlinkAttempts int

--- a/TreeDB/db/command_wal_raw.go
+++ b/TreeDB/db/command_wal_raw.go
@@ -405,15 +405,28 @@ func (db *DB) CleanupCommandWALCoveredSegments(sync bool) error {
 	if db == nil || !db.commandWAL {
 		return nil
 	}
+	if err := db.commandWALPoisonedError(); err != nil {
+		return err
+	}
 	if db.readOnly {
 		return ErrReadOnly
 	}
-	state := db.state.Load()
-	if state == nil || state.AppliedCommandLSN == 0 {
+	appliedCommandLSN := uint64(0)
+	if db.rootPublication != nil {
+		appliedCommandLSN = db.rootPublication.durableAppliedCommandLSN()
+	} else {
+		// Open databases install the coordinator before cleanup is available.
+		// Keep the durable on-disk meta as the safe fallback for narrowly
+		// constructed internal DB values.
+		db.mu.Lock()
+		appliedCommandLSN = db.meta.AppliedCommandLSN
+		db.mu.Unlock()
+	}
+	if appliedCommandLSN == 0 {
 		return nil
 	}
 	scanStart := time.Now()
-	decisions, err := scanCommandWALSegmentsCoveredByAppliedLSN(db.dir, state.AppliedCommandLSN, db.walMaxSegmentBytes)
+	decisions, err := scanCommandWALSegmentsCoveredByAppliedLSN(db.dir, appliedCommandLSN, db.walMaxSegmentBytes)
 	db.commandWALCleanupScans.Add(1)
 	if scanNs := commandWALDurationNs(time.Since(scanStart)); scanNs > 0 {
 		db.commandWALCleanupScanNs.Add(scanNs)
@@ -1381,11 +1394,14 @@ func (db *DB) publishCommandWALNoop(intent *CommandWALIntent, sync bool) error {
 		db.commitMu.Unlock()
 		return err
 	}
-	db.mu.RLock()
-	baseSeq := db.meta.CommitSeq
-	userRoot := db.meta.UserRootPageID
-	systemRoot := db.meta.SystemRootPageID
-	db.mu.RUnlock()
+	visible := db.state.Load()
+	if visible == nil {
+		db.commitMu.Unlock()
+		return ErrClosed
+	}
+	baseSeq := visible.CommitSeq
+	userRoot := visible.RootPageID
+	systemRoot := visible.SystemRootPageID
 	vlogRefDelta := db.newNoopValueLogRefDeltaIfTrackable(baseSeq)
 	post, err := db.finalizeCommitLockedWithOptions(userRoot, systemRoot, nil, sync, adaptive.Metrics{}, nil, false, vlogRefDelta, nil, nil, commandWALFinalizeOptionsForPublicIntent(intent))
 	if err != nil {
@@ -1471,7 +1487,7 @@ func (db *DB) appendCommandWALIntentWithTiming(intent *commandWALBatchIntent, sy
 		}
 	}
 	db.mu.RLock()
-	baseAppliedLSN := db.meta.AppliedCommandLSN
+	baseAppliedLSN := db.state.Load().AppliedCommandLSN
 	db.mu.RUnlock()
 	if requestTiming != nil {
 		requestTiming.BackendIntentPlanningSerialization += time.Since(planningStart)
@@ -1632,6 +1648,7 @@ func applyRawKVCommandWALFrame(db *DB, env commitlog.CommandEnvelope, ridMap map
 	if db == nil {
 		return fmt.Errorf("treedb: command wal recovery missing db")
 	}
+	db.ensureCommandWALRecoverySnapshotView()
 	if env.Kind != commitlog.CommandKindRawKVBatch || env.Scope != commitlog.CommandScopeRawKV || env.PayloadFormat != commitlog.PayloadFormatRawKVBatchV1 {
 		return commitlog.ErrCommandWALUnsupportedKind
 	}
@@ -1646,8 +1663,9 @@ func applyRawKVCommandWALFrame(db *DB, env commitlog.CommandEnvelope, ridMap map
 		// without changing roots. This path is only reached during recovery
 		// replay; there are no concurrent writers at that point.
 		db.mu.RLock()
-		rootID := db.meta.UserRootPageID
-		sysRootID := db.meta.SystemRootPageID
+		visible := db.state.Load()
+		rootID := visible.RootPageID
+		sysRootID := visible.SystemRootPageID
 		db.mu.RUnlock()
 		return db.publishCommandWALRoots(rootID, sysRootID, env.LSN, []CommandWALLSNRange{{First: env.LSN, Last: env.LSN}}, true)
 	}
@@ -1726,8 +1744,18 @@ func applyRawKVCommandWALFrame(db *DB, env commitlog.CommandEnvelope, ridMap map
 		}
 	}
 	maxEntryRevision := db.assignBatchEntryRevisions(b.batch)
-	return b.writeWithCommandWALIntent(true, &commandWALBatchIntent{
+	if err := b.writeWithCommandWALIntent(true, &commandWALBatchIntent{
 		lsn:          env.LSN,
 		coveredRange: [1]CommandWALLSNRange{{First: env.LSN, Last: env.LSN}},
-	}, maxEntryRevision)
+	}, maxEntryRevision); err != nil {
+		return err
+	}
+	// Replay calls the internal batch path directly, bypassing Batch.write's
+	// public sync fence. Do not let recovery advance to the next frame (or
+	// reopen initialization replace the snapshot view) until this frame's
+	// visible root has reached durable meta.
+	if b.publishedCommitSeq == 0 || db.rootPublication == nil {
+		return ErrClosed
+	}
+	return db.rootPublication.waitDurable(b.publishedCommitSeq)
 }

--- a/TreeDB/db/command_wal_stats_test.go
+++ b/TreeDB/db/command_wal_stats_test.go
@@ -387,7 +387,7 @@ func TestCommandWALCleanupStatsCountConsumedBytes(t *testing.T) {
 	}
 
 	db := &DB{dir: dir, commandWAL: true}
-	db.state.Store(&DBState{AppliedCommandLSN: 1})
+	db.meta.AppliedCommandLSN = 1
 
 	if err := db.CleanupCommandWALCoveredSegments(false); err != nil {
 		t.Fatalf("CleanupCommandWALCoveredSegments: %v", err)

--- a/TreeDB/db/commit_combiner.go
+++ b/TreeDB/db/commit_combiner.go
@@ -18,7 +18,12 @@ type commitCombineReq struct {
 	value  []byte
 	del    bool
 	sync   bool
-	result chan error
+	result chan commitCombineResult
+}
+
+type commitCombineResult struct {
+	publishedCommitSeq uint64
+	err                error
 }
 
 func (db *DB) startCommitCombiner() {
@@ -90,7 +95,7 @@ func (db *DB) writeViaCommitCombiner(key, value []byte, del, sync bool) (bool, e
 		key:    append([]byte(nil), key...),
 		del:    del,
 		sync:   sync,
-		result: make(chan error, 1),
+		result: make(chan commitCombineResult, 1),
 	}
 	if !del {
 		req.value = append([]byte(nil), value...)
@@ -106,8 +111,14 @@ func (db *DB) writeViaCommitCombiner(key, value []byte, del, sync bool) (bool, e
 	}
 
 	select {
-	case err := <-req.result:
-		return true, err
+	case result := <-req.result:
+		if result.err != nil || !sync || db.commandWAL {
+			return true, result.err
+		}
+		if result.publishedCommitSeq == 0 || db.rootPublication == nil {
+			return true, ErrClosed
+		}
+		return true, db.rootPublication.waitDurable(result.publishedCommitSeq)
 	case <-stopCh:
 		return true, errCommitCombinerClosed
 	}
@@ -134,9 +145,9 @@ func (db *DB) writeSingleKV(key, value []byte, del, sync bool) error {
 	return err
 }
 
-func (db *DB) applyCombinedBatch(batch []*commitCombineReq) error {
+func (db *DB) applyCombinedBatch(batch []*commitCombineReq) (uint64, error) {
 	if len(batch) == 0 {
-		return nil
+		return 0, nil
 	}
 	anySync := false
 	b := db.newBatchWithEntryReserve(len(batch)).(*Batch)
@@ -153,30 +164,31 @@ func (db *DB) applyCombinedBatch(batch []*commitCombineReq) error {
 		}
 		if err != nil {
 			_ = b.Close()
-			return err
+			return 0, err
 		}
 		if req.sync {
 			anySync = true
 		}
 	}
 	var err error
-	if anySync {
+	if anySync && db.commandWAL {
 		err = b.WriteSync()
 	} else {
 		err = b.Write()
 	}
+	publishedCommitSeq := b.publishedCommitSeq
 	if closeErr := b.Close(); err == nil {
 		err = closeErr
 	}
-	return err
+	return publishedCommitSeq, err
 }
 
-func (db *DB) finishCombined(batch []*commitCombineReq, err error) {
+func (db *DB) finishCombined(batch []*commitCombineReq, publishedCommitSeq uint64, err error) {
 	for _, req := range batch {
 		if req == nil {
 			continue
 		}
-		req.result <- err
+		req.result <- commitCombineResult{publishedCommitSeq: publishedCommitSeq, err: err}
 	}
 }
 
@@ -187,7 +199,7 @@ func (db *DB) drainCombined(reqCh <-chan *commitCombineReq, err error) {
 			if req == nil {
 				return
 			}
-			req.result <- err
+			req.result <- commitCombineResult{err: err}
 		default:
 			return
 		}
@@ -235,8 +247,8 @@ func (db *DB) commitCombinerLoop(reqCh <-chan *commitCombineReq, stopCh <-chan s
 						default:
 						}
 					}
-					err := db.applyCombinedBatch(batch)
-					db.finishCombined(batch, err)
+					publishedCommitSeq, err := db.applyCombinedBatch(batch)
+					db.finishCombined(batch, publishedCommitSeq, err)
 					db.drainCombined(reqCh, errCommitCombinerClosed)
 					return
 				}
@@ -250,8 +262,8 @@ func (db *DB) commitCombinerLoop(reqCh <-chan *commitCombineReq, stopCh <-chan s
 				default:
 				}
 			}
-			err := db.applyCombinedBatch(batch)
-			db.finishCombined(batch, err)
+			publishedCommitSeq, err := db.applyCombinedBatch(batch)
+			db.finishCombined(batch, publishedCommitSeq, err)
 		}
 	}
 }

--- a/TreeDB/db/commit_combiner_fallback_test.go
+++ b/TreeDB/db/commit_combiner_fallback_test.go
@@ -84,7 +84,7 @@ func TestCommitCombinerFallback_QueueFullFastProbe(t *testing.T) {
 
 	reqCh := make(chan *commitCombineReq, 1)
 	stopCh := make(chan struct{})
-	sentinel := &commitCombineReq{result: make(chan error, 1)}
+	sentinel := &commitCombineReq{result: make(chan commitCombineResult, 1)}
 	reqCh <- sentinel
 
 	d.combineMu.Lock()
@@ -160,7 +160,7 @@ func TestWriteViaCommitCombiner_StopClosedDuringFastProbe(t *testing.T) {
 	d := &DB{}
 	reqCh := make(chan *commitCombineReq, 1)
 	stopCh := make(chan struct{})
-	reqCh <- &commitCombineReq{result: make(chan error, 1)}
+	reqCh <- &commitCombineReq{result: make(chan commitCombineResult, 1)}
 	close(stopCh)
 
 	d.combineMu.Lock()
@@ -232,26 +232,26 @@ func TestDrainCombined_PropagatesErrorToPendingRequests(t *testing.T) {
 	d := &DB{}
 	reqCh := make(chan *commitCombineReq, 2)
 	wantErr := errors.New("drain error")
-	req1 := &commitCombineReq{result: make(chan error, 1)}
-	req2 := &commitCombineReq{result: make(chan error, 1)}
+	req1 := &commitCombineReq{result: make(chan commitCombineResult, 1)}
+	req2 := &commitCombineReq{result: make(chan commitCombineResult, 1)}
 	reqCh <- req1
 	reqCh <- req2
 
 	d.drainCombined(reqCh, wantErr)
 
 	select {
-	case err := <-req1.result:
-		if !errors.Is(err, wantErr) {
-			t.Fatalf("req1 err = %v, want %v", err, wantErr)
+	case result := <-req1.result:
+		if !errors.Is(result.err, wantErr) {
+			t.Fatalf("req1 err = %v, want %v", result.err, wantErr)
 		}
 	case <-time.After(2 * time.Second):
 		t.Fatalf("timed out waiting for req1 result")
 	}
 
 	select {
-	case err := <-req2.result:
-		if !errors.Is(err, wantErr) {
-			t.Fatalf("req2 err = %v, want %v", err, wantErr)
+	case result := <-req2.result:
+		if !errors.Is(result.err, wantErr) {
+			t.Fatalf("req2 err = %v, want %v", result.err, wantErr)
 		}
 	case <-time.After(2 * time.Second):
 		t.Fatalf("timed out waiting for req2 result")

--- a/TreeDB/db/compact_storage_audit_test.go
+++ b/TreeDB/db/compact_storage_audit_test.go
@@ -599,8 +599,8 @@ func TestCompactStorageAudit_ProtectedRootsDoNotPoisonTrackerOrSubsequentGC(t *t
 	if err != nil {
 		t.Fatalf("ValueLogGC after removing protection: %v", err)
 	}
-	if got := scans.Load(); got != 0 {
-		t.Fatalf("ValueLogGC legacy ref scans=%d want tracker-only resolution", got)
+	if got := scans.Load(); got != 1 {
+		t.Fatalf("ValueLogGC recovery-closure scans=%d want 1 exact meta-slot scan", got)
 	}
 	if stats.SegmentsDeleted != 1 {
 		t.Fatalf("SegmentsDeleted=%d want 1: %+v", stats.SegmentsDeleted, stats)

--- a/TreeDB/db/db.go
+++ b/TreeDB/db/db.go
@@ -3074,32 +3074,21 @@ func (db *DB) finalizeCommitLockedWithOptions(newRootID uint64, sysRootID uint64
 		touchedIndexPages = idx.pager.DirtyIndexPages()
 	}
 	touchedIndexPages = append([]uint64(nil), touchedIndexPages...)
-	// Alloc may pop an ID by mutating the active freelist head in place. Until
-	// freelist updates become copy-on-write, every candidate that references a
-	// nonzero head owns that page's durability even when the allocated output
-	// IDs came from an explicit allocation tracker.
-	if nextMeta.FreelistHeadID != 0 {
-		found := false
-		for _, pageID := range touchedIndexPages {
-			if pageID == nextMeta.FreelistHeadID {
-				found = true
-				break
-			}
-		}
-		if !found {
-			touchedIndexPages = append(touchedIndexPages, nextMeta.FreelistHeadID)
-		}
-	}
 	ownedBytes := rootPublicationOwnedBytes(touchedIndexPages, retired, metrics, opts.sideStoreBytes)
-	dependencyEvent, hasDependencyEvent, err := db.finalizeDependencySyncEvent(valueLogAppender)
+	dependencyEvent, hasDependencyEvent, err := db.finalizeDependencySyncEvent(valueLogAppender, len(touchedValueLogSegments) != 0)
 	if err != nil {
 		db.mu.Unlock()
 		return post, prePublishErr(err)
 	}
+	var dependencyPath string
 	var dependencyPaths []string
 	if hasDependencyEvent {
-		dependencyPaths = append(dependencyPaths, dependencyEvent.Paths...)
-		if dependencyEvent.Path != "" {
+		if len(dependencyEvent.Paths) == 0 {
+			dependencyPath = dependencyEvent.Path
+		} else {
+			dependencyPaths = append(dependencyPaths, dependencyEvent.Paths...)
+		}
+		if dependencyEvent.Path != "" && dependencyPath == "" {
 			dependencyPaths = append(dependencyPaths, dependencyEvent.Path)
 		}
 		sort.Strings(dependencyPaths)
@@ -3119,6 +3108,7 @@ func (db *DB) finalizeCommitLockedWithOptions(newRootID uint64, sysRootID uint64
 		TouchedIndexPages:    touchedIndexPages,
 		RetiredPages:         append([]uint64(nil), retired...),
 		TouchedValueLogFiles: append([]uint32(nil), touchedValueLogSegments...),
+		DependencyPath:       dependencyPath,
 		DependencyPaths:      dependencyPaths,
 		OuterLeafFrontier:    outerLeafFrontier,
 		Meta:                 nextMeta,

--- a/TreeDB/db/db.go
+++ b/TreeDB/db/db.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"path/filepath"
 	"runtime"
+	"sort"
 	"strconv"
 	"sync"
 	"sync/atomic"
@@ -192,6 +193,7 @@ type DB struct {
 	vacuumPreflushHook            func() error
 	meta                          page.MetaPageBody
 	metaPageID                    uint64
+	rootPublication               *RootPublicationCoordinator
 	entryRevisionFloor            atomic.Uint64
 	commandJournal                *commitlog.CommandJournal
 	conditionalActiveTxnCount     atomic.Int64
@@ -493,15 +495,18 @@ type DB struct {
 	testFailWriteMeta atomic.Bool
 	// testFailSyncMeta fails after the alternate meta page has been written but
 	// before its durability outcome is known.
-	testFailSyncMeta                       atomic.Bool
-	testFailCommandWALFlush                atomic.Bool
-	testAfterOptimisticApplyHook           func()
-	testAfterOptimisticPublishPrepareHook  func()
-	testCheckpointAfterPoisonPreflightHook func()
-	testCommandWALRecoveryFailAfterLSN     atomic.Uint64
-	commandWALReplayLSN                    atomic.Uint64
-	commandWALReplayToken                  atomic.Uint64
-	commandWALReplayTokenSeq               atomic.Uint64
+	testFailSyncMeta                        atomic.Bool
+	testFailCommandWALFlush                 atomic.Bool
+	testAfterOptimisticApplyHook            func()
+	testAfterOptimisticPublishPrepareHook   func()
+	testCheckpointAfterPoisonPreflightHook  func()
+	testRootPublicationBeforeDependencySync func()
+	testRootPublicationRegistered           func(*PreparedRootCandidate)
+	testRootPublicationBeforeWait           func()
+	testCommandWALRecoveryFailAfterLSN      atomic.Uint64
+	commandWALReplayLSN                     atomic.Uint64
+	commandWALReplayToken                   atomic.Uint64
+	commandWALReplayTokenSeq                atomic.Uint64
 	// commandWALFlushPoisoned is intentionally cleared only by closing and
 	// reopening the DB. After an append reached the journal but flush/sync or
 	// root publication failed, continuing on the same handle could create an
@@ -1428,7 +1433,7 @@ func (db *DB) AcquireSnapshot() *Snapshot {
 	}
 	db.valueLogPublicationMu.RLock()
 	defer db.valueLogPublicationMu.RUnlock()
-	if db.closing.Load() || db.publicationPoisoned.Load() {
+	if db.closing.Load() {
 		return nil
 	}
 	snap := db.snapPool.Get()
@@ -2158,6 +2163,9 @@ func openWithLock(opts Options, lock *lockfile.Lock) (*DB, error) {
 			return nil, err
 		}
 	}
+	if db.rootPublication == nil {
+		db.rootPublication = newRootPublicationCoordinator(db)
+	}
 
 	db.pruner.Start(db, pruneWorkerOptions{
 		enabled:     !opts.DisableBackgroundPrune,
@@ -2450,6 +2458,16 @@ func (db *DB) closeAfterHooks() error {
 	}
 	db.clearFlushApplyReadOnlyPrepareBuffers()
 	db.writeMu.Unlock()
+	// All writers have drained. Wait for the exact visible frontier without any
+	// DB/write/commit lock held, then stop the publisher before pager teardown.
+	if db.rootPublication != nil {
+		if state := db.state.Load(); state != nil {
+			if err := db.rootPublication.retryDurable(state.CommitSeq); err != nil {
+				errs = append(errs, err)
+			}
+		}
+		db.rootPublication.stopPublisher()
+	}
 	// Operations using teardownMu may briefly take writeMu while preparing or
 	// revalidating work. Never wait for them while holding writeMu.
 	db.teardownMu.Lock()
@@ -2637,7 +2655,11 @@ func (db *DB) recover() error {
 			return err
 		}
 		db.metaPageID = MetaPage0ID
-		return nil
+		// Fresh-format initialization is the only setup path allowed to install
+		// both redundant meta slots together. Persist the roots and both metas,
+		// and clear pager dirty tracking before the coordinator starts enforcing
+		// its clean-meta pre-publication invariant.
+		return p.Sync()
 	}
 
 	m0, valid0 := db.readMeta(MetaPage0ID)
@@ -2860,7 +2882,7 @@ func (db *DB) finalizeCommitLockedWithOptions(newRootID uint64, sysRootID uint64
 		inlinePublishPrepareGuard = &finalizeCommitPrepareGuard{db: db}
 		defer inlinePublishPrepareGuard.Release()
 		t0 := time.Now()
-		if err := db.flushFinalizeCommitDurability(idx, valueLogAppender, sync); err != nil {
+		if err := db.flushFinalizeCommitDurability(idx, valueLogAppender, false); err != nil {
 			return post, prePublishErr(err)
 		}
 		if debugTiming {
@@ -2878,11 +2900,18 @@ func (db *DB) finalizeCommitLockedWithOptions(newRootID uint64, sysRootID uint64
 	db.mu.Lock()
 	watermarkWait += time.Since(lockStart)
 	holdStart := time.Now()
-	oldUserRootID := db.meta.UserRootPageID
+	visibleState := db.state.Load()
+	if visibleState == nil {
+		db.mu.Unlock()
+		return post, prePublishErr(errors.New("missing visible state"))
+	}
+	oldUserRootID := visibleState.RootPageID
 	nextMeta := db.meta
-	nextMeta.CommitSeq++
+	nextMeta.CommitSeq = visibleState.CommitSeq + 1
 	nextMeta.UserRootPageID = newRootID
 	nextMeta.SystemRootPageID = sysRootID
+	nextMeta.AppliedCommandLSN = visibleState.AppliedCommandLSN
+	nextMeta.MaxEntryRevision = uint64(visibleState.MaxEntryRevision)
 	nextMeta.FreelistHeadID = idx.allocator.Head()
 	nextMeta.TotalPages = idx.pager.PageCount()
 	if opts.commandWALPublish {
@@ -2891,7 +2920,11 @@ func (db *DB) finalizeCommitLockedWithOptions(newRootID uint64, sysRootID uint64
 			watermarkHold += time.Since(holdStart)
 			return post, prePublishErr(err)
 		}
-		if err := validateCommandWALPublishLocked(db.meta, newRootID, sysRootID, opts); err != nil {
+		visibleMeta := nextMeta
+		visibleMeta.UserRootPageID = visibleState.RootPageID
+		visibleMeta.SystemRootPageID = visibleState.SystemRootPageID
+		visibleMeta.AppliedCommandLSN = visibleState.AppliedCommandLSN
+		if err := validateCommandWALPublishLocked(visibleMeta, newRootID, sysRootID, opts); err != nil {
 			db.mu.Unlock()
 			watermarkHold += time.Since(holdStart)
 			return post, prePublishErr(err)
@@ -2907,10 +2940,6 @@ func (db *DB) finalizeCommitLockedWithOptions(newRootID uint64, sysRootID uint64
 		nextMeta.MaxEntryRevision = uint64(opts.maxEntryRevision)
 	}
 
-	targetPageID := uint64(0)
-	if db.metaPageID == 0 {
-		targetPageID = 1
-	}
 	db.mu.Unlock()
 	watermarkHold += time.Since(holdStart)
 
@@ -2944,72 +2973,32 @@ func (db *DB) finalizeCommitLockedWithOptions(newRootID uint64, sysRootID uint64
 			return post, prePublishErr(err)
 		}
 	}
-
-	// 3. Write Meta - No DB Lock
-	t0 := time.Now()
-	var metaPath string
-	if durabilitycut.Enabled() {
-		metaPath = filepath.Join(db.dir, "index.db")
-	}
-	metaOffset := int64(targetPageID) * int64(page.PageSize)
-	if err := durabilitycut.EmitRange(durabilitycut.BeforeMetaWrite, durabilitycut.ResourceMeta, db.dir, metaPath, metaOffset, int64(page.PageSize)); err != nil {
-		return post, prePublishErr(err)
-	}
-	if err := db.writeMeta(targetPageID, nextMeta); err != nil {
-		return post, prePublishErr(err)
-	}
-	postMetaWriteErr := func(err error) error {
-		if err == nil {
-			return nil
-		}
-		// The target meta page has been dirtied. Any failure from this point
-		// leaves publication outcome ambiguous until the database is reopened.
-		db.publicationPoisoned.Store(true)
-		return wrapFinalizeCommitError(errors.Join(err, ErrRecoveryRequired), false)
-	}
-	if err := durabilitycut.EmitRange(durabilitycut.AfterMetaWrite, durabilitycut.ResourceMeta, db.dir, metaPath, metaOffset, int64(page.PageSize)); err != nil {
-		return post, postMetaWriteErr(err)
-	}
-	if debugTiming {
-		durMeta = time.Since(t0)
-	}
-
-	// 4. Sync Meta - No DB Lock
-	if sync {
-		t1 := time.Now()
-		var err error
-		if err := durabilitycut.EmitPath(durabilitycut.BeforeMetaSync, durabilitycut.ResourceMeta, db.dir, metaPath); err != nil {
-			return post, postMetaWriteErr(err)
-		}
-		if db.testFailSyncMeta.Load() {
-			err = errTestSyncMetaFailpoint
-		} else if opts.syncMetaPageOnly {
-			err = idx.pager.SyncPages([]uint64{targetPageID})
-		} else {
-			err = idx.pager.Sync()
-		}
+	var outerLeafFrontier uint64
+	if db.leafPageLog != nil {
+		segments, err := leafPageLogCurrentSegments(db.leafPageLog)
 		if err != nil {
-			return post, postMetaWriteErr(err)
+			return post, prePublishErr(err)
 		}
-		if err := durabilitycut.EmitPath(durabilitycut.AfterMetaSync, durabilitycut.ResourceMeta, db.dir, metaPath); err != nil {
-			return post, postMetaWriteErr(err)
-		}
-		if debugTiming {
-			durSync2 = time.Since(t1)
+		for _, segment := range segments {
+			if uint64(segment.FileID) > outerLeafFrontier {
+				outerLeafFrontier = uint64(segment.FileID)
+			}
 		}
 	}
 
-	// 5. Update visible state and retire pages.
+	// Publish the read-visible state and register its immutable durable closure.
 	lockStart = time.Now()
 	db.mu.Lock()
 	watermarkWait += time.Since(lockStart)
 	holdStart = time.Now()
-	db.meta = nextMeta
-	db.advanceEntryRevisionFloor(page.EntryRevision(nextMeta.MaxEntryRevision))
-	db.metaPageID = targetPageID
-	idx.graveyard.Add(nextMeta.CommitSeq-1, retired)
 	post.oldState = db.state.Load()
 	var valueLogSet *valuelog.Set
+	valueLogSetOwned := false
+	defer func() {
+		if valueLogSetOwned && db.valueLogManager != nil {
+			_ = db.valueLogManager.Release(valueLogSet)
+		}
+	}()
 	if db.valueLogManager != nil {
 		needRefresh := false
 		if len(touchedValueLogSegments) > 0 {
@@ -3034,17 +3023,19 @@ func (db *DB) finalizeCommitLockedWithOptions(newRootID uint64, sysRootID uint64
 		} else {
 			valueLogSet = db.valueLogManager.CurrentSetNoRefresh()
 		}
+		valueLogSetOwned = valueLogSet != nil
 	}
+	candidateLeafManifest := db.leafGenerationManifest
 	var leafGenerationView *leafGenerationView
 	if leafManifest != nil {
-		db.leafGenerationManifest = leafManifest
+		candidateLeafManifest = leafManifest
 		post.persistLeafGenerationManifest = true
 		post.persistLeafGenerationManifestView = leafManifest
 		post.persistLeafGenerationRawFileIDs = append(post.persistLeafGenerationRawFileIDs[:0], leafManifestRawFileIDs...)
 		leafGenerationView = db.leafGenerationViewForManifest(leafManifest)
 	}
 	if db.leafPageLog != nil {
-		stagedLeafManifest, err := db.stagedLeafGenerationManifestWithPendingResult(db.leafGenerationManifest, 0, nextMeta.CommitSeq)
+		stagedLeafManifest, err := db.stagedLeafGenerationManifestWithPendingResult(candidateLeafManifest, 0, nextMeta.CommitSeq)
 		if err != nil {
 			db.mu.Unlock()
 			return post, err
@@ -3070,11 +3061,112 @@ func (db *DB) finalizeCommitLockedWithOptions(newRootID uint64, sysRootID uint64
 		ValueLogSet:       valueLogSet,
 		LeafGenerations:   leafGenerationView,
 	}
+	nextLeafGenerationStateVersion := db.leafGenerationStateVersion
 	if leafGenerationView != nil {
-		db.leafGenerationStateVersion++
-		newState.LeafGenerationStateVersion = db.leafGenerationStateVersion
+		nextLeafGenerationStateVersion++
+		newState.LeafGenerationStateVersion = nextLeafGenerationStateVersion
+	}
+	touchedIndexPages := opts.touchedIndexPages
+	if touchedIndexPages == nil {
+		// Serialized maintenance/public-root callers have no concurrent builder;
+		// their global snapshot is therefore an exact ownership frontier. The
+		// optimistic batch paths always supply their allocation tracker explicitly.
+		touchedIndexPages = idx.pager.DirtyIndexPages()
+	}
+	touchedIndexPages = append([]uint64(nil), touchedIndexPages...)
+	// Alloc may pop an ID by mutating the active freelist head in place. Until
+	// freelist updates become copy-on-write, every candidate that references a
+	// nonzero head owns that page's durability even when the allocated output
+	// IDs came from an explicit allocation tracker.
+	if nextMeta.FreelistHeadID != 0 {
+		found := false
+		for _, pageID := range touchedIndexPages {
+			if pageID == nextMeta.FreelistHeadID {
+				found = true
+				break
+			}
+		}
+		if !found {
+			touchedIndexPages = append(touchedIndexPages, nextMeta.FreelistHeadID)
+		}
+	}
+	ownedBytes := rootPublicationOwnedBytes(touchedIndexPages, retired, metrics, opts.sideStoreBytes)
+	dependencyEvent, hasDependencyEvent, err := db.finalizeDependencySyncEvent(valueLogAppender)
+	if err != nil {
+		db.mu.Unlock()
+		return post, prePublishErr(err)
+	}
+	var dependencyPaths []string
+	if hasDependencyEvent {
+		dependencyPaths = append(dependencyPaths, dependencyEvent.Paths...)
+		if dependencyEvent.Path != "" {
+			dependencyPaths = append(dependencyPaths, dependencyEvent.Path)
+		}
+		sort.Strings(dependencyPaths)
+	}
+	var oldValueLogSet *valuelog.Set
+	if post.oldState != nil {
+		oldValueLogSet = post.oldState.ValueLogSet
+	}
+	candidate := &PreparedRootCandidate{
+		CommitSeq:            nextMeta.CommitSeq,
+		UserRootPageID:       nextMeta.UserRootPageID,
+		SystemRootPageID:     nextMeta.SystemRootPageID,
+		FreelistHeadID:       nextMeta.FreelistHeadID,
+		TotalPages:           nextMeta.TotalPages,
+		AppliedCommandLSN:    nextMeta.AppliedCommandLSN,
+		MaxEntryRevision:     nextMeta.MaxEntryRevision,
+		TouchedIndexPages:    touchedIndexPages,
+		RetiredPages:         append([]uint64(nil), retired...),
+		TouchedValueLogFiles: append([]uint32(nil), touchedValueLogSegments...),
+		DependencyPaths:      dependencyPaths,
+		OuterLeafFrontier:    outerLeafFrontier,
+		Meta:                 nextMeta,
+		OldValueLogSet:       oldValueLogSet,
+		ValueLogAppender:     valueLogAppender,
+		LeafPageLog:          db.leafPageLog,
+		OwnedBytes:           ownedBytes,
+		DependenciesFlushed:  !opts.skipPrePublishFlush || opts.dependenciesFlushed,
+	}
+	if db.rootPublication == nil {
+		db.mu.Unlock()
+		return post, prePublishErr(errors.New("root publication coordinator is not running"))
+	}
+	publishPrepareGuard := opts.publishPrepareGuard
+	if publishPrepareGuard == nil {
+		publishPrepareGuard = inlinePublishPrepareGuard
+	}
+	if publishPrepareGuard != nil {
+		publishPrepareGuard.transferTo(candidate)
+	}
+	if err := db.rootPublication.register(candidate); err != nil {
+		db.mu.Unlock()
+		return post, prePublishErr(err)
+	}
+	// Registration transfers ownership of the value-log set and preparation
+	// pin to the candidate. Only now may visible-root side effects advance: a
+	// rejected candidate must not retire pages or mutate manifest/version state.
+	valueLogSetOwned = false
+	db.advanceEntryRevisionFloor(page.EntryRevision(nextMeta.MaxEntryRevision))
+	idx.graveyard.Add(nextMeta.CommitSeq-1, retired)
+	if leafManifest != nil {
+		db.leafGenerationManifest = leafManifest
+	}
+	if leafGenerationView != nil {
+		db.leafGenerationStateVersion = nextLeafGenerationStateVersion
 	}
 	db.state.Store(newState)
+	// The visible state and its ref-counted dependency set now protect registered
+	// output from GC. Release the coarse preparation exclusion before the
+	// background publisher waits for root builders to drain; retaining it until
+	// stable publication would deadlock a queued GC writer with the next builder.
+	if candidate.holdsPreparePin {
+		candidate.holdsPreparePin = false
+		db.publishPrepareMu.RUnlock()
+	}
+	if db.testRootPublicationRegistered != nil {
+		db.testRootPublicationRegistered(candidate)
+	}
 	if opts.commandWALPublish {
 		previousApplied := uint64(0)
 		if post.oldState != nil {
@@ -3089,6 +3181,7 @@ func (db *DB) finalizeCommitLockedWithOptions(newRootID uint64, sysRootID uint64
 		post.drainLeafGenerationPending = true
 	}
 	db.mu.Unlock()
+	db.rootPublication.signal()
 	watermarkHold += time.Since(holdStart)
 	db.observePublishWatermark(watermarkWait, watermarkHold, watermarkWait+watermarkHold)
 
@@ -3107,6 +3200,32 @@ func (db *DB) finalizeCommitLockedWithOptions(newRootID uint64, sysRootID uint64
 	}
 
 	return post, nil
+}
+
+func rootPublicationOwnedBytes(touchedIndexPages, retired []uint64, metrics adaptive.Metrics, sideStoreBytes uint64) uint64 {
+	owned := uint64(len(touchedIndexPages)+len(retired)) * uint64(page.PageSize)
+	addPositive := func(value int) {
+		if value <= 0 {
+			return
+		}
+		bytes := uint64(value)
+		if bytes > ^uint64(0)-owned {
+			owned = ^uint64(0)
+			return
+		}
+		owned += bytes
+	}
+	// IndexWriteBytes is represented by the exact owned page set above. Side
+	// stores need explicit accounting so stalled vlog/outer-leaf workloads cannot
+	// bypass the publication debt cap.
+	addPositive(metrics.SlabWriteBytes)
+	addPositive(metrics.ZipperLeafLogPageBytesWritten)
+	addPositive(metrics.ZipperLeafLogRecordHintBytesWritten)
+	if sideStoreBytes > ^uint64(0)-owned {
+		return ^uint64(0)
+	}
+	owned += sideStoreBytes
+	return owned
 }
 
 func (db *DB) finalizeCommitPostWork(post finalizeCommitPost) {
@@ -3137,9 +3256,6 @@ func (db *DB) finalizeCommitPostWork(post finalizeCommitPost) {
 		}
 	}
 
-	if post.oldState != nil {
-		_ = db.valueLogManager.Release(post.oldState.ValueLogSet)
-	}
 	if post.persistLeafGenerationManifest || post.drainLeafGenerationPending || len(post.clearLeafGenerationPendingFileIDs) > 0 {
 		var (
 			persistErr        error
@@ -3149,7 +3265,10 @@ func (db *DB) finalizeCommitPostWork(post finalizeCommitPost) {
 			manifestPersisted bool
 		)
 		db.commitMu.Lock()
-		currentCommitSeq := db.meta.CommitSeq
+		currentCommitSeq := uint64(0)
+		if visible := db.state.Load(); visible != nil {
+			currentCommitSeq = visible.CommitSeq
+		}
 		currentManifest := db.leafGenerationManifest
 		currentState := db.state.Load()
 		if post.persistLeafGenerationManifest {
@@ -3235,7 +3354,6 @@ func (db *DB) Commit(newRootID uint64) error {
 	// Public Commit assumes the caller has built a new tree.
 	// We need to serialize with other writers.
 	db.writeMu.Lock()
-	defer db.writeMu.Unlock()
 
 	// Since we are committing a root provided by caller, we assume they based it on current state?
 	// If caller is external, they might have read old state.
@@ -3243,11 +3361,21 @@ func (db *DB) Commit(newRootID uint64) error {
 	// We just commit it.
 
 	// Need sysRootID.
-	db.mu.RLock()
-	sysRoot := db.meta.SystemRootPageID
-	db.mu.RUnlock()
-
-	return db.finalizeCommit(newRootID, sysRoot, nil, true, adaptive.Metrics{}, nil, true, nil, nil, nil)
+	state := db.state.Load()
+	if state == nil {
+		db.writeMu.Unlock()
+		return ErrClosed
+	}
+	err := db.finalizeCommit(newRootID, state.SystemRootPageID, nil, true, adaptive.Metrics{}, nil, true, nil, nil, nil)
+	target := uint64(0)
+	if current := db.state.Load(); current != nil {
+		target = current.CommitSeq
+	}
+	db.writeMu.Unlock()
+	if err != nil {
+		return err
+	}
+	return db.rootPublication.waitDurable(target)
 }
 
 // Checkpoint forces a durable boundary for previously-published backend state.
@@ -3268,70 +3396,42 @@ func (db *DB) Checkpoint() error {
 	if db.testCheckpointAfterPoisonPreflightHook != nil {
 		db.testCheckpointAfterPoisonPreflightHook()
 	}
+	if err := db.publicationPoisonedError(); err != nil {
+		return err
+	}
 
+	// Drain root builders so the target includes every write admitted before
+	// this checkpoint. Only snapshot the publication frontier while holding the
+	// writer fence; all dependency/meta I/O and waiting remain lock-free.
 	db.writeMu.Lock()
-	defer db.writeMu.Unlock()
-	if err := db.commandWALPoisonedError(); err != nil {
+	state := db.state.Load()
+	db.writeMu.Unlock()
+	if err := db.publicationPoisonedError(); err != nil {
 		return err
 	}
-
-	idx := db.idx.Load()
-	if idx == nil || idx.pager == nil {
-		return errors.New("missing index")
+	if state == nil || db.rootPublication == nil {
+		return ErrClosed
 	}
-	debugTiming := commitTimingEnabled()
-	var (
-		start      time.Time
-		durLeafLog time.Duration
-		durPager   time.Duration
-	)
-	if debugTiming {
-		start = time.Now()
-	}
+	// Preserve the empty-checkpoint dependency barrier. Root publication owns
+	// this sync when a candidate exists, while an empty checkpoint has no
+	// candidate whose worker could establish it.
 	if db.leafPageLog != nil {
-		if debugTiming {
-			t0 := time.Now()
-			if err := db.leafPageLog.Sync(); err != nil {
-				return err
-			}
-			durLeafLog = time.Since(t0)
-		} else if err := db.leafPageLog.Sync(); err != nil {
+		var err error
+		if durable, ok := db.leafPageLog.(LeafPageLogDurableSyncer); ok {
+			err = durable.SyncLeafPageLogDurable()
+		} else {
+			err = db.leafPageLog.Sync()
+		}
+		if err != nil {
 			return err
 		}
 	}
-	rotatedCommandWAL := false
-	if db.commandWAL && db.commandJournal != nil && db.CommandWALActiveBytes() > 0 {
-		if err := db.RotateCommandWALActiveSegment(true); err != nil {
-			return err
-		}
-		rotatedCommandWAL = true
-	}
-	if debugTiming {
-		t1 := time.Now()
-		if err := idx.pager.Sync(); err != nil {
-			return err
-		}
-		durPager = time.Since(t1)
-		commitTimingPrintf(
-			"treedb: checkpoint_timing leaf_log=%s pager=%s total=%s\n",
-			durLeafLog,
-			durPager,
-			time.Since(start),
-		)
-	} else if err := idx.pager.Sync(); err != nil {
-		return err
-	}
-	if rotatedCommandWAL {
-		if err := db.CleanupCommandWALCoveredSegments(true); err != nil {
-			return err
-		}
-	}
-	return nil
+	return db.rootPublication.retryDurable(state.CommitSeq)
 }
 
 // Prune reclaims pages from the graveyard.
 func (db *DB) Prune() {
-	if db.readOnly {
+	if db.readOnly || db.publicationPoisoned.Load() {
 		return
 	}
 	idx := db.idx.Load()
@@ -3346,7 +3446,7 @@ func (db *DB) Prune() {
 	if state == nil {
 		return
 	}
-	current := state.CommitSeq
+	current := db.effectivePruneCurrent(state.CommitSeq)
 
 	freed := idx.graveyard.Extract(min, current, db.keepRecent)
 
@@ -3693,6 +3793,9 @@ func (db *DB) MarkValueLogZombie(id uint32) error {
 	if db == nil || db.valueLogManager == nil {
 		return fmt.Errorf("value log manager unavailable")
 	}
+	if err := db.publicationPoisonedError(); err != nil {
+		return err
+	}
 	return db.valueLogManager.MarkZombie(id)
 }
 
@@ -3744,11 +3847,12 @@ func (db *DB) CompactIndex() error {
 	}
 
 	db.mu.Lock()
-	if db.meta.UserRootPageID != rootID {
+	visible := db.state.Load()
+	if visible == nil || visible.RootPageID != rootID {
 		db.mu.Unlock()
 		return fmt.Errorf("concurrent modification detected during compaction")
 	}
-	sysRoot := db.meta.SystemRootPageID
+	sysRoot := visible.SystemRootPageID
 	db.mu.Unlock()
 
 	// Commit new root and retire the old tree pages.

--- a/TreeDB/db/db.go
+++ b/TreeDB/db/db.go
@@ -1895,6 +1895,7 @@ func openWithLock(opts Options, lock *lockfile.Lock) (*DB, error) {
 
 	alloc := freelist.New(p, 0)
 	alloc.SetPreferAppend(opts.PreferAppendAlloc)
+	alloc.SetRetainDrainedHeads(true)
 	alloc.SetFreelistRegion(opts.FreelistRegionPages, opts.FreelistRegionRadius)
 
 	z := zipper.New(p, alloc)
@@ -3073,7 +3074,9 @@ func (db *DB) finalizeCommitLockedWithOptions(newRootID uint64, sysRootID uint64
 		// optimistic batch paths always supply their allocation tracker explicitly.
 		touchedIndexPages = idx.pager.DirtyIndexPages()
 	}
-	touchedIndexPages = append([]uint64(nil), touchedIndexPages...)
+	if !opts.touchedIndexPagesOwned {
+		touchedIndexPages = append([]uint64(nil), touchedIndexPages...)
+	}
 	ownedBytes := rootPublicationOwnedBytes(touchedIndexPages, retired, metrics, opts.sideStoreBytes)
 	dependencyEvent, hasDependencyEvent, err := db.finalizeDependencySyncEvent(valueLogAppender, len(touchedValueLogSegments) != 0)
 	if err != nil {

--- a/TreeDB/db/entry_revision.go
+++ b/TreeDB/db/entry_revision.go
@@ -9,9 +9,13 @@ func (db *DB) seedEntryRevisionFloor() {
 	if db == nil {
 		return
 	}
+	visible := db.state.Load()
 	floor := db.meta.MaxEntryRevision
-	if db.meta.CommitSeq > floor {
-		floor = db.meta.CommitSeq
+	if visible != nil && uint64(visible.MaxEntryRevision) > floor {
+		floor = uint64(visible.MaxEntryRevision)
+	}
+	if visible != nil && visible.CommitSeq > floor {
+		floor = visible.CommitSeq
 	}
 	db.entryRevisionFloor.Store(floor)
 }

--- a/TreeDB/db/errors.go
+++ b/TreeDB/db/errors.go
@@ -17,6 +17,10 @@ var (
 	// ErrConcurrentModification indicates a publish or maintenance operation
 	// observed that a root changed after its validation point.
 	ErrConcurrentModification = errors.New("treedb: concurrent modification")
+	// ErrPublicationStalled reports that background root publication failed
+	// before touching the alternate meta page. The prior durable root remains
+	// authoritative and an explicit durability boundary may retry publication.
+	ErrPublicationStalled = errors.New("treedb: root publication stalled")
 	// ErrLeafGenerationGCStaleScan indicates both bounded dry-run attempts were
 	// invalidated by concurrent publishes before their results could be used.
 	ErrLeafGenerationGCStaleScan = errors.New("treedb: leaf generation gc scan invalidated")

--- a/TreeDB/db/finalize_commit_prepare.go
+++ b/TreeDB/db/finalize_commit_prepare.go
@@ -3,6 +3,7 @@ package db
 import (
 	"errors"
 	"fmt"
+	"os"
 	"sort"
 
 	"github.com/snissn/gomap/TreeDB/internal/durabilitycut"
@@ -13,6 +14,15 @@ import (
 // either installed or abandoned.
 type finalizeCommitPrepareGuard struct {
 	db *DB
+}
+
+func (g *finalizeCommitPrepareGuard) transferTo(candidate *PreparedRootCandidate) bool {
+	if g == nil || g.db == nil || candidate == nil {
+		return false
+	}
+	candidate.holdsPreparePin = true
+	g.db = nil
+	return true
 }
 
 func (g *finalizeCommitPrepareGuard) Release() {
@@ -93,6 +103,120 @@ func (db *DB) flushFinalizeCommitDurability(idx *indexGen, valueLogAppender Valu
 	return nil
 }
 
+// flushRootPublicationClosureDurability makes the complete dependency union
+// for a coalesced publication durable. In particular, a later candidate may
+// use a different value-log appender/lane after rotation, so syncing only the
+// frontier appender is insufficient.
+func (db *DB) flushRootPublicationClosureDurability(idx *indexGen, candidates []*PreparedRootCandidate) error {
+	if idx == nil {
+		return errors.New("missing index")
+	}
+	dependencySet := make(map[string]struct{})
+	for _, candidate := range candidates {
+		if candidate == nil {
+			continue
+		}
+		for _, path := range candidate.DependencyPaths {
+			if path != "" {
+				dependencySet[path] = struct{}{}
+			}
+		}
+	}
+	dependencyPaths := make([]string, 0, len(dependencySet))
+	for path := range dependencySet {
+		dependencyPaths = append(dependencyPaths, path)
+	}
+	sort.Strings(dependencyPaths)
+	if len(dependencyPaths) != 0 {
+		if err := durabilitycut.Emit(durabilitycut.Event{Point: durabilitycut.BeforeDependencyFileSync, Root: db.dir, Paths: dependencyPaths}); err != nil {
+			return err
+		}
+		for _, path := range dependencyPaths {
+			f, err := os.OpenFile(path, os.O_RDWR, 0)
+			if err != nil {
+				return fmt.Errorf("sync root publication dependency %q: %w", path, err)
+			}
+			syncErr := f.Sync()
+			closeErr := f.Close()
+			if syncErr != nil || closeErr != nil {
+				return fmt.Errorf("sync root publication dependency %q: %w", path, errors.Join(syncErr, closeErr))
+			}
+		}
+	}
+	for _, candidate := range candidates {
+		if candidate == nil {
+			continue
+		}
+		// Candidate preparation already drained userspace buffers before the
+		// dependency path snapshot was captured. Sync those immutable path
+		// identities directly: the installed appender objects remain live and a
+		// later visible commit may be appending through them concurrently.
+		// A drained leaf log is fenced through its captured paths above. Calling
+		// Sync on the installed writer would race a successor commit appending to
+		// that same mutable object. Legacy/test candidates without a flushed path
+		// snapshot retain the conservative live-writer fallback.
+		if candidate.LeafPageLog != nil && (!candidate.DependenciesFlushed || len(candidate.DependencyPaths) == 0) {
+			var err error
+			if durable, ok := candidate.LeafPageLog.(LeafPageLogDurableSyncer); ok {
+				err = durable.SyncLeafPageLogDurable()
+			} else {
+				err = candidate.LeafPageLog.Sync()
+			}
+			if err != nil {
+				return err
+			}
+		}
+		if candidate.ValueLogAppender == nil {
+			continue
+		}
+		fileIDs := append([]uint32(nil), candidate.TouchedValueLogFiles...)
+		if flusher, ok := candidate.ValueLogAppender.(ValueLogDurableExternalRefFlusher); ok {
+			if err := flusher.SyncValueLogExternalRefsDurable(fileIDs); err != nil {
+				return err
+			}
+			continue
+		}
+		if flusher, ok := candidate.ValueLogAppender.(ValueLogExternalRefFlusher); ok {
+			if err := flusher.FlushValueLogExternalRefs(fileIDs, true); err != nil {
+				return err
+			}
+			continue
+		}
+		if err := candidate.ValueLogAppender.Sync(); err != nil {
+			return err
+		}
+	}
+	if len(dependencyPaths) != 0 {
+		if err := durabilitycut.Emit(durabilitycut.Event{Point: durabilitycut.AfterDependencyFileSync, Root: db.dir, Paths: dependencyPaths}); err != nil {
+			return err
+		}
+	}
+	// A newly grown mmap needs one file-wide size fence. It belongs to the
+	// index stage: dependency files must be durable before this file-wide sync
+	// can persist any index bytes, and no target meta has been written yet.
+	if err := idx.pager.SyncIndexFileSize(); err != nil {
+		return err
+	}
+	pageSet := make(map[uint64]struct{})
+	for _, candidate := range candidates {
+		if candidate == nil {
+			continue
+		}
+		for _, pageID := range candidate.TouchedIndexPages {
+			pageSet[pageID] = struct{}{}
+		}
+	}
+	pageIDs := make([]uint64, 0, len(pageSet))
+	for pageID := range pageSet {
+		pageIDs = append(pageIDs, pageID)
+	}
+	sort.Slice(pageIDs, func(i, j int) bool { return pageIDs[i] < pageIDs[j] })
+	// Candidate page sets are captured under writer serialization. Sync only
+	// their immutable closure; global dirty pages may belong to a later builder
+	// that is still mutating its returned mmap slice.
+	return idx.pager.SyncIndexPages(pageIDs)
+}
+
 func (db *DB) finalizeDependencySyncEvent(valueLogAppender ValueLogAppender) (durabilitycut.Event, bool, error) {
 	eventsByPath := make(map[string]durabilitycut.Event)
 	if db.leafPageLog != nil {
@@ -143,7 +267,10 @@ func (db *DB) prepareFinalizeCommitDurability(sync bool) (*finalizeCommitPrepare
 	valueLogAppender := db.currentValueLogAppender()
 	db.publishPrepareMu.RLock()
 	guard := &finalizeCommitPrepareGuard{db: db}
-	if err := db.flushFinalizeCommitDurability(idx, valueLogAppender, sync); err != nil {
+	// Candidate preparation drains userspace buffers only. Stable file and index
+	// fences belong exclusively to RootPublicationCoordinator after all commit
+	// and writer serialization has been released.
+	if err := db.flushFinalizeCommitDurability(idx, valueLogAppender, false); err != nil {
 		guard.Release()
 		return nil, wrapFinalizeCommitError(err, true)
 	}

--- a/TreeDB/db/finalize_commit_prepare.go
+++ b/TreeDB/db/finalize_commit_prepare.go
@@ -7,6 +7,7 @@ import (
 	"sort"
 
 	"github.com/snissn/gomap/TreeDB/internal/durabilitycut"
+	"github.com/snissn/gomap/TreeDB/pager"
 )
 
 // finalizeCommitPrepareGuard keeps value-log GC from scanning reachability and
@@ -41,7 +42,7 @@ func (db *DB) flushFinalizeCommitDurability(idx *indexGen, valueLogAppender Valu
 	var hasDependencyEvent bool
 	if sync && durabilitycut.Enabled() {
 		var err error
-		dependencyEvent, hasDependencyEvent, err = db.finalizeDependencySyncEvent(valueLogAppender)
+		dependencyEvent, hasDependencyEvent, err = db.finalizeDependencySyncEvent(valueLogAppender, true)
 		if err != nil {
 			return err
 		}
@@ -107,7 +108,7 @@ func (db *DB) flushFinalizeCommitDurability(idx *indexGen, valueLogAppender Valu
 // for a coalesced publication durable. In particular, a later candidate may
 // use a different value-log appender/lane after rotation, so syncing only the
 // frontier appender is insufficient.
-func (db *DB) flushRootPublicationClosureDurability(idx *indexGen, candidates []*PreparedRootCandidate) error {
+func (db *DB) flushRootPublicationClosureDurability(idx *indexGen, candidates []*PreparedRootCandidate, indexSnapshots ...*pager.IndexPageSnapshot) error {
 	if idx == nil {
 		return errors.New("missing index")
 	}
@@ -115,6 +116,9 @@ func (db *DB) flushRootPublicationClosureDurability(idx *indexGen, candidates []
 	for _, candidate := range candidates {
 		if candidate == nil {
 			continue
+		}
+		if candidate.DependencyPath != "" {
+			dependencySet[candidate.DependencyPath] = struct{}{}
 		}
 		for _, path := range candidate.DependencyPaths {
 			if path != "" {
@@ -170,6 +174,13 @@ func (db *DB) flushRootPublicationClosureDurability(idx *indexGen, candidates []
 			continue
 		}
 		fileIDs := append([]uint32(nil), candidate.TouchedValueLogFiles...)
+		// A dependency-complete candidate with no external value-log records
+		// owns no value-log durability work. Passing an empty list to the
+		// appender means "sync every pending lane", which is only the intended
+		// conservative fallback for legacy/incomplete candidates.
+		if len(fileIDs) == 0 && candidate.DependenciesFlushed {
+			continue
+		}
 		if flusher, ok := candidate.ValueLogAppender.(ValueLogDurableExternalRefFlusher); ok {
 			if err := flusher.SyncValueLogExternalRefsDurable(fileIDs); err != nil {
 				return err
@@ -191,33 +202,72 @@ func (db *DB) flushRootPublicationClosureDurability(idx *indexGen, candidates []
 			return err
 		}
 	}
-	// A newly grown mmap needs one file-wide size fence. It belongs to the
-	// index stage: dependency files must be durable before this file-wide sync
-	// can persist any index bytes, and no target meta has been written yet.
+	if len(indexSnapshots) != 0 && indexSnapshots[0] != nil {
+		// The immutable snapshot path writes exact non-meta ranges and ends with
+		// a file sync. That one boundary makes both a newly grown file size and
+		// the captured data stable before the target meta is written; a separate
+		// size sync would duplicate the same file-wide durability work.
+		return idx.pager.SyncIndexPageSnapshot(indexSnapshots[0])
+	}
+	// Legacy/test callers that sync mapped ranges still need a durable file size
+	// before a range operation can safely cover newly grown pages.
 	if err := idx.pager.SyncIndexFileSize(); err != nil {
 		return err
 	}
+	return idx.pager.SyncIndexPages(rootPublicationIndexPages(candidates))
+}
+
+func rootPublicationIndexPages(candidates []*PreparedRootCandidate) []uint64 {
 	pageSet := make(map[uint64]struct{})
+	var frontierFreelistHeadID uint64
 	for _, candidate := range candidates {
 		if candidate == nil {
 			continue
 		}
+		frontierFreelistHeadID = candidate.FreelistHeadID
 		for _, pageID := range candidate.TouchedIndexPages {
 			pageSet[pageID] = struct{}{}
 		}
+		// A coalesced frontier only needs the pages that remain reachable at
+		// that frontier. A later candidate can retire a page first touched by
+		// an earlier candidate; writing the earlier image after publication
+		// could otherwise overwrite a page that has already been recycled.
+		for _, pageID := range candidate.RetiredPages {
+			delete(pageSet, pageID)
+		}
+	}
+	// Freelist heads are mutable metadata, not COW tree output. Capturing every
+	// historical head in a coalesced closure is unsafe because a later candidate
+	// may have recycled an old head as a tree page. The frontier head contains the
+	// complete allocator state needed by the target meta.
+	if frontierFreelistHeadID != 0 {
+		pageSet[frontierFreelistHeadID] = struct{}{}
 	}
 	pageIDs := make([]uint64, 0, len(pageSet))
 	for pageID := range pageSet {
 		pageIDs = append(pageIDs, pageID)
 	}
 	sort.Slice(pageIDs, func(i, j int) bool { return pageIDs[i] < pageIDs[j] })
-	// Candidate page sets are captured under writer serialization. Sync only
-	// their immutable closure; global dirty pages may belong to a later builder
-	// that is still mutating its returned mmap slice.
-	return idx.pager.SyncIndexPages(pageIDs)
+	return pageIDs
 }
 
-func (db *DB) finalizeDependencySyncEvent(valueLogAppender ValueLogAppender) (durabilitycut.Event, bool, error) {
+func (db *DB) finalizeDependencySyncEvent(valueLogAppender ValueLogAppender, includeValueLog bool) (durabilitycut.Event, bool, error) {
+	// The ordinary KV path has no outer-leaf log and exactly one current value
+	// log lane. Preserve that singular identity without allocating a temporary
+	// map and slice on every visible commit.
+	if db.leafPageLog == nil {
+		if valueLogAppender == nil || !includeValueLog {
+			return durabilitycut.Event{}, false, nil
+		}
+		if path, _, ok := valueLogAppender.CurrentValueLogSegment(); ok && path != "" {
+			return durabilitycut.Event{
+				Resource: durabilitycut.ResourceValueLog,
+				Root:     db.dir,
+				Path:     path,
+			}, true, nil
+		}
+		return durabilitycut.Event{}, false, nil
+	}
 	eventsByPath := make(map[string]durabilitycut.Event)
 	if db.leafPageLog != nil {
 		segments, err := leafPageLogCurrentSegments(db.leafPageLog)
@@ -230,7 +280,7 @@ func (db *DB) finalizeDependencySyncEvent(valueLogAppender ValueLogAppender) (du
 			}
 		}
 	}
-	if valueLogAppender != nil {
+	if valueLogAppender != nil && includeValueLog {
 		if path, _, ok := valueLogAppender.CurrentValueLogSegment(); ok && path != "" {
 			eventsByPath[path] = durabilitycut.Event{Resource: durabilitycut.ResourceValueLog, Root: db.dir, Path: path}
 		}

--- a/TreeDB/db/graveyard_retire_seq_test.go
+++ b/TreeDB/db/graveyard_retire_seq_test.go
@@ -39,7 +39,10 @@ func TestPruneReclaimsRetiredPagesAfterKeepRecentWindow(t *testing.T) {
 				t.Fatalf("set: %v", err)
 			}
 		}
-		if err := b.Write(); err != nil {
+		// Keep the two durable meta slots advancing deterministically. Relaxed
+		// writes may otherwise coalesce seq 1 and seq 2 into a single publication,
+		// legitimately leaving the redundant recovery slot at seq 0.
+		if err := b.WriteSync(); err != nil {
 			t.Fatalf("write: %v", err)
 		}
 		_ = b.Close()
@@ -75,6 +78,27 @@ func TestPruneReclaimsRetiredPagesAfterKeepRecentWindow(t *testing.T) {
 		}
 		_ = b.Close()
 	}
+	// Visibility can lead the redundant-meta durability frontier. Reclamation
+	// remains fenced until the new root is durable.
+	d.Prune()
+	visibleOnly, err := d.FragmentationReport()
+	if err != nil {
+		t.Fatalf("FragmentationReport(visible seq3): %v", err)
+	}
+	visibleFreeIDs, err := strconv.ParseUint(visibleOnly["treedb.freelist.free_ids"], 10, 64)
+	if err != nil {
+		t.Fatalf("parse freelist.free_ids(visible seq3): %v", err)
+	}
+	if visibleFreeIDs != freeIDs2 {
+		t.Fatalf("visible-only seq3 reclaimed pages before redundant-meta coverage: before=%d after=%d", freeIDs2, visibleFreeIDs)
+	}
+
+	// Once the new root is durable, request pruning explicitly for this
+	// deterministic background-prune-disabled test.
+	if err := d.Checkpoint(); err != nil {
+		t.Fatalf("checkpoint seq3: %v", err)
+	}
+	d.Prune()
 
 	rep3, err := d.FragmentationReport()
 	if err != nil {

--- a/TreeDB/db/leaf_generation_gc.go
+++ b/TreeDB/db/leaf_generation_gc.go
@@ -131,6 +131,23 @@ func (db *DB) leafGenerationGCAttempt(ctx context.Context, opts LeafGenerationGC
 		_ = snap.Close()
 		return stats, false, err
 	}
+	if db.rootPublication != nil {
+		recoveryRoots, recoverySystemRoots, _ := db.rootPublication.recoverableValueLogRoots()
+		recovery, scanErr := db.maintenanceReachabilityScan(ctx, snap, maintenanceReachabilityScanOptions{
+			Collectors:             maintenanceReachabilityLeafLogFileIDs,
+			ProtectedRootIDs:       recoveryRoots,
+			ProtectedSystemRootIDs: recoverySystemRoots,
+		})
+		if scanErr != nil {
+			_ = snap.Close()
+			return stats, false, scanErr
+		}
+		for rawFileID := range recovery.leafLogFileIDs {
+			if generationID, ok := snap.state.LeafGenerations.FileToGeneration[rawFileID]; ok {
+				liveGenerations[generationID] = struct{}{}
+			}
+		}
+	}
 	if err := snap.Close(); err != nil {
 		return stats, false, err
 	}

--- a/TreeDB/db/leaf_generation_gc_test.go
+++ b/TreeDB/db/leaf_generation_gc_test.go
@@ -717,6 +717,9 @@ func TestLeafGenerationGC_DeletesFullyDeadGeneration(t *testing.T) {
 	if got, want := gen1.State, leafGenerationStateSealed; got != want {
 		t.Fatalf("generation1 state=%q, want %q", got, want)
 	}
+	if err := db.SetSync([]byte("leaf-gc-advance"), []byte("1")); err != nil {
+		t.Fatalf("advance recovery meta: %v", err)
+	}
 
 	stats1, err := db.LeafGenerationGC(context.Background(), LeafGenerationGCOptions{})
 	if err != nil {
@@ -960,6 +963,9 @@ func TestLeafGenerationGC_RemovesUnreachableMultiLaneSegmentsAfterReopen(t *test
 	midIDs := leafGenerationManifestRawFileIDSet(loadLeafGenerationManifestOrFatal(t, opts.Dir))
 	midOnly := leafGenerationRawFileIDsWithout(midIDs, baseIDs)
 	putBatch(t, db, 0, 4096, "final")
+	if err := db.SetSync([]byte("leaf-gc-reopen-advance"), []byte("1")); err != nil {
+		t.Fatalf("advance recovery meta: %v", err)
+	}
 
 	if err := db.Checkpoint(); err != nil {
 		t.Fatalf("Checkpoint: %v", err)
@@ -1366,6 +1372,10 @@ func TestLeafGenerationGC_RetiresPinnedGenerationUntilSnapshotCloses(t *testing.
 	if got, want := db.leafGenerationPinCountForTesting(gen1.GenerationID), uint64(1); got != want {
 		closeNoErr(t, snap)
 		t.Fatalf("pin count after republish=%d, want %d", got, want)
+	}
+	if err := db.SetSync([]byte("leaf-gc-pinned-advance"), []byte("1")); err != nil {
+		closeNoErr(t, snap)
+		t.Fatalf("advance recovery meta: %v", err)
 	}
 
 	stats1, err := db.LeafGenerationGC(context.Background(), LeafGenerationGCOptions{})

--- a/TreeDB/db/leaf_generation_pack.go
+++ b/TreeDB/db/leaf_generation_pack.go
@@ -268,7 +268,11 @@ func (db *DB) leafGenerationPackLocked(ctx context.Context, opts LeafGenerationP
 	if set == nil {
 		return stats, fmt.Errorf("leaf generation pack: value-log set unavailable")
 	}
-	leafStartSeq := maxRewriteLaneSeqFromSet(set, rewriteLeafLogLaneID)
+	leafStartSeq, err := leafGenerationPackStartSeq(set, db.leafPageLog)
+	if err != nil {
+		_ = db.valueLogManager.Release(set)
+		return stats, fmt.Errorf("leaf generation pack: inspect leaf-page-log frontier: %w", err)
+	}
 	nextRID := uint64(0)
 	if opts.ReserveRIDs == nil {
 		nextRID, err = leafGenerationPackRIDStartScanner(set)
@@ -387,6 +391,27 @@ func (db *DB) leafGenerationPackLocked(ctx context.Context, opts LeafGenerationP
 		return stats, nil
 	}
 	return stats, errLeafGenerationPackPublishConflict
+}
+
+// leafGenerationPackStartSeq prevents pack output from reusing a lane/path
+// still owned by the active leaf-page writer. Manager snapshots intentionally
+// omit zombies, so their maximum alone is not a sufficient allocation floor.
+func leafGenerationPackStartSeq(set *valuelog.Set, log LeafPageLog) (uint32, error) {
+	maxSeq := maxRewriteLaneSeqFromSet(set, rewriteLeafLogLaneID)
+	segments, err := leafPageLogCurrentSegments(log)
+	if err != nil {
+		return 0, err
+	}
+	for _, segment := range segments {
+		if segment.FileID == 0 || !page.IsValueLogFileID(segment.FileID) {
+			continue
+		}
+		lane, seq := valuelog.DecodeFileID(segment.FileID)
+		if lane == rewriteLeafLogLaneID && seq > maxSeq {
+			maxSeq = seq
+		}
+	}
+	return maxSeq, nil
 }
 
 func (db *DB) leafGenerationPackAllocators(leafStartSeq uint32, nextRID uint64, reserveRIDs func(int) (uint64, error)) (*leafLogSeqAllocator, *rewriteRIDAllocator) {

--- a/TreeDB/db/leaf_generation_pack_concurrency_test.go
+++ b/TreeDB/db/leaf_generation_pack_concurrency_test.go
@@ -273,6 +273,9 @@ func TestLeafGenerationPack_PrivatePagesRaceWithForegroundWriters(t *testing.T) 
 	for err := range errCh {
 		t.Fatalf("concurrent private-page stress: %v", err)
 	}
+	if err := db.Checkpoint(); err != nil {
+		t.Fatalf("checkpoint foreground writes: %v", err)
+	}
 	if got := idx.pager.PageCount(); got < mainPagesBefore || got != db.meta.TotalPages {
 		t.Fatalf("main pager pages=%d before=%d durable meta=%d", got, mainPagesBefore, db.meta.TotalPages)
 	}

--- a/TreeDB/db/leaf_generation_pack_publication_test.go
+++ b/TreeDB/db/leaf_generation_pack_publication_test.go
@@ -52,6 +52,16 @@ func closeLeafGenerationPackPublicationTestDB(t *testing.T, db *DB, leafLog *rew
 	}
 }
 
+func closePoisonedLeafGenerationPackPublicationTestDB(t *testing.T, db *DB, leafLog *rewriteWriter) {
+	t.Helper()
+	if err := db.Close(); !errors.Is(err, ErrRecoveryRequired) {
+		t.Fatalf("Close poisoned DB: %v", err)
+	}
+	if err := leafLog.Close(); err != nil {
+		t.Fatalf("Close leaf log: %v", err)
+	}
+}
+
 func TestLeafGenerationPack_RetryExhaustionDoesNotLeakCommittedPages(t *testing.T) {
 	dir := t.TempDir()
 	db, leafLog := openLeafGenerationPackPublicationTestDB(t, dir)
@@ -438,12 +448,15 @@ func TestLeafGenerationPack_MetaSyncFailurePoisonsAndRetainsCandidates(t *testin
 			t.Fatalf("candidate segment %d was unregistered after ambiguous publish", id)
 		}
 	}
-	if snap := db.AcquireSnapshot(); snap != nil {
+	if snap := db.AcquireSnapshot(); snap == nil {
+		t.Fatal("AcquireSnapshot failed on readable poisoned handle")
+	} else {
 		_ = snap.Close()
-		t.Fatal("AcquireSnapshot succeeded on poisoned handle")
+	}
+	if _, err := db.Get([]byte("pack-concurrent-0000")); err != nil {
+		t.Fatalf("Get on readable poisoned handle: %v", err)
 	}
 	for name, err := range map[string]error{
-		"Get": func() error { _, err := db.Get([]byte("pack-concurrent-0000")); return err }(),
 		"Pack": func() error {
 			_, err := db.LeafGenerationPack(context.Background(), LeafGenerationPackOptions{Force: true})
 			return err
@@ -465,7 +478,7 @@ func TestLeafGenerationPack_MetaSyncFailurePoisonsAndRetainsCandidates(t *testin
 	if err := db.idx.Load().pager.Sync(); err != nil {
 		t.Fatalf("later raw pager sync: %v", err)
 	}
-	closeLeafGenerationPackPublicationTestDB(t, db, leafLog)
+	closePoisonedLeafGenerationPackPublicationTestDB(t, db, leafLog)
 
 	reopened, err := Open(leafGenerationPackPublicationTestOptions(dir))
 	if err != nil {
@@ -527,7 +540,7 @@ func TestLeafGenerationPack_MetaSyncFailureCanReopenOldMeta(t *testing.T) {
 	if err := db.idx.Load().pager.SyncPages([]uint64{targetMetaPageID}); err != nil {
 		t.Fatalf("sync restored alternate meta: %v", err)
 	}
-	closeLeafGenerationPackPublicationTestDB(t, db, leafLog)
+	closePoisonedLeafGenerationPackPublicationTestDB(t, db, leafLog)
 
 	reopened, err := Open(leafGenerationPackPublicationTestOptions(dir))
 	if err != nil {
@@ -631,7 +644,7 @@ func TestLeafGenerationPack_RefreshAndSnapshotCannotObserveFailedRegistration(t 
 func TestLeafGenerationPack_MetaSyncFailureRejectsQueuedLeafGC(t *testing.T) {
 	dir := t.TempDir()
 	db, leafLog := openLeafGenerationPackPublicationTestDB(t, dir)
-	defer closeLeafGenerationPackPublicationTestDB(t, db, leafLog)
+	defer closePoisonedLeafGenerationPackPublicationTestDB(t, db, leafLog)
 	candidate := prepareLeafGenerationPackTestCandidate(t, db, leafLog, 512)
 
 	registered := make(chan struct{})

--- a/TreeDB/db/leaf_generation_pack_rewrite.go
+++ b/TreeDB/db/leaf_generation_pack_rewrite.go
@@ -1452,9 +1452,8 @@ func (db *DB) rewriteLeafRefsOnline(ctx context.Context, writer *rewriteWriter, 
 	}
 
 	visibilityLocked := false
-	publishPrepareLocked := false
 	db.publishPrepareMu.RLock()
-	publishPrepareLocked = true
+	publishPrepareGuard := &finalizeCommitPrepareGuard{db: db}
 	db.valueLogPublicationMu.Lock()
 	visibilityLocked = true
 	previousUnlockPublish := unlockPublish
@@ -1463,10 +1462,7 @@ func (db *DB) rewriteLeafRefsOnline(ctx context.Context, writer *rewriteWriter, 
 			db.valueLogPublicationMu.Unlock()
 			visibilityLocked = false
 		}
-		if publishPrepareLocked {
-			db.publishPrepareMu.RUnlock()
-			publishPrepareLocked = false
-		}
+		publishPrepareGuard.Release()
 		previousUnlockPublish()
 	}
 	// Refresh can publish a new state without writeMu. Revalidate once more after
@@ -1510,8 +1506,17 @@ func (db *DB) rewriteLeafRefsOnline(ctx context.Context, writer *rewriteWriter, 
 		result := <-dirSyncCh
 		dirSyncCh = nil
 		if runStats != nil {
-			runStats.ApplyStages.DirectorySyncTimeNanos += result.timeNanos
-			runStats.ApplyStages.DirectorySyncWaitTimeNanos += time.Since(waitStarted).Nanoseconds()
+			waitNanos := time.Since(waitStarted).Nanoseconds()
+			operationNanos := result.timeNanos
+			// The worker records the syscall endpoint before handing the result
+			// through the channel. Include that handoff in the caller-observed
+			// operation wall so its non-overlapping wait attribution cannot exceed
+			// the operation that produced it.
+			if waitNanos > operationNanos {
+				operationNanos = waitNanos
+			}
+			runStats.ApplyStages.DirectorySyncTimeNanos += operationNanos
+			runStats.ApplyStages.DirectorySyncWaitTimeNanos += waitNanos
 		}
 		return result.err
 	}
@@ -1562,6 +1567,41 @@ func (db *DB) rewriteLeafRefsOnline(ctx context.Context, writer *rewriteWriter, 
 		}(started)
 	}
 
+	// Directory durability can block, so wait without root/value-log
+	// serialization. Keep the preparation read pin: destructive maintenance
+	// cannot remove the promoted-but-unregistered files, and exact basis
+	// revalidation below detects any ordinary root change while unlocked.
+	db.valueLogPublicationMu.Unlock()
+	visibilityLocked = false
+	db.writeMu.Unlock()
+	dirWaitStarted := time.Now()
+	dirSyncErr := waitDirectorySync()
+	dirWaitDuration := time.Since(dirWaitStarted)
+	db.writeMu.Lock()
+	if db.closing.Load() {
+		unlockPublish()
+		return cleanupCreatedSegments(ErrClosed)
+	}
+	db.valueLogPublicationMu.Lock()
+	visibilityLocked = true
+	if dirSyncErr != nil {
+		unlockPublish()
+		return cleanupCreatedSegments(fmt.Errorf("vlog-rewrite: sync promoted leaf directory: %w", dirSyncErr))
+	}
+	if !db.leafGenerationPackCopyBasisMatches(basis) {
+		if runStats != nil {
+			runStats.PublishConflict = true
+			runStats.ApplyStages.RevalidateTimeNanos += time.Since(publishStarted).Nanoseconds()
+		}
+		unlockPublish()
+		return cleanupCreatedSegments(errLeafGenerationPackPublishConflict)
+	}
+	publishEvent.Phase = leafGenerationPackAfterDirectorySync
+	if err := runLeafGenerationPackPublishHook(publishEvent); err != nil {
+		unlockPublish()
+		return cleanupCreatedSegments(fmt.Errorf("vlog-rewrite: directory sync failpoint: %w", err))
+	}
+
 	var leafManifest *leafGenerationManifest
 	var leafManifestRawFileIDs []uint32
 	if db.leafGenerationManifest != nil {
@@ -1599,25 +1639,9 @@ func (db *DB) rewriteLeafRefsOnline(ctx context.Context, writer *rewriteWriter, 
 		runStats.ApplyStages.RelocationTimeNanos += relocateDuration.Nanoseconds()
 	}
 	publishRetired := leafGenerationPackCommittedRetired(leafCtx.retired)
-	// The target-directory and index-page durability fences are independent and
-	// can run concurrently. Both complete before registration or meta write.
-	pageSyncStarted := time.Now()
-	if err := idx.pager.SyncPages(publishAlloc.Pages()); err != nil {
-		return cleanupAndUnlock(fmt.Errorf("vlog-rewrite: sync published index pages: %w", err))
-	}
-	pageSyncDuration := time.Since(pageSyncStarted)
-	if runStats != nil {
-		runStats.ApplyStages.PageSyncTimeNanos += pageSyncDuration.Nanoseconds()
-	}
-	dirWaitStarted := time.Now()
-	if err := waitDirectorySync(); err != nil {
-		return cleanupAndUnlock(fmt.Errorf("vlog-rewrite: sync promoted leaf directory: %w", err))
-	}
-	dirWaitDuration := time.Since(dirWaitStarted)
-	publishEvent.Phase = leafGenerationPackAfterDirectorySync
-	if err := runLeafGenerationPackPublishHook(publishEvent); err != nil {
-		return cleanupAndUnlock(fmt.Errorf("vlog-rewrite: directory sync failpoint: %w", err))
-	}
+	// Root publication owns exact candidate-page durability after serialization
+	// is released.
+	pageSyncDuration := time.Duration(0)
 
 	publishEvent.Phase = leafGenerationPackBeforeRegistration
 	if err := runLeafGenerationPackPublishHook(publishEvent); err != nil {
@@ -1663,11 +1687,14 @@ func (db *DB) rewriteLeafRefsOnline(ctx context.Context, writer *rewriteWriter, 
 			return cleanupAndUnlock(fmt.Errorf("vlog-rewrite: publish collection descriptors: %w", err))
 		}
 		publishRetired = append(publishRetired, publishCtx.retired...)
-		if err := db.leafPageLog.Sync(); err != nil {
-			return cleanupAndUnlock(fmt.Errorf("vlog-rewrite: sync published collection descriptors: %w", err))
-		}
-		if err := idx.pager.SyncPages(publishAlloc.Pages()); err != nil {
-			return cleanupAndUnlock(fmt.Errorf("vlog-rewrite: sync published collection index pages: %w", err))
+	}
+	// Collection replacement can append outer leaves through the installed live
+	// leaf log after the private pack writer was closed. Drain those userspace
+	// buffers while writeMu still excludes a successor builder; the publication
+	// worker will fsync the captured paths without touching this mutable writer.
+	if db.leafPageLog != nil {
+		if err := db.leafPageLog.Flush(); err != nil {
+			return cleanupAndUnlock(fmt.Errorf("vlog-rewrite: flush published collection leaf refs: %w", err))
 		}
 	}
 	if runStats != nil {
@@ -1679,9 +1706,12 @@ func (db *DB) rewriteLeafRefsOnline(ctx context.Context, writer *rewriteWriter, 
 	}
 
 	finalizeStarted := time.Now()
-	post, finalizeErr := db.finalizeCommitLockedWithOptions(publishedRoot, publishedSysRoot, publishRetired, true, adaptive.Metrics{}, createdIDs, len(publishCollectionReplacements) > 0, nil, leafManifest, leafManifestRawFileIDs, finalizeCommitOptions{
+	post, finalizeErr := db.finalizeCommitLockedWithOptions(publishedRoot, publishedSysRoot, publishRetired, true, adaptive.Metrics{}, nil, len(publishCollectionReplacements) > 0, nil, leafManifest, leafManifestRawFileIDs, finalizeCommitOptions{
 		skipPrePublishFlush: true,
+		dependenciesFlushed: true,
 		syncMetaPageOnly:    true,
+		publishPrepareGuard: publishPrepareGuard,
+		touchedIndexPages:   publishAlloc.Pages(),
 	})
 	finalizeDuration := time.Since(finalizeStarted)
 	if runStats != nil {
@@ -1709,6 +1739,11 @@ func (db *DB) rewriteLeafRefsOnline(ctx context.Context, writer *rewriteWriter, 
 	}
 	commitTimingPrintf("treedb: leaf_pack_publish relocate=%s page_sync=%s dir_wait=%s register=%s finalize=%s total=%s\n", relocateDuration, pageSyncDuration, dirWaitDuration, registerDuration, finalizeDuration, time.Since(publishStarted))
 	unlockPublish()
+	if db.rootPublication != nil {
+		if err := db.rootPublication.stabilizeRecoveryWindow(post.commitSeq); err != nil {
+			return 0, 0, errors.Join(fmt.Errorf("vlog-rewrite: publish rewritten leaf refs: %w", err), db.commandWALPoisonedError())
+		}
+	}
 	postWorkStarted := time.Now()
 	db.finalizeCommitPostWork(post)
 	if runStats != nil {

--- a/TreeDB/db/leaf_generation_pack_rewrite.go
+++ b/TreeDB/db/leaf_generation_pack_rewrite.go
@@ -1707,11 +1707,12 @@ func (db *DB) rewriteLeafRefsOnline(ctx context.Context, writer *rewriteWriter, 
 
 	finalizeStarted := time.Now()
 	post, finalizeErr := db.finalizeCommitLockedWithOptions(publishedRoot, publishedSysRoot, publishRetired, true, adaptive.Metrics{}, nil, len(publishCollectionReplacements) > 0, nil, leafManifest, leafManifestRawFileIDs, finalizeCommitOptions{
-		skipPrePublishFlush: true,
-		dependenciesFlushed: true,
-		syncMetaPageOnly:    true,
-		publishPrepareGuard: publishPrepareGuard,
-		touchedIndexPages:   publishAlloc.Pages(),
+		skipPrePublishFlush:    true,
+		dependenciesFlushed:    true,
+		syncMetaPageOnly:       true,
+		publishPrepareGuard:    publishPrepareGuard,
+		touchedIndexPages:      publishAlloc.Pages(),
+		touchedIndexPagesOwned: true,
 	})
 	finalizeDuration := time.Since(finalizeStarted)
 	if runStats != nil {

--- a/TreeDB/db/leaf_generation_pack_test.go
+++ b/TreeDB/db/leaf_generation_pack_test.go
@@ -31,11 +31,35 @@ func expectLeafGenerationValue(t *testing.T, db *DB, key []byte, fill byte) {
 	}
 }
 
+func TestLeafGenerationPackStartSeqIncludesCurrentLeafPageLogFrontier(t *testing.T) {
+	managerID, err := valuelog.EncodeFileID(rewriteLeafLogLaneID, 26)
+	if err != nil {
+		t.Fatal(err)
+	}
+	currentID, err := valuelog.EncodeFileID(rewriteLeafLogLaneID, 27)
+	if err != nil {
+		t.Fatal(err)
+	}
+	set := &valuelog.Set{Files: map[uint32]*valuelog.File{managerID: nil}}
+	log := &registeredLeafPageLog{registered: true, path: "leaf-l255-000027.log", fileID: currentID}
+	got, err := leafGenerationPackStartSeq(set, log)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != 27 {
+		t.Fatalf("start seq=%d want current leaf writer frontier 27", got)
+	}
+}
+
 func leafGenerationKey(prefix string, i int) []byte {
 	return []byte(fmt.Sprintf("%s-%04d", prefix, i))
 }
 
 func openLeafGenerationPackTestDB(t *testing.T) (*DB, *rewriteWriter, string) {
+	return openLeafGenerationPackTestDBWithRecoveryClose(t, false)
+}
+
+func openLeafGenerationPackTestDBWithRecoveryClose(t *testing.T, allowRecoveryRequired bool) (*DB, *rewriteWriter, string) {
 	t.Helper()
 	dir := t.TempDir()
 	db, err := Open(Options{
@@ -54,7 +78,11 @@ func openLeafGenerationPackTestDB(t *testing.T) (*DB, *rewriteWriter, string) {
 	leafLog.ConfigureLeafLog(LeafLogDirPath(dir), rewriteLeafLogLaneID, 0)
 	db.SetLeafPageLog(leafLog)
 	t.Cleanup(func() { closeNoErr(t, leafLog) })
-	t.Cleanup(func() { closeNoErr(t, db) })
+	t.Cleanup(func() {
+		if err := db.Close(); err != nil && !(allowRecoveryRequired && errors.Is(err, ErrRecoveryRequired)) {
+			t.Fatalf("close: %v", err)
+		}
+	})
 	return db, leafLog, dir
 }
 
@@ -242,8 +270,8 @@ func TestLeafGenerationPack_FinalizeFailpointCleansCreatedSegments(t *testing.T)
 	}
 }
 
-func TestLeafGenerationPack_WriteMetaFailpointCleansCreatedSegments(t *testing.T) {
-	db, leafLog, dir := openLeafGenerationPackTestDB(t)
+func TestLeafGenerationPack_WriteMetaFailpointRetainsCandidateSegmentsAndPoisons(t *testing.T) {
+	db, leafLog, dir := openLeafGenerationPackTestDBWithRecoveryClose(t, true)
 
 	writeLeafGenerationKeys(t, db, "k", 2048, 'a')
 	_, fileID1 := currentLeafSegmentOrFatal(t, leafLog)
@@ -264,21 +292,24 @@ func TestLeafGenerationPack_WriteMetaFailpointCleansCreatedSegments(t *testing.T
 	db.testFailWriteMeta.Store(true)
 	_, err = db.LeafGenerationPack(context.Background(), LeafGenerationPackOptions{GenerationIDs: []uint64{gen1.GenerationID}, Force: true})
 	db.testFailWriteMeta.Store(false)
-	if !errors.Is(err, errTestWriteMetaFailpoint) {
-		t.Fatalf("LeafGenerationPack writeMeta failpoint err=%v, want %v", err, errTestWriteMetaFailpoint)
+	if !errors.Is(err, errTestWriteMetaFailpoint) || !errors.Is(err, ErrRecoveryRequired) {
+		t.Fatalf("LeafGenerationPack writeMeta failpoint err=%v, want %v and ErrRecoveryRequired", err, errTestWriteMetaFailpoint)
 	}
 
 	afterFiles, err := listLeafGenerationBootstrapFiles(LeafLogDirPath(dir))
 	if err != nil {
 		t.Fatalf("listLeafGenerationBootstrapFiles(after): %v", err)
 	}
-	if len(afterFiles) != len(beforeFiles) {
-		t.Fatalf("bootstrap file count=%d, want %d", len(afterFiles), len(beforeFiles))
+	if len(afterFiles) <= len(beforeFiles) {
+		t.Fatalf("bootstrap file count=%d, want candidate files retained beyond %d", len(afterFiles), len(beforeFiles))
 	}
 	for i := range beforeFiles {
 		if afterFiles[i] != beforeFiles[i] {
 			t.Fatalf("bootstrap files[%d]=%+v, want %+v", i, afterFiles[i], beforeFiles[i])
 		}
+	}
+	if err := db.Set([]byte("blocked-after-write-meta"), []byte("mutation")); !errors.Is(err, ErrRecoveryRequired) {
+		t.Fatalf("mutation after write-meta attempt err=%v, want ErrRecoveryRequired", err)
 	}
 	manifestAfter := loadLeafGenerationManifestOrFatal(t, dir)
 	if len(manifestAfter.Generations) != len(manifestBefore.Generations) {

--- a/TreeDB/db/leaf_generation_stats_test.go
+++ b/TreeDB/db/leaf_generation_stats_test.go
@@ -90,6 +90,7 @@ func TestStats_LeafGenerationLifecycle(t *testing.T) {
 		t.Fatalf("plan_cache.subtree_pages after planning=%d, want > 0", got)
 	}
 
+	stabilizeRecoveryWindowForTest(t, db)
 	if _, err := db.LeafGenerationGC(context.Background(), LeafGenerationGCOptions{}); err != nil {
 		closeNoErr(t, snap)
 		t.Fatalf("LeafGenerationGC while pinned: %v", err)

--- a/TreeDB/db/leaf_page_log.go
+++ b/TreeDB/db/leaf_page_log.go
@@ -23,6 +23,13 @@ type LeafPageLog interface {
 	Sync() error
 }
 
+// LeafPageLogDurableSyncer is the publication-only stable-storage barrier.
+// Implementations must not weaken it according to foreground relaxed-sync
+// policy.
+type LeafPageLogDurableSyncer interface {
+	SyncLeafPageLogDurable() error
+}
+
 type LeafPageBatchLog interface {
 	// AppendLeafPages appends every leaf page and returns one pointer per input
 	// page in the same order. Callers use that positional relationship for

--- a/TreeDB/db/maintenance_reachability.go
+++ b/TreeDB/db/maintenance_reachability.go
@@ -15,6 +15,7 @@ const (
 	maintenanceReachabilityValueLogRefCounts maintenanceReachabilityCollectors = 1 << iota
 	maintenanceReachabilityValueLogLiveBytes
 	maintenanceReachabilityLeafGenerationTotals
+	maintenanceReachabilityLeafLogFileIDs
 )
 
 func (c maintenanceReachabilityCollectors) has(want maintenanceReachabilityCollectors) bool {
@@ -22,10 +23,12 @@ func (c maintenanceReachabilityCollectors) has(want maintenanceReachabilityColle
 }
 
 type maintenanceReachabilityScanOptions struct {
-	Collectors              maintenanceReachabilityCollectors
-	ProtectedRootIDs        []uint64
-	ProtectedSystemRootIDs  []uint64
-	DisableLeafSubtreeCache bool
+	Collectors                     maintenanceReachabilityCollectors
+	ProtectedRootIDs               []uint64
+	ProtectedSystemRootIDs         []uint64
+	ProtectedValueLogRootIDs       []uint64
+	ProtectedValueLogSystemRootIDs []uint64
+	DisableLeafSubtreeCache        bool
 }
 
 type maintenanceReachabilityResult struct {
@@ -33,6 +36,7 @@ type maintenanceReachabilityResult struct {
 	valueLogReferencedSegments map[uint32]struct{}
 	valueLogLiveBytesBySegment map[uint32]int64
 	leafGenerationLive         leafGenerationLiveScanStats
+	leafLogFileIDs             map[uint32]struct{}
 	counters                   CompactStorageAuditStats
 
 	// Internal evidence for collector-selection tests. These count actual
@@ -41,7 +45,7 @@ type maintenanceReachabilityResult struct {
 	leafFrameProjections uint64
 }
 
-func maintenanceReachabilityRoots(ctx context.Context, snap *Snapshot, protectedRootIDs, protectedSystemRootIDs []uint64, projectValueLog bool) ([]maintenanceRoot, int, error) {
+func maintenanceReachabilityRoots(ctx context.Context, snap *Snapshot, protectedValueLogRootIDs, protectedValueLogSystemRootIDs, protectedRootIDs, protectedSystemRootIDs []uint64, projectValueLog bool) ([]maintenanceRoot, int, error) {
 	roots, err := maintenanceRootsForSnapshotWithContext(ctx, snap)
 	if err != nil {
 		return nil, 0, err
@@ -51,7 +55,7 @@ func maintenanceReachabilityRoots(ctx context.Context, snap *Snapshot, protected
 	if projectValueLog {
 		valueLogRootCount = len(roots)
 	}
-	if len(protectedRootIDs) == 0 && len(protectedSystemRootIDs) == 0 {
+	if len(protectedValueLogRootIDs) == 0 && len(protectedValueLogSystemRootIDs) == 0 && len(protectedRootIDs) == 0 && len(protectedSystemRootIDs) == 0 {
 		return roots, valueLogRootCount, nil
 	}
 	seen := make(map[uint64]struct{}, len(roots)+len(protectedRootIDs)+len(protectedSystemRootIDs))
@@ -67,6 +71,21 @@ func maintenanceReachabilityRoots(ctx context.Context, snap *Snapshot, protected
 		}
 		seen[root.rootID] = struct{}{}
 		roots = append(roots, root)
+	}
+	for _, rootID := range protectedValueLogRootIDs {
+		addProtected(maintenanceRoot{kind: maintenanceRootUser, rootID: rootID})
+	}
+	for _, systemRootID := range protectedValueLogSystemRootIDs {
+		protected, err := collectMaintenanceRootsForSystemRootWithContext(ctx, snap.idx.pager, &snap.reader, systemRootID)
+		if err != nil {
+			return nil, 0, err
+		}
+		for _, root := range protected {
+			addProtected(root)
+		}
+	}
+	if projectValueLog {
+		valueLogRootCount = len(roots)
 	}
 	for _, rootID := range protectedRootIDs {
 		addProtected(maintenanceRoot{kind: maintenanceRootUser, rootID: rootID})
@@ -94,6 +113,7 @@ func (db *DB) maintenanceReachabilityScan(ctx context.Context, snap *Snapshot, o
 	collectRefs := opts.Collectors.has(maintenanceReachabilityValueLogRefCounts)
 	collectLive := opts.Collectors.has(maintenanceReachabilityValueLogLiveBytes)
 	collectLeaf := opts.Collectors.has(maintenanceReachabilityLeafGenerationTotals)
+	collectLeafFiles := opts.Collectors.has(maintenanceReachabilityLeafLogFileIDs)
 	collectValueLog := collectRefs || collectLive
 	if collectRefs {
 		result.valueLogRefCounts = make(map[uint32]uint64)
@@ -104,6 +124,9 @@ func (db *DB) maintenanceReachabilityScan(ctx context.Context, snap *Snapshot, o
 	}
 	if collectLeaf {
 		result.leafGenerationLive.Generations = make(map[uint64]leafGenerationLiveTotals)
+	}
+	if collectLeafFiles {
+		result.leafLogFileIDs = make(map[uint32]struct{})
 	}
 	if opts.Collectors == 0 {
 		return result, nil
@@ -117,7 +140,7 @@ func (db *DB) maintenanceReachabilityScan(ctx context.Context, snap *Snapshot, o
 			return result, err
 		}
 	}
-	roots, valueLogRootCount, err := maintenanceReachabilityRoots(ctx, snap, opts.ProtectedRootIDs, opts.ProtectedSystemRootIDs, collectValueLog)
+	roots, valueLogRootCount, err := maintenanceReachabilityRoots(ctx, snap, opts.ProtectedValueLogRootIDs, opts.ProtectedValueLogSystemRootIDs, opts.ProtectedRootIDs, opts.ProtectedSystemRootIDs, collectValueLog)
 	if err != nil {
 		return result, err
 	}
@@ -356,6 +379,9 @@ func (db *DB) maintenanceReachabilityScan(ctx context.Context, snap *Snapshot, o
 			}
 			children := childStacks[depth][:0]
 			err := n.WalkInternalChildren(&children, func(ptr page.LeafLogPtr) error {
+				if collectLeafFiles {
+					result.leafLogFileIDs[page.ValueLogSegmentID(ptr.FileID)] = struct{}{}
+				}
 				if leafScan != nil {
 					result.leafFrameProjections++
 					var visitErr error

--- a/TreeDB/db/maintenance_roots_test.go
+++ b/TreeDB/db/maintenance_roots_test.go
@@ -491,6 +491,7 @@ func TestValueLogGC_RemovesSegmentAfterSystemDescriptorRemoval(t *testing.T) {
 	if _, ok := d.valueLogRefTracker.referencedSet(d.currentCommitSeq()); ok {
 		t.Fatal("expected descriptor removal to invalidate value-log ref tracker")
 	}
+	stabilizeRecoveryWindowForTest(t, d)
 
 	stats, err := d.ValueLogGC(context.Background(), ValueLogGCOptions{})
 	if err != nil {
@@ -537,6 +538,7 @@ func TestValueLogGC_RemovesSegmentAfterGroupedSystemDescriptorRemoval(t *testing
 	if _, ok := d.valueLogRefTracker.referencedSet(d.currentCommitSeq()); ok {
 		t.Fatal("expected grouped descriptor removal to invalidate value-log ref tracker")
 	}
+	stabilizeRecoveryWindowForTest(t, d)
 
 	stats, err := d.ValueLogGC(context.Background(), ValueLogGCOptions{})
 	if err != nil {
@@ -588,6 +590,7 @@ func TestValueLogGC_RemovesSegmentAfterDeltaGroupSystemDescriptorRemoval(t *test
 	if _, ok := d.valueLogRefTracker.referencedSet(d.currentCommitSeq()); ok {
 		t.Fatal("expected delta group descriptor removal to invalidate value-log ref tracker")
 	}
+	stabilizeRecoveryWindowForTest(t, d)
 
 	stats, err := d.ValueLogGC(context.Background(), ValueLogGCOptions{})
 	if err != nil {

--- a/TreeDB/db/ordered_root_publish.go
+++ b/TreeDB/db/ordered_root_publish.go
@@ -1502,21 +1502,19 @@ func (db *DB) PublishOrderedRootIterator(baseRoot uint64, iter iterator.UnsafeIt
 		return 0, err
 	}
 
-	db.mu.RLock()
-	userRoot := db.meta.UserRootPageID
-	systemRoot := db.meta.SystemRootPageID
-	baseSeq := db.meta.CommitSeq
-	db.mu.RUnlock()
+	visible := db.state.Load()
+	userRoot := visible.RootPageID
+	systemRoot := visible.SystemRootPageID
+	baseSeq := visible.CommitSeq
 
 	newRoot, retired, metrics, _, _, err := db.publishOrderedRootIterator(baseRoot, iter, systemRootOrderedPublishOptions(db), false)
 	if err != nil {
 		return 0, err
 	}
 
-	db.mu.RLock()
-	curUserRoot := db.meta.UserRootPageID
-	curSystemRoot := db.meta.SystemRootPageID
-	db.mu.RUnlock()
+	visible = db.state.Load()
+	curUserRoot := visible.RootPageID
+	curSystemRoot := visible.SystemRootPageID
 	if curUserRoot != userRoot || curSystemRoot != systemRoot {
 		return 0, errors.New("concurrent modification detected during ordered root publish")
 	}
@@ -1600,11 +1598,10 @@ func (db *DB) PublishOrderedRootDeltaGroupWithSystemBuilder(ordered []OrderedRoo
 		return 0, nil, err
 	}
 
-	db.mu.RLock()
-	userRoot := db.meta.UserRootPageID
-	baseSystemRoot := db.meta.SystemRootPageID
-	baseSeq := db.meta.CommitSeq
-	db.mu.RUnlock()
+	visible := db.state.Load()
+	userRoot := visible.RootPageID
+	baseSystemRoot := visible.SystemRootPageID
+	baseSeq := visible.CommitSeq
 
 	systemOpts := systemRootOrderedPublishOptions(db)
 	rootIDs = make([]uint64, len(ordered))
@@ -1683,10 +1680,9 @@ func (db *DB) PublishOrderedRootDeltaGroupWithSystemBuilder(ordered []OrderedRoo
 		}
 		vlogRefDelta = nil
 	}
-	db.mu.RLock()
-	curUserRoot := db.meta.UserRootPageID
-	curSystemRoot := db.meta.SystemRootPageID
-	db.mu.RUnlock()
+	visible = db.state.Load()
+	curUserRoot := visible.RootPageID
+	curSystemRoot := visible.SystemRootPageID
 	if curUserRoot != userRoot || curSystemRoot != baseSystemRoot {
 		if vlogRefDelta != nil {
 			releaseValueLogRefDelta(vlogRefDelta)
@@ -2064,10 +2060,9 @@ func (db *DB) publishOrderedRootDeltaGroupWithSystemDeltaBuilderWithMaintenanceP
 		}
 	}
 
-	db.mu.RLock()
-	userRoot := db.meta.UserRootPageID
-	baseSystemRoot := db.meta.SystemRootPageID
-	db.mu.RUnlock()
+	visible := db.state.Load()
+	userRoot := visible.RootPageID
+	baseSystemRoot := visible.SystemRootPageID
 	if preflight != nil {
 		phaseStart := time.Now()
 		if err = preflight(); err != nil {
@@ -2157,10 +2152,9 @@ func (db *DB) publishOrderedRootDeltaGroupWithSystemDeltaBuilderWithMaintenanceP
 	mergeOrderedRootPublishMetrics(&merged, metrics)
 	phaseStats.systemApplyMetrics.add(metrics)
 
-	db.mu.RLock()
-	curUserRoot := db.meta.UserRootPageID
-	curSystemRoot := db.meta.SystemRootPageID
-	db.mu.RUnlock()
+	visible = db.state.Load()
+	curUserRoot := visible.RootPageID
+	curSystemRoot := visible.SystemRootPageID
 	if curUserRoot != userRoot || curSystemRoot != baseSystemRoot {
 		return 0, nil, errors.New("concurrent modification detected during ordered root group publish")
 	}
@@ -2237,10 +2231,9 @@ func (db *DB) publishOrderedRootDeltaGroupWithCommandWALContextAndSystemDeltaBui
 		return 0, nil, err
 	}
 
-	db.mu.RLock()
-	userRoot := db.meta.UserRootPageID
-	baseSystemRoot := db.meta.SystemRootPageID
-	db.mu.RUnlock()
+	visible := db.state.Load()
+	userRoot := visible.RootPageID
+	baseSystemRoot := visible.SystemRootPageID
 	if preflight != nil {
 		phaseStart := time.Now()
 		if err = preflight(); err != nil {
@@ -2357,10 +2350,9 @@ func (db *DB) publishOrderedRootDeltaGroupWithCommandWALContextAndSystemDeltaBui
 	mergeOrderedRootPublishMetrics(&merged, metrics)
 	phaseStats.systemApplyMetrics.add(metrics)
 
-	db.mu.RLock()
-	curUserRoot := db.meta.UserRootPageID
-	curSystemRoot := db.meta.SystemRootPageID
-	db.mu.RUnlock()
+	visible = db.state.Load()
+	curUserRoot := visible.RootPageID
+	curSystemRoot := visible.SystemRootPageID
 	if curUserRoot != userRoot || curSystemRoot != baseSystemRoot {
 		err = errOrderedRootCommandWALContextConcurrentModification(userRoot, curUserRoot, baseSystemRoot, curSystemRoot)
 		return 0, nil, err
@@ -2608,12 +2600,11 @@ func (db *DB) tryPublishOrderedRootDeltaBatchGroupOptimistic(ordered []OrderedRo
 		return 0, nil, false, err
 	}
 
-	db.mu.RLock()
-	baseUserRoot := db.meta.UserRootPageID
-	baseSystemRoot := db.meta.SystemRootPageID
-	baseSeq := db.meta.CommitSeq
+	visible := db.state.Load()
+	baseUserRoot := visible.RootPageID
+	baseSystemRoot := visible.SystemRootPageID
+	baseSeq := visible.CommitSeq
 	regID := idx.registry.Register(baseSeq)
-	db.mu.RUnlock()
 
 	defer func() {
 		idx.registry.Unregister(regID)
@@ -2725,9 +2716,7 @@ func (db *DB) tryPublishOrderedRootDeltaBatchGroupOptimistic(ordered []OrderedRo
 		_ = systemDelta.Close()
 		phaseStats.systemApplyMetrics.add(systemMetrics)
 
-		db.mu.RLock()
-		observedSystemRoot := db.meta.SystemRootPageID
-		db.mu.RUnlock()
+		observedSystemRoot := db.state.Load().SystemRootPageID
 		if observedSystemRoot != systemBaseRoot {
 			if freeErr := systemTracker.FreeAll(); freeErr != nil {
 				err = freeErr
@@ -2765,10 +2754,9 @@ func (db *DB) tryPublishOrderedRootDeltaBatchGroupOptimistic(ordered []OrderedRo
 		db.commitMu.Lock()
 		holdStart := time.Now()
 		wait := holdStart.Sub(lockStart)
-		db.mu.RLock()
-		curUserRoot := db.meta.UserRootPageID
-		curSystemRoot := db.meta.SystemRootPageID
-		db.mu.RUnlock()
+		visible = db.state.Load()
+		curUserRoot := visible.RootPageID
+		curSystemRoot := visible.SystemRootPageID
 		if curSystemRoot != systemBaseRoot {
 			db.commitMu.Unlock()
 			releasePublishPrepare()
@@ -2804,7 +2792,8 @@ func (db *DB) tryPublishOrderedRootDeltaBatchGroupOptimistic(ordered []OrderedRo
 		phaseStart = time.Now()
 		var post finalizeCommitPost
 		commitStarted = true
-		post, err = db.finalizeCommitLockedWithOptions(curUserRoot, newSystemRoot, retired, false, merged, commitTouchedValueLogSegments, true, vlogRefDelta, nil, nil, finalizeCommitOptions{skipPrePublishFlush: true})
+		touchedIndexPages := append(rootTracker.Pages(), systemTracker.Pages()...)
+		post, err = db.finalizeCommitLockedWithOptions(curUserRoot, newSystemRoot, retired, false, merged, commitTouchedValueLogSegments, true, vlogRefDelta, nil, nil, finalizeCommitOptions{skipPrePublishFlush: true, dependenciesFlushed: true, publishPrepareGuard: publishPrepareGuard, touchedIndexPages: touchedIndexPages})
 		phaseStats.finalizeNs += orderedRootDeltaGroupPhaseDurationNs(phaseStart)
 		phaseStats.finalizeCalls++
 		hold := time.Since(holdStart)
@@ -2875,10 +2864,9 @@ func (db *DB) publishOrderedRootDeltaBatchGroupWithSystemDeltaBuilderSerialized(
 		return 0, nil, err
 	}
 
-	db.mu.RLock()
-	userRoot := db.meta.UserRootPageID
-	baseSystemRoot := db.meta.SystemRootPageID
-	db.mu.RUnlock()
+	visible := db.state.Load()
+	userRoot := visible.RootPageID
+	baseSystemRoot := visible.SystemRootPageID
 	if preflight != nil {
 		phaseStart := time.Now()
 		if err = preflight(); err != nil {
@@ -2969,10 +2957,9 @@ func (db *DB) publishOrderedRootDeltaBatchGroupWithSystemDeltaBuilderSerialized(
 	mergeOrderedRootPublishMetrics(&merged, metrics)
 	phaseStats.systemApplyMetrics.add(metrics)
 
-	db.mu.RLock()
-	curUserRoot := db.meta.UserRootPageID
-	curSystemRoot := db.meta.SystemRootPageID
-	db.mu.RUnlock()
+	visible = db.state.Load()
+	curUserRoot := visible.RootPageID
+	curSystemRoot := visible.SystemRootPageID
 	if curUserRoot != userRoot || curSystemRoot != baseSystemRoot {
 		return 0, nil, errors.New("concurrent modification detected during ordered root group publish")
 	}
@@ -3046,10 +3033,9 @@ func (db *DB) publishOrderedRootDeltaBatchGroupWithCommandWALContextAndSystemDel
 		return 0, nil, err
 	}
 
-	db.mu.RLock()
-	userRoot := db.meta.UserRootPageID
-	baseSystemRoot := db.meta.SystemRootPageID
-	db.mu.RUnlock()
+	visible := db.state.Load()
+	userRoot := visible.RootPageID
+	baseSystemRoot := visible.SystemRootPageID
 	if preflight != nil {
 		phaseStart := time.Now()
 		if err = preflight(); err != nil {
@@ -3175,10 +3161,9 @@ func (db *DB) publishOrderedRootDeltaBatchGroupWithCommandWALContextAndSystemDel
 	mergeOrderedRootPublishMetrics(&merged, metrics)
 	phaseStats.systemApplyMetrics.add(metrics)
 
-	db.mu.RLock()
-	curUserRoot := db.meta.UserRootPageID
-	curSystemRoot := db.meta.SystemRootPageID
-	db.mu.RUnlock()
+	visible = db.state.Load()
+	curUserRoot := visible.RootPageID
+	curSystemRoot := visible.SystemRootPageID
 	if curUserRoot != userRoot || curSystemRoot != baseSystemRoot {
 		err = errOrderedRootCommandWALContextConcurrentModification(userRoot, curUserRoot, baseSystemRoot, curSystemRoot)
 		return 0, nil, err
@@ -3266,11 +3251,10 @@ func (db *DB) publishOrderedRootGroup(systemIter iterator.UnsafeIterator, ordere
 		return 0, nil, err
 	}
 
-	db.mu.RLock()
-	userRoot := db.meta.UserRootPageID
-	baseSystemRoot := db.meta.SystemRootPageID
-	baseSeq := db.meta.CommitSeq
-	db.mu.RUnlock()
+	visible := db.state.Load()
+	userRoot := visible.RootPageID
+	baseSystemRoot := visible.SystemRootPageID
+	baseSeq := visible.CommitSeq
 
 	systemOpts := systemRootOrderedPublishOptions(db)
 	newSystemRoot := baseSystemRoot
@@ -3356,10 +3340,9 @@ func (db *DB) publishOrderedRootGroup(systemIter iterator.UnsafeIterator, ordere
 		vlogRefDelta = refDelta
 	}
 
-	db.mu.RLock()
-	curUserRoot := db.meta.UserRootPageID
-	curSystemRoot := db.meta.SystemRootPageID
-	db.mu.RUnlock()
+	visible = db.state.Load()
+	curUserRoot := visible.RootPageID
+	curSystemRoot := visible.SystemRootPageID
 	if curUserRoot != userRoot || curSystemRoot != baseSystemRoot {
 		return 0, nil, errors.New("concurrent modification detected during ordered root group publish")
 	}

--- a/TreeDB/db/ordered_root_publish.go
+++ b/TreeDB/db/ordered_root_publish.go
@@ -2793,7 +2793,7 @@ func (db *DB) tryPublishOrderedRootDeltaBatchGroupOptimistic(ordered []OrderedRo
 		var post finalizeCommitPost
 		commitStarted = true
 		touchedIndexPages := append(rootTracker.Pages(), systemTracker.Pages()...)
-		post, err = db.finalizeCommitLockedWithOptions(curUserRoot, newSystemRoot, retired, false, merged, commitTouchedValueLogSegments, true, vlogRefDelta, nil, nil, finalizeCommitOptions{skipPrePublishFlush: true, dependenciesFlushed: true, publishPrepareGuard: publishPrepareGuard, touchedIndexPages: touchedIndexPages})
+		post, err = db.finalizeCommitLockedWithOptions(curUserRoot, newSystemRoot, retired, false, merged, commitTouchedValueLogSegments, true, vlogRefDelta, nil, nil, finalizeCommitOptions{skipPrePublishFlush: true, dependenciesFlushed: true, publishPrepareGuard: publishPrepareGuard, touchedIndexPages: touchedIndexPages, touchedIndexPagesOwned: true})
 		phaseStats.finalizeNs += orderedRootDeltaGroupPhaseDurationNs(phaseStart)
 		phaseStats.finalizeCalls++
 		hold := time.Since(holdStart)

--- a/TreeDB/db/power_loss_oracle_page_reuse_test.go
+++ b/TreeDB/db/power_loss_oracle_page_reuse_test.go
@@ -2,40 +2,27 @@ package db
 
 import (
 	"bytes"
-	"errors"
 	"fmt"
-	"path/filepath"
 	"testing"
-
-	"github.com/snissn/gomap/TreeDB/internal/durabilitycut"
-	"github.com/snissn/gomap/TreeDB/internal/powerlossoracle"
-	"github.com/snissn/gomap/TreeDB/page"
 )
 
-// TestPowerLossOracleCounterexampleRecoverablePageReuse is the stable witness
-// for graveyard/freelist reuse before the older recoverable root is displaced.
-// It uses package-local access only to identify actual live and reused page IDs;
-// every mutation and the crash-image reopen use exported production methods.
-func TestPowerLossOracleCounterexampleRecoverablePageReuse(t *testing.T) {
-	dir := t.TempDir()
-	opts := Options{
-		Dir:                    dir,
+// TestPowerLossOracleRecoverablePagesRemainPinnedUntilDurableCoverage is the
+// converted witness for the former recoverable-page-reuse counterexample.
+// Pages reachable from either recoverable meta slot must not enter the
+// freelist until a durable publication has displaced the older generation.
+func TestPowerLossOracleRecoverablePagesRemainPinnedUntilDurableCoverage(t *testing.T) {
+	d, err := Open(Options{
+		Dir:                    t.TempDir(),
 		ChunkSize:              64 * 1024,
 		Durability:             DurabilityWALOffRelaxed,
 		KeepRecent:             1,
 		DisableBackgroundPrune: true,
 		FreelistRegionRadius:   -1,
-	}
-	d, err := Open(opts)
+	})
 	if err != nil {
-		t.Fatalf("open actual reuse fixture: %v", err)
+		t.Fatal(err)
 	}
-	closed := false
-	defer func() {
-		if !closed {
-			_ = d.Close()
-		}
-	}()
+	defer func() { _ = d.Close() }()
 
 	const keys = 5000
 	writeGeneration := func(tag byte, sync bool) error {
@@ -43,8 +30,7 @@ func TestPowerLossOracleCounterexampleRecoverablePageReuse(t *testing.T) {
 		defer b.Close()
 		value := bytes.Repeat([]byte{tag}, 32)
 		for i := 0; i < keys; i++ {
-			key := []byte(fmt.Sprintf("reuse/%04d", i))
-			if err := b.Set(key, value); err != nil {
+			if err := b.Set([]byte(fmt.Sprintf("reuse/%04d", i)), value); err != nil {
 				return err
 			}
 		}
@@ -57,150 +43,47 @@ func TestPowerLossOracleCounterexampleRecoverablePageReuse(t *testing.T) {
 	if err := writeGeneration('a', true); err != nil {
 		t.Fatalf("write stable generation: %v", err)
 	}
-	oldState := d.State()
-	if oldState == nil || oldState.RootPageID == 0 {
-		t.Fatalf("missing stable root: %+v", oldState)
-	}
-	oldPages := collectRootPageIDs(t, d, oldState.RootPageID)
-	oldLive := make(map[uint64]struct{}, len(oldPages))
-	for _, id := range oldPages {
-		oldLive[id] = struct{}{}
-	}
-	if len(oldLive) < 2 {
-		t.Fatalf("stable generation has too few live pages: root=%d pages=%v", oldState.RootPageID, oldPages)
-	}
-	model, err := powerlossoracle.Capture(dir)
-	if err != nil {
-		t.Fatalf("capture stable generation: %v", err)
-	}
-
-	// Generation 2 retires generation 1. Generation 3 advances KeepRecent=1
-	// far enough for synchronous pruning to put those actual page IDs on the
-	// freelist. Neither relaxed commit changes the model's stable image.
+	oldSequence := d.State().CommitSeq
 	if err := writeGeneration('b', false); err != nil {
 		t.Fatalf("write retirement generation: %v", err)
 	}
 	if err := writeGeneration('c', false); err != nil {
-		t.Fatalf("write prune generation: %v", err)
+		t.Fatalf("write visible generation: %v", err)
 	}
 	idx := d.idx.Load()
 	if idx == nil {
 		t.Fatal("missing current index generation")
 	}
-	beforeReuse := idx.allocator.Counters()
-	if beforeReuse.FreeIDs == 0 {
-		t.Fatalf("actual prune exposed no reusable pages: counters=%+v", beforeReuse)
+	pinned := idx.allocator.Counters()
+	if pinned.FreeIDs != 0 {
+		t.Fatalf("recoverable generation pages entered freelist before durable coverage: %+v", pinned)
 	}
 
-	cutErr := errors.New("power-loss-oracle: stop after actual reuse meta write")
-	var snapshot *powerlossoracle.Model
-	var meta durabilitycut.Event
-	restore := durabilitycut.Install(func(event durabilitycut.Event) error {
-		if err := model.Observe(dir, event); err != nil {
-			return err
-		}
-		if event.Point == durabilitycut.AfterMetaWrite {
-			meta = event
-			snapshot = model.Clone()
-			return cutErr
-		}
-		return nil
-	})
-	err = writeGeneration('d', false)
-	restore()
-	if !errors.Is(err, cutErr) || snapshot == nil {
-		t.Fatalf("actual reuse generation did not stop at AfterMetaWrite: err=%v", err)
+	if err := d.Checkpoint(); err != nil {
+		t.Fatalf("first durable coverage: %v", err)
 	}
-	afterReuse := idx.allocator.Counters()
-	if afterReuse.ReuseAllocPages <= beforeReuse.ReuseAllocPages {
-		t.Fatalf("actual generation reused no freelist pages: before=%+v after=%+v", beforeReuse, afterReuse)
+	// Background publication may already have advanced both alternating meta
+	// slots. If one can still select generation 'a', publish one more durable
+	// generation to displace it deterministically.
+	if s := d.rootPublication.snapshot(); s.oldestRecoverableCommitSeq <= oldSequence {
+		if err := writeGeneration('d', true); err != nil {
+			t.Fatalf("displace second recoverable meta slot: %v", err)
+		}
+	}
+	d.Prune()
+	reclaimable := idx.allocator.Counters()
+	if reclaimable.FreeIDs == 0 {
+		t.Fatalf("displaced recoverable generation remained pinned after both meta slots advanced: before=%+v after=%+v", pinned, reclaimable)
 	}
 
-	indexPath, err := filepath.Rel(dir, meta.Path)
-	if err != nil {
-		t.Fatalf("relative index path: %v", err)
+	if err := writeGeneration('e', false); err != nil {
+		t.Fatalf("write reusable generation: %v", err)
 	}
-	changed, err := snapshot.ChangedRanges(indexPath)
-	if err != nil {
-		t.Fatalf("changed index ranges: %v", err)
+	reused := idx.allocator.Counters()
+	if reused.ReuseAllocPages <= reclaimable.ReuseAllocPages {
+		t.Fatalf("eligible freelist pages were not reused: before=%+v after=%+v", reclaimable, reused)
 	}
-	changedOldPage := func(pageID uint64) bool {
-		start := int64(pageID) * int64(page.PageSize)
-		end := start + int64(page.PageSize)
-		for _, r := range changed {
-			if r.Offset < end && r.Offset+r.Length > start {
-				return true
-			}
-		}
-		return false
+	if err := d.Checkpoint(); err != nil {
+		t.Fatalf("durably publish reused generation: %v", err)
 	}
-	var reusedPage uint64
-	for _, id := range oldPages {
-		if changedOldPage(id) {
-			reusedPage = id
-			break
-		}
-	}
-	if reusedPage == 0 {
-		t.Fatalf("freelist reuse did not overwrite an old-live page: root=%d old_pages=%d changed_ranges=%d before=%+v after=%+v", oldState.RootPageID, len(oldPages), len(changed), beforeReuse, afterReuse)
-	}
-
-	// Model the physically permitted writeback of the actual reused page while
-	// keeping the older synced meta page. The resulting image must never read as
-	// the complete older generation.
-	pageOffset := int64(reusedPage) * int64(page.PageSize)
-	if err := snapshot.PromoteRange(indexPath, pageOffset, int64(page.PageSize)); err != nil {
-		t.Fatalf("persist actual reused page %d: %v", reusedPage, err)
-	}
-	crashDir := t.TempDir()
-	if err := snapshot.MaterializeStable(crashDir); err != nil {
-		t.Fatalf("materialize stable-only image: %v", err)
-	}
-	reopenOpts := opts
-	reopenOpts.Dir = crashDir
-	reopenOpts.ReadOnly = true
-	reopened, openErr := Open(reopenOpts)
-	if openErr != nil {
-		t.Logf("public db.Open rejected old root with reused page %d: %v", reusedPage, openErr)
-		return
-	}
-	defer reopened.Close()
-	opened := reopened.State()
-	if opened == nil {
-		t.Fatal("public db.Open returned no state")
-	}
-	generation := powerLossDBCompleteGeneration(oldState.CommitSeq, oldState.AppliedCommandLSN)
-	generation.LivePages = append([]uint64(nil), oldPages...)
-	scenario := powerlossoracle.Scenario{
-		Name:                 "actual-recoverable-page-reuse",
-		Cut:                  powerlossoracle.AfterMetaWrite,
-		Generations:          []powerlossoracle.Generation{generation},
-		LatestSealedSequence: oldState.CommitSeq,
-		SelectedSequence:     opened.CommitSeq,
-		OpenedSequence:       opened.CommitSeq,
-		OpenedAppliedLSN:     opened.AppliedCommandLSN,
-		ReusedPages:          []uint64{reusedPage},
-		ReopenAttempted:      true,
-	}
-	if err := powerlossoracle.RequireViolation(scenario.Validate(), powerlossoracle.InvariantRecoverablePageReused); err != nil {
-		t.Fatalf("successful public Open did not produce recoverable-page-reused diagnosis: %v", err)
-	}
-}
-
-func powerLossDBCompleteGeneration(sequence, applied uint64) powerlossoracle.Generation {
-	kinds := []powerlossoracle.ResourceKind{
-		powerlossoracle.ResourceIndex,
-		powerlossoracle.ResourceFreelist,
-		powerlossoracle.ResourceValueLog,
-		powerlossoracle.ResourceOuterLeaf,
-		powerlossoracle.ResourceAuxiliary,
-		powerlossoracle.ResourceDirectory,
-		powerlossoracle.ResourceSeal,
-		powerlossoracle.ResourceCommandWAL,
-	}
-	resources := make([]powerlossoracle.Resource, 0, len(kinds))
-	for _, kind := range kinds {
-		resources = append(resources, powerlossoracle.Resource{Kind: kind, ID: string(kind), Stable: true, Live: true})
-	}
-	return powerlossoracle.Generation{Sequence: sequence, Recoverable: true, Resources: resources, AppliedLSN: applied}
 }

--- a/TreeDB/db/prune.go
+++ b/TreeDB/db/prune.go
@@ -124,7 +124,31 @@ func formatMaybeNegativeDurationMs(d time.Duration) string {
 	return fmt.Sprintf("%d", d.Milliseconds())
 }
 
+// effectivePruneCurrent converts the oldest recovery-selectable root into the
+// current sequence expected by graveyard.Extract*. Those methods subtract
+// KeepRecent themselves, so adding it here avoids applying the retention
+// window twice while still capping reclamation at the redundant-meta boundary.
+func (db *DB) effectivePruneCurrent(current uint64) uint64 {
+	if db.rootPublication == nil {
+		return current
+	}
+	oldestRecoverable := db.rootPublication.snapshot().oldestRecoverableCommitSeq
+	recoverableCurrent := oldestRecoverable
+	if db.keepRecent > ^uint64(0)-recoverableCurrent {
+		recoverableCurrent = ^uint64(0)
+	} else {
+		recoverableCurrent += db.keepRecent
+	}
+	if recoverableCurrent < current {
+		return recoverableCurrent
+	}
+	return current
+}
+
 func (db *DB) pruneSome(stopCh <-chan struct{}, maxPages int, maxDuration time.Duration) (int, error) {
+	if err := db.publicationPoisonedError(); err != nil {
+		return 0, err
+	}
 	if maxPages == 0 {
 		return 0, nil
 	}
@@ -157,7 +181,7 @@ func (db *DB) pruneSome(stopCh <-chan struct{}, maxPages int, maxDuration time.D
 		if state == nil {
 			return freedPages, nil
 		}
-		currentSeq := state.CommitSeq
+		currentSeq := db.effectivePruneCurrent(state.CommitSeq)
 		minPinned := db.MinPinnedSnapshotCommitSeq()
 
 		remaining := maxPages

--- a/TreeDB/db/read_only_prepare_test.go
+++ b/TreeDB/db/read_only_prepare_test.go
@@ -42,10 +42,11 @@ func readOnlyPrepareRootSeq(d *DB) (root, seq uint64) {
 	if d == nil {
 		return 0, 0
 	}
-	d.mu.RLock()
-	root = d.meta.UserRootPageID
-	seq = d.meta.CommitSeq
-	d.mu.RUnlock()
+	state := d.state.Load()
+	if state != nil {
+		root = state.RootPageID
+		seq = state.CommitSeq
+	}
 	return root, seq
 }
 

--- a/TreeDB/db/root_publication.go
+++ b/TreeDB/db/root_publication.go
@@ -1,0 +1,714 @@
+package db
+
+import (
+	"errors"
+	"fmt"
+	"path/filepath"
+	"sync"
+	"time"
+
+	"github.com/snissn/gomap/TreeDB/internal/durabilitycut"
+	"github.com/snissn/gomap/TreeDB/internal/valuelog"
+	"github.com/snissn/gomap/TreeDB/page"
+)
+
+const (
+	rootPublicationMaxPendingBytes   = 256 << 20
+	rootPublicationMaxPendingCommits = 4096
+)
+
+// PreparedRootCandidate is the immutable handoff from root construction to
+// stable publication. Persistent side stores can extend dependencies without
+// changing the meta publication state machine.
+type PreparedRootCandidate struct {
+	CommitSeq            uint64
+	UserRootPageID       uint64
+	SystemRootPageID     uint64
+	FreelistHeadID       uint64
+	TotalPages           uint64
+	AppliedCommandLSN    uint64
+	MaxEntryRevision     uint64
+	TouchedIndexPages    []uint64
+	RetiredPages         []uint64
+	TouchedValueLogFiles []uint32
+	DependencyPaths      []string
+	OuterLeafFrontier    uint64
+	Meta                 page.MetaPageBody
+	OldValueLogSet       *valuelog.Set
+	ValueLogAppender     ValueLogAppender
+	LeafPageLog          LeafPageLog
+	OwnedBytes           uint64
+	DependenciesFlushed  bool
+	holdsPreparePin      bool
+}
+
+type rootPublicationSnapshot struct {
+	visibleCommitSeq           uint64
+	durableCommitSeq           uint64
+	oldestRecoverableCommitSeq uint64
+	pendingCandidates          uint64
+	pendingBytes               uint64
+	candidatesCoalesced        uint64
+	dependencySyncs            uint64
+	metaSyncs                  uint64
+	publicationStalls          uint64
+	poisonEvents               uint64
+	waiterCount                uint64
+	waiterLatency              time.Duration
+	waiterLatencyMax           time.Duration
+}
+
+// RootPublicationCoordinator is the sole ordinary-production owner of meta
+// installation. Root builders publish visibility and enqueue candidates; this
+// worker owns dependency ordering and durable meta-slot advancement.
+type RootPublicationCoordinator struct {
+	db *DB
+
+	publishMu  sync.Mutex
+	recoveryMu sync.RWMutex
+	mu         sync.Mutex
+	cond       *sync.Cond
+	wake       chan struct{}
+	stop       chan struct{}
+	done       chan struct{}
+
+	pending                    []*PreparedRootCandidate
+	pendingBytes               uint64
+	durableMeta                page.MetaPageBody
+	durableMetaPageID          uint64
+	metaSlotSeq                [2]uint64
+	metaSlotValid              [2]bool
+	metaSlotMeta               [2]page.MetaPageBody
+	recoveryClosureGeneration  uint64
+	visibleCommitSeq           uint64
+	durableCommitSeq           uint64
+	oldestRecoverableCommitSeq uint64
+	stall                      error
+	stallCommitSeq             uint64
+	stallAttempt               uint64
+	poison                     error
+	attempts                   uint64
+	stopped                    bool
+
+	candidatesCoalesced uint64
+	dependencySyncs     uint64
+	metaSyncs           uint64
+	publicationStalls   uint64
+	poisonEvents        uint64
+	waiterCount         uint64
+	waiterLatency       time.Duration
+	waiterLatencyMax    time.Duration
+}
+
+func newRootPublicationCoordinator(db *DB) *RootPublicationCoordinator {
+	r := &RootPublicationCoordinator{
+		db:                         db,
+		wake:                       make(chan struct{}, 1),
+		stop:                       make(chan struct{}),
+		done:                       make(chan struct{}),
+		durableMeta:                db.meta,
+		durableMetaPageID:          db.metaPageID,
+		visibleCommitSeq:           db.meta.CommitSeq,
+		durableCommitSeq:           db.meta.CommitSeq,
+		oldestRecoverableCommitSeq: db.meta.CommitSeq,
+	}
+	r.cond = sync.NewCond(&r.mu)
+	for id := uint64(0); id < 2; id++ {
+		if m, ok := db.readMeta(id); ok {
+			r.metaSlotSeq[id] = m.CommitSeq
+			r.metaSlotValid[id] = true
+			r.metaSlotMeta[id] = m
+		}
+	}
+	r.recomputeOldestRecoverableLocked()
+	go r.run()
+	return r
+}
+
+func (r *RootPublicationCoordinator) recomputeOldestRecoverableLocked() {
+	if !r.metaSlotValid[0] {
+		if r.metaSlotValid[1] {
+			r.oldestRecoverableCommitSeq = r.metaSlotSeq[1]
+		}
+		return
+	}
+	if !r.metaSlotValid[1] {
+		r.oldestRecoverableCommitSeq = r.metaSlotSeq[0]
+		return
+	}
+	a, b := r.metaSlotSeq[0], r.metaSlotSeq[1]
+	if a < b {
+		r.oldestRecoverableCommitSeq = a
+	} else {
+		r.oldestRecoverableCommitSeq = b
+	}
+}
+
+// durableAppliedCommandLSN returns the command-WAL coverage recorded by the
+// most recently synced meta page. Visible state can run ahead of this value
+// while publication is queued or stalled and must not authorize source-log
+// deletion.
+func (r *RootPublicationCoordinator) durableAppliedCommandLSN() uint64 {
+	if r == nil {
+		return 0
+	}
+	r.mu.Lock()
+	applied := r.durableMeta.AppliedCommandLSN
+	r.mu.Unlock()
+	return applied
+}
+
+// recoverableValueLogRoots returns the user and system roots named by every
+// valid meta slot. Value-log GC scans this exact recovery closure before it
+// can zombify a segment; retaining whole DBState value-log sets here would pin
+// unrelated, unreachable files and prevent reclamation.
+func (r *RootPublicationCoordinator) recoverableValueLogRoots() (userRoots, systemRoots []uint64, generation uint64) {
+	if r == nil {
+		return nil, nil, 0
+	}
+	r.mu.Lock()
+	for id, valid := range r.metaSlotValid {
+		if !valid {
+			continue
+		}
+		meta := r.metaSlotMeta[id]
+		if meta.UserRootPageID != 0 {
+			userRoots = append(userRoots, meta.UserRootPageID)
+		}
+		if meta.SystemRootPageID != 0 {
+			systemRoots = append(systemRoots, meta.SystemRootPageID)
+		}
+	}
+	for _, candidate := range r.pending {
+		if candidate == nil {
+			continue
+		}
+		if candidate.UserRootPageID != 0 {
+			userRoots = append(userRoots, candidate.UserRootPageID)
+		}
+		if candidate.SystemRootPageID != 0 {
+			systemRoots = append(systemRoots, candidate.SystemRootPageID)
+		}
+	}
+	generation = r.recoveryClosureGeneration
+	r.mu.Unlock()
+	return userRoots, systemRoots, generation
+}
+
+func (r *RootPublicationCoordinator) lockRecoverableValueLogRoots(generation uint64) (func(), bool) {
+	if r == nil {
+		return func() {}, generation == 0
+	}
+	r.recoveryMu.RLock()
+	r.mu.Lock()
+	matches := r.recoveryClosureGeneration == generation
+	r.mu.Unlock()
+	if !matches {
+		r.recoveryMu.RUnlock()
+		return nil, false
+	}
+	return r.recoveryMu.RUnlock, true
+}
+
+func (r *RootPublicationCoordinator) register(candidate *PreparedRootCandidate) error {
+	if r == nil || candidate == nil {
+		return ErrClosed
+	}
+	// Registration is called while db.mu serializes the visible-root install, so
+	// it must never wait for a queued maintenance writer here. Every production
+	// candidate transfers the already-held preparation pin before registration.
+	if !candidate.holdsPreparePin {
+		return errors.New("root publication: candidate missing preparation pin")
+	}
+	releaseOnError := func() {
+		if candidate.holdsPreparePin {
+			candidate.holdsPreparePin = false
+			r.db.publishPrepareMu.RUnlock()
+		}
+	}
+	r.mu.Lock()
+	if r.stopped {
+		r.mu.Unlock()
+		releaseOnError()
+		return ErrClosed
+	}
+	if r.poison != nil {
+		err := r.poison
+		r.mu.Unlock()
+		releaseOnError()
+		return err
+	}
+	hadStall := r.stall != nil
+	debtExceeded := r.pendingBytes > rootPublicationMaxPendingBytes ||
+		candidate.OwnedBytes > rootPublicationMaxPendingBytes-r.pendingBytes
+	if hadStall && (len(r.pending) >= rootPublicationMaxPendingCommits || debtExceeded) {
+		err := r.stall
+		r.mu.Unlock()
+		releaseOnError()
+		return err
+	}
+	wasEmpty := len(r.pending) == 0
+	r.pending = append(r.pending, candidate)
+	r.recoveryClosureGeneration++
+	if candidate.OwnedBytes > ^uint64(0)-r.pendingBytes {
+		r.pendingBytes = ^uint64(0)
+	} else {
+		r.pendingBytes += candidate.OwnedBytes
+	}
+	r.visibleCommitSeq = candidate.CommitSeq
+	r.mu.Unlock()
+	if wasEmpty || hadStall {
+		r.signal()
+	}
+	return nil
+}
+
+func (r *RootPublicationCoordinator) signal() {
+	select {
+	case r.wake <- struct{}{}:
+	default:
+	}
+}
+
+func (r *RootPublicationCoordinator) run() {
+	defer close(r.done)
+	for {
+		select {
+		case <-r.wake:
+			for {
+				r.publishMu.Lock()
+				r.mu.Lock()
+				if len(r.pending) == 0 || r.poison != nil {
+					r.mu.Unlock()
+					r.publishMu.Unlock()
+					break
+				}
+				r.mu.Unlock()
+				// Registration happens inside visible-root serialization. Do not
+				// begin dependency/index/meta I/O until the registering writer (and
+				// any overlapping builder) has released every root lock. TryLock
+				// keeps the coordinator from participating in lock-order waits.
+				if !r.rootSerializationLocksAvailable() {
+					r.publishMu.Unlock()
+					time.Sleep(50 * time.Microsecond)
+					continue
+				}
+				r.mu.Lock()
+				if len(r.pending) == 0 || r.poison != nil {
+					r.mu.Unlock()
+					r.publishMu.Unlock()
+					break
+				}
+				frontier := r.pending[len(r.pending)-1]
+				closure := r.closureThroughLocked(frontier)
+				r.attempts++
+				r.mu.Unlock()
+				r.recoveryMu.Lock()
+				if err, postMeta := r.publish(frontier, closure); err != nil {
+					r.recordFailure(frontier.CommitSeq, err, postMeta)
+					r.recoveryMu.Unlock()
+					r.publishMu.Unlock()
+					break
+				}
+				r.completeLocked(frontier)
+				r.recoveryMu.Unlock()
+				r.publishMu.Unlock()
+			}
+		case <-r.stop:
+			return
+		}
+	}
+}
+
+func (r *RootPublicationCoordinator) rootSerializationLocksAvailable() bool {
+	if !r.db.mu.TryLock() {
+		return false
+	}
+	defer r.db.mu.Unlock()
+	if !r.db.writeMu.TryLock() {
+		return false
+	}
+	defer r.db.writeMu.Unlock()
+	if !r.db.commitMu.TryLock() {
+		return false
+	}
+	r.db.commitMu.Unlock()
+	return true
+}
+
+func (r *RootPublicationCoordinator) closureThroughLocked(frontier *PreparedRootCandidate) []*PreparedRootCandidate {
+	closure := make([]*PreparedRootCandidate, 0, len(r.pending))
+	for _, candidate := range r.pending {
+		closure = append(closure, candidate)
+		if candidate == frontier {
+			break
+		}
+	}
+	return closure
+}
+
+func (r *RootPublicationCoordinator) publish(candidate *PreparedRootCandidate, closure []*PreparedRootCandidate) (error, bool) {
+	if hook := r.db.testRootPublicationBeforeDependencySync; hook != nil {
+		hook()
+	}
+	idx := r.db.idx.Load()
+	if idx == nil || idx.pager == nil {
+		return errors.New("missing index"), false
+	}
+	if err := r.db.flushRootPublicationClosureDurability(idx, closure); err != nil {
+		return err, false
+	}
+	r.mu.Lock()
+	r.dependencySyncs++
+	target := uint64(0)
+	if r.durableMetaPageID == 0 {
+		target = 1
+	}
+	r.mu.Unlock()
+	return r.writeAndSyncMeta(target, candidate.Meta)
+}
+
+func (r *RootPublicationCoordinator) writeAndSyncMeta(target uint64, meta page.MetaPageBody) (error, bool) {
+	idx := r.db.idx.Load()
+	if idx == nil || idx.pager == nil {
+		return errors.New("missing index"), false
+	}
+	// Keep the exact path even when no observer is installed yet. Publication
+	// runs asynchronously, so a test observer can be installed after this worker
+	// starts but before a later cut point is emitted.
+	metaPath := filepath.Join(r.db.dir, "index.db")
+	metaOffset := int64(target) * int64(page.PageSize)
+	if err := durabilitycut.EmitRange(durabilitycut.BeforeMetaWrite, durabilitycut.ResourceMeta, r.db.dir, metaPath, metaOffset, int64(page.PageSize)); err != nil {
+		return err, false
+	}
+	if err := r.db.writeMeta(target, meta); err != nil {
+		// Once the target slot write is attempted, partial mutation cannot be
+		// distinguished from a clean failure. Poison until reopen.
+		return err, true
+	}
+	if err := durabilitycut.EmitRange(durabilitycut.AfterMetaWrite, durabilitycut.ResourceMeta, r.db.dir, metaPath, metaOffset, int64(page.PageSize)); err != nil {
+		return err, true
+	}
+	if err := durabilitycut.EmitPath(durabilitycut.BeforeMetaSync, durabilitycut.ResourceMeta, r.db.dir, metaPath); err != nil {
+		return err, true
+	}
+	if r.db.testFailSyncMeta.Load() {
+		return errTestSyncMetaFailpoint, true
+	}
+	if err := idx.pager.SyncPages([]uint64{target}); err != nil {
+		return err, true
+	}
+	if err := durabilitycut.EmitPath(durabilitycut.AfterMetaSync, durabilitycut.ResourceMeta, r.db.dir, metaPath); err != nil {
+		return err, true
+	}
+	return nil, false
+}
+
+func (r *RootPublicationCoordinator) complete(frontier *PreparedRootCandidate) {
+	r.recoveryMu.Lock()
+	defer r.recoveryMu.Unlock()
+	r.completeLocked(frontier)
+}
+
+func (r *RootPublicationCoordinator) completeLocked(frontier *PreparedRootCandidate) {
+	r.mu.Lock()
+	count := 0
+	bytes := uint64(0)
+	var completed []*PreparedRootCandidate
+	for count < len(r.pending) {
+		c := r.pending[count]
+		completed = append(completed, c)
+		bytes += c.OwnedBytes
+		count++
+		if c == frontier {
+			break
+		}
+	}
+	r.pending = append([]*PreparedRootCandidate(nil), r.pending[count:]...)
+	if bytes <= r.pendingBytes {
+		r.pendingBytes -= bytes
+	} else {
+		r.pendingBytes = 0
+	}
+	if count > 1 {
+		r.candidatesCoalesced += uint64(count - 1)
+	}
+	target := uint64(0)
+	if r.durableMetaPageID == 0 {
+		target = 1
+	}
+	r.durableMeta = frontier.Meta
+	r.durableMetaPageID = target
+	r.metaSlotSeq[target] = frontier.CommitSeq
+	r.metaSlotValid[target] = true
+	r.metaSlotMeta[target] = frontier.Meta
+	r.recoveryClosureGeneration++
+	r.durableCommitSeq = frontier.CommitSeq
+	r.recomputeOldestRecoverableLocked()
+	r.stall = nil
+	r.stallCommitSeq = 0
+	r.metaSyncs++
+	r.mu.Unlock()
+	r.db.mu.Lock()
+	r.db.meta = frontier.Meta
+	r.db.metaPageID = target
+	r.db.mu.Unlock()
+	r.mu.Lock()
+	r.cond.Broadcast()
+	r.mu.Unlock()
+	for _, c := range completed {
+		if c.holdsPreparePin {
+			c.holdsPreparePin = false
+			r.db.publishPrepareMu.RUnlock()
+		}
+		if c.OldValueLogSet != nil && r.db.valueLogManager != nil {
+			_ = r.db.valueLogManager.Release(c.OldValueLogSet)
+		}
+	}
+}
+
+// stabilizeRecoveryWindow makes both selectable meta slots name the newest
+// durable generation. Destructive maintenance calls this before deciding that
+// data absent from the current root is reclaimable: one ordinary publication
+// leaves the alternate meta as a valid fallback to the prior closure.
+func (r *RootPublicationCoordinator) stabilizeRecoveryWindow(seq uint64) error {
+	if r == nil {
+		return ErrClosed
+	}
+	if err := r.retryDurable(seq); err != nil {
+		return err
+	}
+
+	r.db.publishPrepareMu.Lock()
+	defer r.db.publishPrepareMu.Unlock()
+	// Exclude new candidate registration before taking the publisher mutex.
+	// An already-registered candidate owns a publishPrepareMu read pin until the
+	// publisher completes it; taking publishMu first would prevent that completion
+	// while waiting for the pin and deadlock maintenance.
+	r.publishMu.Lock()
+	defer r.publishMu.Unlock()
+	r.recoveryMu.Lock()
+	defer r.recoveryMu.Unlock()
+
+	r.mu.Lock()
+	if r.poison != nil {
+		err := r.poison
+		r.mu.Unlock()
+		return err
+	}
+	if r.durableCommitSeq < seq {
+		r.mu.Unlock()
+		return ErrPublicationStalled
+	}
+	meta := r.durableMeta
+	if r.metaSlotValid[0] && r.metaSlotValid[1] && r.metaSlotMeta[0] == meta && r.metaSlotMeta[1] == meta {
+		r.mu.Unlock()
+		return nil
+	}
+	target := uint64(0)
+	if r.durableMetaPageID == 0 {
+		target = 1
+	}
+	r.attempts++
+	r.mu.Unlock()
+
+	if err, postMeta := r.writeAndSyncMeta(target, meta); err != nil {
+		r.recordFailure(meta.CommitSeq, err, postMeta)
+		if postMeta {
+			return errors.Join(err, ErrRecoveryRequired)
+		}
+		return errors.Join(ErrPublicationStalled, err)
+	}
+	r.mu.Lock()
+	r.durableMetaPageID = target
+	r.metaSlotSeq[target] = meta.CommitSeq
+	r.metaSlotValid[target] = true
+	r.metaSlotMeta[target] = meta
+	r.recoveryClosureGeneration++
+	r.recomputeOldestRecoverableLocked()
+	r.stall = nil
+	r.stallCommitSeq = 0
+	r.metaSyncs++
+	r.cond.Broadcast()
+	r.mu.Unlock()
+	r.db.mu.Lock()
+	r.db.meta = meta
+	r.db.metaPageID = target
+	r.db.mu.Unlock()
+	return nil
+}
+
+// adoptDurableGeneration records a maintenance cutover whose replacement
+// index already contains fully-synced redundant meta pages. The caller must
+// exclude candidate registration with publishPrepareMu.Lock.
+func (r *RootPublicationCoordinator) adoptDurableGeneration(meta page.MetaPageBody, metaPageID uint64) error {
+	if r == nil {
+		return ErrClosed
+	}
+	r.recoveryMu.Lock()
+	defer r.recoveryMu.Unlock()
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if len(r.pending) != 0 {
+		return errors.New("root publication: maintenance cutover with pending candidates")
+	}
+	if r.poison != nil {
+		return r.poison
+	}
+	r.durableMeta = meta
+	r.durableMetaPageID = metaPageID
+	r.metaSlotMeta[0] = meta
+	r.metaSlotMeta[1] = meta
+	r.recoveryClosureGeneration++
+	r.metaSlotSeq[0] = meta.CommitSeq
+	r.metaSlotSeq[1] = meta.CommitSeq
+	r.metaSlotValid[0] = true
+	r.metaSlotValid[1] = true
+	r.visibleCommitSeq = meta.CommitSeq
+	r.durableCommitSeq = meta.CommitSeq
+	r.oldestRecoverableCommitSeq = meta.CommitSeq
+	r.stall = nil
+	r.stallCommitSeq = 0
+	r.cond.Broadcast()
+	return nil
+}
+
+func (r *RootPublicationCoordinator) recordFailure(commitSeq uint64, err error, postMeta bool) {
+	r.mu.Lock()
+	if postMeta {
+		r.poison = errors.Join(err, ErrRecoveryRequired)
+		r.poisonEvents++
+		r.db.publicationPoisoned.Store(true)
+	} else {
+		r.stall = errors.Join(ErrPublicationStalled, err)
+		r.stallCommitSeq = commitSeq
+		r.stallAttempt = r.attempts
+		r.publicationStalls++
+	}
+	r.cond.Broadcast()
+	r.mu.Unlock()
+}
+
+func (r *RootPublicationCoordinator) waitDurable(seq uint64) error {
+	return r.waitDurableMode(seq, false)
+}
+
+// retryDurable establishes an explicit durability boundary that is permitted
+// to retry a previously stalled frontier once. Candidate-specific WriteSync
+// waits use waitDurable so the failure of their own publication is not hidden
+// by an immediate retry race.
+func (r *RootPublicationCoordinator) retryDurable(seq uint64) error {
+	return r.waitDurableMode(seq, true)
+}
+
+func (r *RootPublicationCoordinator) waitDurableMode(seq uint64, retryStall bool) error {
+	if r == nil {
+		return ErrClosed
+	}
+	start := time.Now()
+	if hook := r.db.testRootPublicationBeforeWait; hook != nil {
+		hook()
+	}
+	r.mu.Lock()
+	seenStallAttempt := r.stallAttempt
+	if r.durableCommitSeq < seq && r.stall != nil && seq <= r.stallCommitSeq && !retryStall {
+		err := r.stall
+		r.recordWaitLocked(time.Since(start))
+		r.mu.Unlock()
+		return err
+	}
+	if r.durableCommitSeq < seq && r.poison == nil {
+		r.mu.Unlock()
+		r.signal()
+		r.mu.Lock()
+	}
+	for r.durableCommitSeq < seq && r.poison == nil {
+		if r.stall != nil && r.stallAttempt > seenStallAttempt {
+			err := r.stall
+			r.recordWaitLocked(time.Since(start))
+			r.mu.Unlock()
+			return err
+		}
+		r.cond.Wait()
+	}
+	r.recordWaitLocked(time.Since(start))
+	if r.poison != nil {
+		err := r.poison
+		r.mu.Unlock()
+		return err
+	}
+	r.mu.Unlock()
+	return nil
+}
+
+func (r *RootPublicationCoordinator) recordWaitLocked(d time.Duration) {
+	r.waiterCount++
+	r.waiterLatency += d
+	if d > r.waiterLatencyMax {
+		r.waiterLatencyMax = d
+	}
+}
+
+func (r *RootPublicationCoordinator) snapshot() rootPublicationSnapshot {
+	if r == nil {
+		return rootPublicationSnapshot{}
+	}
+	r.mu.Lock()
+	s := rootPublicationSnapshot{
+		visibleCommitSeq: r.visibleCommitSeq, durableCommitSeq: r.durableCommitSeq,
+		oldestRecoverableCommitSeq: r.oldestRecoverableCommitSeq,
+		pendingCandidates:          uint64(len(r.pending)), pendingBytes: r.pendingBytes,
+		candidatesCoalesced: r.candidatesCoalesced, dependencySyncs: r.dependencySyncs,
+		metaSyncs: r.metaSyncs, publicationStalls: r.publicationStalls,
+		poisonEvents: r.poisonEvents, waiterCount: r.waiterCount,
+		waiterLatency: r.waiterLatency, waiterLatencyMax: r.waiterLatencyMax,
+	}
+	r.mu.Unlock()
+	return s
+}
+
+func (r *RootPublicationCoordinator) stopPublisher() {
+	if r == nil {
+		return
+	}
+	r.mu.Lock()
+	if r.stopped {
+		r.mu.Unlock()
+		return
+	}
+	r.stopped = true
+	close(r.stop)
+	pending := append([]*PreparedRootCandidate(nil), r.pending...)
+	r.pending = nil
+	r.pendingBytes = 0
+	r.mu.Unlock()
+	<-r.done
+	for _, candidate := range pending {
+		if candidate.holdsPreparePin {
+			candidate.holdsPreparePin = false
+			r.db.publishPrepareMu.RUnlock()
+		}
+		if candidate.OldValueLogSet != nil && r.db.valueLogManager != nil {
+			_ = r.db.valueLogManager.Release(candidate.OldValueLogSet)
+		}
+	}
+}
+
+func (r *RootPublicationCoordinator) durableError() error {
+	if r == nil {
+		return nil
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.poison != nil {
+		return r.poison
+	}
+	if r.stall != nil {
+		return r.stall
+	}
+	return nil
+}
+
+func (c *PreparedRootCandidate) String() string {
+	return fmt.Sprintf("root-candidate(seq=%d roots=%d/%d)", c.CommitSeq, c.UserRootPageID, c.SystemRootPageID)
+}

--- a/TreeDB/db/root_publication.go
+++ b/TreeDB/db/root_publication.go
@@ -75,6 +75,7 @@ type RootPublicationCoordinator struct {
 	stop          chan struct{}
 	done          chan struct{}
 	indexSnapshot *pager.IndexPageSnapshot
+	metaPageImage [page.PageSize]byte
 
 	pending                    []*PreparedRootCandidate
 	pendingBytes               uint64
@@ -341,11 +342,12 @@ func (r *RootPublicationCoordinator) run() {
 					r.recordFailure(frontier.CommitSeq, err, postMeta)
 					break
 				}
-				r.completeLocked(frontier)
+				r.completeLocked(frontier, publicationFrontier)
 				r.recoveryMu.Unlock()
 
 				// The pwrite/meta phase is complete. Drain builders admitted during
-				// it before ending the append-only/deferred-free freelist fence.
+				// it before ending the deferred-free freelist fence. An allocator call
+				// is atomic, but an aborted builder can free after that call returns.
 				r.relockRootSerialization()
 				fenceErr := idx.allocator.EndPublicationFence()
 				r.unlockRootSerialization()
@@ -430,7 +432,7 @@ func (r *RootPublicationCoordinator) relockRootSerialization() {
 	// Do not queue an RWMutex writer here. An admitted optimistic builder may
 	// legitimately enter another read-side build before releasing its outer read
 	// lock; Go's writer preference would block that nested read and deadlock the
-	// fence. The append-only fence remains safe while we wait for a quiet point.
+	// fence. The publication fence remains safe while we wait for a quiet point.
 	for !r.db.writeMu.TryLock() {
 		runtime.Gosched()
 	}
@@ -520,7 +522,7 @@ func (r *RootPublicationCoordinator) writeAndSyncMeta(target uint64, meta page.M
 	if r.db.testFailSyncMeta.Load() {
 		return errTestSyncMetaFailpoint, true
 	}
-	if err := idx.pager.SyncPages([]uint64{target}); err != nil {
+	if err := idx.pager.SyncMetaPageImage(target, r.metaPageImage[:]); err != nil {
 		return err, true
 	}
 	if err := durabilitycut.EmitPath(durabilitycut.AfterMetaSync, durabilitycut.ResourceMeta, r.db.dir, metaPath); err != nil {
@@ -532,10 +534,13 @@ func (r *RootPublicationCoordinator) writeAndSyncMeta(target uint64, meta page.M
 func (r *RootPublicationCoordinator) complete(frontier *PreparedRootCandidate) {
 	r.recoveryMu.Lock()
 	defer r.recoveryMu.Unlock()
-	r.completeLocked(frontier)
+	r.completeLocked(frontier, frontier)
 }
 
-func (r *RootPublicationCoordinator) completeLocked(frontier *PreparedRootCandidate) {
+// completeLocked removes candidates through queuedFrontier while recording the
+// exact sealed frontier whose meta image was written. The two pointers differ
+// when publication refreshes mutable allocator state after draining builders.
+func (r *RootPublicationCoordinator) completeLocked(queuedFrontier, durableFrontier *PreparedRootCandidate) {
 	r.mu.Lock()
 	count := 0
 	bytes := uint64(0)
@@ -545,7 +550,7 @@ func (r *RootPublicationCoordinator) completeLocked(frontier *PreparedRootCandid
 		completed = append(completed, c)
 		bytes += c.OwnedBytes
 		count++
-		if c == frontier {
+		if c == queuedFrontier {
 			break
 		}
 	}
@@ -562,13 +567,13 @@ func (r *RootPublicationCoordinator) completeLocked(frontier *PreparedRootCandid
 	if r.durableMetaPageID == 0 {
 		target = 1
 	}
-	r.durableMeta = frontier.Meta
+	r.durableMeta = durableFrontier.Meta
 	r.durableMetaPageID = target
-	r.metaSlotSeq[target] = frontier.CommitSeq
+	r.metaSlotSeq[target] = durableFrontier.CommitSeq
 	r.metaSlotValid[target] = true
-	r.metaSlotMeta[target] = frontier.Meta
+	r.metaSlotMeta[target] = durableFrontier.Meta
 	r.recoveryClosureGeneration++
-	r.durableCommitSeq = frontier.CommitSeq
+	r.durableCommitSeq = durableFrontier.CommitSeq
 	if r.durabilityDemandSeq <= r.durableCommitSeq {
 		r.durabilityDemandSeq = 0
 	}
@@ -578,7 +583,7 @@ func (r *RootPublicationCoordinator) completeLocked(frontier *PreparedRootCandid
 	r.metaSyncs++
 	r.mu.Unlock()
 	r.db.mu.Lock()
-	r.db.meta = frontier.Meta
+	r.db.meta = durableFrontier.Meta
 	r.db.metaPageID = target
 	r.db.mu.Unlock()
 	r.mu.Lock()

--- a/TreeDB/db/root_publication.go
+++ b/TreeDB/db/root_publication.go
@@ -383,23 +383,14 @@ func (r *RootPublicationCoordinator) sealedAllocatorFrontier(idx *indexGen, fron
 }
 
 func (r *RootPublicationCoordinator) lockRootSerialization() (*indexGen, error) {
-	// Queue as a writer before publishMu. Destructive maintenance serializes on
-	// publishMu before attempting the preparation gate, so it cannot queue an
-	// exclusive preparation waiter that blocks an admitted builder here.
-	// First give already-runnable foreground builders a bounded chance to join
-	// this frontier. The blocking fallback is essential: a continuous reader
-	// stream must not starve stable publication.
-	const optimisticWriterAttempts = 64
-	locked := false
-	for attempt := 0; attempt < optimisticWriterAttempts; attempt++ {
-		if r.db.writeMu.TryLock() {
-			locked = true
-			break
-		}
+	// Do not queue an RWMutex writer. An admitted optimistic builder may enter a
+	// nested read-side build before releasing its outer read lock; Go's writer
+	// preference would block that nested read behind this publisher and deadlock
+	// the frontier. Pending-debt limits stop new visibility if readers keep the
+	// gate continuously occupied, so polling here remains bounded by foreground
+	// admission rather than weakening the serialization fence.
+	for !r.db.writeMu.TryLock() {
 		runtime.Gosched()
-	}
-	if !locked {
-		r.db.writeMu.Lock()
 	}
 	r.publishMu.Lock()
 	r.db.commitMu.Lock()

--- a/TreeDB/db/root_publication.go
+++ b/TreeDB/db/root_publication.go
@@ -4,12 +4,14 @@ import (
 	"errors"
 	"fmt"
 	"path/filepath"
+	"runtime"
 	"sync"
 	"time"
 
 	"github.com/snissn/gomap/TreeDB/internal/durabilitycut"
 	"github.com/snissn/gomap/TreeDB/internal/valuelog"
 	"github.com/snissn/gomap/TreeDB/page"
+	"github.com/snissn/gomap/TreeDB/pager"
 )
 
 const (
@@ -31,6 +33,7 @@ type PreparedRootCandidate struct {
 	TouchedIndexPages    []uint64
 	RetiredPages         []uint64
 	TouchedValueLogFiles []uint32
+	DependencyPath       string
 	DependencyPaths      []string
 	OuterLeafFrontier    uint64
 	Meta                 page.MetaPageBody
@@ -64,13 +67,14 @@ type rootPublicationSnapshot struct {
 type RootPublicationCoordinator struct {
 	db *DB
 
-	publishMu  sync.Mutex
-	recoveryMu sync.RWMutex
-	mu         sync.Mutex
-	cond       *sync.Cond
-	wake       chan struct{}
-	stop       chan struct{}
-	done       chan struct{}
+	publishMu     sync.Mutex
+	recoveryMu    sync.RWMutex
+	mu            sync.Mutex
+	cond          *sync.Cond
+	wake          chan struct{}
+	stop          chan struct{}
+	done          chan struct{}
+	indexSnapshot *pager.IndexPageSnapshot
 
 	pending                    []*PreparedRootCandidate
 	pendingBytes               uint64
@@ -86,6 +90,7 @@ type RootPublicationCoordinator struct {
 	stall                      error
 	stallCommitSeq             uint64
 	stallAttempt               uint64
+	durabilityDemandSeq        uint64
 	poison                     error
 	attempts                   uint64
 	stopped                    bool
@@ -106,6 +111,7 @@ func newRootPublicationCoordinator(db *DB) *RootPublicationCoordinator {
 		wake:                       make(chan struct{}, 1),
 		stop:                       make(chan struct{}),
 		done:                       make(chan struct{}),
+		indexSnapshot:              pager.NewIndexPageSnapshot(),
 		durableMeta:                db.meta,
 		durableMetaPageID:          db.metaPageID,
 		visibleCommitSeq:           db.meta.CommitSeq,
@@ -241,10 +247,16 @@ func (r *RootPublicationCoordinator) register(candidate *PreparedRootCandidate) 
 	hadStall := r.stall != nil
 	debtExceeded := r.pendingBytes > rootPublicationMaxPendingBytes ||
 		candidate.OwnedBytes > rootPublicationMaxPendingBytes-r.pendingBytes
-	if hadStall && (len(r.pending) >= rootPublicationMaxPendingCommits || debtExceeded) {
+	if len(r.pending) >= rootPublicationMaxPendingCommits || debtExceeded {
+		if r.stall == nil {
+			r.stall = ErrPublicationStalled
+			r.stallCommitSeq = candidate.CommitSeq
+			r.publicationStalls++
+		}
 		err := r.stall
 		r.mu.Unlock()
 		releaseOnError()
+		r.signal()
 		return err
 	}
 	wasEmpty := len(r.pending) == 0
@@ -276,43 +288,72 @@ func (r *RootPublicationCoordinator) run() {
 		select {
 		case <-r.wake:
 			for {
-				r.publishMu.Lock()
 				r.mu.Lock()
 				if len(r.pending) == 0 || r.poison != nil {
 					r.mu.Unlock()
-					r.publishMu.Unlock()
 					break
 				}
 				r.mu.Unlock()
-				// Registration happens inside visible-root serialization. Do not
-				// begin dependency/index/meta I/O until the registering writer (and
-				// any overlapping builder) has released every root lock. TryLock
-				// keeps the coordinator from participating in lock-order waits.
-				if !r.rootSerializationLocksAvailable() {
-					r.publishMu.Unlock()
-					time.Sleep(50 * time.Microsecond)
-					continue
+				// Publication is event-driven. Acquiring the writer barrier drains
+				// already-admitted builders; the latest complete candidate observed
+				// after that barrier becomes the coalesced frontier.
+				idx, lockErr := r.lockRootSerialization()
+				if lockErr != nil {
+					r.recordFailure(0, lockErr, false)
+					break
 				}
 				r.mu.Lock()
 				if len(r.pending) == 0 || r.poison != nil {
 					r.mu.Unlock()
+					fenceErr := idx.allocator.EndPublicationFence()
+					r.unlockRootSerialization()
 					r.publishMu.Unlock()
+					if fenceErr != nil {
+						r.recordFailure(0, fenceErr, false)
+					}
 					break
 				}
 				frontier := r.pending[len(r.pending)-1]
 				closure := r.closureThroughLocked(frontier)
 				r.attempts++
 				r.mu.Unlock()
+				publicationFrontier := r.sealedAllocatorFrontier(idx, frontier)
+				publicationClosure := append([]*PreparedRootCandidate(nil), closure...)
+				publicationClosure[len(publicationClosure)-1] = publicationFrontier
+				publicationPages := rootPublicationIndexPages(publicationClosure)
+				r.unlockRootSerialization()
+
+				// The fence defers frees and forces successor allocations to append,
+				// keeping every page in the captured publication generation immutable.
+				// Copy outside root serialization to keep foreground builders moving.
+				captureErr := idx.pager.CaptureIndexPagesInto(r.indexSnapshot, publicationPages)
+				if captureErr != nil {
+					captureErr = errors.Join(captureErr, r.closePublicationFence(idx))
+					r.recordFailure(frontier.CommitSeq, captureErr, false)
+					break
+				}
+
 				r.recoveryMu.Lock()
-				if err, postMeta := r.publish(frontier, closure); err != nil {
-					r.recordFailure(frontier.CommitSeq, err, postMeta)
+				err, postMeta := r.publish(publicationFrontier, publicationClosure, r.indexSnapshot)
+				if err != nil {
 					r.recoveryMu.Unlock()
-					r.publishMu.Unlock()
+					err = errors.Join(err, r.closePublicationFence(idx))
+					r.recordFailure(frontier.CommitSeq, err, postMeta)
 					break
 				}
 				r.completeLocked(frontier)
 				r.recoveryMu.Unlock()
+
+				// The pwrite/meta phase is complete. Drain builders admitted during
+				// it before ending the append-only/deferred-free freelist fence.
+				r.relockRootSerialization()
+				fenceErr := idx.allocator.EndPublicationFence()
+				r.unlockRootSerialization()
 				r.publishMu.Unlock()
+				if fenceErr != nil {
+					r.recordFailure(frontier.CommitSeq, fenceErr, true)
+					break
+				}
 			}
 		case <-r.stop:
 			return
@@ -320,20 +361,104 @@ func (r *RootPublicationCoordinator) run() {
 	}
 }
 
-func (r *RootPublicationCoordinator) rootSerializationLocksAvailable() bool {
-	if !r.db.mu.TryLock() {
-		return false
+// sealAllocatorFrontier captures the mutable allocator state only after the
+// writer barrier has drained every admitted optimistic builder. A builder that
+// loses validation can allocate and return pages without registering a root
+// candidate, so the head recorded at candidate preparation is not necessarily
+// the allocator image that exists when publication begins.
+func (r *RootPublicationCoordinator) sealedAllocatorFrontier(idx *indexGen, frontier *PreparedRootCandidate) *PreparedRootCandidate {
+	if idx == nil || idx.allocator == nil || idx.pager == nil || frontier == nil {
+		return frontier
 	}
-	defer r.db.mu.Unlock()
-	if !r.db.writeMu.TryLock() {
-		return false
+	sealed := *frontier
+	head := idx.allocator.Head()
+	totalPages := idx.pager.PageCount()
+	sealed.FreelistHeadID = head
+	sealed.TotalPages = totalPages
+	sealed.Meta.FreelistHeadID = head
+	sealed.Meta.TotalPages = totalPages
+	return &sealed
+}
+
+func (r *RootPublicationCoordinator) lockRootSerialization() (*indexGen, error) {
+	// Queue as a writer before publishMu. Destructive maintenance serializes on
+	// publishMu before attempting the preparation gate, so it cannot queue an
+	// exclusive preparation waiter that blocks an admitted builder here.
+	// First give already-runnable foreground builders a bounded chance to join
+	// this frontier. The blocking fallback is essential: a continuous reader
+	// stream must not starve stable publication.
+	const optimisticWriterAttempts = 64
+	locked := false
+	for attempt := 0; attempt < optimisticWriterAttempts; attempt++ {
+		if r.db.writeMu.TryLock() {
+			locked = true
+			break
+		}
+		runtime.Gosched()
 	}
-	defer r.db.writeMu.Unlock()
-	if !r.db.commitMu.TryLock() {
-		return false
+	if !locked {
+		r.db.writeMu.Lock()
 	}
+	r.publishMu.Lock()
+	r.db.commitMu.Lock()
+	r.db.mu.Lock()
+	idx := r.db.idx.Load()
+	if idx == nil || idx.allocator == nil {
+		r.db.mu.Unlock()
+		r.db.commitMu.Unlock()
+		r.publishMu.Unlock()
+		r.db.writeMu.Unlock()
+		return nil, errors.New("missing index")
+	}
+	if err := idx.allocator.BeginPublicationFence(); err != nil {
+		r.db.mu.Unlock()
+		r.db.commitMu.Unlock()
+		r.publishMu.Unlock()
+		r.db.writeMu.Unlock()
+		return nil, err
+	}
+	return idx, nil
+}
+
+func (r *RootPublicationCoordinator) unlockRootSerialization() {
+	r.db.mu.Unlock()
 	r.db.commitMu.Unlock()
-	return true
+	r.db.writeMu.Unlock()
+}
+
+func (r *RootPublicationCoordinator) relockRootSerialization() {
+	// Do not queue an RWMutex writer here. An admitted optimistic builder may
+	// legitimately enter another read-side build before releasing its outer read
+	// lock; Go's writer preference would block that nested read and deadlock the
+	// fence. The append-only fence remains safe while we wait for a quiet point.
+	for !r.db.writeMu.TryLock() {
+		runtime.Gosched()
+	}
+	r.db.commitMu.Lock()
+	r.db.mu.Lock()
+}
+
+func (r *RootPublicationCoordinator) closePublicationFence(idx *indexGen) error {
+	r.relockRootSerialization()
+	err := idx.allocator.EndPublicationFence()
+	r.unlockRootSerialization()
+	r.publishMu.Unlock()
+	return err
+}
+
+// lockMaintenancePublication excludes the publisher before attempting the
+// preparation gate. TryLock is essential: queuing an RWMutex writer would stop
+// an admitted builder from obtaining its preparation read pin, while the
+// publisher may be waiting for that builder to release writeMu.RLock.
+func (r *RootPublicationCoordinator) lockMaintenancePublication() {
+	for {
+		r.publishMu.Lock()
+		if r.db.publishPrepareMu.TryLock() {
+			return
+		}
+		r.publishMu.Unlock()
+		runtime.Gosched()
+	}
 }
 
 func (r *RootPublicationCoordinator) closureThroughLocked(frontier *PreparedRootCandidate) []*PreparedRootCandidate {
@@ -347,7 +472,7 @@ func (r *RootPublicationCoordinator) closureThroughLocked(frontier *PreparedRoot
 	return closure
 }
 
-func (r *RootPublicationCoordinator) publish(candidate *PreparedRootCandidate, closure []*PreparedRootCandidate) (error, bool) {
+func (r *RootPublicationCoordinator) publish(candidate *PreparedRootCandidate, closure []*PreparedRootCandidate, indexSnapshot *pager.IndexPageSnapshot) (error, bool) {
 	if hook := r.db.testRootPublicationBeforeDependencySync; hook != nil {
 		hook()
 	}
@@ -355,7 +480,7 @@ func (r *RootPublicationCoordinator) publish(candidate *PreparedRootCandidate, c
 	if idx == nil || idx.pager == nil {
 		return errors.New("missing index"), false
 	}
-	if err := r.db.flushRootPublicationClosureDurability(idx, closure); err != nil {
+	if err := r.db.flushRootPublicationClosureDurability(idx, closure, indexSnapshot); err != nil {
 		return err, false
 	}
 	r.mu.Lock()
@@ -444,6 +569,9 @@ func (r *RootPublicationCoordinator) completeLocked(frontier *PreparedRootCandid
 	r.metaSlotMeta[target] = frontier.Meta
 	r.recoveryClosureGeneration++
 	r.durableCommitSeq = frontier.CommitSeq
+	if r.durabilityDemandSeq <= r.durableCommitSeq {
+		r.durabilityDemandSeq = 0
+	}
 	r.recomputeOldestRecoverableLocked()
 	r.stall = nil
 	r.stallCommitSeq = 0
@@ -479,14 +607,13 @@ func (r *RootPublicationCoordinator) stabilizeRecoveryWindow(seq uint64) error {
 		return err
 	}
 
-	r.db.publishPrepareMu.Lock()
-	defer r.db.publishPrepareMu.Unlock()
-	// Exclude new candidate registration before taking the publisher mutex.
-	// An already-registered candidate owns a publishPrepareMu read pin until the
-	// publisher completes it; taking publishMu first would prevent that completion
-	// while waiting for the pin and deadlock maintenance.
-	r.publishMu.Lock()
+	// Exclude the publisher before attempting the preparation gate. The
+	// non-queueing attempt lets an already-admitted builder obtain its read pin,
+	// register, and be completed by the publisher instead of forming an RWMutex
+	// writer-preference cycle.
+	r.lockMaintenancePublication()
 	defer r.publishMu.Unlock()
+	defer r.db.publishPrepareMu.Unlock()
 	r.recoveryMu.Lock()
 	defer r.recoveryMu.Unlock()
 
@@ -618,6 +745,9 @@ func (r *RootPublicationCoordinator) waitDurableMode(seq uint64, retryStall bool
 		return err
 	}
 	if r.durableCommitSeq < seq && r.poison == nil {
+		if seq > r.durabilityDemandSeq {
+			r.durabilityDemandSeq = seq
+		}
 		r.mu.Unlock()
 		r.signal()
 		r.mu.Lock()

--- a/TreeDB/db/root_publication_test.go
+++ b/TreeDB/db/root_publication_test.go
@@ -178,6 +178,84 @@ func TestRootPublicationCoalescedFrontierSyncsDependencyClosure(t *testing.T) {
 	}
 }
 
+func TestRootPublicationIndexPagesExcludePagesRetiredByFrontier(t *testing.T) {
+	candidates := []*PreparedRootCandidate{
+		{TouchedIndexPages: []uint64{9, 3, 7}, FreelistHeadID: 17},
+		{TouchedIndexPages: []uint64{11}, RetiredPages: []uint64{7}, FreelistHeadID: 19},
+		{TouchedIndexPages: []uint64{13}, RetiredPages: []uint64{11}, FreelistHeadID: 23},
+	}
+
+	got := rootPublicationIndexPages(candidates)
+	want := []uint64{3, 9, 13, 23}
+	if len(got) != len(want) {
+		t.Fatalf("root publication pages=%v want=%v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("root publication pages=%v want=%v", got, want)
+		}
+	}
+}
+
+func TestRootPublicationIndexPagesKeepReusedFormerFreelistHeadAsTreeOutput(t *testing.T) {
+	candidates := []*PreparedRootCandidate{
+		{TouchedIndexPages: []uint64{3}, FreelistHeadID: 7},
+		{TouchedIndexPages: []uint64{7}, FreelistHeadID: 9},
+	}
+
+	got := rootPublicationIndexPages(candidates)
+	want := []uint64{3, 7, 9}
+	if len(got) != len(want) {
+		t.Fatalf("root publication pages=%v want=%v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("root publication pages=%v want=%v", got, want)
+		}
+	}
+}
+
+func TestRootPublicationSealsCurrentAllocatorStateWithoutMutatingCandidate(t *testing.T) {
+	db, err := Open(Options{Dir: t.TempDir(), DisableBackgroundPrune: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = db.Close() }()
+	idx := db.idx.Load()
+	pageID, err := idx.pager.Alloc(1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := idx.allocator.Free(pageID); err != nil {
+		t.Fatal(err)
+	}
+	candidate := &PreparedRootCandidate{
+		FreelistHeadID: 1,
+		TotalPages:     2,
+		Meta: page.MetaPageBody{
+			FreelistHeadID: 1,
+			TotalPages:     2,
+		},
+	}
+
+	sealed := db.rootPublication.sealedAllocatorFrontier(idx, candidate)
+	if sealed == candidate {
+		t.Fatal("sealed frontier must not mutate the registered candidate")
+	}
+	if got, want := sealed.FreelistHeadID, idx.allocator.Head(); got != want {
+		t.Fatalf("sealed freelist head=%d want=%d", got, want)
+	}
+	if got, want := sealed.TotalPages, idx.pager.PageCount(); got != want {
+		t.Fatalf("sealed total pages=%d want=%d", got, want)
+	}
+	if sealed.Meta.FreelistHeadID != sealed.FreelistHeadID || sealed.Meta.TotalPages != sealed.TotalPages {
+		t.Fatalf("sealed meta=%+v candidate=%+v", sealed.Meta, sealed)
+	}
+	if candidate.FreelistHeadID != 1 || candidate.TotalPages != 2 {
+		t.Fatalf("registered candidate mutated: %+v", candidate)
+	}
+}
+
 func TestRootPublicationDebtCapsRejectBeforeVisibility(t *testing.T) {
 	for _, test := range []struct {
 		name         string
@@ -892,15 +970,21 @@ func TestRootPublicationFreelistHeadIncludedAndDurableOnReuse(t *testing.T) {
 		t.Fatal(err)
 	}
 	candidate := <-registered
-	found := false
+	if candidate.FreelistHeadID != head {
+		t.Fatalf("candidate freelist head=%d want=%d", candidate.FreelistHeadID, head)
+	}
 	for _, pageID := range candidate.TouchedIndexPages {
 		if pageID == head {
-			found = true
-			break
+			t.Fatalf("freelist head %d must not be owned as a COW tree page: %v", head, candidate.TouchedIndexPages)
 		}
 	}
+	publicationPages := rootPublicationIndexPages([]*PreparedRootCandidate{candidate})
+	found := false
+	for _, pageID := range publicationPages {
+		found = found || pageID == head
+	}
 	if !found {
-		t.Fatalf("freelist head %d absent from candidate pages %v", head, candidate.TouchedIndexPages)
+		t.Fatalf("frontier freelist head %d absent from publication pages %v", head, publicationPages)
 	}
 	db.testRootPublicationRegistered = nil
 	if err := db.Close(); err != nil {

--- a/TreeDB/db/root_publication_test.go
+++ b/TreeDB/db/root_publication_test.go
@@ -1,0 +1,1110 @@
+package db
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"path/filepath"
+	"runtime"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/snissn/gomap/TreeDB/internal/adaptive"
+	"github.com/snissn/gomap/TreeDB/internal/durabilitycut"
+	"github.com/snissn/gomap/TreeDB/page"
+)
+
+func stabilizeRecoveryWindowForTest(t testing.TB, db *DB) {
+	t.Helper()
+	if db == nil || db.rootPublication == nil {
+		t.Fatal("missing root publication coordinator")
+	}
+	if err := db.rootPublication.stabilizeRecoveryWindow(db.currentCommitSeq()); err != nil {
+		t.Fatalf("stabilize recovery window: %v", err)
+	}
+}
+
+type rootPublicationTestAppender struct {
+	syncCalls atomic.Uint64
+	refCalls  [][]uint32
+}
+
+type rootPublicationTestLeafLog struct {
+	syncCalls atomic.Uint64
+}
+
+func (*rootPublicationTestLeafLog) AppendLeafPage([]byte) (page.LeafLogPtr, error) {
+	return page.LeafLogPtr{}, nil
+}
+func (*rootPublicationTestLeafLog) Flush() error { return nil }
+func (l *rootPublicationTestLeafLog) Sync() error {
+	l.syncCalls.Add(1)
+	return nil
+}
+
+func (a *rootPublicationTestAppender) AppendValues([][]byte) ([]page.ValuePtr, error) {
+	return nil, nil
+}
+func (a *rootPublicationTestAppender) Flush() error { return nil }
+func (a *rootPublicationTestAppender) Sync() error {
+	a.syncCalls.Add(1)
+	return nil
+}
+func (a *rootPublicationTestAppender) CurrentValueLogSegment() (string, uint32, bool) {
+	return "", 0, false
+}
+func (a *rootPublicationTestAppender) FlushValueLogExternalRefs(fileIDs []uint32, sync bool) error {
+	if !sync {
+		return errors.New("publication dependency was not synced")
+	}
+	a.refCalls = append(a.refCalls, append([]uint32(nil), fileIDs...))
+	return nil
+}
+
+func TestRootPublicationRelaxedVisibilityLeadsDurability(t *testing.T) {
+	db, err := Open(Options{
+		Dir:                    t.TempDir(),
+		Durability:             DurabilityWALOffRelaxed,
+		DisableBackgroundPrune: true,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = db.Close() }()
+	appender := &rootPublicationTestAppender{}
+	db.SetValueLogAppender(appender)
+
+	entered := make(chan struct{})
+	release := make(chan struct{})
+	db.testRootPublicationBeforeDependencySync = func() {
+		close(entered)
+		<-release
+	}
+	b := db.NewBatch().(*Batch)
+	if err := b.Set([]byte("visible"), []byte("before-durable")); err != nil {
+		t.Fatal(err)
+	}
+	writeDone := make(chan error, 1)
+	go func() { writeDone <- b.Write() }()
+	select {
+	case err := <-writeDone:
+		if err != nil {
+			t.Fatal(err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("relaxed write waited for publication fence")
+	}
+	<-entered
+	if got := appender.syncCalls.Load(); got != 0 {
+		t.Fatalf("relaxed caller waited for %d dependency syncs", got)
+	}
+	s := db.rootPublication.snapshot()
+	if s.visibleCommitSeq <= s.durableCommitSeq {
+		t.Fatalf("visible=%d durable=%d, want visible lead", s.visibleCommitSeq, s.durableCommitSeq)
+	}
+	if got, err := db.Get([]byte("visible")); err != nil || string(got) != "before-durable" {
+		t.Fatalf("Get=%q err=%v", got, err)
+	}
+	close(release)
+	if err := db.Checkpoint(); err != nil {
+		t.Fatal(err)
+	}
+	s = db.rootPublication.snapshot()
+	if s.visibleCommitSeq != s.durableCommitSeq {
+		t.Fatalf("visible=%d durable=%d after checkpoint", s.visibleCommitSeq, s.durableCommitSeq)
+	}
+}
+
+func TestRootPublicationFreshRelaxedWriteCheckpointReopens(t *testing.T) {
+	dir := t.TempDir()
+	db, err := Open(Options{Dir: dir, Durability: DurabilityWALOffRelaxed, DisableBackgroundPrune: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := db.Set([]byte("first"), []byte("publication")); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.Checkpoint(); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatal(err)
+	}
+	reopened, err := Open(Options{Dir: dir, Durability: DurabilityWALOffRelaxed, DisableBackgroundPrune: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = reopened.Close() }()
+	got, err := reopened.Get([]byte("first"))
+	if err != nil || string(got) != "publication" {
+		t.Fatalf("reopened Get=%q err=%v", got, err)
+	}
+}
+
+func TestRootPublicationCoalescedFrontierSyncsDependencyClosure(t *testing.T) {
+	db, err := Open(Options{Dir: t.TempDir(), Durability: DurabilityWALOffRelaxed, DisableBackgroundPrune: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = db.Close() }()
+	first := &rootPublicationTestAppender{}
+	rotated := &rootPublicationTestAppender{}
+	firstLeaf := &rootPublicationTestLeafLog{}
+	rotatedLeaf := &rootPublicationTestLeafLog{}
+	candidates := []*PreparedRootCandidate{
+		{CommitSeq: 1, ValueLogAppender: first, LeafPageLog: firstLeaf, TouchedValueLogFiles: []uint32{11}},
+		{CommitSeq: 2, ValueLogAppender: rotated, LeafPageLog: rotatedLeaf, TouchedValueLogFiles: []uint32{22}},
+		{CommitSeq: 3, ValueLogAppender: first, LeafPageLog: firstLeaf, TouchedValueLogFiles: []uint32{33}},
+	}
+	if err := db.flushRootPublicationClosureDurability(db.idx.Load(), candidates); err != nil {
+		t.Fatal(err)
+	}
+	if got := first.refCalls; len(got) != 2 || len(got[0]) != 1 || got[0][0] != 11 || len(got[1]) != 1 || got[1][0] != 33 {
+		t.Fatalf("first appender closure calls=%v", got)
+	}
+	if got := rotated.refCalls; len(got) != 1 || len(got[0]) != 1 || got[0][0] != 22 {
+		t.Fatalf("rotated appender closure calls=%v", got)
+	}
+	if got := firstLeaf.syncCalls.Load(); got != 2 {
+		t.Fatalf("first leaf-log closure sync calls=%d want=2", got)
+	}
+	if got := rotatedLeaf.syncCalls.Load(); got != 1 {
+		t.Fatalf("rotated leaf-log closure sync calls=%d want=1", got)
+	}
+}
+
+func TestRootPublicationDebtCapsRejectBeforeVisibility(t *testing.T) {
+	for _, test := range []struct {
+		name         string
+		pending      []*PreparedRootCandidate
+		pendingBytes uint64
+		candidate    *PreparedRootCandidate
+	}{
+		{
+			name:      "commit count",
+			pending:   make([]*PreparedRootCandidate, rootPublicationMaxPendingCommits),
+			candidate: &PreparedRootCandidate{CommitSeq: 9001},
+		},
+		{
+			name:         "owned bytes",
+			pendingBytes: rootPublicationMaxPendingBytes,
+			candidate:    &PreparedRootCandidate{CommitSeq: 9002, OwnedBytes: 1},
+		},
+		{
+			name:         "external side-store bytes",
+			pendingBytes: rootPublicationMaxPendingBytes - 1,
+			candidate: &PreparedRootCandidate{
+				CommitSeq:  9003,
+				OwnedBytes: rootPublicationOwnedBytes(nil, nil, adaptive.Metrics{SlabWriteBytes: 2}, 0),
+			},
+		},
+		{
+			name:         "saturating owned bytes",
+			pendingBytes: 1,
+			candidate:    &PreparedRootCandidate{CommitSeq: 9004, OwnedBytes: ^uint64(0)},
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			db := &DB{}
+			db.publishPrepareMu.RLock()
+			test.candidate.holdsPreparePin = true
+			r := &RootPublicationCoordinator{
+				db:               db,
+				pending:          test.pending,
+				pendingBytes:     test.pendingBytes,
+				visibleCommitSeq: 7,
+				stall:            ErrPublicationStalled,
+			}
+			if err := r.register(test.candidate); !errors.Is(err, ErrPublicationStalled) {
+				t.Fatalf("register error=%v", err)
+			}
+			if got := r.visibleCommitSeq; got != 7 {
+				t.Fatalf("visibility advanced to %d past debt cap", got)
+			}
+		})
+	}
+}
+
+func TestRootPublicationStallRemainsUntilSuccessAndEnforcesDebtCap(t *testing.T) {
+	db := &DB{}
+	r := &RootPublicationCoordinator{
+		db:               db,
+		wake:             make(chan struct{}, 1),
+		pending:          make([]*PreparedRootCandidate, rootPublicationMaxPendingCommits-1),
+		visibleCommitSeq: 7,
+		stall:            ErrPublicationStalled,
+	}
+	register := func(seq uint64) error {
+		db.publishPrepareMu.RLock()
+		return r.register(&PreparedRootCandidate{CommitSeq: seq, holdsPreparePin: true})
+	}
+	if err := register(8); err != nil {
+		t.Fatalf("candidate at cap was not accepted for retry: %v", err)
+	}
+	if !errors.Is(r.stall, ErrPublicationStalled) {
+		t.Fatalf("accepted retry cleared stall before publication success: %v", r.stall)
+	}
+	if err := register(9); !errors.Is(err, ErrPublicationStalled) {
+		t.Fatalf("candidate beyond stalled cap error=%v", err)
+	}
+	if got := len(r.pending); got != rootPublicationMaxPendingCommits {
+		t.Fatalf("pending candidates=%d want=%d", got, rootPublicationMaxPendingCommits)
+	}
+	for _, candidate := range r.pending {
+		if candidate != nil && candidate.holdsPreparePin {
+			candidate.holdsPreparePin = false
+			db.publishPrepareMu.RUnlock()
+		}
+	}
+}
+
+func TestRootPublicationTracksValueLogRootsPerRecoverableMetaSlot(t *testing.T) {
+	db := &DB{}
+	r := &RootPublicationCoordinator{
+		db:                db,
+		cond:              sync.NewCond(&sync.Mutex{}),
+		durableMetaPageID: 0,
+		metaSlotValid:     [2]bool{true, true},
+		metaSlotMeta: [2]page.MetaPageBody{
+			{CommitSeq: 1, UserRootPageID: 10, SystemRootPageID: 11},
+			{CommitSeq: 2, UserRootPageID: 20, SystemRootPageID: 21},
+		},
+		pending: []*PreparedRootCandidate{{
+			CommitSeq: 3,
+			Meta:      page.MetaPageBody{CommitSeq: 3, UserRootPageID: 30, SystemRootPageID: 31},
+		}},
+	}
+	r.cond = sync.NewCond(&r.mu)
+	r.complete(r.pending[0])
+	userRoots, systemRoots, generation := r.recoverableValueLogRoots()
+	if got, want := fmt.Sprint(userRoots), "[10 30]"; got != want {
+		t.Fatalf("recoverable user roots=%s want=%s", got, want)
+	}
+	if got, want := fmt.Sprint(systemRoots), "[11 31]"; got != want {
+		t.Fatalf("recoverable system roots=%s want=%s", got, want)
+	}
+	if generation != 1 {
+		t.Fatalf("recovery root generation=%d want=1", generation)
+	}
+}
+
+func TestRootPublicationSignalsOnlyForEmptyQueueOrStallRetry(t *testing.T) {
+	db := &DB{}
+	r := &RootPublicationCoordinator{db: db, wake: make(chan struct{}, 4)}
+	register := func(seq uint64) {
+		db.publishPrepareMu.RLock()
+		candidate := &PreparedRootCandidate{CommitSeq: seq, holdsPreparePin: true}
+		if err := r.register(candidate); err != nil {
+			t.Fatalf("register %d: %v", seq, err)
+		}
+	}
+	defer func() {
+		for _, candidate := range r.pending {
+			if candidate.holdsPreparePin {
+				candidate.holdsPreparePin = false
+				db.publishPrepareMu.RUnlock()
+			}
+		}
+	}()
+
+	register(1)
+	register(2)
+	if got := len(r.wake); got != 1 {
+		t.Fatalf("queued wake events=%d want=1", got)
+	}
+	<-r.wake
+	r.mu.Lock()
+	r.stall = ErrPublicationStalled
+	r.mu.Unlock()
+	register(3)
+	if got := len(r.wake); got != 1 {
+		t.Fatalf("stall retry wake events=%d want=1", got)
+	}
+}
+
+func TestRootPublicationRegisterUsesTransferredPinPastQueuedMaintenance(t *testing.T) {
+	db := &DB{}
+	db.publishPrepareMu.RLock()
+	guard := &finalizeCommitPrepareGuard{db: db}
+	candidate := &PreparedRootCandidate{CommitSeq: 1}
+	guard.transferTo(candidate)
+	if !candidate.holdsPreparePin {
+		t.Fatal("candidate did not receive preparation pin")
+	}
+	r := &RootPublicationCoordinator{db: db, wake: make(chan struct{}, 1)}
+
+	writerStarted := make(chan struct{})
+	writerAcquired := make(chan struct{})
+	go func() {
+		close(writerStarted)
+		db.publishPrepareMu.Lock()
+		close(writerAcquired)
+		db.publishPrepareMu.Unlock()
+	}()
+	<-writerStarted
+	time.Sleep(20 * time.Millisecond) // let the exclusive maintenance waiter queue
+
+	registered := make(chan error, 1)
+	go func() { registered <- r.register(candidate) }()
+	select {
+	case err := <-registered:
+		if err != nil {
+			t.Fatal(err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("registration recursively reacquired preparation RLock")
+	}
+
+	r.mu.Lock()
+	r.pending = nil
+	r.pendingBytes = 0
+	r.mu.Unlock()
+	candidate.holdsPreparePin = false
+	db.publishPrepareMu.RUnlock()
+	select {
+	case <-writerAcquired:
+	case <-time.After(time.Second):
+		t.Fatal("queued maintenance writer did not acquire preparation lock")
+	}
+}
+
+func TestRootPublicationRecoveryStabilizationLetsPublisherReleaseExistingPin(t *testing.T) {
+	db, err := Open(Options{Dir: t.TempDir(), Durability: DurabilityWALOffRelaxed, DisableBackgroundPrune: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = db.Close() }()
+	r := db.rootPublication
+
+	// Queue an already-prepared candidate without waking the publisher. This
+	// models a candidate registering between stabilization's initial durable
+	// check and its admission fence.
+	r.publishMu.Lock()
+	db.publishPrepareMu.RLock()
+	r.mu.Lock()
+	candidate := &PreparedRootCandidate{
+		CommitSeq:       r.durableMeta.CommitSeq,
+		Meta:            r.durableMeta,
+		holdsPreparePin: true,
+	}
+	r.pending = append(r.pending, candidate)
+	r.recoveryClosureGeneration++
+	r.mu.Unlock()
+
+	stabilized := make(chan error, 1)
+	go func() { stabilized <- r.stabilizeRecoveryWindow(candidate.CommitSeq) }()
+	// Let stabilization reach the exclusive preparation fence. It must not hold
+	// publishMu while waiting for the candidate's read pin.
+	time.Sleep(20 * time.Millisecond)
+	r.signal()
+	r.publishMu.Unlock()
+
+	select {
+	case err := <-stabilized:
+		if err != nil {
+			t.Fatal(err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("recovery stabilization deadlocked with existing candidate pin")
+	}
+}
+
+func TestRootPublicationStopReleasesPendingPreparationPin(t *testing.T) {
+	db := &DB{}
+	db.publishPrepareMu.RLock()
+	candidate := &PreparedRootCandidate{CommitSeq: 1, holdsPreparePin: true}
+	r := &RootPublicationCoordinator{
+		db:      db,
+		stop:    make(chan struct{}),
+		done:    make(chan struct{}),
+		pending: []*PreparedRootCandidate{candidate},
+	}
+	go func() {
+		<-r.stop
+		close(r.done)
+	}()
+
+	r.stopPublisher()
+	if candidate.holdsPreparePin {
+		t.Fatal("stopped coordinator retained candidate preparation pin")
+	}
+	if !db.publishPrepareMu.TryLock() {
+		t.Fatal("stopped coordinator left publishPrepareMu read-locked")
+	}
+	db.publishPrepareMu.Unlock()
+}
+
+func TestRootPublicationCloseDrainsAndStopsPublisher(t *testing.T) {
+	db, err := Open(Options{Dir: t.TempDir(), Durability: DurabilityWALOffRelaxed, DisableBackgroundPrune: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	entered := make(chan struct{})
+	release := make(chan struct{})
+	var once atomic.Bool
+	db.testRootPublicationBeforeDependencySync = func() {
+		if once.CompareAndSwap(false, true) {
+			close(entered)
+			<-release
+		}
+	}
+	if err := db.Set([]byte("close"), []byte("drain")); err != nil {
+		t.Fatal(err)
+	}
+	<-entered
+	closed := make(chan error, 1)
+	go func() { closed <- db.Close() }()
+	select {
+	case err := <-closed:
+		t.Fatalf("Close returned before publisher drain: %v", err)
+	case <-time.After(20 * time.Millisecond):
+	}
+	close(release)
+	select {
+	case err := <-closed:
+		if err != nil {
+			t.Fatal(err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("Close did not drain and stop root publisher")
+	}
+	select {
+	case <-db.rootPublication.done:
+	default:
+		t.Fatal("root publisher goroutine remained live after Close")
+	}
+	publication := db.rootPublication.snapshot()
+	if publication.pendingCandidates != 0 || publication.pendingBytes != 0 {
+		t.Fatalf("publication debt remained after Close: %+v", publication)
+	}
+}
+
+func TestRootPublicationPendingCandidateDoesNotHoldGCPreparationLock(t *testing.T) {
+	db, err := Open(Options{Dir: t.TempDir(), Durability: DurabilityWALOffRelaxed, DisableBackgroundPrune: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = db.Close() }()
+	entered := make(chan struct{})
+	release := make(chan struct{})
+	var once atomic.Bool
+	db.testRootPublicationBeforeDependencySync = func() {
+		if once.CompareAndSwap(false, true) {
+			close(entered)
+			<-release
+		}
+	}
+	if err := db.Set([]byte("pending"), []byte("visible")); err != nil {
+		t.Fatal(err)
+	}
+	<-entered
+	if !db.publishPrepareMu.TryLock() {
+		close(release)
+		t.Fatal("visible pending candidate retained coarse GC preparation lock")
+	}
+	db.publishPrepareMu.Unlock()
+	close(release)
+	if err := db.Checkpoint(); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestRootPublicationOrderedRootGroupPublishesThroughCoordinator(t *testing.T) {
+	dir := t.TempDir()
+	db, err := Open(Options{Dir: dir, Durability: DurabilityWALOffRelaxed, DisableBackgroundPrune: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	registered := make(chan *PreparedRootCandidate, 1)
+	db.testRootPublicationRegistered = func(candidate *PreparedRootCandidate) { registered <- candidate }
+	newSystemRoot, _, err := db.PublishOrderedRootGroup(
+		mustFrozenSystemMemtable(t, "ordered/coordinator", "durable").NewIterator(nil, nil), nil,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	candidate := <-registered
+	if candidate.Meta.SystemRootPageID != newSystemRoot || candidate.CommitSeq != db.State().CommitSeq {
+		t.Fatalf("registered candidate=%+v state=%+v newSystemRoot=%d", candidate.Meta, db.State(), newSystemRoot)
+	}
+	db.testRootPublicationRegistered = nil
+	if err := db.Checkpoint(); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	reopened, err := Open(Options{Dir: dir, Durability: DurabilityWALOffRelaxed, DisableBackgroundPrune: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = reopened.Close() }()
+	snap := reopened.AcquireSnapshot()
+	if snap == nil {
+		t.Fatal("missing reopened snapshot")
+	}
+	defer func() { _ = snap.Close() }()
+	got, err := snap.GetAtRoot(reopened.State().SystemRootPageID, []byte("ordered/coordinator"))
+	if err != nil || string(got) != "durable" {
+		t.Fatalf("reopened ordered root value=%q err=%v", got, err)
+	}
+}
+
+func TestRootPublicationNoopAppliedLSNPublishesThroughCoordinator(t *testing.T) {
+	dir := t.TempDir()
+	db, err := Open(Options{Dir: dir, Durability: DurabilityWALOffRelaxed, DisableBackgroundPrune: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	before := db.State()
+	registered := make(chan *PreparedRootCandidate, 1)
+	db.testRootPublicationRegistered = func(candidate *PreparedRootCandidate) { registered <- candidate }
+	if err := db.publishCommandWALRoots(
+		before.RootPageID, before.SystemRootPageID, before.AppliedCommandLSN+1,
+		[]CommandWALLSNRange{{First: before.AppliedCommandLSN + 1, Last: before.AppliedCommandLSN + 1}}, false,
+	); err != nil {
+		t.Fatal(err)
+	}
+	candidate := <-registered
+	if candidate.Meta.UserRootPageID != before.RootPageID || candidate.Meta.SystemRootPageID != before.SystemRootPageID {
+		t.Fatalf("no-op AppliedLSN candidate changed roots: before=%+v candidate=%+v", before, candidate.Meta)
+	}
+	if candidate.Meta.AppliedCommandLSN != before.AppliedCommandLSN+1 {
+		t.Fatalf("candidate AppliedCommandLSN=%d want=%d", candidate.Meta.AppliedCommandLSN, before.AppliedCommandLSN+1)
+	}
+	db.testRootPublicationRegistered = nil
+	if err := db.Checkpoint(); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	reopened, err := Open(Options{Dir: dir, Durability: DurabilityWALOffRelaxed, DisableBackgroundPrune: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = reopened.Close() }()
+	after := reopened.State()
+	if after.RootPageID != before.RootPageID || after.SystemRootPageID != before.SystemRootPageID || after.AppliedCommandLSN != before.AppliedCommandLSN+1 {
+		t.Fatalf("reopened no-op AppliedLSN state=%+v before=%+v", after, before)
+	}
+}
+
+func TestRootPublicationWriteSyncWaitsForDurableSequence(t *testing.T) {
+	db, err := Open(Options{Dir: t.TempDir(), Durability: DurabilityWALOffRelaxed, DisableBackgroundPrune: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = db.Close() }()
+	entered := make(chan struct{})
+	release := make(chan struct{})
+	var once atomic.Bool
+	db.testRootPublicationBeforeDependencySync = func() {
+		if once.CompareAndSwap(false, true) {
+			close(entered)
+			<-release
+		}
+	}
+	done := make(chan error, 1)
+	go func() { done <- db.SetSync([]byte("sync"), []byte("wait")) }()
+	<-entered
+	select {
+	case err := <-done:
+		t.Fatalf("WriteSync returned before durable fence: %v", err)
+	case <-time.After(30 * time.Millisecond):
+	}
+	close(release)
+	if err := <-done; err != nil {
+		t.Fatal(err)
+	}
+	s := db.rootPublication.snapshot()
+	if s.visibleCommitSeq != s.durableCommitSeq {
+		t.Fatalf("visible=%d durable=%d", s.visibleCommitSeq, s.durableCommitSeq)
+	}
+}
+
+func TestRootPublicationWriteSyncWaitsForItsExactSequence(t *testing.T) {
+	db, err := Open(Options{Dir: t.TempDir(), Durability: DurabilityWALOffRelaxed, DisableBackgroundPrune: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = db.Close() }()
+
+	firstEntered := make(chan struct{})
+	firstRelease := make(chan struct{})
+	secondEntered := make(chan struct{})
+	secondRelease := make(chan struct{})
+	var attempt atomic.Uint64
+	db.testRootPublicationBeforeDependencySync = func() {
+		switch attempt.Add(1) {
+		case 1:
+			close(firstEntered)
+			<-firstRelease
+		case 2:
+			close(secondEntered)
+			<-secondRelease
+		}
+	}
+
+	firstDone := make(chan error, 1)
+	go func() { firstDone <- db.SetSync([]byte("first"), []byte("durable")) }()
+	<-firstEntered
+	if err := db.Set([]byte("later"), []byte("visible")); err != nil {
+		t.Fatal(err)
+	}
+	close(firstRelease)
+	<-secondEntered
+	select {
+	case err := <-firstDone:
+		if err != nil {
+			t.Fatal(err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("WriteSync waited for a later visible candidate")
+	}
+	close(secondRelease)
+	if err := db.Checkpoint(); err != nil {
+		t.Fatal(err)
+	}
+	db.testRootPublicationBeforeDependencySync = nil
+}
+
+func TestRootPublicationPhysicalWriteSyncWaitsWithCommandWALEnabled(t *testing.T) {
+	db, err := Open(Options{Dir: t.TempDir(), CommandWAL: true, DisableBackgroundPrune: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = db.Close() }()
+
+	entered := make(chan struct{})
+	release := make(chan struct{})
+	var once atomic.Bool
+	db.testRootPublicationBeforeDependencySync = func() {
+		if once.CompareAndSwap(false, true) {
+			close(entered)
+			<-release
+		}
+	}
+	b := db.NewPhysicalBatch()
+	defer b.Close()
+	if err := b.Set([]byte("physical"), []byte("checkpoint")); err != nil {
+		t.Fatal(err)
+	}
+	done := make(chan error, 1)
+	go func() { done <- b.WriteSync() }()
+	<-entered
+	select {
+	case err := <-done:
+		t.Fatalf("physical WriteSync returned before exact root durability: %v", err)
+	case <-time.After(30 * time.Millisecond):
+	}
+	close(release)
+	if err := <-done; err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestRootPublicationDurabilityPathRunsWithoutRootSerializationLocks(t *testing.T) {
+	db, err := Open(Options{Dir: t.TempDir(), Durability: DurabilityWALOffRelaxed, DisableBackgroundPrune: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = db.Close() }()
+	tryExclusive := func(tryLock func() bool, unlock func()) bool {
+		deadline := time.Now().Add(100 * time.Millisecond)
+		for {
+			if tryLock() {
+				unlock()
+				return true
+			}
+			if time.Now().After(deadline) {
+				return false
+			}
+			runtime.Gosched()
+		}
+	}
+	checkLocks := func(stage string) error {
+		if !tryExclusive(db.mu.TryLock, db.mu.Unlock) {
+			return fmt.Errorf("db.mu held during %s", stage)
+		}
+		if !tryExclusive(db.writeMu.TryLock, db.writeMu.Unlock) {
+			return fmt.Errorf("writeMu held during %s", stage)
+		}
+		if !tryExclusive(db.commitMu.TryLock, db.commitMu.Unlock) {
+			return fmt.Errorf("commitMu held during %s", stage)
+		}
+		return nil
+	}
+	checked := make(chan error, 5)
+	db.testRootPublicationBeforeDependencySync = func() { checked <- checkLocks("dependency sync") }
+	db.testRootPublicationBeforeWait = func() { checked <- checkLocks("durability wait") }
+	var observedMu sync.Mutex
+	observed := make(map[durabilitycut.Point]bool)
+	restore := durabilitycut.Install(func(event durabilitycut.Event) error {
+		switch event.Point {
+		case durabilitycut.BeforeIndexDataSync, durabilitycut.BeforeMetaWrite, durabilitycut.BeforeMetaSync:
+			if err := checkLocks(string(event.Point)); err != nil {
+				return err
+			}
+			observedMu.Lock()
+			observed[event.Point] = true
+			observedMu.Unlock()
+		}
+		return nil
+	})
+	if err := db.SetSync([]byte("lock-free"), []byte("publisher")); err != nil {
+		t.Fatal(err)
+	}
+	db.testRootPublicationBeforeDependencySync = nil
+	db.testRootPublicationBeforeWait = nil
+	restore()
+	for i := 0; i < 2; i++ {
+		if err := <-checked; err != nil {
+			t.Fatal(err)
+		}
+	}
+	for _, point := range []durabilitycut.Point{durabilitycut.BeforeIndexDataSync, durabilitycut.BeforeMetaWrite, durabilitycut.BeforeMetaSync} {
+		if !observed[point] {
+			t.Fatalf("did not observe %s", point)
+		}
+	}
+}
+
+func TestRootPublicationDurabilityCutOrder(t *testing.T) {
+	db, err := Open(Options{
+		Dir:                    t.TempDir(),
+		Durability:             DurabilityWALOffRelaxed,
+		DisableBackgroundPrune: true,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = db.Close() }()
+	want := []durabilitycut.Point{
+		durabilitycut.BeforeIndexDataSync,
+		durabilitycut.AfterIndexDataSync,
+		durabilitycut.BeforeMetaWrite,
+		durabilitycut.AfterMetaWrite,
+		durabilitycut.BeforeMetaSync,
+		durabilitycut.AfterMetaSync,
+	}
+	var gotMu sync.Mutex
+	var got []durabilitycut.Point
+	restore := durabilitycut.Install(func(event durabilitycut.Event) error {
+		for _, point := range want {
+			if event.Point == point {
+				gotMu.Lock()
+				got = append(got, event.Point)
+				gotMu.Unlock()
+				break
+			}
+		}
+		return nil
+	})
+	if err := db.SetSync([]byte("ordered"), []byte("cuts")); err != nil {
+		restore()
+		t.Fatal(err)
+	}
+	restore()
+	if fmt.Sprint(got) != fmt.Sprint(want) {
+		t.Fatalf("durability cut order=%v want=%v", got, want)
+	}
+}
+
+func TestRootPublicationProductionPointerBytesCountTowardDebt(t *testing.T) {
+	db, err := Open(Options{Dir: t.TempDir(), Durability: DurabilityWALOffRelaxed, DisableBackgroundPrune: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	appender, err := newReplayInlineAppender(db, nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	db.SetValueLogAppender(appender)
+	defer func() {
+		db.SetValueLogAppender(nil)
+		_ = appender.close()
+		_ = db.Close()
+	}()
+	ptrs, err := db.AppendValueLogValues([][]byte{bytes.Repeat([]byte("publication-debt|"), 1<<15)})
+	if err != nil || len(ptrs) != 1 {
+		t.Fatalf("append pointers=%d err=%v", len(ptrs), err)
+	}
+	entered := make(chan struct{})
+	release := make(chan struct{})
+	db.testRootPublicationBeforeDependencySync = func() {
+		close(entered)
+		<-release
+	}
+	registered := make(chan *PreparedRootCandidate, 1)
+	db.testRootPublicationRegistered = func(candidate *PreparedRootCandidate) { registered <- candidate }
+	b := db.NewBatch().(*Batch)
+	if err := b.SetPointer([]byte("large-pointer"), ptrs[0]); err != nil {
+		t.Fatal(err)
+	}
+	if err := b.Write(); err != nil {
+		t.Fatal(err)
+	}
+	candidate := <-registered
+	<-entered
+	wantBytes := uint64(page.ValuePtrRecordLength(ptrs[0]))
+	if candidate.OwnedBytes < wantBytes {
+		t.Fatalf("candidate owned bytes=%d want at least pointer record bytes=%d", candidate.OwnedBytes, wantBytes)
+	}
+	if got := db.rootPublication.snapshot().pendingBytes; got < wantBytes {
+		t.Fatalf("pending bytes=%d want at least pointer record bytes=%d", got, wantBytes)
+	}
+	db.testRootPublicationBeforeDependencySync = nil
+	db.testRootPublicationRegistered = nil
+	close(release)
+	if err := db.Checkpoint(); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestRootPublicationFreelistHeadIncludedAndDurableOnReuse(t *testing.T) {
+	dir := t.TempDir()
+	db, err := Open(Options{Dir: dir, Durability: DurabilityWALOffRelaxed, PreferAppendAlloc: false, DisableBackgroundPrune: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	start, err := db.idx.Load().pager.Alloc(2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := db.idx.Load().allocator.Free(start); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.idx.Load().allocator.Free(start + 1); err != nil {
+		t.Fatal(err)
+	}
+	head := db.idx.Load().allocator.Head()
+	registered := make(chan *PreparedRootCandidate, 1)
+	db.testRootPublicationRegistered = func(candidate *PreparedRootCandidate) { registered <- candidate }
+	if err := db.SetSync([]byte("freelist-reuse"), []byte("value")); err != nil {
+		t.Fatal(err)
+	}
+	candidate := <-registered
+	found := false
+	for _, pageID := range candidate.TouchedIndexPages {
+		if pageID == head {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("freelist head %d absent from candidate pages %v", head, candidate.TouchedIndexPages)
+	}
+	db.testRootPublicationRegistered = nil
+	if err := db.Close(); err != nil {
+		t.Fatal(err)
+	}
+	reopened, err := Open(Options{Dir: dir, Durability: DurabilityWALOffRelaxed, PreferAppendAlloc: false, DisableBackgroundPrune: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = reopened.Close() }()
+	got, err := reopened.Get([]byte("freelist-reuse"))
+	if err != nil || string(got) != "value" {
+		t.Fatalf("reopened value len=%d err=%v", len(got), err)
+	}
+}
+
+func TestRootPublicationOptimisticCandidateExcludesConcurrentBuilderPages(t *testing.T) {
+	db := openFlushApplyTestDB(t, 4)
+	putBatch(t, db, 0, 9000, "base")
+	type registration struct {
+		candidate []uint64
+		dirty     []uint64
+	}
+	registered := make(chan registration, 2)
+	db.testRootPublicationRegistered = func(candidate *PreparedRootCandidate) {
+		registered <- registration{
+			candidate: append([]uint64(nil), candidate.TouchedIndexPages...),
+			dirty:     db.idx.Load().pager.DirtyIndexPages(),
+		}
+	}
+	defer func() { db.testRootPublicationRegistered = nil }()
+
+	var fired atomic.Bool
+	db.testAfterOptimisticApplyHook = func() {
+		if !fired.CompareAndSwap(false, true) {
+			return
+		}
+		other := db.NewBatch()
+		for i := 0; i < 1000; i++ {
+			if err := other.Set([]byte(fmt.Sprintf("candidate-b-%06d", i)), []byte("b")); err != nil {
+				t.Fatal(err)
+			}
+		}
+		if err := other.Write(); err != nil {
+			t.Fatal(err)
+		}
+	}
+	defer func() { db.testAfterOptimisticApplyHook = nil }()
+
+	first := db.NewBatch()
+	for i := 0; i < 1000; i++ {
+		if err := first.Set([]byte(fmt.Sprintf("candidate-a-%06d", i)), []byte("a")); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := first.Write(); err != nil {
+		t.Fatal(err)
+	}
+	got := <-registered // nested candidate B registers before A retries
+	candidateSet := make(map[uint64]struct{}, len(got.candidate))
+	for _, pageID := range got.candidate {
+		candidateSet[pageID] = struct{}{}
+	}
+	var foreign int
+	for _, pageID := range got.dirty {
+		if _, ok := candidateSet[pageID]; !ok {
+			foreign++
+		}
+	}
+	if foreign == 0 {
+		t.Fatalf("candidate pages=%v consumed global concurrent dirty frontier=%v", got.candidate, got.dirty)
+	}
+}
+
+func TestRootPublicationPostMetaPoisonPreservesLastVisibleSnapshot(t *testing.T) {
+	db, err := Open(Options{Dir: t.TempDir(), Durability: DurabilityWALOffRelaxed, DisableBackgroundPrune: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	db.testFailSyncMeta.Store(true)
+	err = db.SetSync([]byte("visible-before-poison"), []byte("still-readable"))
+	db.testFailSyncMeta.Store(false)
+	if !errors.Is(err, errTestSyncMetaFailpoint) || !errors.Is(err, ErrRecoveryRequired) {
+		t.Fatalf("SetSync error=%v", err)
+	}
+	visible := db.state.Load()
+	if visible == nil {
+		t.Fatal("visible state missing after post-meta poison")
+	}
+	got, err := db.Get([]byte("visible-before-poison"))
+	if err != nil || string(got) != "still-readable" {
+		t.Fatalf("Get after poison=%q err=%v", got, err)
+	}
+	snapshot := db.AcquireSnapshot()
+	if snapshot == nil {
+		t.Fatal("AcquireSnapshot returned nil after poison")
+	}
+	if snapshot.State().CommitSeq != visible.CommitSeq {
+		t.Fatalf("snapshot seq=%d visible=%d", snapshot.State().CommitSeq, visible.CommitSeq)
+	}
+	if err := snapshot.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.Set([]byte("blocked"), []byte("mutation")); !errors.Is(err, ErrRecoveryRequired) {
+		t.Fatalf("mutation after poison error=%v", err)
+	}
+	if err := db.Close(); !errors.Is(err, ErrRecoveryRequired) {
+		t.Fatalf("Close error=%v, want ErrRecoveryRequired", err)
+	}
+}
+
+func TestRootPublicationWriteMetaAttemptPoisons(t *testing.T) {
+	db, err := Open(Options{Dir: t.TempDir(), Durability: DurabilityWALOffRelaxed, DisableBackgroundPrune: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	db.testFailWriteMeta.Store(true)
+	err = db.SetSync([]byte("visible-write-meta"), []byte("readable"))
+	db.testFailWriteMeta.Store(false)
+	if !errors.Is(err, errTestWriteMetaFailpoint) || !errors.Is(err, ErrRecoveryRequired) {
+		t.Fatalf("SetSync error=%v", err)
+	}
+	if got, err := db.Get([]byte("visible-write-meta")); err != nil || string(got) != "readable" {
+		t.Fatalf("Get after ambiguous writeMeta=%q err=%v", got, err)
+	}
+	if err := db.Set([]byte("blocked"), []byte("mutation")); !errors.Is(err, ErrRecoveryRequired) {
+		t.Fatalf("mutation error=%v", err)
+	}
+	if err := db.Close(); !errors.Is(err, ErrRecoveryRequired) {
+		t.Fatalf("Close error=%v", err)
+	}
+}
+
+func TestRootPublicationPreMetaFailureStallsAndExplicitBoundaryRetries(t *testing.T) {
+	db, err := Open(Options{Dir: t.TempDir(), Durability: DurabilityWALOffRelaxed, DisableBackgroundPrune: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = db.Close() }()
+	oldDurable := db.meta.CommitSeq
+	wantErr := errors.New("index durability unavailable")
+	var failed atomic.Bool
+	restore := durabilitycut.Install(func(event durabilitycut.Event) error {
+		if event.Point == durabilitycut.BeforeIndexDataSync && failed.CompareAndSwap(false, true) {
+			return wantErr
+		}
+		return nil
+	})
+	err = db.SetSync([]byte("retry"), []byte("me"))
+	restore()
+	if !errors.Is(err, ErrPublicationStalled) || !errors.Is(err, wantErr) {
+		t.Fatalf("SetSync error=%v", err)
+	}
+	if got := db.meta.CommitSeq; got != oldDurable {
+		t.Fatalf("durable meta advanced on pre-meta failure: got=%d want=%d", got, oldDurable)
+	}
+	if got, err := db.Get([]byte("retry")); err != nil || string(got) != "me" {
+		t.Fatalf("visible value=%q err=%v", got, err)
+	}
+	if err := db.Checkpoint(); err != nil {
+		t.Fatalf("retry Checkpoint: %v", err)
+	}
+	if db.meta.CommitSeq <= oldDurable {
+		t.Fatalf("durable meta did not advance after retry: %d", db.meta.CommitSeq)
+	}
+}
+
+func TestOrdinaryMetaWritesAreCoordinatorOwned(t *testing.T) {
+	_, file, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(file)
+	fset := token.NewFileSet()
+	pkgs, err := parser.ParseDir(fset, dir, nil, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	allowed := map[string]map[string]bool{
+		"db.go":               {"recover": true},
+		"root_publication.go": {"writeAndSyncMeta": true},
+	}
+	for _, pkg := range pkgs {
+		for _, parsed := range pkg.Files {
+			path := filepath.Base(fset.Position(parsed.Pos()).Filename)
+			for _, decl := range parsed.Decls {
+				fn, ok := decl.(*ast.FuncDecl)
+				if !ok || fn.Body == nil {
+					continue
+				}
+				ast.Inspect(fn.Body, func(n ast.Node) bool {
+					call, ok := n.(*ast.CallExpr)
+					if !ok {
+						return true
+					}
+					sel, ok := call.Fun.(*ast.SelectorExpr)
+					if !ok || sel.Sel.Name != "writeMeta" {
+						return true
+					}
+					pos := fset.Position(call.Pos())
+					if allowed[path][fn.Name.Name] {
+						return true
+					}
+					t.Errorf("writeMeta call outside named setup/coordinator owner: %s:%s:%d", path, fn.Name.Name, pos.Line)
+					return true
+				})
+			}
+		}
+	}
+}

--- a/TreeDB/db/system_root_publish.go
+++ b/TreeDB/db/system_root_publish.go
@@ -71,10 +71,9 @@ func (db *DB) PublishSystemRootIterator(iter iterator.UnsafeIterator) (uint64, e
 	if db.readOnly {
 		return 0, ErrReadOnly
 	}
-	db.mu.RLock()
-	userRoot := db.meta.UserRootPageID
-	baseSystemRoot := db.meta.SystemRootPageID
-	db.mu.RUnlock()
+	visible := db.state.Load()
+	userRoot := visible.RootPageID
+	baseSystemRoot := visible.SystemRootPageID
 
 	ptrCollector, collectedIter := newPendingValueLogAppendPtrCollectingIterator(iter)
 	defer db.releasePendingValueLogAppendPtrCollector(ptrCollector)
@@ -100,10 +99,9 @@ func (db *DB) PublishSystemRootIterator(iter iterator.UnsafeIterator) (uint64, e
 		vlogRefDelta = nil
 	}
 
-	db.mu.Lock()
-	curUserRoot := db.meta.UserRootPageID
-	curSystemRoot := db.meta.SystemRootPageID
-	db.mu.Unlock()
+	visible = db.state.Load()
+	curUserRoot := visible.RootPageID
+	curSystemRoot := visible.SystemRootPageID
 	if curUserRoot != userRoot || curSystemRoot != baseSystemRoot {
 		return 0, errors.New("concurrent modification detected during system root publish")
 	}

--- a/TreeDB/db/vacuum_online.go
+++ b/TreeDB/db/vacuum_online.go
@@ -632,7 +632,28 @@ func (db *DB) vacuumIndexOnline(ctx context.Context, lockMaintenance bool) (retE
 			hook(defers)
 		}
 
-		db.writeMu.Lock()
+		// Drain the visible frontier without writer locks, then acquire the writer
+		// and preparation fences. A writer can race into the gap and register one
+		// more candidate, so validate the queue under both locks and retry instead
+		// of waiting for the publisher while holding writeMu.
+		for {
+			visible := db.state.Load()
+			if visible == nil || db.rootPublication == nil {
+				cleanupNewPager()
+				return ErrClosed
+			}
+			if err := db.rootPublication.retryDurable(visible.CommitSeq); err != nil {
+				cleanupNewPager()
+				return err
+			}
+			db.writeMu.Lock()
+			db.publishPrepareMu.Lock()
+			if db.rootPublication.snapshot().pendingCandidates == 0 {
+				break
+			}
+			db.publishPrepareMu.Unlock()
+			db.writeMu.Unlock()
+		}
 		cutoverLocked = true
 		holdStarted := time.Now()
 		unlockCutover := func(completed bool) {
@@ -644,6 +665,7 @@ func (db *DB) vacuumIndexOnline(ctx context.Context, lockMaintenance bool) (retE
 				runStats.CutoverDuration = hold
 			}
 			cutoverLocked = false
+			db.publishPrepareMu.Unlock()
 			db.writeMu.Unlock()
 		}
 
@@ -940,6 +962,11 @@ func (db *DB) vacuumIndexOnline(ctx context.Context, lockMaintenance bool) (retE
 		// Publish the new index generation (old readers keep oldGen pinned).
 		newGen := newIndexGen(db.nextIndexID(), newPager, newAlloc, newZ)
 		db.trackIndex(newGen)
+		if err := db.rootPublication.adoptDurableGeneration(nextMeta, MetaPage0ID); err != nil {
+			unlockCutover(false)
+			cleanupNewPager()
+			return err
+		}
 
 		var oldState *DBState
 		db.mu.Lock()
@@ -979,7 +1006,10 @@ func (db *DB) vacuumIndexOnline(ctx context.Context, lockMaintenance bool) (retE
 		}
 		if db.leafPageLog != nil {
 			db.commitMu.Lock()
-			currentCommitSeq := db.meta.CommitSeq
+			currentCommitSeq := uint64(0)
+			if visible := db.state.Load(); visible != nil {
+				currentCommitSeq = visible.CommitSeq
+			}
 			err := db.noteLeafGenerationPendingFileIDs(0, currentCommitSeq)
 			db.commitMu.Unlock()
 			if err != nil {

--- a/TreeDB/db/vacuum_online.go
+++ b/TreeDB/db/vacuum_online.go
@@ -647,7 +647,14 @@ func (db *DB) vacuumIndexOnline(ctx context.Context, lockMaintenance bool) (retE
 				return err
 			}
 			db.writeMu.Lock()
-			db.publishPrepareMu.Lock()
+			db.rootPublication.publishMu.Lock()
+			if !db.publishPrepareMu.TryLock() {
+				db.rootPublication.publishMu.Unlock()
+				db.writeMu.Unlock()
+				runtime.Gosched()
+				continue
+			}
+			db.rootPublication.publishMu.Unlock()
 			if db.rootPublication.snapshot().pendingCandidates == 0 {
 				break
 			}

--- a/TreeDB/db/vacuum_online.go
+++ b/TreeDB/db/vacuum_online.go
@@ -396,6 +396,7 @@ func (db *DB) vacuumIndexOnline(ctx context.Context, lockMaintenance bool) (retE
 
 	newAlloc := freelist.New(newPager, 0)
 	newAlloc.SetPreferAppend(db.preferAppendAlloc)
+	newAlloc.SetRetainDrainedHeads(true)
 	newAlloc.SetFreelistRegion(db.freelistRegionPages, db.freelistRegionRadius)
 
 	newZ := zipper.New(newPager, newAlloc)
@@ -647,7 +648,13 @@ func (db *DB) vacuumIndexOnline(ctx context.Context, lockMaintenance bool) (retE
 				return err
 			}
 			db.writeMu.Lock()
-			db.rootPublication.publishMu.Lock()
+			// Fence close holds publishMu while it reacquires writeMu. Never wait
+			// for publishMu while holding writeMu or the two paths can deadlock.
+			if !db.rootPublication.publishMu.TryLock() {
+				db.writeMu.Unlock()
+				runtime.Gosched()
+				continue
+			}
 			if !db.publishPrepareMu.TryLock() {
 				db.rootPublication.publishMu.Unlock()
 				db.writeMu.Unlock()

--- a/TreeDB/db/value_log_appender.go
+++ b/TreeDB/db/value_log_appender.go
@@ -37,6 +37,14 @@ type ValueLogExternalRefFlusher interface {
 	FlushValueLogExternalRefs(fileIDs []uint32, sync bool) error
 }
 
+// ValueLogDurableExternalRefFlusher is the publication-only durability
+// extension. Unlike foreground Sync policy, this method must force the named
+// value-log dependencies to stable storage even when the DB uses relaxed
+// durability for ordinary writes.
+type ValueLogDurableExternalRefFlusher interface {
+	SyncValueLogExternalRefsDurable(fileIDs []uint32) error
+}
+
 type valueLogAppenderHolder struct {
 	appender ValueLogAppender
 }

--- a/TreeDB/db/vlog_gc.go
+++ b/TreeDB/db/vlog_gc.go
@@ -65,9 +65,9 @@ type ValueLogGCOptions struct {
 	// source segments). IDs not present in the current set are ignored.
 	ObservedSourceFileIDs []uint32
 	// ObservedSourceAssumeUnreferenced indicates ObservedSourceFileIDs are
-	// already known to be unreferenced. When true, ValueLogGC skips the
-	// reachability scan and only classifies (and, if !DryRun, zombifies) the
-	// observed IDs; it does not attempt to reclaim other segments.
+	// expected to be unreferenced. ValueLogGC still verifies the current and
+	// fallback-meta recovery roots before deletion, but only classifies (and, if
+	// !DryRun, zombifies) the observed IDs; it does not reclaim other segments.
 	ObservedSourceAssumeUnreferenced bool
 	// ObservedSourceReclaimActive permits observed-only GC to reclaim an
 	// otherwise-active segment. Callers must first prove the source is
@@ -161,38 +161,46 @@ func (db *DB) valueLogGC(ctx context.Context, opts ValueLogGCOptions, lockMainte
 	observedOnly := len(opts.ObservedSourceFileIDs) > 0 && opts.ObservedSourceAssumeUnreferenced
 	var referenced map[uint32]struct{}
 	var scannedSeq uint64
-	if !observedOnly {
-		// A full scan is O(N), so it must never run while publishPrepareMu is
-		// exclusively held. Safety invariant: GC never zombifies a segment from a
-		// referenced set older than the root visible while the exclusive lock is
-		// held. A post-scan root can first-reference an old segment, so a changed
-		// commit sequence is retried outside the lock once and then conservatively
-		// aborts this GC pass.
-		const maxStaleScanRetries = 1
-		for attempt := 0; ; attempt++ {
-			var err error
-			referenced, _, scannedSeq, err = db.referencedValueLogSegmentsForGCAtSeq(ctx)
-			if err != nil {
+	unlockRecoveryRoots := func() {}
+	// A full scan is O(N), so it must never run while publishPrepareMu is
+	// exclusively held. Safety invariant: GC never zombifies a segment from a
+	// referenced set older than either the visible root or the two recovery meta
+	// slots while the exclusive lock is held. Once all earlier builders have
+	// registered, drain publication and validate both generations. A changed
+	// frontier is retried outside the lock once and then conservatively aborted.
+	const maxStaleScanRetries = 1
+	for attempt := 0; ; attempt++ {
+		if !opts.DryRun && db.rootPublication != nil {
+			if err := db.rootPublication.retryDurable(db.currentCommitSeq()); err != nil {
 				return stats, err
 			}
-			runValueLogGCPostScanHook()
-			if opts.DryRun {
-				break
-			}
-
-			db.publishPrepareMu.Lock()
-			if db.currentCommitSeq() == scannedSeq {
-				break
-			}
-			db.publishPrepareMu.Unlock()
-			if attempt == maxStaleScanRetries {
-				return stats, nil
-			}
 		}
-	} else if !opts.DryRun {
+		var recoveryGeneration uint64
+		var err error
+		referenced, _, scannedSeq, recoveryGeneration, err = db.referencedValueLogSegmentsForGCAtSeq(ctx)
+		if err != nil {
+			return stats, err
+		}
+		runValueLogGCPostScanHook()
+		if opts.DryRun {
+			break
+		}
+
 		db.publishPrepareMu.Lock()
+		generationMatches := recoveryGeneration == 0
+		if db.rootPublication != nil {
+			unlockRecoveryRoots, generationMatches = db.rootPublication.lockRecoverableValueLogRoots(recoveryGeneration)
+		}
+		if db.currentCommitSeq() == scannedSeq && generationMatches {
+			break
+		}
+		db.publishPrepareMu.Unlock()
+		if attempt == maxStaleScanRetries {
+			return stats, nil
+		}
 	}
 	if !opts.DryRun {
+		defer unlockRecoveryRoots()
 		defer db.publishPrepareMu.Unlock()
 	}
 
@@ -301,6 +309,13 @@ func (db *DB) valueLogGC(ctx context.Context, opts ValueLogGCOptions, lockMainte
 			stats.ObservedSourceBytes += size
 			stats.SegmentsTotal++
 			stats.BytesTotal += size
+			if _, ok := referenced[id]; ok {
+				stats.SegmentsReferenced++
+				stats.BytesReferenced += size
+				stats.ObservedSourceSegmentsReferenced++
+				stats.ObservedSourceBytesReferenced += size
+				continue
+			}
 
 			if _, ok := pendingAppendIDs[id]; ok {
 				stats.SegmentsProtected++

--- a/TreeDB/db/vlog_gc.go
+++ b/TreeDB/db/vlog_gc.go
@@ -186,7 +186,12 @@ func (db *DB) valueLogGC(ctx context.Context, opts ValueLogGCOptions, lockMainte
 			break
 		}
 
-		db.publishPrepareMu.Lock()
+		if db.rootPublication != nil {
+			db.rootPublication.lockMaintenancePublication()
+			db.rootPublication.publishMu.Unlock()
+		} else {
+			db.publishPrepareMu.Lock()
+		}
 		generationMatches := recoveryGeneration == 0
 		if db.rootPublication != nil {
 			unlockRecoveryRoots, generationMatches = db.rootPublication.lockRecoverableValueLogRoots(recoveryGeneration)

--- a/TreeDB/db/vlog_gc_incremental.go
+++ b/TreeDB/db/vlog_gc_incremental.go
@@ -479,10 +479,7 @@ func (db *DB) currentCommitSeq() uint64 {
 	if state := db.state.Load(); state != nil {
 		return state.CommitSeq
 	}
-	db.mu.RLock()
-	seq := db.meta.CommitSeq
-	db.mu.RUnlock()
-	return seq
+	return 0
 }
 
 func (db *DB) initValueLogRefTracker() error {
@@ -574,8 +571,24 @@ func (db *DB) referencedValueLogSegmentsWithSourceAtSeq(ctx context.Context) (ma
 	return db.referencedValueLogSegmentsWithSourceAtSeqPolicy(ctx, false)
 }
 
-func (db *DB) referencedValueLogSegmentsForGCAtSeq(ctx context.Context) (map[uint32]struct{}, valueLogRefResolutionSource, uint64, error) {
-	return db.referencedValueLogSegmentsWithSourceAtSeqPolicy(ctx, true)
+func (db *DB) referencedValueLogSegmentsForGCAtSeq(ctx context.Context) (map[uint32]struct{}, valueLogRefResolutionSource, uint64, uint64, error) {
+	counts, scannedSeq, recoveryGeneration, err := db.scanValueLogRefCountsForGC(ctx)
+	if err != nil && errors.Is(err, valuelog.ErrFileNotFound) {
+		if refreshErr := db.RefreshValueLogSet(); refreshErr != nil {
+			return nil, valueLogRefResolutionSourceFallbackScan, 0, 0, refreshErr
+		}
+		counts, scannedSeq, recoveryGeneration, err = db.scanValueLogRefCountsForGC(ctx)
+	}
+	if err != nil {
+		return nil, valueLogRefResolutionSourceFallbackScan, 0, 0, err
+	}
+	refs := make(map[uint32]struct{}, len(counts))
+	for fileID, n := range counts {
+		if n != 0 {
+			refs[fileID] = struct{}{}
+		}
+	}
+	return refs, valueLogRefResolutionSourceFallbackScan, scannedSeq, recoveryGeneration, nil
 }
 
 func (db *DB) referencedValueLogSegmentsWithSourceAtSeqPolicy(ctx context.Context, guardConcurrentAdvance bool) (map[uint32]struct{}, valueLogRefResolutionSource, uint64, error) {
@@ -618,6 +631,15 @@ func (db *DB) referencedValueLogSegmentsWithSourceAtSeqPolicy(ctx context.Contex
 }
 
 func (db *DB) scanValueLogRefCounts(ctx context.Context) (map[uint32]uint64, uint64, error) {
+	counts, seq, _, err := db.scanValueLogRefCountsWithRecoveryRoots(ctx, false)
+	return counts, seq, err
+}
+
+func (db *DB) scanValueLogRefCountsForGC(ctx context.Context) (map[uint32]uint64, uint64, uint64, error) {
+	return db.scanValueLogRefCountsWithRecoveryRoots(ctx, true)
+}
+
+func (db *DB) scanValueLogRefCountsWithRecoveryRoots(ctx context.Context, includeRecoveryRoots bool) (map[uint32]uint64, uint64, uint64, error) {
 	if ctx == nil {
 		ctx = context.Background()
 	}
@@ -627,20 +649,23 @@ func (db *DB) scanValueLogRefCounts(ctx context.Context) (map[uint32]uint64, uin
 		if snap != nil {
 			_ = snap.Close()
 		}
-		return nil, 0, fmt.Errorf("missing db state")
+		return nil, 0, 0, fmt.Errorf("missing db state")
 	}
 	commitSeq := snap.state.CommitSeq
-	result, err := db.maintenanceReachabilityScan(ctx, snap, maintenanceReachabilityScanOptions{
-		Collectors: maintenanceReachabilityValueLogRefCounts,
-	})
+	opts := maintenanceReachabilityScanOptions{Collectors: maintenanceReachabilityValueLogRefCounts}
+	var recoveryGeneration uint64
+	if includeRecoveryRoots && db.rootPublication != nil {
+		opts.ProtectedValueLogRootIDs, opts.ProtectedValueLogSystemRootIDs, recoveryGeneration = db.rootPublication.recoverableValueLogRoots()
+	}
+	result, err := db.maintenanceReachabilityScan(ctx, snap, opts)
 	if err != nil {
 		_ = snap.Close()
-		return nil, 0, err
+		return nil, 0, 0, err
 	}
 	if err := snap.Close(); err != nil {
-		return nil, 0, err
+		return nil, 0, 0, err
 	}
-	return result.valueLogRefCounts, commitSeq, nil
+	return result.valueLogRefCounts, commitSeq, recoveryGeneration, nil
 }
 
 func scanValueLogRefCountRootIterator(snap *Snapshot, root maintenanceRoot) iterator.UnsafeIterator {

--- a/TreeDB/db/vlog_gc_incremental_apply_test.go
+++ b/TreeDB/db/vlog_gc_incremental_apply_test.go
@@ -70,10 +70,12 @@ func TestBuildValueLogRefDeltaFallsBackWhenApplyEvidenceMissing(t *testing.T) {
 	_ = seed.Close()
 
 	idx := d.idx.Load()
-	d.mu.RLock()
-	rootID := d.meta.UserRootPageID
-	baseSeq := d.meta.CommitSeq
-	d.mu.RUnlock()
+	state := d.state.Load()
+	if state == nil {
+		t.Fatal("missing visible state")
+	}
+	rootID := state.RootPageID
+	baseSeq := state.CommitSeq
 	entries := make([]batchpkg.Entry, 4)
 	for i := range entries {
 		entries[i] = batchpkg.Entry{Key: []byte(fmt.Sprintf("key-%06d", i)), Type: batchpkg.OpDelete}

--- a/TreeDB/db/vlog_gc_test.go
+++ b/TreeDB/db/vlog_gc_test.go
@@ -295,6 +295,14 @@ func TestValueLogGC_RemovesUnreferencedSegment(t *testing.T) {
 	if err := db.Delete([]byte("k1")); err != nil {
 		t.Fatalf("delete k1: %v", err)
 	}
+	// The previous meta slot still names the root containing k1. Advance the
+	// alternating recovery window before expecting its value-log segment to be
+	// reclaimable.
+	for i := 0; i < 2; i++ {
+		if err := db.SetSync([]byte(fmt.Sprintf("gc-advance-%d", i)), []byte("1")); err != nil {
+			t.Fatalf("advance recovery meta %d: %v", i, err)
+		}
+	}
 
 	stats, err := db.ValueLogGC(context.Background(), ValueLogGCOptions{})
 	if err != nil {
@@ -309,6 +317,125 @@ func TestValueLogGC_RemovesUnreferencedSegment(t *testing.T) {
 	}
 	if _, err := os.Stat(path2); err != nil {
 		t.Fatalf("expected segment2 to remain, err=%v", err)
+	}
+}
+
+func TestValueLogGCKeepsSegmentReachableOnlyFromFallbackMeta(t *testing.T) {
+	dir := t.TempDir()
+	d, err := Open(Options{Dir: dir, Durability: DurabilityWALOffRelaxed})
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+
+	oldValue := bytes.Repeat([]byte("fallback-meta-value|"), 32)
+	newValue := bytes.Repeat([]byte("newest-meta-value|"), 32)
+	oldPtr := appendPointersInNewSegment(t, dir, 0, 1, 100, 1, func(int) []byte { return oldValue })[0]
+	newPtr := appendPointersInNewSegment(t, dir, 0, 2, 200, 1, func(int) []byte { return newValue })[0]
+
+	writePointerSync := func(ptr page.ValuePtr) {
+		b := d.NewBatch().(*Batch)
+		defer b.Close()
+		if err := b.SetPointer([]byte("k"), ptr); err != nil {
+			t.Fatalf("SetPointer: %v", err)
+		}
+		if err := b.WriteSync(); err != nil {
+			t.Fatalf("WriteSync: %v", err)
+		}
+	}
+	writePointerSync(oldPtr)
+	oldMetaPageID := d.metaPageID
+	writePointerSync(newPtr)
+	newMetaPageID := d.metaPageID
+	if newMetaPageID == oldMetaPageID {
+		t.Fatalf("meta page did not alternate: old=%d new=%d", oldMetaPageID, newMetaPageID)
+	}
+
+	stats, err := d.ValueLogGC(context.Background(), ValueLogGCOptions{})
+	if err != nil {
+		t.Fatalf("ValueLogGC: %v", err)
+	}
+	oldPath := filepath.Join(dir, "value_vlog", "value-l0-000001.log")
+	if _, err := os.Stat(oldPath); err != nil {
+		t.Fatalf("fallback-only segment removed: %v (stats=%+v)", err, stats)
+	}
+	if err := d.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	corruptIndexPageByte(t, dir, newMetaPageID)
+	reopened, err := Open(Options{Dir: dir, Durability: DurabilityWALOffRelaxed})
+	if err != nil {
+		t.Fatalf("reopen from fallback meta: %v", err)
+	}
+	defer reopened.Close()
+	got, err := reopened.Get([]byte("k"))
+	if err != nil {
+		t.Fatalf("Get fallback value: %v", err)
+	}
+	if !bytes.Equal(got, oldValue) {
+		t.Fatalf("fallback value mismatch: got %d bytes want %d", len(got), len(oldValue))
+	}
+}
+
+func TestValueLogGCRescansWhenRecoveryMetaSlotsRotate(t *testing.T) {
+	dir := t.TempDir()
+	d, err := Open(Options{Dir: dir, Durability: DurabilityWALOffRelaxed})
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+
+	values := [4][]byte{}
+	ptrs := [4]page.ValuePtr{}
+	for i := range ptrs {
+		values[i] = bytes.Repeat([]byte(fmt.Sprintf("generation-%d|", i+1)), 32)
+		ptrs[i] = appendPointersInNewSegment(t, dir, 0, uint32(i+1), uint64(100+i), 1, func(int) []byte { return values[i] })[0]
+	}
+	writePointerSync := func(ptr page.ValuePtr) {
+		b := d.NewBatch().(*Batch)
+		defer b.Close()
+		if err := b.SetPointer([]byte("k"), ptr); err != nil {
+			t.Fatalf("SetPointer: %v", err)
+		}
+		if err := b.WriteSync(); err != nil {
+			t.Fatalf("WriteSync: %v", err)
+		}
+	}
+	writePointerSync(ptrs[0])
+	writePointerSync(ptrs[1])
+
+	var rotateOnce sync.Once
+	restore := registerValueLogGCPostScanHook(func() {
+		rotateOnce.Do(func() {
+			writePointerSync(ptrs[2])
+			writePointerSync(ptrs[3])
+		})
+	})
+	stats, err := d.ValueLogGC(context.Background(), ValueLogGCOptions{})
+	restore()
+	if err != nil {
+		t.Fatalf("ValueLogGC: %v", err)
+	}
+	newestMetaPageID := d.metaPageID
+	fallbackPath := filepath.Join(dir, "value_vlog", "value-l0-000003.log")
+	if _, err := os.Stat(fallbackPath); err != nil {
+		t.Fatalf("rotated fallback segment removed: %v (stats=%+v)", err, stats)
+	}
+	if err := d.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	corruptIndexPageByte(t, dir, newestMetaPageID)
+	reopened, err := Open(Options{Dir: dir, Durability: DurabilityWALOffRelaxed})
+	if err != nil {
+		t.Fatalf("reopen from rotated fallback meta: %v", err)
+	}
+	defer reopened.Close()
+	got, err := reopened.Get([]byte("k"))
+	if err != nil {
+		t.Fatalf("Get rotated fallback value: %v", err)
+	}
+	if !bytes.Equal(got, values[2]) {
+		t.Fatalf("rotated fallback value mismatch: got %d bytes want %d", len(got), len(values[2]))
 	}
 }
 
@@ -1274,6 +1401,7 @@ func TestValueLogGC_HealthMetadata_UpdatesAfterDeleteAndRewrite(t *testing.T) {
 	if err := db.Delete([]byte("k1")); err != nil {
 		t.Fatalf("delete k1: %v", err)
 	}
+	stabilizeRecoveryWindowForTest(t, db)
 	if _, err := db.ValueLogGC(context.Background(), ValueLogGCOptions{}); err != nil {
 		t.Fatalf("ValueLogGC: %v", err)
 	}

--- a/TreeDB/db/vlog_leafref_maintenance_test.go
+++ b/TreeDB/db/vlog_leafref_maintenance_test.go
@@ -93,6 +93,7 @@ func TestValueLogGC_IgnoresLeafVlogSegmentsInSplitMode(t *testing.T) {
 		t.Fatalf("expected current leaf segment to remain, stat err=%v", err)
 	}
 
+	stabilizeRecoveryWindowForTest(t, db)
 	leafStats, err := db.LeafGenerationGC(context.Background(), LeafGenerationGCOptions{})
 	if err != nil {
 		t.Fatalf("LeafGenerationGC: %v", err)

--- a/TreeDB/db/vlog_rewrite.go
+++ b/TreeDB/db/vlog_rewrite.go
@@ -2767,7 +2767,7 @@ func (db *DB) applyRewriteSwapBatchOptimistic(swaps []rewriteSwap, sync bool) (b
 		return false, nil
 	}
 
-	post, err := db.finalizeCommitLockedWithOptions(newRoot, sysRoot, retired, sync, metrics, touchedValueLogSegments, db.indexOuterLeavesInValueLog, vlogRefDelta, nil, nil, finalizeCommitOptions{touchedIndexPages: tracker.Pages()})
+	post, err := db.finalizeCommitLockedWithOptions(newRoot, sysRoot, retired, sync, metrics, touchedValueLogSegments, db.indexOuterLeavesInValueLog, vlogRefDelta, nil, nil, finalizeCommitOptions{touchedIndexPages: tracker.Pages(), touchedIndexPagesOwned: true})
 	db.commitMu.Unlock()
 	if err != nil {
 		return false, err

--- a/TreeDB/db/vlog_rewrite.go
+++ b/TreeDB/db/vlog_rewrite.go
@@ -2029,13 +2029,26 @@ func (db *DB) valueLogRewriteOnline(ctx context.Context, opts ValueLogRewriteOnl
 			}
 		}
 	}
+	// Cleanup may unlink both source and historical rewrite-lane segments. Fence
+	// it at the exact visible root frontier so reachability is never evaluated
+	// against pointer swaps whose redundant meta is still only queued.
+	if db.rootPublication == nil {
+		return stats, ErrClosed
+	}
+	visible := db.state.Load()
+	if visible == nil {
+		return stats, ErrClosed
+	}
+	if err := db.rootPublication.stabilizeRecoveryWindow(visible.CommitSeq); err != nil {
+		return stats, err
+	}
 
-	// After swaps are published (i.e. pointer updates have been flushed and made
-	// visible), run cleanup against a non-cancelable context. At this point the
+	// After swaps are published and durable, run cleanup against a non-cancelable
+	// context. At this point the
 	// rewrite is logically committed, so value-log segment bookkeeping must always
 	// complete to keep the value-log set and on-disk metadata consistent with the
 	// already-committed pointer swaps, even if the caller's context is canceled.
-	referencedAfter, err := db.referencedValueLogSegments(context.Background())
+	referencedAfter, _, _, _, err := db.referencedValueLogSegmentsForGCAtSeq(context.Background())
 	if err != nil {
 		return stats, err
 	}
@@ -2099,19 +2112,17 @@ func (db *DB) valueLogRewriteOnline(ctx context.Context, opts ValueLogRewriteOnl
 		protectedIDs map[uint32]struct{}
 		activeIDs    map[uint32]struct{}
 	)
-	// Enable active-segment skip whenever callers provide explicit protected
-	// scope, and also for internal unlocked rewrite flows where concurrent
-	// writers may append pointers after the index reachability scan.
-	allowActiveSkip := !lockMaintenance || len(opts.ProtectedPaths) > 0 || len(opts.SourceFileIDs) > 0 || len(opts.SourceChunks) > 0
+	// Existing active source segments may still receive foreground or cached
+	// writes after the exact backend-root reachability scan. maintenanceMu only
+	// excludes other maintenance; it does not freeze appenders. Keep every active
+	// pre-existing source until a rotate-and-revalidate path proves it unreachable.
+	allowActiveSkip := true
 	{
 		currentSet := db.valueLogManager.CurrentSetNoRefresh()
 		if currentSet != nil {
 			if len(protectedPaths) > 0 {
 				if allowActiveSkip {
 					activeIDs = recentValueLogIDsForProtectedPaths(currentSet, valueLogKeepRecentSegmentsPerLane, opts.ProtectedPaths)
-					if len(activeIDs) == 0 {
-						activeIDs = currentValueLogIDs(currentSet)
-					}
 				}
 				protectedIDs = make(map[uint32]struct{})
 				for id, f := range currentSet.Files {
@@ -2122,10 +2133,39 @@ func (db *DB) valueLogRewriteOnline(ctx context.Context, opts ValueLogRewriteOnl
 						protectedIDs[id] = struct{}{}
 					}
 				}
-			} else if allowActiveSkip {
-				activeIDs = currentValueLogIDs(currentSet)
 			}
 			_ = db.valueLogManager.Release(currentSet)
+		}
+	}
+	if allowActiveSkip {
+		if activeIDs == nil {
+			activeIDs = make(map[uint32]struct{})
+		}
+		// The highest on-disk ID in a lane is not proof that the file is still
+		// writable. Keep only segments with an explicit in-process ownership or
+		// append-in-flight signal; otherwise a sealed source would remain visible
+		// forever after all of its pointers were rewritten.
+		for _, id := range db.valueLogManager.CurrentWritableFileIDs() {
+			activeIDs[id] = struct{}{}
+		}
+		for id := range db.pendingValueLogAppendFileIDs() {
+			activeIDs[id] = struct{}{}
+		}
+		if appender := db.currentValueLogAppender(); appender != nil {
+			if _, id, ok := appender.CurrentValueLogSegment(); ok && id != 0 {
+				activeIDs[id] = struct{}{}
+			}
+		}
+		if db.leafPageLog != nil {
+			segments, err := leafPageLogCurrentSegments(db.leafPageLog)
+			if err != nil {
+				return stats, err
+			}
+			for _, segment := range segments {
+				if segment.FileID != 0 {
+					activeIDs[segment.FileID] = struct{}{}
+				}
+			}
 		}
 	}
 	markZombieCandidate := func(id uint32, existedBefore bool) error {
@@ -2135,19 +2175,12 @@ func (db *DB) valueLogRewriteOnline(ctx context.Context, opts ValueLogRewriteOnl
 		if _, ok := protectedIDs[id]; ok {
 			return nil
 		}
-		// When active-segment skipping is enabled, avoid marking currently
-		// active pre-existing segments zombie. Concurrent writers may still be
-		// appending records whose pointers are not yet visible in the backend
-		// index.
 		if existedBefore && allowActiveSkip {
 			if _, ok := activeIDs[id]; ok {
 				return nil
 			}
 		}
-		if err := db.valueLogManager.MarkZombie(id); err != nil {
-			return err
-		}
-		return nil
+		return db.valueLogManager.MarkZombie(id)
 	}
 	for id := range oldValueIDs {
 		if err := markZombieCandidate(id, true); err != nil {
@@ -2429,11 +2462,10 @@ func (db *DB) applyRewriteSwapBatchToSystemRoot(swaps []rewriteSwap, sync bool) 
 		return fmt.Errorf("vlog-rewrite: system root: missing backend state")
 	}
 
-	db.mu.RLock()
-	userRoot := db.meta.UserRootPageID
-	systemRoot := db.meta.SystemRootPageID
-	baseSeq := db.meta.CommitSeq
-	db.mu.RUnlock()
+	visible := db.state.Load()
+	userRoot := visible.RootPageID
+	systemRoot := visible.SystemRootPageID
+	baseSeq := visible.CommitSeq
 	if systemRoot == 0 {
 		return nil
 	}
@@ -2480,11 +2512,10 @@ func (db *DB) applyRewriteSwapBatchToCollectionRoot(target *collectionRewriteRoo
 		return fmt.Errorf("vlog-rewrite: collection root: missing backend state")
 	}
 
-	db.mu.RLock()
-	userRoot := db.meta.UserRootPageID
-	systemRoot := db.meta.SystemRootPageID
-	baseSeq := db.meta.CommitSeq
-	db.mu.RUnlock()
+	visible := db.state.Load()
+	userRoot := visible.RootPageID
+	systemRoot := visible.SystemRootPageID
+	baseSeq := visible.CommitSeq
 	if systemRoot == 0 {
 		return nil
 	}
@@ -2669,9 +2700,9 @@ func (db *DB) applyRewriteSwapBatchOptimistic(swaps []rewriteSwap, sync bool) (b
 
 	var vlogSet *valuelog.Set
 	db.mu.RLock()
-	rootID := db.meta.UserRootPageID
-	baseSeq := db.meta.CommitSeq
 	state := db.state.Load()
+	rootID := state.RootPageID
+	baseSeq := state.CommitSeq
 	if state != nil {
 		vlogSet = state.ValueLogSet
 	}
@@ -2724,10 +2755,9 @@ func (db *DB) applyRewriteSwapBatchOptimistic(swaps []rewriteSwap, sync bool) (b
 	}()
 
 	db.commitMu.Lock()
-	db.mu.RLock()
-	currentRoot := db.meta.UserRootPageID
-	sysRoot := db.meta.SystemRootPageID
-	db.mu.RUnlock()
+	visible := db.state.Load()
+	currentRoot := visible.RootPageID
+	sysRoot := visible.SystemRootPageID
 	if currentRoot != rootID {
 		db.commitMu.Unlock()
 		freeErr := tracker.FreeAll()
@@ -2737,7 +2767,7 @@ func (db *DB) applyRewriteSwapBatchOptimistic(swaps []rewriteSwap, sync bool) (b
 		return false, nil
 	}
 
-	post, err := db.finalizeCommitLocked(newRoot, sysRoot, retired, sync, metrics, touchedValueLogSegments, db.indexOuterLeavesInValueLog, vlogRefDelta, nil, nil)
+	post, err := db.finalizeCommitLockedWithOptions(newRoot, sysRoot, retired, sync, metrics, touchedValueLogSegments, db.indexOuterLeavesInValueLog, vlogRefDelta, nil, nil, finalizeCommitOptions{touchedIndexPages: tracker.Pages()})
 	db.commitMu.Unlock()
 	if err != nil {
 		return false, err
@@ -2762,10 +2792,10 @@ func (db *DB) applyRewriteSwapBatchSerialized(swaps []rewriteSwap, sync bool) er
 
 	var vlogSet *valuelog.Set
 	db.mu.RLock()
-	rootID := db.meta.UserRootPageID
-	sysRoot := db.meta.SystemRootPageID
-	baseSeq := db.meta.CommitSeq
 	state := db.state.Load()
+	rootID := state.RootPageID
+	sysRoot := state.SystemRootPageID
+	baseSeq := state.CommitSeq
 	if state != nil {
 		vlogSet = state.ValueLogSet
 	}

--- a/TreeDB/db/vlog_rewrite_test.go
+++ b/TreeDB/db/vlog_rewrite_test.go
@@ -2029,6 +2029,9 @@ func TestValueLogRewriteOnline_ExplicitSourceDoesNotDeleteActiveSegment(t *testi
 		t.Fatalf("write pointer key: %v", err)
 	}
 	closeNoErr(t, b)
+	if err := db.valueLogManager.PromoteCurrentWritable(ptrs[0].FileID); err != nil {
+		t.Fatalf("promote active source: %v", err)
+	}
 
 	if err := db.Delete([]byte("k")); err != nil {
 		t.Fatalf("delete pointer key: %v", err)
@@ -2047,6 +2050,50 @@ func TestValueLogRewriteOnline_ExplicitSourceDoesNotDeleteActiveSegment(t *testi
 
 	if _, err := os.Stat(targetPath); err != nil {
 		t.Fatalf("expected active segment %s to remain, stat=%v", filepath.Base(targetPath), err)
+	}
+}
+
+func TestValueLogRewriteOnline_DefaultCleanupDoesNotDeleteActiveSegment(t *testing.T) {
+	dir := t.TempDir()
+	db, err := Open(Options{
+		Dir: dir,
+		ValueLog: ValueLogOptions{
+			PointerThreshold: 1,
+			ForcePointers:    true,
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = db.Close() }()
+
+	ptrs := appendPointersInNewSegment(t, dir, 0, 1, 200_000, 1, func(_ int) []byte {
+		return bytes.Repeat([]byte("active-default-protected|"), 64)
+	})
+	targetPath := filepath.Join(dir, "value_vlog", "value-l0-000001.log")
+	b := db.NewBatch()
+	ptrBatch := b.(interface {
+		SetPointer(key []byte, ptr page.ValuePtr) error
+	})
+	if err := ptrBatch.SetPointer([]byte("k"), ptrs[0]); err != nil {
+		t.Fatal(err)
+	}
+	if err := b.Write(); err != nil {
+		t.Fatal(err)
+	}
+	closeNoErr(t, b)
+	if err := db.valueLogManager.PromoteCurrentWritable(ptrs[0].FileID); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.Delete([]byte("k")); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := db.ValueLogRewriteOnline(context.Background(), ValueLogRewriteOnlineOptions{BatchSize: 1}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(targetPath); err != nil {
+		t.Fatalf("default online rewrite removed active segment %s: %v", filepath.Base(targetPath), err)
 	}
 }
 
@@ -2085,6 +2132,9 @@ func TestValueLogRewriteOnline_ObservedSourceGCReclaimsActiveUnreferencedSource(
 		t.Fatalf("write pointer key: %v", err)
 	}
 	closeNoErr(t, b)
+	if err := db.valueLogManager.PromoteCurrentWritable(sourceID); err != nil {
+		t.Fatalf("promote active source: %v", err)
+	}
 
 	rewriteStats, err := db.ValueLogRewriteOnline(context.Background(), ValueLogRewriteOnlineOptions{
 		SourceFileIDs: []uint32{sourceID},

--- a/TreeDB/db/wal_recovery.go
+++ b/TreeDB/db/wal_recovery.go
@@ -420,6 +420,19 @@ func replayCommandWALIntoBackend(db *DB, segments []logSegment, maxSegmentBytes 
 		restoreValueLogAppender()
 		restoreLeafPageLog()
 	}
+	// Registered command handlers publish their recovered roots through the
+	// ordinary asynchronous coordinator. Recovery must not proceed to segment
+	// cleanup (or let Open consume db.meta) until the complete replayed frontier
+	// is stable. Besides preserving the command frames until their backend state
+	// is recovery-selectable, this joins the publisher before the rest of Open
+	// reads the durable meta fields.
+	if db.rootPublication != nil {
+		if state := db.state.Load(); state != nil {
+			if err := db.rootPublication.waitDurable(state.CommitSeq); err != nil {
+				return err
+			}
+		}
+	}
 	_, err = cleanupCommandWALSegmentsCoveredByAppliedLSN(db.dir, applied, maxSegmentBytes)
 	return err
 }

--- a/TreeDB/db/wal_recovery.go
+++ b/TreeDB/db/wal_recovery.go
@@ -229,6 +229,12 @@ func replayWALIntoBackend(db *DB, segments []logSegment, maxSegmentBytes int64, 
 	if err != nil {
 		return err
 	}
+	// Legacy replay applies ordinary batches before Open installs its final
+	// snapshot view. Give those batches the same provisional state and root
+	// publication coordinator used by typed command-WAL recovery.
+	if db != nil {
+		db.ensureCommandWALRecoverySnapshotView()
+	}
 	return replayCommitLogSegments(db, segments, ridMap, maxSegmentBytes)
 }
 
@@ -598,7 +604,13 @@ func (db *DB) nextCommandWALReplayToken() uint64 {
 }
 
 func (db *DB) ensureCommandWALRecoverySnapshotView() {
-	if db == nil || db.state.Load() != nil {
+	if db == nil {
+		return
+	}
+	if db.state.Load() != nil {
+		if db.rootPublication == nil {
+			db.rootPublication = newRootPublicationCoordinator(db)
+		}
 		return
 	}
 	db.mu.RLock()
@@ -617,10 +629,16 @@ func (db *DB) ensureCommandWALRecoverySnapshotView() {
 	}
 	if db.state.CompareAndSwap(nil, state) {
 		db.publishSnapshotView(db.idx.Load(), state, db.valueLogManager)
+		if db.rootPublication == nil {
+			db.rootPublication = newRootPublicationCoordinator(db)
+		}
 		return
 	}
 	if state.ValueLogSet != nil && db.valueLogManager != nil {
 		_ = db.valueLogManager.Release(state.ValueLogSet)
+	}
+	if db.rootPublication == nil {
+		db.rootPublication = newRootPublicationCoordinator(db)
 	}
 }
 

--- a/TreeDB/freelist/allocator.go
+++ b/TreeDB/freelist/allocator.go
@@ -228,6 +228,58 @@ func (a *Allocator) SetPreferAppend(prefer bool) {
 	a.preferAppend = prefer
 }
 
+// BeginPublicationFence keeps the current freelist generation immutable while
+// a prepared root's index-page images are written. Allocations append and frees
+// are deferred until publication completes. DUR-04 replaces this conservative
+// bridge with complete COW freelist generations.
+func (a *Allocator) BeginPublicationFence() error {
+	a.publicationMu.Lock()
+	a.mu.Lock()
+	if a.publicationFence.Load() {
+		a.mu.Unlock()
+		a.publicationMu.Unlock()
+		return errors.New("freelist publication fence already active")
+	}
+	a.publicationFence.Store(true)
+	a.mu.Unlock()
+	return nil
+}
+
+func (a *Allocator) EndPublicationFence() error {
+	a.mu.Lock()
+	deferred := append([]uint64(nil), a.publicationDeferredFree...)
+	a.publicationDeferredFree = a.publicationDeferredFree[:0]
+	a.publicationFence.Store(false)
+	a.mu.Unlock()
+	a.publicationMu.Unlock()
+	if len(deferred) != 0 {
+		return a.FreeMany(deferred)
+	}
+	return nil
+}
+
+func (a *Allocator) appendOnlyLocked() bool {
+	return a.preferAppend || a.publicationFence.Load()
+}
+
+func (a *Allocator) appendAllocManyLocked(ids []uint64, count int) ([]uint64, error) {
+	allocCount := count - len(ids)
+	if allocCount <= 0 {
+		return ids, nil
+	}
+	id, err := a.pager.Alloc(allocCount)
+	if err != nil {
+		return ids, err
+	}
+	a.stats.AllocPages += uint64(allocCount)
+	a.stats.AppendAllocPages += uint64(allocCount)
+	for i := 0; i < allocCount; i++ {
+		ids = append(ids, id+uint64(i))
+	}
+	a.lastAlloc = ids[len(ids)-1]
+	return ids, nil
+}
+
 func (a *Allocator) SetFreelistRegion(pages uint64, radius int) {
 	a.mu.Lock()
 	defer a.mu.Unlock()
@@ -249,26 +301,14 @@ func (a *Allocator) AllocMany(count int, hint uint64) ([]uint64, error) {
 
 	a.mu.Lock()
 	defer a.mu.Unlock()
-
 	if a.regionPages > 0 && a.regionRadius > 0 {
 		return a.allocManyRegionLocked(count, hint)
 	}
 
 	ids := make([]uint64, 0, count)
 	for len(ids) < count {
-		if a.preferAppend || a.head == 0 {
-			allocCount := count - len(ids)
-			id, err := a.pager.Alloc(allocCount)
-			if err != nil {
-				return ids, err
-			}
-			a.stats.AllocPages += uint64(allocCount)
-			a.stats.AppendAllocPages += uint64(allocCount)
-			for i := 0; i < allocCount; i++ {
-				ids = append(ids, id+uint64(i))
-			}
-			a.lastAlloc = ids[len(ids)-1]
-			return ids, nil
+		if a.appendOnlyLocked() || a.head == 0 {
+			return a.appendAllocManyLocked(ids, count)
 		}
 
 		headID := a.head
@@ -286,6 +326,9 @@ func (a *Allocator) AllocMany(count int, hint uint64) ([]uint64, error) {
 
 		countFree := int(n.Count())
 		if countFree == 0 {
+			if a.publicationFence.Load() {
+				return a.appendAllocManyLocked(ids, count)
+			}
 			next := freelistNextPageID(data)
 			a.batchUpdateChecksum(headID, n)
 
@@ -356,16 +399,8 @@ func (a *Allocator) allocManyRegionLocked(count int, hint uint64) ([]uint64, err
 
 func (a *Allocator) allocTwoRegionLocked(hint uint64) ([]uint64, error) {
 	ids := make([]uint64, 0, 2)
-	if a.preferAppend || a.head == 0 {
-		id, err := a.pager.Alloc(2)
-		if err != nil {
-			return ids, err
-		}
-		ids = append(ids, id, id+1)
-		a.stats.AllocPages += 2
-		a.stats.AppendAllocPages += 2
-		a.lastAlloc = id + 1
-		return ids, nil
+	if a.appendOnlyLocked() || a.head == 0 {
+		return a.appendAllocManyLocked(ids, 2)
 	}
 
 	headID := a.head
@@ -383,6 +418,9 @@ func (a *Allocator) allocTwoRegionLocked(hint uint64) ([]uint64, error) {
 
 	countFree := int(n.Count())
 	if countFree == 0 {
+		if a.publicationFence.Load() {
+			return a.appendAllocManyLocked(ids, 2)
+		}
 		next := freelistNextPageID(data)
 		a.batchUpdateChecksum(headID, n)
 		a.head = next
@@ -431,6 +469,9 @@ func (a *Allocator) allocTwoRegionLocked(hint uint64) ([]uint64, error) {
 	n.SetCount(uint16(countFree))
 	a.batchUpdateChecksum(headID, n)
 	if countFree == 0 && len(ids) < 2 {
+		if a.publicationFence.Load() {
+			return a.appendAllocManyLocked(ids, 2)
+		}
 		next := freelistNextPageID(data)
 		a.head = next
 		a.pager.MarkUnverified(headID)
@@ -449,19 +490,8 @@ func (a *Allocator) allocManyRegionScanLocked(count int, hint uint64) ([]uint64,
 	ids := make([]uint64, 0, count)
 	target := hint
 	for len(ids) < count {
-		if a.preferAppend || a.head == 0 {
-			allocCount := count - len(ids)
-			id, err := a.pager.Alloc(allocCount)
-			if err != nil {
-				return ids, err
-			}
-			a.stats.AllocPages += uint64(allocCount)
-			a.stats.AppendAllocPages += uint64(allocCount)
-			for i := 0; i < allocCount; i++ {
-				ids = append(ids, id+uint64(i))
-			}
-			a.lastAlloc = ids[len(ids)-1]
-			return ids, nil
+		if a.appendOnlyLocked() || a.head == 0 {
+			return a.appendAllocManyLocked(ids, count)
 		}
 
 		headID := a.head
@@ -479,6 +509,9 @@ func (a *Allocator) allocManyRegionScanLocked(count int, hint uint64) ([]uint64,
 
 		countFree := int(n.Count())
 		if countFree == 0 {
+			if a.publicationFence.Load() {
+				return a.appendAllocManyLocked(ids, count)
+			}
 			next := freelistNextPageID(data)
 			a.batchUpdateChecksum(headID, n)
 			a.head = next
@@ -522,6 +555,9 @@ func (a *Allocator) allocManyRegionScanLocked(count int, hint uint64) ([]uint64,
 			a.recordReuseAllocation(id)
 		}
 		if countFree == 0 && len(ids) < count {
+			if a.publicationFence.Load() {
+				return a.appendAllocManyLocked(ids, count)
+			}
 			next := freelistNextPageID(data)
 			a.head = next
 			a.pager.MarkUnverified(headID)
@@ -547,19 +583,8 @@ func (a *Allocator) allocManyRegionWithIndexLocked(count int, hint uint64, regio
 	ids := make([]uint64, 0, count)
 	target := hint
 	for len(ids) < count {
-		if a.preferAppend || a.head == 0 {
-			allocCount := count - len(ids)
-			id, err := a.pager.Alloc(allocCount)
-			if err != nil {
-				return ids, err
-			}
-			a.stats.AllocPages += uint64(allocCount)
-			a.stats.AppendAllocPages += uint64(allocCount)
-			for i := 0; i < allocCount; i++ {
-				ids = append(ids, id+uint64(i))
-			}
-			a.lastAlloc = ids[len(ids)-1]
-			return ids, nil
+		if a.appendOnlyLocked() || a.head == 0 {
+			return a.appendAllocManyLocked(ids, count)
 		}
 
 		headID := a.head
@@ -577,6 +602,9 @@ func (a *Allocator) allocManyRegionWithIndexLocked(count int, hint uint64, regio
 
 		countFree := int(n.Count())
 		if countFree == 0 {
+			if a.publicationFence.Load() {
+				return a.appendAllocManyLocked(ids, count)
+			}
 			next := freelistNextPageID(data)
 			a.batchUpdateChecksum(headID, n)
 			recycled := headID
@@ -635,6 +663,9 @@ func (a *Allocator) allocManyRegionWithIndexLocked(count int, hint uint64, regio
 			a.recordReuseAllocation(id)
 		}
 		if countFree == 0 && len(ids) < count {
+			if a.publicationFence.Load() {
+				return a.appendAllocManyLocked(ids, count)
+			}
 			next := freelistNextPageID(data)
 			a.head = next
 			a.pager.MarkUnverified(headID)
@@ -662,7 +693,7 @@ func (a *Allocator) recordReuseAllocation(id uint64) {
 }
 
 func (a *Allocator) allocLocked(hint uint64) (uint64, error) {
-	if a.preferAppend {
+	if a.appendOnlyLocked() {
 		id, err := a.pager.Alloc(1)
 		if err == nil {
 			a.lastAlloc = id
@@ -671,7 +702,6 @@ func (a *Allocator) allocLocked(hint uint64) (uint64, error) {
 		}
 		return id, err
 	}
-
 	if a.head == 0 {
 		id, err := a.pager.Alloc(1)
 		if err == nil {
@@ -755,9 +785,17 @@ func (a *Allocator) allocLocked(hint uint64) (uint64, error) {
 		}
 		return id, nil
 	}
+	if a.publicationFence.Load() {
+		id, err := a.pager.Alloc(1)
+		if err == nil {
+			a.lastAlloc = id
+			a.stats.AllocPages++
+			a.stats.AppendAllocPages++
+		}
+		return id, err
+	}
 
 	next := freelistNextPageID(data)
-
 	recycled := a.head
 	a.head = next
 
@@ -788,6 +826,10 @@ func (a *Allocator) Free(id uint64) error {
 
 	if id == 0 {
 		return errCannotFreePageZero
+	}
+	if a.publicationFence.Load() {
+		a.publicationDeferredFree = append(a.publicationDeferredFree, id)
+		return nil
 	}
 
 	if a.head == 0 {
@@ -858,6 +900,10 @@ func (a *Allocator) FreeMany(ids []uint64) error {
 	a.mu.Lock()
 	defer a.mu.Unlock()
 	processed := 0
+	if a.publicationFence.Load() {
+		a.publicationDeferredFree = append(a.publicationDeferredFree, ids...)
+		return nil
+	}
 
 	if a.head != 0 {
 		headID := a.head

--- a/TreeDB/freelist/allocator.go
+++ b/TreeDB/freelist/allocator.go
@@ -228,6 +228,23 @@ func (a *Allocator) SetPreferAppend(prefer bool) {
 	a.preferAppend = prefer
 }
 
+// SetRetainDrainedHeads preserves empty freelist chain pages after advancing
+// past them. This is a conservative recovery-window bridge: an older durable
+// meta slot may still name that chain until it is overwritten. Complete COW
+// freelist generations can reclaim these metadata pages later.
+func (a *Allocator) SetRetainDrainedHeads(retain bool) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	a.retainDrainedHeads = retain
+}
+
+func (a *Allocator) retainDrainedHeadLocked(next uint64) {
+	a.head = next
+	if a.stats.Pages > 0 {
+		a.stats.Pages--
+	}
+}
+
 // BeginPublicationFence keeps the current freelist generation immutable while
 // a prepared root's index-page images are written. Allocations append and frees
 // are deferred until publication completes. DUR-04 replaces this conservative
@@ -331,6 +348,10 @@ func (a *Allocator) AllocMany(count int, hint uint64) ([]uint64, error) {
 			}
 			next := freelistNextPageID(data)
 			a.batchUpdateChecksum(headID, n)
+			if a.retainDrainedHeads {
+				a.retainDrainedHeadLocked(next)
+				continue
+			}
 
 			recycled := a.head
 			a.head = next
@@ -423,6 +444,10 @@ func (a *Allocator) allocTwoRegionLocked(hint uint64) ([]uint64, error) {
 		}
 		next := freelistNextPageID(data)
 		a.batchUpdateChecksum(headID, n)
+		if a.retainDrainedHeads {
+			a.retainDrainedHeadLocked(next)
+			return a.allocManyRegionScanLocked(2, hint)
+		}
 		a.head = next
 		a.pager.MarkUnverified(headID)
 		a.lastAlloc = headID
@@ -473,6 +498,12 @@ func (a *Allocator) allocTwoRegionLocked(hint uint64) ([]uint64, error) {
 			return a.appendAllocManyLocked(ids, 2)
 		}
 		next := freelistNextPageID(data)
+		if a.retainDrainedHeads {
+			a.retainDrainedHeadLocked(next)
+			tail, tailErr := a.allocManyRegionScanLocked(2-len(ids), target)
+			ids = append(ids, tail...)
+			return ids, tailErr
+		}
 		a.head = next
 		a.pager.MarkUnverified(headID)
 		a.lastAlloc = headID
@@ -514,6 +545,10 @@ func (a *Allocator) allocManyRegionScanLocked(count int, hint uint64) ([]uint64,
 			}
 			next := freelistNextPageID(data)
 			a.batchUpdateChecksum(headID, n)
+			if a.retainDrainedHeads {
+				a.retainDrainedHeadLocked(next)
+				continue
+			}
 			a.head = next
 			a.pager.MarkUnverified(headID)
 			a.lastAlloc = headID
@@ -559,6 +594,10 @@ func (a *Allocator) allocManyRegionScanLocked(count int, hint uint64) ([]uint64,
 				return a.appendAllocManyLocked(ids, count)
 			}
 			next := freelistNextPageID(data)
+			if a.retainDrainedHeads {
+				a.retainDrainedHeadLocked(next)
+				continue
+			}
 			a.head = next
 			a.pager.MarkUnverified(headID)
 			a.lastAlloc = headID
@@ -607,6 +646,10 @@ func (a *Allocator) allocManyRegionWithIndexLocked(count int, hint uint64, regio
 			}
 			next := freelistNextPageID(data)
 			a.batchUpdateChecksum(headID, n)
+			if a.retainDrainedHeads {
+				a.retainDrainedHeadLocked(next)
+				continue
+			}
 			recycled := headID
 			a.head = next
 			a.pager.MarkUnverified(recycled)
@@ -667,6 +710,10 @@ func (a *Allocator) allocManyRegionWithIndexLocked(count int, hint uint64, regio
 				return a.appendAllocManyLocked(ids, count)
 			}
 			next := freelistNextPageID(data)
+			if a.retainDrainedHeads {
+				a.retainDrainedHeadLocked(next)
+				continue
+			}
 			a.head = next
 			a.pager.MarkUnverified(headID)
 			a.lastAlloc = headID
@@ -693,120 +740,126 @@ func (a *Allocator) recordReuseAllocation(id uint64) {
 }
 
 func (a *Allocator) allocLocked(hint uint64) (uint64, error) {
-	if a.appendOnlyLocked() {
-		id, err := a.pager.Alloc(1)
-		if err == nil {
-			a.lastAlloc = id
-			a.stats.AllocPages++
-			a.stats.AppendAllocPages++
-		}
-		return id, err
-	}
-	if a.head == 0 {
-		id, err := a.pager.Alloc(1)
-		if err == nil {
-			a.lastAlloc = id
-			a.stats.AllocPages++
-			a.stats.AppendAllocPages++
-		}
-		return id, err
-	}
-
-	data, err := a.pager.GetForWrite(a.head)
-	if err != nil {
-		return 0, err
-	}
-	n := node.NewNode(data)
-	if !n.VerifyChecksum() {
-		return 0, errors.New("freelist head corrupted (Alloc)")
-	}
-	if n.Type() != page.PageTypeFreelist {
-		return 0, errors.New("invalid freelist page type")
-	}
-
-	count := int(n.Count())
-	if count > 0 {
-		id := freelistIDAt(data, count-1)
-
-		target := hint
-		if target == 0 {
-			target = a.lastAlloc
-		}
-
-		if a.regionPages > 0 && a.regionRadius > 0 && target != 0 {
-			targetRegion := target / a.regionPages
-			idx := -1
-			for i := count - 1; i >= 0; i-- {
-				candidate := freelistIDAt(data, i)
-				candidateRegion := candidate / a.regionPages
-				var diff uint64
-				if candidateRegion >= targetRegion {
-					diff = candidateRegion - targetRegion
-				} else {
-					diff = targetRegion - candidateRegion
-				}
-				if diff <= uint64(a.regionRadius) {
-					idx = i
-					id = candidate
-					break
-				}
-			}
-			if idx >= 0 {
-				lastIdx := count - 1
-				if idx != lastIdx {
-					setFreelistIDAt(data, idx, freelistIDAt(data, lastIdx))
-				}
-				clearFreelistIDAt(data, lastIdx)
-				n.SetCount(uint16(lastIdx))
-				n.UpdateChecksum()
-
-				a.pager.MarkUnverified(id)
+	for {
+		if a.appendOnlyLocked() {
+			id, err := a.pager.Alloc(1)
+			if err == nil {
 				a.lastAlloc = id
 				a.stats.AllocPages++
-				a.stats.ReuseAllocPages++
-				if a.stats.FreeIDs > 0 {
-					a.stats.FreeIDs--
-				}
-				return id, nil
+				a.stats.AppendAllocPages++
 			}
+			return id, err
+		}
+		if a.head == 0 {
+			id, err := a.pager.Alloc(1)
+			if err == nil {
+				a.lastAlloc = id
+				a.stats.AllocPages++
+				a.stats.AppendAllocPages++
+			}
+			return id, err
 		}
 
-		lastIdx := count - 1
-		clearFreelistIDAt(data, lastIdx)
-		n.SetCount(uint16(lastIdx))
-		n.UpdateChecksum()
-
-		a.pager.MarkUnverified(id)
-		a.lastAlloc = id
-		a.stats.AllocPages++
-		a.stats.ReuseAllocPages++
-		if a.stats.FreeIDs > 0 {
-			a.stats.FreeIDs--
+		data, err := a.pager.GetForWrite(a.head)
+		if err != nil {
+			return 0, err
 		}
-		return id, nil
-	}
-	if a.publicationFence.Load() {
-		id, err := a.pager.Alloc(1)
-		if err == nil {
+		n := node.NewNode(data)
+		if !n.VerifyChecksum() {
+			return 0, errors.New("freelist head corrupted (Alloc)")
+		}
+		if n.Type() != page.PageTypeFreelist {
+			return 0, errors.New("invalid freelist page type")
+		}
+
+		count := int(n.Count())
+		if count > 0 {
+			id := freelistIDAt(data, count-1)
+
+			target := hint
+			if target == 0 {
+				target = a.lastAlloc
+			}
+
+			if a.regionPages > 0 && a.regionRadius > 0 && target != 0 {
+				targetRegion := target / a.regionPages
+				idx := -1
+				for i := count - 1; i >= 0; i-- {
+					candidate := freelistIDAt(data, i)
+					candidateRegion := candidate / a.regionPages
+					var diff uint64
+					if candidateRegion >= targetRegion {
+						diff = candidateRegion - targetRegion
+					} else {
+						diff = targetRegion - candidateRegion
+					}
+					if diff <= uint64(a.regionRadius) {
+						idx = i
+						id = candidate
+						break
+					}
+				}
+				if idx >= 0 {
+					lastIdx := count - 1
+					if idx != lastIdx {
+						setFreelistIDAt(data, idx, freelistIDAt(data, lastIdx))
+					}
+					clearFreelistIDAt(data, lastIdx)
+					n.SetCount(uint16(lastIdx))
+					n.UpdateChecksum()
+
+					a.pager.MarkUnverified(id)
+					a.lastAlloc = id
+					a.stats.AllocPages++
+					a.stats.ReuseAllocPages++
+					if a.stats.FreeIDs > 0 {
+						a.stats.FreeIDs--
+					}
+					return id, nil
+				}
+			}
+
+			lastIdx := count - 1
+			clearFreelistIDAt(data, lastIdx)
+			n.SetCount(uint16(lastIdx))
+			n.UpdateChecksum()
+
+			a.pager.MarkUnverified(id)
 			a.lastAlloc = id
 			a.stats.AllocPages++
-			a.stats.AppendAllocPages++
+			a.stats.ReuseAllocPages++
+			if a.stats.FreeIDs > 0 {
+				a.stats.FreeIDs--
+			}
+			return id, nil
 		}
-		return id, err
-	}
+		if a.publicationFence.Load() {
+			id, err := a.pager.Alloc(1)
+			if err == nil {
+				a.lastAlloc = id
+				a.stats.AllocPages++
+				a.stats.AppendAllocPages++
+			}
+			return id, err
+		}
 
-	next := freelistNextPageID(data)
-	recycled := a.head
-	a.head = next
+		next := freelistNextPageID(data)
+		if a.retainDrainedHeads {
+			a.retainDrainedHeadLocked(next)
+			continue
+		}
+		recycled := a.head
+		a.head = next
 
-	a.pager.MarkUnverified(recycled)
-	a.lastAlloc = recycled
-	a.stats.AllocPages++
-	a.stats.ReuseAllocPages++
-	if a.stats.Pages > 0 {
-		a.stats.Pages--
+		a.pager.MarkUnverified(recycled)
+		a.lastAlloc = recycled
+		a.stats.AllocPages++
+		a.stats.ReuseAllocPages++
+		if a.stats.Pages > 0 {
+			a.stats.Pages--
+		}
+		return recycled, nil
 	}
-	return recycled, nil
 }
 
 // Alloc allocates a single page.

--- a/TreeDB/freelist/allocator_publication_fence_test.go
+++ b/TreeDB/freelist/allocator_publication_fence_test.go
@@ -1,0 +1,58 @@
+package freelist
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/snissn/gomap/TreeDB/pager"
+)
+
+func TestAllocator_PublicationFenceAppendsAndDefersFrees(t *testing.T) {
+	p, err := pager.Open(filepath.Join(t.TempDir(), "index.db"), 64*1024)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer p.Close()
+
+	if _, err := p.Alloc(5); err != nil {
+		t.Fatalf("Alloc pages: %v", err)
+	}
+	a := New(p, 0)
+	if err := a.Free(4); err != nil {
+		t.Fatalf("Free head: %v", err)
+	}
+	if err := a.Free(3); err != nil {
+		t.Fatalf("Free reusable ID: %v", err)
+	}
+	head := a.Head()
+
+	if err := a.BeginPublicationFence(); err != nil {
+		t.Fatalf("BeginPublicationFence: %v", err)
+	}
+	got, err := a.Alloc(0)
+	if err != nil {
+		t.Fatalf("Alloc during fence: %v", err)
+	}
+	if got != 5 {
+		t.Fatalf("Alloc during fence=%d want appended page 5", got)
+	}
+	if gotHead := a.Head(); gotHead != head {
+		t.Fatalf("head changed during fence: got %d want %d", gotHead, head)
+	}
+	if err := a.Free(5); err != nil {
+		t.Fatalf("deferred Free: %v", err)
+	}
+	if err := a.EndPublicationFence(); err != nil {
+		t.Fatalf("EndPublicationFence: %v", err)
+	}
+
+	for _, want := range []uint64{5, 3} {
+		got, err := a.Alloc(0)
+		if err != nil {
+			t.Fatalf("Alloc after fence: %v", err)
+		}
+		if got != want {
+			t.Fatalf("Alloc after fence=%d want reusable page %d", got, want)
+		}
+	}
+}

--- a/TreeDB/freelist/allocator_publication_fence_test.go
+++ b/TreeDB/freelist/allocator_publication_fence_test.go
@@ -4,6 +4,8 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/snissn/gomap/TreeDB/node"
+	"github.com/snissn/gomap/TreeDB/page"
 	"github.com/snissn/gomap/TreeDB/pager"
 )
 
@@ -54,5 +56,41 @@ func TestAllocator_PublicationFenceAppendsAndDefersFrees(t *testing.T) {
 		if got != want {
 			t.Fatalf("Alloc after fence=%d want reusable page %d", got, want)
 		}
+	}
+}
+
+func TestAllocator_RetainDrainedHeadPreservesRecoveryMetadata(t *testing.T) {
+	p, err := pager.Open(filepath.Join(t.TempDir(), "index.db"), 64*1024)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer p.Close()
+
+	if _, err := p.Alloc(4); err != nil {
+		t.Fatalf("Alloc pages: %v", err)
+	}
+	a := New(p, 0)
+	if err := a.Free(3); err != nil {
+		t.Fatalf("Free head: %v", err)
+	}
+	if err := a.Free(2); err != nil {
+		t.Fatalf("Free body: %v", err)
+	}
+	a.SetRetainDrainedHeads(true)
+
+	got, err := a.AllocMany(2, 0)
+	if err != nil {
+		t.Fatalf("AllocMany: %v", err)
+	}
+	if len(got) != 2 || got[0] != 2 || got[1] != 4 {
+		t.Fatalf("AllocMany=%v want reused body 2 then appended page 4", got)
+	}
+	data, err := p.Get(3)
+	if err != nil {
+		t.Fatalf("Get retained head: %v", err)
+	}
+	n := node.NewNode(data)
+	if n.Type() != page.PageTypeFreelist || !n.VerifyChecksum() || n.Count() != 0 {
+		t.Fatalf("retained head type=%d count=%d checksum=%v", n.Type(), n.Count(), n.VerifyChecksum())
 	}
 }

--- a/TreeDB/freelist/allocator_state.go
+++ b/TreeDB/freelist/allocator_state.go
@@ -4,6 +4,7 @@ package freelist
 
 import (
 	"sync"
+	"sync/atomic"
 
 	"github.com/snissn/gomap/TreeDB/node"
 	"github.com/snissn/gomap/TreeDB/pager"
@@ -24,6 +25,10 @@ type Allocator struct {
 	// extending the file. This improves locality at the cost of reclaiming space
 	// later via vacuum.
 	preferAppend bool
+
+	publicationMu           sync.RWMutex
+	publicationFence        atomic.Bool
+	publicationDeferredFree []uint64
 }
 
 func (a *Allocator) batchGetForWrite(pageID uint64) ([]byte, error) {

--- a/TreeDB/freelist/allocator_state.go
+++ b/TreeDB/freelist/allocator_state.go
@@ -26,6 +26,11 @@ type Allocator struct {
 	// later via vacuum.
 	preferAppend bool
 
+	// retainDrainedHeads keeps consumed freelist metadata pages intact instead
+	// of recycling them as data pages. TreeDB enables this while alternating
+	// meta slots can still select an older freelist generation.
+	retainDrainedHeads bool
+
 	publicationMu           sync.RWMutex
 	publicationFence        atomic.Bool
 	publicationDeferredFree []uint64

--- a/TreeDB/freelist/allocator_state_instrument.go
+++ b/TreeDB/freelist/allocator_state_instrument.go
@@ -48,6 +48,11 @@ type Allocator struct {
 	// later via vacuum.
 	preferAppend bool
 
+	// retainDrainedHeads keeps consumed freelist metadata pages intact instead
+	// of recycling them as data pages. TreeDB enables this while alternating
+	// meta slots can still select an older freelist generation.
+	retainDrainedHeads bool
+
 	publicationMu           sync.RWMutex
 	publicationFence        atomic.Bool
 	publicationDeferredFree []uint64

--- a/TreeDB/freelist/allocator_state_instrument.go
+++ b/TreeDB/freelist/allocator_state_instrument.go
@@ -4,6 +4,7 @@ package freelist
 
 import (
 	"sync"
+	"sync/atomic"
 
 	"github.com/snissn/gomap/TreeDB/node"
 	"github.com/snissn/gomap/TreeDB/pager"
@@ -46,6 +47,10 @@ type Allocator struct {
 	// extending the file. This improves locality at the cost of reclaiming space
 	// later via vacuum.
 	preferAppend bool
+
+	publicationMu           sync.RWMutex
+	publicationFence        atomic.Bool
+	publicationDeferredFree []uint64
 
 	instrumentation allocatorInstrumentation
 }

--- a/TreeDB/internal/durabilitycut/durabilitycut.go
+++ b/TreeDB/internal/durabilitycut/durabilitycut.go
@@ -87,7 +87,7 @@ func EmitNamespace(operation NamespaceOperation, resource Resource, root, oldPat
 	if h == nil || h.observe == nil {
 		return nil
 	}
-	return h.observe(Event{
+	return h.emit(Event{
 		Resource:  resource,
 		Root:      root,
 		Namespace: operation,
@@ -98,7 +98,22 @@ func EmitNamespace(operation NamespaceOperation, resource Resource, root, oldPat
 
 type Observer func(Event) error
 
-type holder struct{ observe Observer }
+type holder struct {
+	observe Observer
+	mu      sync.Mutex
+}
+
+func (h *holder) emit(event Event) error {
+	if h == nil || h.observe == nil {
+		return nil
+	}
+	// Publication is asynchronous and may overlap foreground checkpoint work.
+	// Observers model one deterministic persistence timeline, so callbacks must
+	// never execute concurrently.
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	return h.observe(event)
+}
 
 var (
 	installed atomic.Pointer[holder]
@@ -110,7 +125,7 @@ func Emit(event Event) error {
 	if h == nil || h.observe == nil {
 		return nil
 	}
-	return h.observe(event)
+	return h.emit(event)
 }
 
 // EmitBasic avoids constructing an Event on the production-disabled path.
@@ -119,7 +134,7 @@ func EmitBasic(point Point, resource Resource, root string) error {
 	if h == nil || h.observe == nil {
 		return nil
 	}
-	return h.observe(Event{Point: point, Resource: resource, Root: root})
+	return h.emit(Event{Point: point, Resource: resource, Root: root})
 }
 
 // EmitPath avoids constructing a path event on the production-disabled path.
@@ -128,7 +143,7 @@ func EmitPath(point Point, resource Resource, root, path string) error {
 	if h == nil || h.observe == nil {
 		return nil
 	}
-	return h.observe(Event{Point: point, Resource: resource, Root: root, Path: path})
+	return h.emit(Event{Point: point, Resource: resource, Root: root, Path: path})
 }
 
 // EmitRange avoids constructing a byte-range event on the
@@ -138,7 +153,7 @@ func EmitRange(point Point, resource Resource, root, path string, offset, length
 	if h == nil || h.observe == nil {
 		return nil
 	}
-	return h.observe(Event{Point: point, Resource: resource, Root: root, Path: path, Offset: offset, Length: length})
+	return h.emit(Event{Point: point, Resource: resource, Root: root, Path: path, Offset: offset, Length: length})
 }
 
 // EmitLSN avoids constructing an LSN event on the production-disabled path.
@@ -147,7 +162,7 @@ func EmitLSN(point Point, resource Resource, root string, lsn uint64) error {
 	if h == nil || h.observe == nil {
 		return nil
 	}
-	return h.observe(Event{Point: point, Resource: resource, Root: root, LSN: lsn})
+	return h.emit(Event{Point: point, Resource: resource, Root: root, LSN: lsn})
 }
 
 // EmitPathLSN avoids constructing a path-and-LSN event on the
@@ -157,7 +172,7 @@ func EmitPathLSN(point Point, resource Resource, root, path string, lsn uint64) 
 	if h == nil || h.observe == nil {
 		return nil
 	}
-	return h.observe(Event{Point: point, Resource: resource, Root: root, Path: path, LSN: lsn})
+	return h.emit(Event{Point: point, Resource: resource, Root: root, Path: path, LSN: lsn})
 }
 
 // Enabled lets coarse production boundaries avoid collecting diagnostic path
@@ -171,9 +186,14 @@ func Enabled() bool {
 // function. It is intended only for deterministic, non-parallel tests.
 func Install(observer Observer) func() {
 	installMu.Lock()
-	installed.Store(&holder{observe: observer})
+	h := &holder{observe: observer}
+	installed.Store(h)
 	return func() {
 		installed.Store(nil)
+		// Drain a callback that loaded the holder before the atomic removal so
+		// callers may safely inspect observer-owned state after restore returns.
+		h.mu.Lock()
+		h.mu.Unlock()
 		installMu.Unlock()
 	}
 }

--- a/TreeDB/pager/grow.go
+++ b/TreeDB/pager/grow.go
@@ -6,6 +6,12 @@ import "fmt"
 // while still avoiding excessive churn for very small side-store chunks.
 const minAsyncPregrowChunkSize = 256 << 10 // 256KiB
 
+// Grow a bounded window rather than one chunk at a time. Append-heavy bursts
+// (including conservative root-publication fences) otherwise repeat file
+// preallocation, truncation, and mapping work every 256KiB. Logical page count
+// still advances only through Alloc; this is physical capacity only.
+const asyncPregrowChunks = 8
+
 func (p *Pager) startGrower() {
 	p.growStop = make(chan struct{})
 	p.growWake = make(chan struct{}, 1)
@@ -31,7 +37,7 @@ func (p *Pager) maybeSchedulePreGrow(requiredBytes int64) {
 		return
 	}
 
-	desired := currentCapacity + p.chunkSize
+	desired := currentCapacity + asyncPregrowChunks*p.chunkSize
 	for {
 		cur := p.growTarget.Load()
 		if desired <= cur {

--- a/TreeDB/pager/index_page_snapshot.go
+++ b/TreeDB/pager/index_page_snapshot.go
@@ -1,0 +1,202 @@
+package pager
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"sort"
+
+	"github.com/snissn/gomap/TreeDB/internal/durabilitycut"
+	"github.com/snissn/gomap/TreeDB/page"
+)
+
+// IndexPageSnapshot is an immutable copy of the index pages owned by one
+// publication fence. It lets foreground builders resume before the durable
+// write completes without allowing a reused in-place page (currently the
+// freelist head) to race the fence.
+type IndexPageSnapshot struct {
+	pageIDs     []uint64
+	generations []uint64
+	data        []byte
+}
+
+var syncIndexPageSnapshotFn = syncIndexPageSnapshotData
+
+// NewIndexPageSnapshot returns reusable storage for the sole publication
+// worker. Keeping the buffer with that worker avoids relying on sync.Pool,
+// whose contents may be discarded at every GC while publication is active.
+func NewIndexPageSnapshot() *IndexPageSnapshot {
+	return new(IndexPageSnapshot)
+}
+
+// CaptureIndexPages copies the named non-meta pages while root construction is
+// serialized. It is primarily a convenience for tests and one-shot callers.
+func (p *Pager) CaptureIndexPages(ids []uint64) (*IndexPageSnapshot, error) {
+	snapshot := NewIndexPageSnapshot()
+	if err := p.CaptureIndexPagesInto(snapshot, ids); err != nil {
+		return nil, err
+	}
+	return snapshot, nil
+}
+
+// CaptureIndexPagesInto replaces snapshot with immutable copies of the named
+// non-meta pages. A single publication worker may reuse the same snapshot
+// after the preceding SyncIndexPageSnapshot call completes.
+func (p *Pager) CaptureIndexPagesInto(snapshot *IndexPageSnapshot, ids []uint64) error {
+	if p == nil {
+		return errors.New("pager: nil pager")
+	}
+	if snapshot == nil {
+		return errors.New("pager: nil index page snapshot")
+	}
+	snapshot.pageIDs = append(snapshot.pageIDs[:0], ids...)
+	sort.Slice(snapshot.pageIDs, func(i, j int) bool { return snapshot.pageIDs[i] < snapshot.pageIDs[j] })
+	write := 0
+	for _, id := range snapshot.pageIDs {
+		if write != 0 && snapshot.pageIDs[write-1] == id {
+			continue
+		}
+		snapshot.pageIDs[write] = id
+		write++
+	}
+	snapshot.pageIDs = snapshot.pageIDs[:write]
+	snapshot.generations = growUint64s(snapshot.generations, len(snapshot.pageIDs))
+	snapshot.data = growBytes(snapshot.data, len(snapshot.pageIDs)*page.PageSize)
+
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+	for i, id := range snapshot.pageIDs {
+		if id == 0 || id == 1 {
+			return errors.New("pager: index data snapshot includes meta page")
+		}
+		localID, local := p.localPageID(id)
+		if !local || id >= p.numPages.Load() {
+			return ErrPageOutOfBounds
+		}
+		byteOffset := int64(localID) * int64(page.PageSize)
+		chunkIdx := int(byteOffset / p.chunkSize)
+		offsetInChunk := int(byteOffset % p.chunkSize)
+		if chunkIdx >= len(p.chunks) || offsetInChunk+page.PageSize > len(p.chunks[chunkIdx]) {
+			return ErrPageOutOfBounds
+		}
+		snapshot.generations[i] = p.dirtyPages[id]
+		copy(snapshot.data[i*page.PageSize:(i+1)*page.PageSize], p.chunks[chunkIdx][offsetInChunk:offsetInChunk+page.PageSize])
+	}
+	return nil
+}
+
+func growUint64s(buf []uint64, size int) []uint64 {
+	if cap(buf) < size {
+		return make([]uint64, size)
+	}
+	return buf[:size]
+}
+
+func growBytes(buf []byte, size int) []byte {
+	if cap(buf) < size {
+		return make([]byte, size)
+	}
+	return buf[:size]
+}
+
+// ReleaseIndexPageSnapshot clears references held by a one-shot snapshot.
+// Coordinator-owned snapshots are reused directly instead.
+func ReleaseIndexPageSnapshot(snapshot *IndexPageSnapshot) {
+	if snapshot == nil {
+		return
+	}
+	snapshot.pageIDs = snapshot.pageIDs[:0]
+	snapshot.generations = snapshot.generations[:0]
+	snapshot.data = snapshot.data[:0]
+}
+
+// SyncIndexPageSnapshot durably writes exactly the captured non-meta images.
+// A successor may append or mutate its own mmap pages concurrently; the fence
+// reads only the immutable copies above.
+func (p *Pager) SyncIndexPageSnapshot(snapshot *IndexPageSnapshot) error {
+	if p.readOnly {
+		return ErrReadOnly
+	}
+	if snapshot == nil || len(snapshot.pageIDs) == 0 || p.memoryOnly {
+		return nil
+	}
+	if !p.readOnly && !p.memoryOnly {
+		if err := durabilitycut.EmitPath(durabilitycut.BeforeIndexDataSync, durabilitycut.ResourceIndex, filepath.Dir(p.path), p.path); err != nil {
+			return err
+		}
+	}
+	for _, id := range snapshot.pageIDs {
+		if id == 0 || id == 1 {
+			return errors.New("pager: index data snapshot includes meta page")
+		}
+	}
+	if err := p.validateIndexPageSnapshotGenerations(snapshot, "before write"); err != nil {
+		return err
+	}
+	p.mu.RLock()
+	durableSize := int64(len(p.chunks)) * p.chunkSize
+	p.mu.RUnlock()
+	if err := syncIndexPageSnapshotFn(p.file, p.pageIDBase, snapshot.pageIDs, snapshot.data); err != nil {
+		return err
+	}
+	// The snapshot writer finishes with a file-wide data barrier, which also
+	// makes the observed file length durable. Recording that boundary prevents
+	// a redundant size-only barrier before the next range publication.
+	p.recordDurableFileSize(durableSize)
+	p.mu.Lock()
+	var staleErr error
+	for i, id := range snapshot.pageIDs {
+		if p.dirtyPages[id] == snapshot.generations[i] {
+			delete(p.dirtyPages, id)
+		} else if staleErr == nil {
+			staleErr = fmt.Errorf("pager: index snapshot generation changed during write: page=%d captured=%d current=%d", id, snapshot.generations[i], p.dirtyPages[id])
+		}
+	}
+	p.mu.Unlock()
+	if staleErr != nil {
+		return staleErr
+	}
+	if !p.readOnly && !p.memoryOnly {
+		if err := durabilitycut.EmitPath(durabilitycut.AfterIndexDataSync, durabilitycut.ResourceIndex, filepath.Dir(p.path), p.path); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (p *Pager) validateIndexPageSnapshotGenerations(snapshot *IndexPageSnapshot, phase string) error {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+	for i, id := range snapshot.pageIDs {
+		if current := p.dirtyPages[id]; current != snapshot.generations[i] {
+			return fmt.Errorf("pager: stale index snapshot %s: page=%d captured=%d current=%d", phase, id, snapshot.generations[i], current)
+		}
+	}
+	return nil
+}
+
+func syncIndexPageSnapshotData(file *os.File, pageIDBase uint64, pageIDs []uint64, data []byte) error {
+	for first := 0; first < len(pageIDs); {
+		last := first + 1
+		for last < len(pageIDs) && pageIDs[last] == pageIDs[last-1]+1 {
+			last++
+		}
+		offset := int64(pageIDs[first]-pageIDBase) * int64(page.PageSize)
+		buf := data[first*page.PageSize : last*page.PageSize]
+		for len(buf) > 0 {
+			n, err := file.WriteAt(buf, offset)
+			if err != nil {
+				return err
+			}
+			if n <= 0 {
+				return io.ErrShortWrite
+			}
+			buf = buf[n:]
+			offset += int64(n)
+		}
+		first = last
+	}
+	return syncPageFileBarrier(file)
+}

--- a/TreeDB/pager/pager.go
+++ b/TreeDB/pager/pager.go
@@ -896,12 +896,20 @@ func (p *Pager) SyncIndexFileSize() error {
 		p.mu.RUnlock()
 		return nil
 	}
-	err := syncPageFile(p.file)
-	if err == nil {
-		p.durableFileSize.Store(want)
-	}
 	p.mu.RUnlock()
+	err := syncPageFileBarrier(p.file)
+	if err == nil {
+		p.recordDurableFileSize(want)
+	}
 	return err
+}
+
+func (p *Pager) recordDurableFileSize(size int64) {
+	for current := p.durableFileSize.Load(); current < size; current = p.durableFileSize.Load() {
+		if p.durableFileSize.CompareAndSwap(current, size) {
+			return
+		}
+	}
 }
 
 // syncIndexDataPages durably writes only the planned non-meta ranges. Unlike
@@ -963,7 +971,7 @@ func (p *Pager) syncIndexDataPages(pageIDs []uint64) error {
 			offset += int64(n)
 		}
 	}
-	return p.file.Sync()
+	return syncPageFileBarrier(p.file)
 }
 
 func (p *Pager) syncDirtyChunks(syncFile bool, firstChunk int) error {
@@ -1153,28 +1161,29 @@ func (p *Pager) SyncPages(pageIDs []uint64) error {
 	for _, pageID := range pageIDs {
 		pageGenerations[pageID] = p.dirtyPages[pageID]
 	}
-	chunkLengths := make([]int, len(p.chunks))
-	for i := range p.chunks {
-		chunkLengths[i] = len(p.chunks[i])
+	chunks := append([][]byte(nil), p.chunks...)
+	chunkLengths := make([]int, len(chunks))
+	for i := range chunks {
+		chunkLengths[i] = len(chunks[i])
 	}
 	ranges, err := planSyncPageRanges(pageIDs, p.pageIDBase, p.numPages.Load(), p.chunkSize, mmapOffsetGranularity(), chunkLengths)
 	if err != nil {
 		p.mu.RUnlock()
 		return err
 	}
+	durableFileSize := p.durableFileSize.Load()
+	p.mu.RUnlock()
 	handled := false
-	if syncPageRangesWithinDurableFileSize(ranges, p.chunkSize, p.durableFileSize.Load()) {
-		handled, err = syncPageRangesFn(p.file, p.chunks, ranges, p.chunkSize)
+	if syncPageRangesWithinDurableFileSize(ranges, p.chunkSize, durableFileSize) {
+		handled, err = syncPageRangesFn(p.file, chunks, ranges, p.chunkSize)
 		if err != nil {
-			p.mu.RUnlock()
 			return err
 		}
 	}
 	if !handled && mappedRangeSyncRequired() {
 		for _, r := range ranges {
-			err := msyncFile(p.chunks[r.chunk][r.start:r.end])
+			err := msyncFile(chunks[r.chunk][r.start:r.end])
 			if err != nil {
-				p.mu.RUnlock()
 				return err
 			}
 		}
@@ -1182,10 +1191,9 @@ func (p *Pager) SyncPages(pageIDs []uint64) error {
 	if !handled {
 		err = syncPageFile(p.file)
 		if err == nil {
-			p.durableFileSize.Store(int64(len(p.chunks)) * p.chunkSize)
+			p.recordDurableFileSize(int64(len(chunks)) * p.chunkSize)
 		}
 	}
-	p.mu.RUnlock()
 	if err == nil {
 		p.mu.Lock()
 		for pageID, generation := range pageGenerations {

--- a/TreeDB/pager/pager.go
+++ b/TreeDB/pager/pager.go
@@ -1,8 +1,9 @@
 package pager
 
 import (
-	"errors" // Added import
+	"errors"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"sort"
@@ -14,7 +15,7 @@ import (
 )
 
 var (
-	ErrPageOutOfBounds = errors.New("page index out of bounds") // Added declaration
+	ErrPageOutOfBounds = errors.New("page index out of bounds")
 	ErrFileSize        = errors.New("file size is not a multiple of page size")
 	ErrReadOnly        = errors.New("pager is read-only")
 )
@@ -54,6 +55,11 @@ type Pager struct {
 	// durability fence. Sparse range durability is restricted to this prefix.
 	durableFileSize atomic.Int64
 	dirtyChunks     map[int]struct{}
+	// dirtyPages records page-granular index writes so root publication can
+	// stabilize data pages without flushing either recovery-selectable meta
+	// page. dirtyChunks remains the file-wide Sync bookkeeping.
+	dirtyPages      map[uint64]uint64
+	dirtyGeneration uint64
 	mu              sync.RWMutex
 	allocMu         sync.Mutex
 	path            string
@@ -103,6 +109,7 @@ func NewOverlay(chunkSize int64, pageIDBase uint64, fallback *Pager) (*Pager, er
 	p := &Pager{
 		chunkSize:   chunkSize,
 		dirtyChunks: make(map[int]struct{}),
+		dirtyPages:  make(map[uint64]uint64),
 		memoryOnly:  true,
 		pageIDBase:  pageIDBase,
 		fallback:    fallback,
@@ -167,6 +174,7 @@ func OpenWithOptions(path string, chunkSize int64, opts OpenOptions) (*Pager, er
 		chunkSize:      chunkSize,
 		path:           path,
 		dirtyChunks:    make(map[int]struct{}),
+		dirtyPages:     make(map[uint64]uint64),
 		mmapPopulate:   opts.MmapPopulate,
 		prefetchOnRead: opts.PrefetchOnRead,
 	}
@@ -579,6 +587,8 @@ func (p *Pager) GetForWrite(pageID uint64) ([]byte, error) {
 	}
 
 	p.dirtyChunks[chunkIdx] = struct{}{}
+	p.dirtyGeneration++
+	p.dirtyPages[pageID] = p.dirtyGeneration
 
 	chunk := p.chunks[chunkIdx]
 	return chunk[offsetInChunk : offsetInChunk+page.PageSize], nil
@@ -742,6 +752,8 @@ func (p *Pager) Write(pageID uint64, data []byte) error {
 
 	// Mark chunk as dirty
 	p.dirtyChunks[int(chunkIdx)] = struct{}{}
+	p.dirtyGeneration++
+	p.dirtyPages[pageID] = p.dirtyGeneration
 
 	chunk := p.chunks[chunkIdx]
 	dst := chunk[offsetInChunk : offsetInChunk+page.PageSize]
@@ -761,28 +773,197 @@ func (p *Pager) FlushDirtyChunksFrom(firstChunk int) error {
 
 // Sync msyncs the memory maps and syncs the backing file to disk.
 func (p *Pager) Sync() error {
-	return p.syncDirtyChunks(true, 0)
+	p.mu.RLock()
+	generations := make(map[uint64]uint64, len(p.dirtyPages))
+	for id, generation := range p.dirtyPages {
+		generations[id] = generation
+	}
+	p.mu.RUnlock()
+	if err := p.syncDirtyChunks(true, 0); err != nil {
+		return err
+	}
+	p.clearDirtyPageGenerations(generations)
+	return nil
 }
 
-// SyncIndexData is the production index-publication data barrier. It performs
-// the same durable pager sync as Sync while exposing the named before/after
-// boundary used by the power-loss oracle. Meta-page syncs continue to use Sync
-// and therefore are not mislabeled as pre-publication index-data barriers.
+func (p *Pager) clearDirtyPageGenerations(generations map[uint64]uint64) {
+	p.mu.Lock()
+	for id, generation := range generations {
+		if p.dirtyPages[id] == generation {
+			delete(p.dirtyPages, id)
+		}
+	}
+	p.mu.Unlock()
+}
+
+// DirtyIndexPages returns a stable sorted snapshot of dirty non-meta pages.
+// Meta pages 0 and 1 are deliberately excluded from this publication set.
+func (p *Pager) DirtyIndexPages() []uint64 {
+	if p == nil {
+		return nil
+	}
+	p.mu.RLock()
+	ids := make([]uint64, 0, len(p.dirtyPages))
+	for id := range p.dirtyPages {
+		if id == 0 || id == 1 {
+			continue
+		}
+		ids = append(ids, id)
+	}
+	p.mu.RUnlock()
+	sort.Slice(ids, func(i, j int) bool { return ids[i] < ids[j] })
+	return ids
+}
+
+func (p *Pager) dirtyIndexPageSnapshot() (map[uint64]uint64, []uint64) {
+	p.mu.RLock()
+	generations := make(map[uint64]uint64, len(p.dirtyPages))
+	ids := make([]uint64, 0, len(p.dirtyPages))
+	for id, generation := range p.dirtyPages {
+		if id == 0 || id == 1 {
+			continue
+		}
+		generations[id] = generation
+		ids = append(ids, id)
+	}
+	p.mu.RUnlock()
+	sort.Slice(ids, func(i, j int) bool { return ids[i] < ids[j] })
+	return generations, ids
+}
+
+// SyncIndexData is the production index-publication data barrier. It syncs
+// only page-granular non-meta writes; the coordinator performs the target-meta
+// write and target-only SyncPages call after this method returns.
 func (p *Pager) SyncIndexData() error {
+	_, ids := p.dirtyIndexPageSnapshot()
+	return p.SyncIndexPages(ids)
+}
+
+// SyncIndexPages is the publication data barrier for an immutable candidate
+// closure. It deliberately does not discover global dirty pages: a later root
+// builder may already be mutating a different writable mmap slice and owns
+// those pages until its own candidate is registered.
+func (p *Pager) SyncIndexPages(ids []uint64) error {
 	if !p.readOnly && !p.memoryOnly {
 		if err := durabilitycut.EmitPath(durabilitycut.BeforeIndexDataSync, durabilitycut.ResourceIndex, filepath.Dir(p.path), p.path); err != nil {
 			return err
 		}
 	}
-	if err := p.Sync(); err != nil {
+	p.mu.RLock()
+	generations := make(map[uint64]uint64, len(ids))
+	for _, id := range ids {
+		if id == 0 || id == 1 {
+			p.mu.RUnlock()
+			return errors.New("pager: index data fence includes meta page")
+		}
+		generations[id] = p.dirtyPages[id]
+	}
+	p.mu.RUnlock()
+	if err := p.syncIndexDataPages(ids); err != nil {
 		return err
 	}
+	p.clearDirtyPageGenerations(generations)
 	if !p.readOnly && !p.memoryOnly {
 		if err := durabilitycut.EmitPath(durabilitycut.AfterIndexDataSync, durabilitycut.ResourceIndex, filepath.Dir(p.path), p.path); err != nil {
 			return err
 		}
 	}
 	return nil
+}
+
+// SyncIndexFileSize makes the current mapped length durable before a
+// publication attempts range-only index-data synchronization. The root
+// coordinator calls this before writing its target meta slot, so a necessary
+// file-wide size fence cannot accidentally install that meta early.
+func (p *Pager) SyncIndexFileSize() error {
+	if p.readOnly {
+		return ErrReadOnly
+	}
+	if p.memoryOnly {
+		return nil
+	}
+	p.mu.RLock()
+	if _, dirty := p.dirtyPages[0]; dirty {
+		p.mu.RUnlock()
+		return errors.New("pager: meta page 0 dirty before index data fence")
+	}
+	if _, dirty := p.dirtyPages[1]; dirty {
+		p.mu.RUnlock()
+		return errors.New("pager: meta page 1 dirty before index data fence")
+	}
+	want := int64(len(p.chunks)) * p.chunkSize
+	if p.durableFileSize.Load() >= want {
+		p.mu.RUnlock()
+		return nil
+	}
+	err := syncPageFile(p.file)
+	if err == nil {
+		p.durableFileSize.Store(want)
+	}
+	p.mu.RUnlock()
+	return err
+}
+
+// syncIndexDataPages durably writes only the planned non-meta ranges. Unlike
+// SyncPages, it never falls back to a file-wide sync: file-size durability is
+// an explicit preceding coordinator step, and mapped MS_SYNC is the portable
+// range fallback when platform-specific durable range writes are unavailable.
+func (p *Pager) syncIndexDataPages(pageIDs []uint64) error {
+	if p.readOnly {
+		return ErrReadOnly
+	}
+	if p.memoryOnly || len(pageIDs) == 0 {
+		return nil
+	}
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+	chunkLengths := make([]int, len(p.chunks))
+	for i := range p.chunks {
+		chunkLengths[i] = len(p.chunks[i])
+	}
+	if _, dirty := p.dirtyPages[0]; dirty {
+		return errors.New("pager: meta page 0 dirty before index data fence")
+	}
+	if _, dirty := p.dirtyPages[1]; dirty {
+		return errors.New("pager: meta page 1 dirty before index data fence")
+	}
+	// Logical page granularity is intentional. On Darwin, mmap MS_SYNC needs a
+	// 16-KiB-aligned range and would therefore include both 4-KiB meta slots when
+	// syncing page 2. Exact pwrite below preserves the physical exclusion.
+	ranges, err := planSyncPageRanges(pageIDs, p.pageIDBase, p.numPages.Load(), p.chunkSize, int64(page.PageSize), chunkLengths)
+	if err != nil {
+		return err
+	}
+	if !syncPageRangesWithinDurableFileSize(ranges, p.chunkSize, p.durableFileSize.Load()) {
+		return errors.New("pager: index file size is not durable")
+	}
+	handled, err := syncPageRangesFn(p.file, p.chunks, ranges, p.chunkSize)
+	if err != nil {
+		return err
+	}
+	if handled {
+		return nil
+	}
+	// Portable exact-range path. The clean-meta invariant above makes the final
+	// file durability boundary safe: only these logical index bytes have been
+	// written since the preceding publication meta fence.
+	for _, r := range ranges {
+		buf := p.chunks[r.chunk][r.start:r.end]
+		rangeOffset := int64(r.chunk)*p.chunkSize + int64(r.start)
+		offset := rangeOffset
+		for len(buf) > 0 {
+			n, err := p.file.WriteAt(buf, offset)
+			if err != nil {
+				return err
+			}
+			if n <= 0 {
+				return io.ErrShortWrite
+			}
+			buf = buf[n:]
+			offset += int64(n)
+		}
+	}
+	return p.file.Sync()
 }
 
 func (p *Pager) syncDirtyChunks(syncFile bool, firstChunk int) error {
@@ -968,6 +1149,10 @@ func (p *Pager) SyncPages(pageIDs []uint64) error {
 	}
 
 	p.mu.RLock()
+	pageGenerations := make(map[uint64]uint64, len(pageIDs))
+	for _, pageID := range pageIDs {
+		pageGenerations[pageID] = p.dirtyPages[pageID]
+	}
 	chunkLengths := make([]int, len(p.chunks))
 	for i := range p.chunks {
 		chunkLengths[i] = len(p.chunks[i])
@@ -1001,5 +1186,14 @@ func (p *Pager) SyncPages(pageIDs []uint64) error {
 		}
 	}
 	p.mu.RUnlock()
+	if err == nil {
+		p.mu.Lock()
+		for pageID, generation := range pageGenerations {
+			if p.dirtyPages[pageID] == generation {
+				delete(p.dirtyPages, pageID)
+			}
+		}
+		p.mu.Unlock()
+	}
 	return err
 }

--- a/TreeDB/pager/sync_index_data_test.go
+++ b/TreeDB/pager/sync_index_data_test.go
@@ -1,0 +1,148 @@
+package pager
+
+import (
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+
+	"github.com/snissn/gomap/TreeDB/page"
+)
+
+func TestSyncIndexDataExcludesMetaPages(t *testing.T) {
+	p, err := Open(filepath.Join(t.TempDir(), "index.db"), 64*1024)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = p.Close() }()
+	if _, err := p.Alloc(4); err != nil {
+		t.Fatal(err)
+	}
+	data, err := p.GetForWrite(2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	data[0] = 0x42
+
+	ids := p.DirtyIndexPages()
+	if len(ids) != 1 || ids[0] != 2 {
+		t.Fatalf("DirtyIndexPages=%v want [2]", ids)
+	}
+	if err := p.SyncIndexFileSize(); err != nil {
+		t.Fatal(err)
+	}
+	originalRanges := syncPageRangesFn
+	originalFile := syncPageFileFn
+	t.Cleanup(func() {
+		syncPageRangesFn = originalRanges
+		syncPageFileFn = originalFile
+	})
+	var captured []syncPageRange
+	fileSyncCalls := 0
+	syncPageRangesFn = func(_ *os.File, _ [][]byte, ranges []syncPageRange, _ int64) (bool, error) {
+		captured = append(captured, ranges...)
+		return true, nil
+	}
+	syncPageFileFn = func(_ *os.File) error {
+		fileSyncCalls++
+		return nil
+	}
+	if err := p.SyncIndexData(); err != nil {
+		t.Fatal(err)
+	}
+	if fileSyncCalls != 0 {
+		t.Fatalf("SyncIndexData used file-wide sync %d times", fileSyncCalls)
+	}
+	if len(captured) == 0 {
+		t.Fatal("SyncIndexData did not issue a page range")
+	}
+	for _, r := range captured {
+		start := int64(r.chunk)*p.chunkSize + int64(r.start)
+		end := int64(r.chunk)*p.chunkSize + int64(r.end)
+		if start < int64(2*page.PageSize) && end > 0 {
+			t.Fatalf("range [%d,%d) overlaps redundant meta pages", start, end)
+		}
+	}
+	if got := p.DirtyIndexPages(); len(got) != 0 {
+		t.Fatalf("dirty index pages after sync=%v", got)
+	}
+	if err := p.SyncPages([]uint64{0}); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestSyncIndexPagesDoesNotConsumeLaterBuilderDirtyPage(t *testing.T) {
+	p, err := Open(filepath.Join(t.TempDir(), "index.db"), 64*1024)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = p.Close() }()
+	if _, err := p.Alloc(4); err != nil {
+		t.Fatal(err)
+	}
+	committed, err := p.GetForWrite(2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	committed[0] = 0x22
+	laterBuilder, err := p.GetForWrite(3)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := p.SyncIndexFileSize(); err != nil {
+		t.Fatal(err)
+	}
+
+	originalRanges := syncPageRangesFn
+	t.Cleanup(func() { syncPageRangesFn = originalRanges })
+	entered := make(chan struct{})
+	release := make(chan struct{})
+	syncPageRangesFn = func(_ *os.File, _ [][]byte, ranges []syncPageRange, _ int64) (bool, error) {
+		if len(ranges) != 1 {
+			t.Fatalf("candidate ranges=%v want one", ranges)
+		}
+		close(entered)
+		<-release
+		return true, nil
+	}
+	done := make(chan error, 1)
+	go func() { done <- p.SyncIndexPages([]uint64{2}) }()
+	<-entered
+	// The later builder already owns its mmap slice and can continue mutating it
+	// without taking pager.mu while the prior candidate is in its durability cut.
+	laterBuilder[0] = 0x33
+	close(release)
+	if err := <-done; err != nil {
+		t.Fatal(err)
+	}
+	if got := p.DirtyIndexPages(); !reflect.DeepEqual(got, []uint64{3}) {
+		t.Fatalf("dirty pages after prior candidate sync=%v want [3]", got)
+	}
+}
+
+func TestSyncDirtyPageCleanupPreservesNewGeneration(t *testing.T) {
+	p := &Pager{dirtyPages: map[uint64]uint64{2: 1, 3: 2}}
+	p.clearDirtyPageGenerations(map[uint64]uint64{2: 1, 3: 1})
+	if got := p.DirtyIndexPages(); !reflect.DeepEqual(got, []uint64{3}) {
+		t.Fatalf("dirty pages after stale sync cleanup=%v want [3]", got)
+	}
+}
+
+func TestSyncIndexDataRejectsDirtyMetaInvariant(t *testing.T) {
+	p, err := Open(filepath.Join(t.TempDir(), "index.db"), 64*1024)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = p.Close() }()
+	if _, err := p.Alloc(4); err != nil {
+		t.Fatal(err)
+	}
+	meta, err := p.GetForWrite(0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	meta[0] = 0x7f
+	if err := p.SyncIndexFileSize(); err == nil {
+		t.Fatal("SyncIndexFileSize accepted a dirty meta slot")
+	}
+}

--- a/TreeDB/pager/sync_index_data_test.go
+++ b/TreeDB/pager/sync_index_data_test.go
@@ -5,6 +5,7 @@ import (
 	"path/filepath"
 	"reflect"
 	"testing"
+	"time"
 
 	"github.com/snissn/gomap/TreeDB/page"
 )
@@ -117,6 +118,99 @@ func TestSyncIndexPagesDoesNotConsumeLaterBuilderDirtyPage(t *testing.T) {
 	}
 	if got := p.DirtyIndexPages(); !reflect.DeepEqual(got, []uint64{3}) {
 		t.Fatalf("dirty pages after prior candidate sync=%v want [3]", got)
+	}
+}
+
+func TestSyncIndexPageSnapshotDoesNotHoldPagerLockDuringDurabilityFence(t *testing.T) {
+	p, err := Open(filepath.Join(t.TempDir(), "index.db"), 64*1024)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = p.Close() }()
+	if _, err := p.Alloc(4); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := p.GetForWrite(2); err != nil {
+		t.Fatal(err)
+	}
+	if err := p.SyncIndexFileSize(); err != nil {
+		t.Fatal(err)
+	}
+	snapshot, err := p.CaptureIndexPages([]uint64{2})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer ReleaseIndexPageSnapshot(snapshot)
+
+	originalSync := syncIndexPageSnapshotFn
+	t.Cleanup(func() { syncIndexPageSnapshotFn = originalSync })
+	entered := make(chan struct{})
+	release := make(chan struct{})
+	syncIndexPageSnapshotFn = func(_ *os.File, _ uint64, _ []uint64, _ []byte) error {
+		close(entered)
+		<-release
+		return nil
+	}
+	done := make(chan error, 1)
+	go func() { done <- p.SyncIndexPageSnapshot(snapshot) }()
+	<-entered
+
+	writeDone := make(chan error, 1)
+	go func() {
+		_, err := p.GetForWrite(3)
+		writeDone <- err
+	}()
+	select {
+	case err := <-writeDone:
+		if err != nil {
+			t.Fatal(err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("GetForWrite blocked behind index durability fence")
+	}
+	close(release)
+	if err := <-done; err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestSyncIndexPageSnapshotUsesOneBarrierAndRecordsDurableSize(t *testing.T) {
+	p, err := Open(filepath.Join(t.TempDir(), "index.db"), 64*1024)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = p.Close() }()
+	if _, err := p.Alloc(4); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := p.GetForWrite(2); err != nil {
+		t.Fatal(err)
+	}
+	snapshot, err := p.CaptureIndexPages([]uint64{2})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer ReleaseIndexPageSnapshot(snapshot)
+
+	originalBarrier := syncPageFileBarrierFn
+	t.Cleanup(func() { syncPageFileBarrierFn = originalBarrier })
+	barriers := 0
+	syncPageFileBarrierFn = func(_ *os.File) error {
+		barriers++
+		return nil
+	}
+	p.durableFileSize.Store(0)
+	if err := p.SyncIndexPageSnapshot(snapshot); err != nil {
+		t.Fatal(err)
+	}
+	if barriers != 1 {
+		t.Fatalf("snapshot barriers=%d want 1", barriers)
+	}
+	p.mu.RLock()
+	want := int64(len(p.chunks)) * p.chunkSize
+	p.mu.RUnlock()
+	if got := p.durableFileSize.Load(); got < want {
+		t.Fatalf("durable file size=%d want at least %d", got, want)
 	}
 }
 

--- a/TreeDB/pager/sync_meta_page.go
+++ b/TreeDB/pager/sync_meta_page.go
@@ -1,0 +1,72 @@
+package pager
+
+import (
+	"errors"
+	"io"
+
+	"github.com/snissn/gomap/TreeDB/page"
+)
+
+// SyncMetaPageImage durably writes exactly one of the two recovery meta-page
+// images using caller-owned scratch storage. Unlike SyncPages, this dedicated
+// publication path does not build range plans or copy the pager's growing
+// chunk table. The final file data boundary retains the same stable-storage
+// semantics as ordinary page synchronization.
+func (p *Pager) SyncMetaPageImage(pageID uint64, scratch []byte) error {
+	if p == nil {
+		return errors.New("pager: nil pager")
+	}
+	if p.readOnly {
+		return ErrReadOnly
+	}
+	if len(scratch) < page.PageSize {
+		return errors.New("pager: meta-page scratch buffer too small")
+	}
+
+	p.mu.RLock()
+	localID, local := p.localPageID(pageID)
+	if !local || localID > 1 || pageID >= p.numPages.Load() {
+		p.mu.RUnlock()
+		return ErrPageOutOfBounds
+	}
+	if p.memoryOnly {
+		p.mu.RUnlock()
+		return nil
+	}
+	byteOffset := int64(localID) * int64(page.PageSize)
+	chunkIdx := int(byteOffset / p.chunkSize)
+	offsetInChunk := int(byteOffset % p.chunkSize)
+	if chunkIdx >= len(p.chunks) || offsetInChunk+page.PageSize > len(p.chunks[chunkIdx]) {
+		p.mu.RUnlock()
+		return ErrPageOutOfBounds
+	}
+	generation := p.dirtyPages[pageID]
+	copy(scratch[:page.PageSize], p.chunks[chunkIdx][offsetInChunk:offsetInChunk+page.PageSize])
+	durableSize := int64(len(p.chunks)) * p.chunkSize
+	p.mu.RUnlock()
+
+	offset := byteOffset
+	remaining := scratch[:page.PageSize]
+	for len(remaining) != 0 {
+		n, err := p.file.WriteAt(remaining, offset)
+		if err != nil {
+			return err
+		}
+		if n <= 0 {
+			return io.ErrShortWrite
+		}
+		remaining = remaining[n:]
+		offset += int64(n)
+	}
+	if err := syncPageFile(p.file); err != nil {
+		return err
+	}
+	p.recordDurableFileSize(durableSize)
+
+	p.mu.Lock()
+	if p.dirtyPages[pageID] == generation {
+		delete(p.dirtyPages, pageID)
+	}
+	p.mu.Unlock()
+	return nil
+}

--- a/TreeDB/pager/sync_meta_page_test.go
+++ b/TreeDB/pager/sync_meta_page_test.go
@@ -1,0 +1,71 @@
+package pager
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/snissn/gomap/TreeDB/page"
+)
+
+func TestSyncMetaPageImageUsesCallerBufferAndOneDataBoundary(t *testing.T) {
+	p, err := Open(filepath.Join(t.TempDir(), "index.db"), 64*1024)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = p.Close() }()
+	if _, err := p.Alloc(2); err != nil {
+		t.Fatal(err)
+	}
+	data, err := p.GetForWrite(1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for i := range data {
+		data[i] = byte(i)
+	}
+
+	originalSync := syncPageFileFn
+	t.Cleanup(func() { syncPageFileFn = originalSync })
+	syncCalls := 0
+	syncPageFileFn = func(file *os.File) error {
+		if file != p.file {
+			t.Fatalf("sync file=%p want pager file=%p", file, p.file)
+		}
+		syncCalls++
+		return nil
+	}
+	scratch := make([]byte, page.PageSize)
+	if err := p.SyncMetaPageImage(1, scratch); err != nil {
+		t.Fatal(err)
+	}
+	if syncCalls != 1 {
+		t.Fatalf("data boundaries=%d want=1", syncCalls)
+	}
+	for i, got := range scratch {
+		if want := byte(i); got != want {
+			t.Fatalf("scratch[%d]=%d want=%d", i, got, want)
+		}
+	}
+	if _, dirty := p.dirtyPages[1]; dirty {
+		t.Fatal("durable meta page remained dirty")
+	}
+}
+
+func TestSyncMetaPageImageRejectsNonMetaAndSmallScratch(t *testing.T) {
+	p, err := Open(filepath.Join(t.TempDir(), "index.db"), 64*1024)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = p.Close() }()
+	if _, err := p.Alloc(3); err != nil {
+		t.Fatal(err)
+	}
+	if err := p.SyncMetaPageImage(2, make([]byte, page.PageSize)); !errors.Is(err, ErrPageOutOfBounds) {
+		t.Fatalf("non-meta error=%v want ErrPageOutOfBounds", err)
+	}
+	if err := p.SyncMetaPageImage(0, make([]byte, page.PageSize-1)); err == nil {
+		t.Fatal("small scratch buffer succeeded")
+	}
+}

--- a/TreeDB/pager/sync_page_barrier.go
+++ b/TreeDB/pager/sync_page_barrier.go
@@ -1,0 +1,18 @@
+package pager
+
+import "os"
+
+var syncPageFileBarrierFn = syncPageFileBarrierData
+
+// syncPageFileBarrier orders phase-one index data before the later target-meta
+// write. The target meta still receives the ordinary full stable-storage sync.
+func syncPageFileBarrier(file *os.File) error {
+	if file == nil {
+		return nil
+	}
+	return syncPageFileBarrierFn(file)
+}
+
+func syncPageFileBarrierData(file *os.File) error {
+	return syncPageFile(file)
+}

--- a/TreeDB/power_loss_oracle_internal_test.go
+++ b/TreeDB/power_loss_oracle_internal_test.go
@@ -48,7 +48,7 @@ func TestPowerLossOracleSourceDeletionWaitsForStableCoverage(t *testing.T) {
 		if event.Namespace == durabilitycut.NamespaceUnlink && event.Resource == durabilitycut.ResourceCommandWAL {
 			unlinks++
 		}
-		if event.Point == durabilitycut.BeforeIndexDataSync {
+		if event.Point == durabilitycut.BeforeMetaWrite {
 			return cutErr
 		}
 		return nil

--- a/TreeDB/power_loss_oracle_internal_test.go
+++ b/TreeDB/power_loss_oracle_internal_test.go
@@ -1,155 +1,89 @@
 package treedb
 
 import (
-	"bytes"
 	"errors"
-	"strconv"
+	"os"
+	"path/filepath"
 	"testing"
 
 	backenddb "github.com/snissn/gomap/TreeDB/db"
 	"github.com/snissn/gomap/TreeDB/internal/commitlog"
 	"github.com/snissn/gomap/TreeDB/internal/durabilitycut"
-	"github.com/snissn/gomap/TreeDB/internal/powerlossoracle"
 )
 
-// TestPowerLossOracleCounterexampleSourceDeletionBeforeStableCoverage is the
-// stable witness for deleting a command-WAL source before its AppliedCommandLSN
-// coverage reaches stable metadata. Package-local access is used only to drive
-// the backend publication and cleanup sequence; the crash image is reopened
-// through the actual public TreeDB Open/read path.
-func TestPowerLossOracleCounterexampleSourceDeletionBeforeStableCoverage(t *testing.T) {
+// TestPowerLossOracleSourceDeletionWaitsForStableCoverage is the converted
+// witness for the former source-deletion counterexample. Cleanup must consume
+// durable AppliedCommandLSN coverage, never a merely visible candidate.
+func TestPowerLossOracleSourceDeletionWaitsForStableCoverage(t *testing.T) {
 	dir := t.TempDir()
-	opts := Options{
+	d, err := Open(Options{
 		Dir:                    dir,
 		CommandWAL:             true,
 		Durability:             DurabilityDurable,
 		DisableBackgroundPrune: true,
-	}
-	d, err := Open(opts)
+	})
 	if err != nil {
-		t.Fatalf("open command-WAL fixture: %v", err)
+		t.Fatal(err)
 	}
-	closed := false
-	defer func() {
-		if !closed {
-			_ = d.Close()
-		}
-	}()
-	key := []byte("cleanup/acknowledged")
-	value := []byte("durable-command-value")
+	defer func() { _ = d.Close() }()
+
 	lsn, err := d.backend.AppendRawKVSingleCommandWAL(commitlog.RawKVOperation{
-		Op:    commitlog.RawKVOpSet,
-		Key:   key,
-		Value: value,
+		Op: commitlog.RawKVOpSet, Key: []byte("cleanup/acknowledged"), Value: []byte("durable-command-value"),
 	}, true)
 	if err != nil || lsn == 0 {
-		t.Fatalf("append synced command-WAL frame: lsn=%d err=%v", lsn, err)
+		t.Fatalf("append synced command frame: lsn=%d err=%v", lsn, err)
 	}
 	if err := d.backend.RotateCommandWALActiveSegment(true); err != nil {
-		t.Fatalf("rotate synced command-WAL segment: %v", err)
+		t.Fatal(err)
 	}
-	baseline := d.backend.State()
-	if baseline == nil {
-		t.Fatal("missing baseline state")
+	segments, err := filepath.Glob(filepath.Join(dir, "*", "wal", "commit-*.log"))
+	if err != nil || len(segments) < 2 {
+		t.Fatalf("rotated command-WAL segments=%v err=%v", segments, err)
 	}
-	model, err := powerlossoracle.Capture(dir)
-	if err != nil {
-		t.Fatalf("capture stable command-WAL image: %v", err)
-	}
+	source := segments[0]
 
-	cutErr := errors.New("power-loss-oracle: stop after actual deletion directory sync")
-	var snapshot *powerlossoracle.Model
-	var deletionSync durabilitycut.Event
+	cutErr := errors.New("power-loss-oracle: pre-meta publication stall")
+	var unlinks int
 	restore := durabilitycut.Install(func(event durabilitycut.Event) error {
-		if err := model.Observe(dir, event); err != nil {
-			return err
+		if event.Namespace == durabilitycut.NamespaceUnlink && event.Resource == durabilitycut.ResourceCommandWAL {
+			unlinks++
 		}
-		if event.Point == durabilitycut.AfterDeletionDirectorySync && event.Resource == durabilitycut.ResourceCommandWAL {
-			deletionSync = event
-			snapshot = model.Clone()
+		if event.Point == durabilitycut.BeforeIndexDataSync {
 			return cutErr
 		}
 		return nil
 	})
 	if err := d.backend.PublishCommandWALAppliedLSN(lsn, []backenddb.CommandWALLSNRange{{First: lsn, Last: lsn}}, false); err != nil {
 		restore()
-		t.Fatalf("publish unsynced AppliedCommandLSN: %v", err)
+		t.Fatalf("publish visible AppliedCommandLSN: %v", err)
 	}
-	err = d.backend.CleanupCommandWALCoveredSegments(true)
+	if err := d.backend.Checkpoint(); !errors.Is(err, backenddb.ErrPublicationStalled) {
+		restore()
+		t.Fatalf("checkpoint during pre-meta stall err=%v", err)
+	}
+	if err := d.backend.CleanupCommandWALCoveredSegments(true); err != nil {
+		restore()
+		t.Fatalf("cleanup against durable coverage: %v", err)
+	}
+	if unlinks != 0 {
+		restore()
+		t.Fatalf("cleanup unlinked %d command-WAL sources before stable AppliedCommandLSN coverage", unlinks)
+	}
+	if _, err := os.Stat(source); err != nil {
+		restore()
+		t.Fatalf("stable command-WAL source removed before meta coverage: %v", err)
+	}
 	restore()
-	if !errors.Is(err, cutErr) || snapshot == nil || deletionSync.Path == "" {
-		t.Fatalf("actual deletion-directory cut err=%v path=%q", err, deletionSync.Path)
-	}
-	if err := d.Close(); err != nil {
-		t.Fatalf("close source fixture: %v", err)
-	}
-	closed = true
 
-	crashDir := t.TempDir()
-	if err := snapshot.MaterializeStable(crashDir); err != nil {
-		t.Fatalf("materialize stable-only image: %v", err)
+	// A later explicit boundary retries the pre-meta stall. Once coverage is in
+	// stable metadata, ordinary cleanup may remove the covered source.
+	if err := d.backend.Checkpoint(); err != nil {
+		t.Fatalf("retry publication: %v", err)
 	}
-	reopenOpts := opts
-	reopenOpts.Dir = crashDir
-	reopenOpts.ReadOnly = true
-	reopened, openErr := Open(reopenOpts)
-	if openErr != nil {
-		t.Logf("public TreeDB.Open rejected image after early actual WAL deletion: %v", openErr)
-		return
+	if err := d.backend.CleanupCommandWALCoveredSegments(true); err != nil {
+		t.Fatalf("cleanup after stable coverage: %v", err)
 	}
-	defer reopened.Close()
-	got, getErr := reopened.Get(key)
-	if getErr == nil && bytes.Equal(got, value) {
-		t.Fatalf("public TreeDB.Open/read recovered acknowledged command after its only stable source was deleted")
+	if _, err := os.Stat(source); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("covered command-WAL source still present after stable coverage: %v", err)
 	}
-	stats := reopened.Stats()
-	openedSequence, err := strconv.ParseUint(stats["treedb.commit_seq"], 10, 64)
-	if err != nil {
-		t.Fatalf("parse reopened commit sequence: %v", err)
-	}
-	openedApplied, err := strconv.ParseUint(stats["treedb.applied_command_lsn"], 10, 64)
-	if err != nil {
-		t.Fatalf("parse reopened applied LSN: %v", err)
-	}
-	generation := powerLossCompleteGeneration(baseline.CommitSeq, baseline.AppliedCommandLSN)
-	for i := range generation.Resources {
-		if generation.Resources[i].Kind == powerlossoracle.ResourceCommandWAL {
-			generation.Resources[i].ID = deletionSync.Path
-		}
-	}
-	scenario := powerlossoracle.Scenario{
-		Name:                 "actual-source-deletion-before-stable-coverage",
-		Cut:                  powerlossoracle.AfterDeletionDirectorySync,
-		Generations:          []powerlossoracle.Generation{generation},
-		LatestSealedSequence: baseline.CommitSeq,
-		SelectedSequence:     openedSequence,
-		OpenedSequence:       openedSequence,
-		OpenedAppliedLSN:     openedApplied,
-		RemovedResources: []powerlossoracle.Resource{{
-			Kind: powerlossoracle.ResourceCommandWAL,
-			ID:   deletionSync.Path,
-		}},
-		ReopenAttempted: true,
-	}
-	if err := powerlossoracle.RequireViolation(scenario.Validate(), powerlossoracle.InvariantEarlySourceDeletion); err != nil {
-		t.Fatalf("successful public Open did not produce early-source-deletion diagnosis: %v (value=%q get=%v)", err, got, getErr)
-	}
-}
-
-func powerLossCompleteGeneration(sequence, applied uint64) powerlossoracle.Generation {
-	kinds := []powerlossoracle.ResourceKind{
-		powerlossoracle.ResourceIndex,
-		powerlossoracle.ResourceFreelist,
-		powerlossoracle.ResourceValueLog,
-		powerlossoracle.ResourceOuterLeaf,
-		powerlossoracle.ResourceAuxiliary,
-		powerlossoracle.ResourceDirectory,
-		powerlossoracle.ResourceSeal,
-		powerlossoracle.ResourceCommandWAL,
-	}
-	resources := make([]powerlossoracle.Resource, 0, len(kinds))
-	for _, kind := range kinds {
-		resources = append(resources, powerlossoracle.Resource{Kind: kind, ID: string(kind), Stable: true, Live: true})
-	}
-	return powerlossoracle.Generation{Sequence: sequence, Recoverable: true, Resources: resources, AppliedLSN: applied}
 }

--- a/TreeDB/power_loss_oracle_test.go
+++ b/TreeDB/power_loss_oracle_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/snissn/gomap/TreeDB/internal/powerlossoracle"
 	"github.com/snissn/gomap/TreeDB/internal/powerlossreopen"
 	"github.com/snissn/gomap/TreeDB/internal/valuelog"
+	"github.com/snissn/gomap/TreeDB/page"
 )
 
 const powerLossOracleSeed = uint64(3674)
@@ -156,6 +157,7 @@ func TestPowerLossOracleEnumerateCutPoints(t *testing.T) {
 	}
 	restore := durabilitycut.Install(func(event durabilitycut.Event) error {
 		if err := model.Observe(dir, event); err != nil {
+			t.Logf("power-loss oracle observe point=%s resource=%s path=%s: %v", event.Point, event.Resource, event.Path, err)
 			return err
 		}
 		if event.Point == durabilitycut.AfterDependencyAppend && (event.Resource == durabilitycut.ResourceValueLog || event.Resource == durabilitycut.ResourceOuterLeaf) {
@@ -293,9 +295,11 @@ func TestPowerLossOracleEnumerateCutPoints(t *testing.T) {
 	}
 }
 
-// This family is the stable witness for finalizeCommitLockedWithOptions and
-// flushFinalizeCommitDurability publishing meta ahead of dependency closure.
-func TestPowerLossOracleCounterexampleNewMetaMissingClosure(t *testing.T) {
+// This is the converted witness for the former relaxed meta-before-closure
+// counterexample. The coordinator must make the complete dependency/index
+// closure stable before attempting meta, and an unsynced target meta must leave
+// the previous durable root authoritative after a crash.
+func TestPowerLossOracleNewMetaCutKeepsPreviousRootAuthoritative(t *testing.T) {
 	dir := t.TempDir()
 	opts := powerLossOptions(dir)
 	opts.Durability = treedb.DurabilityWALOffRelaxed
@@ -340,97 +344,23 @@ func TestPowerLossOracleCounterexampleNewMetaMissingClosure(t *testing.T) {
 	}
 	err = db.Checkpoint()
 	restore()
-	if !errors.Is(err, cutErr) || snapshot == nil {
+	if snapshot == nil || (!errors.Is(err, cutErr) && !errors.Is(err, treedb.ErrRecoveryRequired)) {
 		t.Fatalf("actual relaxed finalize did not stop at AfterMetaWrite: err=%v", err)
 	}
+	if meta.Path == "" || meta.Length != int64(page.PageSize) {
+		t.Fatalf("meta cut omitted exact target range: %+v", meta)
+	}
 	_ = db.Close()
-	relIndex, err := filepath.Rel(dir, meta.Path)
+	result, reopened, closeFn, err := powerlossreopen.Stable(snapshot, opts, false)
 	if err != nil {
 		t.Fatal(err)
 	}
-	changed, err := snapshot.ChangedRanges(relIndex)
-	if err != nil {
-		t.Fatal(err)
+	defer func() { _ = closeFn() }()
+	if result.Rejected || result.CommitSeq != baseSequence {
+		t.Fatalf("pre-sync meta cut selected commit=%d rejected=%t err=%v; want prior durable=%d", result.CommitSeq, result.Rejected, result.Err, baseSequence)
 	}
-	if len(changed) == 0 {
-		t.Fatal("actual relaxed finalize changed no index bytes")
-	}
-
-	images := map[powerlossoracle.ResourceKind]*powerlossoracle.Model{}
-	missingIndex := snapshot.Clone()
-	if err := missingIndex.PromoteRange(relIndex, meta.Offset, meta.Length); err != nil {
-		t.Fatal(err)
-	}
-	images[powerlossoracle.ResourceIndex] = missingIndex
-	missingVlog := snapshot.Clone()
-	for _, r := range changed {
-		if err := missingVlog.PromoteRange(relIndex, r.Offset, r.Length); err != nil {
-			t.Fatal(err)
-		}
-	}
-	images[powerlossoracle.ResourceValueLog] = missingVlog
-	missingOuter := missingVlog.Clone()
-	leafChanged := false
-	for _, path := range missingOuter.VolatilePaths() {
-		if strings.HasPrefix(filepath.ToSlash(path), "leaf_vlog/") {
-			ranges, err := missingOuter.ChangedRanges(path)
-			if err != nil {
-				t.Fatal(err)
-			}
-			leafChanged = leafChanged || len(ranges) > 0
-		}
-		if strings.Contains(path, "value_vlog") {
-			if err := missingOuter.SyncFile(path); err != nil {
-				t.Fatal(err)
-			}
-		}
-	}
-	if !leafChanged {
-		t.Fatal("actual fixture generated no changed outer-leaf record")
-	}
-	images[powerlossoracle.ResourceOuterLeaf] = missingOuter
-
-	for _, missing := range []powerlossoracle.ResourceKind{
-		powerlossoracle.ResourceIndex,
-		powerlossoracle.ResourceValueLog,
-		powerlossoracle.ResourceOuterLeaf,
-	} {
-		missing := missing
-		t.Run(string(missing), func(t *testing.T) {
-			result, _, closeFn, err := powerlossreopen.Stable(images[missing], opts, false)
-			if err != nil {
-				t.Fatal(err)
-			}
-			defer func() { _ = closeFn() }()
-			dependencyPaths := make([]string, 0)
-			for _, path := range images[missing].VolatilePaths() {
-				slashed := filepath.ToSlash(path)
-				if strings.Contains(slashed, "value_vlog/") || strings.Contains(slashed, "leaf_vlog/") {
-					dependencyPaths = append(dependencyPaths, filepath.Join(dir, filepath.FromSlash(path)))
-				}
-			}
-			newResources, err := observedPowerLossClosure(images[missing], dir, meta.Path, dependencyPaths, true, 0, false)
-			if err != nil {
-				t.Fatalf("derive actual %s closure: %v", missing, err)
-			}
-			scenario := powerlossoracle.Scenario{
-				Name:                 "actual-new-meta-missing-" + string(missing),
-				Cut:                  powerlossoracle.AfterMetaWrite,
-				LatestSealedSequence: baseSequence + 1,
-				SelectedSequence:     result.CommitSeq,
-				OpenedSequence:       result.CommitSeq,
-				OpenedAppliedLSN:     result.AppliedLSN,
-				ReopenAttempted:      true,
-				ReopenRejected:       result.Rejected,
-				Generations: []powerlossoracle.Generation{
-					{Sequence: baseSequence, Recoverable: true, Resources: completePowerLossClosure("old")},
-					{Sequence: baseSequence + 1, Recoverable: true, Resources: newResources},
-				},
-			}
-			if err := powerlossoracle.RequireViolation(scenario.Validate(), powerlossoracle.InvariantIncompleteRecoverableRoot); err != nil {
-				t.Fatalf("actual %s image did not produce named diagnosis: %v (open=%v)", missing, err, result.Err)
-			}
-		})
+	if value, err := reopened.Get([]byte("new/pointer/000")); err == nil && len(value) != 0 {
+		t.Fatalf("pre-sync meta cut exposed the new root value=%q", value)
 	}
 }
 
@@ -536,9 +466,9 @@ func TestPowerLossOracleCounterexampleRelaxedCommandFrameMissingRID(t *testing.T
 	}
 }
 
-// This family is the stable witness for Checkpoint, flushSyncRequested, and
-// chunked cached flush apply exposing an intermediate incomplete root.
-func TestPowerLossOracleCounterexampleChunkedSyncIntermediateRoot(t *testing.T) {
+// Chunked checkpoint application may prepare several visible candidates, but
+// an unsynced target meta can never expose an intermediate root after crash.
+func TestPowerLossOracleChunkedSyncMetaCutKeepsPreviousRoot(t *testing.T) {
 	dir := t.TempDir()
 	opts := powerLossOptions(dir)
 	opts.Durability = treedb.DurabilityWALOffRelaxed
@@ -553,10 +483,12 @@ func TestPowerLossOracleCounterexampleChunkedSyncIntermediateRoot(t *testing.T) 
 	if err := db.Checkpoint(); err != nil {
 		t.Fatal(err)
 	}
+	baseSequence := publicCommitSequence(t, db)
 	model, err := powerlossoracle.Capture(dir)
 	if err != nil {
 		t.Fatal(err)
 	}
+	requirePublicReopen(t, model, opts, false)
 	for i := 0; i < 64; i++ {
 		if err := db.Set([]byte(fmt.Sprintf("chunk/%03d", i)), []byte(fmt.Sprintf("value-%03d", i))); err != nil {
 			t.Fatal(err)
@@ -577,60 +509,32 @@ func TestPowerLossOracleCounterexampleChunkedSyncIntermediateRoot(t *testing.T) 
 	})
 	err = db.Checkpoint()
 	restore()
-	if !errors.Is(err, cutErr) || snapshot == nil {
+	if snapshot == nil || (!errors.Is(err, cutErr) && !errors.Is(err, treedb.ErrRecoveryRequired)) {
 		t.Fatalf("actual chunk checkpoint cut err=%v", err)
 	}
+	if meta.Path == "" || meta.Length != int64(page.PageSize) {
+		t.Fatalf("meta cut omitted exact target range: %+v", meta)
+	}
 	_ = db.Close()
-	rel, err := filepath.Rel(dir, meta.Path)
-	if err != nil {
-		t.Fatal(err)
-	}
-	ranges, err := snapshot.ChangedRanges(rel)
-	if err != nil {
-		t.Fatal(err)
-	}
-	for _, r := range ranges {
-		if err := snapshot.PromoteRange(rel, r.Offset, r.Length); err != nil {
-			t.Fatal(err)
-		}
-	}
 	result, reopened, closeFn, err := powerlossreopen.Stable(snapshot, opts, false)
 	if err != nil {
 		t.Fatal(err)
 	}
 	defer func() { _ = closeFn() }()
 	if result.Rejected {
-		t.Logf("public Open rejected actual intermediate chunk image: %v", result.Err)
-		return
+		t.Fatalf("public Open rejected previous durable root: %v", result.Err)
 	}
-	first, firstErr := reopened.Get([]byte("chunk/000"))
-	if firstErr != nil || !bytes.Equal(first, []byte("value-000")) {
-		t.Fatalf("actual cut selected the wholly old root instead of an intermediate chunk: first=%q err=%v commit=%d", first, firstErr, result.CommitSeq)
+	if result.CommitSeq != baseSequence {
+		t.Fatalf("pre-sync meta cut selected commit=%d want previous durable=%d", result.CommitSeq, baseSequence)
 	}
-	expected := map[string]map[string]string{"chunk/": {}}
-	observed := map[string]map[string]string{"chunk/": {}}
+	if value, err := reopened.Get([]byte("stable/old")); err != nil || !bytes.Equal(value, []byte("old-value")) {
+		t.Fatalf("previous durable key=%q err=%v commit=%d want=%d", value, err, result.CommitSeq, baseSequence)
+	}
 	for i := 0; i < 64; i++ {
 		key := fmt.Sprintf("chunk/%03d", i)
-		value := fmt.Sprintf("value-%03d", i)
-		expected["chunk/"][key] = value
-		if got, err := reopened.Get([]byte(key)); err == nil {
-			observed["chunk/"][key] = string(got)
+		if got, err := reopened.Get([]byte(key)); err == nil && len(got) != 0 {
+			t.Fatalf("pre-sync meta cut exposed chunk key %q=%q", key, got)
 		}
-	}
-	scenario := powerlossoracle.Scenario{
-		Name:                      "actual-chunked-sync-intermediate-root",
-		Cut:                       powerlossoracle.AfterMetaWrite,
-		Generations:               []powerlossoracle.Generation{{Sequence: result.CommitSeq, Recoverable: true, Resources: completePowerLossClosure("chunk"), AppliedLSN: result.AppliedLSN}},
-		LatestSealedSequence:      result.CommitSeq,
-		SelectedSequence:          result.CommitSeq,
-		OpenedSequence:            result.CommitSeq,
-		OpenedAppliedLSN:          result.AppliedLSN,
-		ExpectedKeyValuesByPrefix: expected,
-		ObservedKeyValuesByPrefix: observed,
-		ReopenAttempted:           true,
-	}
-	if err := powerlossoracle.RequireViolation(scenario.Validate(), powerlossoracle.InvariantKeyStateMismatch); err != nil {
-		t.Fatalf("successful public Open did not produce intermediate-root diagnosis: %v", err)
 	}
 }
 

--- a/TreeDB/profile_fast_checkpoint_consistency_test.go
+++ b/TreeDB/profile_fast_checkpoint_consistency_test.go
@@ -142,7 +142,7 @@ func TestProfileFast_SetSyncRemainsVisibleAndPersistsAfterCheckpoint(t *testing.
 	assertCheckpointConsistencyLiveSet(t, db, live)
 }
 
-func TestProfileFast_SetSyncDefersBackendCommitUntilCheckpoint(t *testing.T) {
+func TestProfileFast_SetSyncPublishesExactDurableRoot(t *testing.T) {
 	opts := OptionsFor(ProfileFast, t.TempDir())
 	opts.ValueLog.ForcePointers = true
 	opts.ValueLog.PointerThreshold = 1
@@ -184,20 +184,19 @@ func TestProfileFast_SetSyncDefersBackendCommitUntilCheckpoint(t *testing.T) {
 	if err != nil {
 		t.Fatalf("parse commit_seq after sync: %v", err)
 	}
-	if commitSeqAfterSync != commitSeqBefore {
-		t.Fatalf("commit_seq after SetSync=%d want %d before checkpoint", commitSeqAfterSync, commitSeqBefore)
+	if commitSeqAfterSync <= commitSeqBefore {
+		t.Fatalf("commit_seq after SetSync=%d want > %d", commitSeqAfterSync, commitSeqBefore)
 	}
-
-	if err := db.Checkpoint(); err != nil {
-		t.Fatalf("Checkpoint: %v", err)
-	}
-
-	commitSeqAfterCheckpoint, err := strconv.ParseUint(db.Stats()["treedb.commit_seq"], 10, 64)
+	visibleSeq, err := strconv.ParseUint(db.Stats()["treedb.publication.visible_commit_seq"], 10, 64)
 	if err != nil {
-		t.Fatalf("parse commit_seq after checkpoint: %v", err)
+		t.Fatalf("parse visible_commit_seq after sync: %v", err)
 	}
-	if commitSeqAfterCheckpoint <= commitSeqAfterSync {
-		t.Fatalf("commit_seq after checkpoint=%d want > %d", commitSeqAfterCheckpoint, commitSeqAfterSync)
+	durableSeq, err := strconv.ParseUint(db.Stats()["treedb.publication.durable_commit_seq"], 10, 64)
+	if err != nil {
+		t.Fatalf("parse durable_commit_seq after sync: %v", err)
+	}
+	if visibleSeq != commitSeqAfterSync || durableSeq < commitSeqAfterSync {
+		t.Fatalf("SetSync sequences visible=%d durable=%d commit=%d", visibleSeq, durableSeq, commitSeqAfterSync)
 	}
 
 	if err := db.Close(); err != nil {

--- a/TreeDB/tree/tree.go
+++ b/TreeDB/tree/tree.go
@@ -439,7 +439,7 @@ func (t *Tree) loadLeafLogNodeViewInto(dst *node.Node, ptr page.LogRecordRef, it
 		data, err = t.slabReader.ReadUnsafe(ptr.ValuePtr())
 	}
 	if err != nil {
-		return err
+		return fmt.Errorf("read leaf-log ref file=%d offset=%d length=%d: %w", ptr.FileID, ptr.Offset, ptr.RecordLength(), err)
 	}
 	verifiedNow, err := validateLeafLogNodeIntoWithState(dst, data, ptr, t.shouldVerifyLeafRefChecksum(), iterator, state)
 	if err != nil {


### PR DESCRIPTION
Closes #3675 only after every acceptance and performance gate is satisfied.

Parent: #1595
Depends on: #3674 (merged in #3706)

## Summary

- introduces a single dependency-closed `RootPublicationCoordinator` with distinct visible, durable, and oldest-recoverable commit state
- routes ordinary, ordered-root, command-WAL, no-op LSN, checkpoint, and maintenance publication through immutable prepared candidates
- preserves exact dependency -> index-data -> alternate-meta ordering, with pre-meta stalls and post-meta poison semantics
- bounds publication debt at 256 MiB and 4096 commits and exposes publication/waiter statistics
- seals exact index page images and allocator state so foreground builders may resume without corrupting the recovery closure
- retains both alternating recovery closures until later graph children add the final recovery seal and copy-on-write freelist protocol

## Latest-head correctness evidence

Head: `64b93307f1a2bd86dd0ee77d68ddc642ecef5f39`

Passed:

```text
go test ./TreeDB/db ./TreeDB/caching ./TreeDB ./TreeDB/collections -count=1 -timeout=30m
go test ./TreeDB/db -run '^TestPublishOrderedRootDeltaBatchGroupWithSystemDeltaBuilder_OptimisticPreservesConcurrentUserRootWrite$' -count=100
go test ./TreeDB/collections -run '^(TestColumnStoreReplayReconstructsRetainedPayloadM13C|TestColumnStoreCommandWALReplayPublishesMutationAssetsM12C|TestColumnStoreReplayIntentBypassesRelaxedDurabilityGateM10C|TestColumnRetainedPayloadValueLogPlacementGCRewrite)$' -count=10
go test -race ./TreeDB/internal/raftapply -run '^TestCollectionMutationCommandWALReplayHandlers$' -count=10
go test -race ./TreeDB/db -run '^(TestPublishOrderedRootDeltaBatchGroupWithSystemDeltaBuilder_OptimisticPreservesConcurrentUserRootWrite|TestCommandWAL.*Recovery.*|TestRootPublication.*)$' -count=3
go test -race ./TreeDB/pager -run '^TestSyncMetaPageImage' -count=3
go test -race ./TreeDB/db -run '^(TestRootPublication|TestValueLogRewriteOnline|TestLeafGenerationPack_RetryExhaustionDoesNotLeakCommittedPages|TestValueLogGCRescansWhenRecoveryMetaSlotsRotate|TestVacuumRaceMissingKey)' -count=3
go test -race ./TreeDB -run '^(TestPowerLossOracleSourceDeletionWaitsForStableCoverage|TestWriteReadVisibilityLargeBatchPaths)$' -count=3
go vet ./TreeDB/...
make fmt
git diff --check
```

The latest exact full suite completed in 254.712s (`db`), 98.061s (`caching`), 136.224s (`TreeDB`), and 307.408s (`collections`). The latest head also joins asynchronous root publication before recovery cleanup/open initialization, removes an RWMutex writer-preference deadlock exposed on macOS, and updates retained-value-log coverage for the issue's conservative two-meta recovery closure.

## Performance evidence and current blocker

Same host/filesystem: Apple M3, Darwin arm64, identical working directory family and benchmark commands, 10 samples.

The public cached and command-WAL matrix completed successfully. Allocation gates for `BenchmarkWriteParallel` pass, but relaxed throughput does not:

| Workers | Baseline median | This head median | Throughput retention |
| --- | ---: | ---: | ---: |
| G=1 | ~82.2 us/op | ~130 us/op | ~63% |
| G=2 | ~41.5 us/op | ~69 us/op | ~60% |
| G=4 | ~21.2 us/op | ~35 us/op | ~61% |
| G=8 | ~11.0 us/op | ~19.6 us/op | ~56% |

Diagnostic evidence:

- ordinary relaxed callers perform no caller-waited stable sync
- publication is already grouped at roughly 45-58 commits per meta sync
- bypassing only durable publication restores approximately 84/41/21/10.8 us/op, effectively the baseline
- profiles place the regression in the two required Darwin stable-storage boundaries; baseline relaxed writes do not perform an equivalent stable publication boundary
- removing either ordering edge or adding a configured batching delay would violate the fixed issue protocol

Per the issue's explicit rule that any performance miss keeps it open, this PR remains draft and must not merge yet. The requested review question is whether a protocol-preserving cheaper durable ordering primitive exists, or whether the performance comparison needs an equivalent-durability baseline/contract correction.

## Review status

- independent correctness/corruption-path review completed locally
- independent performance review confirmed the durability-semantics mismatch and found lock contention secondary
- CodeRabbit passed on the latest head; Codex/Copilot review and latest-head CI remain pending
