### PR TITLE
[DUR-02] Land dormant bounded root-publication scheduler

### DIFF
--- a/TreeDB/internal/rootpublication/STATE_TABLE.md
+++ b/TreeDB/internal/rootpublication/STATE_TABLE.md
@@ -1,0 +1,26 @@
+# Dormant root-publication coordinator state table
+
+The coordinator mutex owns pending candidates/debt, visible/durable/recoverable
+frontiers, waiters, timer state, admission counts, failure state, and statistics.
+Candidate builders own one reference-counted admission lease; nested builders
+share that lease. `Publisher.Publish` executes with neither ownership held.
+
+| From | Event | To | Ownership and observable result |
+| --- | --- | --- | --- |
+| idle | first enqueue | pending-window | Candidate/debt retained; visible advances; timer anchors now. |
+| pending-window | later enqueue/supersede | pending-window | Latest data frontier wins; earlier debt, opaque dependency-obligation union, and waiters remain; timer is not reset. |
+| pending-window | timer, waiter, soft bytes, hard admission, or drain | publishing | Snapshot latest candidate plus deterministic accumulated debt; wait for active builders to reach zero; call publisher without the coordinator lock. |
+| publishing | success | idle or pending-window | Remove only captured debt; durable/recoverable advance; satisfy every waiter at or below durable; update EWMA; remaining debt starts a fresh window. |
+| publishing | pre-meta/retryable failure | stalled-pending | Retain candidate/debt; fail captured waiters and hard-admission acknowledgements with the callback error; an explicit later waiter/drain retries. |
+| publishing | ambiguous/post-meta result | poisoned | Retain debt until stop/reopen ownership cleanup; fail all waiters; every future enqueue, admission, wait, and drain returns `ErrRecoveryRequired`. |
+| any live state | stop | stopped | Cancel callback context, fail waiters, join the sole scheduler goroutine, and report unpublished debt instead of silently discarding it. |
+
+Hard admission is crossed only when pending debt is **greater than** 256 MiB or
+65,536 commits. The crossing enqueue is owned before acknowledgement and wakes
+publication; its acknowledgement waits for durable progress or returns the
+publisher error. Ordinary work at or below both limits never waits for stable
+I/O. Soft publication wakes at 64 MiB.
+
+The adaptive delay is `clamp(20 * EWMA(service duration), 10ms, 100ms)`. EWMA
+uses weight 1/8 for the latest successful service duration. Retryable failures
+do not update it.

--- a/TreeDB/internal/rootpublication/admission.go
+++ b/TreeDB/internal/rootpublication/admission.go
@@ -1,0 +1,72 @@
+package rootpublication
+
+import (
+	"context"
+	"sync"
+)
+
+// BuilderToken accounts one active candidate builder. Nested returns another
+// handle to the same lease; the coordinator sees one active builder until the
+// final handle is released.
+type BuilderToken struct {
+	lease *builderLease
+	once  sync.Once
+}
+
+type builderLease struct {
+	coordinator *Coordinator
+	mu          sync.Mutex
+	refs        uint64
+	released    bool
+}
+
+func (c *Coordinator) AcquireBuilder(ctx context.Context) (*BuilderToken, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if err := c.terminalErrorLocked(); err != nil {
+		return nil, err
+	}
+	c.activeBuilders++
+	return &BuilderToken{lease: &builderLease{coordinator: c, refs: 1}}, nil
+}
+
+func (t *BuilderToken) Nested() (*BuilderToken, error) {
+	if t == nil || t.lease == nil {
+		return nil, ErrClosed
+	}
+	t.lease.mu.Lock()
+	defer t.lease.mu.Unlock()
+	if t.lease.released {
+		return nil, ErrClosed
+	}
+	t.lease.refs++
+	return &BuilderToken{lease: t.lease}, nil
+}
+
+func (t *BuilderToken) Release() {
+	if t == nil || t.lease == nil {
+		return
+	}
+	t.once.Do(func() {
+		lease := t.lease
+		lease.mu.Lock()
+		if lease.refs > 0 {
+			lease.refs--
+		}
+		last := lease.refs == 0 && !lease.released
+		if last {
+			lease.released = true
+		}
+		lease.mu.Unlock()
+		if last {
+			lease.coordinator.mu.Lock()
+			lease.coordinator.activeBuilders--
+			lease.coordinator.notifyLocked()
+			lease.coordinator.mu.Unlock()
+			lease.coordinator.signal()
+		}
+	})
+}

--- a/TreeDB/internal/rootpublication/admission.go
+++ b/TreeDB/internal/rootpublication/admission.go
@@ -74,6 +74,7 @@ func (t *BuilderToken) Release() {
 	}
 	handle.released = true
 	lease := handle.lease
+	handle.lease = nil
 	handle.mu.Unlock()
 
 	lease.mu.Lock()

--- a/TreeDB/internal/rootpublication/admission.go
+++ b/TreeDB/internal/rootpublication/admission.go
@@ -9,8 +9,16 @@ import (
 // handle to the same lease; the coordinator sees one active builder until the
 // final handle is released.
 type BuilderToken struct {
-	lease *builderLease
-	once  sync.Once
+	handle *builderHandle
+}
+
+// builderHandle is separately allocated so copying the exported BuilderToken
+// preserves one release/nesting identity instead of copying synchronization
+// state and decrementing the shared lease twice.
+type builderHandle struct {
+	mu       sync.Mutex
+	lease    *builderLease
+	released bool
 }
 
 type builderLease struct {
@@ -30,43 +38,58 @@ func (c *Coordinator) AcquireBuilder(ctx context.Context) (*BuilderToken, error)
 		return nil, err
 	}
 	c.activeBuilders++
-	return &BuilderToken{lease: &builderLease{coordinator: c, refs: 1}}, nil
+	lease := &builderLease{coordinator: c, refs: 1}
+	return &BuilderToken{handle: &builderHandle{lease: lease}}, nil
 }
 
 func (t *BuilderToken) Nested() (*BuilderToken, error) {
-	if t == nil || t.lease == nil {
+	if t == nil || t.handle == nil {
 		return nil, ErrClosed
 	}
-	t.lease.mu.Lock()
-	defer t.lease.mu.Unlock()
-	if t.lease.released {
+	handle := t.handle
+	handle.mu.Lock()
+	defer handle.mu.Unlock()
+	if handle.released || handle.lease == nil {
 		return nil, ErrClosed
 	}
-	t.lease.refs++
-	return &BuilderToken{lease: t.lease}, nil
+	lease := handle.lease
+	lease.mu.Lock()
+	defer lease.mu.Unlock()
+	if lease.released {
+		return nil, ErrClosed
+	}
+	lease.refs++
+	return &BuilderToken{handle: &builderHandle{lease: lease}}, nil
 }
 
 func (t *BuilderToken) Release() {
-	if t == nil || t.lease == nil {
+	if t == nil || t.handle == nil {
 		return
 	}
-	t.once.Do(func() {
-		lease := t.lease
-		lease.mu.Lock()
-		if lease.refs > 0 {
-			lease.refs--
-		}
-		last := lease.refs == 0 && !lease.released
-		if last {
-			lease.released = true
-		}
-		lease.mu.Unlock()
-		if last {
-			lease.coordinator.mu.Lock()
-			lease.coordinator.activeBuilders--
-			lease.coordinator.notifyLocked()
-			lease.coordinator.mu.Unlock()
-			lease.coordinator.signal()
-		}
-	})
+	handle := t.handle
+	handle.mu.Lock()
+	if handle.released || handle.lease == nil {
+		handle.mu.Unlock()
+		return
+	}
+	handle.released = true
+	lease := handle.lease
+	handle.mu.Unlock()
+
+	lease.mu.Lock()
+	if lease.refs > 0 {
+		lease.refs--
+	}
+	last := lease.refs == 0 && !lease.released
+	if last {
+		lease.released = true
+	}
+	lease.mu.Unlock()
+	if last {
+		lease.coordinator.mu.Lock()
+		lease.coordinator.activeBuilders--
+		lease.coordinator.notifyLocked()
+		lease.coordinator.mu.Unlock()
+		lease.coordinator.signal()
+	}
 }

--- a/TreeDB/internal/rootpublication/admission.go
+++ b/TreeDB/internal/rootpublication/admission.go
@@ -21,12 +21,12 @@ type builderLease struct {
 }
 
 func (c *Coordinator) AcquireBuilder(ctx context.Context) (*BuilderToken, error) {
-	if err := ctx.Err(); err != nil {
-		return nil, err
-	}
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	if err := c.terminalErrorLocked(); err != nil {
+		return nil, err
+	}
+	if err := ctx.Err(); err != nil {
 		return nil, err
 	}
 	c.activeBuilders++

--- a/TreeDB/internal/rootpublication/clock.go
+++ b/TreeDB/internal/rootpublication/clock.go
@@ -1,6 +1,7 @@
 package rootpublication
 
 import (
+	"sort"
 	"sync"
 	"time"
 )
@@ -33,6 +34,7 @@ type FakeClock struct {
 	mu     sync.Mutex
 	now    time.Time
 	timers map[*fakeTimer]struct{}
+	nextID uint64
 }
 
 func NewFakeClock(now time.Time) *FakeClock {
@@ -48,7 +50,8 @@ func (c *FakeClock) Now() time.Time {
 func (c *FakeClock) NewTimer(d time.Duration) Timer {
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	t := &fakeTimer{clock: c, when: c.now.Add(d), ch: make(chan time.Time, 1), active: true}
+	c.nextID++
+	t := &fakeTimer{clock: c, when: c.now.Add(d), ch: make(chan time.Time, 1), active: true, id: c.nextID}
 	c.timers[t] = struct{}{}
 	return t
 }
@@ -57,6 +60,14 @@ func (c *FakeClock) Advance(d time.Duration) {
 	c.mu.Lock()
 	c.now = c.now.Add(d)
 	now := c.now
+	due := c.takeDueTimersLocked(now)
+	c.mu.Unlock()
+	for _, timer := range due {
+		timer.ch <- timer.when
+	}
+}
+
+func (c *FakeClock) takeDueTimersLocked(now time.Time) []*fakeTimer {
 	var due []*fakeTimer
 	for timer := range c.timers {
 		if timer.active && !timer.when.After(now) {
@@ -65,10 +76,13 @@ func (c *FakeClock) Advance(d time.Duration) {
 			due = append(due, timer)
 		}
 	}
-	c.mu.Unlock()
-	for _, timer := range due {
-		timer.ch <- timer.when
-	}
+	sort.Slice(due, func(i, j int) bool {
+		if !due[i].when.Equal(due[j].when) {
+			return due[i].when.Before(due[j].when)
+		}
+		return due[i].id < due[j].id
+	})
+	return due
 }
 
 type fakeTimer struct {
@@ -76,6 +90,7 @@ type fakeTimer struct {
 	when   time.Time
 	ch     chan time.Time
 	active bool
+	id     uint64
 }
 
 func (t *fakeTimer) C() <-chan time.Time { return t.ch }

--- a/TreeDB/internal/rootpublication/clock.go
+++ b/TreeDB/internal/rootpublication/clock.go
@@ -1,0 +1,92 @@
+package rootpublication
+
+import (
+	"sync"
+	"time"
+)
+
+type Timer interface {
+	C() <-chan time.Time
+	Stop() bool
+}
+
+type Clock interface {
+	Now() time.Time
+	NewTimer(time.Duration) Timer
+}
+
+type realClock struct{}
+
+func (realClock) Now() time.Time { return time.Now() }
+func (realClock) NewTimer(d time.Duration) Timer {
+	return realTimer{timer: time.NewTimer(d)}
+}
+
+type realTimer struct{ timer *time.Timer }
+
+func (t realTimer) C() <-chan time.Time { return t.timer.C }
+func (t realTimer) Stop() bool          { return t.timer.Stop() }
+
+// FakeClock is a deterministic clock seam for scheduler and service-time
+// tests. Advance synchronously fires every timer due at the resulting time.
+type FakeClock struct {
+	mu     sync.Mutex
+	now    time.Time
+	timers map[*fakeTimer]struct{}
+}
+
+func NewFakeClock(now time.Time) *FakeClock {
+	return &FakeClock{now: now, timers: make(map[*fakeTimer]struct{})}
+}
+
+func (c *FakeClock) Now() time.Time {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.now
+}
+
+func (c *FakeClock) NewTimer(d time.Duration) Timer {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	t := &fakeTimer{clock: c, when: c.now.Add(d), ch: make(chan time.Time, 1), active: true}
+	c.timers[t] = struct{}{}
+	return t
+}
+
+func (c *FakeClock) Advance(d time.Duration) {
+	c.mu.Lock()
+	c.now = c.now.Add(d)
+	now := c.now
+	var due []*fakeTimer
+	for timer := range c.timers {
+		if timer.active && !timer.when.After(now) {
+			timer.active = false
+			delete(c.timers, timer)
+			due = append(due, timer)
+		}
+	}
+	c.mu.Unlock()
+	for _, timer := range due {
+		timer.ch <- timer.when
+	}
+}
+
+type fakeTimer struct {
+	clock  *FakeClock
+	when   time.Time
+	ch     chan time.Time
+	active bool
+}
+
+func (t *fakeTimer) C() <-chan time.Time { return t.ch }
+
+func (t *fakeTimer) Stop() bool {
+	t.clock.mu.Lock()
+	defer t.clock.mu.Unlock()
+	wasActive := t.active
+	if t.active {
+		t.active = false
+		delete(t.clock.timers, t)
+	}
+	return wasActive
+}

--- a/TreeDB/internal/rootpublication/clock_test.go
+++ b/TreeDB/internal/rootpublication/clock_test.go
@@ -29,3 +29,32 @@ func TestFakeClockDueTimersUseDeadlineThenCreationOrder(t *testing.T) {
 		t.Fatal("future timer was consumed")
 	}
 }
+
+func TestStaleStoppedTimerFiringCannotReplaceCurrentTimer(t *testing.T) {
+	clock := NewFakeClock(time.Unix(2, 0))
+	c := &Coordinator{clock: clock, firstPendingAt: clock.Now(), wakeReason: WakeNone}
+
+	c.installTimerLocked()
+	staleTimer := c.timer
+	staleGeneration := c.timerGeneration
+	c.clearPublishRequestLocked()
+	c.installTimerLocked()
+	currentTimer := c.timer
+	currentGeneration := c.timerGeneration
+	if currentTimer == staleTimer || currentGeneration == staleGeneration {
+		t.Fatal("replacement timer did not receive a distinct identity")
+	}
+
+	c.handleTimerFiredLocked(staleGeneration)
+	if c.timer != currentTimer || c.timerGeneration != currentGeneration {
+		t.Fatal("stale timer firing replaced the current timer")
+	}
+	if c.publishNow || c.wakeReason != WakeNone {
+		t.Fatalf("stale timer firing requested publication: now=%v reason=%v", c.publishNow, c.wakeReason)
+	}
+
+	c.handleTimerFiredLocked(currentGeneration)
+	if c.timer != nil || !c.publishNow || c.wakeReason != WakeTimer {
+		t.Fatalf("current timer firing was ignored: timer=%v now=%v reason=%v", c.timer, c.publishNow, c.wakeReason)
+	}
+}

--- a/TreeDB/internal/rootpublication/clock_test.go
+++ b/TreeDB/internal/rootpublication/clock_test.go
@@ -1,0 +1,31 @@
+package rootpublication
+
+import (
+	"testing"
+	"time"
+)
+
+func TestFakeClockDueTimersUseDeadlineThenCreationOrder(t *testing.T) {
+	clock := NewFakeClock(time.Unix(1, 0))
+	tiedFirst := clock.NewTimer(3 * time.Millisecond).(*fakeTimer)
+	early := clock.NewTimer(time.Millisecond).(*fakeTimer)
+	tiedSecond := clock.NewTimer(3 * time.Millisecond).(*fakeTimer)
+	later := clock.NewTimer(4 * time.Millisecond).(*fakeTimer)
+
+	clock.mu.Lock()
+	due := clock.takeDueTimersLocked(clock.now.Add(3 * time.Millisecond))
+	clock.mu.Unlock()
+
+	want := []*fakeTimer{early, tiedFirst, tiedSecond}
+	if len(due) != len(want) {
+		t.Fatalf("due timer count=%d, want %d", len(due), len(want))
+	}
+	for i := range want {
+		if due[i] != want[i] {
+			t.Fatalf("due timer %d=%p, want %p", i, due[i], want[i])
+		}
+	}
+	if !later.active {
+		t.Fatal("future timer was consumed")
+	}
+}

--- a/TreeDB/internal/rootpublication/coordinator.go
+++ b/TreeDB/internal/rootpublication/coordinator.go
@@ -1,0 +1,616 @@
+package rootpublication
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+	"time"
+)
+
+type Options struct {
+	Clock                      Clock
+	Publisher                  Publisher
+	InitialDurableFrontier     Frontier
+	OldestRecoverableCommitSeq uint64
+}
+
+type pendingEntry struct {
+	candidate *PreparedRootCandidate
+	bytes     uint64
+}
+
+type durabilityWaiter struct {
+	seq uint64
+	ch  chan error
+}
+
+// Coordinator owns only in-memory scheduling state. It is intentionally not
+// reachable from any production TreeDB handle in this ticket.
+type Coordinator struct {
+	mu sync.Mutex
+
+	clock     Clock
+	publisher Publisher
+	ctx       context.Context
+	cancel    context.CancelFunc
+	wake      chan struct{}
+	changed   chan struct{}
+	done      chan struct{}
+
+	pending        []pendingEntry
+	pendingBytes   uint64
+	firstPendingAt time.Time
+	timer          Timer
+	wakeReason     WakeReason
+	publishNow     bool
+	publishing     bool
+	drainRequests  uint64
+	stopping       bool
+	stopped        bool
+	poison         error
+
+	visible           Frontier
+	durable           Frontier
+	oldestRecoverable uint64
+	waiters           []*durabilityWaiter
+	activeBuilders    uint64
+
+	ewmaService        time.Duration
+	lastService        time.Duration
+	lastGroupSize      uint64
+	admissionWaits     uint64
+	preMetaFailures    uint64
+	retries            uint64
+	publishCalls       uint64
+	failureGeneration  uint64
+	lastRetryableError error
+	lastFailureSeq     uint64
+	nextAttemptID      uint64
+	activeAttempt      PublishAttempt
+	reportingAttempt   bool
+}
+
+// PublishAttempt is an opaque identity for exactly one captured callback.
+// ReportPublishResult rejects zero, stale, duplicate, and mismatched attempts.
+type PublishAttempt struct {
+	id        uint64
+	candidate *PreparedRootCandidate
+	groupSize uint64
+	started   time.Time
+	waiters   []*durabilityWaiter
+}
+
+func New(options Options) (*Coordinator, error) {
+	if options.Publisher == nil {
+		return nil, errors.New("root publication: nil publisher")
+	}
+	if options.OldestRecoverableCommitSeq > options.InitialDurableFrontier.commitSeq {
+		return nil, fmt.Errorf("root publication: oldest recoverable sequence %d exceeds durable sequence %d",
+			options.OldestRecoverableCommitSeq, options.InitialDurableFrontier.commitSeq)
+	}
+	clock := options.Clock
+	if clock == nil {
+		clock = realClock{}
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	c := &Coordinator{
+		clock: clock, publisher: options.Publisher, ctx: ctx, cancel: cancel,
+		wake: make(chan struct{}, 1), changed: make(chan struct{}), done: make(chan struct{}), wakeReason: WakeNone,
+		visible: options.InitialDurableFrontier, durable: options.InitialDurableFrontier,
+		oldestRecoverable: options.OldestRecoverableCommitSeq,
+	}
+	if c.oldestRecoverable == 0 {
+		c.oldestRecoverable = c.durable.commitSeq
+	}
+	go c.run()
+	return c, nil
+}
+
+// Enqueue transfers one immutable candidate into the pending frontier. Below
+// hard admission this never waits for Publish. If accepting it crosses either
+// hard limit, acknowledgement waits for durable progress or a publisher error.
+func (c *Coordinator) Enqueue(ctx context.Context, candidate *PreparedRootCandidate) error {
+	return c.enqueue(ctx, candidate, false)
+}
+
+// Supersede has the same admission contract as Enqueue and names the semantic
+// replacement explicitly for callers and tests.
+func (c *Coordinator) Supersede(ctx context.Context, candidate *PreparedRootCandidate) error {
+	return c.enqueue(ctx, candidate, true)
+}
+
+func (c *Coordinator) enqueue(ctx context.Context, candidate *PreparedRootCandidate, supersede bool) error {
+	if candidate == nil {
+		return fmt.Errorf("%w: nil candidate", ErrInvalidCandidate)
+	}
+	c.mu.Lock()
+	if err := c.terminalErrorLocked(); err != nil {
+		c.mu.Unlock()
+		return err
+	}
+	if candidate.frontier.commitSeq <= c.visible.commitSeq ||
+		(c.visible.commitSeq != 0 && !candidate.frontier.Dominates(c.visible)) {
+		c.mu.Unlock()
+		return fmt.Errorf("%w: frontier %d does not dominate visible %d", ErrInvalidCandidate, candidate.frontier.commitSeq, c.visible.commitSeq)
+	}
+	if supersede && len(c.pending) == 0 {
+		c.mu.Unlock()
+		return fmt.Errorf("%w: no pending candidate to supersede", ErrInvalidCandidate)
+	}
+	wasEmpty := len(c.pending) == 0
+	entryBytes := candidate.OwnedBytes()
+	c.pending = append(c.pending, pendingEntry{candidate: candidate, bytes: entryBytes})
+	c.pendingBytes = saturatingAdd(c.pendingBytes, entryBytes)
+	c.visible = candidate.frontier
+	if wasEmpty {
+		c.firstPendingAt = c.clock.Now()
+		c.installTimerLocked()
+	}
+	hard := c.pendingBytes > HardPendingBytes || uint64(len(c.pending)) > HardPendingCommits
+	if c.pendingBytes >= SoftPendingBytes {
+		c.requestPublishLocked(WakeSoftBytes)
+	}
+	if hard {
+		c.admissionWaits++
+		c.requestPublishLocked(WakeHardAdmission)
+	}
+	failureGeneration := c.failureGeneration
+	seq := candidate.frontier.commitSeq
+	c.mu.Unlock()
+	c.signal()
+	if !hard {
+		return nil
+	}
+	return c.waitForAdmission(ctx, seq, failureGeneration)
+}
+
+func (c *Coordinator) waitForAdmission(ctx context.Context, seq, failureGeneration uint64) error {
+	for {
+		c.mu.Lock()
+		if err := c.terminalErrorLocked(); err != nil {
+			c.mu.Unlock()
+			return err
+		}
+		if c.durable.commitSeq >= seq ||
+			(c.pendingBytes <= HardPendingBytes && uint64(len(c.pending)) <= HardPendingCommits) {
+			c.mu.Unlock()
+			return nil
+		}
+		if c.failureGeneration > failureGeneration {
+			if seq <= c.lastFailureSeq {
+				err := c.lastRetryableError
+				c.mu.Unlock()
+				return err
+			}
+			failureGeneration = c.failureGeneration
+		}
+		changed := c.changed
+		c.mu.Unlock()
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-changed:
+		}
+	}
+}
+
+// WaitThrough returns only when a durable frontier reaches seq. Installing a
+// waiter is an immediate scheduler trigger. Retryable failure is returned to
+// every waiter captured by that attempt; a later call explicitly retries.
+func (c *Coordinator) WaitThrough(ctx context.Context, seq uint64) error {
+	c.mu.Lock()
+	if c.durable.commitSeq >= seq {
+		c.mu.Unlock()
+		return nil
+	}
+	if err := c.terminalErrorLocked(); err != nil {
+		c.mu.Unlock()
+		return err
+	}
+	if seq > c.visible.commitSeq {
+		c.mu.Unlock()
+		return fmt.Errorf("%w: wait sequence %d exceeds visible %d", ErrInvalidCandidate, seq, c.visible.commitSeq)
+	}
+	waiter := &durabilityWaiter{seq: seq, ch: make(chan error, 1)}
+	c.waiters = append(c.waiters, waiter)
+	c.requestPublishLocked(WakeWaiter)
+	c.mu.Unlock()
+	c.signal()
+	select {
+	case err := <-waiter.ch:
+		return err
+	case <-ctx.Done():
+		c.mu.Lock()
+		if c.durable.commitSeq >= seq {
+			c.removeWaiterLocked(waiter)
+			c.mu.Unlock()
+			return nil
+		}
+		select {
+		case err := <-waiter.ch:
+			c.mu.Unlock()
+			return err
+		default:
+		}
+		c.removeWaiterLocked(waiter)
+		c.mu.Unlock()
+		return ctx.Err()
+	}
+}
+
+func (c *Coordinator) removeWaiterLocked(target *durabilityWaiter) {
+	for i, waiter := range c.waiters {
+		if waiter == target {
+			c.waiters = append(c.waiters[:i], c.waiters[i+1:]...)
+			break
+		}
+	}
+}
+
+// ReportPublishResult applies the result for the exact active attempt. The
+// synchronous scheduler is the attempt owner and opens the reporting window
+// only after Publish returns. Tests may use this method to prove stale and
+// duplicate reports are rejected, but cannot manufacture state transitions.
+func (c *Coordinator) ReportPublishResult(attempt PublishAttempt, result PublishResult) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if !c.reportingAttempt || attempt.id == 0 || attempt.id != c.activeAttempt.id ||
+		attempt.candidate != c.activeAttempt.candidate || attempt.groupSize != c.activeAttempt.groupSize {
+		return fmt.Errorf("%w: stale or mismatched attempt", ErrPublisherProtocol)
+	}
+	c.reportingAttempt = false
+	c.finishPublishLocked(attempt.candidate, attempt.groupSize, result, c.clock.Now().Sub(attempt.started))
+	c.activeAttempt = PublishAttempt{}
+	return nil
+}
+
+func (c *Coordinator) Drain(ctx context.Context) error {
+	c.mu.Lock()
+	if err := c.terminalErrorLocked(); err != nil {
+		c.mu.Unlock()
+		return err
+	}
+	if len(c.pending) == 0 && !c.publishing {
+		c.mu.Unlock()
+		return nil
+	}
+	c.drainRequests++
+	c.requestPublishLocked(WakeDrain)
+	failureGeneration := c.failureGeneration
+	c.mu.Unlock()
+	c.signal()
+	defer c.endDrain()
+	for {
+		c.mu.Lock()
+		if c.poison != nil {
+			err := c.poison
+			c.mu.Unlock()
+			return err
+		}
+		if c.failureGeneration > failureGeneration {
+			err := c.lastRetryableError
+			c.mu.Unlock()
+			return err
+		}
+		if len(c.pending) == 0 && !c.publishing {
+			c.mu.Unlock()
+			return nil
+		}
+		changed := c.changed
+		c.mu.Unlock()
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-changed:
+		}
+	}
+}
+
+func (c *Coordinator) endDrain() {
+	c.mu.Lock()
+	if c.drainRequests > 0 {
+		c.drainRequests--
+	}
+	c.mu.Unlock()
+}
+
+// Stop cancels a stalled Publisher through its context, fails all waiters, and
+// waits for the single scheduler goroutine. It does not silently claim pending
+// debt was durable.
+func (c *Coordinator) Stop(ctx context.Context) error {
+	c.mu.Lock()
+	if c.stopped {
+		c.mu.Unlock()
+		return nil
+	}
+	c.stopping = true
+	c.cancel()
+	if c.timer != nil {
+		c.timer.Stop()
+		c.timer = nil
+	}
+	c.failWaitersLocked(ErrPublicationStopped, true)
+	c.notifyLocked()
+	c.mu.Unlock()
+	c.signal()
+	select {
+	case <-c.done:
+		c.mu.Lock()
+		debt := len(c.pending) != 0
+		c.pending = nil
+		c.pendingBytes = 0
+		c.stopped = true
+		c.mu.Unlock()
+		if debt {
+			return ErrPublicationStopped
+		}
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+func (c *Coordinator) Stats() Stats {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	age := time.Duration(0)
+	if len(c.pending) != 0 {
+		age = c.clock.Now().Sub(c.firstPendingAt)
+	}
+	return Stats{
+		VisibleCommitSeq: c.visible.commitSeq, DurableCommitSeq: c.durable.commitSeq,
+		OldestRecoverableCommitSeq: c.oldestRecoverable, PendingCommits: uint64(len(c.pending)),
+		PendingBytes: c.pendingBytes, PendingAge: age, LastGroupSize: c.lastGroupSize,
+		LastServiceDuration: c.lastService, EWMAServiceDuration: c.ewmaService,
+		PublishDelay: c.publishDelayLocked(), AdmissionWaits: c.admissionWaits,
+		ActiveBuilders: c.activeBuilders, WaiterCount: uint64(len(c.waiters)),
+		PreMetaFailures: c.preMetaFailures, Retries: c.retries, Poisoned: c.poison != nil,
+		WakeReason: c.wakeReason, PublishCalls: c.publishCalls,
+	}
+}
+
+func (c *Coordinator) run() {
+	defer close(c.done)
+	for {
+		c.mu.Lock()
+		if c.stopping {
+			c.mu.Unlock()
+			return
+		}
+		var timerC <-chan time.Time
+		if c.timer != nil {
+			timerC = c.timer.C()
+		}
+		ready := c.publishNow && !c.publishing && len(c.pending) != 0 && c.activeBuilders == 0 && c.poison == nil
+		if ready {
+			groupSize := len(c.pending)
+			group := make([]*PreparedRootCandidate, groupSize)
+			for i := range group {
+				group[i] = c.pending[i].candidate
+			}
+			candidate := coalesceCandidates(group)
+			c.publishNow = false
+			c.publishing = true
+			c.publishCalls++
+			if c.lastRetryableError != nil {
+				c.retries++
+			}
+			c.nextAttemptID++
+			attempt := PublishAttempt{
+				id: c.nextAttemptID, candidate: candidate, groupSize: uint64(groupSize),
+				started: c.clock.Now(), waiters: append([]*durabilityWaiter(nil), c.waiters...),
+			}
+			c.activeAttempt = attempt
+			c.mu.Unlock()
+			result := c.publisher.Publish(c.ctx, candidate)
+			c.mu.Lock()
+			c.reportingAttempt = true
+			c.mu.Unlock()
+			_ = c.ReportPublishResult(attempt, result)
+			continue
+		}
+		c.mu.Unlock()
+		select {
+		case <-c.ctx.Done():
+			return
+		case <-c.wake:
+		case <-timerC:
+			c.mu.Lock()
+			c.timer = nil
+			c.requestPublishLocked(WakeTimer)
+			c.mu.Unlock()
+		}
+	}
+}
+
+func (c *Coordinator) finishPublishLocked(candidate *PreparedRootCandidate, groupSize uint64, result PublishResult, service time.Duration) {
+	c.publishing = false
+	if c.stopping {
+		return
+	}
+	switch result.Outcome {
+	case PublishSucceeded:
+		durableSeq := result.DurableCommitSeq
+		if durableSeq == 0 {
+			durableSeq = candidate.frontier.commitSeq
+		}
+		if result.Err != nil || durableSeq != candidate.frontier.commitSeq {
+			err := result.Err
+			if err == nil {
+				err = fmt.Errorf("durable sequence %d differs from candidate %d", durableSeq, candidate.frontier.commitSeq)
+			}
+			c.recordRetryableLocked(errors.Join(ErrPublisherProtocol, err), c.activeAttempt)
+			return
+		}
+		oldest := result.OldestRecoverableCommitSeq
+		if oldest == 0 {
+			oldest = c.oldestRecoverable
+		}
+		if oldest < c.oldestRecoverable || oldest > durableSeq {
+			c.recordRetryableLocked(errors.Join(ErrPublisherProtocol,
+				fmt.Errorf("oldest recoverable sequence %d outside monotonic range [%d,%d]", oldest, c.oldestRecoverable, durableSeq)), c.activeAttempt)
+			return
+		}
+		remove := int(groupSize)
+		if remove > len(c.pending) {
+			remove = len(c.pending)
+		}
+		var removedBytes uint64
+		for _, entry := range c.pending[:remove] {
+			removedBytes = saturatingAdd(removedBytes, entry.bytes)
+		}
+		c.pending = append([]pendingEntry(nil), c.pending[remove:]...)
+		if removedBytes <= c.pendingBytes {
+			c.pendingBytes -= removedBytes
+		} else {
+			c.pendingBytes = 0
+		}
+		c.durable = candidate.frontier
+		c.durable.commitSeq = durableSeq
+		c.oldestRecoverable = oldest
+		c.lastGroupSize = groupSize
+		c.lastService = service
+		if c.ewmaService == 0 {
+			c.ewmaService = service
+		} else {
+			c.ewmaService = (7*c.ewmaService + service) / 8
+		}
+		c.lastRetryableError = nil
+		c.satisfyWaitersLocked()
+		if c.timer != nil {
+			c.timer.Stop()
+			c.timer = nil
+		}
+		if len(c.pending) != 0 {
+			c.firstPendingAt = c.clock.Now()
+			if c.drainRequests != 0 || len(c.waiters) != 0 || c.pendingBytes >= SoftPendingBytes {
+				reason := WakeDrain
+				if len(c.waiters) != 0 {
+					reason = WakeWaiter
+				} else if c.pendingBytes >= SoftPendingBytes {
+					reason = WakeSoftBytes
+				}
+				c.requestPublishLocked(reason)
+			} else {
+				c.installTimerLocked()
+			}
+		}
+	case PublishRetryableFailure:
+		c.recordRetryableLocked(result.Err, c.activeAttempt)
+	case PublishAmbiguous:
+		err := result.Err
+		if err == nil {
+			err = errors.New("ambiguous target-meta mutation")
+		}
+		c.poison = errors.Join(ErrRecoveryRequired, err)
+		c.failWaitersLocked(c.poison, true)
+	default:
+		c.recordRetryableLocked(fmt.Errorf("%w: unknown outcome %d", ErrPublisherProtocol, result.Outcome), c.activeAttempt)
+	}
+	c.notifyLocked()
+	c.signal()
+}
+
+func (c *Coordinator) recordRetryableLocked(err error, attempt PublishAttempt) {
+	if err == nil {
+		err = errors.New("retryable publication failure")
+	}
+	c.preMetaFailures++
+	c.failureGeneration++
+	c.lastRetryableError = err
+	c.lastFailureSeq = attempt.candidate.frontier.commitSeq
+	c.failCapturedWaitersLocked(err, attempt.waiters)
+	c.notifyLocked()
+}
+
+func (c *Coordinator) failCapturedWaitersLocked(err error, captured []*durabilityWaiter) {
+	if len(captured) == 0 {
+		return
+	}
+	set := make(map[*durabilityWaiter]struct{}, len(captured))
+	for _, waiter := range captured {
+		set[waiter] = struct{}{}
+	}
+	remaining := c.waiters[:0]
+	for _, waiter := range c.waiters {
+		if _, ok := set[waiter]; ok {
+			waiter.ch <- err
+		} else {
+			remaining = append(remaining, waiter)
+		}
+	}
+	c.waiters = remaining
+}
+
+func (c *Coordinator) satisfyWaitersLocked() {
+	remaining := c.waiters[:0]
+	for _, waiter := range c.waiters {
+		if waiter.seq <= c.durable.commitSeq {
+			waiter.ch <- nil
+		} else {
+			remaining = append(remaining, waiter)
+		}
+	}
+	c.waiters = remaining
+}
+
+func (c *Coordinator) failWaitersLocked(err error, all bool) {
+	remaining := c.waiters[:0]
+	for _, waiter := range c.waiters {
+		if all || waiter.seq <= c.visible.commitSeq {
+			waiter.ch <- err
+		} else {
+			remaining = append(remaining, waiter)
+		}
+	}
+	c.waiters = remaining
+}
+
+func (c *Coordinator) terminalErrorLocked() error {
+	if c.poison != nil {
+		return c.poison
+	}
+	if c.stopping || c.stopped {
+		return ErrClosed
+	}
+	return nil
+}
+
+func (c *Coordinator) publishDelayLocked() time.Duration {
+	delay := 20 * c.ewmaService
+	if delay < minPublishDelay {
+		return minPublishDelay
+	}
+	if delay > maxPublishDelay {
+		return maxPublishDelay
+	}
+	return delay
+}
+
+func (c *Coordinator) installTimerLocked() {
+	if c.timer == nil {
+		c.timer = c.clock.NewTimer(c.publishDelayLocked())
+	}
+}
+
+func (c *Coordinator) requestPublishLocked(reason WakeReason) {
+	c.publishNow = true
+	c.wakeReason = reason
+	if c.timer != nil {
+		c.timer.Stop()
+		c.timer = nil
+	}
+}
+
+func (c *Coordinator) signal() {
+	select {
+	case c.wake <- struct{}{}:
+	default:
+	}
+}
+
+func (c *Coordinator) notifyLocked() {
+	close(c.changed)
+	c.changed = make(chan struct{})
+}

--- a/TreeDB/internal/rootpublication/coordinator.go
+++ b/TreeDB/internal/rootpublication/coordinator.go
@@ -376,7 +376,7 @@ func (c *Coordinator) Stop(ctx context.Context) error {
 		c.stopping = true
 		c.cancel()
 		c.clearPublishRequestLocked()
-		c.failWaitersLocked(ErrPublicationStopped, true)
+		c.failWaitersLocked(ErrPublicationStopped)
 		c.notifyLocked()
 	}
 	c.mu.Unlock()
@@ -540,7 +540,7 @@ func (c *Coordinator) finishPublishLocked(candidate *PreparedRootCandidate, grou
 		}
 		c.poison = errors.Join(ErrRecoveryRequired, err)
 		c.retryAttempt = PublishAttempt{}
-		c.failWaitersLocked(c.poison, true)
+		c.failWaitersLocked(c.poison)
 		c.clearPublishRequestLocked()
 	default:
 		c.recordRetryableLocked(fmt.Errorf("%w: unknown outcome %d", ErrPublisherProtocol, result.Outcome), c.activeAttempt)
@@ -694,22 +694,12 @@ func (c *Coordinator) satisfyWaitersLocked() {
 	c.waiters = remaining
 }
 
-func (c *Coordinator) failWaitersLocked(err error, all bool) {
-	waiters := c.waiters
-	remaining := waiters[:0]
-	for _, waiter := range waiters {
-		if all || waiter.seq <= c.visible.commitSeq {
-			waiter.ch <- err
-		} else {
-			remaining = append(remaining, waiter)
-		}
+func (c *Coordinator) failWaitersLocked(err error) {
+	for _, waiter := range c.waiters {
+		waiter.ch <- err
 	}
-	clear(waiters[len(remaining):])
-	if all {
-		c.waiters = nil
-		return
-	}
-	c.waiters = remaining
+	clear(c.waiters)
+	c.waiters = nil
 }
 
 func (c *Coordinator) terminalErrorLocked() error {

--- a/TreeDB/internal/rootpublication/coordinator.go
+++ b/TreeDB/internal/rootpublication/coordinator.go
@@ -249,7 +249,10 @@ func (c *Coordinator) WaitThrough(ctx context.Context, seq uint64) error {
 func (c *Coordinator) removeWaiterLocked(target *durabilityWaiter) {
 	for i, waiter := range c.waiters {
 		if waiter == target {
-			c.waiters = append(c.waiters[:i], c.waiters[i+1:]...)
+			copy(c.waiters[i:], c.waiters[i+1:])
+			last := len(c.waiters) - 1
+			c.waiters[last] = nil
+			c.waiters = c.waiters[:last]
 			break
 		}
 	}
@@ -334,10 +337,7 @@ func (c *Coordinator) Stop(ctx context.Context) error {
 	if !c.stopping {
 		c.stopping = true
 		c.cancel()
-		if c.timer != nil {
-			c.timer.Stop()
-			c.timer = nil
-		}
+		c.clearPublishRequestLocked()
 		c.failWaitersLocked(ErrPublicationStopped, true)
 		c.notifyLocked()
 	}
@@ -402,6 +402,7 @@ func (c *Coordinator) run() {
 			}
 			candidate := coalesceCandidates(group)
 			c.publishNow = false
+			c.wakeReason = WakeNone
 			c.publishing = true
 			c.publishCalls++
 			if c.lastRetryableError != nil {
@@ -489,24 +490,7 @@ func (c *Coordinator) finishPublishLocked(candidate *PreparedRootCandidate, grou
 		}
 		c.lastRetryableError = nil
 		c.satisfyWaitersLocked()
-		if c.timer != nil {
-			c.timer.Stop()
-			c.timer = nil
-		}
-		if len(c.pending) != 0 {
-			c.firstPendingAt = c.clock.Now()
-			if c.drainRequests != 0 || len(c.waiters) != 0 || c.pendingBytes >= SoftPendingBytes {
-				reason := WakeDrain
-				if len(c.waiters) != 0 {
-					reason = WakeWaiter
-				} else if c.pendingBytes >= SoftPendingBytes {
-					reason = WakeSoftBytes
-				}
-				c.requestPublishLocked(reason)
-			} else {
-				c.installTimerLocked()
-			}
-		}
+		c.recomputePublishRequestLocked()
 	case PublishRetryableFailure:
 		c.recordRetryableLocked(result.Err, c.activeAttempt)
 	case PublishAmbiguous:
@@ -516,6 +500,7 @@ func (c *Coordinator) finishPublishLocked(candidate *PreparedRootCandidate, grou
 		}
 		c.poison = errors.Join(ErrRecoveryRequired, err)
 		c.failWaitersLocked(c.poison, true)
+		c.clearPublishRequestLocked()
 	default:
 		c.recordRetryableLocked(fmt.Errorf("%w: unknown outcome %d", ErrPublisherProtocol, result.Outcome), c.activeAttempt)
 	}
@@ -532,7 +517,39 @@ func (c *Coordinator) recordRetryableLocked(err error, attempt PublishAttempt) {
 	c.lastRetryableError = err
 	c.lastFailureSeq = attempt.candidate.frontier.commitSeq
 	c.failCapturedWaitersLocked(err, attempt.waiters)
+	if !c.publishNow {
+		c.wakeReason = WakeNone
+	}
 	c.notifyLocked()
+}
+
+func (c *Coordinator) clearPublishRequestLocked() {
+	c.publishNow = false
+	c.wakeReason = WakeNone
+	if c.timer != nil {
+		c.timer.Stop()
+		c.timer = nil
+	}
+}
+
+func (c *Coordinator) recomputePublishRequestLocked() {
+	c.clearPublishRequestLocked()
+	if len(c.pending) == 0 {
+		return
+	}
+	c.firstPendingAt = c.clock.Now()
+	switch {
+	case c.pendingBytes > HardPendingBytes || uint64(len(c.pending)) > HardPendingCommits:
+		c.requestPublishLocked(WakeHardAdmission)
+	case len(c.waiters) != 0:
+		c.requestPublishLocked(WakeWaiter)
+	case c.pendingBytes >= SoftPendingBytes:
+		c.requestPublishLocked(WakeSoftBytes)
+	case c.drainRequests != 0:
+		c.requestPublishLocked(WakeDrain)
+	default:
+		c.installTimerLocked()
+	}
 }
 
 func (c *Coordinator) failCapturedWaitersLocked(err error, captured []*durabilityWaiter) {
@@ -543,37 +560,47 @@ func (c *Coordinator) failCapturedWaitersLocked(err error, captured []*durabilit
 	for _, waiter := range captured {
 		set[waiter] = struct{}{}
 	}
-	remaining := c.waiters[:0]
-	for _, waiter := range c.waiters {
+	waiters := c.waiters
+	remaining := waiters[:0]
+	for _, waiter := range waiters {
 		if _, ok := set[waiter]; ok {
 			waiter.ch <- err
 		} else {
 			remaining = append(remaining, waiter)
 		}
 	}
+	clear(waiters[len(remaining):])
 	c.waiters = remaining
 }
 
 func (c *Coordinator) satisfyWaitersLocked() {
-	remaining := c.waiters[:0]
-	for _, waiter := range c.waiters {
+	waiters := c.waiters
+	remaining := waiters[:0]
+	for _, waiter := range waiters {
 		if waiter.seq <= c.durable.commitSeq {
 			waiter.ch <- nil
 		} else {
 			remaining = append(remaining, waiter)
 		}
 	}
+	clear(waiters[len(remaining):])
 	c.waiters = remaining
 }
 
 func (c *Coordinator) failWaitersLocked(err error, all bool) {
-	remaining := c.waiters[:0]
-	for _, waiter := range c.waiters {
+	waiters := c.waiters
+	remaining := waiters[:0]
+	for _, waiter := range waiters {
 		if all || waiter.seq <= c.visible.commitSeq {
 			waiter.ch <- err
 		} else {
 			remaining = append(remaining, waiter)
 		}
+	}
+	clear(waiters[len(remaining):])
+	if all {
+		c.waiters = nil
+		return
 	}
 	c.waiters = remaining
 }

--- a/TreeDB/internal/rootpublication/coordinator.go
+++ b/TreeDB/internal/rootpublication/coordinator.go
@@ -48,6 +48,7 @@ type Coordinator struct {
 	drainRequests  uint64
 	stopping       bool
 	stopped        bool
+	stopErr        error
 	poison         error
 
 	visible           Frontier
@@ -321,31 +322,36 @@ func (c *Coordinator) endDrain() {
 func (c *Coordinator) Stop(ctx context.Context) error {
 	c.mu.Lock()
 	if c.stopped {
+		err := c.stopErr
 		c.mu.Unlock()
-		return nil
+		return err
 	}
-	c.stopping = true
-	c.cancel()
-	if c.timer != nil {
-		c.timer.Stop()
-		c.timer = nil
+	if !c.stopping {
+		c.stopping = true
+		c.cancel()
+		if c.timer != nil {
+			c.timer.Stop()
+			c.timer = nil
+		}
+		c.failWaitersLocked(ErrPublicationStopped, true)
+		c.notifyLocked()
 	}
-	c.failWaitersLocked(ErrPublicationStopped, true)
-	c.notifyLocked()
 	c.mu.Unlock()
 	c.signal()
 	select {
 	case <-c.done:
 		c.mu.Lock()
-		debt := len(c.pending) != 0
-		c.pending = nil
-		c.pendingBytes = 0
-		c.stopped = true
-		c.mu.Unlock()
-		if debt {
-			return ErrPublicationStopped
+		if !c.stopped {
+			if len(c.pending) != 0 {
+				c.stopErr = ErrPublicationStopped
+			}
+			c.pending = nil
+			c.pendingBytes = 0
+			c.stopped = true
 		}
-		return nil
+		err := c.stopErr
+		c.mu.Unlock()
+		return err
 	case <-ctx.Done():
 		return ctx.Err()
 	}

--- a/TreeDB/internal/rootpublication/coordinator.go
+++ b/TreeDB/internal/rootpublication/coordinator.go
@@ -122,13 +122,14 @@ func (c *Coordinator) Supersede(ctx context.Context, candidate *PreparedRootCand
 }
 
 func (c *Coordinator) enqueue(ctx context.Context, candidate *PreparedRootCandidate, supersede bool) error {
-	if candidate == nil {
-		return fmt.Errorf("%w: nil candidate", ErrInvalidCandidate)
-	}
 	c.mu.Lock()
 	if err := c.terminalErrorLocked(); err != nil {
 		c.mu.Unlock()
 		return err
+	}
+	if candidate == nil {
+		c.mu.Unlock()
+		return fmt.Errorf("%w: nil candidate", ErrInvalidCandidate)
 	}
 	if candidate.frontier.commitSeq <= c.visible.commitSeq ||
 		(c.visible.commitSeq != 0 && !candidate.frontier.Dominates(c.visible)) {
@@ -201,13 +202,13 @@ func (c *Coordinator) waitForAdmission(ctx context.Context, seq, failureGenerati
 // every waiter captured by that attempt; a later call explicitly retries.
 func (c *Coordinator) WaitThrough(ctx context.Context, seq uint64) error {
 	c.mu.Lock()
-	if c.durable.commitSeq >= seq {
-		c.mu.Unlock()
-		return nil
-	}
 	if err := c.terminalErrorLocked(); err != nil {
 		c.mu.Unlock()
 		return err
+	}
+	if c.durable.commitSeq >= seq {
+		c.mu.Unlock()
+		return nil
 	}
 	if seq > c.visible.commitSeq {
 		c.mu.Unlock()
@@ -223,6 +224,11 @@ func (c *Coordinator) WaitThrough(ctx context.Context, seq uint64) error {
 		return err
 	case <-ctx.Done():
 		c.mu.Lock()
+		if err := c.terminalErrorLocked(); err != nil {
+			c.removeWaiterLocked(waiter)
+			c.mu.Unlock()
+			return err
+		}
 		if c.durable.commitSeq >= seq {
 			c.removeWaiterLocked(waiter)
 			c.mu.Unlock()
@@ -284,8 +290,7 @@ func (c *Coordinator) Drain(ctx context.Context) error {
 	defer c.endDrain()
 	for {
 		c.mu.Lock()
-		if c.poison != nil {
-			err := c.poison
+		if err := c.terminalErrorLocked(); err != nil {
 			c.mu.Unlock()
 			return err
 		}

--- a/TreeDB/internal/rootpublication/coordinator.go
+++ b/TreeDB/internal/rootpublication/coordinator.go
@@ -25,6 +25,10 @@ type durabilityWaiter struct {
 	ch  chan error
 }
 
+type drainRequest struct {
+	err error
+}
+
 // Coordinator owns only in-memory scheduling state. It is intentionally not
 // reachable from any production TreeDB handle in this ticket.
 type Coordinator struct {
@@ -45,7 +49,7 @@ type Coordinator struct {
 	wakeReason     WakeReason
 	publishNow     bool
 	publishing     bool
-	drainRequests  uint64
+	drains         []*drainRequest
 	stopping       bool
 	stopped        bool
 	stopErr        error
@@ -69,6 +73,7 @@ type Coordinator struct {
 	lastFailureSeq     uint64
 	nextAttemptID      uint64
 	activeAttempt      PublishAttempt
+	retryAttempt       PublishAttempt
 	reportingAttempt   bool
 }
 
@@ -78,6 +83,7 @@ type PublishAttempt struct {
 	id        uint64
 	candidate *PreparedRootCandidate
 	groupSize uint64
+	drains    []*drainRequest
 	started   time.Time
 	waiters   []*durabilityWaiter
 }
@@ -247,13 +253,24 @@ func (c *Coordinator) WaitThrough(ctx context.Context, seq uint64) error {
 }
 
 func (c *Coordinator) removeWaiterLocked(target *durabilityWaiter) {
+	removed := false
 	for i, waiter := range c.waiters {
 		if waiter == target {
 			copy(c.waiters[i:], c.waiters[i+1:])
 			last := len(c.waiters) - 1
 			c.waiters[last] = nil
 			c.waiters = c.waiters[:last]
+			removed = true
 			break
+		}
+	}
+	if removed && c.wakeReason == WakeWaiter {
+		if c.publishing {
+			c.recomputeRetryPublishRequestLocked(c.activeAttempt)
+		} else if c.lastRetryableError != nil {
+			c.recomputeRetryPublishRequestLocked(c.retryAttempt)
+		} else {
+			c.recomputePublishRequestLocked(false)
 		}
 	}
 }
@@ -285,20 +302,20 @@ func (c *Coordinator) Drain(ctx context.Context) error {
 		c.mu.Unlock()
 		return nil
 	}
-	c.drainRequests++
+	request := &drainRequest{}
+	c.drains = append(c.drains, request)
 	c.requestPublishLocked(WakeDrain)
-	failureGeneration := c.failureGeneration
 	c.mu.Unlock()
 	c.signal()
-	defer c.endDrain()
+	defer c.endDrain(request)
 	for {
 		c.mu.Lock()
 		if err := c.terminalErrorLocked(); err != nil {
 			c.mu.Unlock()
 			return err
 		}
-		if c.failureGeneration > failureGeneration {
-			err := c.lastRetryableError
+		if request.err != nil {
+			err := request.err
 			c.mu.Unlock()
 			return err
 		}
@@ -316,12 +333,33 @@ func (c *Coordinator) Drain(ctx context.Context) error {
 	}
 }
 
-func (c *Coordinator) endDrain() {
+func (c *Coordinator) endDrain(target *drainRequest) {
 	c.mu.Lock()
-	if c.drainRequests > 0 {
-		c.drainRequests--
+	removed := false
+	for i, request := range c.drains {
+		if request == target {
+			copy(c.drains[i:], c.drains[i+1:])
+			last := len(c.drains) - 1
+			c.drains[last] = nil
+			c.drains = c.drains[:last]
+			removed = true
+			break
+		}
+	}
+	recomputed := removed && c.wakeReason == WakeDrain
+	if recomputed {
+		if c.publishing {
+			c.recomputeRetryPublishRequestLocked(c.activeAttempt)
+		} else if c.lastRetryableError != nil {
+			c.recomputeRetryPublishRequestLocked(c.retryAttempt)
+		} else {
+			c.recomputePublishRequestLocked(false)
+		}
 	}
 	c.mu.Unlock()
+	if recomputed {
+		c.signal()
+	}
 }
 
 // Stop cancels a stalled Publisher through its context, fails all waiters, and
@@ -411,7 +449,8 @@ func (c *Coordinator) run() {
 			c.nextAttemptID++
 			attempt := PublishAttempt{
 				id: c.nextAttemptID, candidate: candidate, groupSize: uint64(groupSize),
-				started: c.clock.Now(), waiters: append([]*durabilityWaiter(nil), c.waiters...),
+				drains: append([]*drainRequest(nil), c.drains...), started: c.clock.Now(),
+				waiters: append([]*durabilityWaiter(nil), c.waiters...),
 			}
 			c.activeAttempt = attempt
 			c.mu.Unlock()
@@ -489,8 +528,9 @@ func (c *Coordinator) finishPublishLocked(candidate *PreparedRootCandidate, grou
 			c.ewmaService = (7*c.ewmaService + service) / 8
 		}
 		c.lastRetryableError = nil
+		c.retryAttempt = PublishAttempt{}
 		c.satisfyWaitersLocked()
-		c.recomputePublishRequestLocked()
+		c.recomputePublishRequestLocked(true)
 	case PublishRetryableFailure:
 		c.recordRetryableLocked(result.Err, c.activeAttempt)
 	case PublishAmbiguous:
@@ -499,6 +539,7 @@ func (c *Coordinator) finishPublishLocked(candidate *PreparedRootCandidate, grou
 			err = errors.New("ambiguous target-meta mutation")
 		}
 		c.poison = errors.Join(ErrRecoveryRequired, err)
+		c.retryAttempt = PublishAttempt{}
 		c.failWaitersLocked(c.poison, true)
 		c.clearPublishRequestLocked()
 	default:
@@ -515,11 +556,11 @@ func (c *Coordinator) recordRetryableLocked(err error, attempt PublishAttempt) {
 	c.preMetaFailures++
 	c.failureGeneration++
 	c.lastRetryableError = err
+	c.retryAttempt = attempt
 	c.lastFailureSeq = attempt.candidate.frontier.commitSeq
 	c.failCapturedWaitersLocked(err, attempt.waiters)
-	if !c.publishNow {
-		c.wakeReason = WakeNone
-	}
+	c.failCapturedDrainsLocked(err, attempt.drains)
+	c.recomputeRetryPublishRequestLocked(attempt)
 	c.notifyLocked()
 }
 
@@ -532,12 +573,14 @@ func (c *Coordinator) clearPublishRequestLocked() {
 	}
 }
 
-func (c *Coordinator) recomputePublishRequestLocked() {
+func (c *Coordinator) recomputePublishRequestLocked(resetWindow bool) {
 	c.clearPublishRequestLocked()
 	if len(c.pending) == 0 {
 		return
 	}
-	c.firstPendingAt = c.clock.Now()
+	if resetWindow {
+		c.firstPendingAt = c.clock.Now()
+	}
 	switch {
 	case c.pendingBytes > HardPendingBytes || uint64(len(c.pending)) > HardPendingCommits:
 		c.requestPublishLocked(WakeHardAdmission)
@@ -545,10 +588,74 @@ func (c *Coordinator) recomputePublishRequestLocked() {
 		c.requestPublishLocked(WakeWaiter)
 	case c.pendingBytes >= SoftPendingBytes:
 		c.requestPublishLocked(WakeSoftBytes)
-	case c.drainRequests != 0:
+	case hasLiveDrain(c.drains):
 		c.requestPublishLocked(WakeDrain)
-	default:
+	case !c.publishing:
 		c.installTimerLocked()
+	}
+}
+
+func (c *Coordinator) recomputeRetryPublishRequestLocked(attempt PublishAttempt) {
+	c.clearPublishRequestLocked()
+	if len(c.pending) == 0 {
+		return
+	}
+	start := int(attempt.groupSize)
+	if start > len(c.pending) {
+		start = len(c.pending)
+	}
+	remaining := c.pending[start:]
+	switch {
+	case len(remaining) != 0 && (c.pendingBytes > HardPendingBytes || uint64(len(c.pending)) > HardPendingCommits):
+		c.requestPublishLocked(WakeHardAdmission)
+	case len(c.waiters) != 0:
+		c.requestPublishLocked(WakeWaiter)
+	case len(remaining) != 0 && c.pendingBytes >= SoftPendingBytes:
+		c.requestPublishLocked(WakeSoftBytes)
+	case hasUncapturedDrain(c.drains, attempt.drains):
+		c.requestPublishLocked(WakeDrain)
+	}
+}
+
+func hasUncapturedDrain(current, captured []*drainRequest) bool {
+	if len(current) == 0 {
+		return false
+	}
+	set := make(map[*drainRequest]struct{}, len(captured))
+	for _, request := range captured {
+		set[request] = struct{}{}
+	}
+	for _, request := range current {
+		if request.err == nil {
+			if _, ok := set[request]; !ok {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func hasLiveDrain(current []*drainRequest) bool {
+	for _, request := range current {
+		if request.err == nil {
+			return true
+		}
+	}
+	return false
+}
+
+func (c *Coordinator) failCapturedDrainsLocked(err error, captured []*drainRequest) {
+	if len(captured) == 0 {
+		return
+	}
+	set := make(map[*drainRequest]struct{}, len(captured))
+	for _, request := range captured {
+		set[request] = struct{}{}
+	}
+	for _, request := range c.drains {
+		if _, ok := set[request]; ok {
+			request.err = err
+		}
 	}
 }
 
@@ -627,9 +734,15 @@ func (c *Coordinator) publishDelayLocked() time.Duration {
 }
 
 func (c *Coordinator) installTimerLocked() {
-	if c.timer == nil {
-		c.timer = c.clock.NewTimer(c.publishDelayLocked())
+	if c.timer != nil {
+		return
 	}
+	remaining := c.publishDelayLocked() - c.clock.Now().Sub(c.firstPendingAt)
+	if remaining <= 0 {
+		c.requestPublishLocked(WakeTimer)
+		return
+	}
+	c.timer = c.clock.NewTimer(remaining)
 }
 
 func (c *Coordinator) requestPublishLocked(reason WakeReason) {

--- a/TreeDB/internal/rootpublication/coordinator.go
+++ b/TreeDB/internal/rootpublication/coordinator.go
@@ -42,18 +42,19 @@ type Coordinator struct {
 	changed   chan struct{}
 	done      chan struct{}
 
-	pending        []pendingEntry
-	pendingBytes   uint64
-	firstPendingAt time.Time
-	timer          Timer
-	wakeReason     WakeReason
-	publishNow     bool
-	publishing     bool
-	drains         []*drainRequest
-	stopping       bool
-	stopped        bool
-	stopErr        error
-	poison         error
+	pending         []pendingEntry
+	pendingBytes    uint64
+	firstPendingAt  time.Time
+	timer           Timer
+	timerGeneration uint64
+	wakeReason      WakeReason
+	publishNow      bool
+	publishing      bool
+	drains          []*drainRequest
+	stopping        bool
+	stopped         bool
+	stopErr         error
+	poison          error
 
 	visible           Frontier
 	durable           Frontier
@@ -428,8 +429,10 @@ func (c *Coordinator) run() {
 			return
 		}
 		var timerC <-chan time.Time
+		var timerGeneration uint64
 		if c.timer != nil {
 			timerC = c.timer.C()
+			timerGeneration = c.timerGeneration
 		}
 		ready := c.publishNow && !c.publishing && len(c.pending) != 0 && c.activeBuilders == 0 && c.poison == nil
 		if ready {
@@ -468,8 +471,7 @@ func (c *Coordinator) run() {
 		case <-c.wake:
 		case <-timerC:
 			c.mu.Lock()
-			c.timer = nil
-			c.requestPublishLocked(WakeTimer)
+			c.handleTimerFiredLocked(timerGeneration)
 			c.mu.Unlock()
 		}
 	}
@@ -732,7 +734,16 @@ func (c *Coordinator) installTimerLocked() {
 		c.requestPublishLocked(WakeTimer)
 		return
 	}
+	c.timerGeneration++
 	c.timer = c.clock.NewTimer(remaining)
+}
+
+func (c *Coordinator) handleTimerFiredLocked(generation uint64) {
+	if c.timer == nil || generation != c.timerGeneration {
+		return
+	}
+	c.timer = nil
+	c.requestPublishLocked(WakeTimer)
 }
 
 func (c *Coordinator) requestPublishLocked(reason WakeReason) {

--- a/TreeDB/internal/rootpublication/coordinator_bench_test.go
+++ b/TreeDB/internal/rootpublication/coordinator_bench_test.go
@@ -2,10 +2,12 @@ package rootpublication
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sync"
 	"sync/atomic"
 	"testing"
+	"time"
 )
 
 type countingPublisher struct{ calls atomic.Uint64 }
@@ -15,7 +17,101 @@ func (p *countingPublisher) Publish(context.Context, *PreparedRootCandidate) Pub
 	return PublishResult{Outcome: PublishSucceeded}
 }
 
-func BenchmarkCoordinatorPrimitive(b *testing.B) {
+func runProducers(b *testing.B, producers int, operation func()) {
+	b.Helper()
+	var next atomic.Int64
+	next.Store(int64(b.N))
+	var workers sync.WaitGroup
+	workers.Add(producers)
+	for range producers {
+		go func() {
+			defer workers.Done()
+			for next.Add(-1) >= 0 {
+				operation()
+			}
+		}()
+	}
+	workers.Wait()
+}
+
+func BenchmarkCoordinatorEnqueue(b *testing.B) {
+	for _, producers := range []int{1, 2, 4, 8} {
+		b.Run(fmt.Sprintf("producers=%d", producers), func(b *testing.B) {
+			clock := NewFakeClock(time.Unix(1, 0))
+			publisher := new(countingPublisher)
+			coordinator, err := New(Options{Clock: clock, Publisher: publisher})
+			if err != nil {
+				b.Fatal(err)
+			}
+			defer stopClean(b, coordinator)
+			var seq atomic.Uint64
+			var retries atomic.Uint64
+			b.ReportAllocs()
+			b.ResetTimer()
+			runProducers(b, producers, func() {
+				for {
+					n := seq.Add(1)
+					prepared, _ := NewPreparedRootCandidate(CandidateSpec{Frontier: NewFrontier(n, n, n, n, n)})
+					err := coordinator.Enqueue(context.Background(), prepared)
+					if err == nil {
+						return
+					}
+					if !errors.Is(err, ErrInvalidCandidate) {
+						b.Error(err)
+						return
+					}
+					retries.Add(1)
+				}
+			})
+			b.StopTimer()
+			b.ReportMetric(float64(retries.Load())/float64(b.N), "contention-retries/op")
+			b.ReportMetric(float64(publisher.calls.Load())/float64(b.N), "stable-io/op")
+		})
+	}
+}
+
+func BenchmarkCoordinatorSupersede(b *testing.B) {
+	for _, producers := range []int{1, 2, 4, 8} {
+		b.Run(fmt.Sprintf("producers=%d", producers), func(b *testing.B) {
+			clock := NewFakeClock(time.Unix(1, 0))
+			publisher := new(countingPublisher)
+			coordinator, err := New(Options{Clock: clock, Publisher: publisher})
+			if err != nil {
+				b.Fatal(err)
+			}
+			defer stopClean(b, coordinator)
+			seed, _ := NewPreparedRootCandidate(CandidateSpec{Frontier: NewFrontier(1, 1, 1, 1, 1)})
+			if err := coordinator.Enqueue(context.Background(), seed); err != nil {
+				b.Fatal(err)
+			}
+			var seq atomic.Uint64
+			seq.Store(1)
+			var retries atomic.Uint64
+			b.ReportAllocs()
+			b.ResetTimer()
+			runProducers(b, producers, func() {
+				for {
+					n := seq.Add(1)
+					prepared, _ := NewPreparedRootCandidate(CandidateSpec{Frontier: NewFrontier(n, n, n, n, n)})
+					err := coordinator.Supersede(context.Background(), prepared)
+					if err == nil {
+						return
+					}
+					if !errors.Is(err, ErrInvalidCandidate) {
+						b.Error(err)
+						return
+					}
+					retries.Add(1)
+				}
+			})
+			b.StopTimer()
+			b.ReportMetric(float64(retries.Load())/float64(b.N), "contention-retries/op")
+			b.ReportMetric(float64(publisher.calls.Load())/float64(b.N), "stable-io/op")
+		})
+	}
+}
+
+func BenchmarkCoordinatorWait(b *testing.B) {
 	for _, producers := range []int{1, 2, 4, 8} {
 		b.Run(fmt.Sprintf("producers=%d", producers), func(b *testing.B) {
 			publisher := new(countingPublisher)
@@ -25,68 +121,51 @@ func BenchmarkCoordinatorPrimitive(b *testing.B) {
 			}
 			defer stopClean(b, coordinator)
 			var seq atomic.Uint64
+			var retries atomic.Uint64
+			started := time.Now()
 			b.ReportAllocs()
-			b.SetParallelism(producers)
 			b.ResetTimer()
-			b.RunParallel(func(pb *testing.PB) {
-				for pb.Next() {
-					n := seq.Add(1)
-					prepared, err := NewPreparedRootCandidate(CandidateSpec{Frontier: NewFrontier(n, n, n, n, n), IndexBytes: 1})
-					if err != nil {
-						b.Fatal(err)
+			runProducers(b, producers, func() {
+				var mySeq uint64
+				for {
+					mySeq = seq.Add(1)
+					prepared, _ := NewPreparedRootCandidate(CandidateSpec{Frontier: NewFrontier(mySeq, mySeq, mySeq, mySeq, mySeq)})
+					err := coordinator.Enqueue(context.Background(), prepared)
+					if err == nil {
+						break
 					}
-					// Serialize frontier installation exactly as the future commit
-					// combiner does; producer contention remains part of the result.
-					for {
-						err = coordinator.Enqueue(context.Background(), prepared)
-						if err == nil {
-							break
-						}
-						if !errorsIsInvalidCandidate(err) {
-							b.Fatal(err)
-						}
-						// A later producer won visibility; create the next frontier.
-						n = seq.Add(1)
-						prepared, _ = NewPreparedRootCandidate(CandidateSpec{Frontier: NewFrontier(n, n, n, n, n), IndexBytes: 1})
+					if !errors.Is(err, ErrInvalidCandidate) {
+						b.Error(err)
+						return
 					}
+					retries.Add(1)
+				}
+				err := coordinator.WaitThrough(context.Background(), mySeq)
+				if err != nil {
+					b.Error(err)
 				}
 			})
 			b.StopTimer()
-			if err := coordinator.Drain(context.Background()); err != nil {
-				b.Fatal(err)
+			elapsed := time.Since(started).Seconds()
+			if elapsed > 0 {
+				b.ReportMetric(float64(publisher.calls.Load())/elapsed, "groups/s")
 			}
-			if publisher.calls.Load() == 0 {
-				b.Fatal("benchmark did not drain")
-			}
+			b.ReportMetric(float64(retries.Load())/float64(b.N), "contention-retries/op")
 		})
 	}
 }
 
-func errorsIsInvalidCandidate(err error) bool {
-	return err != nil // benchmark retries only monotonic-frontier races
-}
-
-func BenchmarkCoordinatorSupersede(b *testing.B) {
-	publisher := new(countingPublisher)
-	coordinator, err := New(Options{Publisher: publisher})
+func TestBenchmarkHelpersRecognizeExpectedStop(t *testing.T) {
+	// Keep the benchmark cleanup contract explicit: unpublished ordinary debt is
+	// reported, never silently called durable.
+	c, err := New(Options{Clock: NewFakeClock(time.Unix(1, 0)), Publisher: new(countingPublisher)})
 	if err != nil {
-		b.Fatal(err)
+		t.Fatal(err)
 	}
-	defer stopClean(b, coordinator)
-	var mu sync.Mutex
-	var seq uint64
-	b.ReportAllocs()
-	for i := 0; i < b.N; i++ {
-		mu.Lock()
-		seq++
-		prepared, _ := NewPreparedRootCandidate(CandidateSpec{Frontier: NewFrontier(seq, seq, seq, seq, seq), DependencyBytes: 1})
-		if err := coordinator.Enqueue(context.Background(), prepared); err != nil {
-			b.Fatal(err)
-		}
-		mu.Unlock()
+	if err := c.Enqueue(context.Background(), candidate(t, 1, 0)); err != nil {
+		t.Fatal(err)
 	}
-	b.StopTimer()
-	if publisher.calls.Load() != 0 {
-		b.Fatalf("stable I/O calls during enqueue=%d", publisher.calls.Load())
+	if err := c.Stop(context.Background()); !errors.Is(err, ErrPublicationStopped) {
+		t.Fatalf("stop=%v", err)
 	}
 }

--- a/TreeDB/internal/rootpublication/coordinator_bench_test.go
+++ b/TreeDB/internal/rootpublication/coordinator_bench_test.go
@@ -1,0 +1,92 @@
+package rootpublication
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"sync/atomic"
+	"testing"
+)
+
+type countingPublisher struct{ calls atomic.Uint64 }
+
+func (p *countingPublisher) Publish(context.Context, *PreparedRootCandidate) PublishResult {
+	p.calls.Add(1)
+	return PublishResult{Outcome: PublishSucceeded}
+}
+
+func BenchmarkCoordinatorPrimitive(b *testing.B) {
+	for _, producers := range []int{1, 2, 4, 8} {
+		b.Run(fmt.Sprintf("producers=%d", producers), func(b *testing.B) {
+			publisher := new(countingPublisher)
+			coordinator, err := New(Options{Publisher: publisher})
+			if err != nil {
+				b.Fatal(err)
+			}
+			defer stopClean(b, coordinator)
+			var seq atomic.Uint64
+			b.ReportAllocs()
+			b.SetParallelism(producers)
+			b.ResetTimer()
+			b.RunParallel(func(pb *testing.PB) {
+				for pb.Next() {
+					n := seq.Add(1)
+					prepared, err := NewPreparedRootCandidate(CandidateSpec{Frontier: NewFrontier(n, n, n, n, n), IndexBytes: 1})
+					if err != nil {
+						b.Fatal(err)
+					}
+					// Serialize frontier installation exactly as the future commit
+					// combiner does; producer contention remains part of the result.
+					for {
+						err = coordinator.Enqueue(context.Background(), prepared)
+						if err == nil {
+							break
+						}
+						if !errorsIsInvalidCandidate(err) {
+							b.Fatal(err)
+						}
+						// A later producer won visibility; create the next frontier.
+						n = seq.Add(1)
+						prepared, _ = NewPreparedRootCandidate(CandidateSpec{Frontier: NewFrontier(n, n, n, n, n), IndexBytes: 1})
+					}
+				}
+			})
+			b.StopTimer()
+			if err := coordinator.Drain(context.Background()); err != nil {
+				b.Fatal(err)
+			}
+			if publisher.calls.Load() == 0 {
+				b.Fatal("benchmark did not drain")
+			}
+		})
+	}
+}
+
+func errorsIsInvalidCandidate(err error) bool {
+	return err != nil // benchmark retries only monotonic-frontier races
+}
+
+func BenchmarkCoordinatorSupersede(b *testing.B) {
+	publisher := new(countingPublisher)
+	coordinator, err := New(Options{Publisher: publisher})
+	if err != nil {
+		b.Fatal(err)
+	}
+	defer stopClean(b, coordinator)
+	var mu sync.Mutex
+	var seq uint64
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		mu.Lock()
+		seq++
+		prepared, _ := NewPreparedRootCandidate(CandidateSpec{Frontier: NewFrontier(seq, seq, seq, seq, seq), DependencyBytes: 1})
+		if err := coordinator.Enqueue(context.Background(), prepared); err != nil {
+			b.Fatal(err)
+		}
+		mu.Unlock()
+	}
+	b.StopTimer()
+	if publisher.calls.Load() != 0 {
+		b.Fatalf("stable I/O calls during enqueue=%d", publisher.calls.Load())
+	}
+}

--- a/TreeDB/internal/rootpublication/coordinator_test.go
+++ b/TreeDB/internal/rootpublication/coordinator_test.go
@@ -179,14 +179,9 @@ func TestWaiterRemovalClearsDiscardedBackingSlots(t *testing.T) {
 		c.satisfyWaitersLocked()
 		assertClearedTail(t, c.waiters)
 	})
-	t.Run("visible failure", func(t *testing.T) {
-		c := &Coordinator{waiters: newWaiters(), visible: NewFrontier(2, 0, 0, 0, 0)}
-		c.failWaitersLocked(errors.New("visible"), false)
-		assertClearedTail(t, c.waiters)
-	})
 	t.Run("terminal failure", func(t *testing.T) {
 		c := &Coordinator{waiters: newWaiters()}
-		c.failWaitersLocked(ErrPublicationStopped, true)
+		c.failWaitersLocked(ErrPublicationStopped)
 		if c.waiters != nil {
 			t.Fatalf("terminal waiter storage retained: len=%d cap=%d", len(c.waiters), cap(c.waiters))
 		}

--- a/TreeDB/internal/rootpublication/coordinator_test.go
+++ b/TreeDB/internal/rootpublication/coordinator_test.go
@@ -463,7 +463,7 @@ func TestSuccessfulPublishPreservesRealRemainingImmediateTriggers(t *testing.T) 
 			waitFor(t, func() bool {
 				c.mu.Lock()
 				defer c.mu.Unlock()
-				return c.drainRequests == 1 && c.publishNow
+				return len(c.drains) == 1 && c.publishNow
 			})
 			return done
 		}},
@@ -783,6 +783,202 @@ func TestRetryableFailureDoesNotFailWaiterAddedInFlight(t *testing.T) {
 	}
 }
 
+func TestCanceledInFlightWaiterDoesNotLeakRetryWake(t *testing.T) {
+	firstEntered := make(chan struct{})
+	firstRelease := make(chan struct{})
+	calls := make(chan uint64, 2)
+	want := errors.New("first pre-meta failure")
+	var attempts atomic.Uint64
+	c, err := New(Options{Clock: NewFakeClock(time.Unix(400, 0)), Publisher: PublisherFunc(func(_ context.Context, candidate *PreparedRootCandidate) PublishResult {
+		calls <- candidate.Frontier().CommitSeq()
+		if attempts.Add(1) == 1 {
+			close(firstEntered)
+			<-firstRelease
+			return PublishResult{Outcome: PublishRetryableFailure, Err: want}
+		}
+		return PublishResult{Outcome: PublishSucceeded}
+	})})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer stopClean(t, c)
+	if err := c.Enqueue(context.Background(), candidate(t, 1, 1)); err != nil {
+		t.Fatal(err)
+	}
+	firstDone := make(chan error, 1)
+	go func() { firstDone <- c.WaitThrough(context.Background(), 1) }()
+	select {
+	case <-firstEntered:
+	case <-time.After(time.Second):
+		t.Fatal("first publication did not start")
+	}
+	if seq := <-calls; seq != 1 {
+		t.Fatalf("first publication seq=%d", seq)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	secondDone := make(chan error, 1)
+	go func() { secondDone <- c.WaitThrough(ctx, 1) }()
+	waitFor(t, func() bool { return c.Stats().WaiterCount == 2 })
+	builder, err := c.AcquireBuilder(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	close(firstRelease)
+	if err := <-firstDone; !errors.Is(err, want) {
+		t.Fatalf("first wait=%v", err)
+	}
+	waitFor(t, func() bool { return !c.Stats().Poisoned && c.Stats().PreMetaFailures == 1 })
+	cancel()
+	if err := <-secondDone; !errors.Is(err, context.Canceled) {
+		t.Fatalf("second wait=%v", err)
+	}
+	c.mu.Lock()
+	publishNow, wakeReason, timerInstalled := c.publishNow, c.wakeReason, c.timer != nil
+	c.mu.Unlock()
+	if publishNow || wakeReason != WakeNone || timerInstalled {
+		t.Fatalf("canceled in-flight waiter leaked retry: publishNow=%t reason=%q timerInstalled=%t", publishNow, wakeReason, timerInstalled)
+	}
+	builder.Release()
+	select {
+	case seq := <-calls:
+		t.Fatalf("canceled in-flight waiter retried seq %d", seq)
+	default:
+	}
+	if err := c.WaitThrough(context.Background(), 1); err != nil {
+		t.Fatalf("explicit retry=%v", err)
+	}
+	if seq := <-calls; seq != 1 {
+		t.Fatalf("explicit retry seq=%d", seq)
+	}
+}
+
+func TestInFlightEnqueueCrossingSoftBoundaryRetainsRetryWake(t *testing.T) {
+	firstEntered := make(chan struct{})
+	firstRelease := make(chan struct{})
+	secondEntered := make(chan struct{})
+	want := errors.New("first pre-meta failure")
+	var attempts atomic.Uint64
+	c, err := New(Options{Clock: NewFakeClock(time.Unix(410, 0)), Publisher: PublisherFunc(func(_ context.Context, _ *PreparedRootCandidate) PublishResult {
+		if attempts.Add(1) == 1 {
+			close(firstEntered)
+			<-firstRelease
+			return PublishResult{Outcome: PublishRetryableFailure, Err: want}
+		}
+		close(secondEntered)
+		return PublishResult{Outcome: PublishSucceeded}
+	})})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer stopClean(t, c)
+	if err := c.Enqueue(context.Background(), candidate(t, 1, SoftPendingBytes-(1<<20))); err != nil {
+		t.Fatal(err)
+	}
+	firstDone := make(chan error, 1)
+	go func() { firstDone <- c.WaitThrough(context.Background(), 1) }()
+	select {
+	case <-firstEntered:
+	case <-time.After(time.Second):
+		t.Fatal("first publication did not start")
+	}
+	if err := c.Supersede(context.Background(), candidate(t, 2, 2<<20)); err != nil {
+		t.Fatal(err)
+	}
+	c.mu.Lock()
+	pendingBytes, publishNow, wakeReason := c.pendingBytes, c.publishNow, c.wakeReason
+	c.mu.Unlock()
+	if pendingBytes < SoftPendingBytes || !publishNow || wakeReason != WakeSoftBytes {
+		t.Fatalf("in-flight soft crossing not recorded: bytes=%d publishNow=%t reason=%q", pendingBytes, publishNow, wakeReason)
+	}
+	close(firstRelease)
+	if err := <-firstDone; !errors.Is(err, want) {
+		t.Fatalf("first wait=%v", err)
+	}
+	select {
+	case <-secondEntered:
+	case <-time.After(time.Second):
+		t.Fatal("fresh soft crossing did not trigger retry")
+	}
+	waitFor(t, func() bool { return c.Stats().DurableCommitSeq == 2 })
+}
+
+func TestDrainIdentityTurnoverPreservesFreshInFlightDrain(t *testing.T) {
+	firstEntered := make(chan struct{})
+	firstRelease := make(chan struct{})
+	secondEntered := make(chan struct{})
+	want := errors.New("first pre-meta failure")
+	var attempts atomic.Uint64
+	c, err := New(Options{Clock: NewFakeClock(time.Unix(420, 0)), Publisher: PublisherFunc(func(_ context.Context, _ *PreparedRootCandidate) PublishResult {
+		if attempts.Add(1) == 1 {
+			close(firstEntered)
+			<-firstRelease
+			return PublishResult{Outcome: PublishRetryableFailure, Err: want}
+		}
+		close(secondEntered)
+		return PublishResult{Outcome: PublishSucceeded}
+	})})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer stopClean(t, c)
+	if err := c.Enqueue(context.Background(), candidate(t, 1, 1)); err != nil {
+		t.Fatal(err)
+	}
+	firstCtx, cancelFirst := context.WithCancel(context.Background())
+	firstDone := make(chan error, 1)
+	go func() { firstDone <- c.Drain(firstCtx) }()
+	select {
+	case <-firstEntered:
+	case <-time.After(time.Second):
+		t.Fatal("first drain did not start publication")
+	}
+	secondDone := make(chan error, 1)
+	go func() { secondDone <- c.Drain(context.Background()) }()
+	waitFor(t, func() bool {
+		c.mu.Lock()
+		defer c.mu.Unlock()
+		return len(c.drains) == 2 && c.publishNow && c.wakeReason == WakeDrain
+	})
+	cancelFirst()
+	if err := <-firstDone; !errors.Is(err, context.Canceled) {
+		t.Fatalf("captured drain cancellation=%v", err)
+	}
+	waitFor(t, func() bool {
+		c.mu.Lock()
+		defer c.mu.Unlock()
+		return len(c.drains) == 1 && c.publishNow && c.wakeReason == WakeDrain
+	})
+	close(firstRelease)
+	select {
+	case <-secondEntered:
+	case <-time.After(time.Second):
+		t.Fatal("fresh drain was stranded by captured drain turnover")
+	}
+	if err := <-secondDone; err != nil {
+		t.Fatalf("fresh drain=%v", err)
+	}
+}
+
+func TestErroredCapturedDrainDoesNotOwnRetryWakeAfterFreshDrainEnds(t *testing.T) {
+	want := errors.New("captured drain failed")
+	captured := &drainRequest{err: want}
+	fresh := &drainRequest{}
+	entry := pendingEntry{candidate: candidate(t, 1, 1), bytes: 1}
+	c := &Coordinator{
+		clock: NewFakeClock(time.Unix(430, 0)), pending: []pendingEntry{entry}, pendingBytes: 1,
+		firstPendingAt: time.Unix(430, 0), drains: []*drainRequest{captured, fresh},
+		publishNow: true, wakeReason: WakeDrain, lastRetryableError: want,
+		retryAttempt: PublishAttempt{groupSize: 1, drains: []*drainRequest{captured}},
+	}
+	c.endDrain(fresh)
+	if len(c.drains) != 1 || c.drains[0] != captured {
+		t.Fatalf("drain ownership after fresh removal=%v", c.drains)
+	}
+	if c.publishNow || c.wakeReason != WakeNone || c.timer != nil {
+		t.Fatalf("errored captured drain retained retry wake: publishNow=%t reason=%q timer=%v", c.publishNow, c.wakeReason, c.timer)
+	}
+}
+
 func TestHardAdmissionAddedInFlightIgnoresPriorGroupFailure(t *testing.T) {
 	firstEntered := make(chan struct{})
 	firstRelease := make(chan struct{})
@@ -945,6 +1141,44 @@ func TestStopReturnsSameDebtResultToEveryCaller(t *testing.T) {
 	}
 	if err := c.Stop(context.Background()); !errors.Is(err, ErrPublicationStopped) {
 		t.Fatalf("second stop=%v", err)
+	}
+}
+
+func TestConcurrentDrainAndStop(t *testing.T) {
+	c, err := New(Options{Clock: NewFakeClock(time.Unix(290, 0)), Publisher: PublisherFunc(func(context.Context, *PreparedRootCandidate) PublishResult {
+		return PublishResult{Outcome: PublishSucceeded}
+	})})
+	if err != nil {
+		t.Fatal(err)
+	}
+	builder, err := c.AcquireBuilder(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := c.Enqueue(context.Background(), candidate(t, 1, 1)); err != nil {
+		t.Fatal(err)
+	}
+	drained := make(chan error, 1)
+	go func() { drained <- c.Drain(context.Background()) }()
+	waitFor(t, func() bool {
+		c.mu.Lock()
+		defer c.mu.Unlock()
+		return len(c.drains) == 1 && c.publishNow && c.wakeReason == WakeDrain
+	})
+	stopped := make(chan error, 1)
+	go func() { stopped <- c.Stop(context.Background()) }()
+	if err := <-drained; !errors.Is(err, ErrClosed) {
+		t.Fatalf("drain during stop=%v", err)
+	}
+	if err := <-stopped; !errors.Is(err, ErrPublicationStopped) {
+		t.Fatalf("stop with debt=%v", err)
+	}
+	builder.Release()
+	c.mu.Lock()
+	drains, publishNow, wakeReason := len(c.drains), c.publishNow, c.wakeReason
+	c.mu.Unlock()
+	if drains != 0 || publishNow || wakeReason != WakeNone {
+		t.Fatalf("terminal ownership leaked: drains=%d publishNow=%t reason=%q", drains, publishNow, wakeReason)
 	}
 }
 
@@ -1137,6 +1371,178 @@ func TestCanceledDrainDoesNotLeavePermanentDrainMode(t *testing.T) {
 	case seq := <-calls:
 		t.Fatalf("canceled drain auto-published remaining seq=%d", seq)
 	case <-time.After(20 * time.Millisecond):
+	}
+}
+
+func TestCanceledDrainRestoresAnchoredTimerInsteadOfLeakingImmediateWake(t *testing.T) {
+	clock := NewFakeClock(time.Unix(350, 0))
+	calls := make(chan uint64, 1)
+	c, err := New(Options{Clock: clock, Publisher: PublisherFunc(func(_ context.Context, candidate *PreparedRootCandidate) PublishResult {
+		calls <- candidate.Frontier().CommitSeq()
+		return PublishResult{Outcome: PublishSucceeded}
+	})})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer stopClean(t, c)
+	builder, err := c.AcquireBuilder(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := c.Enqueue(context.Background(), candidate(t, 1, 1)); err != nil {
+		t.Fatal(err)
+	}
+	clock.Advance(5 * time.Millisecond)
+	ctx, cancel := context.WithCancel(context.Background())
+	drained := make(chan error, 1)
+	go func() { drained <- c.Drain(ctx) }()
+	waitFor(t, func() bool {
+		c.mu.Lock()
+		defer c.mu.Unlock()
+		return len(c.drains) == 1 && c.publishNow && c.wakeReason == WakeDrain
+	})
+	cancel()
+	if err := <-drained; !errors.Is(err, context.Canceled) {
+		t.Fatalf("drain=%v", err)
+	}
+	c.mu.Lock()
+	publishNow, wakeReason, timerInstalled := c.publishNow, c.wakeReason, c.timer != nil
+	c.mu.Unlock()
+	if publishNow || wakeReason != WakeNone || !timerInstalled {
+		t.Fatalf("canceled drain wake retained: publishNow=%t reason=%q timerInstalled=%t", publishNow, wakeReason, timerInstalled)
+	}
+	builder.Release()
+	select {
+	case seq := <-calls:
+		t.Fatalf("canceled drain published seq %d immediately", seq)
+	default:
+	}
+	clock.Advance(4 * time.Millisecond)
+	select {
+	case seq := <-calls:
+		t.Fatalf("canceled drain published seq %d before anchored timer", seq)
+	default:
+	}
+	clock.Advance(time.Millisecond)
+	select {
+	case seq := <-calls:
+		if seq != 1 {
+			t.Fatalf("timer publication seq=%d", seq)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("restored anchored timer did not publish")
+	}
+}
+
+func TestCanceledWaiterRestoresAnchoredTimerInsteadOfLeakingImmediateWake(t *testing.T) {
+	clock := NewFakeClock(time.Unix(360, 0))
+	calls := make(chan uint64, 1)
+	c, err := New(Options{Clock: clock, Publisher: PublisherFunc(func(_ context.Context, candidate *PreparedRootCandidate) PublishResult {
+		calls <- candidate.Frontier().CommitSeq()
+		return PublishResult{Outcome: PublishSucceeded}
+	})})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer stopClean(t, c)
+	builder, err := c.AcquireBuilder(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := c.Enqueue(context.Background(), candidate(t, 1, 1)); err != nil {
+		t.Fatal(err)
+	}
+	clock.Advance(5 * time.Millisecond)
+	ctx, cancel := context.WithCancel(context.Background())
+	waitDone := make(chan error, 1)
+	go func() { waitDone <- c.WaitThrough(ctx, 1) }()
+	waitFor(t, func() bool {
+		c.mu.Lock()
+		defer c.mu.Unlock()
+		return len(c.waiters) == 1 && c.publishNow && c.wakeReason == WakeWaiter
+	})
+	cancel()
+	if err := <-waitDone; !errors.Is(err, context.Canceled) {
+		t.Fatalf("wait=%v", err)
+	}
+	c.mu.Lock()
+	publishNow, wakeReason, timerInstalled := c.publishNow, c.wakeReason, c.timer != nil
+	c.mu.Unlock()
+	if publishNow || wakeReason != WakeNone || !timerInstalled {
+		t.Fatalf("canceled waiter wake retained: publishNow=%t reason=%q timerInstalled=%t", publishNow, wakeReason, timerInstalled)
+	}
+	builder.Release()
+	clock.Advance(4 * time.Millisecond)
+	select {
+	case seq := <-calls:
+		t.Fatalf("canceled waiter published seq %d before anchored timer", seq)
+	default:
+	}
+	clock.Advance(time.Millisecond)
+	select {
+	case seq := <-calls:
+		if seq != 1 {
+			t.Fatalf("timer publication seq=%d", seq)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("restored anchored timer did not publish")
+	}
+}
+
+func TestCanceledExplicitWakePublishesWhenAnchoredDeadlineElapsed(t *testing.T) {
+	for _, kind := range []string{"waiter", "drain"} {
+		t.Run(kind, func(t *testing.T) {
+			clock := NewFakeClock(time.Unix(370, 0))
+			calls := make(chan uint64, 1)
+			c, err := New(Options{Clock: clock, Publisher: PublisherFunc(func(_ context.Context, candidate *PreparedRootCandidate) PublishResult {
+				calls <- candidate.Frontier().CommitSeq()
+				return PublishResult{Outcome: PublishSucceeded}
+			})})
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer stopClean(t, c)
+			builder, err := c.AcquireBuilder(context.Background())
+			if err != nil {
+				t.Fatal(err)
+			}
+			if err := c.Enqueue(context.Background(), candidate(t, 1, 1)); err != nil {
+				t.Fatal(err)
+			}
+			ctx, cancel := context.WithCancel(context.Background())
+			done := make(chan error, 1)
+			if kind == "waiter" {
+				go func() { done <- c.WaitThrough(ctx, 1) }()
+				waitFor(t, func() bool { return c.Stats().WaiterCount == 1 })
+			} else {
+				go func() { done <- c.Drain(ctx) }()
+				waitFor(t, func() bool {
+					c.mu.Lock()
+					defer c.mu.Unlock()
+					return len(c.drains) == 1
+				})
+			}
+			clock.Advance(minPublishDelay + time.Millisecond)
+			cancel()
+			if err := <-done; !errors.Is(err, context.Canceled) {
+				t.Fatalf("canceled %s=%v", kind, err)
+			}
+			c.mu.Lock()
+			publishNow, wakeReason := c.publishNow, c.wakeReason
+			c.mu.Unlock()
+			if !publishNow || wakeReason != WakeTimer {
+				t.Fatalf("elapsed deadline not restored: publishNow=%t reason=%q", publishNow, wakeReason)
+			}
+			builder.Release()
+			select {
+			case seq := <-calls:
+				if seq != 1 {
+					t.Fatalf("timer publication seq=%d", seq)
+				}
+			case <-time.After(time.Second):
+				t.Fatal("elapsed anchored deadline did not publish")
+			}
+		})
 	}
 }
 

--- a/TreeDB/internal/rootpublication/coordinator_test.go
+++ b/TreeDB/internal/rootpublication/coordinator_test.go
@@ -1,0 +1,653 @@
+package rootpublication
+
+import (
+	"context"
+	"errors"
+	"math/rand"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func candidate(t testing.TB, seq, bytes uint64, obligations ...byte) *PreparedRootCandidate {
+	t.Helper()
+	ids := make([]ObligationID, len(obligations))
+	for i, value := range obligations {
+		ids[i][0] = value
+	}
+	c, err := NewPreparedRootCandidate(CandidateSpec{
+		Frontier:        NewFrontier(seq, seq*10, seq*20, seq, seq),
+		DependencyBytes: bytes,
+		Obligations:     ids,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return c
+}
+
+func stopClean(t testing.TB, c *Coordinator) {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	if err := c.Stop(ctx); err != nil && !errors.Is(err, ErrPublicationStopped) {
+		t.Fatalf("stop: %v", err)
+	}
+}
+
+func waitForCall(t testing.TB, calls <-chan *PreparedRootCandidate) *PreparedRootCandidate {
+	t.Helper()
+	select {
+	case call := <-calls:
+		return call
+	case <-time.After(time.Second):
+		t.Fatal("publisher was not called")
+		return nil
+	}
+}
+
+func TestVisibleFrontierDoesNotSatisfyDurabilityWaiter(t *testing.T) {
+	calls := make(chan *PreparedRootCandidate, 1)
+	release := make(chan struct{})
+	c, err := New(Options{Publisher: PublisherFunc(func(ctx context.Context, candidate *PreparedRootCandidate) PublishResult {
+		calls <- candidate
+		select {
+		case <-release:
+			return PublishResult{Outcome: PublishSucceeded}
+		case <-ctx.Done():
+			return PublishResult{Outcome: PublishRetryableFailure, Err: ctx.Err()}
+		}
+	})})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer stopClean(t, c)
+	if err := c.Enqueue(context.Background(), candidate(t, 1, 10)); err != nil {
+		t.Fatal(err)
+	}
+	done := make(chan error, 1)
+	go func() { done <- c.WaitThrough(context.Background(), 1) }()
+	waitForCall(t, calls)
+	select {
+	case err := <-done:
+		t.Fatalf("visible-only frontier satisfied waiter: %v", err)
+	default:
+	}
+	stats := c.Stats()
+	if stats.VisibleCommitSeq != 1 || stats.DurableCommitSeq != 0 || stats.WaiterCount != 1 {
+		t.Fatalf("frontier/waiter stats=%+v", stats)
+	}
+	close(release)
+	if err := <-done; err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestSupersedeRetainsDebtWaitersAndDeterministicObligationUnion(t *testing.T) {
+	calls := make(chan *PreparedRootCandidate, 1)
+	release := make(chan struct{})
+	c, err := New(Options{Publisher: PublisherFunc(func(ctx context.Context, candidate *PreparedRootCandidate) PublishResult {
+		calls <- candidate
+		select {
+		case <-release:
+			return PublishResult{Outcome: PublishSucceeded}
+		case <-ctx.Done():
+			return PublishResult{Outcome: PublishRetryableFailure, Err: ctx.Err()}
+		}
+	})})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer stopClean(t, c)
+	if err := c.Enqueue(context.Background(), candidate(t, 1, 11, 3, 1)); err != nil {
+		t.Fatal(err)
+	}
+	waitDone := make(chan error, 1)
+	go func() { waitDone <- c.WaitThrough(context.Background(), 1) }()
+	// The waiter wakes publication. Keep the first callback blocked, then enqueue
+	// a later candidate; it must remain as a fresh window after commit 1.
+	first := waitForCall(t, calls)
+	if first.Frontier().CommitSeq() != 1 {
+		t.Fatalf("first seq=%d", first.Frontier().CommitSeq())
+	}
+	if err := c.Supersede(context.Background(), candidate(t, 2, 13, 2, 1)); err != nil {
+		t.Fatal(err)
+	}
+	if got := c.Stats().PendingBytes; got != 24 {
+		t.Fatalf("pending bytes=%d", got)
+	}
+	close(release)
+	if err := <-waitDone; err != nil {
+		t.Fatal(err)
+	}
+	// A second waiter captures the remaining window. The first debt was removed;
+	// the second candidate keeps its own deterministic normalized obligations.
+	secondDone := make(chan error, 1)
+	go func() { secondDone <- c.WaitThrough(context.Background(), 2) }()
+	second := waitForCall(t, calls)
+	if got, want := second.Obligations(), []ObligationID{{1}, {2}}; len(got) != len(want) || got[0] != want[0] || got[1] != want[1] {
+		t.Fatalf("second obligations=%v want=%v", got, want)
+	}
+	if second.DependencyBytes() != 13 {
+		t.Fatalf("second debt=%d", second.DependencyBytes())
+	}
+	if err := <-secondDone; err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestCoalescedSupersedeUnionsAllUncoveredObligations(t *testing.T) {
+	calls := make(chan *PreparedRootCandidate, 1)
+	c, err := New(Options{Publisher: PublisherFunc(func(_ context.Context, candidate *PreparedRootCandidate) PublishResult {
+		calls <- candidate
+		return PublishResult{Outcome: PublishSucceeded}
+	})})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer stopClean(t, c)
+	if err := c.Enqueue(context.Background(), candidate(t, 1, 7, 3, 1)); err != nil {
+		t.Fatal(err)
+	}
+	if err := c.Supersede(context.Background(), candidate(t, 2, 9, 2, 3)); err != nil {
+		t.Fatal(err)
+	}
+	done := make(chan error, 1)
+	go func() { done <- c.WaitThrough(context.Background(), 2) }()
+	got := waitForCall(t, calls)
+	if got.DependencyBytes() != 16 {
+		t.Fatalf("coalesced dependency bytes=%d", got.DependencyBytes())
+	}
+	want := []ObligationID{{1}, {2}, {3}}
+	if obligations := got.Obligations(); len(obligations) != 3 || obligations[0] != want[0] || obligations[1] != want[1] || obligations[2] != want[2] {
+		t.Fatalf("coalesced obligations=%v want=%v", obligations, want)
+	}
+	if err := <-done; err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestTimerAnchorsFirstCandidateAndAdaptiveDelay(t *testing.T) {
+	clock := NewFakeClock(time.Unix(100, 0))
+	calls := make(chan uint64, 4)
+	c, err := New(Options{Clock: clock, Publisher: PublisherFunc(func(_ context.Context, candidate *PreparedRootCandidate) PublishResult {
+		calls <- candidate.Frontier().CommitSeq()
+		clock.Advance(3 * time.Millisecond)
+		return PublishResult{Outcome: PublishSucceeded}
+	})})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer stopClean(t, c)
+	if err := c.Enqueue(context.Background(), candidate(t, 1, 1)); err != nil {
+		t.Fatal(err)
+	}
+	clock.Advance(5 * time.Millisecond)
+	if err := c.Supersede(context.Background(), candidate(t, 2, 1)); err != nil {
+		t.Fatal(err)
+	}
+	clock.Advance(4 * time.Millisecond)
+	select {
+	case seq := <-calls:
+		t.Fatalf("timer reset/early call seq=%d", seq)
+	default:
+	}
+	clock.Advance(time.Millisecond)
+	select {
+	case seq := <-calls:
+		if seq != 2 {
+			t.Fatalf("coalesced timer seq=%d", seq)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("anchored timer did not fire")
+	}
+	for c.Stats().DurableCommitSeq != 2 {
+		time.Sleep(time.Millisecond)
+	}
+	if delay := c.Stats().PublishDelay; delay != 60*time.Millisecond {
+		t.Fatalf("adaptive delay=%s", delay)
+	}
+	if err := c.Enqueue(context.Background(), candidate(t, 3, 1)); err != nil {
+		t.Fatal(err)
+	}
+	clock.Advance(59 * time.Millisecond)
+	select {
+	case seq := <-calls:
+		t.Fatalf("adaptive timer early seq=%d", seq)
+	default:
+	}
+	clock.Advance(time.Millisecond)
+	select {
+	case seq := <-calls:
+		if seq != 3 {
+			t.Fatalf("seq=%d", seq)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("adaptive timer did not fire")
+	}
+}
+
+func TestHardAdmissionBlocksBeforeAcknowledgement(t *testing.T) {
+	entered := make(chan struct{}, 1)
+	release := make(chan struct{})
+	c, err := New(Options{Publisher: PublisherFunc(func(ctx context.Context, _ *PreparedRootCandidate) PublishResult {
+		entered <- struct{}{}
+		select {
+		case <-release:
+			return PublishResult{Outcome: PublishSucceeded}
+		case <-ctx.Done():
+			return PublishResult{Outcome: PublishRetryableFailure, Err: ctx.Err()}
+		}
+	})})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer stopClean(t, c)
+	done := make(chan error, 1)
+	go func() { done <- c.Enqueue(context.Background(), candidate(t, 1, HardPendingBytes+1)) }()
+	select {
+	case <-entered:
+	case <-time.After(time.Second):
+		t.Fatal("hard admission did not trigger publish")
+	}
+	select {
+	case err := <-done:
+		t.Fatalf("hard enqueue acknowledged before durable progress: %v", err)
+	default:
+	}
+	close(release)
+	if err := <-done; err != nil {
+		t.Fatal(err)
+	}
+	if c.Stats().AdmissionWaits != 1 {
+		t.Fatalf("stats=%+v", c.Stats())
+	}
+}
+
+func TestHardAdmissionReturnsPublisherErrorOrContext(t *testing.T) {
+	want := errors.New("pre-meta")
+	c, err := New(Options{Publisher: PublisherFunc(func(context.Context, *PreparedRootCandidate) PublishResult {
+		return PublishResult{Outcome: PublishRetryableFailure, Err: want}
+	})})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer stopClean(t, c)
+	if err := c.Enqueue(context.Background(), candidate(t, 1, HardPendingBytes+1)); !errors.Is(err, want) {
+		t.Fatalf("hard error=%v", err)
+	}
+
+	stalled, err := New(Options{Publisher: PublisherFunc(func(ctx context.Context, _ *PreparedRootCandidate) PublishResult {
+		<-ctx.Done()
+		return PublishResult{Outcome: PublishRetryableFailure, Err: ctx.Err()}
+	})})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer stopClean(t, stalled)
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	if err := stalled.Enqueue(ctx, candidate(t, 1, HardPendingBytes+1)); !errors.Is(err, context.Canceled) {
+		t.Fatalf("hard context error=%v", err)
+	}
+}
+
+func TestRetryableFailureRetainsDebtAndFailsOnlyCapturedWaiters(t *testing.T) {
+	want := errors.New("sync dependency")
+	var attempt atomic.Uint64
+	c, err := New(Options{Publisher: PublisherFunc(func(context.Context, *PreparedRootCandidate) PublishResult {
+		if attempt.Add(1) == 1 {
+			return PublishResult{Outcome: PublishRetryableFailure, Err: want}
+		}
+		return PublishResult{Outcome: PublishSucceeded}
+	})})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer stopClean(t, c)
+	if err := c.Enqueue(context.Background(), candidate(t, 1, 99)); err != nil {
+		t.Fatal(err)
+	}
+	if err := c.WaitThrough(context.Background(), 1); !errors.Is(err, want) {
+		t.Fatalf("first wait=%v", err)
+	}
+	stats := c.Stats()
+	if stats.PendingCommits != 1 || stats.PendingBytes != 99 || stats.PreMetaFailures != 1 || stats.WaiterCount != 0 {
+		t.Fatalf("retained stats=%+v", stats)
+	}
+	if err := c.WaitThrough(context.Background(), 1); err != nil {
+		t.Fatalf("retry wait=%v", err)
+	}
+	if stats := c.Stats(); stats.PendingCommits != 0 || stats.Retries != 1 {
+		t.Fatalf("retry stats=%+v", stats)
+	}
+}
+
+func TestAmbiguousResultPoisonsFutureOperations(t *testing.T) {
+	want := errors.New("meta sync unknown")
+	c, err := New(Options{Publisher: PublisherFunc(func(context.Context, *PreparedRootCandidate) PublishResult {
+		return PublishResult{Outcome: PublishAmbiguous, Err: want}
+	})})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer stopClean(t, c)
+	if err := c.Enqueue(context.Background(), candidate(t, 1, 1)); err != nil {
+		t.Fatal(err)
+	}
+	if err := c.WaitThrough(context.Background(), 1); !errors.Is(err, ErrRecoveryRequired) || !errors.Is(err, want) {
+		t.Fatalf("poison wait=%v", err)
+	}
+	if err := c.Enqueue(context.Background(), candidate(t, 2, 1)); !errors.Is(err, ErrRecoveryRequired) {
+		t.Fatalf("enqueue after poison=%v", err)
+	}
+	if _, err := c.AcquireBuilder(context.Background()); !errors.Is(err, ErrRecoveryRequired) {
+		t.Fatalf("admission after poison=%v", err)
+	}
+	if err := c.Drain(context.Background()); !errors.Is(err, ErrRecoveryRequired) {
+		t.Fatalf("drain after poison=%v", err)
+	}
+}
+
+func TestStopCancelsStalledPublisherWithoutLeaks(t *testing.T) {
+	entered := make(chan struct{})
+	c, err := New(Options{Publisher: PublisherFunc(func(ctx context.Context, _ *PreparedRootCandidate) PublishResult {
+		close(entered)
+		<-ctx.Done()
+		return PublishResult{Outcome: PublishRetryableFailure, Err: ctx.Err()}
+	})})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := c.Enqueue(context.Background(), candidate(t, 1, SoftPendingBytes)); err != nil {
+		t.Fatal(err)
+	}
+	select {
+	case <-entered:
+	case <-time.After(time.Second):
+		t.Fatal("publisher did not stall")
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	if err := c.Stop(ctx); !errors.Is(err, ErrPublicationStopped) {
+		t.Fatalf("stop=%v", err)
+	}
+	select {
+	case <-c.done:
+	default:
+		t.Fatal("scheduler goroutine leaked")
+	}
+	if stats := c.Stats(); stats.WaiterCount != 0 || stats.ActiveBuilders != 0 {
+		t.Fatalf("leaked ownership stats=%+v", stats)
+	}
+}
+
+func TestNestedAdmissionUsesOneTokenAndCallbackRunsUnlocked(t *testing.T) {
+	callback := make(chan struct{})
+	var c *Coordinator
+	candidateOne := candidate(t, 1, SoftPendingBytes)
+	created, err := New(Options{Publisher: PublisherFunc(func(ctx context.Context, got *PreparedRootCandidate) PublishResult {
+		if got != candidateOne {
+			t.Errorf("candidate identity changed without coalescing")
+		}
+		_ = c.Stats()                       // coordinator lock is not held
+		token, err := c.AcquireBuilder(ctx) // no admission/build lock is held
+		if err != nil {
+			t.Errorf("callback admission: %v", err)
+		} else {
+			token.Release()
+		}
+		close(callback)
+		return PublishResult{Outcome: PublishSucceeded}
+	})})
+	if err != nil {
+		t.Fatal(err)
+	}
+	c = created
+	defer stopClean(t, c)
+	outer, err := c.AcquireBuilder(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	nested, err := outer.Nested()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if c.Stats().ActiveBuilders != 1 {
+		t.Fatalf("nested token double-counted: %+v", c.Stats())
+	}
+	if err := c.Enqueue(context.Background(), candidateOne); err != nil {
+		t.Fatal(err)
+	}
+	select {
+	case <-callback:
+		t.Fatal("publisher ran with active builder")
+	default:
+	}
+	outer.Release()
+	select {
+	case <-callback:
+		t.Fatal("publisher ran before nested release")
+	default:
+	}
+	nested.Release()
+	select {
+	case <-callback:
+	case <-time.After(time.Second):
+		t.Fatal("publisher deadlocked after nested release")
+	}
+}
+
+func TestWaitCancellationRaceRechecksDurableFrontier(t *testing.T) {
+	release := make(chan struct{})
+	c, err := New(Options{Publisher: PublisherFunc(func(context.Context, *PreparedRootCandidate) PublishResult {
+		<-release
+		return PublishResult{Outcome: PublishSucceeded}
+	})})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer stopClean(t, c)
+	if err := c.Enqueue(context.Background(), candidate(t, 1, 1)); err != nil {
+		t.Fatal(err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() { done <- c.WaitThrough(ctx, 1) }()
+	close(release)
+	for c.Stats().DurableCommitSeq != 1 {
+		time.Sleep(time.Millisecond)
+	}
+	cancel()
+	if err := <-done; err != nil {
+		t.Fatalf("durable frontier lost cancellation race: %v", err)
+	}
+	if c.Stats().WaiterCount != 0 {
+		t.Fatalf("waiter leaked: %+v", c.Stats())
+	}
+}
+
+func TestCanceledDrainDoesNotLeavePermanentDrainMode(t *testing.T) {
+	firstEntered := make(chan struct{})
+	firstRelease := make(chan struct{})
+	calls := make(chan uint64, 4)
+	var count atomic.Uint64
+	c, err := New(Options{Publisher: PublisherFunc(func(ctx context.Context, candidate *PreparedRootCandidate) PublishResult {
+		calls <- candidate.Frontier().CommitSeq()
+		if count.Add(1) == 1 {
+			close(firstEntered)
+			select {
+			case <-firstRelease:
+			case <-ctx.Done():
+				return PublishResult{Outcome: PublishRetryableFailure, Err: ctx.Err()}
+			}
+		}
+		return PublishResult{Outcome: PublishSucceeded}
+	})})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer stopClean(t, c)
+	if err := c.Enqueue(context.Background(), candidate(t, 1, 1)); err != nil {
+		t.Fatal(err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	drained := make(chan error, 1)
+	go func() { drained <- c.Drain(ctx) }()
+	select {
+	case <-firstEntered:
+	case <-time.After(time.Second):
+		t.Fatal("drain did not publish")
+	}
+	cancel()
+	if err := <-drained; !errors.Is(err, context.Canceled) {
+		t.Fatalf("drain cancel=%v", err)
+	}
+	if err := c.Supersede(context.Background(), candidate(t, 2, 1)); err != nil {
+		t.Fatal(err)
+	}
+	close(firstRelease)
+	for c.Stats().DurableCommitSeq != 1 {
+		time.Sleep(time.Millisecond)
+	}
+	select {
+	case seq := <-calls:
+		if seq != 1 {
+			t.Fatalf("first call=%d", seq)
+		}
+	default:
+	}
+	select {
+	case seq := <-calls:
+		t.Fatalf("canceled drain auto-published remaining seq=%d", seq)
+	case <-time.After(20 * time.Millisecond):
+	}
+}
+
+func TestReportPublishResultRejectsStaleMismatchedAndDuplicateAttempts(t *testing.T) {
+	c, err := New(Options{Publisher: PublisherFunc(func(context.Context, *PreparedRootCandidate) PublishResult {
+		return PublishResult{Outcome: PublishSucceeded}
+	})})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer stopClean(t, c)
+	bogus := PublishAttempt{id: 1, candidate: candidate(t, 1, 1), groupSize: 1}
+	if err := c.ReportPublishResult(bogus, PublishResult{Outcome: PublishSucceeded}); !errors.Is(err, ErrPublisherProtocol) {
+		t.Fatalf("bogus report=%v", err)
+	}
+	if stats := c.Stats(); stats.DurableCommitSeq != 0 || stats.PendingCommits != 0 {
+		t.Fatalf("bogus report mutated state: %+v", stats)
+	}
+}
+
+func TestSuccessCannotClaimDifferentDurableSequence(t *testing.T) {
+	c, err := New(Options{Publisher: PublisherFunc(func(context.Context, *PreparedRootCandidate) PublishResult {
+		return PublishResult{Outcome: PublishSucceeded, DurableCommitSeq: 2}
+	})})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer stopClean(t, c)
+	if err := c.Enqueue(context.Background(), candidate(t, 1, 1)); err != nil {
+		t.Fatal(err)
+	}
+	if err := c.WaitThrough(context.Background(), 1); !errors.Is(err, ErrPublisherProtocol) {
+		t.Fatalf("mixed frontier result=%v", err)
+	}
+	if stats := c.Stats(); stats.DurableCommitSeq != 0 || stats.PendingCommits != 1 {
+		t.Fatalf("mixed frontier mutated state: %+v", stats)
+	}
+}
+
+func TestRandomizedCoordinatorModel(t *testing.T) {
+	rng := rand.New(rand.NewSource(3675))
+	var mu sync.Mutex
+	next := PublishResult{Outcome: PublishSucceeded}
+	c, err := New(Options{Publisher: PublisherFunc(func(context.Context, *PreparedRootCandidate) PublishResult {
+		mu.Lock()
+		result := next
+		mu.Unlock()
+		return result
+	})})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer stopClean(t, c)
+	var seq, durable, pendingBytes, pendingCommits uint64
+	for step := 0; step < 400; step++ {
+		seq++
+		bytes := uint64(rng.Intn(1024) + 1)
+		prepared := candidate(t, seq, bytes, byte(rng.Intn(16)))
+		var enqueueErr error
+		if pendingCommits == 0 || rng.Intn(2) == 0 {
+			enqueueErr = c.Enqueue(context.Background(), prepared)
+		} else {
+			enqueueErr = c.Supersede(context.Background(), prepared)
+		}
+		if enqueueErr != nil {
+			t.Fatalf("step %d enqueue: %v", step, enqueueErr)
+		}
+		pendingBytes += bytes
+		pendingCommits++
+		if rng.Intn(4) == 0 {
+			failure := rng.Intn(5) == 0
+			mu.Lock()
+			if failure {
+				next = PublishResult{Outcome: PublishRetryableFailure, Err: errors.New("model retry")}
+			} else {
+				next = PublishResult{Outcome: PublishSucceeded}
+			}
+			mu.Unlock()
+			err := c.WaitThrough(context.Background(), seq)
+			if failure {
+				if err == nil {
+					t.Fatalf("step %d expected retry failure", step)
+				}
+				stats := c.Stats()
+				if stats.PendingBytes != pendingBytes || stats.PendingCommits != pendingCommits {
+					t.Fatalf("step %d retry lost debt: %+v", step, stats)
+				}
+				mu.Lock()
+				next = PublishResult{Outcome: PublishSucceeded}
+				mu.Unlock()
+				if err := c.WaitThrough(context.Background(), seq); err != nil {
+					t.Fatalf("step %d retry: %v", step, err)
+				}
+			}
+			durable = seq
+			pendingBytes, pendingCommits = 0, 0
+		}
+		if rng.Intn(8) == 0 {
+			outer, err := c.AcquireBuilder(context.Background())
+			if err != nil {
+				t.Fatal(err)
+			}
+			nested, err := outer.Nested()
+			if err != nil {
+				t.Fatal(err)
+			}
+			if rng.Intn(2) == 0 {
+				outer.Release()
+				nested.Release()
+			} else {
+				nested.Release()
+				outer.Release()
+			}
+		}
+		stats := c.Stats()
+		if stats.VisibleCommitSeq != seq || stats.DurableCommitSeq != durable || stats.PendingBytes != pendingBytes || stats.PendingCommits != pendingCommits || stats.ActiveBuilders != 0 {
+			t.Fatalf("step %d model=%d/%d/%d/%d stats=%+v", step, seq, durable, pendingBytes, pendingCommits, stats)
+		}
+	}
+	mu.Lock()
+	next = PublishResult{Outcome: PublishSucceeded}
+	mu.Unlock()
+	if err := c.Drain(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if stats := c.Stats(); stats.DurableCommitSeq != seq || stats.PendingCommits != 0 {
+		t.Fatalf("final stats=%+v", stats)
+	}
+}

--- a/TreeDB/internal/rootpublication/coordinator_test.go
+++ b/TreeDB/internal/rootpublication/coordinator_test.go
@@ -1023,6 +1023,12 @@ func TestCopiedAndReleasedBuilderHandleCannotResurrectOrDoubleReleaseLease(t *te
 	clone := *outer
 	outer.Release()
 	clone.Release()
+	outer.handle.mu.Lock()
+	retainsLease := outer.handle.lease != nil
+	outer.handle.mu.Unlock()
+	if retainsLease {
+		t.Fatal("released copied handle retained shared lease")
+	}
 	if stats := c.Stats(); stats.ActiveBuilders != 1 {
 		t.Fatalf("copied handle double-released shared lease: %+v", stats)
 	}

--- a/TreeDB/internal/rootpublication/coordinator_test.go
+++ b/TreeDB/internal/rootpublication/coordinator_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"math/rand"
+	"runtime"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -44,6 +45,68 @@ func waitForCall(t testing.TB, calls <-chan *PreparedRootCandidate) *PreparedRoo
 	case <-time.After(time.Second):
 		t.Fatal("publisher was not called")
 		return nil
+	}
+}
+
+func waitFor(t testing.TB, predicate func() bool) {
+	t.Helper()
+	deadline := time.Now().Add(time.Second)
+	for !predicate() {
+		if time.Now().After(deadline) {
+			t.Fatal("condition did not become true")
+		}
+		time.Sleep(time.Millisecond)
+	}
+}
+
+func TestPreparedCandidateCopiesAndNormalizesObligations(t *testing.T) {
+	input := []ObligationID{{3}, {1}, {3}}
+	prepared, err := NewPreparedRootCandidate(CandidateSpec{
+		Frontier: NewFrontier(1, 2, 3, 4, 5), Obligations: input,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	input[0][0] = 9
+	got := prepared.Obligations()
+	got[0][0] = 8
+	if want := []ObligationID{{1}, {3}}; len(prepared.Obligations()) != 2 || prepared.Obligations()[0] != want[0] || prepared.Obligations()[1] != want[1] {
+		t.Fatalf("candidate obligations mutated: %v", prepared.Obligations())
+	}
+}
+
+type testExtension uint64
+
+func (e testExtension) union(other immutableExtension) immutableExtension {
+	return e | other.(testExtension)
+}
+
+func TestCoalescingUnionsEveryReservedExtensionSlot(t *testing.T) {
+	one, err := newPreparedRootCandidateWithExtensions(CandidateSpec{Frontier: NewFrontier(1, 1, 1, 1, 1)}, extensionSlots{
+		resourceSet: testExtension(1), cowFreelist: testExtension(2), durableRootRecord: testExtension(4),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	two, err := newPreparedRootCandidateWithExtensions(CandidateSpec{Frontier: NewFrontier(2, 2, 2, 2, 2)}, extensionSlots{
+		resourceSet: testExtension(8), cowFreelist: testExtension(16), durableRootRecord: testExtension(32),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := coalesceCandidates([]*PreparedRootCandidate{one, two}).extensions
+	if got.resourceSet != testExtension(9) || got.cowFreelist != testExtension(18) || got.durableRootRecord != testExtension(36) {
+		t.Fatalf("extension union=%+v", got)
+	}
+}
+
+func TestNewRejectsRecoverableFrontierNewerThanDurable(t *testing.T) {
+	_, err := New(Options{
+		Publisher:              PublisherFunc(func(context.Context, *PreparedRootCandidate) PublishResult { return PublishResult{} }),
+		InitialDurableFrontier: NewFrontier(4, 0, 0, 0, 0), OldestRecoverableCommitSeq: 5,
+	})
+	if err == nil {
+		t.Fatal("accepted oldest recoverable frontier newer than durable")
 	}
 }
 
@@ -202,9 +265,7 @@ func TestTimerAnchorsFirstCandidateAndAdaptiveDelay(t *testing.T) {
 	case <-time.After(time.Second):
 		t.Fatal("anchored timer did not fire")
 	}
-	for c.Stats().DurableCommitSeq != 2 {
-		time.Sleep(time.Millisecond)
-	}
+	waitFor(t, func() bool { return c.Stats().DurableCommitSeq == 2 })
 	if delay := c.Stats().PublishDelay; delay != 60*time.Millisecond {
 		t.Fatalf("adaptive delay=%s", delay)
 	}
@@ -265,6 +326,47 @@ func TestHardAdmissionBlocksBeforeAcknowledgement(t *testing.T) {
 	}
 }
 
+func TestExactHardByteBoundaryAcknowledgesWithoutWaiting(t *testing.T) {
+	if HardPendingCommits != 65_536 || HardPendingBytes != 256<<20 || SoftPendingBytes != 64<<20 {
+		t.Fatalf("scheduler constants soft=%d hard-bytes=%d hard-commits=%d", SoftPendingBytes, HardPendingBytes, HardPendingCommits)
+	}
+	entered := make(chan struct{}, 1)
+	release := make(chan struct{})
+	c, err := New(Options{Clock: NewFakeClock(time.Unix(250, 0)), Publisher: PublisherFunc(func(ctx context.Context, _ *PreparedRootCandidate) PublishResult {
+		entered <- struct{}{}
+		select {
+		case <-release:
+			return PublishResult{Outcome: PublishSucceeded}
+		case <-ctx.Done():
+			return PublishResult{Outcome: PublishRetryableFailure, Err: ctx.Err()}
+		}
+	})})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer stopClean(t, c)
+	if err := c.Enqueue(context.Background(), candidate(t, 1, HardPendingBytes)); err != nil {
+		t.Fatalf("exact hard boundary waited/failed: %v", err)
+	}
+	select {
+	case <-entered:
+	case <-time.After(time.Second):
+		t.Fatal("soft trigger did not start publisher")
+	}
+	done := make(chan error, 1)
+	go func() { done <- c.Supersede(context.Background(), candidate(t, 2, 1)) }()
+	waitFor(t, func() bool { return c.Stats().AdmissionWaits == 1 })
+	select {
+	case err := <-done:
+		t.Fatalf("hard crossing acknowledged before progress: %v", err)
+	default:
+	}
+	close(release)
+	if err := <-done; err != nil {
+		t.Fatal(err)
+	}
+}
+
 func TestHardAdmissionReturnsPublisherErrorOrContext(t *testing.T) {
 	want := errors.New("pre-meta")
 	c, err := New(Options{Publisher: PublisherFunc(func(context.Context, *PreparedRootCandidate) PublishResult {
@@ -321,6 +423,127 @@ func TestRetryableFailureRetainsDebtAndFailsOnlyCapturedWaiters(t *testing.T) {
 	}
 	if stats := c.Stats(); stats.PendingCommits != 0 || stats.Retries != 1 {
 		t.Fatalf("retry stats=%+v", stats)
+	}
+}
+
+func TestRetryableFailureDoesNotFailWaiterAddedInFlight(t *testing.T) {
+	firstEntered := make(chan struct{})
+	firstRelease := make(chan struct{})
+	secondEntered := make(chan struct{})
+	secondRelease := make(chan struct{})
+	want := errors.New("first pre-meta failure")
+	var calls atomic.Uint64
+	c, err := New(Options{Publisher: PublisherFunc(func(ctx context.Context, _ *PreparedRootCandidate) PublishResult {
+		switch calls.Add(1) {
+		case 1:
+			close(firstEntered)
+			select {
+			case <-firstRelease:
+				return PublishResult{Outcome: PublishRetryableFailure, Err: want}
+			case <-ctx.Done():
+				return PublishResult{Outcome: PublishRetryableFailure, Err: ctx.Err()}
+			}
+		default:
+			close(secondEntered)
+			select {
+			case <-secondRelease:
+				return PublishResult{Outcome: PublishSucceeded}
+			case <-ctx.Done():
+				return PublishResult{Outcome: PublishRetryableFailure, Err: ctx.Err()}
+			}
+		}
+	})})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer stopClean(t, c)
+	if err := c.Enqueue(context.Background(), candidate(t, 1, 1)); err != nil {
+		t.Fatal(err)
+	}
+	firstDone := make(chan error, 1)
+	go func() { firstDone <- c.WaitThrough(context.Background(), 1) }()
+	select {
+	case <-firstEntered:
+	case <-time.After(time.Second):
+		t.Fatal("first attempt did not start")
+	}
+	secondDone := make(chan error, 1)
+	go func() { secondDone <- c.WaitThrough(context.Background(), 1) }()
+	waitFor(t, func() bool { return c.Stats().WaiterCount == 2 })
+	close(firstRelease)
+	if err := <-firstDone; !errors.Is(err, want) {
+		t.Fatalf("captured waiter error=%v", err)
+	}
+	select {
+	case err := <-secondDone:
+		t.Fatalf("in-flight waiter received prior failure: %v", err)
+	default:
+	}
+	select {
+	case <-secondEntered:
+	case <-time.After(time.Second):
+		t.Fatal("in-flight waiter did not trigger retry")
+	}
+	close(secondRelease)
+	if err := <-secondDone; err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestHardAdmissionAddedInFlightIgnoresPriorGroupFailure(t *testing.T) {
+	firstEntered := make(chan struct{})
+	firstRelease := make(chan struct{})
+	secondEntered := make(chan struct{})
+	secondRelease := make(chan struct{})
+	priorFailure := errors.New("prior group failed")
+	var calls atomic.Uint64
+	c, err := New(Options{Publisher: PublisherFunc(func(ctx context.Context, _ *PreparedRootCandidate) PublishResult {
+		if calls.Add(1) == 1 {
+			close(firstEntered)
+			select {
+			case <-firstRelease:
+				return PublishResult{Outcome: PublishRetryableFailure, Err: priorFailure}
+			case <-ctx.Done():
+				return PublishResult{Outcome: PublishRetryableFailure, Err: ctx.Err()}
+			}
+		}
+		close(secondEntered)
+		select {
+		case <-secondRelease:
+			return PublishResult{Outcome: PublishSucceeded}
+		case <-ctx.Done():
+			return PublishResult{Outcome: PublishRetryableFailure, Err: ctx.Err()}
+		}
+	})})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer stopClean(t, c)
+	if err := c.Enqueue(context.Background(), candidate(t, 1, SoftPendingBytes)); err != nil {
+		t.Fatal(err)
+	}
+	select {
+	case <-firstEntered:
+	case <-time.After(time.Second):
+		t.Fatal("first group did not start")
+	}
+	hardDone := make(chan error, 1)
+	go func() { hardDone <- c.Supersede(context.Background(), candidate(t, 2, HardPendingBytes)) }()
+	waitFor(t, func() bool { return c.Stats().AdmissionWaits == 1 })
+	close(firstRelease)
+	select {
+	case err := <-hardDone:
+		t.Fatalf("later hard admission received prior failure: %v", err)
+	default:
+	}
+	select {
+	case <-secondEntered:
+	case <-time.After(time.Second):
+		t.Fatal("later hard group did not publish")
+	}
+	close(secondRelease)
+	if err := <-hardDone; err != nil {
+		t.Fatal(err)
 	}
 }
 
@@ -456,9 +679,7 @@ func TestWaitCancellationRaceRechecksDurableFrontier(t *testing.T) {
 	done := make(chan error, 1)
 	go func() { done <- c.WaitThrough(ctx, 1) }()
 	close(release)
-	for c.Stats().DurableCommitSeq != 1 {
-		time.Sleep(time.Millisecond)
-	}
+	waitFor(t, func() bool { return c.Stats().DurableCommitSeq == 1 })
 	cancel()
 	if err := <-done; err != nil {
 		t.Fatalf("durable frontier lost cancellation race: %v", err)
@@ -469,11 +690,12 @@ func TestWaitCancellationRaceRechecksDurableFrontier(t *testing.T) {
 }
 
 func TestCanceledDrainDoesNotLeavePermanentDrainMode(t *testing.T) {
+	clock := NewFakeClock(time.Unix(200, 0))
 	firstEntered := make(chan struct{})
 	firstRelease := make(chan struct{})
 	calls := make(chan uint64, 4)
 	var count atomic.Uint64
-	c, err := New(Options{Publisher: PublisherFunc(func(ctx context.Context, candidate *PreparedRootCandidate) PublishResult {
+	c, err := New(Options{Clock: clock, Publisher: PublisherFunc(func(ctx context.Context, candidate *PreparedRootCandidate) PublishResult {
 		calls <- candidate.Frontier().CommitSeq()
 		if count.Add(1) == 1 {
 			close(firstEntered)
@@ -526,12 +748,18 @@ func TestCanceledDrainDoesNotLeavePermanentDrainMode(t *testing.T) {
 }
 
 func TestReportPublishResultRejectsStaleMismatchedAndDuplicateAttempts(t *testing.T) {
-	c, err := New(Options{Publisher: PublisherFunc(func(context.Context, *PreparedRootCandidate) PublishResult {
+	var saved PublishAttempt
+	var c *Coordinator
+	created, err := New(Options{Publisher: PublisherFunc(func(context.Context, *PreparedRootCandidate) PublishResult {
+		c.mu.Lock()
+		saved = c.activeAttempt
+		c.mu.Unlock()
 		return PublishResult{Outcome: PublishSucceeded}
 	})})
 	if err != nil {
 		t.Fatal(err)
 	}
+	c = created
 	defer stopClean(t, c)
 	bogus := PublishAttempt{id: 1, candidate: candidate(t, 1, 1), groupSize: 1}
 	if err := c.ReportPublishResult(bogus, PublishResult{Outcome: PublishSucceeded}); !errors.Is(err, ErrPublisherProtocol) {
@@ -539,6 +767,23 @@ func TestReportPublishResultRejectsStaleMismatchedAndDuplicateAttempts(t *testin
 	}
 	if stats := c.Stats(); stats.DurableCommitSeq != 0 || stats.PendingCommits != 0 {
 		t.Fatalf("bogus report mutated state: %+v", stats)
+	}
+	if err := c.Enqueue(context.Background(), candidate(t, 1, 1)); err != nil {
+		t.Fatal(err)
+	}
+	if err := c.WaitThrough(context.Background(), 1); err != nil {
+		t.Fatal(err)
+	}
+	if err := c.ReportPublishResult(saved, PublishResult{Outcome: PublishSucceeded}); !errors.Is(err, ErrPublisherProtocol) {
+		t.Fatalf("duplicate report=%v", err)
+	}
+	mismatched := saved
+	mismatched.groupSize++
+	if err := c.ReportPublishResult(mismatched, PublishResult{Outcome: PublishSucceeded}); !errors.Is(err, ErrPublisherProtocol) {
+		t.Fatalf("mismatched report=%v", err)
+	}
+	if stats := c.Stats(); stats.DurableCommitSeq != 1 || stats.PendingCommits != 0 {
+		t.Fatalf("stale reports mutated state: %+v", stats)
 	}
 }
 
@@ -561,11 +806,60 @@ func TestSuccessCannotClaimDifferentDurableSequence(t *testing.T) {
 	}
 }
 
+func TestOldestRecoverableMustAdvanceMonotonicallyWithinDurableFrontier(t *testing.T) {
+	for _, test := range []struct {
+		name   string
+		oldest uint64
+	}{{"regression", 2}, {"beyond-durable", 7}} {
+		t.Run(test.name, func(t *testing.T) {
+			c, err := New(Options{
+				InitialDurableFrontier: NewFrontier(5, 5, 5, 5, 5), OldestRecoverableCommitSeq: 3,
+				Publisher: PublisherFunc(func(context.Context, *PreparedRootCandidate) PublishResult {
+					return PublishResult{Outcome: PublishSucceeded, OldestRecoverableCommitSeq: test.oldest}
+				}),
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer stopClean(t, c)
+			if err := c.Enqueue(context.Background(), candidate(t, 6, 1)); err != nil {
+				t.Fatal(err)
+			}
+			if err := c.WaitThrough(context.Background(), 6); !errors.Is(err, ErrPublisherProtocol) {
+				t.Fatalf("oldest=%d error=%v", test.oldest, err)
+			}
+			if stats := c.Stats(); stats.DurableCommitSeq != 5 || stats.OldestRecoverableCommitSeq != 3 || stats.PendingCommits != 1 {
+				t.Fatalf("invalid oldest mutated state: %+v", stats)
+			}
+		})
+	}
+	c, err := New(Options{
+		InitialDurableFrontier: NewFrontier(5, 5, 5, 5, 5), OldestRecoverableCommitSeq: 3,
+		Publisher: PublisherFunc(func(context.Context, *PreparedRootCandidate) PublishResult {
+			return PublishResult{Outcome: PublishSucceeded, OldestRecoverableCommitSeq: 4}
+		}),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer stopClean(t, c)
+	if err := c.Enqueue(context.Background(), candidate(t, 6, 1)); err != nil {
+		t.Fatal(err)
+	}
+	if err := c.WaitThrough(context.Background(), 6); err != nil {
+		t.Fatal(err)
+	}
+	if stats := c.Stats(); stats.DurableCommitSeq != 6 || stats.OldestRecoverableCommitSeq != 4 {
+		t.Fatalf("valid oldest stats=%+v", stats)
+	}
+}
+
 func TestRandomizedCoordinatorModel(t *testing.T) {
 	rng := rand.New(rand.NewSource(3675))
+	clock := NewFakeClock(time.Unix(300, 0))
 	var mu sync.Mutex
 	next := PublishResult{Outcome: PublishSucceeded}
-	c, err := New(Options{Publisher: PublisherFunc(func(context.Context, *PreparedRootCandidate) PublishResult {
+	c, err := New(Options{Clock: clock, Publisher: PublisherFunc(func(context.Context, *PreparedRootCandidate) PublishResult {
 		mu.Lock()
 		result := next
 		mu.Unlock()
@@ -579,6 +873,13 @@ func TestRandomizedCoordinatorModel(t *testing.T) {
 	for step := 0; step < 400; step++ {
 		seq++
 		bytes := uint64(rng.Intn(1024) + 1)
+		hardAdmission := rng.Intn(25) == 0
+		if hardAdmission {
+			bytes = HardPendingBytes + 1
+			mu.Lock()
+			next = PublishResult{Outcome: PublishSucceeded}
+			mu.Unlock()
+		}
 		prepared := candidate(t, seq, bytes, byte(rng.Intn(16)))
 		var enqueueErr error
 		if pendingCommits == 0 || rng.Intn(2) == 0 {
@@ -591,7 +892,11 @@ func TestRandomizedCoordinatorModel(t *testing.T) {
 		}
 		pendingBytes += bytes
 		pendingCommits++
-		if rng.Intn(4) == 0 {
+		if hardAdmission {
+			durable = seq
+			pendingBytes, pendingCommits = 0, 0
+		}
+		if !hardAdmission && rng.Intn(4) == 0 {
 			failure := rng.Intn(5) == 0
 			mu.Lock()
 			if failure {
@@ -650,4 +955,102 @@ func TestRandomizedCoordinatorModel(t *testing.T) {
 	if stats := c.Stats(); stats.DurableCommitSeq != seq || stats.PendingCommits != 0 {
 		t.Fatalf("final stats=%+v", stats)
 	}
+}
+
+func TestRandomizedPoisonAdmissionAndShutdownModel(t *testing.T) {
+	rng := rand.New(rand.NewSource(1595_3675))
+	for cycle := 0; cycle < 80; cycle++ {
+		clock := NewFakeClock(time.Unix(int64(500+cycle), 0))
+		poison := rng.Intn(7) == 0
+		var publishCalls atomic.Uint64
+		c, err := New(Options{Clock: clock, Publisher: PublisherFunc(func(context.Context, *PreparedRootCandidate) PublishResult {
+			publishCalls.Add(1)
+			if poison {
+				return PublishResult{Outcome: PublishAmbiguous, Err: errors.New("model ambiguous meta")}
+			}
+			return PublishResult{Outcome: PublishSucceeded}
+		})})
+		if err != nil {
+			t.Fatal(err)
+		}
+		seq := uint64(1)
+		outer, err := c.AcquireBuilder(context.Background())
+		if err != nil {
+			t.Fatal(err)
+		}
+		nested, err := outer.Nested()
+		if err != nil {
+			t.Fatal(err)
+		}
+		prepared := candidate(t, seq, HardPendingBytes+1, byte(cycle))
+		done := make(chan error, 1)
+		go func() { done <- c.Enqueue(context.Background(), prepared) }()
+		select {
+		case err := <-done:
+			t.Fatalf("cycle %d hard admission passed active builder: %v", cycle, err)
+		default:
+		}
+		if rng.Intn(2) == 0 {
+			outer.Release()
+			nested.Release()
+		} else {
+			nested.Release()
+			outer.Release()
+		}
+		err = <-done
+		if poison {
+			if !errors.Is(err, ErrRecoveryRequired) {
+				t.Fatalf("cycle %d poison=%v", cycle, err)
+			}
+			if err := c.WaitThrough(context.Background(), seq); !errors.Is(err, ErrRecoveryRequired) {
+				t.Fatalf("cycle %d poison wait=%v", cycle, err)
+			}
+		} else if err != nil {
+			t.Fatalf("cycle %d hard admission=%v", cycle, err)
+		}
+		if rng.Intn(2) == 0 && !poison {
+			if err := c.Drain(context.Background()); err != nil {
+				t.Fatalf("cycle %d drain=%v", cycle, err)
+			}
+			if err := c.Stop(context.Background()); err != nil {
+				t.Fatalf("cycle %d drained stop=%v", cycle, err)
+			}
+		} else {
+			err := c.Stop(context.Background())
+			if poison && !errors.Is(err, ErrPublicationStopped) {
+				t.Fatalf("cycle %d poison stop=%v", cycle, err)
+			}
+		}
+		if _, err := c.AcquireBuilder(context.Background()); !errors.Is(err, ErrClosed) && !errors.Is(err, ErrRecoveryRequired) {
+			t.Fatalf("cycle %d admission after shutdown=%v", cycle, err)
+		}
+		if stats := c.Stats(); stats.ActiveBuilders != 0 || stats.WaiterCount != 0 || publishCalls.Load() == 0 {
+			t.Fatalf("cycle %d shutdown stats=%+v calls=%d", cycle, stats, publishCalls.Load())
+		}
+	}
+}
+
+func TestOrdinaryEnqueueHasZeroStableIOAndNoPerEnqueueGoroutine(t *testing.T) {
+	clock := NewFakeClock(time.Unix(400, 0))
+	var calls atomic.Uint64
+	before := runtime.NumGoroutine()
+	c, err := New(Options{Clock: clock, Publisher: PublisherFunc(func(context.Context, *PreparedRootCandidate) PublishResult {
+		calls.Add(1)
+		return PublishResult{Outcome: PublishSucceeded}
+	})})
+	if err != nil {
+		t.Fatal(err)
+	}
+	for seq := uint64(1); seq <= 10_000; seq++ {
+		if err := c.Enqueue(context.Background(), candidate(t, seq, 1)); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if calls.Load() != 0 {
+		t.Fatalf("ordinary enqueue made %d stable-I/O calls", calls.Load())
+	}
+	if delta := runtime.NumGoroutine() - before; delta > 2 {
+		t.Fatalf("enqueue goroutine growth=%d", delta)
+	}
+	stopClean(t, c)
 }

--- a/TreeDB/internal/rootpublication/coordinator_test.go
+++ b/TreeDB/internal/rootpublication/coordinator_test.go
@@ -147,6 +147,80 @@ func TestVisibleFrontierDoesNotSatisfyDurabilityWaiter(t *testing.T) {
 	}
 }
 
+func TestWaiterRemovalClearsDiscardedBackingSlots(t *testing.T) {
+	newWaiters := func() []*durabilityWaiter {
+		return []*durabilityWaiter{
+			{seq: 1, ch: make(chan error, 1)},
+			{seq: 2, ch: make(chan error, 1)},
+			{seq: 3, ch: make(chan error, 1)},
+		}
+	}
+	assertClearedTail := func(t *testing.T, waiters []*durabilityWaiter) {
+		t.Helper()
+		backing := waiters[:cap(waiters)]
+		for i := len(waiters); i < len(backing); i++ {
+			if backing[i] != nil {
+				t.Fatalf("discarded waiter retained at backing slot %d", i)
+			}
+		}
+	}
+	t.Run("remove", func(t *testing.T) {
+		c := &Coordinator{waiters: newWaiters()}
+		c.removeWaiterLocked(c.waiters[1])
+		assertClearedTail(t, c.waiters)
+	})
+	t.Run("captured failure", func(t *testing.T) {
+		c := &Coordinator{waiters: newWaiters()}
+		c.failCapturedWaitersLocked(errors.New("captured"), []*durabilityWaiter{c.waiters[0], c.waiters[2]})
+		assertClearedTail(t, c.waiters)
+	})
+	t.Run("durable satisfaction", func(t *testing.T) {
+		c := &Coordinator{waiters: newWaiters(), durable: NewFrontier(2, 0, 0, 0, 0)}
+		c.satisfyWaitersLocked()
+		assertClearedTail(t, c.waiters)
+	})
+	t.Run("visible failure", func(t *testing.T) {
+		c := &Coordinator{waiters: newWaiters(), visible: NewFrontier(2, 0, 0, 0, 0)}
+		c.failWaitersLocked(errors.New("visible"), false)
+		assertClearedTail(t, c.waiters)
+	})
+	t.Run("terminal failure", func(t *testing.T) {
+		c := &Coordinator{waiters: newWaiters()}
+		c.failWaitersLocked(ErrPublicationStopped, true)
+		if c.waiters != nil {
+			t.Fatalf("terminal waiter storage retained: len=%d cap=%d", len(c.waiters), cap(c.waiters))
+		}
+	})
+}
+
+func TestStopDropsWaiterBackingStorage(t *testing.T) {
+	c, err := New(Options{Clock: NewFakeClock(time.Unix(150, 0)), Publisher: PublisherFunc(func(ctx context.Context, _ *PreparedRootCandidate) PublishResult {
+		<-ctx.Done()
+		return PublishResult{Outcome: PublishRetryableFailure, Err: ctx.Err()}
+	})})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := c.Enqueue(context.Background(), candidate(t, 1, 1)); err != nil {
+		t.Fatal(err)
+	}
+	waitDone := make(chan error, 1)
+	go func() { waitDone <- c.WaitThrough(context.Background(), 1) }()
+	waitFor(t, func() bool { return c.Stats().WaiterCount == 1 && c.Stats().PublishCalls == 1 })
+	if err := c.Stop(context.Background()); !errors.Is(err, ErrPublicationStopped) {
+		t.Fatalf("stop=%v", err)
+	}
+	if err := <-waitDone; !errors.Is(err, ErrPublicationStopped) {
+		t.Fatalf("wait after stop=%v", err)
+	}
+	c.mu.Lock()
+	waiters := c.waiters
+	c.mu.Unlock()
+	if waiters != nil {
+		t.Fatalf("stop retained waiter storage: len=%d cap=%d", len(waiters), cap(waiters))
+	}
+}
+
 func TestSupersedeRetainsDebtWaitersAndDeterministicObligationUnion(t *testing.T) {
 	calls := make(chan *PreparedRootCandidate, 1)
 	release := make(chan struct{})
@@ -286,6 +360,181 @@ func TestTimerAnchorsFirstCandidateAndAdaptiveDelay(t *testing.T) {
 		}
 	case <-time.After(time.Second):
 		t.Fatal("adaptive timer did not fire")
+	}
+}
+
+func TestSatisfiedInFlightWaiterDoesNotLeakImmediateWake(t *testing.T) {
+	clock := NewFakeClock(time.Unix(200, 0))
+	firstEntered := make(chan struct{})
+	firstRelease := make(chan struct{})
+	calls := make(chan uint64, 2)
+	c, err := New(Options{Clock: clock, Publisher: PublisherFunc(func(ctx context.Context, candidate *PreparedRootCandidate) PublishResult {
+		seq := candidate.Frontier().CommitSeq()
+		calls <- seq
+		if seq == 1 {
+			close(firstEntered)
+			select {
+			case <-firstRelease:
+			case <-ctx.Done():
+				return PublishResult{Outcome: PublishRetryableFailure, Err: ctx.Err()}
+			}
+		}
+		return PublishResult{Outcome: PublishSucceeded}
+	})})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer stopClean(t, c)
+	if err := c.Enqueue(context.Background(), candidate(t, 1, 1)); err != nil {
+		t.Fatal(err)
+	}
+	firstDone := make(chan error, 1)
+	go func() { firstDone <- c.WaitThrough(context.Background(), 1) }()
+	select {
+	case <-firstEntered:
+	case <-time.After(time.Second):
+		t.Fatal("first publication did not start")
+	}
+	if seq := <-calls; seq != 1 {
+		t.Fatalf("first publication seq=%d", seq)
+	}
+	secondDone := make(chan error, 1)
+	go func() { secondDone <- c.WaitThrough(context.Background(), 1) }()
+	waitFor(t, func() bool { return c.Stats().WaiterCount == 2 })
+	close(firstRelease)
+	if err := <-firstDone; err != nil {
+		t.Fatal(err)
+	}
+	if err := <-secondDone; err != nil {
+		t.Fatal(err)
+	}
+	waitFor(t, func() bool {
+		stats := c.Stats()
+		return stats.DurableCommitSeq == 1 && stats.PendingCommits == 0
+	})
+	c.mu.Lock()
+	publishNow, wakeReason := c.publishNow, c.wakeReason
+	c.mu.Unlock()
+	if publishNow || wakeReason != WakeNone {
+		t.Fatalf("satisfied waiter leaked wake: publishNow=%t reason=%q", publishNow, wakeReason)
+	}
+
+	if err := c.Enqueue(context.Background(), candidate(t, 2, 1)); err != nil {
+		t.Fatal(err)
+	}
+	c.mu.Lock()
+	publishNow, timerInstalled := c.publishNow, c.timer != nil
+	c.mu.Unlock()
+	if publishNow || !timerInstalled {
+		t.Fatalf("below-soft enqueue skipped timer: publishNow=%t timerInstalled=%t", publishNow, timerInstalled)
+	}
+	clock.Advance(minPublishDelay - time.Millisecond)
+	select {
+	case seq := <-calls:
+		t.Fatalf("seq %d published before timer window", seq)
+	default:
+	}
+	clock.Advance(time.Millisecond)
+	select {
+	case seq := <-calls:
+		if seq != 2 {
+			t.Fatalf("timer publication seq=%d", seq)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timer publication did not start")
+	}
+}
+
+func TestSuccessfulPublishPreservesRealRemainingImmediateTriggers(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		bytes uint64
+		wake  func(*Coordinator) <-chan error
+	}{
+		{name: "waiter", bytes: 1, wake: func(c *Coordinator) <-chan error {
+			done := make(chan error, 1)
+			go func() { done <- c.WaitThrough(context.Background(), 2) }()
+			waitFor(t, func() bool { return c.Stats().WaiterCount == 2 })
+			return done
+		}},
+		{name: "drain", bytes: 1, wake: func(c *Coordinator) <-chan error {
+			done := make(chan error, 1)
+			go func() { done <- c.Drain(context.Background()) }()
+			waitFor(t, func() bool {
+				c.mu.Lock()
+				defer c.mu.Unlock()
+				return c.drainRequests == 1 && c.publishNow
+			})
+			return done
+		}},
+		{name: "soft debt", bytes: SoftPendingBytes, wake: func(c *Coordinator) <-chan error {
+			waitFor(t, func() bool {
+				c.mu.Lock()
+				defer c.mu.Unlock()
+				return c.publishNow && c.wakeReason == WakeSoftBytes
+			})
+			return nil
+		}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			clock := NewFakeClock(time.Unix(300, 0))
+			firstEntered := make(chan struct{})
+			firstRelease := make(chan struct{})
+			calls := make(chan uint64, 2)
+			c, err := New(Options{Clock: clock, Publisher: PublisherFunc(func(ctx context.Context, candidate *PreparedRootCandidate) PublishResult {
+				seq := candidate.Frontier().CommitSeq()
+				calls <- seq
+				if seq == 1 {
+					close(firstEntered)
+					select {
+					case <-firstRelease:
+					case <-ctx.Done():
+						return PublishResult{Outcome: PublishRetryableFailure, Err: ctx.Err()}
+					}
+				}
+				return PublishResult{Outcome: PublishSucceeded}
+			})})
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer stopClean(t, c)
+			if err := c.Enqueue(context.Background(), candidate(t, 1, 1)); err != nil {
+				t.Fatal(err)
+			}
+			firstDone := make(chan error, 1)
+			go func() { firstDone <- c.WaitThrough(context.Background(), 1) }()
+			select {
+			case <-firstEntered:
+			case <-time.After(time.Second):
+				t.Fatal("first publication did not start")
+			}
+			if seq := <-calls; seq != 1 {
+				t.Fatalf("first publication seq=%d", seq)
+			}
+			if err := c.Supersede(context.Background(), candidate(t, 2, tc.bytes)); err != nil {
+				t.Fatal(err)
+			}
+			triggerDone := tc.wake(c)
+			close(firstRelease)
+			select {
+			case seq := <-calls:
+				if seq != 2 {
+					t.Fatalf("remaining immediate publication seq=%d", seq)
+				}
+			case <-time.After(time.Second):
+				t.Fatal("remaining immediate trigger was lost")
+			}
+			if err := <-firstDone; err != nil {
+				t.Fatal(err)
+			}
+			if triggerDone != nil {
+				if err := <-triggerDone; err != nil {
+					t.Fatal(err)
+				}
+			} else {
+				waitFor(t, func() bool { return c.Stats().DurableCommitSeq == 2 })
+			}
+		})
 	}
 }
 
@@ -752,6 +1001,51 @@ func TestNestedAdmissionUsesOneTokenAndCallbackRunsUnlocked(t *testing.T) {
 	case <-callback:
 	case <-time.After(time.Second):
 		t.Fatal("publisher deadlocked after nested release")
+	}
+}
+
+func TestCopiedAndReleasedBuilderHandleCannotResurrectOrDoubleReleaseLease(t *testing.T) {
+	c, err := New(Options{Publisher: PublisherFunc(func(context.Context, *PreparedRootCandidate) PublishResult {
+		return PublishResult{Outcome: PublishSucceeded}
+	})})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer stopClean(t, c)
+	outer, err := c.AcquireBuilder(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	child, err := outer.Nested()
+	if err != nil {
+		t.Fatal(err)
+	}
+	clone := *outer
+	outer.Release()
+	clone.Release()
+	if stats := c.Stats(); stats.ActiveBuilders != 1 {
+		t.Fatalf("copied handle double-released shared lease: %+v", stats)
+	}
+	if _, err := outer.Nested(); !errors.Is(err, ErrClosed) {
+		t.Fatalf("released outer nested again: %v", err)
+	}
+	if _, err := clone.Nested(); !errors.Is(err, ErrClosed) {
+		t.Fatalf("released clone nested again: %v", err)
+	}
+	grandchild, err := child.Nested()
+	if err != nil {
+		t.Fatalf("live child could not nest: %v", err)
+	}
+	child.Release()
+	if stats := c.Stats(); stats.ActiveBuilders != 1 {
+		t.Fatalf("shared lease released before final live handle: %+v", stats)
+	}
+	grandchild.Release()
+	if stats := c.Stats(); stats.ActiveBuilders != 0 {
+		t.Fatalf("shared lease not released exactly once: %+v", stats)
+	}
+	if _, err := child.Nested(); !errors.Is(err, ErrClosed) {
+		t.Fatalf("released child nested again: %v", err)
 	}
 }
 

--- a/TreeDB/internal/rootpublication/coordinator_test.go
+++ b/TreeDB/internal/rootpublication/coordinator_test.go
@@ -367,6 +367,50 @@ func TestExactHardByteBoundaryAcknowledgesWithoutWaiting(t *testing.T) {
 	}
 }
 
+func TestExactHardCommitBoundaryAcknowledgesThenNextCommitWaits(t *testing.T) {
+	clock := NewFakeClock(time.Unix(275, 0))
+	entered := make(chan struct{}, 1)
+	release := make(chan struct{})
+	c, err := New(Options{Clock: clock, Publisher: PublisherFunc(func(ctx context.Context, _ *PreparedRootCandidate) PublishResult {
+		entered <- struct{}{}
+		select {
+		case <-release:
+			return PublishResult{Outcome: PublishSucceeded}
+		case <-ctx.Done():
+			return PublishResult{Outcome: PublishRetryableFailure, Err: ctx.Err()}
+		}
+	})})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer stopClean(t, c)
+	for seq := uint64(1); seq <= HardPendingCommits; seq++ {
+		if err := c.Enqueue(context.Background(), candidate(t, seq, 0)); err != nil {
+			t.Fatalf("exact-boundary seq=%d: %v", seq, err)
+		}
+	}
+	if stats := c.Stats(); stats.PendingCommits != HardPendingCommits || stats.AdmissionWaits != 0 {
+		t.Fatalf("exact commit boundary stats=%+v", stats)
+	}
+	done := make(chan error, 1)
+	go func() { done <- c.Supersede(context.Background(), candidate(t, HardPendingCommits+1, 0)) }()
+	select {
+	case <-entered:
+	case <-time.After(time.Second):
+		t.Fatal("commit hard crossing did not publish")
+	}
+	waitFor(t, func() bool { return c.Stats().AdmissionWaits == 1 })
+	select {
+	case err := <-done:
+		t.Fatalf("65,537th commit acknowledged before progress: %v", err)
+	default:
+	}
+	close(release)
+	if err := <-done; err != nil {
+		t.Fatal(err)
+	}
+}
+
 func TestHardAdmissionReturnsPublisherErrorOrContext(t *testing.T) {
 	want := errors.New("pre-meta")
 	c, err := New(Options{Publisher: PublisherFunc(func(context.Context, *PreparedRootCandidate) PublishResult {
@@ -603,6 +647,24 @@ func TestStopCancelsStalledPublisherWithoutLeaks(t *testing.T) {
 	}
 	if stats := c.Stats(); stats.WaiterCount != 0 || stats.ActiveBuilders != 0 {
 		t.Fatalf("leaked ownership stats=%+v", stats)
+	}
+}
+
+func TestStopReturnsSameDebtResultToEveryCaller(t *testing.T) {
+	c, err := New(Options{Clock: NewFakeClock(time.Unix(280, 0)), Publisher: PublisherFunc(func(context.Context, *PreparedRootCandidate) PublishResult {
+		return PublishResult{Outcome: PublishSucceeded}
+	})})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := c.Enqueue(context.Background(), candidate(t, 1, 1)); err != nil {
+		t.Fatal(err)
+	}
+	if err := c.Stop(context.Background()); !errors.Is(err, ErrPublicationStopped) {
+		t.Fatalf("first stop=%v", err)
+	}
+	if err := c.Stop(context.Background()); !errors.Is(err, ErrPublicationStopped) {
+		t.Fatalf("second stop=%v", err)
 	}
 }
 

--- a/TreeDB/internal/rootpublication/coordinator_test.go
+++ b/TreeDB/internal/rootpublication/coordinator_test.go
@@ -617,6 +617,37 @@ func TestAmbiguousResultPoisonsFutureOperations(t *testing.T) {
 	}
 }
 
+func TestPoisonedWaitThroughFailsClosedBeforeDurableFastPath(t *testing.T) {
+	want := errors.New("later meta sync unknown")
+	c, err := New(Options{
+		InitialDurableFrontier: NewFrontier(5, 50, 100, 5, 5),
+		Publisher: PublisherFunc(func(context.Context, *PreparedRootCandidate) PublishResult {
+			return PublishResult{Outcome: PublishAmbiguous, Err: want}
+		}),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer stopClean(t, c)
+	if err := c.Enqueue(context.Background(), candidate(t, 6, 1)); err != nil {
+		t.Fatal(err)
+	}
+	if err := c.WaitThrough(context.Background(), 6); !errors.Is(err, ErrRecoveryRequired) {
+		t.Fatalf("poisoning wait=%v", err)
+	}
+	if err := c.WaitThrough(context.Background(), 5); !errors.Is(err, ErrRecoveryRequired) || !errors.Is(err, want) {
+		t.Fatalf("already-durable wait bypassed poison: %v", err)
+	}
+	if err := c.Enqueue(context.Background(), nil); !errors.Is(err, ErrRecoveryRequired) {
+		t.Fatalf("invalid enqueue bypassed poison: %v", err)
+	}
+	canceled, cancel := context.WithCancel(context.Background())
+	cancel()
+	if _, err := c.AcquireBuilder(canceled); !errors.Is(err, ErrRecoveryRequired) {
+		t.Fatalf("canceled admission bypassed poison: %v", err)
+	}
+}
+
 func TestStopCancelsStalledPublisherWithoutLeaks(t *testing.T) {
 	entered := make(chan struct{})
 	c, err := New(Options{Publisher: PublisherFunc(func(ctx context.Context, _ *PreparedRootCandidate) PublishResult {

--- a/TreeDB/internal/rootpublication/types.go
+++ b/TreeDB/internal/rootpublication/types.go
@@ -1,0 +1,259 @@
+// Package rootpublication provides the dormant scheduling primitive for
+// coalescing prepared TreeDB roots before stable publication.
+//
+// The package deliberately has no connection to TreeDB's current commit,
+// pager, meta, recovery, maintenance, or public-profile paths. Later durability
+// tickets add exact resource ownership and stable-root publication before the
+// coordinator is activated.
+package rootpublication
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"sort"
+	"time"
+)
+
+const (
+	SoftPendingBytes   = uint64(64 << 20)
+	HardPendingBytes   = uint64(256 << 20)
+	HardPendingCommits = uint64(65_536)
+
+	minPublishDelay = 10 * time.Millisecond
+	maxPublishDelay = 100 * time.Millisecond
+)
+
+var (
+	ErrClosed             = errors.New("root publication coordinator closed")
+	ErrRecoveryRequired   = errors.New("root publication recovery required")
+	ErrInvalidCandidate   = errors.New("invalid root publication candidate")
+	ErrPublisherProtocol  = errors.New("root publication publisher protocol error")
+	ErrPublicationStopped = errors.New("root publication stopped before debt drained")
+)
+
+// Frontier is the scalar, immutable visible/durable boundary associated with a
+// prepared root. Root page identities may change freely; the sequence and
+// dependency frontiers must only advance.
+type Frontier struct {
+	commitSeq         uint64
+	userRootPageID    uint64
+	systemRootPageID  uint64
+	appliedCommandLSN uint64
+	maxEntryRevision  uint64
+}
+
+func NewFrontier(commitSeq, userRootPageID, systemRootPageID, appliedCommandLSN, maxEntryRevision uint64) Frontier {
+	return Frontier{
+		commitSeq: commitSeq, userRootPageID: userRootPageID,
+		systemRootPageID: systemRootPageID, appliedCommandLSN: appliedCommandLSN,
+		maxEntryRevision: maxEntryRevision,
+	}
+}
+
+func (f Frontier) CommitSeq() uint64         { return f.commitSeq }
+func (f Frontier) UserRootPageID() uint64    { return f.userRootPageID }
+func (f Frontier) SystemRootPageID() uint64  { return f.systemRootPageID }
+func (f Frontier) AppliedCommandLSN() uint64 { return f.appliedCommandLSN }
+func (f Frontier) MaxEntryRevision() uint64  { return f.maxEntryRevision }
+
+func (f Frontier) Dominates(older Frontier) bool {
+	return f.commitSeq > older.commitSeq &&
+		f.appliedCommandLSN >= older.appliedCommandLSN &&
+		f.maxEntryRevision >= older.maxEntryRevision
+}
+
+// CandidateSpec is copied into a PreparedRootCandidate. DependencyBytes and
+// IndexBytes represent owned unpublished debt, not a path or resource identity.
+type CandidateSpec struct {
+	Frontier        Frontier
+	FreelistHeadID  uint64
+	TotalPages      uint64
+	DependencyBytes uint64
+	IndexBytes      uint64
+	Obligations     []ObligationID
+}
+
+// ObligationID is an opaque, path-free identity for dependency ownership. Its
+// concrete resource interpretation belongs to #3677. This foundation only
+// needs a comparable value so supersession can retain a deterministic union.
+type ObligationID [16]byte
+
+// extensionSlots reserve package-private typed ownership points for #3677,
+// #3678, and #3679. Keeping them private prevents this foundation from
+// inventing a path-based identity or prematurely exposing a public contract.
+type immutableExtension interface {
+	union(immutableExtension) immutableExtension
+}
+
+type extensionSlots struct {
+	resourceSet       immutableExtension
+	cowFreelist       immutableExtension
+	durableRootRecord immutableExtension
+}
+
+// PreparedRootCandidate is immutable after construction. All fields are
+// private and coalescing creates a new value rather than mutating an enqueued
+// candidate.
+type PreparedRootCandidate struct {
+	frontier        Frontier
+	freelistHeadID  uint64
+	totalPages      uint64
+	dependencyBytes uint64
+	indexBytes      uint64
+	obligations     []ObligationID
+	extensions      extensionSlots
+}
+
+func NewPreparedRootCandidate(spec CandidateSpec) (*PreparedRootCandidate, error) {
+	return newPreparedRootCandidateWithExtensions(spec, extensionSlots{})
+}
+
+func newPreparedRootCandidateWithExtensions(spec CandidateSpec, extensions extensionSlots) (*PreparedRootCandidate, error) {
+	if spec.Frontier.commitSeq == 0 {
+		return nil, fmt.Errorf("%w: commit sequence is zero", ErrInvalidCandidate)
+	}
+	return &PreparedRootCandidate{
+		frontier: spec.Frontier, freelistHeadID: spec.FreelistHeadID,
+		totalPages: spec.TotalPages, dependencyBytes: spec.DependencyBytes,
+		indexBytes: spec.IndexBytes, obligations: normalizeObligations(spec.Obligations), extensions: extensions,
+	}, nil
+}
+
+func (c *PreparedRootCandidate) Frontier() Frontier      { return c.frontier }
+func (c *PreparedRootCandidate) FreelistHeadID() uint64  { return c.freelistHeadID }
+func (c *PreparedRootCandidate) TotalPages() uint64      { return c.totalPages }
+func (c *PreparedRootCandidate) DependencyBytes() uint64 { return c.dependencyBytes }
+func (c *PreparedRootCandidate) IndexBytes() uint64      { return c.indexBytes }
+func (c *PreparedRootCandidate) Obligations() []ObligationID {
+	return append([]ObligationID(nil), c.obligations...)
+}
+func (c *PreparedRootCandidate) OwnedBytes() uint64 {
+	return saturatingAdd(c.dependencyBytes, c.indexBytes)
+}
+
+func coalesceCandidates(candidates []*PreparedRootCandidate) *PreparedRootCandidate {
+	if len(candidates) == 1 {
+		return candidates[0]
+	}
+	latest := candidates[len(candidates)-1]
+	coalesced := *latest
+	coalesced.dependencyBytes = 0
+	coalesced.indexBytes = 0
+	coalesced.obligations = nil
+	coalesced.extensions = extensionSlots{}
+	for _, candidate := range candidates {
+		coalesced.dependencyBytes = saturatingAdd(coalesced.dependencyBytes, candidate.dependencyBytes)
+		coalesced.indexBytes = saturatingAdd(coalesced.indexBytes, candidate.indexBytes)
+		coalesced.obligations = append(coalesced.obligations, candidate.obligations...)
+		coalesced.extensions = unionExtensionSlots(coalesced.extensions, candidate.extensions)
+	}
+	coalesced.obligations = normalizeObligations(coalesced.obligations)
+	return &coalesced
+}
+
+func unionExtensionSlots(older, newer extensionSlots) extensionSlots {
+	return extensionSlots{
+		resourceSet:       unionExtensionValue(older.resourceSet, newer.resourceSet),
+		cowFreelist:       unionExtensionValue(older.cowFreelist, newer.cowFreelist),
+		durableRootRecord: unionExtensionValue(older.durableRootRecord, newer.durableRootRecord),
+	}
+}
+
+func unionExtensionValue(older, newer immutableExtension) immutableExtension {
+	if older == nil {
+		return newer
+	}
+	if newer == nil {
+		return older
+	}
+	return older.union(newer)
+}
+
+func normalizeObligations(obligations []ObligationID) []ObligationID {
+	normalized := append([]ObligationID(nil), obligations...)
+	sort.Slice(normalized, func(i, j int) bool {
+		return bytes.Compare(normalized[i][:], normalized[j][:]) < 0
+	})
+	if len(normalized) < 2 {
+		return normalized
+	}
+	out := normalized[:1]
+	for _, obligation := range normalized[1:] {
+		if obligation != out[len(out)-1] {
+			out = append(out, obligation)
+		}
+	}
+	return out
+}
+
+func saturatingAdd(a, b uint64) uint64 {
+	if ^uint64(0)-a < b {
+		return ^uint64(0)
+	}
+	return a + b
+}
+
+type PublishOutcome uint8
+
+const (
+	PublishSucceeded PublishOutcome = iota
+	PublishRetryableFailure
+	PublishAmbiguous
+)
+
+// PublishResult classifies whether the target meta could have changed. A zero
+// durable sequence on success means the candidate's exact sequence.
+type PublishResult struct {
+	Outcome                    PublishOutcome
+	DurableCommitSeq           uint64
+	OldestRecoverableCommitSeq uint64
+	Err                        error
+}
+
+// Publisher performs synchronous stable I/O. The coordinator always invokes
+// it without holding its state lock or an admission/build token. Implementations
+// must observe ctx so Stop can terminate a stalled callback deterministically.
+type Publisher interface {
+	Publish(ctx context.Context, candidate *PreparedRootCandidate) PublishResult
+}
+
+type PublisherFunc func(context.Context, *PreparedRootCandidate) PublishResult
+
+func (f PublisherFunc) Publish(ctx context.Context, c *PreparedRootCandidate) PublishResult {
+	return f(ctx, c)
+}
+
+type WakeReason string
+
+const (
+	WakeNone          WakeReason = "none"
+	WakeTimer         WakeReason = "timer"
+	WakeWaiter        WakeReason = "durability_waiter"
+	WakeSoftBytes     WakeReason = "soft_bytes"
+	WakeHardAdmission WakeReason = "hard_admission"
+	WakeRetry         WakeReason = "retry"
+	WakeDrain         WakeReason = "drain"
+)
+
+type Stats struct {
+	VisibleCommitSeq           uint64
+	DurableCommitSeq           uint64
+	OldestRecoverableCommitSeq uint64
+	PendingCommits             uint64
+	PendingBytes               uint64
+	PendingAge                 time.Duration
+	LastGroupSize              uint64
+	LastServiceDuration        time.Duration
+	EWMAServiceDuration        time.Duration
+	PublishDelay               time.Duration
+	AdmissionWaits             uint64
+	ActiveBuilders             uint64
+	WaiterCount                uint64
+	PreMetaFailures            uint64
+	Retries                    uint64
+	Poisoned                   bool
+	WakeReason                 WakeReason
+	PublishCalls               uint64
+}


### PR DESCRIPTION
Closes #3675
Parent: #1595
Supersedes #3712 as the scoped DUR-02 merge unit.

## Outcome

Adds the dormant `TreeDB/internal/rootpublication` scheduling primitive without routing any current TreeDB commit, pager, meta, recovery, maintenance, or public-profile path through it.

- immutable, private-field prepared candidates and scalar visible/durable/recoverable frontiers
- deterministic coalescing of dependency bytes, index bytes, opaque path-free obligations, reserved resource/COW/root-record extension slots, and durability waiters
- first-candidate timer anchoring with `clamp(20 * EWMA(service), 10ms, 100ms)`
- 64 MiB soft wake and exact hard admission behavior: the 256 MiB / 65,536-commit boundary acknowledges without waiting; the crossing write waits for durable progress, its covered publisher error, or context cancellation
- reference-counted nested builder admission with one owned release path
- retryable/pre-meta failure retention, attempt-captured waiter/error ownership, and permanent ambiguous/post-meta poison
- fail-closed terminal-state precedence, including waits for already-durable frontiers after poison
- cancellable synchronous publisher seam, deterministic fake clock, drain/stop, exact-attempt result reporting, and complete scheduler stats
- no polling lock loop and no per-enqueue goroutine

## Checked state table

The complete ownership/transition table is in `TreeDB/internal/rootpublication/STATE_TABLE.md`.

| From | Event | To | Ownership result |
| --- | --- | --- | --- |
| idle | first enqueue | pending window | visible advances; candidate/debt retained; timer anchors once |
| pending | later enqueue/supersede | pending | latest data wins; uncovered debt/extension union and waiters remain |
| pending | timer/waiter/soft/hard/drain | publishing | active builders drain; synchronous callback runs without coordinator/admission lock |
| publishing | success | idle/new window | only captured debt is removed; durable/recoverable advance; EWMA updates |
| publishing | retryable/pre-meta failure | stalled pending | candidate/debt retained; only attempt-captured waiters and covered hard acks fail |
| publishing | ambiguous/post-meta | poisoned | all future enqueue/admission/wait/drain operations return `ErrRecoveryRequired` |
| live | stop | stopped | callback context canceled; sole worker joined; unpublished debt reported |

## TDD / red evidence

Commit `965394cf5c3edf6412543abca4f1042a170d05cc` contains the state/model/benchmark contract before the implementation. A detached worktree at that exact commit produced the expected red compile result:

```text
TreeDB/internal/rootpublication/coordinator_bench_test.go:13:55: undefined: PreparedRootCandidate
TreeDB/internal/rootpublication/coordinator_bench_test.go:22:24: undefined: New
TreeDB/internal/rootpublication/coordinator_test.go:13:71: undefined: PreparedRootCandidate
FAIL github.com/snissn/gomap/TreeDB/internal/rootpublication [build failed]
```

The green suite covers every requested TDD edge, adversarial stale/duplicate reporting, in-flight waiter/hard-admission failure ownership, exact byte and commit hard boundaries, constructor/result frontier validation, cancellation races, repeated Stop determinism, zero ordinary stable I/O, and randomized state/model sequences.

Review regression `TestPoisonedWaitThroughFailsClosedBeforeDurableFastPath` starts from an existing durable frontier, poisons a later publication, and proves that a subsequent wait for the older durable sequence returns `ErrRecoveryRequired`. The same terminal-first audit covers invalid enqueue, canceled builder admission, waiter cancellation, and drain-loop completion paths.

The final concurrency review loop also adds deterministic regressions for satisfied in-flight waiter wake ownership, copy-safe builder-handle release, concurrent Drain/Stop, canceled in-flight waiter retry ownership, and anchored timer restoration after pre-callback waiter cancellation. Attempt-captured drain identities prevent an older failed drain from owning a fresh request, waiter compaction clears discarded backing slots so terminal completion releases retained references, and fake-clock timers due in one advance are ordered by deadline plus a stable creation-order tie-breaker. Coordinator timer generations also ensure that a stopped timer channel already captured by the worker cannot clear or supersede its replacement timer.

## Fake-clock evidence

`TestTimerAnchorsFirstCandidateAndAdaptiveDelay` advances a deterministic clock to prove that a later candidate does not reset the initial 10 ms window. A 3 ms successful callback yields the exact next delay of 60 ms; no callback occurs at 59 ms and publication occurs at 60 ms. `TestFakeClockDueTimersUseDeadlineThenCreationOrder` fixes multi-timer delivery order, while `TestStaleStoppedTimerFiringCannotReplaceCurrentTimer` proves that stale delivery from an already-selected stopped channel is ignored after replacement. Random models use a non-advancing fake clock so ordinary enqueue cannot accidentally publish due to wall time.

## Validation at exact head

Head: `de851950816e16581a22bac3a0be60623e63ad3b`
Base and merge-base: `2ef63b845ec94980fd0e40d535b46a4a1bdac175` (normal merge refresh after unrelated typed-column PR #3723)

```text
go test ./TreeDB/internal/rootpublication -run '^Test(StaleStoppedTimerFiringCannotReplaceCurrentTimer|FakeClockDueTimersUseDeadlineThenCreationOrder)$' -count=500
ok github.com/snissn/gomap/TreeDB/internal/rootpublication 0.526s

go test -race ./TreeDB/internal/rootpublication -run '^Test(StaleStoppedTimerFiringCannotReplaceCurrentTimer|FakeClockDueTimersUseDeadlineThenCreationOrder)$' -count=200
ok github.com/snissn/gomap/TreeDB/internal/rootpublication 1.488s

go test -race ./TreeDB/internal/rootpublication -run 'Test(StaleStoppedTimerFiringCannotReplaceCurrentTimer|FakeClockDueTimersUseDeadlineThenCreationOrder|SatisfiedInFlightWaiterDoesNotLeakImmediateWake|CopiedAndReleasedBuilderHandleCannotResurrectOrDoubleReleaseLease|ConcurrentDrainAndStop|CanceledInFlightWaiterDoesNotLeakRetryWake|CanceledWaiterRestoresAnchoredTimerInsteadOfLeakingImmediateWake|CanceledDrainRestoresAnchoredTimerInsteadOfLeakingImmediateWake|WaiterRemovalClearsDiscardedBackingSlots)$' -count=100
ok github.com/snissn/gomap/TreeDB/internal/rootpublication 2.299s

go test ./TreeDB/internal/rootpublication -count=1
ok github.com/snissn/gomap/TreeDB/internal/rootpublication 0.468s

go test -race ./TreeDB/internal/rootpublication -count=1
ok github.com/snissn/gomap/TreeDB/internal/rootpublication 1.518s

go test ./TreeDB/internal/rootpublication -run 'TestRandomized(CoordinatorModel|PoisonAdmissionAndShutdownModel)$' -count=20
ok github.com/snissn/gomap/TreeDB/internal/rootpublication 0.297s

go vet ./TreeDB/internal/rootpublication

git diff --check origin/main...HEAD
# clean; merge-base diff remains the eight files under TreeDB/internal/rootpublication/
```

## Primitive benchmark

Command:

```text
go test ./TreeDB/internal/rootpublication -run '^$' -bench 'BenchmarkCoordinator(Enqueue|Supersede|Wait)' -benchtime=10000x -count=1
```

Apple M3 / darwin arm64:

| Operation | Producers | ns/op | B/op | allocs/op | contention retries/op | stable I/O/op | groups/s |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| enqueue | 1 | 87.93 | 210 | 1 | 0 | 0 | - |
| enqueue | 2 | 110.7 | 217 | 1 | 0.02410 | 0 | - |
| enqueue | 4 | 217.0 | 227 | 1 | 0.06040 | 0 | - |
| enqueue | 8 | 193.6 | 219 | 1 | 0.02810 | 0 | - |
| supersede | 1 | 70.25 | 210 | 1 | 0 | 0 | - |
| supersede | 2 | 106.2 | 215 | 1 | 0.01720 | 0 | - |
| supersede | 4 | 174.9 | 225 | 1 | 0.05370 | 0 | - |
| supersede | 8 | 233.4 | 250 | 1 | 0.1417 | 0 | - |
| wait | 1 | 904.3 | 672 | 10 | 0 | callback | 1,100,287 |
| wait | 2 | 1162 | 643 | 9 | 0.02420 | callback | 714,589 |
| wait | 4 | 1290 | 613 | 9 | 0.1342 | callback | 529,061 |
| wait | 8 | 1225 | 566 | 8 | 0.2505 | callback | 374,088 |

The producer benchmark allows proposals to contend inside the coordinator. A stale proposal retries with a newer monotonic frontier, and the retry rate is reported explicitly. `TestOrdinaryEnqueueHasZeroStableIOAndNoPerEnqueueGoroutine` separately enforces zero stable-I/O calls and bounded goroutine count for 10,000 ordinary enqueues.

## Inertness / scope audit

- exact base and merge-base: `origin/main@2ef63b845ec94980fd0e40d535b46a4a1bdac175`
- diff contains only eight files under `TreeDB/internal/rootpublication/`
- production package imports are standard library only: `bytes`, `context`, `errors`, `fmt`, `sort`, `sync`, `time`
- no references from outside the new private package
- no pager/page/meta/storage/file/path/public-profile dependency
- no production `TryLock`, `runtime.Gosched`, or `time.After` polling
- the sole production `go` statement starts the one coordinator worker in `New`; enqueue/supersede do not spawn goroutines

## Explicit non-goals

- no stable file/meta publication (#3679)
- no exact dependency inventory (#3677)
- no COW freelist implementation (#3678)
- no TreeDB API/commit-path activation (#3680)
- no maintenance integration (#3681)
- no public profile name or option

The private extension slots are intentionally dormant and union-capable; their exact immutable types remain owned by the dependent tickets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added root publication scheduling with candidate queuing, coalescing, superseding, durability waits, retries, draining, and graceful shutdown.
  * Added publication progress statistics and recovery-state reporting.
  * Added builder admission tokens supporting nested ownership and safe release.
  * Added deterministic clock and timer support for controlled scheduling.

* **Documentation**
  * Documented coordinator states, transitions, timing, admission thresholds, retries, and recovery behavior.

* **Tests**
  * Added extensive coverage for concurrency, timing, failures, shutdown, admission, recovery, and randomized state transitions.
  * Added performance benchmarks for common coordinator operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->