### PR TITLE
perf(collections): bound query-ready build handoff

### DIFF
--- a/TreeDB/collections/column_asset_manager.go
+++ b/TreeDB/collections/column_asset_manager.go
@@ -1795,7 +1795,7 @@ func (c *columnPhysicalAssetReadCache) trackResourceRead(ref ColumnAssetRef, raw
 func mappedResourceKeyForColumnAssetRef(ref ColumnAssetRef) mappedresource.Key {
 	class := mappedresource.ClassTypedRowAsset
 	switch ref.Kind {
-	case ColumnAssetKindTCS1TypedColumnPart, ColumnAssetKindTCS1AggregateMetadata, ColumnAssetKindTCS1DictionaryCodes, ColumnAssetKindTCS1Int64Values, ColumnAssetKindTCS1HNSWSearchPack:
+	case ColumnAssetKindTCS1TypedColumnPart, ColumnAssetKindTCS1AggregateMetadata, ColumnAssetKindTCS1DictionaryCodes, ColumnAssetKindTCS1Int64Values, ColumnAssetKindTCS1HNSWSearchPack, ColumnAssetKindQueryReadyBase, ColumnAssetKindQueryReadyDelta, ColumnAssetKindQueryReadyConsolidatedBase:
 		class = mappedresource.ClassTypedColumnAsset
 	}
 	return mappedresource.Key{

--- a/TreeDB/collections/column_asset_reachability.go
+++ b/TreeDB/collections/column_asset_reachability.go
@@ -1382,7 +1382,7 @@ func columnAssetReachabilitySegmentPath(segmentDir, name string) string {
 }
 
 func columnAssetReachabilityRefCanContributeRange(ref ColumnAssetRef, namespace string) bool {
-	return (ref.Kind == ColumnAssetKindTCS1PartImage || ref.Kind == ColumnAssetKindTCS1TypedColumnPart || ref.Kind == ColumnAssetKindTCS1AggregateMetadata || ref.Kind == ColumnAssetKindTCS1DictionaryCodes || ref.Kind == ColumnAssetKindTCS1Int64Values || ref.Kind == ColumnAssetKindTCS1HNSWSearchPack) &&
+	return (ref.Kind == ColumnAssetKindTCS1PartImage || ref.Kind == ColumnAssetKindTCS1TypedColumnPart || ref.Kind == ColumnAssetKindTCS1AggregateMetadata || ref.Kind == ColumnAssetKindTCS1DictionaryCodes || ref.Kind == ColumnAssetKindTCS1Int64Values || ref.Kind == ColumnAssetKindTCS1HNSWSearchPack || ref.Kind == ColumnAssetKindQueryReadyBase || ref.Kind == ColumnAssetKindQueryReadyDelta || ref.Kind == ColumnAssetKindQueryReadyConsolidatedBase) &&
 		ref.Namespace == namespace &&
 		ref.Generation != 0 &&
 		ref.PartID != 0 &&

--- a/TreeDB/collections/column_publish_plan.go
+++ b/TreeDB/collections/column_publish_plan.go
@@ -68,6 +68,15 @@ const (
 	// ColumnAssetKindTCS1HNSWSearchPack references one durable
 	// hnsw_search_pack_v1 serving artifact owned by vector-index state.
 	ColumnAssetKindTCS1HNSWSearchPack ColumnAssetKind = "tcs1_hnsw_search_pack"
+	// ColumnAssetKindQueryReadyBase references one rebuildable,
+	// non-authoritative QRBG image held in the existing prepared-asset registry.
+	ColumnAssetKindQueryReadyBase ColumnAssetKind = "query_ready_base_v1"
+	// ColumnAssetKindQueryReadyDelta references one rebuildable,
+	// non-authoritative QRDG delta image held before publication handoff.
+	ColumnAssetKindQueryReadyDelta ColumnAssetKind = "query_ready_delta_v1"
+	// ColumnAssetKindQueryReadyConsolidatedBase references one rebuildable QRDG
+	// consolidated-base image. It does not itself publish or select recovery state.
+	ColumnAssetKindQueryReadyConsolidatedBase ColumnAssetKind = "query_ready_consolidated_base_v1"
 )
 
 // ColumnAssetRef is the durable typed address of a column-asset-manager-owned
@@ -1105,7 +1114,7 @@ func validateColumnManifestPartRoleForAsset(role ColumnManifestPartRole, kind Co
 
 func validateColumnAssetRefForPlan(ref ColumnAssetRef) error {
 	switch ref.Kind {
-	case ColumnAssetKindTCS1PartImage, ColumnAssetKindTCS1TypedColumnPart, ColumnAssetKindTCS1AggregateMetadata, ColumnAssetKindTCS1DictionaryCodes, ColumnAssetKindTCS1Int64Values, ColumnAssetKindTCS1HNSWSearchPack:
+	case ColumnAssetKindTCS1PartImage, ColumnAssetKindTCS1TypedColumnPart, ColumnAssetKindTCS1AggregateMetadata, ColumnAssetKindTCS1DictionaryCodes, ColumnAssetKindTCS1Int64Values, ColumnAssetKindTCS1HNSWSearchPack, ColumnAssetKindQueryReadyBase, ColumnAssetKindQueryReadyDelta, ColumnAssetKindQueryReadyConsolidatedBase:
 	default:
 		if ref.Kind == "" {
 			return errors.New("collections: column asset ref kind is required")

--- a/TreeDB/collections/column_publish_plan.go
+++ b/TreeDB/collections/column_publish_plan.go
@@ -1029,6 +1029,10 @@ func validateColumnPreparedAssetForPlan(asset ColumnPreparedAsset) error {
 	if err := validateColumnAssetRefForPlan(asset.Ref); err != nil {
 		return err
 	}
+	switch asset.Ref.Kind {
+	case ColumnAssetKindQueryReadyBase, ColumnAssetKindQueryReadyDelta, ColumnAssetKindQueryReadyConsolidatedBase:
+		return fmt.Errorf("collections: non-authoritative query-ready asset kind %s cannot enter a manifest publish plan", asset.Ref.Kind)
+	}
 	if asset.Rows < 0 {
 		return fmt.Errorf("collections: column prepared asset rows=%d cannot be negative", asset.Rows)
 	}

--- a/TreeDB/collections/query_ready_build.go
+++ b/TreeDB/collections/query_ready_build.go
@@ -1,0 +1,444 @@
+package collections
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"math"
+	"sync"
+	"time"
+
+	"github.com/snissn/gomap/TreeDB/internal/typedcolumn"
+)
+
+// Query-ready generations remain rebuildable prepared assets. This bridge
+// deliberately uses the existing column asset manager and prepared-asset
+// lifecycle registry; it does not publish a root, select recovery state, or
+// claim deletion ownership.
+const (
+	queryReadyBaseAssetPartID             = uint64(0x51524201)
+	queryReadyDeltaAssetPartID            = uint64(0x51524401)
+	queryReadyConsolidatedBaseAssetPartID = uint64(0x51524301)
+)
+
+type queryReadyBuildKind uint8
+
+const (
+	queryReadyBuildBase queryReadyBuildKind = iota + 1
+	queryReadyBuildDelta
+	queryReadyBuildConsolidatedBase
+)
+
+type queryReadyBuildRequest struct {
+	Kind              queryReadyBuildKind
+	Identity          typedcolumn.QueryReadyBaseIdentity
+	Parts             []typedcolumn.QueryReadyBasePartInput
+	Tombstones        []typedcolumn.Tombstone
+	Base              *typedcolumn.QueryReadyBaseGeneration
+	Deltas            []*typedcolumn.QueryReadyDeltaGeneration
+	ThroughGeneration uint64
+	Bound             typedcolumn.QueryReadyDeltaBoundPolicy
+}
+
+type queryReadyBuildLimits struct {
+	MaxWorkers       int
+	MaxInFlightBytes int64
+}
+
+// QueryReadyBuildBoundError is returned before output allocation when one
+// request cannot fit its per-worker share of the configured in-flight bound.
+type QueryReadyBuildBoundError struct {
+	RequiredBytes int64
+	MaxBytes      int64
+	MaxWorkers    int
+}
+
+// QueryReadyBuildBackpressureError reports the deliberate zero-queue
+// admission policy. Callers retry or schedule externally; this coordinator
+// never grows an internal request queue.
+type QueryReadyBuildBackpressureError struct {
+	MaxWorkers int
+}
+
+func (e *QueryReadyBuildBackpressureError) Error() string {
+	return fmt.Sprintf("collections: query-ready build workers saturated (max=%d, queue=0)", e.MaxWorkers)
+}
+
+func (e *QueryReadyBuildBoundError) Error() string {
+	if e == nil {
+		return "collections: query-ready build bound exceeded"
+	}
+	return fmt.Sprintf("collections: query-ready build requires %d in-flight bytes; per-worker bound is %d with %d workers", e.RequiredBytes, e.MaxBytes, e.MaxWorkers)
+}
+
+type queryReadyBuildCoordinatorStats struct {
+	ActiveWorkers       int
+	PeakWorkers         int
+	InFlightBytes       int64
+	PeakInFlight        int64
+	BoundRejections     int64
+	AdmissionRejections int64
+	MaxQueueDepth       int
+}
+
+type queryReadyBuildCoordinator struct {
+	collection     *Collection
+	limits         queryReadyBuildLimits
+	slots          chan struct{}
+	beforeRegister func()
+	afterAdmission func()
+
+	mu         sync.Mutex
+	statsValue queryReadyBuildCoordinatorStats
+}
+
+func newQueryReadyBuildCoordinator(collection *Collection, limits queryReadyBuildLimits) (*queryReadyBuildCoordinator, error) {
+	if collection == nil || collection.db == nil {
+		return nil, errors.New("collections: query-ready build requires an open collection")
+	}
+	if limits.MaxWorkers <= 0 {
+		return nil, errors.New("collections: query-ready build max workers must be positive")
+	}
+	if limits.MaxInFlightBytes <= 0 || limits.MaxInFlightBytes < int64(limits.MaxWorkers) {
+		return nil, errors.New("collections: query-ready build max in-flight bytes must cover every worker")
+	}
+	return &queryReadyBuildCoordinator{collection: collection, limits: limits, slots: make(chan struct{}, limits.MaxWorkers)}, nil
+}
+
+func (c *queryReadyBuildCoordinator) stats() queryReadyBuildCoordinatorStats {
+	if c == nil {
+		return queryReadyBuildCoordinatorStats{}
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.statsValue
+}
+
+type queryReadyBuildStats struct {
+	Kind                       queryReadyBuildKind
+	Rows                       int64
+	InputBytes                 int64
+	OutputBytes                int64
+	BytesCopied                int64
+	BytesCompressed            int64
+	BytesHashed                int64
+	BytesChecksummed           int64
+	BaseBytesRewritten         int64
+	AssetsProduced             int
+	PartsProduced              int
+	WriteAmplification         float64
+	ReservedInFlightBytes      int64
+	EncodedBufferPeakBytes     int64
+	EstimatedPeakInFlightBytes int64
+	WorkerLimit                int
+	QueueCapacity              int
+	QueueWaitTime              time.Duration
+	BaseBuildTime              time.Duration
+	DeltaBuildTime             time.Duration
+	ConsolidationTime          time.Duration
+	AssetPreparationTime       time.Duration
+	ManagerRegistrationTime    time.Duration
+	HandoffTime                time.Duration
+	TotalTime                  time.Duration
+}
+
+type queryReadyPreparedGeneration struct {
+	Asset        ColumnPreparedAsset
+	Identity     typedcolumn.QueryReadyBaseIdentity
+	AssetPath    string
+	Dependencies []typedcolumn.QueryReadyBaseDependency
+	Stats        queryReadyBuildStats
+	lease        *ColumnAssetLifecycleRegistryLease
+	rootDir      string
+
+	mu      sync.Mutex
+	aborted bool
+}
+
+// OpenFileDescriptor returns M3's exact immutable byte-range descriptor. It
+// translates the existing asset-manager kind once at the M5/M3 handoff, so
+// callers do not rediscover a current lane by pathname. The asset-manager
+// checksum remains available on Asset.Ref and binds this same selected range.
+func (p *queryReadyPreparedGeneration) OpenFileDescriptor() (typedcolumn.QueryReadyGenerationFile, error) {
+	if p == nil {
+		return typedcolumn.QueryReadyGenerationFile{}, errors.New("collections: nil query-ready prepared generation")
+	}
+	var kind typedcolumn.QueryReadyGenerationKind
+	switch p.Asset.Ref.Kind {
+	case ColumnAssetKindQueryReadyBase:
+		kind = typedcolumn.QueryReadyGenerationBase
+	case ColumnAssetKindQueryReadyDelta:
+		kind = typedcolumn.QueryReadyGenerationDelta
+	case ColumnAssetKindQueryReadyConsolidatedBase:
+		kind = typedcolumn.QueryReadyGenerationConsolidatedBase
+	default:
+		return typedcolumn.QueryReadyGenerationFile{}, fmt.Errorf("collections: unsupported query-ready asset kind %q", p.Asset.Ref.Kind)
+	}
+	return typedcolumn.QueryReadyGenerationFile{
+		Path: p.AssetPath, Offset: p.Asset.Ref.Offset, Length: p.Asset.Ref.Length,
+		Kind: kind, Identity: p.Identity,
+	}, nil
+}
+
+// Abort releases the prepared-asset registration and reclaims the just-written
+// tail when it is still safe. It never deletes a published or interleaved
+// asset; those remain with the existing reachability/GC owners.
+func (p *queryReadyPreparedGeneration) Abort() error {
+	if p == nil {
+		return nil
+	}
+	p.mu.Lock()
+	if p.aborted {
+		p.mu.Unlock()
+		return nil
+	}
+	p.aborted = true
+	lease := p.lease
+	p.lease = nil
+	asset := p.Asset
+	rootDir := p.rootDir
+	p.mu.Unlock()
+	var releaseErr error
+	if lease != nil {
+		releaseErr = lease.Close()
+	}
+	return errors.Join(releaseErr, cleanupColumnPreparedAssets(rootDir, []ColumnPreparedAsset{asset}))
+}
+
+func (c *queryReadyBuildCoordinator) prepare(ctx context.Context, request queryReadyBuildRequest) (_ *queryReadyPreparedGeneration, retErr error) {
+	started := time.Now()
+	if c == nil || c.collection == nil || c.collection.db == nil {
+		return nil, errors.New("collections: nil query-ready build coordinator")
+	}
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	required, err := estimateQueryReadyBuildWorkingBytes(request)
+	if err != nil {
+		return nil, err
+	}
+	if request.Kind == queryReadyBuildConsolidatedBase {
+		expected := typedcolumn.QueryReadyBaseIdentity{Generation: request.ThroughGeneration, SchemaHash: request.Base.Identity.SchemaHash}
+		if request.Identity != expected {
+			return nil, fmt.Errorf("collections: query-ready consolidation identity=%+v want %+v", request.Identity, expected)
+		}
+	}
+	perWorker := c.limits.MaxInFlightBytes / int64(c.limits.MaxWorkers)
+	if required > perWorker {
+		c.mu.Lock()
+		c.statsValue.BoundRejections++
+		c.mu.Unlock()
+		return nil, &QueryReadyBuildBoundError{RequiredBytes: required, MaxBytes: perWorker, MaxWorkers: c.limits.MaxWorkers}
+	}
+	select {
+	case c.slots <- struct{}{}:
+	default:
+		c.mu.Lock()
+		c.statsValue.AdmissionRejections++
+		c.mu.Unlock()
+		return nil, &QueryReadyBuildBackpressureError{MaxWorkers: c.limits.MaxWorkers}
+	}
+	queueWait := time.Duration(0)
+	c.mu.Lock()
+	c.statsValue.ActiveWorkers++
+	c.statsValue.InFlightBytes += required
+	if c.statsValue.ActiveWorkers > c.statsValue.PeakWorkers {
+		c.statsValue.PeakWorkers = c.statsValue.ActiveWorkers
+	}
+	if c.statsValue.InFlightBytes > c.statsValue.PeakInFlight {
+		c.statsValue.PeakInFlight = c.statsValue.InFlightBytes
+	}
+	c.mu.Unlock()
+	if c.afterAdmission != nil {
+		c.afterAdmission()
+	}
+	defer func() {
+		c.mu.Lock()
+		c.statsValue.ActiveWorkers--
+		c.statsValue.InFlightBytes -= required
+		c.mu.Unlock()
+		<-c.slots
+	}()
+
+	stats := queryReadyBuildStats{
+		Kind: request.Kind, ReservedInFlightBytes: required, EstimatedPeakInFlightBytes: required, WorkerLimit: c.limits.MaxWorkers,
+		QueueCapacity: 0, QueueWaitTime: queueWait,
+	}
+	var payload []byte
+	var dependencies []typedcolumn.QueryReadyBaseDependency
+	var kind ColumnAssetKind
+	var partID uint64
+	switch request.Kind {
+	case queryReadyBuildBase:
+		built, err := typedcolumn.BuildQueryReadyBaseGeneration(request.Identity, request.Parts)
+		if err != nil {
+			return nil, err
+		}
+		payload, dependencies = built.Bytes, built.Dependencies
+		kind, partID = ColumnAssetKindQueryReadyBase, queryReadyBaseAssetPartID
+		stats.Rows, stats.InputBytes, stats.OutputBytes = built.Stats.Rows, built.Stats.InputBytes, built.Stats.OutputBytes
+		stats.BytesCopied, stats.BytesHashed, stats.BytesChecksummed = built.Stats.BytesCopied, built.Stats.BytesHashed, built.Stats.BytesChecksummed
+		stats.EncodedBufferPeakBytes, stats.BaseBuildTime = built.Stats.OutputBytes, built.Stats.BuildTime
+	case queryReadyBuildDelta:
+		built, err := typedcolumn.BuildQueryReadyDeltaGeneration(request.Identity, request.Parts, request.Tombstones)
+		if err != nil {
+			return nil, err
+		}
+		payload, dependencies = built.Bytes, built.Dependencies
+		kind, partID = ColumnAssetKindQueryReadyDelta, queryReadyDeltaAssetPartID
+		stats.Rows, stats.InputBytes, stats.OutputBytes = built.Stats.Rows, built.Stats.InputBytes, built.Stats.OutputBytes
+		stats.BytesCopied, stats.BytesCompressed, stats.BytesHashed, stats.BytesChecksummed = built.Stats.BytesCopied, built.Stats.BytesCompressed, built.Stats.BytesHashed, built.Stats.BytesChecksummed
+		stats.EncodedBufferPeakBytes, stats.WriteAmplification = built.Stats.PeakEncodedBufferBytes, built.Stats.WriteAmplification
+		stats.BaseBuildTime, stats.DeltaBuildTime = built.Stats.BaseBuildTime, built.Stats.BuildTime
+	case queryReadyBuildConsolidatedBase:
+		policy := request.Bound
+		if policy == (typedcolumn.QueryReadyDeltaBoundPolicy{}) {
+			policy = typedcolumn.DefaultQueryReadyDeltaBoundPolicy()
+		}
+		built, err := typedcolumn.ConsolidateQueryReadyBaseDeltaWithPolicy(request.Base, request.Deltas, request.ThroughGeneration, policy)
+		if err != nil {
+			return nil, err
+		}
+		payload, dependencies = built.Bytes, built.Dependencies
+		kind, partID = ColumnAssetKindQueryReadyConsolidatedBase, queryReadyConsolidatedBaseAssetPartID
+		stats.Rows, stats.InputBytes, stats.OutputBytes = built.Stats.RowsMerged, built.Stats.InputBytes, built.Stats.OutputBytes
+		stats.BytesCopied, stats.BytesHashed, stats.BytesChecksummed, stats.EncodedBufferPeakBytes = built.Stats.BytesCopied, built.Stats.BytesHashed, built.Stats.BytesChecksummed, built.Stats.PeakEncodedBufferBytes
+		stats.WriteAmplification, stats.ConsolidationTime = built.Stats.WriteAmplification, built.Stats.BuildTime
+	default:
+		return nil, fmt.Errorf("collections: unsupported query-ready build kind %d", request.Kind)
+	}
+	if stats.EncodedBufferPeakBytes > required {
+		return nil, fmt.Errorf("collections: query-ready encoded buffer used %d bytes above reserved bound %d", stats.EncodedBufferPeakBytes, required)
+	}
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+
+	meta := c.collection.Meta()
+	if meta.Options.ColumnStore == nil || meta.Options.ColumnStore.AssetManager == nil {
+		return nil, errors.New("collections: query-ready build requires existing column asset manager")
+	}
+	prepareStarted := time.Now()
+	ref, err := writeColumnAssetToManager(c.collection.db.ColumnAssetRootDir(), *meta.Options.ColumnStore, payload, kind, request.Identity.Generation, partID)
+	stats.AssetPreparationTime = time.Since(prepareStarted)
+	if err != nil {
+		return nil, err
+	}
+	asset := ColumnPreparedAsset{Ref: ref, Rows: queryReadyRowsAsInt(stats.Rows), Bytes: int64(len(payload)), GenerationID: request.Identity.Generation, Reason: "query_ready_build"}
+	assetPath, err := columnAssetSegmentPath(c.collection.db.ColumnAssetRootDir(), ref)
+	if err != nil {
+		return nil, err
+	}
+	stats.BytesChecksummed += int64(len(payload))
+	cleanup := true
+	defer func() {
+		if retErr != nil && cleanup {
+			retErr = errors.Join(retErr, cleanupColumnPreparedAssets(c.collection.db.ColumnAssetRootDir(), []ColumnPreparedAsset{asset}))
+		}
+	}()
+	if c.beforeRegister != nil {
+		c.beforeRegister()
+	}
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	registerStarted := time.Now()
+	lease, err := c.collection.RegisterColumnAssetPreparedAssets(ColumnAssetPreparedAssetRegistrationOptions{
+		Owner: fmt.Sprintf("query-ready-generation-%d", request.Identity.Generation), Source: "query_ready_build", Reason: "rebuildable non-authoritative generation", Refs: []ColumnAssetRef{ref},
+	})
+	stats.ManagerRegistrationTime = time.Since(registerStarted)
+	if err != nil {
+		return nil, err
+	}
+	stats.AssetsProduced, stats.PartsProduced = 1, len(dependencies)
+	stats.HandoffTime = stats.AssetPreparationTime + stats.ManagerRegistrationTime
+	stats.TotalTime = time.Since(started)
+	cleanup = false
+	return &queryReadyPreparedGeneration{Asset: asset, Identity: request.Identity, AssetPath: assetPath, Dependencies: append([]typedcolumn.QueryReadyBaseDependency(nil), dependencies...), Stats: stats, lease: lease, rootDir: c.collection.db.ColumnAssetRootDir()}, nil
+}
+
+func estimateQueryReadyBuildWorkingBytes(request queryReadyBuildRequest) (int64, error) {
+	// These estimates intentionally cover allocations created after admission,
+	// not the immutable input images already owned by the caller. In addition to
+	// the encoded output they reserve space for validation/build plans, stable
+	// dependencies, consolidation input views, selection metadata, and
+	// tombstone normalization maps/slices. They are conservative rather than a
+	// claim about exact Go heap use.
+	const (
+		fixedBuildBytes       = int64(64 << 10)
+		perPartMetadataBytes  = int64(1024)
+		perDeltaMetadataBytes = int64(256)
+		perTombstoneBytes     = int64(256)
+		perPartAlignmentBytes = int64(64)
+	)
+	add := func(total, value int64) (int64, error) {
+		if value < 0 || total > math.MaxInt64-value {
+			return 0, errors.New("collections: query-ready build size overflow")
+		}
+		return total + value, nil
+	}
+	total := fixedBuildBytes
+	addPart := func(imageBytes int) error {
+		var err error
+		total, err = add(total, int64(imageBytes)+perPartAlignmentBytes+perPartMetadataBytes)
+		return err
+	}
+	tombstones := int64(len(request.Tombstones))
+	if request.Kind == queryReadyBuildConsolidatedBase {
+		if request.Base == nil {
+			return 0, errors.New("collections: query-ready consolidation requires base")
+		}
+		for _, view := range request.Base.Parts {
+			if err := addPart(len(view.Image.Bytes)); err != nil {
+				return 0, err
+			}
+		}
+		for _, delta := range request.Deltas {
+			if delta == nil || delta.Base == nil {
+				return 0, errors.New("collections: query-ready consolidation has nil delta")
+			}
+			var err error
+			total, err = add(total, perDeltaMetadataBytes)
+			if err != nil {
+				return 0, err
+			}
+			for _, view := range delta.Base.Parts {
+				if err := addPart(len(view.Image.Bytes)); err != nil {
+					return 0, err
+				}
+			}
+			if int64(len(delta.Tombstones)) > math.MaxInt64-tombstones {
+				return 0, errors.New("collections: query-ready build tombstone count overflow")
+			}
+			tombstones += int64(len(delta.Tombstones))
+		}
+	} else {
+		for _, part := range request.Parts {
+			if err := addPart(len(part.Image.Bytes)); err != nil {
+				return 0, err
+			}
+		}
+	}
+	if request.Kind != queryReadyBuildBase {
+		if tombstones > math.MaxInt64/perTombstoneBytes {
+			return 0, errors.New("collections: query-ready build tombstone size overflow")
+		}
+		var err error
+		total, err = add(total, fixedBuildBytes+tombstones*perTombstoneBytes)
+		if err != nil {
+			return 0, err
+		}
+	}
+	return total, nil
+}
+
+func queryReadyRowsAsInt(rows int64) int {
+	if rows <= 0 {
+		return 0
+	}
+	maxInt := int(^uint(0) >> 1)
+	if rows > int64(maxInt) {
+		return maxInt
+	}
+	return int(rows)
+}

--- a/TreeDB/collections/query_ready_build.go
+++ b/TreeDB/collections/query_ready_build.go
@@ -397,6 +397,12 @@ func estimateQueryReadyBuildWorkingBytes(request queryReadyBuildRequest) (int64,
 			if delta == nil || delta.Base == nil {
 				return 0, errors.New("collections: query-ready consolidation has nil delta")
 			}
+			// Consolidation validates the full inventory but only builds the
+			// prefix visible through ThroughGeneration. Future payloads must not
+			// consume admission capacity for an older selected prefix.
+			if delta.Identity.Generation > request.ThroughGeneration {
+				continue
+			}
 			var err error
 			total, err = add(total, perDeltaMetadataBytes)
 			if err != nil {

--- a/TreeDB/collections/query_ready_build.go
+++ b/TreeDB/collections/query_ready_build.go
@@ -35,6 +35,7 @@ type queryReadyBuildRequest struct {
 	Parts             []typedcolumn.QueryReadyBasePartInput
 	Tombstones        []typedcolumn.Tombstone
 	Base              *typedcolumn.QueryReadyBaseGeneration
+	ConsolidatedBase  *typedcolumn.QueryReadyDeltaGeneration
 	Deltas            []*typedcolumn.QueryReadyDeltaGeneration
 	ThroughGeneration uint64
 	Bound             typedcolumn.QueryReadyDeltaBoundPolicy
@@ -218,7 +219,11 @@ func (c *queryReadyBuildCoordinator) prepare(ctx context.Context, request queryR
 		return nil, err
 	}
 	if request.Kind == queryReadyBuildConsolidatedBase {
-		expected := typedcolumn.QueryReadyBaseIdentity{Generation: request.ThroughGeneration, SchemaHash: request.Base.Identity.SchemaHash}
+		base, _, err := queryReadyConsolidationBase(request)
+		if err != nil {
+			return nil, err
+		}
+		expected := typedcolumn.QueryReadyBaseIdentity{Generation: request.ThroughGeneration, SchemaHash: base.Identity.SchemaHash}
 		if request.Identity != expected {
 			return nil, fmt.Errorf("collections: query-ready consolidation identity=%+v want %+v", request.Identity, expected)
 		}
@@ -295,7 +300,13 @@ func (c *queryReadyBuildCoordinator) prepare(ctx context.Context, request queryR
 		if policy == (typedcolumn.QueryReadyDeltaBoundPolicy{}) {
 			policy = typedcolumn.DefaultQueryReadyDeltaBoundPolicy()
 		}
-		built, err := typedcolumn.ConsolidateQueryReadyBaseDeltaWithPolicy(request.Base, request.Deltas, request.ThroughGeneration, policy)
+		var built typedcolumn.QueryReadyConsolidationResult
+		var err error
+		if request.ConsolidatedBase != nil {
+			built, err = typedcolumn.ConsolidateQueryReadyConsolidatedBaseDeltaWithPolicy(request.ConsolidatedBase, request.Deltas, request.ThroughGeneration, policy)
+		} else {
+			built, err = typedcolumn.ConsolidateQueryReadyBaseDeltaWithPolicy(request.Base, request.Deltas, request.ThroughGeneration, policy)
+		}
 		if err != nil {
 			return nil, err
 		}
@@ -385,10 +396,12 @@ func estimateQueryReadyBuildWorkingBytes(request queryReadyBuildRequest) (int64,
 	}
 	tombstones := int64(len(request.Tombstones))
 	if request.Kind == queryReadyBuildConsolidatedBase {
-		if request.Base == nil {
-			return 0, errors.New("collections: query-ready consolidation requires base")
+		base, inheritedTombstones, err := queryReadyConsolidationBase(request)
+		if err != nil {
+			return 0, err
 		}
-		for _, view := range request.Base.Parts {
+		tombstones = int64(len(inheritedTombstones))
+		for _, view := range base.Parts {
 			if err := addPart(len(view.Image.Bytes)); err != nil {
 				return 0, err
 			}
@@ -436,6 +449,28 @@ func estimateQueryReadyBuildWorkingBytes(request queryReadyBuildRequest) (int64,
 		}
 	}
 	return total, nil
+}
+
+func queryReadyConsolidationBase(request queryReadyBuildRequest) (*typedcolumn.QueryReadyBaseGeneration, []typedcolumn.Tombstone, error) {
+	if request.Base != nil && request.ConsolidatedBase != nil {
+		return nil, nil, errors.New("collections: query-ready consolidation requires exactly one base kind")
+	}
+	if request.ConsolidatedBase != nil {
+		if request.ConsolidatedBase.Kind != typedcolumn.QueryReadyGenerationConsolidatedBase || request.ConsolidatedBase.Base == nil {
+			return nil, nil, errors.New("collections: query-ready consolidation has invalid consolidated base")
+		}
+		if len(request.Tombstones) != 0 {
+			return nil, nil, errors.New("collections: query-ready consolidation tombstones must come from consolidated base")
+		}
+		return request.ConsolidatedBase.Base, request.ConsolidatedBase.Tombstones, nil
+	}
+	if request.Base == nil {
+		return nil, nil, errors.New("collections: query-ready consolidation requires base")
+	}
+	if len(request.Tombstones) != 0 {
+		return nil, nil, errors.New("collections: inherited tombstones require consolidated base")
+	}
+	return request.Base, nil, nil
 }
 
 func queryReadyRowsAsInt(rows int64) int {

--- a/TreeDB/collections/query_ready_build_test.go
+++ b/TreeDB/collections/query_ready_build_test.go
@@ -332,6 +332,80 @@ func TestQueryReadyConsolidationBuildMatchesSnapshot(t *testing.T) {
 	}
 }
 
+func TestQueryReadyConsolidationPreservesInheritedTombstones(t *testing.T) {
+	d, col, baseIdentity, baseParts := queryReadyBuildFixture(t, 14)
+	defer func() { _ = d.Close() }()
+	baseBuilt, err := typedcolumn.BuildQueryReadyBaseGeneration(baseIdentity, baseParts)
+	if err != nil {
+		t.Fatalf("build base: %v", err)
+	}
+	base, err := typedcolumn.OpenQueryReadyBaseGeneration(baseBuilt.Bytes, baseIdentity)
+	if err != nil {
+		t.Fatalf("open base: %v", err)
+	}
+	secondIdentity := baseIdentity
+	secondIdentity.Generation++
+	secondBuilt, err := typedcolumn.BuildQueryReadyDeltaGeneration(secondIdentity, nil, []typedcolumn.Tombstone{{PrimaryID: 2, GenerationID: secondIdentity.Generation}})
+	if err != nil {
+		t.Fatalf("build second generation: %v", err)
+	}
+	second, err := typedcolumn.OpenQueryReadyDeltaGeneration(secondBuilt.Bytes, secondIdentity)
+	if err != nil {
+		t.Fatalf("open second generation: %v", err)
+	}
+	firstConsolidation, err := typedcolumn.ConsolidateQueryReadyBaseDelta(base, []*typedcolumn.QueryReadyDeltaGeneration{second}, secondIdentity.Generation)
+	if err != nil {
+		t.Fatalf("first consolidation: %v", err)
+	}
+	consolidated, err := typedcolumn.OpenQueryReadyConsolidatedBaseGeneration(firstConsolidation.Bytes, secondIdentity)
+	if err != nil {
+		t.Fatalf("open first consolidation: %v", err)
+	}
+	thirdIdentity := secondIdentity
+	thirdIdentity.Generation++
+	thirdImage := queryReadyBuildImage(t, thirdIdentity.Generation, []int64{1}, []int64{100})
+	thirdBuilt, err := typedcolumn.BuildQueryReadyDeltaGeneration(thirdIdentity, []typedcolumn.QueryReadyBasePartInput{{SourceGeneration: thirdIdentity.Generation, Image: thirdImage}}, nil)
+	if err != nil {
+		t.Fatalf("build third generation: %v", err)
+	}
+	third, err := typedcolumn.OpenQueryReadyDeltaGeneration(thirdBuilt.Bytes, thirdIdentity)
+	if err != nil {
+		t.Fatalf("open third generation: %v", err)
+	}
+	coordinator, err := newQueryReadyBuildCoordinator(col, queryReadyBuildLimits{MaxWorkers: 1, MaxInFlightBytes: 16 << 20})
+	if err != nil {
+		t.Fatal(err)
+	}
+	prepared, err := coordinator.prepare(context.Background(), queryReadyBuildRequest{
+		Kind: queryReadyBuildConsolidatedBase, Identity: thirdIdentity,
+		ConsolidatedBase: consolidated,
+		Deltas:           []*typedcolumn.QueryReadyDeltaGeneration{third}, ThroughGeneration: thirdIdentity.Generation,
+	})
+	if err != nil {
+		t.Fatalf("prepare reconsolidation: %v", err)
+	}
+	defer func() { _ = prepared.Abort() }()
+	raw, err := os.ReadFile(prepared.AssetPath)
+	if err != nil {
+		t.Fatalf("read prepared reconsolidation: %v", err)
+	}
+	start, end := prepared.Asset.Ref.Offset, prepared.Asset.Ref.Offset+prepared.Asset.Ref.Length
+	reconsolidated, err := typedcolumn.OpenQueryReadyConsolidatedBaseGeneration(raw[start:end], thirdIdentity)
+	if err != nil {
+		t.Fatalf("open prepared reconsolidation: %v", err)
+	}
+	if reconsolidated.OriginBaseParts != consolidated.OriginBaseParts || reconsolidated.AccumulatedDeltaParts != consolidated.AccumulatedDeltaParts+len(third.Base.Parts) || len(reconsolidated.Tombstones) != 1 {
+		t.Fatalf("reconsolidated lineage/tombstones=%d/%d/%v", reconsolidated.OriginBaseParts, reconsolidated.AccumulatedDeltaParts, reconsolidated.Tombstones)
+	}
+	reader, err := typedcolumn.NewQueryReadyConsolidatedBaseDeltaReader(reconsolidated, nil, typedcolumn.QueryReadyBaseDeltaOptions{SnapshotGeneration: thirdIdentity.Generation, Bound: typedcolumn.QueryReadyDeltaBoundPolicy{MaxVisibleGenerations: 4, MaxAccumulatedDeltaParts: 8}})
+	if err != nil {
+		t.Fatalf("prepare reconsolidated reader: %v", err)
+	}
+	if value, ok, err := reader.ValueAtLatest(2, "value"); err != nil || ok {
+		t.Fatalf("inherited deletion resurrected: value=%d ok=%v err=%v tombstones=%v", value, ok, err, reconsolidated.Tombstones)
+	}
+}
+
 func TestQueryReadyConsolidationRejectsDescriptorIdentityMismatchBeforeAdmission(t *testing.T) {
 	d, col, identity, parts := queryReadyBuildFixture(t, 13)
 	defer func() { _ = d.Close() }()

--- a/TreeDB/collections/query_ready_build_test.go
+++ b/TreeDB/collections/query_ready_build_test.go
@@ -165,6 +165,52 @@ func TestQueryReadyConsolidationBoundRejectionDoesNotAllocatePlanningSlice(t *te
 	}
 }
 
+func TestQueryReadyConsolidationAdmissionIgnoresFutureDeltaPayloads(t *testing.T) {
+	d, col, identity, parts := queryReadyBuildFixture(t, 92)
+	defer func() { _ = d.Close() }()
+	built, err := typedcolumn.BuildQueryReadyBaseGeneration(identity, parts)
+	if err != nil {
+		t.Fatalf("build base: %v", err)
+	}
+	base, err := typedcolumn.OpenQueryReadyBaseGeneration(built.Bytes, identity)
+	if err != nil {
+		t.Fatalf("open base: %v", err)
+	}
+	largeViews := make([]typedcolumn.QueryReadyBasePartView, 4096)
+	for i := range largeViews {
+		largeViews[i] = base.Parts[0]
+	}
+	futureIdentity := identity
+	futureIdentity.Generation++
+	future := &typedcolumn.QueryReadyDeltaGeneration{
+		Kind:     typedcolumn.QueryReadyGenerationDelta,
+		Identity: futureIdentity,
+		Base:     &typedcolumn.QueryReadyBaseGeneration{Identity: futureIdentity, Parts: largeViews},
+	}
+	request := queryReadyBuildRequest{
+		Kind: queryReadyBuildConsolidatedBase, Identity: identity, Base: base,
+		Deltas: []*typedcolumn.QueryReadyDeltaGeneration{future}, ThroughGeneration: identity.Generation,
+	}
+	baseOnlyRequired, err := estimateQueryReadyBuildWorkingBytes(queryReadyBuildRequest{
+		Kind: queryReadyBuildConsolidatedBase, Identity: identity, Base: base, ThroughGeneration: identity.Generation,
+	})
+	if err != nil {
+		t.Fatalf("estimate base-only consolidation: %v", err)
+	}
+	coordinator, err := newQueryReadyBuildCoordinator(col, queryReadyBuildLimits{MaxWorkers: 1, MaxInFlightBytes: baseOnlyRequired})
+	if err != nil {
+		t.Fatal(err)
+	}
+	prepared, err := coordinator.prepare(context.Background(), request)
+	if err != nil {
+		t.Fatalf("future delta payload rejected selected-prefix consolidation: %v", err)
+	}
+	defer func() { _ = prepared.Abort() }()
+	if prepared.Stats.ReservedInFlightBytes != baseOnlyRequired || len(prepared.Dependencies) != len(base.Parts) {
+		t.Fatalf("prepared future-filtered consolidation stats=%+v dependencies=%d", prepared.Stats, len(prepared.Dependencies))
+	}
+}
+
 func TestQueryReadyBuildZeroQueueBackpressureBoundsConcurrentWorkers(t *testing.T) {
 	d, col, identity, parts := queryReadyBuildFixture(t, 11)
 	defer func() { _ = d.Close() }()

--- a/TreeDB/collections/query_ready_build_test.go
+++ b/TreeDB/collections/query_ready_build_test.go
@@ -1,0 +1,399 @@
+package collections
+
+import (
+	"context"
+	"crypto/sha256"
+	"errors"
+	"os"
+	"slices"
+	"sync"
+	"testing"
+
+	backenddb "github.com/snissn/gomap/TreeDB/db"
+	"github.com/snissn/gomap/TreeDB/internal/typedcolumn"
+)
+
+func TestQueryReadyBuildProducesDeterministicCompleteAssetSet(t *testing.T) {
+	d, col, identity, parts := queryReadyBuildFixture(t, 7)
+	defer func() { _ = d.Close() }()
+	coordinator, err := newQueryReadyBuildCoordinator(col, queryReadyBuildLimits{MaxWorkers: 1, MaxInFlightBytes: 16 << 20})
+	if err != nil {
+		t.Fatal(err)
+	}
+	first, err := coordinator.prepare(context.Background(), queryReadyBuildRequest{Kind: queryReadyBuildBase, Identity: identity, Parts: parts})
+	if err != nil {
+		t.Fatalf("prepare first: %v", err)
+	}
+	defer func() { _ = first.Abort() }()
+	second, err := coordinator.prepare(context.Background(), queryReadyBuildRequest{Kind: queryReadyBuildBase, Identity: identity, Parts: slices.Clone(parts)})
+	if err != nil {
+		t.Fatalf("prepare second: %v", err)
+	}
+	defer func() { _ = second.Abort() }()
+	if first.Asset.Ref.Kind != ColumnAssetKindQueryReadyBase || first.Asset.Ref.Generation != identity.Generation || first.Asset.Ref.PartID != queryReadyBaseAssetPartID {
+		t.Fatalf("first asset identity=%+v", first.Asset.Ref)
+	}
+	if first.Asset.Ref.Kind != second.Asset.Ref.Kind || first.Asset.Ref.Generation != second.Asset.Ref.Generation || first.Asset.Ref.PartID != second.Asset.Ref.PartID || first.Asset.Ref.Length != second.Asset.Ref.Length || first.Asset.Ref.Checksum != second.Asset.Ref.Checksum {
+		t.Fatalf("logical asset set is not deterministic: first=%+v second=%+v", first.Asset.Ref, second.Asset.Ref)
+	}
+	descriptor, err := second.OpenFileDescriptor()
+	if err != nil {
+		t.Fatalf("open-file descriptor: %v", err)
+	}
+	if descriptor.Path == "" || descriptor.Offset <= 0 || descriptor.Length != second.Asset.Ref.Length || descriptor.Identity != identity || descriptor.Kind != typedcolumn.QueryReadyGenerationBase {
+		t.Fatalf("incomplete nonzero-range descriptor: %+v", descriptor)
+	}
+	if !typedcolumn.QueryReadyGenerationFileOpenSupported() {
+		t.Skip("query-ready generation file mapping is unsupported on this platform")
+	}
+	key := typedcolumn.QueryReadyGenerationOpenKey{Identity: identity, ManifestHash: sha256.Sum256([]byte("query-ready-build-handoff"))}
+	cache := typedcolumn.NewQueryReadyGenerationOpenCache(key)
+	defer func() { _ = cache.Close() }()
+	opened, err := cache.Open(typedcolumn.QueryReadyGenerationOpenFiles{
+		Key: key, Base: descriptor, SnapshotGeneration: identity.Generation,
+		Bound: typedcolumn.QueryReadyDeltaBoundPolicy{MaxVisibleGenerations: 1, MaxAccumulatedDeltaParts: len(parts)},
+	})
+	if err != nil {
+		t.Fatalf("M3 open of M5 nonzero asset range: %v", err)
+	}
+	if opened.PartCount() != len(parts) || cache.Stats().MappedFiles != 1 || cache.Stats().PayloadBytesCopied != 0 || cache.Stats().WholePartDecodesDuringOpen != 0 {
+		t.Fatalf("M3 open did not retain direct query-ready views: parts=%d stats=%+v", opened.PartCount(), cache.Stats())
+	}
+	if len(first.Dependencies) != len(parts) || len(second.Dependencies) != len(parts) || first.Dependencies[0] != second.Dependencies[0] {
+		t.Fatalf("incomplete/non-deterministic dependencies: first=%+v second=%+v", first.Dependencies, second.Dependencies)
+	}
+	if first.Stats.AssetsProduced != 1 || first.Stats.PartsProduced != len(parts) || first.Stats.Rows == 0 || first.Stats.ManagerRegistrationTime <= 0 || first.Stats.HandoffTime <= 0 {
+		t.Fatalf("incomplete build/handoff stats: %+v", first.Stats)
+	}
+}
+
+func TestQueryReadyBuildCancellationLeavesNoRegisteredPartialGeneration(t *testing.T) {
+	d, col, identity, parts := queryReadyBuildFixture(t, 8)
+	defer func() { _ = d.Close() }()
+	ctx, cancel := context.WithCancel(context.Background())
+	coordinator, err := newQueryReadyBuildCoordinator(col, queryReadyBuildLimits{MaxWorkers: 1, MaxInFlightBytes: 16 << 20})
+	if err != nil {
+		t.Fatal(err)
+	}
+	coordinator.beforeRegister = cancel
+	if _, err := coordinator.prepare(ctx, queryReadyBuildRequest{Kind: queryReadyBuildBase, Identity: identity, Parts: parts}); !errors.Is(err, context.Canceled) {
+		t.Fatalf("prepare err=%v want context.Canceled", err)
+	}
+	columnAssetLifecycleProcessRegistries.Lock()
+	defer columnAssetLifecycleProcessRegistries.Unlock()
+	for _, record := range columnAssetLifecycleProcessRegistries.records {
+		if record.Class == ColumnAssetLifecycleRegistryPreparedAsset && record.Owner == "query-ready-generation-8" {
+			t.Fatalf("canceled build left prepared registry record: %+v", record)
+		}
+	}
+}
+
+func TestQueryReadyBuildBoundedInFlightWork(t *testing.T) {
+	d, col, identity, parts := queryReadyBuildFixture(t, 9)
+	defer func() { _ = d.Close() }()
+	coordinator, err := newQueryReadyBuildCoordinator(col, queryReadyBuildLimits{MaxWorkers: 1, MaxInFlightBytes: 1})
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = coordinator.prepare(context.Background(), queryReadyBuildRequest{Kind: queryReadyBuildBase, Identity: identity, Parts: parts})
+	var boundErr *QueryReadyBuildBoundError
+	if !errors.As(err, &boundErr) || boundErr.RequiredBytes <= boundErr.MaxBytes {
+		t.Fatalf("prepare err=%v bound=%+v want typed in-flight rejection", err, boundErr)
+	}
+	if stats := coordinator.stats(); stats.ActiveWorkers != 0 || stats.InFlightBytes != 0 || stats.BoundRejections != 1 || stats.MaxQueueDepth != 0 {
+		t.Fatalf("coordinator stats after rejection=%+v", stats)
+	}
+}
+
+func TestQueryReadyConsolidationBoundRejectionDoesNotAllocatePlanningSlice(t *testing.T) {
+	d, col, identity, parts := queryReadyBuildFixture(t, 91)
+	defer func() { _ = d.Close() }()
+	built, err := typedcolumn.BuildQueryReadyBaseGeneration(identity, parts)
+	if err != nil {
+		t.Fatalf("build base: %v", err)
+	}
+	base, err := typedcolumn.OpenQueryReadyBaseGeneration(built.Bytes, identity)
+	if err != nil {
+		t.Fatalf("open base: %v", err)
+	}
+	largeViews := make([]typedcolumn.QueryReadyBasePartView, 4096)
+	for i := range largeViews {
+		largeViews[i] = base.Parts[0]
+	}
+	largeBase := &typedcolumn.QueryReadyBaseGeneration{Identity: base.Identity, Parts: largeViews}
+	tombstones := make([]typedcolumn.Tombstone, 4096)
+	largeDelta := &typedcolumn.QueryReadyDeltaGeneration{
+		Base:       &typedcolumn.QueryReadyBaseGeneration{Identity: base.Identity, Parts: largeViews},
+		Tombstones: tombstones,
+	}
+	smallRequest := queryReadyBuildRequest{Kind: queryReadyBuildConsolidatedBase, Identity: identity, Base: base, ThroughGeneration: identity.Generation}
+	largeRequest := queryReadyBuildRequest{Kind: queryReadyBuildConsolidatedBase, Identity: identity, Base: largeBase, Deltas: []*typedcolumn.QueryReadyDeltaGeneration{largeDelta}, ThroughGeneration: identity.Generation}
+	smallRequired, err := estimateQueryReadyBuildWorkingBytes(smallRequest)
+	if err != nil {
+		t.Fatalf("estimate small: %v", err)
+	}
+	largeRequired, err := estimateQueryReadyBuildWorkingBytes(largeRequest)
+	if err != nil {
+		t.Fatalf("estimate large: %v", err)
+	}
+	if largeRequired <= smallRequired+int64(len(tombstones))*256 {
+		t.Fatalf("large reservation=%d does not cover all part/tombstone metadata above small=%d", largeRequired, smallRequired)
+	}
+	if allocs := testing.AllocsPerRun(20, func() {
+		if _, err := estimateQueryReadyBuildWorkingBytes(largeRequest); err != nil {
+			panic(err)
+		}
+	}); allocs != 0 {
+		t.Fatalf("allocation-free admission estimate allocated %.1f times", allocs)
+	}
+	coordinator, err := newQueryReadyBuildCoordinator(col, queryReadyBuildLimits{MaxWorkers: 1, MaxInFlightBytes: 1})
+	if err != nil {
+		t.Fatal(err)
+	}
+	smallAllocs := testing.AllocsPerRun(20, func() {
+		if _, err := coordinator.prepare(context.Background(), smallRequest); err == nil {
+			panic("small request unexpectedly admitted")
+		}
+	})
+	largeAllocs := testing.AllocsPerRun(20, func() {
+		if _, err := coordinator.prepare(context.Background(), largeRequest); err == nil {
+			panic("large request unexpectedly admitted")
+		}
+	})
+	if largeAllocs > smallAllocs || largeAllocs > 2 {
+		t.Fatalf("bound rejection allocations scale with parts: small=%.1f large=%.1f", smallAllocs, largeAllocs)
+	}
+}
+
+func TestQueryReadyBuildZeroQueueBackpressureBoundsConcurrentWorkers(t *testing.T) {
+	d, col, identity, parts := queryReadyBuildFixture(t, 11)
+	defer func() { _ = d.Close() }()
+	coordinator, err := newQueryReadyBuildCoordinator(col, queryReadyBuildLimits{MaxWorkers: 1, MaxInFlightBytes: 16 << 20})
+	if err != nil {
+		t.Fatal(err)
+	}
+	entered := make(chan struct{})
+	release := make(chan struct{})
+	var once sync.Once
+	coordinator.afterAdmission = func() {
+		once.Do(func() { close(entered) })
+		<-release
+	}
+	firstDone := make(chan error, 1)
+	go func() {
+		prepared, err := coordinator.prepare(context.Background(), queryReadyBuildRequest{Kind: queryReadyBuildBase, Identity: identity, Parts: parts})
+		if prepared != nil {
+			_ = prepared.Abort()
+		}
+		firstDone <- err
+	}()
+	<-entered
+	_, err = coordinator.prepare(context.Background(), queryReadyBuildRequest{Kind: queryReadyBuildBase, Identity: identity, Parts: parts})
+	var backpressure *QueryReadyBuildBackpressureError
+	if !errors.As(err, &backpressure) || backpressure.MaxWorkers != 1 {
+		t.Fatalf("second prepare err=%v want zero-queue backpressure", err)
+	}
+	close(release)
+	if err := <-firstDone; err != nil {
+		t.Fatalf("first prepare: %v", err)
+	}
+	stats := coordinator.stats()
+	if stats.PeakWorkers != 1 || stats.AdmissionRejections != 1 || stats.MaxQueueDepth != 0 || stats.PeakInFlight > 16<<20 {
+		t.Fatalf("bounded coordinator stats=%+v", stats)
+	}
+}
+
+func TestQueryReadyDeltaPublishDoesNotRewriteBase(t *testing.T) {
+	d, col, identity, parts := queryReadyBuildFixture(t, 10)
+	defer func() { _ = d.Close() }()
+	identity.Generation++
+	parts[0].SourceGeneration = identity.Generation
+	before := sha256.Sum256(parts[0].Image.Bytes)
+	coordinator, err := newQueryReadyBuildCoordinator(col, queryReadyBuildLimits{MaxWorkers: 1, MaxInFlightBytes: 16 << 20})
+	if err != nil {
+		t.Fatal(err)
+	}
+	prepared, err := coordinator.prepare(context.Background(), queryReadyBuildRequest{Kind: queryReadyBuildDelta, Identity: identity, Parts: parts})
+	if err != nil {
+		t.Fatalf("prepare delta: %v", err)
+	}
+	defer func() { _ = prepared.Abort() }()
+	if after := sha256.Sum256(parts[0].Image.Bytes); after != before {
+		t.Fatal("delta handoff rewrote source/base part bytes")
+	}
+	if prepared.Asset.Ref.Kind != ColumnAssetKindQueryReadyDelta || prepared.Stats.BaseBytesRewritten != 0 {
+		t.Fatalf("delta asset/stats=%+v/%+v", prepared.Asset.Ref, prepared.Stats)
+	}
+}
+
+func TestQueryReadyConsolidationBuildMatchesSnapshot(t *testing.T) {
+	d, col, baseIdentity, baseParts := queryReadyBuildFixture(t, 12)
+	defer func() { _ = d.Close() }()
+	baseBuilt, err := typedcolumn.BuildQueryReadyBaseGeneration(baseIdentity, baseParts)
+	if err != nil {
+		t.Fatalf("build base: %v", err)
+	}
+	base, err := typedcolumn.OpenQueryReadyBaseGeneration(baseBuilt.Bytes, baseIdentity)
+	if err != nil {
+		t.Fatalf("open base: %v", err)
+	}
+	deltaIdentity := baseIdentity
+	deltaIdentity.Generation++
+	deltaImage := queryReadyBuildImage(t, deltaIdentity.Generation, []int64{1, 3}, []int64{100, 300})
+	deltaBuilt, err := typedcolumn.BuildQueryReadyDeltaGeneration(deltaIdentity, []typedcolumn.QueryReadyBasePartInput{{SourceGeneration: deltaIdentity.Generation, Image: deltaImage}}, []typedcolumn.Tombstone{{PrimaryID: 2, GenerationID: deltaIdentity.Generation}})
+	if err != nil {
+		t.Fatalf("build delta: %v", err)
+	}
+	delta, err := typedcolumn.OpenQueryReadyDeltaGeneration(deltaBuilt.Bytes, deltaIdentity)
+	if err != nil {
+		t.Fatalf("open delta: %v", err)
+	}
+	want, err := typedcolumn.NewQueryReadyBaseDeltaReader(base, []*typedcolumn.QueryReadyDeltaGeneration{delta}, typedcolumn.QueryReadyBaseDeltaOptions{SnapshotGeneration: deltaIdentity.Generation, Bound: typedcolumn.QueryReadyDeltaBoundPolicy{MaxVisibleGenerations: 4, MaxAccumulatedDeltaParts: 8}})
+	if err != nil {
+		t.Fatalf("prepare expected reader: %v", err)
+	}
+	coordinator, err := newQueryReadyBuildCoordinator(col, queryReadyBuildLimits{MaxWorkers: 1, MaxInFlightBytes: 16 << 20})
+	if err != nil {
+		t.Fatal(err)
+	}
+	prepared, err := coordinator.prepare(context.Background(), queryReadyBuildRequest{Kind: queryReadyBuildConsolidatedBase, Identity: deltaIdentity, Base: base, Deltas: []*typedcolumn.QueryReadyDeltaGeneration{delta}, ThroughGeneration: deltaIdentity.Generation})
+	if err != nil {
+		t.Fatalf("prepare consolidation: %v", err)
+	}
+	defer func() { _ = prepared.Abort() }()
+	raw, err := os.ReadFile(prepared.AssetPath)
+	if err != nil {
+		t.Fatalf("read prepared consolidation: %v", err)
+	}
+	start, end := prepared.Asset.Ref.Offset, prepared.Asset.Ref.Offset+prepared.Asset.Ref.Length
+	if start < 0 || end > int64(len(raw)) {
+		t.Fatalf("prepared asset range=%d:%d file=%d", start, end, len(raw))
+	}
+	consolidated, err := typedcolumn.OpenQueryReadyConsolidatedBaseGeneration(raw[start:end], deltaIdentity)
+	if err != nil {
+		t.Fatalf("open prepared consolidation: %v", err)
+	}
+	got, err := typedcolumn.NewQueryReadyConsolidatedBaseDeltaReader(consolidated, nil, typedcolumn.QueryReadyBaseDeltaOptions{SnapshotGeneration: deltaIdentity.Generation, Bound: typedcolumn.QueryReadyDeltaBoundPolicy{MaxVisibleGenerations: 4, MaxAccumulatedDeltaParts: 8}})
+	if err != nil {
+		t.Fatalf("prepare consolidated reader: %v", err)
+	}
+	for _, id := range []int64{1, 2, 3} {
+		wantValue, wantOK, wantErr := want.ValueAtLatest(id, "value")
+		gotValue, gotOK, gotErr := got.ValueAtLatest(id, "value")
+		if wantErr != nil || gotErr != nil || wantOK != gotOK || wantValue != gotValue {
+			t.Fatalf("id=%d before=(%d,%v,%v) after=(%d,%v,%v)", id, wantValue, wantOK, wantErr, gotValue, gotOK, gotErr)
+		}
+	}
+}
+
+func TestQueryReadyConsolidationRejectsDescriptorIdentityMismatchBeforeAdmission(t *testing.T) {
+	d, col, identity, parts := queryReadyBuildFixture(t, 13)
+	defer func() { _ = d.Close() }()
+	built, err := typedcolumn.BuildQueryReadyBaseGeneration(identity, parts)
+	if err != nil {
+		t.Fatalf("build base: %v", err)
+	}
+	base, err := typedcolumn.OpenQueryReadyBaseGeneration(built.Bytes, identity)
+	if err != nil {
+		t.Fatalf("open base: %v", err)
+	}
+	coordinator, err := newQueryReadyBuildCoordinator(col, queryReadyBuildLimits{MaxWorkers: 1, MaxInFlightBytes: 16 << 20})
+	if err != nil {
+		t.Fatal(err)
+	}
+	wrong := identity
+	wrong.Generation++
+	_, err = coordinator.prepare(context.Background(), queryReadyBuildRequest{
+		Kind: queryReadyBuildConsolidatedBase, Identity: wrong, Base: base, ThroughGeneration: identity.Generation,
+	})
+	if err == nil {
+		t.Fatal("mismatched descriptor identity unexpectedly admitted")
+	}
+	if stats := coordinator.stats(); stats.ActiveWorkers != 0 || stats.PeakWorkers != 0 || stats.InFlightBytes != 0 {
+		t.Fatalf("identity mismatch allocated/admitted build work: %+v", stats)
+	}
+}
+
+func queryReadyBuildFixture(t testing.TB, generation uint64) (*backenddb.DB, *Collection, typedcolumn.QueryReadyBaseIdentity, []typedcolumn.QueryReadyBasePartInput) {
+	t.Helper()
+	dir := prepareColumnAssetReachabilityCommandWALDirM15A(t)
+	d, err := backenddb.Open(backenddb.Options{Dir: dir, DisableBackgroundPrune: true})
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	col := openColumnAssetLifecycleTestCollection1954(t, d)
+	image := queryReadyBuildImage(t, generation, []int64{1, 2}, []int64{10, 20})
+	identity := typedcolumn.QueryReadyBaseIdentity{Generation: generation, SchemaHash: sha256.Sum256([]byte(col.Meta().Name))}
+	return d, col, identity, []typedcolumn.QueryReadyBasePartInput{{SourceGeneration: generation, Image: image}}
+}
+
+func queryReadyBuildImage(t testing.TB, partID uint64, ids, values []int64) typedcolumn.ColumnPartImage {
+	t.Helper()
+	opts := typedcolumn.Options{
+		SchemaVersion: 1,
+		SchemaMode:    typedcolumn.ColumnSchemaFixed,
+		Columns: []typedcolumn.ColumnDefinition{
+			{Name: "id", Type: typedcolumn.ColumnTypeInt64, Encoding: typedcolumn.EncodingRawInt64, Compression: typedcolumn.CompressionNone},
+			{Name: "value", Type: typedcolumn.ColumnTypeInt64, Encoding: typedcolumn.EncodingRawInt64, Compression: typedcolumn.CompressionNone},
+		},
+		LogicalPrimaryKey: typedcolumn.LogicalPrimaryKey{Columns: []string{"id"}},
+		SortKey:           typedcolumn.SortKey{Columns: []typedcolumn.SortKeyColumn{{Column: "id"}}},
+		PartPolicy:        typedcolumn.ColumnPartPolicy{RowsPerGranule: 16},
+	}
+	part, err := typedcolumn.BuildColumnPart(partID, opts, typedcolumn.Batch{Rows: len(ids), Columns: map[string][]int64{"id": ids, "value": values}})
+	if err != nil {
+		t.Fatalf("build typed part: %v", err)
+	}
+	image, err := typedcolumn.BuildColumnPartImage(part, typedcolumn.ColumnPartImageOptions{})
+	if err != nil {
+		t.Fatalf("build typed image: %v", err)
+	}
+	return image
+}
+
+func BenchmarkQueryReadyBuildExistingManagerHandoff(b *testing.B) {
+	d, col, identity, parts := queryReadyBuildFixture(b, 20)
+	defer func() { _ = d.Close() }()
+	coordinator, err := newQueryReadyBuildCoordinator(col, queryReadyBuildLimits{MaxWorkers: 1, MaxInFlightBytes: 16 << 20})
+	if err != nil {
+		b.Fatal(err)
+	}
+	for _, tc := range []struct {
+		name string
+		kind queryReadyBuildKind
+	}{
+		{name: "base", kind: queryReadyBuildBase},
+		{name: "delta", kind: queryReadyBuildDelta},
+	} {
+		b.Run(tc.name, func(b *testing.B) {
+			requestIdentity := identity
+			requestParts := slices.Clone(parts)
+			if tc.kind == queryReadyBuildDelta {
+				requestIdentity.Generation++
+				requestParts[0].SourceGeneration = requestIdentity.Generation
+			}
+			request := queryReadyBuildRequest{Kind: tc.kind, Identity: requestIdentity, Parts: requestParts}
+			var sample queryReadyBuildStats
+			b.ReportAllocs()
+			b.ResetTimer()
+			for range b.N {
+				prepared, err := coordinator.prepare(context.Background(), request)
+				if err != nil {
+					b.Fatal(err)
+				}
+				sample = prepared.Stats
+				if err := prepared.Abort(); err != nil {
+					b.Fatal(err)
+				}
+			}
+			b.ReportMetric(float64(sample.OutputBytes), "asset-bytes/op")
+			b.ReportMetric(float64(sample.EstimatedPeakInFlightBytes), "reserved-inflight-bytes/op")
+			b.ReportMetric(float64(sample.EncodedBufferPeakBytes), "encoded-buffer-bytes/op")
+			b.ReportMetric(float64(sample.BytesCopied), "copied-bytes/op")
+			b.ReportMetric(float64(sample.BytesHashed), "hashed-bytes/op")
+			b.ReportMetric(float64(sample.BytesChecksummed), "checksummed-bytes/op")
+			b.ReportMetric(float64(sample.AssetPreparationTime.Nanoseconds()), "asset-prepare-ns/op")
+			b.ReportMetric(float64(sample.ManagerRegistrationTime.Nanoseconds()), "register-ns/op")
+		})
+	}
+}

--- a/TreeDB/collections/query_ready_build_test.go
+++ b/TreeDB/collections/query_ready_build_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"os"
 	"slices"
+	"strings"
 	"sync"
 	"testing"
 
@@ -64,6 +65,34 @@ func TestQueryReadyBuildProducesDeterministicCompleteAssetSet(t *testing.T) {
 	}
 	if first.Stats.AssetsProduced != 1 || first.Stats.PartsProduced != len(parts) || first.Stats.Rows == 0 || first.Stats.ManagerRegistrationTime <= 0 || first.Stats.HandoffTime <= 0 {
 		t.Fatalf("incomplete build/handoff stats: %+v", first.Stats)
+	}
+}
+
+func TestQueryReadyPreparedAssetCannotEnterAuthoritativePublishPlan(t *testing.T) {
+	for _, kind := range []ColumnAssetKind{ColumnAssetKindQueryReadyBase, ColumnAssetKindQueryReadyDelta, ColumnAssetKindQueryReadyConsolidatedBase} {
+		t.Run(string(kind), func(t *testing.T) {
+			asset := ColumnPreparedAsset{
+				Ref: ColumnAssetRef{
+					Kind:       kind,
+					Namespace:  "query-ready-test",
+					Generation: 7,
+					PartID:     queryReadyBaseAssetPartID,
+					FileID:     1,
+					Offset:     64,
+					Length:     128,
+				},
+				Rows:         1,
+				Bytes:        128,
+				GenerationID: 7,
+				Reason:       "query_ready_build",
+			}
+			if err := validateColumnAssetRefForPlan(asset.Ref); err != nil {
+				t.Fatalf("query-ready ref must remain valid for prepared-asset lifecycle registration: %v", err)
+			}
+			if err := validateColumnPreparedAssetForPlan(asset); err == nil || !strings.Contains(err.Error(), "non-authoritative") {
+				t.Fatalf("validateColumnPreparedAssetForPlan err=%v want non-authoritative rejection", err)
+			}
+		})
 	}
 }
 

--- a/TreeDB/collections/typed_storage_naming_test.go
+++ b/TreeDB/collections/typed_storage_naming_test.go
@@ -402,6 +402,7 @@ var typedStorageLegacyNameAllowlist = []typedStorageLegacyNameAllowlistEntry{
 	{path: "TreeDB/collections/index_insert_search_bench_test.go", classification: typedStorageLegacyCompatibility, matchingLines: 2, occurrences: 2},
 	{path: "TreeDB/collections/hybrid_search_executor_test.go", classification: typedStorageLegacyCompatibility, matchingLines: 2, occurrences: 2},
 	{path: "TreeDB/collections/quantized_asset_reopen_test.go", classification: typedStorageLegacyCompatibility, matchingLines: 6, occurrences: 6},
+	{path: "TreeDB/collections/query_ready_build.go", classification: typedStorageLegacyCompatibility, matchingLines: 2, occurrences: 3},
 	{path: "TreeDB/collections/query_ready_generation_open.go", classification: typedStorageLegacyCompatibility, matchingLines: 9, occurrences: 9},
 	{path: "TreeDB/collections/query_ready_generation_open_test.go", classification: typedStorageLegacyCompatibility, matchingLines: 19, occurrences: 19},
 	{path: "TreeDB/collections/column_vector_graph_quantized_asset_test.go", classification: typedStorageLegacyDerived, matchingLines: 12, occurrences: 14},

--- a/TreeDB/internal/typedcolumn/query_ready_base.go
+++ b/TreeDB/internal/typedcolumn/query_ready_base.go
@@ -54,13 +54,15 @@ type QueryReadyBaseDependency struct {
 }
 
 type QueryReadyBaseBuildStats struct {
-	Parts          int
-	Rows           int64
-	InputBytes     int64
-	OutputBytes    int64
-	BytesCopied    int64
-	ValidationTime time.Duration
-	BuildTime      time.Duration
+	Parts            int
+	Rows             int64
+	InputBytes       int64
+	OutputBytes      int64
+	BytesCopied      int64
+	BytesHashed      int64
+	BytesChecksummed int64
+	ValidationTime   time.Duration
+	BuildTime        time.Duration
 }
 
 type QueryReadyBaseBuildResult struct {
@@ -136,33 +138,55 @@ type queryReadyBaseBuildPart struct {
 	dependency QueryReadyBaseDependency
 }
 
+type queryReadyBaseBuildPlan struct {
+	parts          []queryReadyBaseBuildPart
+	payloadOffset  int
+	totalBytes     int
+	validationTime time.Duration
+}
+
 // BuildQueryReadyBaseGeneration validates and embeds an already
 // snapshot-visible set of typed-column images. It is deterministic for the
 // same identity and logical input set.
 func BuildQueryReadyBaseGeneration(identity QueryReadyBaseIdentity, inputs []QueryReadyBasePartInput) (QueryReadyBaseBuildResult, error) {
 	started := time.Now()
-	if err := validateQueryReadyBaseIdentity(identity); err != nil {
+	plan, err := prepareQueryReadyBaseGeneration(identity, inputs)
+	if err != nil {
 		return QueryReadyBaseBuildResult{}, err
+	}
+	out := make([]byte, plan.totalBytes)
+	result := encodeQueryReadyBaseGeneration(identity, plan, out)
+	result.Stats.BuildTime = time.Since(started)
+	return result, nil
+}
+
+// prepareQueryReadyBaseGeneration validates the complete logical input set and
+// computes the exact deterministic layout without allocating the output image.
+// Envelope builders use the plan to encode QRBG directly into their final
+// buffer, avoiding a second whole-generation allocation and copy.
+func prepareQueryReadyBaseGeneration(identity QueryReadyBaseIdentity, inputs []QueryReadyBasePartInput) (queryReadyBaseBuildPlan, error) {
+	if err := validateQueryReadyBaseIdentity(identity); err != nil {
+		return queryReadyBaseBuildPlan{}, err
 	}
 	parts := make([]queryReadyBaseBuildPart, len(inputs))
 	var validationTime time.Duration
 	for i, input := range inputs {
 		if input.SourceGeneration == 0 {
-			return QueryReadyBaseBuildResult{}, fmt.Errorf("typedcolumn: query-ready base part[%d] source generation is zero", i)
+			return queryReadyBaseBuildPlan{}, fmt.Errorf("typedcolumn: query-ready base part[%d] source generation is zero", i)
 		}
 		if input.SourceGeneration > identity.Generation {
-			return QueryReadyBaseBuildResult{}, fmt.Errorf("typedcolumn: query-ready base part[%d] source generation=%d exceeds base generation=%d", i, input.SourceGeneration, identity.Generation)
+			return queryReadyBaseBuildPlan{}, fmt.Errorf("typedcolumn: query-ready base part[%d] source generation=%d exceeds base generation=%d", i, input.SourceGeneration, identity.Generation)
 		}
 		validationStarted := time.Now()
 		parsed, err := ParseColumnPartImage(input.Image.Bytes)
 		if err != nil {
-			return QueryReadyBaseBuildResult{}, fmt.Errorf("typedcolumn: query-ready base part[%d] validate image: %w", i, err)
+			return queryReadyBaseBuildPlan{}, fmt.Errorf("typedcolumn: query-ready base part[%d] validate image: %w", i, err)
 		}
 		if _, err := ColumnPartFromImageWithOptions(parsed, ColumnPartImageReadOptions{}); err != nil {
-			return QueryReadyBaseBuildResult{}, fmt.Errorf("typedcolumn: query-ready base part[%d] validate structures: %w", i, err)
+			return queryReadyBaseBuildPlan{}, fmt.Errorf("typedcolumn: query-ready base part[%d] validate structures: %w", i, err)
 		}
 		if _, err := CertifyColumnPartLayoutContractFromImage(parsed); err != nil {
-			return QueryReadyBaseBuildResult{}, fmt.Errorf("typedcolumn: query-ready base part[%d] certify layout: %w", i, err)
+			return queryReadyBaseBuildPlan{}, fmt.Errorf("typedcolumn: query-ready base part[%d] certify layout: %w", i, err)
 		}
 		validationTime += time.Since(validationStarted)
 		parts[i] = queryReadyBaseBuildPart{
@@ -186,30 +210,40 @@ func BuildQueryReadyBaseGeneration(identity QueryReadyBaseIdentity, inputs []Que
 	})
 	for i := 1; i < len(parts); i++ {
 		if parts[i-1].input.SourceGeneration == parts[i].input.SourceGeneration && parts[i-1].parsed.PartID == parts[i].parsed.PartID {
-			return QueryReadyBaseBuildResult{}, fmt.Errorf("typedcolumn: query-ready base duplicate dependency generation=%d part_id=%d", parts[i].input.SourceGeneration, parts[i].parsed.PartID)
+			return queryReadyBaseBuildPlan{}, fmt.Errorf("typedcolumn: query-ready base duplicate dependency generation=%d part_id=%d", parts[i].input.SourceGeneration, parts[i].parsed.PartID)
 		}
 	}
 	if len(parts) > math.MaxUint32 || len(parts) > (math.MaxInt-queryReadyBaseHeaderBytes)/queryReadyBasePartEntryBytes {
-		return QueryReadyBaseBuildResult{}, fmt.Errorf("typedcolumn: query-ready base parts=%d exceed format bounds", len(parts))
+		return queryReadyBaseBuildPlan{}, fmt.Errorf("typedcolumn: query-ready base parts=%d exceed format bounds", len(parts))
 	}
 	tableBytes := len(parts) * queryReadyBasePartEntryBytes
 	payloadOffset, err := queryReadyBaseAlign(queryReadyBaseHeaderBytes+tableBytes, queryReadyBasePayloadAlignment)
 	if err != nil {
-		return QueryReadyBaseBuildResult{}, err
+		return queryReadyBaseBuildPlan{}, err
 	}
 	totalBytes := payloadOffset
 	for i := range parts {
 		totalBytes, err = queryReadyBaseAlign(totalBytes, columnPartImageSectionAlignment)
 		if err != nil {
-			return QueryReadyBaseBuildResult{}, err
+			return queryReadyBaseBuildPlan{}, err
 		}
 		parts[i].offset = totalBytes
 		if len(parts[i].input.Image.Bytes) > math.MaxInt-totalBytes {
-			return QueryReadyBaseBuildResult{}, errors.New("typedcolumn: query-ready base image exceeds host size")
+			return queryReadyBaseBuildPlan{}, errors.New("typedcolumn: query-ready base image exceeds host size")
 		}
 		totalBytes += len(parts[i].input.Image.Bytes)
 	}
-	out := make([]byte, totalBytes)
+	return queryReadyBaseBuildPlan{parts: parts, payloadOffset: payloadOffset, totalBytes: totalBytes, validationTime: validationTime}, nil
+}
+
+func encodeQueryReadyBaseGeneration(identity QueryReadyBaseIdentity, plan queryReadyBaseBuildPlan, out []byte) QueryReadyBaseBuildResult {
+	parts := plan.parts
+	payloadOffset := plan.payloadOffset
+	totalBytes := plan.totalBytes
+	if len(out) != totalBytes {
+		panic("typedcolumn: internal query-ready base output length mismatch")
+	}
+	tableBytes := len(parts) * queryReadyBasePartEntryBytes
 	binary.LittleEndian.PutUint32(out[0:4], queryReadyBaseMagic)
 	binary.LittleEndian.PutUint16(out[4:6], queryReadyBaseVersion)
 	binary.LittleEndian.PutUint64(out[8:16], identity.Generation)
@@ -240,15 +274,16 @@ func BuildQueryReadyBaseGeneration(identity QueryReadyBaseIdentity, inputs []Que
 		Bytes:        out,
 		Dependencies: dependencies,
 		Stats: QueryReadyBaseBuildStats{
-			Parts:          len(parts),
-			Rows:           rows,
-			InputBytes:     inputBytes,
-			OutputBytes:    int64(len(out)),
-			BytesCopied:    inputBytes,
-			ValidationTime: validationTime,
-			BuildTime:      time.Since(started),
+			Parts:            len(parts),
+			Rows:             rows,
+			InputBytes:       inputBytes,
+			OutputBytes:      int64(len(out)),
+			BytesCopied:      inputBytes,
+			BytesHashed:      inputBytes,
+			BytesChecksummed: int64(tableBytes + queryReadyBaseHeaderBytes),
+			ValidationTime:   plan.validationTime,
 		},
-	}, nil
+	}
 }
 
 func OpenQueryReadyBaseGeneration(data []byte, expected QueryReadyBaseIdentity) (*QueryReadyBaseGeneration, error) {

--- a/TreeDB/internal/typedcolumn/query_ready_base_test.go
+++ b/TreeDB/internal/typedcolumn/query_ready_base_test.go
@@ -333,6 +333,9 @@ func BenchmarkQueryReadyBaseGenerationBuild(b *testing.B) {
 	}
 	b.ReportMetric(float64(len(sample.Bytes)), "asset-bytes")
 	b.ReportMetric(float64(len(sample.Bytes)-len(image.Bytes)), "overhead-bytes")
+	b.ReportMetric(float64(sample.Stats.BytesCopied), "copied-bytes/op")
+	b.ReportMetric(float64(sample.Stats.BytesHashed), "hashed-bytes/op")
+	b.ReportMetric(float64(sample.Stats.BytesChecksummed), "checksummed-bytes/op")
 }
 
 func BenchmarkQueryReadyBaseGenerationOpen(b *testing.B) {

--- a/TreeDB/internal/typedcolumn/query_ready_delta.go
+++ b/TreeDB/internal/typedcolumn/query_ready_delta.go
@@ -32,22 +32,30 @@ const (
 )
 
 type QueryReadyDeltaBuildStats struct {
-	Parts                 int
-	Rows                  int64
-	Tombstones            int
-	OriginBaseParts       int
-	AccumulatedDeltaParts int
-	InputBytes            int64
-	OutputBytes           int64
-	BytesCopied           int64
-	PeakWorkingBytes      int64
-	WriteAmplification    float64
-	BuildTime             time.Duration
+	Parts                  int
+	Rows                   int64
+	Tombstones             int
+	OriginBaseParts        int
+	AccumulatedDeltaParts  int
+	InputBytes             int64
+	OutputBytes            int64
+	BytesCopied            int64
+	BytesHashed            int64
+	BytesChecksummed       int64
+	BytesCompressed        int64
+	PeakEncodedBufferBytes int64
+	WriteAmplification     float64
+	ValidationTime         time.Duration
+	BaseBuildTime          time.Duration
+	TombstonePrepareTime   time.Duration
+	EnvelopeBuildTime      time.Duration
+	BuildTime              time.Duration
 }
 
 type QueryReadyDeltaBuildResult struct {
-	Bytes []byte
-	Stats QueryReadyDeltaBuildStats
+	Bytes        []byte
+	Dependencies []QueryReadyBaseDependency
+	Stats        QueryReadyDeltaBuildStats
 }
 
 type QueryReadyDeltaOpenStats struct {
@@ -139,14 +147,16 @@ func buildQueryReadyDeltaEnvelope(kind QueryReadyGenerationKind, identity QueryR
 	if kind == QueryReadyGenerationConsolidatedBase && lineage.OriginBaseParts+lineage.AccumulatedDeltaParts != len(parts) {
 		return QueryReadyDeltaBuildResult{}, fmt.Errorf("typedcolumn: query-ready consolidated lineage parts=%d+%d want embedded=%d", lineage.OriginBaseParts, lineage.AccumulatedDeltaParts, len(parts))
 	}
-	inner, err := BuildQueryReadyBaseGeneration(identity, parts)
+	basePlan, err := prepareQueryReadyBaseGeneration(identity, parts)
 	if err != nil {
 		return QueryReadyDeltaBuildResult{}, fmt.Errorf("typedcolumn: build query-ready generation parts: %w", err)
 	}
+	tombstoneStarted := time.Now()
 	normalized, err := normalizeQueryReadyTombstones(tombstones, identity.Generation)
 	if err != nil {
 		return QueryReadyDeltaBuildResult{}, err
 	}
+	tombstonePrepareTime := time.Since(tombstoneStarted)
 	if len(normalized) > (math.MaxInt-queryReadyDeltaHeaderBytes)/queryReadyDeltaTombstoneBytes || len(normalized) > math.MaxUint32 {
 		return QueryReadyDeltaBuildResult{}, fmt.Errorf("typedcolumn: query-ready tombstones=%d exceed format bounds", len(normalized))
 	}
@@ -155,10 +165,11 @@ func buildQueryReadyDeltaEnvelope(kind QueryReadyGenerationKind, identity QueryR
 	if err != nil {
 		return QueryReadyDeltaBuildResult{}, err
 	}
-	if len(inner.Bytes) > math.MaxInt-payloadOffset {
+	if basePlan.totalBytes > math.MaxInt-payloadOffset {
 		return QueryReadyDeltaBuildResult{}, errors.New("typedcolumn: query-ready delta image exceeds host size")
 	}
-	totalBytes := payloadOffset + len(inner.Bytes)
+	totalBytes := payloadOffset + basePlan.totalBytes
+	envelopeStarted := time.Now()
 	out := make([]byte, totalBytes)
 	binary.LittleEndian.PutUint32(out[0:4], queryReadyDeltaMagic)
 	binary.LittleEndian.PutUint16(out[4:6], queryReadyDeltaVersion)
@@ -168,7 +179,7 @@ func buildQueryReadyDeltaEnvelope(kind QueryReadyGenerationKind, identity QueryR
 	binary.LittleEndian.PutUint32(out[48:52], uint32(len(normalized)))
 	binary.LittleEndian.PutUint64(out[64:72], uint64(payloadOffset))
 	binary.LittleEndian.PutUint64(out[72:80], uint64(totalBytes))
-	binary.LittleEndian.PutUint64(out[80:88], uint64(len(inner.Bytes)))
+	binary.LittleEndian.PutUint64(out[80:88], uint64(basePlan.totalBytes))
 	binary.LittleEndian.PutUint32(out[88:92], uint32(lineage.OriginBaseParts))
 	binary.LittleEndian.PutUint32(out[92:96], uint32(lineage.AccumulatedDeltaParts))
 	table := out[queryReadyDeltaHeaderBytes : queryReadyDeltaHeaderBytes+tableBytes]
@@ -178,20 +189,29 @@ func buildQueryReadyDeltaEnvelope(kind QueryReadyGenerationKind, identity QueryR
 		binary.LittleEndian.PutUint64(entry[8:16], tombstone.GenerationID)
 	}
 	binary.LittleEndian.PutUint32(out[56:60], crc32.Checksum(table, queryReadyBaseCRCTable))
-	copy(out[payloadOffset:], inner.Bytes)
+	baseEncodeStarted := time.Now()
+	inner := encodeQueryReadyBaseGeneration(identity, basePlan, out[payloadOffset:])
+	baseEncodeTime := time.Since(baseEncodeStarted)
 	binary.LittleEndian.PutUint32(out[52:56], queryReadyDeltaHeaderChecksum(out[:queryReadyDeltaHeaderBytes]))
 	inputBytes := inner.Stats.InputBytes + int64(len(normalized)*queryReadyDeltaTombstoneBytes)
 	writeAmplification := float64(0)
 	if inputBytes > 0 {
 		writeAmplification = float64(len(out)) / float64(inputBytes)
 	}
-	return QueryReadyDeltaBuildResult{Bytes: out, Stats: QueryReadyDeltaBuildStats{
+	return QueryReadyDeltaBuildResult{Bytes: out, Dependencies: inner.Dependencies, Stats: QueryReadyDeltaBuildStats{
 		Parts: len(parts), Rows: inner.Stats.Rows, Tombstones: len(normalized),
 		OriginBaseParts: lineage.OriginBaseParts, AccumulatedDeltaParts: lineage.AccumulatedDeltaParts,
 		InputBytes: inputBytes, OutputBytes: int64(len(out)),
-		BytesCopied:        inner.Stats.BytesCopied + int64(len(inner.Bytes)+len(table)),
-		PeakWorkingBytes:   int64(len(inner.Bytes) + len(out)),
-		WriteAmplification: writeAmplification, BuildTime: time.Since(started),
+		BytesCopied:            inner.Stats.BytesCopied + int64(len(table)),
+		BytesHashed:            inner.Stats.InputBytes,
+		BytesChecksummed:       inner.Stats.BytesChecksummed + int64(len(table)+queryReadyDeltaHeaderBytes),
+		PeakEncodedBufferBytes: int64(len(out)),
+		WriteAmplification:     writeAmplification,
+		ValidationTime:         basePlan.validationTime,
+		BaseBuildTime:          basePlan.validationTime + baseEncodeTime,
+		TombstonePrepareTime:   tombstonePrepareTime,
+		EnvelopeBuildTime:      time.Since(envelopeStarted),
+		BuildTime:              time.Since(started),
 	}}, nil
 }
 
@@ -733,8 +753,10 @@ type QueryReadyConsolidationStats struct {
 	InputBytes               int64
 	OutputBytes              int64
 	BytesCopied              int64
+	BytesHashed              int64
+	BytesChecksummed         int64
 	WriteAmplification       float64
-	PeakWorkingBytes         int64
+	PeakEncodedBufferBytes   int64
 	CodeTranslations         int
 	DocumentMaterializations int
 	Fallbacks                int
@@ -742,8 +764,9 @@ type QueryReadyConsolidationStats struct {
 }
 
 type QueryReadyConsolidationResult struct {
-	Bytes []byte
-	Stats QueryReadyConsolidationStats
+	Bytes        []byte
+	Dependencies []QueryReadyBaseDependency
+	Stats        QueryReadyConsolidationStats
 }
 
 // ConsolidateQueryReadyBaseDelta deterministically folds the selected delta
@@ -838,10 +861,11 @@ func consolidateQueryReadyBaseDelta(base *QueryReadyBaseGeneration, baseTombston
 	if inputBytes > 0 {
 		writeAmplification = float64(len(built.Bytes)) / float64(inputBytes)
 	}
-	return QueryReadyConsolidationResult{Bytes: built.Bytes, Stats: QueryReadyConsolidationStats{
+	return QueryReadyConsolidationResult{Bytes: built.Bytes, Dependencies: built.Dependencies, Stats: QueryReadyConsolidationStats{
 		SelectedDeltaGenerations: len(selected), InputGenerations: 1 + len(selected), OutputGenerations: 1,
 		PartsMerged: len(parts), RowsMerged: built.Stats.Rows, TombstonesMerged: built.Stats.Tombstones,
 		InputBytes: inputBytes, OutputBytes: int64(len(built.Bytes)), BytesCopied: built.Stats.BytesCopied,
-		WriteAmplification: writeAmplification, PeakWorkingBytes: built.Stats.PeakWorkingBytes, BuildTime: time.Since(started),
+		BytesHashed: built.Stats.BytesHashed, BytesChecksummed: built.Stats.BytesChecksummed,
+		WriteAmplification: writeAmplification, PeakEncodedBufferBytes: built.Stats.PeakEncodedBufferBytes, BuildTime: time.Since(started),
 	}}, nil
 }

--- a/TreeDB/internal/typedcolumn/query_ready_delta_test.go
+++ b/TreeDB/internal/typedcolumn/query_ready_delta_test.go
@@ -1,6 +1,7 @@
 package typedcolumn
 
 import (
+	"bytes"
 	"encoding/binary"
 	"errors"
 	"hash/crc32"
@@ -52,6 +53,56 @@ func TestQueryReadyDeltaBuildDoesNotRewriteImmutableBase(t *testing.T) {
 	}
 	if deltaBuilt.Stats.Rows != 1 || deltaBuilt.Stats.Parts != 1 || deltaBuilt.Stats.InputBytes != int64(len(deltaImage.Bytes)) {
 		t.Fatalf("delta build stats include unrelated base work: %+v base_bytes=%d delta_image=%d", deltaBuilt.Stats, len(baseBuilt.Bytes), len(deltaImage.Bytes))
+	}
+}
+
+func TestQueryReadyDeltaBuildUsesSingleBoundedOutputBuffer(t *testing.T) {
+	image := queryReadyDeltaTestImage(t, 2201, map[int64]int64{1: 10, 2: 20, 3: 30})
+	identity := queryReadyBaseTestIdentity(2)
+	parts := []QueryReadyBasePartInput{{SourceGeneration: 2, Image: image}}
+	standalone, err := BuildQueryReadyBaseGeneration(identity, parts)
+	if err != nil {
+		t.Fatalf("BuildQueryReadyBaseGeneration: %v", err)
+	}
+	result, err := BuildQueryReadyDeltaGeneration(identity, parts, []Tombstone{{PrimaryID: 9, GenerationID: 2}})
+	if err != nil {
+		t.Fatalf("BuildQueryReadyDeltaGeneration: %v", err)
+	}
+	if got, want := result.Stats.PeakEncodedBufferBytes, result.Stats.OutputBytes; got != want {
+		t.Fatalf("peak encoded buffer bytes=%d want one final output buffer=%d", got, want)
+	}
+	if got, want := result.Stats.BytesCopied, result.Stats.InputBytes; got != want {
+		t.Fatalf("bytes copied=%d want input bytes copied once=%d", got, want)
+	}
+	opened, err := OpenQueryReadyDeltaGeneration(result.Bytes, identity)
+	if err != nil {
+		t.Fatalf("OpenQueryReadyDeltaGeneration: %v", err)
+	}
+	if !bytes.Equal(opened.Base.Parts[0].Image.Bytes, image.Bytes) {
+		t.Fatal("embedded typed-column image changed")
+	}
+	if !bytes.Equal(opened.Base.Bytes(), standalone.Bytes) {
+		t.Fatal("directly encoded embedded QRBG differs from standalone deterministic QRBG")
+	}
+}
+
+func TestQueryReadyDeltaBuildPhaseCountersAreComplete(t *testing.T) {
+	image := queryReadyDeltaTestImage(t, 2202, map[int64]int64{1: 10, 2: 20})
+	result, err := BuildQueryReadyDeltaGeneration(queryReadyBaseTestIdentity(2), []QueryReadyBasePartInput{{SourceGeneration: 2, Image: image}}, nil)
+	if err != nil {
+		t.Fatalf("BuildQueryReadyDeltaGeneration: %v", err)
+	}
+	if result.Stats.ValidationTime <= 0 || result.Stats.BaseBuildTime <= 0 || result.Stats.EnvelopeBuildTime <= 0 {
+		t.Fatalf("missing phase timing: %+v", result.Stats)
+	}
+	if got, want := result.Stats.BytesHashed, int64(len(image.Bytes)); got != want {
+		t.Fatalf("bytes hashed=%d want %d", got, want)
+	}
+	if result.Stats.BytesChecksummed <= int64(queryReadyBaseHeaderBytes+queryReadyDeltaHeaderBytes) {
+		t.Fatalf("bytes checksummed=%d want headers plus metadata tables", result.Stats.BytesChecksummed)
+	}
+	if len(result.Dependencies) != 1 || result.Dependencies[0].PartID != image.PartID {
+		t.Fatalf("dependencies=%+v want complete part dependency", result.Dependencies)
 	}
 }
 
@@ -744,11 +795,15 @@ func BenchmarkQueryReadyBaseDeltaConsolidation(b *testing.B) {
 	b.StopTimer()
 	result := queryReadyDeltaConsolidationSink
 	b.ReportMetric(result.Stats.WriteAmplification, "write_amp/op")
-	b.ReportMetric(float64(result.Stats.PeakWorkingBytes), "peak_working_bytes/op")
+	b.ReportMetric(float64(result.Stats.PeakEncodedBufferBytes), "peak_encoded_buffer_bytes/op")
+	b.ReportMetric(float64(result.Stats.BytesCopied), "copied-bytes/op")
+	b.ReportMetric(float64(result.Stats.BytesHashed), "hashed-bytes/op")
+	b.ReportMetric(float64(result.Stats.BytesChecksummed), "checksummed-bytes/op")
 }
 
 func BenchmarkQueryReadyDeltaGenerationBuild(b *testing.B) {
-	image := queryReadyDeltaBenchmarkImage(b, 6001, 512, 64, 0)
+	rows := queryReadyDeltaBenchmarkRows(b, "QUERY_READY_BENCH_DELTA_ROWS", 512)
+	image := queryReadyDeltaBenchmarkImage(b, 6001, rows, min(rows, 64), 0)
 	parts := []QueryReadyBasePartInput{{SourceGeneration: 2, Image: image}}
 	tombstones := make([]Tombstone, 128)
 	for i := range tombstones {
@@ -766,7 +821,13 @@ func BenchmarkQueryReadyDeltaGenerationBuild(b *testing.B) {
 		}
 	})
 	b.Run("qrdg_derived_envelope_build", func(b *testing.B) {
+		sample, err := BuildQueryReadyDeltaGeneration(identity, parts, tombstones)
+		if err != nil {
+			b.Fatal(err)
+		}
 		b.ReportAllocs()
+		b.SetBytes(int64(len(image.Bytes)))
+		b.ResetTimer()
 		for range b.N {
 			result, err := BuildQueryReadyDeltaGeneration(identity, parts, tombstones)
 			if err != nil {
@@ -774,6 +835,11 @@ func BenchmarkQueryReadyDeltaGenerationBuild(b *testing.B) {
 			}
 			queryReadyDeltaConsolidationSink.Bytes = result.Bytes
 		}
+		b.ReportMetric(float64(sample.Stats.BytesCopied), "copied-bytes/op")
+		b.ReportMetric(float64(sample.Stats.BytesHashed), "hashed-bytes/op")
+		b.ReportMetric(float64(sample.Stats.BytesChecksummed), "checksummed-bytes/op")
+		b.ReportMetric(float64(sample.Stats.PeakEncodedBufferBytes), "peak_encoded_buffer_bytes/op")
+		b.ReportMetric(sample.Stats.WriteAmplification, "write_amp/op")
 	})
 }
 

--- a/TreeDB/internal/typedcolumn/query_ready_delta_test.go
+++ b/TreeDB/internal/typedcolumn/query_ready_delta_test.go
@@ -8,6 +8,7 @@ import (
 	"math/rand"
 	"os"
 	"path/filepath"
+	"runtime"
 	"slices"
 	"strconv"
 	"testing"
@@ -92,7 +93,13 @@ func TestQueryReadyDeltaBuildPhaseCountersAreComplete(t *testing.T) {
 	if err != nil {
 		t.Fatalf("BuildQueryReadyDeltaGeneration: %v", err)
 	}
-	if result.Stats.ValidationTime <= 0 || result.Stats.BaseBuildTime <= 0 || result.Stats.EnvelopeBuildTime <= 0 {
+	if result.Stats.BaseBuildTime < result.Stats.ValidationTime || result.Stats.BuildTime < result.Stats.BaseBuildTime || result.Stats.BuildTime < result.Stats.EnvelopeBuildTime || result.Stats.BuildTime < result.Stats.TombstonePrepareTime {
+		t.Fatalf("inconsistent phase timing: %+v", result.Stats)
+	}
+	// Windows' monotonic clock may report zero for every sub-millisecond
+	// phase. Preserve the ordering assertions above there rather than treating
+	// clock granularity as missing instrumentation.
+	if runtime.GOOS != "windows" && (result.Stats.ValidationTime <= 0 || result.Stats.BaseBuildTime <= 0 || result.Stats.EnvelopeBuildTime <= 0) {
 		t.Fatalf("missing phase timing: %+v", result.Stats)
 	}
 	if got, want := result.Stats.BytesHashed, int64(len(image.Bytes)); got != want {

--- a/TreeDB/internal/typedcolumn/transplant_test.go
+++ b/TreeDB/internal/typedcolumn/transplant_test.go
@@ -636,6 +636,10 @@ func TestTypedColumnTransplantNoProductionPublication(t *testing.T) {
 		// identity and reader leases without exposing query-shaped operators or
 		// publication ownership.
 		filepath.Clean(filepath.Join(collectionsDir, "query_ready_generation_open.go")): {},
+		// #3700 is the scoped query-ready build/handoff bridge. It writes
+		// rebuildable prepared generations through the existing asset manager;
+		// it does not publish a root or introduce another recovery data plane.
+		filepath.Clean(filepath.Join(collectionsDir, "query_ready_build.go")): {},
 	}
 	fset := token.NewFileSet()
 	err := filepath.WalkDir(collectionsDir, func(path string, d fs.DirEntry, walkErr error) error {
@@ -656,7 +660,7 @@ func TestTypedColumnTransplantNoProductionPublication(t *testing.T) {
 			if _, ok := allowedImports[filepath.Clean(path)]; ok {
 				continue
 			}
-			t.Fatalf("production collections import typedcolumn in %s; typed-column data-plane imports must stay in approved seams (#1754 adapter, #1782 vector graph, #1949 sort-key pruning, #1993 row-ref state, #2013 document-ID state, #2041 prepared views, #2118 physical accounting, #3698 query-ready generation open)", path)
+			t.Fatalf("production collections import typedcolumn in %s; typed-column data-plane imports must stay in approved seams (#1754 adapter, #1782 vector graph, #1949 sort-key pruning, #1993 row-ref state, #2013 document-ID state, #2041 prepared views, #2118 physical accounting, #3698 query-ready generation open, #3700 query-ready build handoff)", path)
 		}
 		return nil
 	})

--- a/docs/architecture/query-ready-build-handoff.md
+++ b/docs/architecture/query-ready-build-handoff.md
@@ -1,0 +1,93 @@
+# Query-ready build bounds and prepared-asset handoff
+
+M5 builds QRBG/QRDG images as rebuildable, non-authoritative derived assets and
+hands them to TreeDB's existing column asset manager. It does not add another
+publisher, manifest, recovery selector, WAL record, sync protocol, GC path, or
+deletion owner.
+
+## Pipeline and ownership
+
+`queryReadyBuildCoordinator` owns the bounded work before authoritative
+publication:
+
+1. estimate a conservative request reservation from source image bytes, part
+   metadata, tombstones, and alignment slack;
+2. admit at most `MaxWorkers`, with a per-worker share of
+   `MaxInFlightBytes`;
+3. build a deterministic base, delta, or consolidated-base image;
+4. append the complete image through the existing column asset manager;
+5. register the complete ref set through
+   `RegisterColumnAssetPreparedAssets`;
+6. return the stable asset ref, exact segment byte range, diagnostic path,
+   generation/schema identity, sorted source dependencies, and the existing
+   lifecycle lease.
+
+`OpenFileDescriptor` translates the asset-manager kind into M3's
+`typedcolumn.QueryReadyGenerationFile` at this handoff. The descriptor keeps
+the manager's exact nonzero offset and length, so M3 maps and validates the
+prepared range directly instead of reading the whole asset file or locating a
+lane again by pathname. The manager checksum remains on the returned asset ref
+and binds the same byte range.
+
+The admission queue is intentionally zero. Saturated calls fail with
+`QueryReadyBuildBackpressureError`, so the build layer cannot accumulate an
+unbounded internal request queue. A request larger than its worker share fails
+before output allocation with `QueryReadyBuildBoundError`. The coordinator
+tracks current/peak workers, reserved in-flight bytes, and both rejection
+classes.
+
+Cancellation is cooperative at phase boundaries: before admission, after
+image construction, and after the asset append but before registration. QRBG
+and QRDG validation is currently a synchronous CPU phase and is not interrupted
+mid-part. Cancellation or registration failure after append invokes the
+existing safe prepared-tail cleanup; no lifecycle record is installed. A
+successful result remains protected by the existing prepared-asset lease until
+the caller hands it to publication or calls `Abort`.
+
+## Measurement contract
+
+Build stats distinguish:
+
+- base, delta, consolidation, asset append, existing-manager registration, and
+  total handoff duration;
+- rows, input/output bytes, assets, parts, copied bytes, compressed bytes,
+  SHA-256 dependency bytes, checksum bytes, and base bytes rewritten;
+- write amplification;
+- one final encoded-buffer size from the format builder; and
+- the conservative coordinator reservation used for bounded admission.
+
+The reservation is a safety bound, not a claim about exact Go live heap. The
+encoded-buffer counter excludes caller-owned inputs and Go metadata. Focused
+`-benchmem` evidence supplies cumulative bytes and allocations, while a
+same-host process RSS/live-heap capture remains the peak-memory evidence.
+
+The handoff does not hash the complete QRBG/QRDG output again. The stable asset
+ref already carries the manager checksum, the formats carry internal header and
+table CRC-32C, and every QRBG dependency carries its image SHA-256. Adding a
+second whole-output SHA-256 pass would duplicate current validation work; the
+later authoritative token inventory may add a digest only if its shared
+publication contract requires one.
+
+The profile-selected M5 primary metric is QRDG build allocation/latency. On the
+M2 baseline host, the derived envelope took about `46.5 us`, `74.4 KB/op`, and
+`114 allocs/op`, versus `28.3 us`, `40.0 KB/op`, and `105 allocs/op` for the
+validated inner container. The implementation encodes QRBG directly into the
+final QRDG buffer while preserving all QRBG/QRDG validation, SHA-256, CRC-32C,
+identity, deterministic-byte, and reopen checks.
+
+Numeric guardrails for this change are:
+
+- output bytes and write amplification unchanged;
+- QRDG `B/op` and encoded-buffer bytes no greater than the former
+  inner-plus-outer construction;
+- no material regression in base build or consolidation latency/allocations;
+- bounded worker count and conservative in-flight reservation under concurrent
+  saturation; and
+- no registered partial generation after cancellation/error.
+
+The canonical 1M load target remains TreeDB no slower than `1.5x` ClickHouse.
+This M2-based branch does not yet route the production JSONBench load through
+query-ready asset construction, so a canonical load run cannot honestly
+attribute a load change to this pipeline. M6 owns that integrated matrix after
+M4 consumes the prepared assets. Production-shaped focused QRBG/QRDG and
+consolidation evidence is still required here.

--- a/docs/architecture/query-ready-delta-generation.md
+++ b/docs/architecture/query-ready-delta-generation.md
@@ -71,7 +71,7 @@ Focused benchmarks separate preparation from warm reused lookup:
   update/delete/reinsert generations;
 - `BenchmarkQueryReadyBaseDeltaWarmLookup` measures lookup after preparation;
 - `BenchmarkQueryReadyBaseDeltaConsolidation` reports write amplification and
-  peak simultaneous inner-plus-outer working bytes;
+  the peak encoded output buffer bytes;
 - `BenchmarkQueryReadyDeltaGenerationBuild` compares validated typed-part
   container production with QRDG envelope production.
 
@@ -79,11 +79,12 @@ Run them on one host with `-benchmem -count=5`. The checked-in default of eight
 accumulated delta-derived parts is the last allowed point on the required
 `N=0..8` curve; `N=9` is the explicit beyond-bound point. The generation limit
 of four triggers earlier for the ordinary default query path. Build/consolidate
-copy counters include typed-column images copied into the inner QRBG, the inner
-QRBG copied into QRDG, and tombstone-table bytes. Peak working bytes account for
-the simultaneously live inner and outer buffers. Process peak RSS remains a
-separate same-host measurement rather than being inferred from Go allocation
-profiles.
+copy counters include typed-column images copied directly into the final QRDG
+buffer and tombstone-table bytes. QRDG construction uses one final encoded
+buffer rather than simultaneously retaining inner and outer generation images.
+The encoded-buffer counter intentionally excludes caller-owned inputs and Go
+metadata; bounded pipeline admission reports a conservative in-flight
+reservation, while process peak RSS remains a separate same-host measurement.
 
 The benchmark fixture defaults remain CI-sized. Same-host production-shape
 captures may set `QUERY_READY_BENCH_BASE_ROWS` and


### PR DESCRIPTION
Closes #3700

Parent: #3694

Depends on merged #3696, #3697, and integration contract from merged #3698.

Current exact head: `4ce29663d3495b16ae26a8bed292785d00055e19`.

## Outcome

- Adds a bounded zero-queue coordinator for QRBG base, QRDG delta, and
  consolidated-base preparation through the existing column asset manager.
- Reserves conservative in-flight bytes before output allocation, caps active
  workers, reports typed bound/backpressure errors, and exposes phase/resource
  accounting.
- Registers only complete deterministic prepared assets with the existing
  lifecycle registry; cancellation/error cleanup cannot install a partial
  generation and does not create a publisher, root, WAL, recovery selector, or
  deletion owner.
- Encodes QRBG directly into the final QRDG allocation, removing the simultaneous
  complete inner buffer/copy while preserving format validation, dependency
  SHA-256, CRC-32C, deterministic bytes, and reopen behavior.
- Emits M3's native `QueryReadyGenerationFile` for the exact nonzero
  asset-manager range. A post-rebase integration test proves M3 mmaps that range
  directly with zero payload copies and zero whole-part decode during open.

## TDD record

The original implementation began with focused failing tests for deterministic
complete asset sets, cancellation cleanup, bounded in-flight work, zero-queue
backpressure, no base rewrite for delta publication, and consolidation parity.
Raw red transcripts are under:

- `/mnt/fast4tb/gomap_graph_3694/m5_evidence/red_query_ready_build_bounds.txt`
- `/mnt/fast4tb/gomap_graph_3694/m5_evidence/red_query_ready_handoff.txt`

After #3698 merged, the integration test first failed because
`OpenFileDescriptor` did not exist, then passed after the native M3 descriptor
bridge was implemented. The tracked-file naming inventory also failed closed
before its exact entry was added:

- `/mnt/fast4tb/gomap_graph_3694/m5_evidence_post_m3/red_open_descriptor.txt`
- `/mnt/fast4tb/gomap_graph_3694/m5_evidence_post_m3/red_naming_inventory.txt`

## Correctness validation

- Query-ready collection tests: 10 repetitions passed.
- Query-ready typed-column tests: 10 repetitions passed.
- Query-ready collection race tests: 3 repetitions passed.
- Targeted collections/typedcolumn vet passed.
- Exact-head `GOWORK=off make test` passed.

## Performance evidence

Primary metric: QRDG/consolidation allocation volume and latency.

Guardrails: base build, output bytes, write amplification, deterministic output,
validation/integrity, worker/buffer bounds, peak RSS, and existing-manager
handoff allocations.

Paired same-host current-main (`2ae647d41`) versus implementation head
(`08ace5ada`), identical `-benchmem -count=5` commands. The exact PR head adds
only the Windows clock-granularity portability assertion described below:

- QRDG build median: 48.452 us -> 45.456 us (-6.2%); 74,447 -> 49,856 B/op
  (-33.0%); 114 -> 113 allocs/op.
- CI-size consolidation median: 123.887 us -> 113.694 us (-8.2%); 212,446 ->
  138,667 B/op (-34.7%); 433 -> 432 allocs/op.
- Base build median: 1.400 ms -> 1.375 ms (-1.8%), with flat allocation volume
  and allocation count.
- Output bytes and write amplification are unchanged.

Paired 1M consolidation (`QUERY_READY_BENCH_BASE_ROWS=1000000`, five samples):

- median latency: 155.874 ms -> 116.717 ms (-25.1%);
- allocation volume: 237,969,392 -> 125,771,760 B/op (-47.1%);
- allocations remain about 55.1K/op and write amplification remains 1.000;
- three fresh-process samples report median max RSS 626,944 -> 616,320 KiB.
  The ranges overlap, so B/op is the stronger memory result.

Existing-manager handoff remains bounded: base is about 26.5 KB/op and 146
allocs/op under a 69,904-byte reservation; delta is about 30.7 KB/op and 148
allocs/op under a 135,440-byte reservation. Append/fsync latency is reported
separately from CPU-only build work.

Evidence summaries and raw artifacts:

- `/mnt/fast4tb/gomap_graph_3694/m5_evidence/SUMMARY.md`
- `/mnt/fast4tb/gomap_graph_3694/m5_evidence_post_m3/SUMMARY.md`

## Canonical load boundary

The production JSONBench load path does not yet consume these prepared assets,
so a canonical load run on this PR would not measure this implementation. This
PR therefore does not claim the final <=1.5x ClickHouse load target. #3699 owns
production encoded consumption and #3701 owns the integrated canonical 1M
matrix, refreshed profiles, and residual closeout.

## Latest-head CI follow-up

The first `windows-core-1` run exposed a branch-caused test portability defect:
Windows can report zero for each sub-millisecond monotonic-clock phase. The
implementation counters and byte evidence were complete. The exact head keeps
phase-ordering consistency assertions on every platform and requires positive
sub-phase durations where clock resolution supports them. The focused test
passed 100 repetitions, Windows amd64 cross-compilation passed, and exact-head
`GOWORK=off make test` passed before the follow-up push.

Exact-head Codex review then found that admission reserved every known delta
even though consolidation selects only generations through
`ThroughGeneration`. A large future delta could therefore falsely reject an
older prefix that fit the bound. Red-first
`TestQueryReadyConsolidationAdmissionIgnoresFutureDeltaPayloads` reproduced an
18,027,024-byte reservation against a 135,440-byte selected-prefix bound. The
estimator now validates every inventory entry but charges only selected
generations, matching execution; the test passes x100 and x10 under race.
