### PR TITLE
feat(typedcolumn): add query-ready base generations

### DIFF
--- a/TreeDB/docs/spec/storage-format.md
+++ b/TreeDB/docs/spec/storage-format.md
@@ -133,6 +133,78 @@ version iterators cannot surface it as a logical record. The zero marker plus
 `M` identifies metadata and leaves nonzero codec version markers available for
 future versioned-key formats.
 
+## 1.2 Query-Ready Typed-Column Base Generation V1
+
+A query-ready base generation (`QRBG` V1) is a rebuildable, non-authoritative
+container for a snapshot-visible set of immutable typed-column part images. It
+is a local derived format: it is not an index root, WAL record, recovery
+selector, primary document store, or GC/rewrite owner. Until the authoritative
+asset-root lifecycle publishes this format, the embedded typed-column images
+remain the recoverable source state and a missing QRBG may be rebuilt.
+
+All integer fields are little-endian. The 80-byte header is:
+
+```text
+offset  size  field
+0       4     magic = "QRBG" (bytes 51 52 42 47)
+4       2     version = 1
+6       2     reserved = 0
+8       8     exact base generation (nonzero)
+16      32    exact collection schema SHA-256 (nonzero)
+48      4     part count
+52      4     header CRC-32C
+56      4     part-table CRC-32C
+60      4     reserved = 0
+64      8     payload offset
+72      8     total container bytes
+```
+
+The header checksum is CRC-32C (Castagnoli) over all 80 header bytes with
+bytes `[52,56)` zeroed. The table checksum is CRC-32C over exactly
+`part_count * 80` bytes beginning at offset 80.
+
+Each 80-byte part-table entry is:
+
+```text
+offset  size  field
+0       8     source generation
+8       8     typed-column part ID
+16      8     embedded image offset
+24      8     embedded image byte length
+32      8     row count
+40      8     typed-column manifest byte length
+48      32    SHA-256 of the complete embedded image
+```
+
+Entries are strictly ordered by `(source generation, part ID)`. Source
+generations are nonzero and cannot exceed the header's base generation;
+duplicate identities are invalid. Entry row count, part ID, and manifest length
+must exactly match the embedded typed-column image metadata.
+
+The payload begins at `payload_offset`, aligned to 4096 bytes. Every embedded
+image begins at the typed-column image section alignment. Bytes between the
+part table and payload, and between embedded images, must be zero. Images may
+not overlap or extend beyond `total_container_bytes`; that field must equal the
+exact file length, so unaccounted trailing bytes are invalid. The final image
+ends at the end of the container. An empty base is represented by a zero-entry
+table, 4096-byte payload offset, zero padding, and total length equal to that
+payload offset.
+
+Open requires the caller's expected generation and schema hash and fails closed
+on either mismatch, an unsupported version, nonzero reserved bytes or padding,
+checksum failure, malformed bounds/order, or an invalid embedded typed-column
+manifest/layout. Successful file open uses a read-only mapping where supported.
+Encoded payloads and dictionaries remain direct slices of that mapping; format
+validation must not require whole-part payload attachment, re-encoding, or a
+query-shaped dictionary/rank/offset reconstruction. File-backed views must be
+closed before their files are replaced or deleted.
+
+The implementation and format tests are in
+`TreeDB/internal/typedcolumn/query_ready_base.go` and
+`TreeDB/internal/typedcolumn/query_ready_base_test.go`. The collection-level
+ownership, lifecycle boundary, and performance contract are described in
+`docs/architecture/query-ready-base-generation.md`.
+
 ## 2. Index Page Basics
 
 ### 2.1 Fixed page size

--- a/TreeDB/internal/typedcolumn/query_ready_base.go
+++ b/TreeDB/internal/typedcolumn/query_ready_base.go
@@ -392,11 +392,8 @@ func openQueryReadyBaseGeneration(data []byte, expected QueryReadyBaseIdentity, 
 		}
 		// Decode only bounded structural metadata. Encoded column payloads and
 		// dictionaries remain mmap-backed and are not decoded or copied.
-		if _, err := ColumnPartFromImageWithOptions(image, ColumnPartImageReadOptions{}); err != nil {
+		if err := validateQueryReadyBasePartStructures(image); err != nil {
 			return nil, fmt.Errorf("typedcolumn: query-ready base part[%d] validate structures: %w", i, err)
-		}
-		if _, err := CertifyColumnPartLayoutContractFromImage(image); err != nil {
-			return nil, fmt.Errorf("typedcolumn: query-ready base part[%d] certify layout: %w", i, err)
 		}
 		dependency := QueryReadyBaseDependency{SourceGeneration: sourceGeneration, PartID: partID, Rows: image.Rows, ImageBytes: len(partBytes), ImageChecksum: wantChecksum}
 		dependencies = append(dependencies, dependency)
@@ -413,6 +410,117 @@ func openQueryReadyBaseGeneration(data []byte, expected QueryReadyBaseIdentity, 
 	stats.ValidationTime = time.Since(started)
 	stats.OpenTime = stats.ValidationTime
 	return &QueryReadyBaseGeneration{Identity: identity, Dependencies: dependencies, Parts: parts, Stats: stats, data: data, release: release}, nil
+}
+
+// validateQueryReadyBasePartStructures validates the metadata and physical
+// layout needed to publish a query-ready direct view. It deliberately does not
+// attach block payloads: variable-width attachment decodes global offsets and
+// re-encodes every block, turning open into an O(payload) allocation path.
+func validateQueryReadyBasePartStructures(image ColumnPartImage) error {
+	if image.TotalBytes() == 0 {
+		return errors.New("typedcolumn: empty part image")
+	}
+	if err := image.validateForRead(); err != nil {
+		return err
+	}
+	descriptorSection, err := image.singleSection(ColumnPartImageSectionDescriptor)
+	if err != nil {
+		return err
+	}
+	descriptorRaw := image.sectionBytes(descriptorSection)
+	desc, columns, err := decodeColumnPartDescriptorSection(descriptorRaw)
+	if err != nil {
+		return err
+	}
+	if desc.PartID != image.PartID {
+		return fmt.Errorf("typedcolumn: descriptor part id=%d manifest part id=%d", desc.PartID, image.PartID)
+	}
+	if desc.RowCount != image.Rows {
+		return fmt.Errorf("typedcolumn: descriptor rows=%d manifest rows=%d", desc.RowCount, image.Rows)
+	}
+	sortKey, err := decodeSortKeyMetadataSection(image)
+	if err != nil {
+		return err
+	}
+	desc.SortKey = sortKey
+	marks, err := decodeSortKeyMarksSection(image)
+	if err != nil {
+		return err
+	}
+	if err := validateDecodedSortKeyMarks(desc, marks); err != nil {
+		return err
+	}
+	if err := validateColumnDataSectionsForColumns(image, columns); err != nil {
+		return err
+	}
+	if err := restoreColumnDefinitionCompressionFromImageSections(image, columns); err != nil {
+		return err
+	}
+	contractSection, err := image.LayoutContractSection()
+	if err != nil {
+		return err
+	}
+	if _, err := CertifyColumnPartLayoutContract(image, desc, columns, descriptorRaw, image.sectionBytes(contractSection)); err != nil {
+		return fmt.Errorf("certify layout: %w", err)
+	}
+	for _, columnDesc := range desc.Columns {
+		column, ok := columns[columnDesc.Name]
+		if !ok {
+			return fmt.Errorf("typedcolumn: descriptor column %s missing decoded column", columnDesc.Name)
+		}
+		switch column.Definition.Encoding {
+		case EncodingRawBytesOffsets:
+			offsetsSection, valuesSection, ok := image.columnOffsetsListSections(columnDesc.Name)
+			if !ok {
+				return fmt.Errorf("typedcolumn: image missing bytes sections %s", columnDesc.Name)
+			}
+			offsetsRaw := image.sectionBytes(offsetsSection)
+			if err := ValidateRawBytesOffsetsSections(offsetsSection, valuesSection, offsetsRaw, image.sectionBytes(valuesSection), image.Rows); err != nil {
+				return err
+			}
+			if err := validateQueryReadyBaseVariableWidthBlocks(columnDesc.Name, column, offsetsRaw, 1); err != nil {
+				return err
+			}
+		case EncodingRawUint32OffsetsList:
+			offsetsSection, valuesSection, ok := image.columnOffsetsListSections(columnDesc.Name)
+			if !ok {
+				return fmt.Errorf("typedcolumn: image missing offsets-list sections %s", columnDesc.Name)
+			}
+			offsetsRaw := image.sectionBytes(offsetsSection)
+			if err := ValidateRawUint32OffsetsListSections(offsetsSection, valuesSection, offsetsRaw, image.sectionBytes(valuesSection), image.Rows); err != nil {
+				return err
+			}
+			if err := validateQueryReadyBaseVariableWidthBlocks(columnDesc.Name, column, offsetsRaw, 4); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func validateQueryReadyBaseVariableWidthBlocks(name string, column ColumnPartColumn, offsetsRaw []byte, valueWidth int) error {
+	for i, block := range column.Blocks {
+		first := block.Descriptor.FirstRow
+		last := first + block.Descriptor.RowCount
+		begin := binary.LittleEndian.Uint64(offsetsRaw[first*8 : first*8+8])
+		end := binary.LittleEndian.Uint64(offsetsRaw[last*8 : last*8+8])
+		values := end - begin // Global offset validation already proved end >= begin.
+		if values > uint64(math.MaxInt/valueWidth) {
+			return fmt.Errorf("typedcolumn: image column %s block %d values=%d exceed host bounds", name, i, values)
+		}
+		offsetsBytes, err := checkedMulInt(block.Descriptor.RowCount+1, 8, "query-ready base block offsets bytes")
+		if err != nil {
+			return err
+		}
+		wantStored, err := checkedAddInt(offsetsBytes, int(values)*valueWidth, "query-ready base variable-width block bytes")
+		if err != nil {
+			return err
+		}
+		if block.Descriptor.StoredBytes != wantStored {
+			return fmt.Errorf("typedcolumn: image column %s block %d stored bytes=%d want %d from global offsets", name, i, block.Descriptor.StoredBytes, wantStored)
+		}
+	}
+	return nil
 }
 
 func queryReadyBaseStructuralBytes(image ColumnPartImage) int {

--- a/TreeDB/internal/typedcolumn/query_ready_base.go
+++ b/TreeDB/internal/typedcolumn/query_ready_base.go
@@ -407,6 +407,9 @@ func openQueryReadyBaseGeneration(data []byte, expected QueryReadyBaseIdentity, 
 		previousSource, previousPart = sourceGeneration, partID
 		previousEnd = offset + length
 	}
+	if previousEnd != len(data) {
+		return nil, fmt.Errorf("typedcolumn: query-ready base has %d trailing bytes after final part", len(data)-previousEnd)
+	}
 	stats.ValidationTime = time.Since(started)
 	stats.OpenTime = stats.ValidationTime
 	return &QueryReadyBaseGeneration{Identity: identity, Dependencies: dependencies, Parts: parts, Stats: stats, data: data, release: release}, nil

--- a/TreeDB/internal/typedcolumn/query_ready_base.go
+++ b/TreeDB/internal/typedcolumn/query_ready_base.go
@@ -1,0 +1,466 @@
+package typedcolumn
+
+import (
+	"crypto/sha256"
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"hash/crc32"
+	"math"
+	"os"
+	"slices"
+	"sort"
+	"sync"
+	"time"
+)
+
+// Query-ready base generation images are rebuildable, non-authoritative
+// derived assets. They deliberately do not participate in WAL, root
+// publication, recovery selection, or garbage collection.
+const (
+	queryReadyBaseMagic            = uint32(0x47425251) // "QRBG", little-endian.
+	queryReadyBaseVersion          = uint16(1)
+	queryReadyBaseHeaderBytes      = 80
+	queryReadyBasePartEntryBytes   = 80
+	queryReadyBasePayloadAlignment = 4096
+)
+
+var queryReadyBaseCRCTable = crc32.MakeTable(crc32.Castagnoli)
+
+// QueryReadyBaseIdentity binds a rebuildable image to the collection schema
+// and snapshot generation from which its visible typed-column parts were
+// selected.
+type QueryReadyBaseIdentity struct {
+	Generation uint64
+	SchemaHash [sha256.Size]byte
+}
+
+// QueryReadyBasePartInput is one snapshot-visible typed-column part. Build
+// sorts inputs by source generation and part ID, so caller iteration order is
+// not encoded into the durable image.
+type QueryReadyBasePartInput struct {
+	SourceGeneration uint64
+	Image            ColumnPartImage
+}
+
+// QueryReadyBaseDependency is the complete rebuild dependency for one embedded
+// immutable typed-column image.
+type QueryReadyBaseDependency struct {
+	SourceGeneration uint64
+	PartID           uint64
+	Rows             int
+	ImageBytes       int
+	ImageChecksum    [sha256.Size]byte
+}
+
+type QueryReadyBaseBuildStats struct {
+	Parts          int
+	Rows           int64
+	InputBytes     int64
+	OutputBytes    int64
+	BytesCopied    int64
+	ValidationTime time.Duration
+	BuildTime      time.Duration
+}
+
+type QueryReadyBaseBuildResult struct {
+	Bytes        []byte
+	Dependencies []QueryReadyBaseDependency
+	Stats        QueryReadyBaseBuildStats
+}
+
+type QueryReadyBaseOpenStats struct {
+	Parts                   int
+	Rows                    int64
+	BytesMapped             int64
+	BytesRead               int64
+	BytesDecoded            int64
+	BytesCopied             int64
+	BytesValidated          int64
+	WholePartDecodes        int
+	DictionaryConstructions int
+	ValidationTime          time.Duration
+	OpenTime                time.Duration
+	Mapped                  bool
+}
+
+type QueryReadyBasePartView struct {
+	Dependency QueryReadyBaseDependency
+	Offset     int
+	Image      ColumnPartImage
+}
+
+// QueryReadyBaseGeneration is a validated read-only view. For file opens, all
+// embedded image byte slices point directly into the read-only mapping and are
+// valid until Close.
+type QueryReadyBaseGeneration struct {
+	Identity     QueryReadyBaseIdentity
+	Dependencies []QueryReadyBaseDependency
+	Parts        []QueryReadyBasePartView
+	Stats        QueryReadyBaseOpenStats
+
+	data      []byte
+	release   func() error
+	closeOnce sync.Once
+	closeErr  error
+}
+
+func (g *QueryReadyBaseGeneration) Bytes() []byte {
+	if g == nil {
+		return nil
+	}
+	return g.data
+}
+
+func (g *QueryReadyBaseGeneration) Close() error {
+	if g == nil {
+		return nil
+	}
+	g.closeOnce.Do(func() {
+		if g.release != nil {
+			g.closeErr = g.release()
+		}
+		g.data = nil
+		for i := range g.Parts {
+			g.Parts[i].Image.Bytes = nil
+		}
+	})
+	return g.closeErr
+}
+
+type queryReadyBaseBuildPart struct {
+	input      QueryReadyBasePartInput
+	parsed     ColumnPartImage
+	checksum   [sha256.Size]byte
+	offset     int
+	dependency QueryReadyBaseDependency
+}
+
+// BuildQueryReadyBaseGeneration validates and embeds an already
+// snapshot-visible set of typed-column images. It is deterministic for the
+// same identity and logical input set.
+func BuildQueryReadyBaseGeneration(identity QueryReadyBaseIdentity, inputs []QueryReadyBasePartInput) (QueryReadyBaseBuildResult, error) {
+	started := time.Now()
+	if err := validateQueryReadyBaseIdentity(identity); err != nil {
+		return QueryReadyBaseBuildResult{}, err
+	}
+	parts := make([]queryReadyBaseBuildPart, len(inputs))
+	var validationTime time.Duration
+	for i, input := range inputs {
+		if input.SourceGeneration == 0 {
+			return QueryReadyBaseBuildResult{}, fmt.Errorf("typedcolumn: query-ready base part[%d] source generation is zero", i)
+		}
+		if input.SourceGeneration > identity.Generation {
+			return QueryReadyBaseBuildResult{}, fmt.Errorf("typedcolumn: query-ready base part[%d] source generation=%d exceeds base generation=%d", i, input.SourceGeneration, identity.Generation)
+		}
+		validationStarted := time.Now()
+		parsed, err := ParseColumnPartImage(input.Image.Bytes)
+		if err != nil {
+			return QueryReadyBaseBuildResult{}, fmt.Errorf("typedcolumn: query-ready base part[%d] validate image: %w", i, err)
+		}
+		if _, err := ColumnPartFromImageWithOptions(parsed, ColumnPartImageReadOptions{}); err != nil {
+			return QueryReadyBaseBuildResult{}, fmt.Errorf("typedcolumn: query-ready base part[%d] validate structures: %w", i, err)
+		}
+		if _, err := CertifyColumnPartLayoutContractFromImage(parsed); err != nil {
+			return QueryReadyBaseBuildResult{}, fmt.Errorf("typedcolumn: query-ready base part[%d] certify layout: %w", i, err)
+		}
+		validationTime += time.Since(validationStarted)
+		parts[i] = queryReadyBaseBuildPart{
+			input:    input,
+			parsed:   parsed,
+			checksum: sha256.Sum256(input.Image.Bytes),
+		}
+		parts[i].dependency = QueryReadyBaseDependency{
+			SourceGeneration: input.SourceGeneration,
+			PartID:           parsed.PartID,
+			Rows:             parsed.Rows,
+			ImageBytes:       len(input.Image.Bytes),
+			ImageChecksum:    parts[i].checksum,
+		}
+	}
+	sort.Slice(parts, func(i, j int) bool {
+		if parts[i].input.SourceGeneration != parts[j].input.SourceGeneration {
+			return parts[i].input.SourceGeneration < parts[j].input.SourceGeneration
+		}
+		return parts[i].parsed.PartID < parts[j].parsed.PartID
+	})
+	for i := 1; i < len(parts); i++ {
+		if parts[i-1].input.SourceGeneration == parts[i].input.SourceGeneration && parts[i-1].parsed.PartID == parts[i].parsed.PartID {
+			return QueryReadyBaseBuildResult{}, fmt.Errorf("typedcolumn: query-ready base duplicate dependency generation=%d part_id=%d", parts[i].input.SourceGeneration, parts[i].parsed.PartID)
+		}
+	}
+	if len(parts) > math.MaxUint32 || len(parts) > (math.MaxInt-queryReadyBaseHeaderBytes)/queryReadyBasePartEntryBytes {
+		return QueryReadyBaseBuildResult{}, fmt.Errorf("typedcolumn: query-ready base parts=%d exceed format bounds", len(parts))
+	}
+	tableBytes := len(parts) * queryReadyBasePartEntryBytes
+	payloadOffset, err := queryReadyBaseAlign(queryReadyBaseHeaderBytes+tableBytes, queryReadyBasePayloadAlignment)
+	if err != nil {
+		return QueryReadyBaseBuildResult{}, err
+	}
+	totalBytes := payloadOffset
+	for i := range parts {
+		totalBytes, err = queryReadyBaseAlign(totalBytes, columnPartImageSectionAlignment)
+		if err != nil {
+			return QueryReadyBaseBuildResult{}, err
+		}
+		parts[i].offset = totalBytes
+		if len(parts[i].input.Image.Bytes) > math.MaxInt-totalBytes {
+			return QueryReadyBaseBuildResult{}, errors.New("typedcolumn: query-ready base image exceeds host size")
+		}
+		totalBytes += len(parts[i].input.Image.Bytes)
+	}
+	out := make([]byte, totalBytes)
+	binary.LittleEndian.PutUint32(out[0:4], queryReadyBaseMagic)
+	binary.LittleEndian.PutUint16(out[4:6], queryReadyBaseVersion)
+	binary.LittleEndian.PutUint64(out[8:16], identity.Generation)
+	copy(out[16:48], identity.SchemaHash[:])
+	binary.LittleEndian.PutUint32(out[48:52], uint32(len(parts)))
+	binary.LittleEndian.PutUint64(out[64:72], uint64(payloadOffset))
+	binary.LittleEndian.PutUint64(out[72:80], uint64(totalBytes))
+	dependencies := make([]QueryReadyBaseDependency, len(parts))
+	var rows, inputBytes int64
+	for i := range parts {
+		entry := out[queryReadyBaseHeaderBytes+i*queryReadyBasePartEntryBytes:]
+		binary.LittleEndian.PutUint64(entry[0:8], parts[i].input.SourceGeneration)
+		binary.LittleEndian.PutUint64(entry[8:16], parts[i].parsed.PartID)
+		binary.LittleEndian.PutUint64(entry[16:24], uint64(parts[i].offset))
+		binary.LittleEndian.PutUint64(entry[24:32], uint64(len(parts[i].input.Image.Bytes)))
+		binary.LittleEndian.PutUint64(entry[32:40], uint64(parts[i].parsed.Rows))
+		binary.LittleEndian.PutUint64(entry[40:48], uint64(parts[i].parsed.ManifestBytes))
+		copy(entry[48:80], parts[i].checksum[:])
+		copy(out[parts[i].offset:], parts[i].input.Image.Bytes)
+		dependencies[i] = parts[i].dependency
+		rows += int64(parts[i].parsed.Rows)
+		inputBytes += int64(len(parts[i].input.Image.Bytes))
+	}
+	table := out[queryReadyBaseHeaderBytes : queryReadyBaseHeaderBytes+tableBytes]
+	binary.LittleEndian.PutUint32(out[56:60], crc32.Checksum(table, queryReadyBaseCRCTable))
+	binary.LittleEndian.PutUint32(out[52:56], queryReadyBaseHeaderChecksum(out[:queryReadyBaseHeaderBytes]))
+	return QueryReadyBaseBuildResult{
+		Bytes:        out,
+		Dependencies: dependencies,
+		Stats: QueryReadyBaseBuildStats{
+			Parts:          len(parts),
+			Rows:           rows,
+			InputBytes:     inputBytes,
+			OutputBytes:    int64(len(out)),
+			BytesCopied:    inputBytes,
+			ValidationTime: validationTime,
+			BuildTime:      time.Since(started),
+		},
+	}, nil
+}
+
+func OpenQueryReadyBaseGeneration(data []byte, expected QueryReadyBaseIdentity) (*QueryReadyBaseGeneration, error) {
+	return openQueryReadyBaseGeneration(data, expected, false, nil)
+}
+
+func OpenQueryReadyBaseGenerationFile(path string, expected QueryReadyBaseIdentity) (*QueryReadyBaseGeneration, error) {
+	started := time.Now()
+	file, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	data, err := mmapQueryReadyBaseFile(file)
+	if err != nil {
+		_ = file.Close()
+		return nil, fmt.Errorf("typedcolumn: mmap query-ready base %q: %w", path, err)
+	}
+	release := func() error {
+		unmapErr := munmapQueryReadyBaseFile(data)
+		closeErr := file.Close()
+		return errors.Join(unmapErr, closeErr)
+	}
+	base, err := openQueryReadyBaseGeneration(data, expected, true, release)
+	if err != nil {
+		_ = release()
+		return nil, err
+	}
+	base.Stats.OpenTime = time.Since(started)
+	return base, nil
+}
+
+func openQueryReadyBaseGeneration(data []byte, expected QueryReadyBaseIdentity, mapped bool, release func() error) (*QueryReadyBaseGeneration, error) {
+	started := time.Now()
+	if err := validateQueryReadyBaseIdentity(expected); err != nil {
+		return nil, err
+	}
+	if len(data) < queryReadyBaseHeaderBytes {
+		return nil, fmt.Errorf("typedcolumn: query-ready base bytes=%d shorter than header=%d", len(data), queryReadyBaseHeaderBytes)
+	}
+	if got := binary.LittleEndian.Uint32(data[0:4]); got != queryReadyBaseMagic {
+		return nil, fmt.Errorf("typedcolumn: invalid query-ready base magic 0x%x", got)
+	}
+	if got := binary.LittleEndian.Uint16(data[4:6]); got != queryReadyBaseVersion {
+		return nil, fmt.Errorf("typedcolumn: unsupported query-ready base version %d", got)
+	}
+	if binary.LittleEndian.Uint16(data[6:8]) != 0 || binary.LittleEndian.Uint32(data[60:64]) != 0 {
+		return nil, errors.New("typedcolumn: query-ready base reserved header bytes are nonzero")
+	}
+	if got, want := binary.LittleEndian.Uint32(data[52:56]), queryReadyBaseHeaderChecksum(data[:queryReadyBaseHeaderBytes]); got != want {
+		return nil, fmt.Errorf("typedcolumn: query-ready base header checksum=%08x want %08x", got, want)
+	}
+	identity := QueryReadyBaseIdentity{Generation: binary.LittleEndian.Uint64(data[8:16])}
+	copy(identity.SchemaHash[:], data[16:48])
+	if identity.Generation != expected.Generation {
+		return nil, fmt.Errorf("typedcolumn: query-ready base generation=%d want %d", identity.Generation, expected.Generation)
+	}
+	if identity.SchemaHash != expected.SchemaHash {
+		return nil, fmt.Errorf("typedcolumn: query-ready base schema hash=%x want %x", identity.SchemaHash, expected.SchemaHash)
+	}
+	partCount := uint64(binary.LittleEndian.Uint32(data[48:52]))
+	if partCount > uint64((math.MaxInt-queryReadyBaseHeaderBytes)/queryReadyBasePartEntryBytes) {
+		return nil, fmt.Errorf("typedcolumn: query-ready base part count=%d exceeds host bounds", partCount)
+	}
+	tableEnd := queryReadyBaseHeaderBytes + int(partCount)*queryReadyBasePartEntryBytes
+	if tableEnd > len(data) {
+		return nil, fmt.Errorf("typedcolumn: query-ready base part table bytes=%d exceed image bytes=%d", tableEnd, len(data))
+	}
+	table := data[queryReadyBaseHeaderBytes:tableEnd]
+	if got, want := crc32.Checksum(table, queryReadyBaseCRCTable), binary.LittleEndian.Uint32(data[56:60]); got != want {
+		return nil, fmt.Errorf("typedcolumn: query-ready base table checksum=%08x want %08x", got, want)
+	}
+	payloadOffset64 := binary.LittleEndian.Uint64(data[64:72])
+	totalBytes64 := binary.LittleEndian.Uint64(data[72:80])
+	if totalBytes64 != uint64(len(data)) {
+		return nil, fmt.Errorf("typedcolumn: query-ready base total bytes=%d want provided bytes=%d", totalBytes64, len(data))
+	}
+	if payloadOffset64 > uint64(len(data)) || payloadOffset64 < uint64(tableEnd) || payloadOffset64%queryReadyBasePayloadAlignment != 0 {
+		return nil, fmt.Errorf("typedcolumn: query-ready base payload offset=%d invalid for table_end=%d total=%d", payloadOffset64, tableEnd, len(data))
+	}
+	if err := queryReadyBaseValidateZeroPadding(data[tableEnd:int(payloadOffset64)], "header"); err != nil {
+		return nil, err
+	}
+	parts := make([]QueryReadyBasePartView, 0, int(partCount))
+	dependencies := make([]QueryReadyBaseDependency, 0, int(partCount))
+	stats := QueryReadyBaseOpenStats{
+		Mapped:         mapped,
+		BytesRead:      int64(len(data)),
+		BytesDecoded:   queryReadyBaseHeaderBytes + int64(len(table)),
+		BytesValidated: int64(len(data)),
+	}
+	if mapped {
+		stats.BytesMapped = int64(len(data))
+	}
+	previousEnd := int(payloadOffset64)
+	var previousSource, previousPart uint64
+	for i := 0; i < int(partCount); i++ {
+		entry := table[i*queryReadyBasePartEntryBytes : (i+1)*queryReadyBasePartEntryBytes]
+		sourceGeneration := binary.LittleEndian.Uint64(entry[0:8])
+		partID := binary.LittleEndian.Uint64(entry[8:16])
+		offset64 := binary.LittleEndian.Uint64(entry[16:24])
+		length64 := binary.LittleEndian.Uint64(entry[24:32])
+		rows64 := binary.LittleEndian.Uint64(entry[32:40])
+		manifest64 := binary.LittleEndian.Uint64(entry[40:48])
+		if sourceGeneration == 0 || sourceGeneration > identity.Generation {
+			return nil, fmt.Errorf("typedcolumn: query-ready base part[%d] source generation=%d invalid for base generation=%d", i, sourceGeneration, identity.Generation)
+		}
+		if i > 0 && (sourceGeneration < previousSource || (sourceGeneration == previousSource && partID <= previousPart)) {
+			return nil, fmt.Errorf("typedcolumn: query-ready base part[%d] dependency order is not strictly increasing", i)
+		}
+		if offset64 > math.MaxInt || length64 > math.MaxInt || rows64 > math.MaxInt || manifest64 > math.MaxInt {
+			return nil, fmt.Errorf("typedcolumn: query-ready base part[%d] fields exceed host bounds", i)
+		}
+		offset, length := int(offset64), int(length64)
+		if offset < previousEnd || offset%columnPartImageSectionAlignment != 0 || length < ColumnPartImageManifestHeaderBytes || length > len(data)-offset {
+			return nil, fmt.Errorf("typedcolumn: query-ready base part[%d] offset=%d length=%d invalid for previous_end=%d total=%d", i, offset, length, previousEnd, len(data))
+		}
+		if err := queryReadyBaseValidateZeroPadding(data[previousEnd:offset], fmt.Sprintf("before part[%d]", i)); err != nil {
+			return nil, err
+		}
+		partBytes := data[offset : offset+length]
+		var wantChecksum [sha256.Size]byte
+		copy(wantChecksum[:], entry[48:80])
+		gotChecksum := sha256.Sum256(partBytes)
+		if gotChecksum != wantChecksum {
+			return nil, fmt.Errorf("typedcolumn: query-ready base part[%d] checksum=%x want %x", i, gotChecksum, wantChecksum)
+		}
+		manifestLength, err := ColumnPartImageManifestLength(partBytes[:ColumnPartImageManifestHeaderBytes])
+		if err != nil {
+			return nil, fmt.Errorf("typedcolumn: query-ready base part[%d] manifest header: %w", i, err)
+		}
+		if manifestLength != int(manifest64) || manifestLength > len(partBytes) {
+			return nil, fmt.Errorf("typedcolumn: query-ready base part[%d] manifest bytes=%d want %d", i, manifestLength, manifest64)
+		}
+		image, err := ParseColumnPartImageManifest(partBytes[:manifestLength], len(partBytes))
+		if err != nil {
+			return nil, fmt.Errorf("typedcolumn: query-ready base part[%d] manifest: %w", i, err)
+		}
+		image.Bytes = partBytes
+		if image.PartID != partID || image.Rows != int(rows64) {
+			return nil, fmt.Errorf("typedcolumn: query-ready base part[%d] identity part/rows=%d/%d want %d/%d", i, image.PartID, image.Rows, partID, rows64)
+		}
+		// Decode only bounded structural metadata. Encoded column payloads and
+		// dictionaries remain mmap-backed and are not decoded or copied.
+		if _, err := ColumnPartFromImageWithOptions(image, ColumnPartImageReadOptions{}); err != nil {
+			return nil, fmt.Errorf("typedcolumn: query-ready base part[%d] validate structures: %w", i, err)
+		}
+		if _, err := CertifyColumnPartLayoutContractFromImage(image); err != nil {
+			return nil, fmt.Errorf("typedcolumn: query-ready base part[%d] certify layout: %w", i, err)
+		}
+		dependency := QueryReadyBaseDependency{SourceGeneration: sourceGeneration, PartID: partID, Rows: image.Rows, ImageBytes: len(partBytes), ImageChecksum: wantChecksum}
+		dependencies = append(dependencies, dependency)
+		parts = append(parts, QueryReadyBasePartView{Dependency: dependency, Offset: offset, Image: image})
+		stats.Parts++
+		stats.Rows += int64(image.Rows)
+		stats.BytesDecoded += int64(manifestLength + queryReadyBaseStructuralBytes(image))
+		previousSource, previousPart = sourceGeneration, partID
+		previousEnd = offset + length
+	}
+	stats.ValidationTime = time.Since(started)
+	stats.OpenTime = stats.ValidationTime
+	return &QueryReadyBaseGeneration{Identity: identity, Dependencies: dependencies, Parts: parts, Stats: stats, data: data, release: release}, nil
+}
+
+func queryReadyBaseStructuralBytes(image ColumnPartImage) int {
+	total := 0
+	for _, section := range image.Sections {
+		switch section.Kind {
+		case ColumnPartImageSectionDescriptor, ColumnPartImageSectionSortKeyMetadata, ColumnPartImageSectionSortKeyMarks, ColumnPartImageSectionLayoutContract:
+			total += section.Length
+		}
+	}
+	return total
+}
+
+func validateQueryReadyBaseIdentity(identity QueryReadyBaseIdentity) error {
+	if identity.Generation == 0 {
+		return errors.New("typedcolumn: query-ready base generation is zero")
+	}
+	if identity.SchemaHash == ([sha256.Size]byte{}) {
+		return errors.New("typedcolumn: query-ready base schema hash is zero")
+	}
+	return nil
+}
+
+func queryReadyBaseHeaderChecksum(header []byte) uint32 {
+	copyHeader := slices.Clone(header)
+	for i := 52; i < 56; i++ {
+		copyHeader[i] = 0
+	}
+	return crc32.Checksum(copyHeader, queryReadyBaseCRCTable)
+}
+
+func queryReadyBaseAlign(value, alignment int) (int, error) {
+	if value < 0 || alignment <= 0 {
+		return 0, errors.New("typedcolumn: invalid query-ready base alignment")
+	}
+	remainder := value % alignment
+	if remainder == 0 {
+		return value, nil
+	}
+	add := alignment - remainder
+	if value > math.MaxInt-add {
+		return 0, errors.New("typedcolumn: query-ready base aligned size exceeds host bounds")
+	}
+	return value + add, nil
+}
+
+func queryReadyBaseValidateZeroPadding(data []byte, label string) error {
+	for i, value := range data {
+		if value != 0 {
+			return fmt.Errorf("typedcolumn: query-ready base %s padding byte[%d]=%d want 0", label, i, value)
+		}
+	}
+	return nil
+}

--- a/TreeDB/internal/typedcolumn/query_ready_base_mmap_fallback.go
+++ b/TreeDB/internal/typedcolumn/query_ready_base_mmap_fallback.go
@@ -1,0 +1,16 @@
+//go:build !(darwin || linux || freebsd || netbsd || openbsd)
+
+package typedcolumn
+
+import (
+	"errors"
+	"os"
+)
+
+func queryReadyBaseMmapSupported() bool { return false }
+
+func mmapQueryReadyBaseFile(_ *os.File) ([]byte, error) {
+	return nil, errors.New("typedcolumn: query-ready base mmap is unsupported on this platform")
+}
+
+func munmapQueryReadyBaseFile(_ []byte) error { return nil }

--- a/TreeDB/internal/typedcolumn/query_ready_base_mmap_unix.go
+++ b/TreeDB/internal/typedcolumn/query_ready_base_mmap_unix.go
@@ -1,0 +1,31 @@
+//go:build darwin || linux || freebsd || netbsd || openbsd
+
+package typedcolumn
+
+import (
+	"os"
+	"syscall"
+)
+
+func queryReadyBaseMmapSupported() bool { return true }
+
+func mmapQueryReadyBaseFile(file *os.File) ([]byte, error) {
+	if file == nil {
+		return nil, os.ErrInvalid
+	}
+	info, err := file.Stat()
+	if err != nil {
+		return nil, err
+	}
+	if info.Size() <= 0 || info.Size() > int64(^uint(0)>>1) {
+		return nil, os.ErrInvalid
+	}
+	return syscall.Mmap(int(file.Fd()), 0, int(info.Size()), syscall.PROT_READ, syscall.MAP_SHARED)
+}
+
+func munmapQueryReadyBaseFile(data []byte) error {
+	if len(data) == 0 {
+		return nil
+	}
+	return syscall.Munmap(data)
+}

--- a/TreeDB/internal/typedcolumn/query_ready_base_test.go
+++ b/TreeDB/internal/typedcolumn/query_ready_base_test.go
@@ -2,6 +2,8 @@ package typedcolumn
 
 import (
 	"crypto/sha256"
+	"encoding/binary"
+	"hash/crc32"
 	"os"
 	"path/filepath"
 	"slices"
@@ -78,6 +80,20 @@ func TestQueryReadyBaseGenerationRejectsCorruptionAndTruncation(t *testing.T) {
 				t.Fatalf("err=%v want containing %q", err, tc.want)
 			}
 		})
+	}
+}
+
+func TestQueryReadyBaseGenerationRejectsUnaccountedTrailingBytes(t *testing.T) {
+	identity := queryReadyBaseTestIdentity(48)
+	image := mustTransplantImage(t, mustTransplantPart(t, 708, transplantTestOptions(nil), transplantTestBatch()))
+	result, err := BuildQueryReadyBaseGeneration(identity, []QueryReadyBasePartInput{{SourceGeneration: 25, Image: image}})
+	if err != nil {
+		t.Fatalf("BuildQueryReadyBaseGeneration: %v", err)
+	}
+	shorter := mustTransplantImage(t, mustTransplantPart(t, 708, transplantTestOptions(nil), transplantConstantBatch(1, 42)))
+	forged := queryReadyBaseReplaceFinalPartWithShorterImage(t, result.Bytes, shorter)
+	if _, err := OpenQueryReadyBaseGeneration(forged, identity); err == nil || !strings.Contains(err.Error(), "trailing") {
+		t.Fatalf("forged trailing bytes err=%v want trailing rejection", err)
 	}
 }
 
@@ -363,5 +379,32 @@ func queryReadyBaseCorruptLastByte(data []byte) []byte {
 func queryReadyBaseCorruptByte(data []byte, offset int) []byte {
 	out := slices.Clone(data)
 	out[offset] ^= 0xff
+	return out
+}
+
+func queryReadyBaseReplaceFinalPartWithShorterImage(tb testing.TB, data []byte, image ColumnPartImage) []byte {
+	tb.Helper()
+	out := slices.Clone(data)
+	partCount := int(binary.LittleEndian.Uint32(out[48:52]))
+	if partCount == 0 {
+		tb.Fatal("cannot shorten empty query-ready base")
+	}
+	entryOffset := queryReadyBaseHeaderBytes + (partCount-1)*queryReadyBasePartEntryBytes
+	entry := out[entryOffset : entryOffset+queryReadyBasePartEntryBytes]
+	partOffset := int(binary.LittleEndian.Uint64(entry[16:24]))
+	oldPartLength := int(binary.LittleEndian.Uint64(entry[24:32]))
+	if len(image.Bytes) >= oldPartLength {
+		tb.Fatalf("replacement image bytes=%d must be shorter than final part=%d", len(image.Bytes), oldPartLength)
+	}
+	copy(out[partOffset:], image.Bytes)
+	binary.LittleEndian.PutUint64(entry[24:32], uint64(len(image.Bytes)))
+	binary.LittleEndian.PutUint64(entry[32:40], uint64(image.Rows))
+	binary.LittleEndian.PutUint64(entry[40:48], uint64(image.ManifestBytes))
+	checksum := sha256.Sum256(out[partOffset : partOffset+len(image.Bytes)])
+	copy(entry[48:80], checksum[:])
+	tableEnd := queryReadyBaseHeaderBytes + partCount*queryReadyBasePartEntryBytes
+	tableChecksum := crc32.Checksum(out[queryReadyBaseHeaderBytes:tableEnd], queryReadyBaseCRCTable)
+	binary.LittleEndian.PutUint32(out[56:60], tableChecksum)
+	binary.LittleEndian.PutUint32(out[52:56], queryReadyBaseHeaderChecksum(out[:queryReadyBaseHeaderBytes]))
 	return out
 }

--- a/TreeDB/internal/typedcolumn/query_ready_base_test.go
+++ b/TreeDB/internal/typedcolumn/query_ready_base_test.go
@@ -6,10 +6,13 @@ import (
 	"hash/crc32"
 	"os"
 	"path/filepath"
+	"runtime"
 	"slices"
 	"strconv"
 	"strings"
 	"testing"
+
+	"github.com/snissn/gomap/TreeDB/internal/crc"
 )
 
 func TestQueryReadyBaseGenerationReopenParity(t *testing.T) {
@@ -192,6 +195,86 @@ func TestQueryReadyBaseGenerationOpenAvoidsWholePartDecode(t *testing.T) {
 	}
 }
 
+func TestQueryReadyBaseGenerationVariableWidthOpenIsPayloadAllocationIndependent(t *testing.T) {
+	const (
+		rows        = 4096
+		bytesPerRow = 1024
+		listPerRow  = 16
+		openRuns    = 3
+	)
+	identity := queryReadyBaseTestIdentity(49)
+	image, payloadBytes := queryReadyBaseVariableWidthImage(t, 709, rows, bytesPerRow, listPerRow)
+	result, err := BuildQueryReadyBaseGeneration(identity, []QueryReadyBasePartInput{{SourceGeneration: 26, Image: image}})
+	if err != nil {
+		t.Fatalf("BuildQueryReadyBaseGeneration: %v", err)
+	}
+
+	runtime.GC()
+	var before runtime.MemStats
+	runtime.ReadMemStats(&before)
+	for range openRuns {
+		base, err := OpenQueryReadyBaseGeneration(result.Bytes, identity)
+		if err != nil {
+			t.Fatalf("OpenQueryReadyBaseGeneration: %v", err)
+		}
+		wantDecoded := int64(queryReadyBaseHeaderBytes + queryReadyBasePartEntryBytes + image.ManifestBytes + queryReadyBaseStructuralBytes(image))
+		if base.Stats.BytesDecoded != wantDecoded || base.Stats.BytesCopied != 0 || base.Stats.WholePartDecodes != 0 || base.Stats.DictionaryConstructions != 0 {
+			t.Fatalf("open stats=%+v want decoded=%d with no payload copies/decodes/dictionaries", base.Stats, wantDecoded)
+		}
+		if base.Stats.BytesRead != int64(len(result.Bytes)) || base.Stats.BytesValidated != int64(len(result.Bytes)) {
+			t.Fatalf("read/validated bytes=%d/%d want %d", base.Stats.BytesRead, base.Stats.BytesValidated, len(result.Bytes))
+		}
+		queryReadyBaseGenerationSink = base
+	}
+	var after runtime.MemStats
+	runtime.ReadMemStats(&after)
+	allocatedPerOpen := int64(after.TotalAlloc-before.TotalAlloc) / openRuns
+	if max := int64(payloadBytes / 4); allocatedPerOpen > max {
+		t.Fatalf("variable-width open allocated %d bytes/op for %d payload bytes; want <= %d (bounded metadata only)", allocatedPerOpen, payloadBytes, max)
+	}
+}
+
+func TestQueryReadyBaseGenerationVariableWidthValidationFailsClosed(t *testing.T) {
+	image, _ := queryReadyBaseVariableWidthImage(t, 710, 16, 8, 4)
+	for _, tc := range []struct {
+		name   string
+		column string
+		offset int
+		value  uint64
+		want   string
+	}{
+		{name: "bytes non-monotonic", column: "opaque", offset: 2, value: 0, want: "before previous"},
+		{name: "list final mismatch", column: "neighbors", offset: 16, value: 63, want: "final offset=63 values=64"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			corrupt := cloneColumnPartImageBytes(image)
+			offsetsSection, _, ok := corrupt.columnOffsetsListSections(tc.column)
+			if !ok {
+				t.Fatalf("missing variable-width sections for %s", tc.column)
+			}
+			binary.LittleEndian.PutUint64(corrupt.Bytes[offsetsSection.Offset+tc.offset*8:], tc.value)
+			queryReadyBaseRewriteLayoutContractChecksum(t, &corrupt, tc.column, crc.Checksum(corrupt.sectionBytes(offsetsSection)))
+			if err := validateQueryReadyBasePartStructures(corrupt); err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("validateQueryReadyBasePartStructures err=%v want containing %q", err, tc.want)
+			}
+		})
+	}
+
+	t.Run("bytes block boundary mismatch", func(t *testing.T) {
+		boundaryImage, _ := queryReadyBaseVariableWidthImage(t, 711, 1024, 8, 1)
+		corrupt := cloneColumnPartImageBytes(boundaryImage)
+		offsetsSection, _, ok := corrupt.columnOffsetsListSections("opaque")
+		if !ok {
+			t.Fatal("missing bytes sections")
+		}
+		binary.LittleEndian.PutUint64(corrupt.Bytes[offsetsSection.Offset+512*8:], 512*8-1)
+		queryReadyBaseRewriteLayoutContractChecksum(t, &corrupt, "opaque", crc.Checksum(corrupt.sectionBytes(offsetsSection)))
+		if err := validateQueryReadyBasePartStructures(corrupt); err == nil || !strings.Contains(err.Error(), "block 0 stored bytes") {
+			t.Fatalf("validateQueryReadyBasePartStructures err=%v want block-boundary rejection", err)
+		}
+	})
+}
+
 func TestQueryReadyBaseGenerationPreservesNullableAndDictionaryDomains(t *testing.T) {
 	opts := transplantTestOptions(nil)
 	opts.Columns[2].Encoding = EncodingNullableInt64
@@ -279,6 +362,37 @@ func BenchmarkQueryReadyBaseGenerationOpen(b *testing.B) {
 	b.ReportMetric(float64(sample.Stats.BytesValidated), "validated-bytes")
 }
 
+func BenchmarkQueryReadyBaseGenerationVariableWidthOpen(b *testing.B) {
+	const (
+		bytesPerRow = 64
+		listPerRow  = 4
+	)
+	identity := queryReadyBaseTestIdentity(103)
+	image, payloadBytes := queryReadyBaseVariableWidthImage(b, 1005, queryReadyBaseBenchmarkRows(b), bytesPerRow, listPerRow)
+	result, err := BuildQueryReadyBaseGeneration(identity, []QueryReadyBasePartInput{{SourceGeneration: 102, Image: image}})
+	if err != nil {
+		b.Fatal(err)
+	}
+	sample, err := OpenQueryReadyBaseGeneration(result.Bytes, identity)
+	if err != nil {
+		b.Fatal(err)
+	}
+	b.ReportAllocs()
+	b.SetBytes(int64(len(result.Bytes)))
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		base, err := OpenQueryReadyBaseGeneration(result.Bytes, identity)
+		if err != nil {
+			b.Fatal(err)
+		}
+		queryReadyBaseGenerationSink = base
+	}
+	b.ReportMetric(float64(payloadBytes), "payload-bytes")
+	b.ReportMetric(float64(sample.Stats.BytesDecoded), "decoded-bytes")
+	b.ReportMetric(float64(sample.Stats.BytesCopied), "copied-bytes")
+	b.ReportMetric(float64(sample.Stats.BytesValidated), "validated-bytes")
+}
+
 // BenchmarkQueryReadyBaseGenerationLegacyPartOpen is the pre-QRBG comparison:
 // parse and reconstruct the complete typed-column part state that callers
 // historically prepared before executing a query.
@@ -352,6 +466,102 @@ func queryReadyBaseBenchmarkImage(tb testing.TB, partID uint64, rows int) Column
 	return image
 }
 
+func queryReadyBaseVariableWidthImage(tb testing.TB, partID uint64, rows, bytesPerRow, listPerRow int) (ColumnPartImage, int) {
+	tb.Helper()
+	ids := make([]int64, rows)
+	byteOffsets := make([]uint64, rows+1)
+	byteValues := make([]byte, rows*bytesPerRow)
+	listOffsets := make([]uint64, rows+1)
+	listValues := make([]uint32, rows*listPerRow)
+	for row := 0; row < rows; row++ {
+		ids[row] = int64(row)
+		byteOffsets[row+1] = uint64((row + 1) * bytesPerRow)
+		listOffsets[row+1] = uint64((row + 1) * listPerRow)
+		for i := row * bytesPerRow; i < (row+1)*bytesPerRow; i++ {
+			byteValues[i] = byte(row + i)
+		}
+		for i := row * listPerRow; i < (row+1)*listPerRow; i++ {
+			listValues[i] = uint32(row + i)
+		}
+	}
+	part, err := BuildColumnPart(partID, Options{
+		SchemaVersion: 1,
+		SchemaMode:    ColumnSchemaFixed,
+		Columns: []ColumnDefinition{
+			{Name: "id", Type: ColumnTypeInt64, Encoding: EncodingRawInt64, Compression: CompressionNone, CompressionSet: true, StatsDisabled: true},
+			{Name: "opaque", Type: ColumnTypeBytes, Encoding: EncodingRawBytesOffsets, Compression: CompressionNone, CompressionSet: true},
+			{Name: "neighbors", Type: ColumnTypeAdjacencyList, Encoding: EncodingRawUint32OffsetsList, Compression: CompressionNone, CompressionSet: true},
+		},
+		LogicalPrimaryKey: LogicalPrimaryKey{Columns: []string{"id"}},
+		SortKey:           SortKey{Columns: []SortKeyColumn{{Column: "id"}}},
+		PartPolicy:        ColumnPartPolicy{RowsPerGranule: 512, DefaultCodecBlockRows: 512},
+		Compression:       ColumnCompressionPolicy{Default: CompressionNone},
+	}, Batch{
+		Rows:    rows,
+		Columns: map[string][]int64{"id": ids},
+		BytesColumns: map[string]RawBytesOffsets{
+			"opaque": {Rows: rows, Offsets: byteOffsets, Values: byteValues},
+		},
+		Uint32OffsetsLists: map[string]RawUint32OffsetsList{
+			"neighbors": {Rows: rows, Offsets: listOffsets, Values: listValues},
+		},
+	})
+	if err != nil {
+		tb.Fatalf("BuildColumnPart: %v", err)
+	}
+	image, err := BuildColumnPartImage(part, ColumnPartImageOptions{LayoutLogicalTypes: map[string]string{
+		"id": "int64", "opaque": "bytes", "neighbors": "adjacency_list",
+	}})
+	if err != nil {
+		tb.Fatalf("BuildColumnPartImage: %v", err)
+	}
+	payloadBytes := len(byteOffsets)*8 + len(byteValues) + len(listOffsets)*8 + len(listValues)*4
+	return image, payloadBytes
+}
+
+func queryReadyBaseRewriteLayoutContractChecksum(tb testing.TB, image *ColumnPartImage, column string, checksum uint32) {
+	tb.Helper()
+	section, err := image.LayoutContractSection()
+	if err != nil {
+		tb.Fatalf("LayoutContractSection: %v", err)
+	}
+	contract, err := DecodeColumnPartLayoutContract(image.sectionBytes(section))
+	if err != nil {
+		tb.Fatalf("DecodeColumnPartLayoutContract: %v", err)
+	}
+	found := false
+	for i := range contract.Columns {
+		if contract.Columns[i].Name == column {
+			contract.Columns[i].OffsetsSection.Checksum = checksum
+			found = true
+			break
+		}
+	}
+	if !found {
+		tb.Fatalf("layout contract missing column %s", column)
+	}
+	var enc columnPartImageEncoder
+	enc.u16(contract.Version)
+	enc.u16(0)
+	enc.u64(contract.PartID)
+	enc.i64(int64(contract.Rows))
+	enc.u16(contract.ImageVersion)
+	enc.u16(0)
+	enc.i64(int64(contract.ManifestBytes))
+	encodeColumnPartLayoutContractSection(&enc, contract.Descriptor)
+	enc.u32(uint32(len(contract.Columns)))
+	for _, contractColumn := range contract.Columns {
+		if err := encodeColumnPartLayoutContractColumn(&enc, contractColumn); err != nil {
+			tb.Fatalf("encode layout contract column %s: %v", contractColumn.Name, err)
+		}
+	}
+	raw := enc.bytes()
+	if len(raw) != section.Length {
+		tb.Fatalf("rewritten layout contract bytes=%d want %d", len(raw), section.Length)
+	}
+	copy(image.Bytes[section.Offset:section.Offset+section.Length], raw)
+}
+
 func queryReadyBaseBenchmarkRows(tb testing.TB) int {
 	tb.Helper()
 	const defaultRows = 1 << 15
@@ -408,3 +618,5 @@ func queryReadyBaseReplaceFinalPartWithShorterImage(tb testing.TB, data []byte, 
 	binary.LittleEndian.PutUint32(out[52:56], queryReadyBaseHeaderChecksum(out[:queryReadyBaseHeaderBytes]))
 	return out
 }
+
+var queryReadyBaseGenerationSink *QueryReadyBaseGeneration

--- a/TreeDB/internal/typedcolumn/query_ready_base_test.go
+++ b/TreeDB/internal/typedcolumn/query_ready_base_test.go
@@ -1,0 +1,367 @@
+package typedcolumn
+
+import (
+	"crypto/sha256"
+	"os"
+	"path/filepath"
+	"slices"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+func TestQueryReadyBaseGenerationReopenParity(t *testing.T) {
+	identity := queryReadyBaseTestIdentity(41)
+	image := mustTransplantImage(t, mustTransplantPart(t, 701, transplantTestOptions([]SortKeyColumn{{Column: "id"}}), transplantTestBatch()))
+	result, err := BuildQueryReadyBaseGeneration(identity, []QueryReadyBasePartInput{{SourceGeneration: 17, Image: image}})
+	if err != nil {
+		t.Fatalf("BuildQueryReadyBaseGeneration: %v", err)
+	}
+	path := filepath.Join(t.TempDir(), "base.qrb")
+	if err := os.WriteFile(path, result.Bytes, 0o600); err != nil {
+		t.Fatalf("write base: %v", err)
+	}
+	var base *QueryReadyBaseGeneration
+	if queryReadyBaseMmapSupported() {
+		base, err = OpenQueryReadyBaseGenerationFile(path, identity)
+		if err != nil {
+			t.Fatalf("OpenQueryReadyBaseGenerationFile: %v", err)
+		}
+	} else {
+		if _, err := OpenQueryReadyBaseGenerationFile(path, identity); err == nil || !strings.Contains(err.Error(), "mmap") {
+			t.Fatalf("unsupported mmap err=%v", err)
+		}
+		reopenedBytes, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatalf("read base: %v", err)
+		}
+		base, err = OpenQueryReadyBaseGeneration(reopenedBytes, identity)
+		if err != nil {
+			t.Fatalf("OpenQueryReadyBaseGeneration: %v", err)
+		}
+	}
+	t.Cleanup(func() { _ = base.Close() })
+	if len(base.Parts) != 1 || base.Parts[0].Dependency.SourceGeneration != 17 {
+		t.Fatalf("parts=%+v", base.Parts)
+	}
+	part, err := ColumnPartFromImage(base.Parts[0].Image)
+	if err != nil {
+		t.Fatalf("ColumnPartFromImage: %v", err)
+	}
+	scan, err := part.NewScanner().ScanProjected([]string{"value", "kind_code"})
+	if err != nil {
+		t.Fatalf("ScanProjected: %v", err)
+	}
+	assertTransplantInt64s(t, "value", scan.Columns["value"], []int64{100, 200, 300, 400, 500, 600})
+	assertTransplantInt64s(t, "kind_code", scan.Columns["kind_code"], []int64{0, 0, 1, 1, 1, 2})
+}
+
+func TestQueryReadyBaseGenerationRejectsCorruptionAndTruncation(t *testing.T) {
+	identity := queryReadyBaseTestIdentity(42)
+	image := mustTransplantImage(t, mustTransplantPart(t, 702, transplantTestOptions(nil), transplantTestBatch()))
+	result, err := BuildQueryReadyBaseGeneration(identity, []QueryReadyBasePartInput{{SourceGeneration: 18, Image: image}})
+	if err != nil {
+		t.Fatalf("BuildQueryReadyBaseGeneration: %v", err)
+	}
+	for _, tc := range []struct {
+		name string
+		data []byte
+		want string
+	}{
+		{name: "truncated", data: result.Bytes[:len(result.Bytes)-1], want: "total bytes"},
+		{name: "payload checksum", data: queryReadyBaseCorruptLastByte(result.Bytes), want: "checksum"},
+		{name: "padding", data: queryReadyBaseCorruptByte(result.Bytes, queryReadyBaseHeaderBytes+queryReadyBasePartEntryBytes), want: "padding"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := OpenQueryReadyBaseGeneration(tc.data, identity)
+			if err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("err=%v want containing %q", err, tc.want)
+			}
+		})
+	}
+}
+
+func TestQueryReadyBaseGenerationRejectsSchemaOrGenerationMismatch(t *testing.T) {
+	identity := queryReadyBaseTestIdentity(43)
+	image := mustTransplantImage(t, mustTransplantPart(t, 703, transplantTestOptions(nil), transplantTestBatch()))
+	result, err := BuildQueryReadyBaseGeneration(identity, []QueryReadyBasePartInput{{SourceGeneration: 19, Image: image}})
+	if err != nil {
+		t.Fatalf("BuildQueryReadyBaseGeneration: %v", err)
+	}
+	wrongGeneration := identity
+	wrongGeneration.Generation++
+	if _, err := OpenQueryReadyBaseGeneration(result.Bytes, wrongGeneration); err == nil || !strings.Contains(err.Error(), "generation") {
+		t.Fatalf("generation mismatch err=%v", err)
+	}
+	wrongSchema := identity
+	wrongSchema.SchemaHash[0] ^= 0xff
+	if _, err := OpenQueryReadyBaseGeneration(result.Bytes, wrongSchema); err == nil || !strings.Contains(err.Error(), "schema") {
+		t.Fatalf("schema mismatch err=%v", err)
+	}
+}
+
+func TestQueryReadyBaseGenerationBuildIsDeterministic(t *testing.T) {
+	identity := queryReadyBaseTestIdentity(44)
+	left := mustTransplantImage(t, mustTransplantPart(t, 705, transplantTestOptions(nil), transplantTestBatch()))
+	right := mustTransplantImage(t, mustTransplantPart(t, 704, transplantTestOptions(nil), transplantTestBatch()))
+	a, err := BuildQueryReadyBaseGeneration(identity, []QueryReadyBasePartInput{{SourceGeneration: 22, Image: left}, {SourceGeneration: 21, Image: right}})
+	if err != nil {
+		t.Fatalf("build a: %v", err)
+	}
+	b, err := BuildQueryReadyBaseGeneration(identity, []QueryReadyBasePartInput{{SourceGeneration: 21, Image: right}, {SourceGeneration: 22, Image: left}})
+	if err != nil {
+		t.Fatalf("build b: %v", err)
+	}
+	if !slices.Equal(a.Bytes, b.Bytes) {
+		t.Fatalf("deterministic builds differ: %d/%d bytes", len(a.Bytes), len(b.Bytes))
+	}
+	if a.Dependencies[0].PartID != 704 || a.Dependencies[1].PartID != 705 {
+		t.Fatalf("dependency order=%+v", a.Dependencies)
+	}
+}
+
+func TestQueryReadyBaseGenerationEmptyBaseReopens(t *testing.T) {
+	identity := queryReadyBaseTestIdentity(47)
+	result, err := BuildQueryReadyBaseGeneration(identity, nil)
+	if err != nil {
+		t.Fatalf("build empty base: %v", err)
+	}
+	base, err := OpenQueryReadyBaseGeneration(result.Bytes, identity)
+	if err != nil {
+		t.Fatalf("open empty base: %v", err)
+	}
+	if len(base.Parts) != 0 || base.Stats.Rows != 0 || base.Stats.WholePartDecodes != 0 {
+		t.Fatalf("empty base=%+v stats=%+v", base.Parts, base.Stats)
+	}
+}
+
+func TestQueryReadyBaseGenerationOpenAvoidsWholePartDecode(t *testing.T) {
+	identity := queryReadyBaseTestIdentity(45)
+	image := mustTransplantImage(t, mustTransplantPart(t, 706, transplantTestOptions(nil), transplantTestBatch()))
+	result, err := BuildQueryReadyBaseGeneration(identity, []QueryReadyBasePartInput{{SourceGeneration: 23, Image: image}})
+	if err != nil {
+		t.Fatalf("BuildQueryReadyBaseGeneration: %v", err)
+	}
+	path := filepath.Join(t.TempDir(), "base.qrb")
+	if err := os.WriteFile(path, result.Bytes, 0o600); err != nil {
+		t.Fatalf("write base: %v", err)
+	}
+	var base *QueryReadyBaseGeneration
+	if queryReadyBaseMmapSupported() {
+		base, err = OpenQueryReadyBaseGenerationFile(path, identity)
+		if err != nil {
+			t.Fatalf("open base: %v", err)
+		}
+	} else {
+		if _, err := OpenQueryReadyBaseGenerationFile(path, identity); err == nil || !strings.Contains(err.Error(), "mmap") {
+			t.Fatalf("unsupported mmap err=%v", err)
+		}
+		base, err = OpenQueryReadyBaseGeneration(result.Bytes, identity)
+		if err != nil {
+			t.Fatalf("open in-memory base: %v", err)
+		}
+	}
+	t.Cleanup(func() { _ = base.Close() })
+	if base.Stats.Mapped != queryReadyBaseMmapSupported() || base.Stats.BytesCopied != 0 || base.Stats.WholePartDecodes != 0 || base.Stats.DictionaryConstructions != 0 {
+		t.Fatalf("open stats=%+v", base.Stats)
+	}
+	if base.Stats.BytesRead != int64(len(result.Bytes)) || base.Stats.BytesValidated != int64(len(result.Bytes)) {
+		t.Fatalf("read/validated bytes=%d/%d want %d", base.Stats.BytesRead, base.Stats.BytesValidated, len(result.Bytes))
+	}
+	if base.Stats.BytesDecoded >= int64(len(result.Bytes)) {
+		t.Fatalf("decoded bytes=%d want below asset bytes=%d", base.Stats.BytesDecoded, len(result.Bytes))
+	}
+	if len(base.Parts[0].Image.Bytes) == 0 || &base.Parts[0].Image.Bytes[0] != &base.Bytes()[base.Parts[0].Offset] {
+		t.Fatalf("part image is not a direct view of mapped base bytes")
+	}
+}
+
+func TestQueryReadyBaseGenerationPreservesNullableAndDictionaryDomains(t *testing.T) {
+	opts := transplantTestOptions(nil)
+	opts.Columns[2].Encoding = EncodingNullableInt64
+	batch := transplantTestBatch()
+	batch.Nulls = map[string][]bool{"value": {false, true, false, false, true, false}}
+	part := mustTransplantPart(t, 707, opts, batch)
+	image := mustTransplantImage(t, part)
+	identity := queryReadyBaseTestIdentity(46)
+	result, err := BuildQueryReadyBaseGeneration(identity, []QueryReadyBasePartInput{{SourceGeneration: 24, Image: image}})
+	if err != nil {
+		t.Fatalf("build base: %v", err)
+	}
+	base, err := OpenQueryReadyBaseGeneration(result.Bytes, identity)
+	if err != nil {
+		t.Fatalf("open base: %v", err)
+	}
+	reopened, err := ColumnPartFromImage(base.Parts[0].Image)
+	if err != nil {
+		t.Fatalf("reopen part: %v", err)
+	}
+	if got := reopened.Options.Columns[3].Cardinality; got != 3 {
+		t.Fatalf("dictionary cardinality=%d want 3", got)
+	}
+	if got := reopened.Options.Columns[2].Name; got != "value" {
+		t.Fatalf("nullable column=%q", got)
+	}
+	block := reopened.Columns["value"].Blocks[0].Granule
+	values, nulls, _, err := new(GranuleReader).DecodeNullableInt64(block)
+	if err != nil {
+		t.Fatalf("DecodeNullableInt64: %v", err)
+	}
+	if len(values) != len(nulls) || !slices.Equal(nulls, []bool{true, false}) {
+		t.Fatalf("nullable values/nulls=%v/%v", values, nulls)
+	}
+}
+
+func BenchmarkQueryReadyBaseGenerationBuild(b *testing.B) {
+	identity := queryReadyBaseTestIdentity(100)
+	image := queryReadyBaseBenchmarkImage(b, 1001, queryReadyBaseBenchmarkRows(b))
+	input := []QueryReadyBasePartInput{{SourceGeneration: 99, Image: image}}
+	sample, err := BuildQueryReadyBaseGeneration(identity, input)
+	if err != nil {
+		b.Fatal(err)
+	}
+	b.ReportAllocs()
+	b.SetBytes(int64(len(image.Bytes)))
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		result, err := BuildQueryReadyBaseGeneration(identity, input)
+		if err != nil {
+			b.Fatal(err)
+		}
+		if len(result.Bytes) == 0 {
+			b.Fatal("empty base")
+		}
+	}
+	b.ReportMetric(float64(len(sample.Bytes)), "asset-bytes")
+	b.ReportMetric(float64(len(sample.Bytes)-len(image.Bytes)), "overhead-bytes")
+}
+
+func BenchmarkQueryReadyBaseGenerationOpen(b *testing.B) {
+	identity := queryReadyBaseTestIdentity(101)
+	image := queryReadyBaseBenchmarkImage(b, 1002, queryReadyBaseBenchmarkRows(b))
+	result, err := BuildQueryReadyBaseGeneration(identity, []QueryReadyBasePartInput{{SourceGeneration: 100, Image: image}})
+	if err != nil {
+		b.Fatal(err)
+	}
+	sample, err := OpenQueryReadyBaseGeneration(result.Bytes, identity)
+	if err != nil {
+		b.Fatal(err)
+	}
+	b.ReportAllocs()
+	b.SetBytes(int64(len(result.Bytes)))
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		base, err := OpenQueryReadyBaseGeneration(result.Bytes, identity)
+		if err != nil {
+			b.Fatal(err)
+		}
+		if base.Stats.WholePartDecodes != 0 {
+			b.Fatalf("whole part decodes=%d", base.Stats.WholePartDecodes)
+		}
+	}
+	b.ReportMetric(float64(sample.Stats.BytesDecoded), "decoded-bytes")
+	b.ReportMetric(float64(sample.Stats.BytesValidated), "validated-bytes")
+}
+
+// BenchmarkQueryReadyBaseGenerationLegacyPartOpen is the pre-QRBG comparison:
+// parse and reconstruct the complete typed-column part state that callers
+// historically prepared before executing a query.
+func BenchmarkQueryReadyBaseGenerationLegacyPartOpen(b *testing.B) {
+	image := queryReadyBaseBenchmarkImage(b, 1004, queryReadyBaseBenchmarkRows(b))
+	b.ReportAllocs()
+	b.SetBytes(int64(len(image.Bytes)))
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		parsed, err := ParseColumnPartImage(image.Bytes)
+		if err != nil {
+			b.Fatal(err)
+		}
+		part, err := ColumnPartFromImage(parsed)
+		if err != nil {
+			b.Fatal(err)
+		}
+		if part.Descriptor.RowCount == 0 {
+			b.Fatal("empty part")
+		}
+	}
+}
+
+func BenchmarkQueryReadyBaseGenerationDirectViewAccess(b *testing.B) {
+	identity := queryReadyBaseTestIdentity(102)
+	image := queryReadyBaseBenchmarkImage(b, 1003, queryReadyBaseBenchmarkRows(b))
+	result, err := BuildQueryReadyBaseGeneration(identity, []QueryReadyBasePartInput{{SourceGeneration: 101, Image: image}})
+	if err != nil {
+		b.Fatal(err)
+	}
+	base, err := OpenQueryReadyBaseGeneration(result.Bytes, identity)
+	if err != nil {
+		b.Fatal(err)
+	}
+	var section ColumnPartImageSection
+	for _, candidate := range base.Parts[0].Image.Sections {
+		if candidate.Kind == ColumnPartImageSectionColumnData {
+			section = candidate
+			break
+		}
+	}
+	if section.Length == 0 {
+		b.Fatal("missing column data section")
+	}
+	b.ReportAllocs()
+	b.ResetTimer()
+	var sink byte
+	for i := 0; i < b.N; i++ {
+		view := base.Parts[0].Image.sectionBytes(section)
+		sink ^= view[len(view)-1]
+	}
+	if sink == 0xff {
+		b.Log(sink)
+	}
+}
+
+func queryReadyBaseBenchmarkImage(tb testing.TB, partID uint64, rows int) ColumnPartImage {
+	tb.Helper()
+	opts := transplantTestOptions(nil)
+	opts.PartPolicy.RowsPerGranule = 8192
+	part, err := BuildColumnPart(partID, opts, transplantConstantBatch(rows, 42))
+	if err != nil {
+		tb.Fatalf("BuildColumnPart: %v", err)
+	}
+	image, err := BuildColumnPartImage(part, ColumnPartImageOptions{Dictionaries: map[string]map[string]int64{
+		"kind_code": {"user": 0, "reply": 1, "system": 2},
+	}})
+	if err != nil {
+		tb.Fatalf("BuildColumnPartImage: %v", err)
+	}
+	return image
+}
+
+func queryReadyBaseBenchmarkRows(tb testing.TB) int {
+	tb.Helper()
+	const defaultRows = 1 << 15
+	raw := os.Getenv("TREEDB_QUERY_READY_BASE_BENCH_ROWS")
+	if raw == "" {
+		return defaultRows
+	}
+	rows, err := strconv.Atoi(raw)
+	if err != nil || rows <= 0 {
+		tb.Fatalf("TREEDB_QUERY_READY_BASE_BENCH_ROWS=%q must be a positive integer", raw)
+	}
+	return rows
+}
+
+func queryReadyBaseTestIdentity(generation uint64) QueryReadyBaseIdentity {
+	return QueryReadyBaseIdentity{Generation: generation, SchemaHash: sha256.Sum256([]byte("schema-v1"))}
+}
+
+func queryReadyBaseCorruptLastByte(data []byte) []byte {
+	out := slices.Clone(data)
+	out[len(out)-1] ^= 0xff
+	return out
+}
+
+func queryReadyBaseCorruptByte(data []byte, offset int) []byte {
+	out := slices.Clone(data)
+	out[offset] ^= 0xff
+	return out
+}

--- a/docs/architecture/query-ready-base-generation.md
+++ b/docs/architecture/query-ready-base-generation.md
@@ -1,0 +1,60 @@
+# Query-ready typed-column base generation v1
+
+TreeDB's query-ready base generation (`QRBG` v1) is an immutable,
+query-independent container for a snapshot-visible set of typed-column part
+images. It is a rebuildable derived asset: it is not a primary document store,
+durability root, WAL record, recovery selector, or GC owner.
+
+## Identity and compatibility
+
+Every image records an exact base generation and 32-byte collection schema
+hash. Open requires both expected values and fails closed on a mismatch. The
+format is pre-alpha; incompatible versions are rejected and should be rebuilt
+rather than migrated.
+
+The part table is sorted by source generation and part ID. Each dependency
+records the source generation, part ID, row count, byte range, manifest length,
+and SHA-256 image checksum. Header and table CRC-32C checksums protect the
+container metadata. Embedded typed-column images retain their self-describing
+descriptor, null/default bitmaps, encoded values, dictionary/code domain,
+offsets, sort marks, layout contract, statistics, and pruning metadata.
+
+The builder validates each complete typed-column image before embedding it.
+For identical identity and logical input parts, the output bytes are
+deterministic regardless of caller iteration order.
+
+## Open contract
+
+`OpenQueryReadyBaseGenerationFile` uses a read-only file mapping on supported
+platforms. Open validates container bounds and checksums, parses each embedded
+part manifest, and validates bounded structural metadata before exposing a
+view. Encoded column payloads and dictionaries remain direct slices of the
+mapping; open does not decode the complete payload, construct a query-shaped
+dictionary, or copy part bytes.
+
+Open stats make the contract observable: mapped/read/validated/decoded/copied
+bytes, part and row counts, whole-part decodes, dictionary constructions, and
+validation/open duration. Build stats report input/output/copied bytes, rows,
+parts, and build/validation duration.
+
+Callers must close file-backed views before replacing or deleting their files.
+Lifecycle registration, authoritative publication/recovery, and reclamation
+remain owned by the existing asset-root and GC work. A caller may place QRBG
+files in the column asset manager's prepared namespace, but QRBG v1 does not
+publish or unlink them itself.
+
+## Performance guardrails
+
+The performance objective is lower reopen preparation cost without hidden
+whole-part decode or payload copying. Focused evidence uses:
+
+- `BenchmarkQueryReadyBaseGenerationBuild`
+- `BenchmarkQueryReadyBaseGenerationOpen`
+- `BenchmarkQueryReadyBaseGenerationDirectViewAccess`
+
+Run with `-benchmem -count=5` on one host. Report build/open throughput,
+`B/op`, `allocs/op`, peak RSS for a production-shaped reopen, and output asset
+bytes. Payload duplication, unbounded RSS or allocations, and work deferred
+silently into the first query are regressions. The canonical 1M cold/reopen
+profile remains a graph-level validation owned by the later integration and
+closeout milestones once production queries consume this asset.


### PR DESCRIPTION
Closes #3696
Depends on #3695
Parent: #3694

## Outcome

Adds the rebuildable, non-authoritative `QRBG` v1 typed-column base-generation contract:

- deterministic dependency ordering by source generation and part ID;
- exact base generation and SHA-256 schema identity;
- versioned header/table plus per-part integrity and exact byte-range validation;
- embedded self-describing typed-column images with nullable, dictionary/code, offsets, sort marks, pruning, and layout contracts preserved;
- bounded structural validation and direct read-only mmap-backed part views without whole-payload decode or copy;
- explicit dependency identity, `Close` lifecycle, and build/open counters;
- pre-alpha format and lifecycle documentation;
- no WAL, root publication/recovery, GC/unlink, or primary-document ownership change.

Production collection open/query integration remains owned by M3/M4. This PR only supplies the versioned base asset contract; it does not start descendant work.

## Test-driven development

The six issue-named format/open contracts were written first. Initial red transcript (undefined contract surface):

`/mnt/fast4tb/gomap_graph_3694/m1_evidence/red_test.txt`

Coordinator review then found a forged-table case that could leave trailing bytes after the last declared part. A focused regression reproduced the pre-fix acceptance (`err=<nil>`) before the exact-end check was added:

`/mnt/fast4tb/gomap_graph_3694/m1_evidence/red_trailing_bytes.txt`

Final coverage includes reopen parity, corruption/truncation, schema/generation mismatch, deterministic multipart build, empty base, mmap/no-whole-decode open, nullable/dictionary preservation, layout certification, and forged trailing bytes.

## Validation

- `GOWORK=off go test ./TreeDB/internal/typedcolumn`
- `GOWORK=off go test ./TreeDB/internal/typedcolumn -run '^TestQueryReadyBaseGeneration' -count=1`
- `GOWORK=off go vet ./TreeDB/internal/typedcolumn`
- Windows amd64 test-binary cross-compile
- `git diff --check origin/main...HEAD`

All pass on head `9ffb0603b9a901567a3054245c700ed0ac430d2b`.

## Performance evidence

Same host, identical generated typed-column input, `-benchmem -count=5`; artifacts:

`/mnt/fast4tb/gomap_graph_3694/m1_evidence/`

32K representative part:

| Lane | Median | Throughput | B/op | allocs/op |
| --- | ---: | ---: | ---: | ---: |
| QRBG build | ~1.43 ms | ~1.36 GB/s | ~1.99 MB | 150 |
| QRBG open | ~1.164 ms | ~1.68 GB/s | ~29.5 KB | 150 |
| legacy full-part preparation | ~4.43 ms | ~0.44 GB/s | 5.46 MB | 302 |
| direct-view access | ~4.2 ns | n/a | 0 | 0 |

The 1.95 MB asset adds 4 KB container overhead. Open validates 1.95 MB but structurally decodes only 6,392 bytes and reports zero complete-part decodes, dictionary constructions, or payload copies.

Representative 1M-row typed-column artifact:

- asset: 59,307,939 bytes, including 4 KB container overhead;
- build: 55.6 ms, 59.8 MB/op, 984 allocs/op;
- open: 35.2 ms, 481,856 B/op, 983 allocs/op;
- open structurally decoded 129,914 bytes while validating 59.3 MB;
- process peak RSS: 569,600 KB, including test binary plus 1M fixture/image construction and the retained source/base images.

CPU profile attributes open primarily to required SHA-256 validation; allocation profile is bounded structural descriptor/layout state. Manager-level verified-file caching may optimize repeated opens in M3 without weakening this default fail-closed open contract.

## Guardrails and deferred integration

- QRBG is rebuildable and non-authoritative until the existing asset-root owners register it.
- Canonical Bluesky cold/reopen query validation is intentionally deferred to M3/M4 because production queries do not consume QRBG yet.
- The accepted storage gap remains a non-goal; this PR adds only ~4 KB container overhead to the representative images.


## Exact-head review follow-up

Codex review found that variable-width payload attachment violated the no-copy open contract. Red evidence measured 9,235,098 B/open for 4,522,000 payload bytes. Head `9ffb0603b9a901567a3054245c700ed0ac430d2b` replaces attachment with metadata-only descriptor/sort/layout/section and offsets/block-boundary validation. A 3 MiB variable-width open improved from 3.737 ms, 7,276 KiB/op, 802 allocs/op to 2.197 ms, 103.4 KiB/op, 514 allocs/op; copied bytes remain 0 and only 44,925 structural bytes are decoded. Focused race coverage and checksummed corruption fixtures pass.
