### PR TITLE
typedcolumn: add bounded query-ready delta generations

### DIFF
--- a/TreeDB/docs/spec/storage-format.md
+++ b/TreeDB/docs/spec/storage-format.md
@@ -205,6 +205,67 @@ The implementation and format tests are in
 ownership, lifecycle boundary, and performance contract are described in
 `docs/architecture/query-ready-base-generation.md`.
 
+## 1.3 Query-Ready Delta / Consolidated Base Envelope V1
+
+A query-ready delta generation (`QRDG` V1) is a rebuildable, non-authoritative
+envelope containing one QRBG V1 image and a sorted tombstone table. Kind `1`
+represents one ordinary delta generation. Kind `2` represents a standalone,
+bounded multipart replacement base produced by deterministic consolidation.
+It is not an authoritative publication, recovery, or reclamation format.
+
+All integer fields are little-endian. The 96-byte header is:
+
+```text
+offset  size  field
+0       4     magic = "QRDG" (bytes 51 52 44 47)
+4       2     version = 1
+6       2     kind (1=delta, 2=consolidated base)
+8       8     exact envelope generation (nonzero)
+16      32    exact collection schema SHA-256 (nonzero)
+48      4     tombstone count
+52      4     header CRC-32C
+56      4     tombstone-table CRC-32C
+60      4     reserved = 0
+64      8     embedded QRBG payload offset
+72      8     total envelope bytes
+80      8     embedded QRBG byte length
+88      4     original-base part count
+92      4     accumulated delta-derived part count
+```
+
+The header checksum is CRC-32C (Castagnoli) over all 96 header bytes with bytes
+`[52,56)` zeroed. The tombstone checksum covers exactly
+`tombstone_count * 16` bytes after the header. Each entry is `i64 primary_id`
+followed by `u64 tombstone_generation`. Entries are strictly increasing by
+primary ID and contain only the highest tombstone generation retained for that
+ID; generations are nonzero and cannot exceed the envelope generation.
+
+The embedded QRBG begins at a 4096-byte-aligned payload offset. Padding between
+the tombstone table and payload is zero. The declared total and inner lengths
+must account for the exact file length; corruption, truncation, trailing bytes,
+or a malformed inner QRBG fail closed. Schema and generation identity must
+match both the caller's expectation and the embedded QRBG.
+
+Ordinary delta kind requires both lineage counts to be zero and every embedded
+part source generation to equal the envelope generation. Consolidated-base
+kind requires:
+
+```text
+original_base_part_count + accumulated_delta_part_count == embedded_part_count
+```
+
+Consolidation may preserve mixed historical source generations. Its output
+generation is exactly the highest selected delta-prefix generation, or the
+unchanged prior base generation if the prefix is empty. Repeated consolidation
+carries forward tombstones and accumulated lineage; it cannot reset the
+delta-derived count. A later physical base rewrite may define a new origin.
+
+The implementation, fail-closed tests, and format mutations are in
+`TreeDB/internal/typedcolumn/query_ready_delta.go` and
+`TreeDB/internal/typedcolumn/query_ready_delta_test.go`. The visibility, bound,
+dictionary-domain, performance, and lifecycle contract is in
+`docs/architecture/query-ready-delta-generation.md`.
+
 ## 2. Index Page Basics
 
 ### 2.1 Fixed page size

--- a/TreeDB/internal/typedcolumn/part_set.go
+++ b/TreeDB/internal/typedcolumn/part_set.go
@@ -148,6 +148,42 @@ func (r *PartSetReader) ValueAtLatest(primaryID int64, columnName string) (int64
 	return value, true, nil
 }
 
+// NullableInt64AtLatest returns the physical nullable/default state from the
+// latest-visible row without constructing a cross-part value domain.
+func (r *PartSetReader) NullableInt64AtLatest(primaryID int64, columnName string) (value int64, null, defaulted, ok bool, err error) {
+	if r == nil {
+		return 0, false, false, false, nil
+	}
+	ref, ok := r.latest[primaryID]
+	if !ok {
+		return 0, false, false, false, nil
+	}
+	if ref.PartIndex < 0 || ref.PartIndex >= len(r.parts) {
+		return 0, false, false, false, fmt.Errorf("typedcolumn: row ref part index %d outside %d parts", ref.PartIndex, len(r.parts))
+	}
+	part := r.parts[ref.PartIndex].Part
+	column, exists := part.Columns[columnName]
+	if !exists {
+		return 0, false, false, false, fmt.Errorf("typedcolumn: missing column %s", columnName)
+	}
+	if column.Definition.Encoding != EncodingNullableInt64 {
+		return 0, false, false, false, fmt.Errorf("typedcolumn: column %s encoding=%s want %s", columnName, column.Definition.Encoding, EncodingNullableInt64)
+	}
+	var reader GranuleReader
+	for _, block := range column.Blocks {
+		if ref.PartRow < block.Descriptor.FirstRow || ref.PartRow >= block.Descriptor.FirstRow+block.Descriptor.RowCount {
+			continue
+		}
+		values, nulls, defaults, decodeErr := reader.DecodeNullableInt64(block.Granule)
+		if decodeErr != nil {
+			return 0, false, false, false, decodeErr
+		}
+		row := ref.PartRow - block.Descriptor.FirstRow
+		return values[row], nulls[row], defaults[row], true, nil
+	}
+	return 0, false, false, false, fmt.Errorf("typedcolumn: locator row %d outside column %s", ref.PartRow, columnName)
+}
+
 func (r *PartSetReader) VisibleRowsForPart(partIndex int) ([]int, bool) {
 	visible := r.visibleRowsForPart(partIndex)
 	return append([]int(nil), visible.Rows...), visible.All

--- a/TreeDB/internal/typedcolumn/query_ready_delta.go
+++ b/TreeDB/internal/typedcolumn/query_ready_delta.go
@@ -1,0 +1,775 @@
+package typedcolumn
+
+import (
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"hash/crc32"
+	"math"
+	"slices"
+	"sort"
+	"time"
+)
+
+// Query-ready delta generation envelopes are rebuildable, non-authoritative
+// derived assets. They do not publish roots, participate in WAL/recovery, or
+// own reclamation. The embedded QRBG keeps M1's schema and part validation.
+const (
+	queryReadyDeltaMagic            = uint32(0x47445251) // "QRDG", little-endian.
+	queryReadyDeltaVersion          = uint16(1)
+	queryReadyDeltaHeaderBytes      = 96
+	queryReadyDeltaTombstoneBytes   = 16
+	queryReadyDeltaPayloadAlignment = 4096
+)
+
+type QueryReadyGenerationKind uint16
+
+const (
+	QueryReadyGenerationDelta            QueryReadyGenerationKind = 1
+	QueryReadyGenerationConsolidatedBase QueryReadyGenerationKind = 2
+)
+
+type QueryReadyDeltaBuildStats struct {
+	Parts                 int
+	Rows                  int64
+	Tombstones            int
+	OriginBaseParts       int
+	AccumulatedDeltaParts int
+	InputBytes            int64
+	OutputBytes           int64
+	BytesCopied           int64
+	PeakWorkingBytes      int64
+	WriteAmplification    float64
+	BuildTime             time.Duration
+}
+
+type QueryReadyDeltaBuildResult struct {
+	Bytes []byte
+	Stats QueryReadyDeltaBuildStats
+}
+
+type QueryReadyDeltaOpenStats struct {
+	Parts          int
+	Rows           int64
+	Tombstones     int
+	BytesRead      int64
+	BytesDecoded   int64
+	BytesCopied    int64
+	BytesValidated int64
+	OpenTime       time.Duration
+}
+
+// QueryReadyDeltaGeneration is either one immutable delta or a consolidated
+// replacement base. Base contains the M1 QRBG part set; Tombstones is the
+// deterministic latest tombstone per primary ID needed to reproduce visibility.
+type QueryReadyDeltaGeneration struct {
+	Kind                  QueryReadyGenerationKind
+	Identity              QueryReadyBaseIdentity
+	Base                  *QueryReadyBaseGeneration
+	Tombstones            []Tombstone
+	OriginBaseParts       int
+	AccumulatedDeltaParts int
+	Stats                 QueryReadyDeltaOpenStats
+	data                  []byte
+}
+
+func (g *QueryReadyDeltaGeneration) Bytes() []byte {
+	if g == nil {
+		return nil
+	}
+	return g.data
+}
+
+func (g *QueryReadyDeltaGeneration) Close() error {
+	if g == nil || g.Base == nil {
+		return nil
+	}
+	err := g.Base.Close()
+	g.data = nil
+	return err
+}
+
+func BuildQueryReadyDeltaGeneration(identity QueryReadyBaseIdentity, parts []QueryReadyBasePartInput, tombstones []Tombstone) (QueryReadyDeltaBuildResult, error) {
+	return buildQueryReadyDeltaEnvelope(QueryReadyGenerationDelta, identity, parts, tombstones, queryReadyDeltaLineage{})
+}
+
+type queryReadyDeltaLineage struct {
+	OriginBaseParts       int
+	AccumulatedDeltaParts int
+}
+
+func buildQueryReadyDeltaEnvelope(kind QueryReadyGenerationKind, identity QueryReadyBaseIdentity, parts []QueryReadyBasePartInput, tombstones []Tombstone, lineage queryReadyDeltaLineage) (QueryReadyDeltaBuildResult, error) {
+	started := time.Now()
+	if kind != QueryReadyGenerationDelta && kind != QueryReadyGenerationConsolidatedBase {
+		return QueryReadyDeltaBuildResult{}, fmt.Errorf("typedcolumn: unsupported query-ready generation kind %d", kind)
+	}
+	if err := validateQueryReadyBaseIdentity(identity); err != nil {
+		return QueryReadyDeltaBuildResult{}, err
+	}
+	if lineage.OriginBaseParts < 0 || lineage.AccumulatedDeltaParts < 0 || lineage.OriginBaseParts > math.MaxUint32 || lineage.AccumulatedDeltaParts > math.MaxUint32 {
+		return QueryReadyDeltaBuildResult{}, fmt.Errorf("typedcolumn: query-ready lineage parts origin=%d accumulated_delta=%d exceed format bounds", lineage.OriginBaseParts, lineage.AccumulatedDeltaParts)
+	}
+	if kind == QueryReadyGenerationDelta && lineage != (queryReadyDeltaLineage{}) {
+		return QueryReadyDeltaBuildResult{}, errors.New("typedcolumn: query-ready delta cannot carry consolidated-base lineage")
+	}
+	if kind == QueryReadyGenerationDelta {
+		for i, part := range parts {
+			if part.SourceGeneration != identity.Generation {
+				return QueryReadyDeltaBuildResult{}, fmt.Errorf("typedcolumn: query-ready delta part[%d] source generation=%d want envelope generation=%d", i, part.SourceGeneration, identity.Generation)
+			}
+		}
+	}
+	if kind == QueryReadyGenerationConsolidatedBase && lineage.OriginBaseParts+lineage.AccumulatedDeltaParts != len(parts) {
+		return QueryReadyDeltaBuildResult{}, fmt.Errorf("typedcolumn: query-ready consolidated lineage parts=%d+%d want embedded=%d", lineage.OriginBaseParts, lineage.AccumulatedDeltaParts, len(parts))
+	}
+	inner, err := BuildQueryReadyBaseGeneration(identity, parts)
+	if err != nil {
+		return QueryReadyDeltaBuildResult{}, fmt.Errorf("typedcolumn: build query-ready generation parts: %w", err)
+	}
+	normalized, err := normalizeQueryReadyTombstones(tombstones, identity.Generation)
+	if err != nil {
+		return QueryReadyDeltaBuildResult{}, err
+	}
+	if len(normalized) > (math.MaxInt-queryReadyDeltaHeaderBytes)/queryReadyDeltaTombstoneBytes || len(normalized) > math.MaxUint32 {
+		return QueryReadyDeltaBuildResult{}, fmt.Errorf("typedcolumn: query-ready tombstones=%d exceed format bounds", len(normalized))
+	}
+	tableBytes := len(normalized) * queryReadyDeltaTombstoneBytes
+	payloadOffset, err := queryReadyBaseAlign(queryReadyDeltaHeaderBytes+tableBytes, queryReadyDeltaPayloadAlignment)
+	if err != nil {
+		return QueryReadyDeltaBuildResult{}, err
+	}
+	if len(inner.Bytes) > math.MaxInt-payloadOffset {
+		return QueryReadyDeltaBuildResult{}, errors.New("typedcolumn: query-ready delta image exceeds host size")
+	}
+	totalBytes := payloadOffset + len(inner.Bytes)
+	out := make([]byte, totalBytes)
+	binary.LittleEndian.PutUint32(out[0:4], queryReadyDeltaMagic)
+	binary.LittleEndian.PutUint16(out[4:6], queryReadyDeltaVersion)
+	binary.LittleEndian.PutUint16(out[6:8], uint16(kind))
+	binary.LittleEndian.PutUint64(out[8:16], identity.Generation)
+	copy(out[16:48], identity.SchemaHash[:])
+	binary.LittleEndian.PutUint32(out[48:52], uint32(len(normalized)))
+	binary.LittleEndian.PutUint64(out[64:72], uint64(payloadOffset))
+	binary.LittleEndian.PutUint64(out[72:80], uint64(totalBytes))
+	binary.LittleEndian.PutUint64(out[80:88], uint64(len(inner.Bytes)))
+	binary.LittleEndian.PutUint32(out[88:92], uint32(lineage.OriginBaseParts))
+	binary.LittleEndian.PutUint32(out[92:96], uint32(lineage.AccumulatedDeltaParts))
+	table := out[queryReadyDeltaHeaderBytes : queryReadyDeltaHeaderBytes+tableBytes]
+	for i, tombstone := range normalized {
+		entry := table[i*queryReadyDeltaTombstoneBytes : (i+1)*queryReadyDeltaTombstoneBytes]
+		binary.LittleEndian.PutUint64(entry[0:8], uint64(tombstone.PrimaryID))
+		binary.LittleEndian.PutUint64(entry[8:16], tombstone.GenerationID)
+	}
+	binary.LittleEndian.PutUint32(out[56:60], crc32.Checksum(table, queryReadyBaseCRCTable))
+	copy(out[payloadOffset:], inner.Bytes)
+	binary.LittleEndian.PutUint32(out[52:56], queryReadyDeltaHeaderChecksum(out[:queryReadyDeltaHeaderBytes]))
+	inputBytes := inner.Stats.InputBytes + int64(len(normalized)*queryReadyDeltaTombstoneBytes)
+	writeAmplification := float64(0)
+	if inputBytes > 0 {
+		writeAmplification = float64(len(out)) / float64(inputBytes)
+	}
+	return QueryReadyDeltaBuildResult{Bytes: out, Stats: QueryReadyDeltaBuildStats{
+		Parts: len(parts), Rows: inner.Stats.Rows, Tombstones: len(normalized),
+		OriginBaseParts: lineage.OriginBaseParts, AccumulatedDeltaParts: lineage.AccumulatedDeltaParts,
+		InputBytes: inputBytes, OutputBytes: int64(len(out)),
+		BytesCopied:        inner.Stats.BytesCopied + int64(len(inner.Bytes)+len(table)),
+		PeakWorkingBytes:   int64(len(inner.Bytes) + len(out)),
+		WriteAmplification: writeAmplification, BuildTime: time.Since(started),
+	}}, nil
+}
+
+func OpenQueryReadyDeltaGeneration(data []byte, expected QueryReadyBaseIdentity) (*QueryReadyDeltaGeneration, error) {
+	return openQueryReadyDeltaEnvelope(data, expected, QueryReadyGenerationDelta)
+}
+
+func OpenQueryReadyConsolidatedBaseGeneration(data []byte, expected QueryReadyBaseIdentity) (*QueryReadyDeltaGeneration, error) {
+	return openQueryReadyDeltaEnvelope(data, expected, QueryReadyGenerationConsolidatedBase)
+}
+
+func openQueryReadyDeltaEnvelope(data []byte, expected QueryReadyBaseIdentity, expectedKind QueryReadyGenerationKind) (*QueryReadyDeltaGeneration, error) {
+	started := time.Now()
+	if err := validateQueryReadyBaseIdentity(expected); err != nil {
+		return nil, err
+	}
+	if len(data) < queryReadyDeltaHeaderBytes {
+		return nil, fmt.Errorf("typedcolumn: query-ready delta bytes=%d shorter than header=%d", len(data), queryReadyDeltaHeaderBytes)
+	}
+	if got := binary.LittleEndian.Uint32(data[0:4]); got != queryReadyDeltaMagic {
+		return nil, fmt.Errorf("typedcolumn: invalid query-ready delta magic 0x%x", got)
+	}
+	if got := binary.LittleEndian.Uint16(data[4:6]); got != queryReadyDeltaVersion {
+		return nil, fmt.Errorf("typedcolumn: unsupported query-ready delta version %d", got)
+	}
+	kind := QueryReadyGenerationKind(binary.LittleEndian.Uint16(data[6:8]))
+	if kind != expectedKind {
+		return nil, fmt.Errorf("typedcolumn: query-ready generation kind=%d want %d", kind, expectedKind)
+	}
+	if binary.LittleEndian.Uint32(data[60:64]) != 0 {
+		return nil, errors.New("typedcolumn: query-ready delta reserved header bytes are nonzero")
+	}
+	if got, want := binary.LittleEndian.Uint32(data[52:56]), queryReadyDeltaHeaderChecksum(data[:queryReadyDeltaHeaderBytes]); got != want {
+		return nil, fmt.Errorf("typedcolumn: query-ready delta header checksum=%08x want %08x", got, want)
+	}
+	identity := QueryReadyBaseIdentity{Generation: binary.LittleEndian.Uint64(data[8:16])}
+	copy(identity.SchemaHash[:], data[16:48])
+	if identity.Generation != expected.Generation {
+		return nil, fmt.Errorf("typedcolumn: query-ready delta generation=%d want %d", identity.Generation, expected.Generation)
+	}
+	if identity.SchemaHash != expected.SchemaHash {
+		return nil, fmt.Errorf("typedcolumn: query-ready delta schema hash=%x want %x", identity.SchemaHash, expected.SchemaHash)
+	}
+	tombstoneCount := uint64(binary.LittleEndian.Uint32(data[48:52]))
+	if tombstoneCount > uint64((math.MaxInt-queryReadyDeltaHeaderBytes)/queryReadyDeltaTombstoneBytes) {
+		return nil, fmt.Errorf("typedcolumn: query-ready delta tombstone count=%d exceeds host bounds", tombstoneCount)
+	}
+	tableEnd := queryReadyDeltaHeaderBytes + int(tombstoneCount)*queryReadyDeltaTombstoneBytes
+	if tableEnd > len(data) {
+		return nil, fmt.Errorf("typedcolumn: query-ready delta tombstone table bytes=%d exceed image=%d", tableEnd, len(data))
+	}
+	table := data[queryReadyDeltaHeaderBytes:tableEnd]
+	if got, want := crc32.Checksum(table, queryReadyBaseCRCTable), binary.LittleEndian.Uint32(data[56:60]); got != want {
+		return nil, fmt.Errorf("typedcolumn: query-ready delta tombstone checksum=%08x want %08x", got, want)
+	}
+	payloadOffset64 := binary.LittleEndian.Uint64(data[64:72])
+	totalBytes64 := binary.LittleEndian.Uint64(data[72:80])
+	innerBytes64 := binary.LittleEndian.Uint64(data[80:88])
+	originBaseParts := int(binary.LittleEndian.Uint32(data[88:92]))
+	accumulatedDeltaParts := int(binary.LittleEndian.Uint32(data[92:96]))
+	if totalBytes64 != uint64(len(data)) {
+		return nil, fmt.Errorf("typedcolumn: query-ready delta total bytes=%d want provided=%d", totalBytes64, len(data))
+	}
+	if payloadOffset64 > uint64(len(data)) || payloadOffset64 < uint64(tableEnd) || payloadOffset64%queryReadyDeltaPayloadAlignment != 0 {
+		return nil, fmt.Errorf("typedcolumn: query-ready delta payload offset=%d invalid table_end=%d total=%d", payloadOffset64, tableEnd, len(data))
+	}
+	if innerBytes64 != uint64(len(data))-payloadOffset64 {
+		return nil, fmt.Errorf("typedcolumn: query-ready delta inner bytes=%d want %d", innerBytes64, uint64(len(data))-payloadOffset64)
+	}
+	if err := queryReadyBaseValidateZeroPadding(data[tableEnd:int(payloadOffset64)], "query-ready delta header"); err != nil {
+		return nil, err
+	}
+	tombstones := make([]Tombstone, int(tombstoneCount))
+	for i := range tombstones {
+		entry := table[i*queryReadyDeltaTombstoneBytes : (i+1)*queryReadyDeltaTombstoneBytes]
+		tombstones[i] = Tombstone{PrimaryID: int64(binary.LittleEndian.Uint64(entry[0:8])), GenerationID: binary.LittleEndian.Uint64(entry[8:16])}
+		if tombstones[i].GenerationID == 0 || tombstones[i].GenerationID > identity.Generation {
+			return nil, fmt.Errorf("typedcolumn: query-ready delta tombstone[%d] generation=%d invalid for generation=%d", i, tombstones[i].GenerationID, identity.Generation)
+		}
+		if i > 0 && tombstones[i-1].PrimaryID >= tombstones[i].PrimaryID {
+			return nil, fmt.Errorf("typedcolumn: query-ready delta tombstones are not strictly ordered at %d", i)
+		}
+	}
+	innerData := data[int(payloadOffset64):]
+	base, err := OpenQueryReadyBaseGeneration(innerData, identity)
+	if err != nil {
+		return nil, fmt.Errorf("typedcolumn: open query-ready delta parts: %w", err)
+	}
+	if kind == QueryReadyGenerationDelta && (originBaseParts != 0 || accumulatedDeltaParts != 0) {
+		return nil, errors.New("typedcolumn: query-ready delta carries consolidated-base lineage")
+	}
+	if kind == QueryReadyGenerationDelta {
+		for i, dependency := range base.Dependencies {
+			if dependency.SourceGeneration != identity.Generation {
+				return nil, fmt.Errorf("typedcolumn: query-ready delta part[%d] source generation=%d want envelope generation=%d", i, dependency.SourceGeneration, identity.Generation)
+			}
+		}
+	}
+	if kind == QueryReadyGenerationConsolidatedBase && originBaseParts+accumulatedDeltaParts != len(base.Parts) {
+		return nil, fmt.Errorf("typedcolumn: query-ready consolidated lineage parts=%d+%d want embedded=%d", originBaseParts, accumulatedDeltaParts, len(base.Parts))
+	}
+	return &QueryReadyDeltaGeneration{
+		Kind: kind, Identity: identity, Base: base, Tombstones: tombstones,
+		OriginBaseParts: originBaseParts, AccumulatedDeltaParts: accumulatedDeltaParts, data: data,
+		Stats: QueryReadyDeltaOpenStats{
+			Parts: len(base.Parts), Rows: base.Stats.Rows, Tombstones: len(tombstones),
+			BytesRead: int64(len(data)), BytesDecoded: int64(queryReadyDeltaHeaderBytes+len(table)) + base.Stats.BytesDecoded,
+			BytesValidated: int64(len(data)), OpenTime: time.Since(started),
+		},
+	}, nil
+}
+
+func normalizeQueryReadyTombstones(input []Tombstone, generation uint64) ([]Tombstone, error) {
+	latest := make(map[int64]uint64, len(input))
+	for i, tombstone := range input {
+		if tombstone.GenerationID == 0 || tombstone.GenerationID > generation {
+			return nil, fmt.Errorf("typedcolumn: query-ready tombstone[%d] generation=%d invalid for generation=%d", i, tombstone.GenerationID, generation)
+		}
+		if tombstone.GenerationID > latest[tombstone.PrimaryID] {
+			latest[tombstone.PrimaryID] = tombstone.GenerationID
+		}
+	}
+	out := make([]Tombstone, 0, len(latest))
+	for primaryID, tombstoneGeneration := range latest {
+		out = append(out, Tombstone{PrimaryID: primaryID, GenerationID: tombstoneGeneration})
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].PrimaryID < out[j].PrimaryID })
+	return out, nil
+}
+
+func queryReadyDeltaHeaderChecksum(header []byte) uint32 {
+	copyHeader := slices.Clone(header)
+	clear(copyHeader[52:56])
+	return crc32.Checksum(copyHeader, queryReadyBaseCRCTable)
+}
+
+type QueryReadyDeltaBoundPolicy struct {
+	MaxVisibleGenerations    int
+	MaxAccumulatedDeltaParts int
+	MaxRows                  int64
+	MaxBytes                 int64
+}
+
+// DefaultQueryReadyDeltaBoundPolicy is intentionally small and observable.
+// The generation bound is selected from the checked-in N=0..8 focused curve;
+// byte and row limits are workload-specific overrides rather than hidden caps.
+func DefaultQueryReadyDeltaBoundPolicy() QueryReadyDeltaBoundPolicy {
+	return QueryReadyDeltaBoundPolicy{MaxVisibleGenerations: 4, MaxAccumulatedDeltaParts: 8}
+}
+
+type QueryReadyDeltaBoundDecision struct {
+	VisibleGenerations      int
+	BaseInternalParts       int
+	OriginBaseParts         int
+	BaseDeltaDerivedParts   int
+	DeltaParts              int
+	TotalParts              int
+	AccumulatedDeltaParts   int
+	Rows                    int64
+	Bytes                   int64
+	Triggered               bool
+	GenerationLimitTriggers int
+	PartLimitTriggers       int
+	RowLimitTriggers        int
+	ByteLimitTriggers       int
+	Reason                  string
+}
+
+type QueryReadyDeltaBoundError struct {
+	Phase    string
+	Decision QueryReadyDeltaBoundDecision
+}
+
+func (e *QueryReadyDeltaBoundError) Error() string {
+	if e == nil {
+		return "typedcolumn: query-ready bound triggered"
+	}
+	d := e.Decision
+	return fmt.Sprintf("typedcolumn: query-ready %s bound triggered reason=%s origin_base_parts=%d base_delta_parts=%d new_delta_parts=%d accumulated_delta_parts=%d total_parts=%d generations=%d rows=%d bytes=%d", e.Phase, d.Reason, d.OriginBaseParts, d.BaseDeltaDerivedParts, d.DeltaParts, d.AccumulatedDeltaParts, d.TotalParts, d.VisibleGenerations, d.Rows, d.Bytes)
+}
+
+func EvaluateQueryReadyDeltaBound(deltas []*QueryReadyDeltaGeneration, snapshot uint64, policy QueryReadyDeltaBoundPolicy) QueryReadyDeltaBoundDecision {
+	if policy == (QueryReadyDeltaBoundPolicy{}) {
+		policy = DefaultQueryReadyDeltaBoundPolicy()
+	}
+	decision := QueryReadyDeltaBoundDecision{}
+	seen := make(map[uint64]struct{}, len(deltas))
+	for _, delta := range deltas {
+		if delta == nil || delta.Identity.Generation > snapshot {
+			continue
+		}
+		if _, ok := seen[delta.Identity.Generation]; !ok {
+			seen[delta.Identity.Generation] = struct{}{}
+			decision.VisibleGenerations++
+		}
+		if delta.Base != nil {
+			decision.DeltaParts += len(delta.Base.Parts)
+			decision.TotalParts += len(delta.Base.Parts)
+		}
+		decision.Rows += delta.Stats.Rows
+		if delta.Base != nil {
+			for _, view := range delta.Base.Parts {
+				decision.Bytes += int64(view.Dependency.ImageBytes)
+			}
+		}
+		decision.Bytes += int64(len(delta.Tombstones) * queryReadyDeltaTombstoneBytes)
+	}
+	if policy.MaxVisibleGenerations > 0 && decision.VisibleGenerations > policy.MaxVisibleGenerations {
+		decision.Triggered = true
+		decision.GenerationLimitTriggers = 1
+		decision.Reason = "visible_generations"
+	}
+	decision.AccumulatedDeltaParts = decision.DeltaParts
+	if policy.MaxAccumulatedDeltaParts > 0 && decision.AccumulatedDeltaParts > policy.MaxAccumulatedDeltaParts {
+		decision.Triggered = true
+		decision.PartLimitTriggers = 1
+		if decision.Reason == "" {
+			decision.Reason = "accumulated_delta_parts"
+		}
+	}
+	if policy.MaxRows > 0 && decision.Rows > policy.MaxRows {
+		decision.Triggered = true
+		decision.RowLimitTriggers = 1
+		if decision.Reason == "" {
+			decision.Reason = "rows"
+		}
+	}
+	if policy.MaxBytes > 0 && decision.Bytes > policy.MaxBytes {
+		decision.Triggered = true
+		decision.ByteLimitTriggers = 1
+		if decision.Reason == "" {
+			decision.Reason = "bytes"
+		}
+	}
+	return decision
+}
+
+func evaluateQueryReadyBaseDeltaBound(base *QueryReadyBaseGeneration, baseTombstones []Tombstone, baseOriginParts, baseAccumulatedDeltaParts int, deltas []*QueryReadyDeltaGeneration, snapshot uint64, policy QueryReadyDeltaBoundPolicy) QueryReadyDeltaBoundDecision {
+	decision := EvaluateQueryReadyDeltaBound(deltas, snapshot, policy)
+	if base == nil {
+		return decision
+	}
+	decision.BaseInternalParts = len(base.Parts)
+	decision.OriginBaseParts = baseOriginParts
+	if decision.OriginBaseParts == 0 && baseAccumulatedDeltaParts == 0 {
+		decision.OriginBaseParts = len(base.Parts)
+	}
+	decision.BaseDeltaDerivedParts = baseAccumulatedDeltaParts
+	decision.TotalParts = decision.BaseInternalParts + decision.DeltaParts
+	decision.AccumulatedDeltaParts = decision.BaseDeltaDerivedParts + decision.DeltaParts
+	decision.Rows += base.Stats.Rows
+	for _, view := range base.Parts {
+		decision.Bytes += int64(view.Dependency.ImageBytes)
+	}
+	decision.Bytes += int64(len(baseTombstones) * queryReadyDeltaTombstoneBytes)
+	// Re-evaluate total-work axes now that the base's internal multipart work
+	// is accounted for. Delta-only generation triggering above is preserved.
+	decision.PartLimitTriggers = 0
+	decision.RowLimitTriggers = 0
+	decision.ByteLimitTriggers = 0
+	if decision.GenerationLimitTriggers == 0 {
+		decision.Triggered = false
+		decision.Reason = ""
+	}
+	if policy == (QueryReadyDeltaBoundPolicy{}) {
+		policy = DefaultQueryReadyDeltaBoundPolicy()
+	}
+	if policy.MaxAccumulatedDeltaParts > 0 && decision.AccumulatedDeltaParts > policy.MaxAccumulatedDeltaParts {
+		decision.Triggered = true
+		decision.PartLimitTriggers = 1
+		if decision.Reason == "" {
+			decision.Reason = "accumulated_delta_parts"
+		}
+	}
+	if policy.MaxRows > 0 && decision.Rows > policy.MaxRows {
+		decision.Triggered = true
+		decision.RowLimitTriggers = 1
+		if decision.Reason == "" {
+			decision.Reason = "rows"
+		}
+	}
+	if policy.MaxBytes > 0 && decision.Bytes > policy.MaxBytes {
+		decision.Triggered = true
+		decision.ByteLimitTriggers = 1
+		if decision.Reason == "" {
+			decision.Reason = "bytes"
+		}
+	}
+	return decision
+}
+
+type QueryReadyBaseDeltaOptions struct {
+	SnapshotGeneration uint64
+	Bound              QueryReadyDeltaBoundPolicy
+}
+
+type QueryReadyBaseDeltaStats struct {
+	VisibleBaseGenerations        int
+	VisibleDeltaGenerations       int
+	BaseInternalParts             int
+	OriginBaseParts               int
+	BaseDeltaDerivedParts         int
+	DeltaParts                    int
+	TotalParts                    int
+	AccumulatedDeltaParts         int
+	RowsMerged                    int
+	TombstonesApplied             int
+	PartsDecoded                  int
+	BytesDecoded                  int64
+	BytesCopied                   int64
+	LocalDictionaryDecodes        int
+	GlobalDictionaryConstructions int
+	CodeTranslations              int
+	ThresholdTriggers             int
+	GenerationLimitTriggers       int
+	PartLimitTriggers             int
+	RowLimitTriggers              int
+	ByteLimitTriggers             int
+	Fallbacks                     int
+}
+
+type QueryReadyBaseDeltaReader struct {
+	reader       *PartSetReader
+	dictionaries []map[string]map[int64]string
+	stats        QueryReadyBaseDeltaStats
+}
+
+func (r *QueryReadyBaseDeltaReader) Stats() QueryReadyBaseDeltaStats {
+	if r == nil {
+		return QueryReadyBaseDeltaStats{}
+	}
+	return r.stats
+}
+
+func (r *QueryReadyBaseDeltaReader) ValueAtLatest(primaryID int64, column string) (int64, bool, error) {
+	if r == nil || r.reader == nil {
+		return 0, false, nil
+	}
+	return r.reader.ValueAtLatest(primaryID, column)
+}
+
+func (r *QueryReadyBaseDeltaReader) NullableInt64AtLatest(primaryID int64, column string) (value int64, null, defaulted, ok bool, err error) {
+	if r == nil || r.reader == nil {
+		return 0, false, false, false, nil
+	}
+	return r.reader.NullableInt64AtLatest(primaryID, column)
+}
+
+// DictionaryValueAtLatest resolves a low-cardinality code in the selected
+// row's part-local domain. Divergent code assignments across parts therefore
+// retain their semantic values without a global dictionary or code rewrite.
+func (r *QueryReadyBaseDeltaReader) DictionaryValueAtLatest(primaryID int64, column string) (string, bool, error) {
+	if r == nil || r.reader == nil {
+		return "", false, nil
+	}
+	ref, ok := r.reader.latest[primaryID]
+	if !ok {
+		return "", false, nil
+	}
+	if ref.PartIndex < 0 || ref.PartIndex >= len(r.dictionaries) {
+		return "", false, fmt.Errorf("typedcolumn: dictionary row ref part index=%d outside %d", ref.PartIndex, len(r.dictionaries))
+	}
+	code, err := r.reader.valueAtRowRef(ref, column)
+	if err != nil {
+		return "", false, err
+	}
+	values, ok := r.dictionaries[ref.PartIndex][column]
+	if !ok {
+		return "", false, fmt.Errorf("typedcolumn: missing part-local dictionary for column %s", column)
+	}
+	value, ok := values[code]
+	if !ok {
+		return "", false, fmt.Errorf("typedcolumn: part-local dictionary column %s missing code %d", column, code)
+	}
+	return value, true, nil
+}
+
+func NewQueryReadyBaseDeltaReader(base *QueryReadyBaseGeneration, deltas []*QueryReadyDeltaGeneration, opts QueryReadyBaseDeltaOptions) (*QueryReadyBaseDeltaReader, error) {
+	if base == nil {
+		return nil, errors.New("typedcolumn: nil query-ready base")
+	}
+	return newQueryReadyBaseDeltaReader(base, nil, len(base.Parts), 0, deltas, opts)
+}
+
+func NewQueryReadyConsolidatedBaseDeltaReader(base *QueryReadyDeltaGeneration, deltas []*QueryReadyDeltaGeneration, opts QueryReadyBaseDeltaOptions) (*QueryReadyBaseDeltaReader, error) {
+	if base == nil || base.Kind != QueryReadyGenerationConsolidatedBase || base.Base == nil {
+		return nil, errors.New("typedcolumn: invalid consolidated query-ready base")
+	}
+	return newQueryReadyBaseDeltaReader(base.Base, base.Tombstones, base.OriginBaseParts, base.AccumulatedDeltaParts, deltas, opts)
+}
+
+func newQueryReadyBaseDeltaReader(base *QueryReadyBaseGeneration, baseTombstones []Tombstone, baseOriginParts, baseAccumulatedDeltaParts int, deltas []*QueryReadyDeltaGeneration, opts QueryReadyBaseDeltaOptions) (*QueryReadyBaseDeltaReader, error) {
+	if opts.SnapshotGeneration == 0 {
+		return nil, errors.New("typedcolumn: query-ready snapshot generation is zero")
+	}
+	if base.Identity.Generation > opts.SnapshotGeneration {
+		return nil, fmt.Errorf("typedcolumn: query-ready base generation=%d exceeds snapshot=%d", base.Identity.Generation, opts.SnapshotGeneration)
+	}
+	selected := make([]*QueryReadyDeltaGeneration, 0, len(deltas))
+	seenGeneration := make(map[uint64]struct{}, len(deltas))
+	for i, delta := range deltas {
+		if delta == nil || delta.Base == nil || delta.Kind != QueryReadyGenerationDelta {
+			return nil, fmt.Errorf("typedcolumn: invalid query-ready delta at index %d", i)
+		}
+		if delta.Identity.SchemaHash != base.Identity.SchemaHash {
+			return nil, fmt.Errorf("typedcolumn: query-ready delta generation=%d schema mismatch", delta.Identity.Generation)
+		}
+		if delta.Identity.Generation <= base.Identity.Generation {
+			return nil, fmt.Errorf("typedcolumn: query-ready delta generation=%d not newer than base=%d", delta.Identity.Generation, base.Identity.Generation)
+		}
+		if _, exists := seenGeneration[delta.Identity.Generation]; exists {
+			return nil, fmt.Errorf("typedcolumn: duplicate query-ready delta generation=%d", delta.Identity.Generation)
+		}
+		seenGeneration[delta.Identity.Generation] = struct{}{}
+		if delta.Identity.Generation <= opts.SnapshotGeneration {
+			selected = append(selected, delta)
+		}
+	}
+	sort.Slice(selected, func(i, j int) bool { return selected[i].Identity.Generation < selected[j].Identity.Generation })
+	decision := evaluateQueryReadyBaseDeltaBound(base, baseTombstones, baseOriginParts, baseAccumulatedDeltaParts, selected, opts.SnapshotGeneration, opts.Bound)
+	if decision.Triggered {
+		return nil, &QueryReadyDeltaBoundError{Phase: "merge", Decision: decision}
+	}
+	refs := make([]PartRef, 0, len(base.Parts)+len(selected))
+	dictionaries := make([]map[string]map[int64]string, 0, len(base.Parts)+len(selected))
+	tombstones := append([]Tombstone(nil), baseTombstones...)
+	stats := QueryReadyBaseDeltaStats{
+		VisibleBaseGenerations: 1, VisibleDeltaGenerations: len(selected),
+		BaseInternalParts: decision.BaseInternalParts, OriginBaseParts: decision.OriginBaseParts,
+		BaseDeltaDerivedParts: decision.BaseDeltaDerivedParts, DeltaParts: decision.DeltaParts,
+		TotalParts: decision.TotalParts, AccumulatedDeltaParts: decision.AccumulatedDeltaParts,
+	}
+	appendParts := func(role PartRole, parts []QueryReadyBasePartView) error {
+		for _, view := range parts {
+			part, err := ColumnPartFromImage(view.Image)
+			if err != nil {
+				return err
+			}
+			refs = append(refs, PartRef{Role: role, GenerationID: view.Dependency.SourceGeneration, Part: part})
+			decoded, err := view.Image.Dictionaries()
+			if err != nil {
+				return err
+			}
+			inverse := make(map[string]map[int64]string, len(decoded))
+			for column, values := range decoded {
+				byCode := make(map[int64]string, len(values))
+				for value, code := range values {
+					byCode[code] = value
+				}
+				inverse[column] = byCode
+				stats.LocalDictionaryDecodes++
+			}
+			dictionaries = append(dictionaries, inverse)
+			stats.PartsDecoded++
+			stats.RowsMerged += view.Dependency.Rows
+			stats.BytesDecoded += int64(view.Dependency.ImageBytes)
+		}
+		return nil
+	}
+	if err := appendParts(PartRoleBase, base.Parts); err != nil {
+		return nil, fmt.Errorf("typedcolumn: decode query-ready base: %w", err)
+	}
+	for _, delta := range selected {
+		if err := appendParts(PartRoleDelta, delta.Base.Parts); err != nil {
+			return nil, fmt.Errorf("typedcolumn: decode query-ready delta %d: %w", delta.Identity.Generation, err)
+		}
+		tombstones = append(tombstones, delta.Tombstones...)
+	}
+	reader, err := NewPartSetReader(refs, tombstones)
+	if err != nil {
+		return nil, err
+	}
+	stats.TombstonesApplied = len(tombstones)
+	return &QueryReadyBaseDeltaReader{reader: reader, dictionaries: dictionaries, stats: stats}, nil
+}
+
+type QueryReadyConsolidationStats struct {
+	SelectedDeltaGenerations int
+	InputGenerations         int
+	OutputGenerations        int
+	PartsMerged              int
+	RowsMerged               int64
+	TombstonesMerged         int
+	InputBytes               int64
+	OutputBytes              int64
+	BytesCopied              int64
+	WriteAmplification       float64
+	PeakWorkingBytes         int64
+	CodeTranslations         int
+	DocumentMaterializations int
+	Fallbacks                int
+	BuildTime                time.Duration
+}
+
+type QueryReadyConsolidationResult struct {
+	Bytes []byte
+	Stats QueryReadyConsolidationStats
+}
+
+// ConsolidateQueryReadyBaseDelta deterministically folds the selected delta
+// prefix into one standalone replacement base envelope. It preserves encoded
+// part images and local dictionary domains byte-for-byte and persists the
+// latest tombstones; no document materialization or lifecycle publication is
+// performed. Existing base/delta objects remain valid for old snapshots.
+func ConsolidateQueryReadyBaseDelta(base *QueryReadyBaseGeneration, deltas []*QueryReadyDeltaGeneration, throughGeneration uint64) (QueryReadyConsolidationResult, error) {
+	return ConsolidateQueryReadyBaseDeltaWithPolicy(base, deltas, throughGeneration, DefaultQueryReadyDeltaBoundPolicy())
+}
+
+func ConsolidateQueryReadyBaseDeltaWithPolicy(base *QueryReadyBaseGeneration, deltas []*QueryReadyDeltaGeneration, throughGeneration uint64, policy QueryReadyDeltaBoundPolicy) (QueryReadyConsolidationResult, error) {
+	if base == nil {
+		return QueryReadyConsolidationResult{}, errors.New("typedcolumn: nil query-ready base")
+	}
+	return consolidateQueryReadyBaseDelta(base, nil, len(base.Parts), 0, deltas, throughGeneration, policy)
+}
+
+func ConsolidateQueryReadyConsolidatedBaseDelta(base *QueryReadyDeltaGeneration, deltas []*QueryReadyDeltaGeneration, throughGeneration uint64) (QueryReadyConsolidationResult, error) {
+	return ConsolidateQueryReadyConsolidatedBaseDeltaWithPolicy(base, deltas, throughGeneration, DefaultQueryReadyDeltaBoundPolicy())
+}
+
+func ConsolidateQueryReadyConsolidatedBaseDeltaWithPolicy(base *QueryReadyDeltaGeneration, deltas []*QueryReadyDeltaGeneration, throughGeneration uint64, policy QueryReadyDeltaBoundPolicy) (QueryReadyConsolidationResult, error) {
+	if base == nil || base.Kind != QueryReadyGenerationConsolidatedBase || base.Base == nil {
+		return QueryReadyConsolidationResult{}, errors.New("typedcolumn: invalid consolidated query-ready base")
+	}
+	return consolidateQueryReadyBaseDelta(base.Base, base.Tombstones, base.OriginBaseParts, base.AccumulatedDeltaParts, deltas, throughGeneration, policy)
+}
+
+func consolidateQueryReadyBaseDelta(base *QueryReadyBaseGeneration, baseTombstones []Tombstone, originBaseParts, accumulatedDeltaParts int, deltas []*QueryReadyDeltaGeneration, throughGeneration uint64, policy QueryReadyDeltaBoundPolicy) (QueryReadyConsolidationResult, error) {
+	started := time.Now()
+	if base == nil {
+		return QueryReadyConsolidationResult{}, errors.New("typedcolumn: nil query-ready base")
+	}
+	if throughGeneration < base.Identity.Generation {
+		return QueryReadyConsolidationResult{}, fmt.Errorf("typedcolumn: consolidation generation=%d before base=%d", throughGeneration, base.Identity.Generation)
+	}
+	selected := make([]*QueryReadyDeltaGeneration, 0, len(deltas))
+	seen := make(map[uint64]struct{}, len(deltas))
+	for i, delta := range deltas {
+		if delta == nil || delta.Kind != QueryReadyGenerationDelta || delta.Base == nil {
+			return QueryReadyConsolidationResult{}, fmt.Errorf("typedcolumn: invalid consolidation delta at %d", i)
+		}
+		if delta.Identity.SchemaHash != base.Identity.SchemaHash {
+			return QueryReadyConsolidationResult{}, fmt.Errorf("typedcolumn: consolidation delta %d schema mismatch", delta.Identity.Generation)
+		}
+		if delta.Identity.Generation <= base.Identity.Generation {
+			return QueryReadyConsolidationResult{}, fmt.Errorf("typedcolumn: consolidation delta %d not newer than base %d", delta.Identity.Generation, base.Identity.Generation)
+		}
+		if _, ok := seen[delta.Identity.Generation]; ok {
+			return QueryReadyConsolidationResult{}, fmt.Errorf("typedcolumn: duplicate consolidation delta generation=%d", delta.Identity.Generation)
+		}
+		seen[delta.Identity.Generation] = struct{}{}
+		if delta.Identity.Generation <= throughGeneration {
+			selected = append(selected, delta)
+		}
+	}
+	sort.Slice(selected, func(i, j int) bool { return selected[i].Identity.Generation < selected[j].Identity.Generation })
+	wantGeneration := base.Identity.Generation
+	if len(selected) > 0 {
+		wantGeneration = selected[len(selected)-1].Identity.Generation
+	}
+	if throughGeneration != wantGeneration {
+		return QueryReadyConsolidationResult{}, fmt.Errorf("typedcolumn: consolidation generation=%d overclaims selected prefix ending at %d", throughGeneration, wantGeneration)
+	}
+	decision := evaluateQueryReadyBaseDeltaBound(base, baseTombstones, originBaseParts, accumulatedDeltaParts, selected, throughGeneration, policy)
+	if decision.Triggered {
+		return QueryReadyConsolidationResult{}, &QueryReadyDeltaBoundError{Phase: "consolidation", Decision: decision}
+	}
+	parts := make([]QueryReadyBasePartInput, 0, len(base.Parts))
+	tombstones := append([]Tombstone(nil), baseTombstones...)
+	inputBytes := int64(len(baseTombstones) * queryReadyDeltaTombstoneBytes)
+	for _, view := range base.Parts {
+		parts = append(parts, QueryReadyBasePartInput{SourceGeneration: view.Dependency.SourceGeneration, Image: view.Image})
+		inputBytes += int64(view.Dependency.ImageBytes)
+	}
+	for _, delta := range selected {
+		for _, view := range delta.Base.Parts {
+			parts = append(parts, QueryReadyBasePartInput{SourceGeneration: view.Dependency.SourceGeneration, Image: view.Image})
+			inputBytes += int64(view.Dependency.ImageBytes)
+		}
+		tombstones = append(tombstones, delta.Tombstones...)
+	}
+	identity := QueryReadyBaseIdentity{Generation: throughGeneration, SchemaHash: base.Identity.SchemaHash}
+	built, err := buildQueryReadyDeltaEnvelope(QueryReadyGenerationConsolidatedBase, identity, parts, tombstones, queryReadyDeltaLineage{
+		OriginBaseParts: originBaseParts, AccumulatedDeltaParts: accumulatedDeltaParts + decision.DeltaParts,
+	})
+	if err != nil {
+		return QueryReadyConsolidationResult{}, err
+	}
+	writeAmplification := float64(0)
+	if inputBytes > 0 {
+		writeAmplification = float64(len(built.Bytes)) / float64(inputBytes)
+	}
+	return QueryReadyConsolidationResult{Bytes: built.Bytes, Stats: QueryReadyConsolidationStats{
+		SelectedDeltaGenerations: len(selected), InputGenerations: 1 + len(selected), OutputGenerations: 1,
+		PartsMerged: len(parts), RowsMerged: built.Stats.Rows, TombstonesMerged: built.Stats.Tombstones,
+		InputBytes: inputBytes, OutputBytes: int64(len(built.Bytes)), BytesCopied: built.Stats.BytesCopied,
+		WriteAmplification: writeAmplification, PeakWorkingBytes: built.Stats.PeakWorkingBytes, BuildTime: time.Since(started),
+	}}, nil
+}

--- a/TreeDB/internal/typedcolumn/query_ready_delta_test.go
+++ b/TreeDB/internal/typedcolumn/query_ready_delta_test.go
@@ -1,0 +1,893 @@
+package typedcolumn
+
+import (
+	"encoding/binary"
+	"errors"
+	"hash/crc32"
+	"math/rand"
+	"os"
+	"path/filepath"
+	"slices"
+	"strconv"
+	"testing"
+)
+
+var (
+	queryReadyDeltaReaderSink        *QueryReadyBaseDeltaReader
+	queryReadyDeltaConsolidationSink QueryReadyConsolidationResult
+	queryReadyDeltaStringSink        string
+)
+
+func TestQueryReadyBaseDeltaInsertUpdateDeleteVisibility(t *testing.T) {
+	base := queryReadyDeltaTestBase(t, 1, map[int64]int64{1: 10, 2: 20})
+	delta := queryReadyDeltaTestGeneration(t, 2, map[int64]int64{2: 200, 3: 300}, []Tombstone{{PrimaryID: 1, GenerationID: 2}})
+	reader, err := NewQueryReadyBaseDeltaReader(base, []*QueryReadyDeltaGeneration{delta}, QueryReadyBaseDeltaOptions{
+		SnapshotGeneration: 2,
+		Bound:              QueryReadyDeltaBoundPolicy{MaxVisibleGenerations: 4},
+	})
+	if err != nil {
+		t.Fatalf("NewQueryReadyBaseDeltaReader: %v", err)
+	}
+	queryReadyDeltaAssertValues(t, reader, map[int64]int64{2: 200, 3: 300}, 1, 2, 3)
+	stats := reader.Stats()
+	if stats.VisibleDeltaGenerations != 1 || stats.TombstonesApplied != 1 || stats.RowsMerged != 4 || stats.Fallbacks != 0 {
+		t.Fatalf("stats=%+v", stats)
+	}
+}
+
+func TestQueryReadyDeltaBuildDoesNotRewriteImmutableBase(t *testing.T) {
+	baseImage := queryReadyDeltaTestImage(t, 3051, map[int64]int64{1: 10, 2: 20})
+	baseBuilt, err := BuildQueryReadyBaseGeneration(queryReadyBaseTestIdentity(1), []QueryReadyBasePartInput{{SourceGeneration: 1, Image: baseImage}})
+	if err != nil {
+		t.Fatalf("build base: %v", err)
+	}
+	before := slices.Clone(baseBuilt.Bytes)
+	deltaImage := queryReadyDeltaTestImage(t, 3052, map[int64]int64{2: 200})
+	deltaBuilt, err := BuildQueryReadyDeltaGeneration(queryReadyBaseTestIdentity(2), []QueryReadyBasePartInput{{SourceGeneration: 2, Image: deltaImage}}, nil)
+	if err != nil {
+		t.Fatalf("build delta: %v", err)
+	}
+	if !slices.Equal(before, baseBuilt.Bytes) {
+		t.Fatalf("one-row delta mutated/rebuilt immutable base")
+	}
+	if deltaBuilt.Stats.Rows != 1 || deltaBuilt.Stats.Parts != 1 || deltaBuilt.Stats.InputBytes != int64(len(deltaImage.Bytes)) {
+		t.Fatalf("delta build stats include unrelated base work: %+v base_bytes=%d delta_image=%d", deltaBuilt.Stats, len(baseBuilt.Bytes), len(deltaImage.Bytes))
+	}
+}
+
+func TestQueryReadyBaseDeltaSnapshotIsolationAcrossGenerations(t *testing.T) {
+	base := queryReadyDeltaTestBase(t, 1, map[int64]int64{1: 10})
+	delta2 := queryReadyDeltaTestGeneration(t, 2, map[int64]int64{1: 20}, nil)
+	delta3 := queryReadyDeltaTestGeneration(t, 3, map[int64]int64{1: 30}, nil)
+	for _, tc := range []struct {
+		snapshot uint64
+		want     int64
+		visible  int
+	}{{1, 10, 0}, {2, 20, 1}, {3, 30, 2}} {
+		reader, err := NewQueryReadyBaseDeltaReader(base, []*QueryReadyDeltaGeneration{delta3, delta2}, QueryReadyBaseDeltaOptions{
+			SnapshotGeneration: tc.snapshot,
+			Bound:              QueryReadyDeltaBoundPolicy{MaxVisibleGenerations: 4},
+		})
+		if err != nil {
+			t.Fatalf("snapshot %d: %v", tc.snapshot, err)
+		}
+		value, ok, err := reader.ValueAtLatest(1, "value")
+		if err != nil || !ok || value != tc.want {
+			t.Fatalf("snapshot %d value/ok/err=(%d,%v,%v) want %d,true,nil", tc.snapshot, value, ok, err, tc.want)
+		}
+		if got := reader.Stats().VisibleDeltaGenerations; got != tc.visible {
+			t.Fatalf("snapshot %d visible deltas=%d want %d", tc.snapshot, got, tc.visible)
+		}
+	}
+}
+
+func TestQueryReadyDeltaTombstoneSuppressesBaseAndOlderDelta(t *testing.T) {
+	base := queryReadyDeltaTestBase(t, 1, map[int64]int64{1: 10, 2: 20})
+	delta2 := queryReadyDeltaTestGeneration(t, 2, map[int64]int64{1: 20, 3: 30}, nil)
+	delta3 := queryReadyDeltaTestGeneration(t, 3, nil, []Tombstone{{PrimaryID: 1, GenerationID: 3}, {PrimaryID: 2, GenerationID: 3}})
+	reader, err := NewQueryReadyBaseDeltaReader(base, []*QueryReadyDeltaGeneration{delta2, delta3}, QueryReadyBaseDeltaOptions{SnapshotGeneration: 3, Bound: QueryReadyDeltaBoundPolicy{MaxVisibleGenerations: 4}})
+	if err != nil {
+		t.Fatalf("NewQueryReadyBaseDeltaReader: %v", err)
+	}
+	queryReadyDeltaAssertValues(t, reader, map[int64]int64{3: 30}, 1, 2, 3)
+}
+
+func TestQueryReadyDeltaDictionaryDomainExtensionParity(t *testing.T) {
+	baseImage := queryReadyDeltaDictionaryImage(t, 3101, map[int64]int64{1: 0, 2: 1}, map[string]int64{"user": 0, "reply": 1})
+	baseBuilt, err := BuildQueryReadyBaseGeneration(queryReadyBaseTestIdentity(1), []QueryReadyBasePartInput{{SourceGeneration: 1, Image: baseImage}})
+	if err != nil {
+		t.Fatalf("build base: %v", err)
+	}
+	base, err := OpenQueryReadyBaseGeneration(baseBuilt.Bytes, queryReadyBaseTestIdentity(1))
+	if err != nil {
+		t.Fatalf("open base: %v", err)
+	}
+	deltaImage := queryReadyDeltaDictionaryImage(t, 3102, map[int64]int64{2: 0, 3: 2}, map[string]int64{"moderator": 0, "reply": 1, "system": 2})
+	deltaBuilt, err := BuildQueryReadyDeltaGeneration(queryReadyBaseTestIdentity(2), []QueryReadyBasePartInput{{SourceGeneration: 2, Image: deltaImage}}, nil)
+	if err != nil {
+		t.Fatalf("build delta: %v", err)
+	}
+	delta, err := OpenQueryReadyDeltaGeneration(deltaBuilt.Bytes, queryReadyBaseTestIdentity(2))
+	if err != nil {
+		t.Fatalf("open delta: %v", err)
+	}
+	reader, err := NewQueryReadyBaseDeltaReader(base, []*QueryReadyDeltaGeneration{delta}, QueryReadyBaseDeltaOptions{SnapshotGeneration: 2, Bound: QueryReadyDeltaBoundPolicy{MaxVisibleGenerations: 4}})
+	if err != nil {
+		t.Fatalf("NewQueryReadyBaseDeltaReader: %v", err)
+	}
+	for id, want := range map[int64]int64{1: 0, 2: 0, 3: 2} {
+		got, ok, err := reader.ValueAtLatest(id, "kind_code")
+		if err != nil || !ok || got != want {
+			t.Fatalf("kind_code id=%d got=(%d,%v,%v) want=%d", id, got, ok, err, want)
+		}
+	}
+	for id, want := range map[int64]string{1: "user", 2: "moderator", 3: "system"} {
+		got, ok, err := reader.DictionaryValueAtLatest(id, "kind_code")
+		if err != nil || !ok || got != want {
+			t.Fatalf("dictionary value id=%d got=(%q,%v,%v) want=%q", id, got, ok, err, want)
+		}
+	}
+	if stats := reader.Stats(); stats.CodeTranslations != 0 || stats.GlobalDictionaryConstructions != 0 || stats.LocalDictionaryDecodes != 2 {
+		t.Fatalf("local per-part domains should not be globally translated/rebuilt: %+v", stats)
+	}
+}
+
+func TestQueryReadyDeltaDictionaryHighCardinalityBoundaryAndLastGranule(t *testing.T) {
+	baseValues := make(map[int64]int64, 17)
+	baseDictionary := make(map[string]int64, 256)
+	for code := 0; code < 256; code++ {
+		baseDictionary["base_"+strconv.Itoa(code)] = int64(code)
+	}
+	for id := int64(1); id <= 17; id++ {
+		baseValues[id] = id - 1
+	}
+	baseImage := queryReadyDeltaDictionaryImage(t, 3151, baseValues, baseDictionary)
+	baseBuilt, err := BuildQueryReadyBaseGeneration(queryReadyBaseTestIdentity(1), []QueryReadyBasePartInput{{SourceGeneration: 1, Image: baseImage}})
+	if err != nil {
+		t.Fatalf("build base: %v", err)
+	}
+	base, err := OpenQueryReadyBaseGeneration(baseBuilt.Bytes, queryReadyBaseTestIdentity(1))
+	if err != nil {
+		t.Fatalf("open base: %v", err)
+	}
+	deltaDictionary := make(map[string]int64, 257)
+	for code := 0; code <= 256; code++ {
+		deltaDictionary["delta_"+strconv.Itoa(code)] = int64(code)
+	}
+	// id=17 is the first row of the second 16-row granule. Code 256 crosses
+	// the dense dictionary uint8/uint16 width boundary.
+	deltaValues := make(map[int64]int64, 17)
+	for id := int64(1); id <= 16; id++ {
+		deltaValues[id] = id - 1
+	}
+	deltaValues[17] = 256
+	deltaImage := queryReadyDeltaDictionaryImage(t, 3152, deltaValues, deltaDictionary)
+	deltaBuilt, err := BuildQueryReadyDeltaGeneration(queryReadyBaseTestIdentity(2), []QueryReadyBasePartInput{{SourceGeneration: 2, Image: deltaImage}}, nil)
+	if err != nil {
+		t.Fatalf("build delta: %v", err)
+	}
+	delta, err := OpenQueryReadyDeltaGeneration(deltaBuilt.Bytes, queryReadyBaseTestIdentity(2))
+	if err != nil {
+		t.Fatalf("open delta: %v", err)
+	}
+	reader, err := NewQueryReadyBaseDeltaReader(base, []*QueryReadyDeltaGeneration{delta}, QueryReadyBaseDeltaOptions{SnapshotGeneration: 2, Bound: QueryReadyDeltaBoundPolicy{MaxVisibleGenerations: 4, MaxAccumulatedDeltaParts: 8}})
+	if err != nil {
+		t.Fatalf("reader: %v", err)
+	}
+	value, ok, err := reader.DictionaryValueAtLatest(17, "kind_code")
+	if err != nil || !ok || value != "delta_256" {
+		t.Fatalf("boundary dictionary value=(%q,%v,%v) want delta_256,true,nil", value, ok, err)
+	}
+}
+
+func TestQueryReadyBaseDeltaNullableTransitionsSurviveConsolidation(t *testing.T) {
+	base := queryReadyDeltaNullableBase(t, 1, 3201, []int64{1, 2}, []int64{10, 20}, []bool{false, true})
+	delta := queryReadyDeltaNullableGeneration(t, 2, 3202, []int64{1, 2}, []int64{100, 200}, []bool{true, false})
+	reader, err := NewQueryReadyBaseDeltaReader(base, []*QueryReadyDeltaGeneration{delta}, QueryReadyBaseDeltaOptions{SnapshotGeneration: 2, Bound: QueryReadyDeltaBoundPolicy{MaxVisibleGenerations: 4}})
+	if err != nil {
+		t.Fatalf("reader: %v", err)
+	}
+	if value, null, _, ok, err := reader.NullableInt64AtLatest(1, "maybe"); err != nil || !ok || !null || value != 0 {
+		t.Fatalf("id=1 state=(%d,%v,%v,%v)", value, null, ok, err)
+	}
+	if value, null, _, ok, err := reader.NullableInt64AtLatest(2, "maybe"); err != nil || !ok || null || value != 200 {
+		t.Fatalf("id=2 state=(%d,%v,%v,%v)", value, null, ok, err)
+	}
+	result, err := ConsolidateQueryReadyBaseDelta(base, []*QueryReadyDeltaGeneration{delta}, 2)
+	if err != nil {
+		t.Fatalf("consolidate: %v", err)
+	}
+	consolidated, err := OpenQueryReadyConsolidatedBaseGeneration(result.Bytes, queryReadyBaseTestIdentity(2))
+	if err != nil {
+		t.Fatalf("reopen: %v", err)
+	}
+	after, err := NewQueryReadyConsolidatedBaseDeltaReader(consolidated, nil, QueryReadyBaseDeltaOptions{SnapshotGeneration: 2, Bound: QueryReadyDeltaBoundPolicy{MaxVisibleGenerations: 4}})
+	if err != nil {
+		t.Fatalf("reader after: %v", err)
+	}
+	for _, id := range []int64{1, 2} {
+		beforeValue, beforeNull, beforeDefault, beforeOK, beforeErr := reader.NullableInt64AtLatest(id, "maybe")
+		afterValue, afterNull, afterDefault, afterOK, afterErr := after.NullableInt64AtLatest(id, "maybe")
+		if beforeErr != nil || afterErr != nil || beforeValue != afterValue || beforeNull != afterNull || beforeDefault != afterDefault || beforeOK != afterOK {
+			t.Fatalf("id=%d before=(%d,%v,%v,%v,%v) after=(%d,%v,%v,%v,%v)", id, beforeValue, beforeNull, beforeDefault, beforeOK, beforeErr, afterValue, afterNull, afterDefault, afterOK, afterErr)
+		}
+	}
+}
+
+func TestQueryReadyDeltaEmptyRepeatedDeleteReinsertAndSameGenerationTieBreak(t *testing.T) {
+	emptyBuilt, err := BuildQueryReadyDeltaGeneration(queryReadyBaseTestIdentity(5), nil, nil)
+	if err != nil {
+		t.Fatalf("build empty: %v", err)
+	}
+	empty, err := OpenQueryReadyDeltaGeneration(emptyBuilt.Bytes, queryReadyBaseTestIdentity(5))
+	if err != nil || len(empty.Base.Parts) != 0 {
+		t.Fatalf("open empty parts=%d err=%v", len(empty.Base.Parts), err)
+	}
+	base := queryReadyDeltaTestBase(t, 1, map[int64]int64{1: 10})
+	deleted := queryReadyDeltaTestGeneration(t, 2, nil, []Tombstone{{PrimaryID: 1, GenerationID: 2}})
+	reinserted := queryReadyDeltaTestGeneration(t, 3, map[int64]int64{1: 30}, nil)
+	left := queryReadyDeltaTestImage(t, 3301, map[int64]int64{1: 31})
+	right := queryReadyDeltaTestImage(t, 3302, map[int64]int64{1: 32})
+	tieBuilt, err := BuildQueryReadyDeltaGeneration(queryReadyBaseTestIdentity(4), []QueryReadyBasePartInput{{SourceGeneration: 4, Image: right}, {SourceGeneration: 4, Image: left}}, nil)
+	if err != nil {
+		t.Fatalf("build tie: %v", err)
+	}
+	tie, err := OpenQueryReadyDeltaGeneration(tieBuilt.Bytes, queryReadyBaseTestIdentity(4))
+	if err != nil {
+		t.Fatalf("open tie: %v", err)
+	}
+	reader, err := NewQueryReadyBaseDeltaReader(base, []*QueryReadyDeltaGeneration{tie, reinserted, deleted, empty}, QueryReadyBaseDeltaOptions{SnapshotGeneration: 5, Bound: QueryReadyDeltaBoundPolicy{MaxVisibleGenerations: 4}})
+	if err != nil {
+		t.Fatalf("reader: %v", err)
+	}
+	value, ok, err := reader.ValueAtLatest(1, "value")
+	if err != nil || !ok || value != 32 {
+		t.Fatalf("same-generation tie value/ok/err=(%d,%v,%v) want 32,true,nil", value, ok, err)
+	}
+}
+
+func TestQueryReadyDeltaBoundTriggersAtConfiguredWorkLimit(t *testing.T) {
+	base := queryReadyDeltaTestBase(t, 1, map[int64]int64{1: 1})
+	var deltas []*QueryReadyDeltaGeneration
+	for generation := uint64(2); generation <= 6; generation++ {
+		deltas = append(deltas, queryReadyDeltaTestGeneration(t, generation, map[int64]int64{1: int64(generation)}, nil))
+	}
+	decision := EvaluateQueryReadyDeltaBound(deltas, 6, QueryReadyDeltaBoundPolicy{MaxVisibleGenerations: 4})
+	if !decision.Triggered || decision.VisibleGenerations != 5 || decision.GenerationLimitTriggers != 1 {
+		t.Fatalf("decision=%+v", decision)
+	}
+	if _, err := NewQueryReadyBaseDeltaReader(base, deltas, QueryReadyBaseDeltaOptions{SnapshotGeneration: 6, Bound: QueryReadyDeltaBoundPolicy{MaxVisibleGenerations: 4, MaxAccumulatedDeltaParts: 8}}); err == nil {
+		t.Fatalf("expected configured delta bound failure")
+	} else {
+		var boundErr *QueryReadyDeltaBoundError
+		if !errors.As(err, &boundErr) || boundErr.Decision.GenerationLimitTriggers != 1 || boundErr.Decision.VisibleGenerations != 5 {
+			t.Fatalf("generation bound error=%v", err)
+		}
+	}
+	rows := EvaluateQueryReadyDeltaBound(deltas, 6, QueryReadyDeltaBoundPolicy{MaxVisibleGenerations: 8, MaxRows: 4})
+	if !rows.Triggered || rows.RowLimitTriggers != 1 || rows.Reason != "rows" || rows.Rows != 5 {
+		t.Fatalf("row decision=%+v", rows)
+	}
+	bytes := EvaluateQueryReadyDeltaBound(deltas, 6, QueryReadyDeltaBoundPolicy{MaxVisibleGenerations: 8, MaxBytes: 1})
+	if !bytes.Triggered || bytes.ByteLimitTriggers != 1 || bytes.Reason != "bytes" || bytes.Bytes <= 1 {
+		t.Fatalf("byte decision=%+v", bytes)
+	}
+	override := EvaluateQueryReadyDeltaBound(deltas, 6, QueryReadyDeltaBoundPolicy{MaxVisibleGenerations: 8, MaxRows: rows.Rows, MaxBytes: bytes.Bytes})
+	if override.Triggered {
+		t.Fatalf("inclusive configured limits should allow exact work: %+v", override)
+	}
+	for _, tc := range []struct {
+		name   string
+		policy QueryReadyDeltaBoundPolicy
+		check  func(QueryReadyDeltaBoundDecision) bool
+	}{
+		{name: "rows", policy: QueryReadyDeltaBoundPolicy{MaxVisibleGenerations: 8, MaxAccumulatedDeltaParts: 8, MaxRows: 5}, check: func(d QueryReadyDeltaBoundDecision) bool { return d.RowLimitTriggers == 1 && d.Reason == "rows" }},
+		{name: "bytes", policy: QueryReadyDeltaBoundPolicy{MaxVisibleGenerations: 8, MaxAccumulatedDeltaParts: 8, MaxBytes: 1}, check: func(d QueryReadyDeltaBoundDecision) bool { return d.ByteLimitTriggers == 1 && d.Reason == "bytes" }},
+	} {
+		t.Run("public error "+tc.name, func(t *testing.T) {
+			_, err := NewQueryReadyBaseDeltaReader(base, deltas, QueryReadyBaseDeltaOptions{SnapshotGeneration: 6, Bound: tc.policy})
+			var boundErr *QueryReadyDeltaBoundError
+			if !errors.As(err, &boundErr) || !tc.check(boundErr.Decision) {
+				t.Fatalf("bound error=%v decision=%+v", err, func() QueryReadyDeltaBoundDecision {
+					if boundErr == nil {
+						return QueryReadyDeltaBoundDecision{}
+					}
+					return boundErr.Decision
+				}())
+			}
+		})
+	}
+}
+
+func TestQueryReadyDeltaDefaultBoundAllowsLargeOriginBaseButCapsGrowth(t *testing.T) {
+	identity := queryReadyBaseTestIdentity(1)
+	parts := make([]QueryReadyBasePartInput, 10)
+	for i := range parts {
+		parts[i] = QueryReadyBasePartInput{SourceGeneration: 1, Image: queryReadyDeltaTestImage(t, uint64(3500+i), map[int64]int64{int64(i + 1): int64(i)})}
+	}
+	built, err := BuildQueryReadyBaseGeneration(identity, parts)
+	if err != nil {
+		t.Fatalf("build origin base: %v", err)
+	}
+	base, err := OpenQueryReadyBaseGeneration(built.Bytes, identity)
+	if err != nil {
+		t.Fatalf("open origin base: %v", err)
+	}
+	reader, err := NewQueryReadyBaseDeltaReader(base, nil, QueryReadyBaseDeltaOptions{SnapshotGeneration: 1})
+	if err != nil {
+		t.Fatalf("default relative bound rejected origin base: %v", err)
+	}
+	stats := reader.Stats()
+	if stats.OriginBaseParts != 10 || stats.AccumulatedDeltaParts != 0 || stats.TotalParts != 10 {
+		t.Fatalf("relative bound stats=%+v", stats)
+	}
+}
+
+func TestQueryReadyDeltaGenerationFailsClosedOnIdentityOrderAndCorruption(t *testing.T) {
+	identity := queryReadyBaseTestIdentity(5)
+	image := queryReadyDeltaTestImage(t, 3401, map[int64]int64{1: 10})
+	built, err := BuildQueryReadyDeltaGeneration(identity, []QueryReadyBasePartInput{{SourceGeneration: 5, Image: image}}, []Tombstone{{PrimaryID: 1, GenerationID: 4}, {PrimaryID: 2, GenerationID: 5}})
+	if err != nil {
+		t.Fatalf("build: %v", err)
+	}
+	wrongGeneration := identity
+	wrongGeneration.Generation++
+	if _, err := OpenQueryReadyDeltaGeneration(built.Bytes, wrongGeneration); err == nil {
+		t.Fatalf("expected generation mismatch")
+	}
+	wrongSchema := identity
+	wrongSchema.SchemaHash[0] ^= 0xff
+	if _, err := OpenQueryReadyDeltaGeneration(built.Bytes, wrongSchema); err == nil {
+		t.Fatalf("expected schema mismatch")
+	}
+	for _, tc := range []struct {
+		name string
+		data []byte
+	}{
+		{name: "truncated", data: slices.Clone(built.Bytes[:len(built.Bytes)-1])},
+		{name: "header", data: queryReadyDeltaCorruptByte(built.Bytes, 8)},
+		{name: "inner", data: queryReadyDeltaCorruptByte(built.Bytes, len(built.Bytes)-1)},
+		{name: "tombstone order", data: queryReadyDeltaReverseTombstones(built.Bytes)},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if _, err := OpenQueryReadyDeltaGeneration(tc.data, identity); err == nil {
+				t.Fatalf("expected fail-closed error")
+			}
+		})
+	}
+	if _, err := BuildQueryReadyDeltaGeneration(identity, nil, []Tombstone{{PrimaryID: 1, GenerationID: 6}}); err == nil {
+		t.Fatalf("expected future tombstone generation rejection")
+	}
+	if _, err := BuildQueryReadyDeltaGeneration(identity, []QueryReadyBasePartInput{{SourceGeneration: 4, Image: image}}, nil); err == nil {
+		t.Fatalf("expected mixed historical source generation rejection for ordinary delta")
+	}
+	tamperedLineage := slices.Clone(built.Bytes)
+	binary.LittleEndian.PutUint32(tamperedLineage[88:92], 1)
+	binary.LittleEndian.PutUint32(tamperedLineage[52:56], queryReadyDeltaHeaderChecksum(tamperedLineage[:queryReadyDeltaHeaderBytes]))
+	if _, err := OpenQueryReadyDeltaGeneration(tamperedLineage, identity); err == nil {
+		t.Fatalf("expected ordinary delta lineage rejection")
+	}
+}
+
+func TestQueryReadyDeltaRepeatedConsolidationCarriesLineageTombstonesAndBound(t *testing.T) {
+	base := queryReadyDeltaTestBase(t, 1, map[int64]int64{1: 10, 2: 20})
+	delta2 := queryReadyDeltaTestGeneration(t, 2, map[int64]int64{2: 200}, []Tombstone{{PrimaryID: 1, GenerationID: 2}})
+	policy := QueryReadyDeltaBoundPolicy{MaxVisibleGenerations: 4, MaxAccumulatedDeltaParts: 2}
+	first, err := ConsolidateQueryReadyBaseDeltaWithPolicy(base, []*QueryReadyDeltaGeneration{delta2}, 2, policy)
+	if err != nil {
+		t.Fatalf("first consolidation: %v", err)
+	}
+	consolidated2, err := OpenQueryReadyConsolidatedBaseGeneration(first.Bytes, queryReadyBaseTestIdentity(2))
+	if err != nil {
+		t.Fatalf("open first consolidation: %v", err)
+	}
+	if consolidated2.OriginBaseParts != 1 || consolidated2.AccumulatedDeltaParts != 1 || len(consolidated2.Tombstones) != 1 {
+		t.Fatalf("first lineage/tombstones=%d/%d/%v", consolidated2.OriginBaseParts, consolidated2.AccumulatedDeltaParts, consolidated2.Tombstones)
+	}
+	oldSnapshot, err := NewQueryReadyConsolidatedBaseDeltaReader(consolidated2, nil, QueryReadyBaseDeltaOptions{SnapshotGeneration: 2, Bound: policy})
+	if err != nil {
+		t.Fatalf("old snapshot reader: %v", err)
+	}
+	queryReadyDeltaAssertValues(t, oldSnapshot, map[int64]int64{2: 200}, 1, 2)
+
+	delta3 := queryReadyDeltaTestGeneration(t, 3, map[int64]int64{1: 300}, nil)
+	second, err := ConsolidateQueryReadyConsolidatedBaseDeltaWithPolicy(consolidated2, []*QueryReadyDeltaGeneration{delta3}, 3, policy)
+	if err != nil {
+		t.Fatalf("second consolidation: %v", err)
+	}
+	consolidated3, err := OpenQueryReadyConsolidatedBaseGeneration(second.Bytes, queryReadyBaseTestIdentity(3))
+	if err != nil {
+		t.Fatalf("open second consolidation: %v", err)
+	}
+	if consolidated3.OriginBaseParts != 1 || consolidated3.AccumulatedDeltaParts != 2 || len(consolidated3.Tombstones) != 1 {
+		t.Fatalf("second lineage/tombstones=%d/%d/%v", consolidated3.OriginBaseParts, consolidated3.AccumulatedDeltaParts, consolidated3.Tombstones)
+	}
+	newSnapshot, err := NewQueryReadyConsolidatedBaseDeltaReader(consolidated3, nil, QueryReadyBaseDeltaOptions{SnapshotGeneration: 3, Bound: policy})
+	if err != nil {
+		t.Fatalf("new snapshot reader: %v", err)
+	}
+	queryReadyDeltaAssertValues(t, newSnapshot, map[int64]int64{1: 300, 2: 200}, 1, 2)
+	// The prior consolidated object remains independently readable after the
+	// replacement exists; its tombstone still suppresses id=1.
+	queryReadyDeltaAssertValues(t, oldSnapshot, map[int64]int64{2: 200}, 1, 2)
+
+	delta4 := queryReadyDeltaTestGeneration(t, 4, map[int64]int64{2: 400}, nil)
+	decision := evaluateQueryReadyBaseDeltaBound(consolidated3.Base, consolidated3.Tombstones, consolidated3.OriginBaseParts, consolidated3.AccumulatedDeltaParts, []*QueryReadyDeltaGeneration{delta4}, 4, policy)
+	if !decision.Triggered || decision.Reason != "accumulated_delta_parts" || decision.OriginBaseParts != 1 || decision.BaseDeltaDerivedParts != 2 || decision.DeltaParts != 1 || decision.AccumulatedDeltaParts != 3 || decision.PartLimitTriggers != 1 {
+		t.Fatalf("repeated-cycle decision=%+v", decision)
+	}
+	if _, err := ConsolidateQueryReadyConsolidatedBaseDeltaWithPolicy(consolidated3, []*QueryReadyDeltaGeneration{delta4}, 4, policy); err == nil {
+		t.Fatalf("expected repeated consolidation bound rejection")
+	} else {
+		var boundErr *QueryReadyDeltaBoundError
+		if !errors.As(err, &boundErr) || boundErr.Decision.PartLimitTriggers != 1 || boundErr.Decision.AccumulatedDeltaParts != 3 {
+			t.Fatalf("consolidation bound error=%v", err)
+		}
+	}
+	if _, err := NewQueryReadyConsolidatedBaseDeltaReader(consolidated3, []*QueryReadyDeltaGeneration{delta4}, QueryReadyBaseDeltaOptions{SnapshotGeneration: 4, Bound: policy}); err == nil {
+		t.Fatalf("expected reader bound rejection before decode")
+	}
+
+	tampered := slices.Clone(second.Bytes)
+	binary.LittleEndian.PutUint32(tampered[88:92], uint32(consolidated3.OriginBaseParts+1))
+	binary.LittleEndian.PutUint32(tampered[52:56], queryReadyDeltaHeaderChecksum(tampered[:queryReadyDeltaHeaderBytes]))
+	if _, err := OpenQueryReadyConsolidatedBaseGeneration(tampered, queryReadyBaseTestIdentity(3)); err == nil {
+		t.Fatalf("expected tampered consolidated lineage rejection")
+	}
+}
+
+func TestQueryReadyBaseDeltaConsolidationRejectsGenerationOverclaim(t *testing.T) {
+	base := queryReadyDeltaTestBase(t, 1, map[int64]int64{1: 10})
+	delta2 := queryReadyDeltaTestGeneration(t, 2, map[int64]int64{1: 20}, nil)
+	if _, err := ConsolidateQueryReadyBaseDelta(base, nil, 2); err == nil {
+		t.Fatalf("expected no-delta generation overclaim rejection")
+	}
+	if _, err := ConsolidateQueryReadyBaseDelta(base, []*QueryReadyDeltaGeneration{delta2}, 3); err == nil {
+		t.Fatalf("expected selected-prefix generation overclaim rejection")
+	}
+}
+
+func TestQueryReadyBaseDeltaConsolidationParityAfterReopen(t *testing.T) {
+	base := queryReadyDeltaTestBase(t, 1, map[int64]int64{1: 10, 2: 20})
+	delta2 := queryReadyDeltaTestGeneration(t, 2, map[int64]int64{2: 200, 3: 300}, nil)
+	delta3 := queryReadyDeltaTestGeneration(t, 3, map[int64]int64{1: 100}, []Tombstone{{PrimaryID: 3, GenerationID: 3}})
+	want, err := NewQueryReadyBaseDeltaReader(base, []*QueryReadyDeltaGeneration{delta2, delta3}, QueryReadyBaseDeltaOptions{SnapshotGeneration: 3, Bound: QueryReadyDeltaBoundPolicy{MaxVisibleGenerations: 4}})
+	if err != nil {
+		t.Fatalf("before consolidation: %v", err)
+	}
+	result, err := ConsolidateQueryReadyBaseDelta(base, []*QueryReadyDeltaGeneration{delta2, delta3}, 3)
+	if err != nil {
+		t.Fatalf("ConsolidateQueryReadyBaseDelta: %v", err)
+	}
+	again, err := ConsolidateQueryReadyBaseDelta(base, []*QueryReadyDeltaGeneration{delta3, delta2}, 3)
+	if err != nil {
+		t.Fatalf("deterministic retry: %v", err)
+	}
+	if !slices.Equal(result.Bytes, again.Bytes) {
+		t.Fatalf("retried consolidation bytes differ")
+	}
+	path := filepath.Join(t.TempDir(), "consolidated.qrd")
+	if err := os.WriteFile(path, result.Bytes, 0o600); err != nil {
+		t.Fatalf("write consolidated: %v", err)
+	}
+	reopenedBytes, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read consolidated: %v", err)
+	}
+	consolidated, err := OpenQueryReadyConsolidatedBaseGeneration(reopenedBytes, queryReadyBaseTestIdentity(3))
+	if err != nil {
+		t.Fatalf("OpenQueryReadyConsolidatedBaseGeneration: %v", err)
+	}
+	after, err := NewQueryReadyConsolidatedBaseDeltaReader(consolidated, nil, QueryReadyBaseDeltaOptions{SnapshotGeneration: 3, Bound: QueryReadyDeltaBoundPolicy{MaxVisibleGenerations: 4}})
+	if err != nil {
+		t.Fatalf("after consolidation: %v", err)
+	}
+	for id := int64(1); id <= 3; id++ {
+		beforeValue, beforeOK, beforeErr := want.ValueAtLatest(id, "value")
+		afterValue, afterOK, afterErr := after.ValueAtLatest(id, "value")
+		if beforeErr != nil || afterErr != nil || beforeOK != afterOK || beforeValue != afterValue {
+			t.Fatalf("id=%d before=(%d,%v,%v) after=(%d,%v,%v)", id, beforeValue, beforeOK, beforeErr, afterValue, afterOK, afterErr)
+		}
+	}
+	if result.Stats.OutputGenerations != 1 || result.Stats.SelectedDeltaGenerations != 2 || result.Stats.TombstonesMerged != 1 || result.Stats.DocumentMaterializations != 0 {
+		t.Fatalf("consolidation stats=%+v", result.Stats)
+	}
+	old, err := NewQueryReadyBaseDeltaReader(base, nil, QueryReadyBaseDeltaOptions{SnapshotGeneration: 1, Bound: QueryReadyDeltaBoundPolicy{MaxVisibleGenerations: 4}})
+	if err != nil {
+		t.Fatalf("old snapshot after consolidation: %v", err)
+	}
+	queryReadyDeltaAssertValues(t, old, map[int64]int64{1: 10, 2: 20}, 1, 2, 3)
+}
+
+func TestQueryReadyBaseDeltaRandomizedModelParity(t *testing.T) {
+	rng := rand.New(rand.NewSource(3697))
+	model := map[int64]int64{1: 10, 2: 20, 3: 30}
+	base := queryReadyDeltaTestBase(t, 1, model)
+	var deltas []*QueryReadyDeltaGeneration
+	for generation := uint64(2); generation <= 25; generation++ {
+		writes := make(map[int64]int64)
+		var tombstones []Tombstone
+		for range 1 + rng.Intn(4) {
+			id := int64(1 + rng.Intn(12))
+			if rng.Intn(4) == 0 {
+				delete(model, id)
+				tombstones = append(tombstones, Tombstone{PrimaryID: id, GenerationID: generation})
+				delete(writes, id)
+			} else {
+				value := int64(rng.Intn(10000))
+				model[id] = value
+				writes[id] = value
+			}
+		}
+		deltas = append(deltas, queryReadyDeltaTestGeneration(t, generation, writes, tombstones))
+	}
+	reader, err := NewQueryReadyBaseDeltaReader(base, deltas, QueryReadyBaseDeltaOptions{SnapshotGeneration: 25, Bound: QueryReadyDeltaBoundPolicy{MaxVisibleGenerations: 32}})
+	if err != nil {
+		t.Fatalf("NewQueryReadyBaseDeltaReader: %v", err)
+	}
+	for id := int64(1); id <= 12; id++ {
+		got, ok, err := reader.ValueAtLatest(id, "value")
+		want, wantOK := model[id]
+		if err != nil || ok != wantOK || (ok && got != want) {
+			t.Fatalf("id=%d got=(%d,%v,%v) want=(%d,%v)", id, got, ok, err, want, wantOK)
+		}
+	}
+}
+
+func queryReadyDeltaTestBase(t *testing.T, generation uint64, values map[int64]int64) *QueryReadyBaseGeneration {
+	t.Helper()
+	image := queryReadyDeltaTestImage(t, 1000+generation, values)
+	result, err := BuildQueryReadyBaseGeneration(queryReadyBaseTestIdentity(generation), []QueryReadyBasePartInput{{SourceGeneration: generation, Image: image}})
+	if err != nil {
+		t.Fatalf("BuildQueryReadyBaseGeneration: %v", err)
+	}
+	base, err := OpenQueryReadyBaseGeneration(result.Bytes, queryReadyBaseTestIdentity(generation))
+	if err != nil {
+		t.Fatalf("OpenQueryReadyBaseGeneration: %v", err)
+	}
+	return base
+}
+
+func queryReadyDeltaTestGeneration(t *testing.T, generation uint64, values map[int64]int64, tombstones []Tombstone) *QueryReadyDeltaGeneration {
+	t.Helper()
+	var parts []QueryReadyBasePartInput
+	if len(values) > 0 {
+		parts = append(parts, QueryReadyBasePartInput{SourceGeneration: generation, Image: queryReadyDeltaTestImage(t, 2000+generation, values)})
+	}
+	result, err := BuildQueryReadyDeltaGeneration(queryReadyBaseTestIdentity(generation), parts, tombstones)
+	if err != nil {
+		t.Fatalf("BuildQueryReadyDeltaGeneration: %v", err)
+	}
+	delta, err := OpenQueryReadyDeltaGeneration(result.Bytes, queryReadyBaseTestIdentity(generation))
+	if err != nil {
+		t.Fatalf("OpenQueryReadyDeltaGeneration: %v", err)
+	}
+	return delta
+}
+
+func queryReadyDeltaTestImage(t *testing.T, partID uint64, values map[int64]int64) ColumnPartImage {
+	t.Helper()
+	ids := make([]int64, 0, len(values))
+	for id := range values {
+		ids = append(ids, id)
+	}
+	slices.Sort(ids)
+	vals := make([]int64, len(ids))
+	for i, id := range ids {
+		vals[i] = values[id]
+	}
+	opts := Options{
+		SchemaVersion: 1,
+		SchemaMode:    ColumnSchemaFixed,
+		Columns: []ColumnDefinition{
+			{Name: "id", Type: ColumnTypeInt64, Encoding: EncodingRawInt64, Compression: CompressionNone},
+			{Name: "value", Type: ColumnTypeInt64, Encoding: EncodingRawInt64, Compression: CompressionNone},
+		},
+		LogicalPrimaryKey: LogicalPrimaryKey{Columns: []string{"id"}},
+		SortKey:           SortKey{Columns: []SortKeyColumn{{Column: "id"}}},
+		PartPolicy:        ColumnPartPolicy{RowsPerGranule: 16},
+	}
+	part, err := BuildColumnPart(partID, opts, Batch{Rows: len(ids), Columns: map[string][]int64{"id": ids, "value": vals}})
+	if err != nil {
+		t.Fatalf("BuildColumnPart: %v", err)
+	}
+	image, err := BuildColumnPartImage(part, ColumnPartImageOptions{})
+	if err != nil {
+		t.Fatalf("BuildColumnPartImage: %v", err)
+	}
+	return image
+}
+
+func queryReadyDeltaDictionaryImage(t *testing.T, partID uint64, values map[int64]int64, dictionary map[string]int64) ColumnPartImage {
+	t.Helper()
+	ids := make([]int64, 0, len(values))
+	for id := range values {
+		ids = append(ids, id)
+	}
+	slices.Sort(ids)
+	codes := make([]int64, len(ids))
+	for i, id := range ids {
+		codes[i] = values[id]
+	}
+	opts := Options{SchemaVersion: 1, SchemaMode: ColumnSchemaFixed, Columns: []ColumnDefinition{
+		{Name: "id", Type: ColumnTypeInt64, Encoding: EncodingRawInt64, Compression: CompressionNone},
+		{Name: "kind_code", Type: ColumnTypeLowCardinalityCode, Compression: CompressionNone, Cardinality: uint32(len(dictionary))},
+	}, LogicalPrimaryKey: LogicalPrimaryKey{Columns: []string{"id"}}, SortKey: SortKey{Columns: []SortKeyColumn{{Column: "id"}}}, PartPolicy: ColumnPartPolicy{RowsPerGranule: 16}}
+	part, err := BuildColumnPart(partID, opts, Batch{Rows: len(ids), Columns: map[string][]int64{"id": ids, "kind_code": codes}})
+	if err != nil {
+		t.Fatalf("build dictionary part: %v", err)
+	}
+	image, err := BuildColumnPartImage(part, ColumnPartImageOptions{Dictionaries: map[string]map[string]int64{"kind_code": dictionary}})
+	if err != nil {
+		t.Fatalf("build dictionary image: %v", err)
+	}
+	return image
+}
+
+func queryReadyDeltaNullableBase(t *testing.T, generation, partID uint64, ids, values []int64, nulls []bool) *QueryReadyBaseGeneration {
+	t.Helper()
+	image := queryReadyDeltaNullableImage(t, partID, ids, values, nulls)
+	built, err := BuildQueryReadyBaseGeneration(queryReadyBaseTestIdentity(generation), []QueryReadyBasePartInput{{SourceGeneration: generation, Image: image}})
+	if err != nil {
+		t.Fatalf("build nullable base: %v", err)
+	}
+	base, err := OpenQueryReadyBaseGeneration(built.Bytes, queryReadyBaseTestIdentity(generation))
+	if err != nil {
+		t.Fatalf("open nullable base: %v", err)
+	}
+	return base
+}
+
+func queryReadyDeltaNullableGeneration(t *testing.T, generation, partID uint64, ids, values []int64, nulls []bool) *QueryReadyDeltaGeneration {
+	t.Helper()
+	image := queryReadyDeltaNullableImage(t, partID, ids, values, nulls)
+	built, err := BuildQueryReadyDeltaGeneration(queryReadyBaseTestIdentity(generation), []QueryReadyBasePartInput{{SourceGeneration: generation, Image: image}}, nil)
+	if err != nil {
+		t.Fatalf("build nullable delta: %v", err)
+	}
+	delta, err := OpenQueryReadyDeltaGeneration(built.Bytes, queryReadyBaseTestIdentity(generation))
+	if err != nil {
+		t.Fatalf("open nullable delta: %v", err)
+	}
+	return delta
+}
+
+func queryReadyDeltaNullableImage(t *testing.T, partID uint64, ids, values []int64, nulls []bool) ColumnPartImage {
+	t.Helper()
+	opts := Options{SchemaVersion: 1, SchemaMode: ColumnSchemaFixed, Columns: []ColumnDefinition{
+		{Name: "id", Type: ColumnTypeInt64, Encoding: EncodingRawInt64, Compression: CompressionNone},
+		{Name: "maybe", Type: ColumnTypeInt64, Encoding: EncodingNullableInt64, Compression: CompressionNone},
+	}, LogicalPrimaryKey: LogicalPrimaryKey{Columns: []string{"id"}}, SortKey: SortKey{Columns: []SortKeyColumn{{Column: "id"}}}, PartPolicy: ColumnPartPolicy{RowsPerGranule: 16}}
+	part, err := BuildColumnPart(partID, opts, Batch{Rows: len(ids), Columns: map[string][]int64{"id": ids, "maybe": values}, Nulls: map[string][]bool{"maybe": nulls}})
+	if err != nil {
+		t.Fatalf("build nullable part: %v", err)
+	}
+	image, err := BuildColumnPartImage(part, ColumnPartImageOptions{})
+	if err != nil {
+		t.Fatalf("build nullable image: %v", err)
+	}
+	return image
+}
+
+func queryReadyDeltaCorruptByte(data []byte, offset int) []byte {
+	out := slices.Clone(data)
+	out[offset] ^= 0xff
+	return out
+}
+
+func queryReadyDeltaReverseTombstones(data []byte) []byte {
+	out := slices.Clone(data)
+	first := slices.Clone(out[queryReadyDeltaHeaderBytes : queryReadyDeltaHeaderBytes+queryReadyDeltaTombstoneBytes])
+	second := slices.Clone(out[queryReadyDeltaHeaderBytes+queryReadyDeltaTombstoneBytes : queryReadyDeltaHeaderBytes+2*queryReadyDeltaTombstoneBytes])
+	copy(out[queryReadyDeltaHeaderBytes:], second)
+	copy(out[queryReadyDeltaHeaderBytes+queryReadyDeltaTombstoneBytes:], first)
+	table := out[queryReadyDeltaHeaderBytes : queryReadyDeltaHeaderBytes+2*queryReadyDeltaTombstoneBytes]
+	binary.LittleEndian.PutUint32(out[56:60], crc32.Checksum(table, queryReadyBaseCRCTable))
+	binary.LittleEndian.PutUint32(out[52:56], queryReadyDeltaHeaderChecksum(out[:queryReadyDeltaHeaderBytes]))
+	return out
+}
+
+func BenchmarkQueryReadyBaseDeltaPrepareCurve(b *testing.B) {
+	for _, shape := range []string{"low_cardinality", "high_cardinality", "tombstone_heavy", "nullable_mixed_reinsert"} {
+		for _, generations := range []int{0, 1, 2, 4, 8, 9} {
+			b.Run(shape+"/N="+strconv.Itoa(generations), func(b *testing.B) {
+				base, deltas := queryReadyDeltaBenchmarkFixture(b, generations, shape)
+				policy := QueryReadyDeltaBoundPolicy{MaxVisibleGenerations: 16, MaxAccumulatedDeltaParts: 16}
+				b.ReportAllocs()
+				b.ResetTimer()
+				for range b.N {
+					reader, err := NewQueryReadyBaseDeltaReader(base, deltas, QueryReadyBaseDeltaOptions{SnapshotGeneration: uint64(generations + 1), Bound: policy})
+					if err != nil {
+						b.Fatal(err)
+					}
+					queryReadyDeltaReaderSink = reader
+				}
+				b.StopTimer()
+				decision := evaluateQueryReadyBaseDeltaBound(base, nil, len(base.Parts), 0, deltas, uint64(generations+1), policy)
+				b.ReportMetric(float64(decision.TotalParts), "merge_parts/op")
+				b.ReportMetric(float64(decision.Rows), "merge_rows/op")
+				b.ReportMetric(float64(decision.Bytes), "merge_bytes/op")
+			})
+		}
+	}
+}
+
+func BenchmarkQueryReadyBaseDeltaWarmLookup(b *testing.B) {
+	base, deltas := queryReadyDeltaBenchmarkFixture(b, 4, "high_cardinality")
+	reader, err := NewQueryReadyBaseDeltaReader(base, deltas, QueryReadyBaseDeltaOptions{SnapshotGeneration: 5, Bound: QueryReadyDeltaBoundPolicy{MaxVisibleGenerations: 8, MaxAccumulatedDeltaParts: 8}})
+	if err != nil {
+		b.Fatal(err)
+	}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for range b.N {
+		value, ok, err := reader.DictionaryValueAtLatest(1, "kind_code")
+		if err != nil || !ok {
+			b.Fatalf("lookup=%q/%v/%v", value, ok, err)
+		}
+		queryReadyDeltaStringSink = value
+	}
+}
+
+func BenchmarkQueryReadyBaseDeltaConsolidation(b *testing.B) {
+	base, deltas := queryReadyDeltaBenchmarkFixture(b, 4, "high_cardinality")
+	policy := QueryReadyDeltaBoundPolicy{MaxVisibleGenerations: 8, MaxAccumulatedDeltaParts: 8}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for range b.N {
+		result, err := ConsolidateQueryReadyBaseDeltaWithPolicy(base, deltas, 5, policy)
+		if err != nil {
+			b.Fatal(err)
+		}
+		queryReadyDeltaConsolidationSink = result
+	}
+	b.StopTimer()
+	result := queryReadyDeltaConsolidationSink
+	b.ReportMetric(result.Stats.WriteAmplification, "write_amp/op")
+	b.ReportMetric(float64(result.Stats.PeakWorkingBytes), "peak_working_bytes/op")
+}
+
+func BenchmarkQueryReadyDeltaGenerationBuild(b *testing.B) {
+	image := queryReadyDeltaBenchmarkImage(b, 6001, 512, 64, 0)
+	parts := []QueryReadyBasePartInput{{SourceGeneration: 2, Image: image}}
+	tombstones := make([]Tombstone, 128)
+	for i := range tombstones {
+		tombstones[i] = Tombstone{PrimaryID: int64(i + 1), GenerationID: 2}
+	}
+	identity := queryReadyBaseTestIdentity(2)
+	b.Run("validated_part_container_only", func(b *testing.B) {
+		b.ReportAllocs()
+		for range b.N {
+			result, err := BuildQueryReadyBaseGeneration(identity, parts)
+			if err != nil {
+				b.Fatal(err)
+			}
+			queryReadyDeltaConsolidationSink.Bytes = result.Bytes
+		}
+	})
+	b.Run("qrdg_derived_envelope_build", func(b *testing.B) {
+		b.ReportAllocs()
+		for range b.N {
+			result, err := BuildQueryReadyDeltaGeneration(identity, parts, tombstones)
+			if err != nil {
+				b.Fatal(err)
+			}
+			queryReadyDeltaConsolidationSink.Bytes = result.Bytes
+		}
+	})
+}
+
+func queryReadyDeltaBenchmarkFixture(tb testing.TB, generations int, shape string) (*QueryReadyBaseGeneration, []*QueryReadyDeltaGeneration) {
+	tb.Helper()
+	const (
+		baseRows  = 512
+		deltaRows = 64
+	)
+	cardinality := 4
+	if shape == "high_cardinality" {
+		cardinality = baseRows
+	}
+	baseImage := queryReadyDeltaBenchmarkImage(tb, 5001, baseRows, cardinality, 0)
+	if shape == "nullable_mixed_reinsert" {
+		baseImage = queryReadyDeltaBenchmarkNullableImage(tb, 5001, baseRows, 0)
+	}
+	baseBuilt, err := BuildQueryReadyBaseGeneration(queryReadyBaseTestIdentity(1), []QueryReadyBasePartInput{{SourceGeneration: 1, Image: baseImage}})
+	if err != nil {
+		tb.Fatalf("build benchmark base: %v", err)
+	}
+	base, err := OpenQueryReadyBaseGeneration(baseBuilt.Bytes, queryReadyBaseTestIdentity(1))
+	if err != nil {
+		tb.Fatalf("open benchmark base: %v", err)
+	}
+	deltas := make([]*QueryReadyDeltaGeneration, 0, generations)
+	for i := 0; i < generations; i++ {
+		generation := uint64(i + 2)
+		var parts []QueryReadyBasePartInput
+		var tombstones []Tombstone
+		if shape == "tombstone_heavy" {
+			for row := 0; row < deltaRows; row++ {
+				tombstones = append(tombstones, Tombstone{PrimaryID: int64(row + 1), GenerationID: generation})
+			}
+		} else if shape == "nullable_mixed_reinsert" {
+			parts = append(parts, QueryReadyBasePartInput{SourceGeneration: generation, Image: queryReadyDeltaBenchmarkNullableImage(tb, 5100+generation, deltaRows, i+1)})
+			for row := 0; row < deltaRows; row += 4 {
+				tombstones = append(tombstones, Tombstone{PrimaryID: int64(row + 1), GenerationID: generation})
+			}
+		} else {
+			parts = append(parts, QueryReadyBasePartInput{SourceGeneration: generation, Image: queryReadyDeltaBenchmarkImage(tb, 5100+generation, deltaRows, cardinality, i+1)})
+		}
+		built, err := BuildQueryReadyDeltaGeneration(queryReadyBaseTestIdentity(generation), parts, tombstones)
+		if err != nil {
+			tb.Fatalf("build benchmark delta %d: %v", generation, err)
+		}
+		delta, err := OpenQueryReadyDeltaGeneration(built.Bytes, queryReadyBaseTestIdentity(generation))
+		if err != nil {
+			tb.Fatalf("open benchmark delta %d: %v", generation, err)
+		}
+		deltas = append(deltas, delta)
+	}
+	return base, deltas
+}
+
+func queryReadyDeltaBenchmarkNullableImage(tb testing.TB, partID uint64, rows, generationOffset int) ColumnPartImage {
+	tb.Helper()
+	ids := make([]int64, rows)
+	values := make([]int64, rows)
+	nulls := make([]bool, rows)
+	for i := range rows {
+		ids[i] = int64(i + 1)
+		values[i] = int64((generationOffset+1)*1000 + i)
+		nulls[i] = (i+generationOffset)%3 == 0
+	}
+	opts := Options{SchemaVersion: 1, SchemaMode: ColumnSchemaFixed, Columns: []ColumnDefinition{
+		{Name: "id", Type: ColumnTypeInt64, Encoding: EncodingRawInt64, Compression: CompressionNone},
+		{Name: "maybe", Type: ColumnTypeInt64, Encoding: EncodingNullableInt64, Compression: CompressionNone},
+	}, LogicalPrimaryKey: LogicalPrimaryKey{Columns: []string{"id"}}, SortKey: SortKey{Columns: []SortKeyColumn{{Column: "id"}}}, PartPolicy: ColumnPartPolicy{RowsPerGranule: 128}}
+	part, err := BuildColumnPart(partID, opts, Batch{Rows: rows, Columns: map[string][]int64{"id": ids, "maybe": values}, Nulls: map[string][]bool{"maybe": nulls}})
+	if err != nil {
+		tb.Fatalf("build nullable benchmark part: %v", err)
+	}
+	image, err := BuildColumnPartImage(part, ColumnPartImageOptions{})
+	if err != nil {
+		tb.Fatalf("build nullable benchmark image: %v", err)
+	}
+	return image
+}
+
+func queryReadyDeltaBenchmarkImage(tb testing.TB, partID uint64, rows, cardinality, generationOffset int) ColumnPartImage {
+	tb.Helper()
+	ids := make([]int64, rows)
+	codes := make([]int64, rows)
+	for i := range rows {
+		ids[i] = int64(i + 1)
+		codes[i] = int64((i + generationOffset) % cardinality)
+	}
+	dictionary := make(map[string]int64, cardinality)
+	for code := 0; code < cardinality; code++ {
+		dictionary["value_"+strconv.Itoa((code+generationOffset)%cardinality)] = int64(code)
+	}
+	opts := Options{SchemaVersion: 1, SchemaMode: ColumnSchemaFixed, Columns: []ColumnDefinition{
+		{Name: "id", Type: ColumnTypeInt64, Encoding: EncodingRawInt64, Compression: CompressionNone},
+		{Name: "kind_code", Type: ColumnTypeLowCardinalityCode, Compression: CompressionNone, Cardinality: uint32(cardinality)},
+	}, LogicalPrimaryKey: LogicalPrimaryKey{Columns: []string{"id"}}, SortKey: SortKey{Columns: []SortKeyColumn{{Column: "id"}}}, PartPolicy: ColumnPartPolicy{RowsPerGranule: 128}}
+	part, err := BuildColumnPart(partID, opts, Batch{Rows: rows, Columns: map[string][]int64{"id": ids, "kind_code": codes}})
+	if err != nil {
+		tb.Fatalf("build benchmark part: %v", err)
+	}
+	image, err := BuildColumnPartImage(part, ColumnPartImageOptions{Dictionaries: map[string]map[string]int64{"kind_code": dictionary}})
+	if err != nil {
+		tb.Fatalf("build benchmark image: %v", err)
+	}
+	return image
+}
+
+func queryReadyDeltaAssertValues(t *testing.T, reader *QueryReadyBaseDeltaReader, want map[int64]int64, ids ...int64) {
+	t.Helper()
+	for _, id := range ids {
+		value, ok, err := reader.ValueAtLatest(id, "value")
+		wantValue, wantOK := want[id]
+		if err != nil || ok != wantOK || (ok && value != wantValue) {
+			t.Fatalf("id=%d got=(%d,%v,%v) want=(%d,%v)", id, value, ok, err, wantValue, wantOK)
+		}
+	}
+}

--- a/TreeDB/internal/typedcolumn/query_ready_delta_test.go
+++ b/TreeDB/internal/typedcolumn/query_ready_delta_test.go
@@ -779,10 +779,8 @@ func BenchmarkQueryReadyDeltaGenerationBuild(b *testing.B) {
 
 func queryReadyDeltaBenchmarkFixture(tb testing.TB, generations int, shape string) (*QueryReadyBaseGeneration, []*QueryReadyDeltaGeneration) {
 	tb.Helper()
-	const (
-		baseRows  = 512
-		deltaRows = 64
-	)
+	baseRows := queryReadyDeltaBenchmarkRows(tb, "QUERY_READY_BENCH_BASE_ROWS", 512)
+	deltaRows := queryReadyDeltaBenchmarkRows(tb, "QUERY_READY_BENCH_DELTA_ROWS", 64)
 	cardinality := 4
 	if shape == "high_cardinality" {
 		cardinality = baseRows
@@ -827,6 +825,19 @@ func queryReadyDeltaBenchmarkFixture(tb testing.TB, generations int, shape strin
 		deltas = append(deltas, delta)
 	}
 	return base, deltas
+}
+
+func queryReadyDeltaBenchmarkRows(tb testing.TB, name string, fallback int) int {
+	tb.Helper()
+	raw := os.Getenv(name)
+	if raw == "" {
+		return fallback
+	}
+	rows, err := strconv.Atoi(raw)
+	if err != nil || rows <= 0 {
+		tb.Fatalf("%s=%q must be a positive integer", name, raw)
+	}
+	return rows
 }
 
 func queryReadyDeltaBenchmarkNullableImage(tb testing.TB, partID uint64, rows, generationOffset int) ColumnPartImage {

--- a/docs/architecture/query-ready-delta-generation.md
+++ b/docs/architecture/query-ready-delta-generation.md
@@ -79,3 +79,9 @@ QRBG copied into QRDG, and tombstone-table bytes. Peak working bytes account for
 the simultaneously live inner and outer buffers. Process peak RSS remains a
 separate same-host measurement rather than being inferred from Go allocation
 profiles.
+
+The benchmark fixture defaults remain CI-sized. Same-host production-shape
+captures may set `QUERY_READY_BENCH_BASE_ROWS` and
+`QUERY_READY_BENCH_DELTA_ROWS`; both must be positive integers. For example,
+the M2 evidence used 1,000,000 base rows and 10,000 rows per delta while
+selecting the low-cardinality `N=0`, `N=4`, and `N=8` sub-benchmarks.

--- a/docs/architecture/query-ready-delta-generation.md
+++ b/docs/architecture/query-ready-delta-generation.md
@@ -1,0 +1,81 @@
+# Query-ready delta generations and bounded multipart consolidation
+
+TreeDB's query-ready delta generation (`QRDG` v1) is a rebuildable,
+non-authoritative envelope around M1's validated `QRBG` part container plus a
+deterministic tombstone table. It supplies a physical delta representation and
+a base-plus-delta preparation contract without becoming a WAL record, root,
+recovery selector, primary document store, snapshot registry, or GC/unlink
+owner.
+
+## Visibility and dictionary semantics
+
+`NewQueryReadyBaseDeltaReader` prepares one latest-visible view by decoding the
+selected immutable parts and delegating inserts, updates, deletes,
+same-generation tie-breaking, and tombstone visibility to the existing
+`PartSetReader`. This is preparation state reused by warm lookups; it is not
+claimed as query-independent open state. Persisting that state is owned by M3.
+
+Low-cardinality domains remain part-local. Preparation decodes each local
+dictionary once, and `DictionaryValueAtLatest` resolves a selected code through
+the selected row's part. Thus code reuse such as `0=user` in a base and
+`0=moderator` in a delta retains the correct semantic value without a global
+dictionary construction or code translation. Counters distinguish local
+dictionary decodes from global dictionary constructions and translations.
+
+## Bounds and consolidation
+
+The default policy permits at most four visible delta generations and eight
+accumulated delta-derived parts. The latter is relative to the original base:
+an existing base with any valid part count remains usable at `N=0`. A
+consolidated envelope persists the original-base part count and accumulated
+delta-derived part count; repeated consolidation may only increase the latter.
+Only a later true physical base rewrite may reset that lineage.
+
+Rows and encoded bytes can be bounded with explicit overrides. Decisions and
+the public `QueryReadyDeltaBoundError` report original base parts,
+delta-derived parts already inside a consolidated base, newly visible delta
+parts, total parts, rows, bytes, and the specific generation/part/row/byte
+trigger. Reader preparation and consolidation gate before whole-part decoding
+or output copying, so callers can schedule physical rewrite from structured
+evidence without parsing error text.
+
+M2 consolidation is deliberately a **bounded multipart replacement**, not a
+physical row compaction. It deterministically embeds the old base parts and a
+selected delta prefix in one standalone consolidated QRDG, carries forward the
+latest tombstone per primary ID, and records lineage. Reopen without the
+consumed deltas preserves visibility, including deletes, dictionary domains,
+nullable state, and same-generation part-ID tie-breaking. Old base/delta
+objects remain independently usable by old snapshots. The output generation
+must equal the highest consumed prefix generation (or the unchanged base
+generation when no delta is consumed), preventing an envelope from claiming a
+gap it did not consume.
+
+The multipart bound is fail-closed. When accumulated delta-derived work reaches
+the configured ceiling, M2 exposes a **physical-rewrite-required** condition;
+another multipart consolidation cannot relieve the bound. It does not fall
+back to document scans, silently reset lineage, or emit an immediately unusable
+replacement. M4 may replace this multipart execution with a true encoded
+physical rewrite.
+
+## Measurement contract
+
+Focused benchmarks separate preparation from warm reused lookup:
+
+- `BenchmarkQueryReadyBaseDeltaPrepareCurve` covers `N=0,1,2,4,8,9`, low- and
+  high-cardinality domains, tombstone-heavy deltas, and nullable mixed
+  update/delete/reinsert generations;
+- `BenchmarkQueryReadyBaseDeltaWarmLookup` measures lookup after preparation;
+- `BenchmarkQueryReadyBaseDeltaConsolidation` reports write amplification and
+  peak simultaneous inner-plus-outer working bytes;
+- `BenchmarkQueryReadyDeltaGenerationBuild` compares validated typed-part
+  container production with QRDG envelope production.
+
+Run them on one host with `-benchmem -count=5`. The checked-in default of eight
+accumulated delta-derived parts is the last allowed point on the required
+`N=0..8` curve; `N=9` is the explicit beyond-bound point. The generation limit
+of four triggers earlier for the ordinary default query path. Build/consolidate
+copy counters include typed-column images copied into the inner QRBG, the inner
+QRBG copied into QRDG, and tombstone-table bytes. Peak working bytes account for
+the simultaneously live inner and outer buffers. Process peak RSS remains a
+separate same-host measurement rather than being inferred from Go allocation
+profiles.


### PR DESCRIPTION
Closes #3697.
Depends on merged #3696 and contract #3695.

## What lands

- QRDG v1 derived envelope with exact generation/schema validation, CRC-protected tombstones, embedded QRBG validation, and fail-closed lineage.
- Snapshot-correct base-plus-delta inserts, updates, deletes, reinserts, nullable transitions, same-generation tie-breaking, and old/new snapshot coexistence.
- Part-local low-cardinality semantics, including intentional cross-part code collisions, without global dictionary construction or code translation.
- Observable default bounds: four currently visible delta generations and eight accumulated delta-derived parts, relative to any original base size.
- Deterministic standalone multipart consolidation with carried tombstones/lineage; repeated growth fails closed with a typed decision. Only a later physical rewrite may reset lineage.
- Canonical storage-format and architecture documentation. No root publisher, recovery selector, WAL/GC owner, or unified document segment.

## Test-first evidence

The initial issue-named suite was captured red before implementation because the QRDG build/open/reader/consolidation APIs did not exist. The preserved transcript is under `/mnt/fast4tb/gomap_graph_3694/m2_evidence/red_query_ready_delta.txt` on the execution host.

Coverage now includes deterministic issue-named tests, randomized model parity, empty deltas, repeated delete/reinsert, tombstones, divergent dictionary domains, 255/256 code and granule boundaries, corruption/truncation/order/identity failures, repeated reopened consolidation, generation overclaim, and public generation/part/row/byte trigger evidence.

Latest local gates:

- `GOWORK=off make test` — pass on implementation head (repository-wide, including the Makefile's repeated TreeDB/unified-bench lanes).
- focused tests and full `TreeDB/internal/typedcolumn` tests — pass.
- focused `-race`, `go vet`, formatting/diff checks, and Windows cross-compilation — pass.

## Performance evidence

Performance class: objective with correctness-sensitive consolidation. Production collection mutation/query routing is not wired to QRDG in this milestone, so existing production timing paths are unchanged; the evidence measures derived-asset production, preparation, warm reuse, and consolidation directly.

CI-sized `-benchmem -count=5` N-curves cover N=0/1/2/4/8/9 for low/high-cardinality, tombstone-heavy, and nullable update/delete/reinsert shapes. Representative results:

- low-card preparation: N0 ~193–202 us, 320,784 B/op, 166 allocs; N8 ~358–389 us, 446,849 B/op, 991 allocs; N9 ~361–423 us, 464,721 B/op, 1,098 allocs.
- high-card preparation: N0 ~225 us, 382,848 B/op, 679 allocs; N8 ~820–847 us, 1,005,362 B/op, 5,608 allocs; N9 ~882–932 us, 1,085,282 B/op, 6,228 allocs.
- warm reused dictionary lookup: 326.7–340.4 ns/op, 768 B/op, 2 allocs/op.
- consolidation: 126.8–127.8 us/op, 212,445–212,447 B/op, 433 allocs/op, 1.122x write amplification, 146,742 encoded working bytes.
- derived QRDG build: 50.3–54.6 us/op, 74,448 B/op, 114 allocs/op, versus 30.8–42.2 us/op, 40,024–40,025 B/op, 105 allocs/op for the validated inner part container.
- consolidation-process peak RSS control: 113,920 KB (whole Go test process caveat).

A same-host production-shape control used 1,000,000 base rows plus 10,000 rows per delta, five independent `-benchtime=1x` samples:

- N0: 595–634 ms, ~634–635 MB/op, ~75.3k allocs.
- N4: 602–625 ms, ~640–641 MB/op, ~78.1k allocs.
- N8: 607–698 ms, ~645–646 MB/op, ~80.8k allocs.
- whole-process peak RSS: 1,045,588 KB.

Artifacts are under `/mnt/fast4tb/gomap_graph_3694/m2_evidence` on the execution host. These preparation allocations are intentionally visible transitional debt for M3/M4; this PR does not label them query-independent or encoded-direct execution.
