### PR TITLE
bench(treedb): report detailed leaf-pack apply stages

### DIFF
--- a/TreeDB/db/compact_storage_bench_test.go
+++ b/TreeDB/db/compact_storage_bench_test.go
@@ -12,6 +12,10 @@ func BenchmarkCompactStorageLeafPackMultiPass(b *testing.B) {
 	var liveScans, packPasses atomic.Uint64
 	var packPhaseNanos, packApplyNanos, packCopyNanos int64
 	var packPublishWaitNanos, packPublishHoldNanos int64
+	var packSetupNanos, packTreeRewriteNanos, packLeafSyncNanos, packCopyCloseNanos int64
+	var packRevalidateNanos, packPromotionNanos, packRelocationNanos, packPageSyncNanos int64
+	var packDirectorySyncNanos, packDirectorySyncWaitNanos, packRegistrationNanos int64
+	var packCollectionPublishNanos, packFinalizeNanos, packPostWorkNanos, packCleanupNanos int64
 	unregister := registerLeafGenerationLiveScanHook(func() { liveScans.Add(1) })
 	defer unregister()
 
@@ -56,6 +60,22 @@ func BenchmarkCompactStorageLeafPackMultiPass(b *testing.B) {
 			packCopyNanos += pack.Pack.CopyTimeNanos
 			packPublishWaitNanos += pack.Pack.PublishWaitNanos
 			packPublishHoldNanos += pack.Pack.PublishHoldNanos
+			stages := pack.Pack.ApplyStages
+			packSetupNanos += stages.SetupTimeNanos
+			packTreeRewriteNanos += stages.TreeRewriteTimeNanos
+			packLeafSyncNanos += stages.LeafSyncTimeNanos
+			packCopyCloseNanos += stages.CopyCloseTimeNanos
+			packRevalidateNanos += stages.RevalidateTimeNanos
+			packPromotionNanos += stages.PromotionTimeNanos
+			packRelocationNanos += stages.RelocationTimeNanos
+			packPageSyncNanos += stages.PageSyncTimeNanos
+			packDirectorySyncNanos += stages.DirectorySyncTimeNanos
+			packDirectorySyncWaitNanos += stages.DirectorySyncWaitTimeNanos
+			packRegistrationNanos += stages.RegistrationTimeNanos
+			packCollectionPublishNanos += stages.CollectionPublishTimeNanos
+			packFinalizeNanos += stages.FinalizeTimeNanos
+			packPostWorkNanos += stages.PostWorkTimeNanos
+			packCleanupNanos += stages.CleanupTimeNanos
 		}
 		db.compactStorageAfterPhase = nil
 		if err := db.Close(); err != nil {
@@ -71,6 +91,21 @@ func BenchmarkCompactStorageLeafPackMultiPass(b *testing.B) {
 		b.ReportMetric(float64(packCopyNanos)/float64(b.N), "pack_copy_ns/op")
 		b.ReportMetric(float64(packPublishWaitNanos)/float64(b.N), "pack_publish_wait_ns/op")
 		b.ReportMetric(float64(packPublishHoldNanos)/float64(b.N), "pack_publish_hold_ns/op")
+		b.ReportMetric(float64(packSetupNanos)/float64(b.N), "pack_setup_ns/op")
+		b.ReportMetric(float64(packTreeRewriteNanos)/float64(b.N), "pack_tree_rewrite_ns/op")
+		b.ReportMetric(float64(packLeafSyncNanos)/float64(b.N), "pack_leaf_sync_ns/op")
+		b.ReportMetric(float64(packCopyCloseNanos)/float64(b.N), "pack_copy_close_ns/op")
+		b.ReportMetric(float64(packRevalidateNanos)/float64(b.N), "pack_revalidate_ns/op")
+		b.ReportMetric(float64(packPromotionNanos)/float64(b.N), "pack_promotion_ns/op")
+		b.ReportMetric(float64(packRelocationNanos)/float64(b.N), "pack_relocation_ns/op")
+		b.ReportMetric(float64(packPageSyncNanos)/float64(b.N), "pack_page_sync_ns/op")
+		b.ReportMetric(float64(packDirectorySyncNanos)/float64(b.N), "pack_directory_sync_ns/op")
+		b.ReportMetric(float64(packDirectorySyncWaitNanos)/float64(b.N), "pack_directory_sync_wait_ns/op")
+		b.ReportMetric(float64(packRegistrationNanos)/float64(b.N), "pack_registration_ns/op")
+		b.ReportMetric(float64(packCollectionPublishNanos)/float64(b.N), "pack_collection_publish_ns/op")
+		b.ReportMetric(float64(packFinalizeNanos)/float64(b.N), "pack_finalize_ns/op")
+		b.ReportMetric(float64(packPostWorkNanos)/float64(b.N), "pack_post_work_ns/op")
+		b.ReportMetric(float64(packCleanupNanos)/float64(b.N), "pack_cleanup_ns/op")
 	}
 }
 


### PR DESCRIPTION
## Summary

- report every structured leaf-pack `ApplyStages` field from `BenchmarkCompactStorageLeafPackMultiPass`
- retain all existing coarse metrics and the byte-identical fixture
- make the #3715 root-cause stop decision reproducible without changing production behavior

Refs #3715. This PR intentionally does not close the issue: current evidence disproves the proposed relocation optimization's ability to meet the production performance gate.

## Root-Cause Evidence

Base production code: `d1b2d909ee6a1fd409d63ef895245c04b0f1376f`  
Instrumentation head: `38211ae0e`  
Benchmark source SHA-256: `95bc5f1c4a6778583fb9a52b6d4cb4e7f7e04030a78ef24d8ea9f1a0cfe9f63a`

```sh
GOWORK=off GOMEMLIMIT=4GiB GOMAXPROCS=1 go test -c -o db-detailed.test ./TreeDB/db
taskset -c 2 env GOWORK=off GOMEMLIMIT=4GiB GOMAXPROCS=1 \
  ./db-detailed.test -test.run '^$' \
  -test.bench '^BenchmarkCompactStorageLeafPackMultiPass$' \
  -test.benchtime=3x -test.count=6 -test.benchmem
```

Host: 11th Gen Intel Core i5-11400F, Linux amd64, CPU 2, `GOMAXPROCS=1`.

| Metric | Six-sample median |
| --- | ---: |
| pack apply | 82.90 ms/op |
| tree rewrite | 0.944 ms/op |
| relocation | 0.058 ms/op |
| tree rewrite + relocation | 1.002 ms/op (~1.2% of apply) |
| leaf sync | 29.82 ms/op |
| page sync | 37.17 ms/op |
| finalize | 14.52 ms/op |

Relocation is measurable but cannot deliver #3715's >=10% apply reduction even if eliminated entirely. The proposed production patch was stopped and discarded under the issue's root-cause gate. Durability barriers dominate and are outside this PR's ownership.

Raw output: `/mnt/fast4tb/gomap-3715-baseline/root-cause-six-samples.txt` on the benchmark host.

## Validation

```sh
GOWORK=off GOMEMLIMIT=4GiB GOMAXPROCS=2 go test -p 1 ./TreeDB/db \
  -run 'TestLeafGenerationPack|TestCompactStorage.*LeafPack' -count=1
```

Result: `ok github.com/snissn/gomap/TreeDB/db 9.333s`.

## Risk

Benchmark-only reporting change. It reads existing stats, adds no production state, and preserves all prior metric names.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced compact storage benchmarking with detailed timing metrics for individual leaf-packing stages.
  * Benchmark reports now provide greater visibility into processing, synchronization, promotion, cleanup, and related operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->