### PR TITLE
bench: stabilize Dgraph durability attribution gates

### DIFF
--- a/TreeDB/caching/db.go
+++ b/TreeDB/caching/db.go
@@ -2443,7 +2443,8 @@ const (
 )
 
 // SetIteratorDebug toggles attaching debug metadata to iterators returned by
-// CachingDB.Iterator. It is intended for benchmarking/diagnostics.
+// CachingDB.Iterator and collecting iterator shape counters in Stats. It is
+// intended for benchmarking/diagnostics and is disabled by default.
 func SetIteratorDebug(enabled bool) {
 	iteratorDebugEnabled.Store(enabled)
 }
@@ -32303,7 +32304,10 @@ func (db *DB) Drain() error {
 
 // Iterator implements DB.Iterator
 func (db *DB) Iterator(start, end []byte) (merging.Iterator, error) {
-	db.iteratorCallsTotal.Add(1)
+	iteratorDebug := iteratorDebugEnabled.Load()
+	if iteratorDebug {
+		db.iteratorCallsTotal.Add(1)
+	}
 	db.noteRead()
 	if err := db.ensureBackendRange(); err != nil {
 		return nil, err
@@ -32340,7 +32344,9 @@ func (db *DB) Iterator(start, end []byte) (merging.Iterator, error) {
 			db.mu.Unlock()
 			return nil, err
 		}
-		db.iteratorSnapshotRotationsTotal.Add(1)
+		if iteratorDebug {
+			db.iteratorSnapshotRotationsTotal.Add(1)
+		}
 	}
 
 	backendRangeKnown := db.backendRangeKnown
@@ -32366,8 +32372,8 @@ func (db *DB) Iterator(start, end []byte) (merging.Iterator, error) {
 			view = nil
 		}
 		decorate := func(it merging.Iterator, sourcesUsed int) merging.Iterator {
-			db.observeIteratorShape(0, sourcesUsed)
-			if iteratorDebugEnabled.Load() {
+			if iteratorDebug {
+				db.observeIteratorShape(0, sourcesUsed)
 				it = &debugIterator{Iterator: it, queueLen: 0, sourcesUsed: sourcesUsed}
 			}
 			return db.wrapForegroundIterator(it)
@@ -32430,8 +32436,8 @@ func (db *DB) Iterator(start, end []byte) (merging.Iterator, error) {
 	queueLen := len(queue)
 	hasMemSource := false
 	decorateIterator := func(it merging.Iterator, sourcesUsed int) merging.Iterator {
-		db.observeIteratorShape(queueLen, sourcesUsed)
-		if iteratorDebugEnabled.Load() {
+		if iteratorDebug {
+			db.observeIteratorShape(queueLen, sourcesUsed)
 			it = &debugIterator{Iterator: it, queueLen: queueLen, sourcesUsed: sourcesUsed}
 		}
 		if hasMemSource && view != nil {

--- a/TreeDB/caching/db.go
+++ b/TreeDB/caching/db.go
@@ -8964,6 +8964,11 @@ type DB struct {
 	debugPtrDenied                                               atomic.Int64
 	debugPtrDisabled                                             atomic.Int64
 	checkpointRuns                                               atomic.Uint64
+	iteratorCallsTotal                                           atomic.Uint64
+	iteratorSnapshotRotationsTotal                               atomic.Uint64
+	iteratorSourcesTotal                                         atomic.Uint64
+	iteratorSourcesMax                                           atomic.Uint64
+	iteratorQueueLenMax                                          atomic.Uint64
 	checkpointTotalNs                                            atomic.Uint64
 	checkpointMaxNs                                              atomic.Uint64
 	checkpointNoopSkips                                          atomic.Uint64
@@ -29982,6 +29987,11 @@ func (db *DB) Stats() map[string]string {
 	stats["treedb.cache.value_log.directory_sync.errors_total"] = fmt.Sprintf("%d", valueLogDirectorySyncErrors)
 
 	stats["treedb.cache.queue_len"] = fmt.Sprintf("%d", queueLen)
+	stats["treedb.cache.iterator.calls_total"] = fmt.Sprintf("%d", db.iteratorCallsTotal.Load())
+	stats["treedb.cache.iterator.snapshot_rotations_total"] = fmt.Sprintf("%d", db.iteratorSnapshotRotationsTotal.Load())
+	stats["treedb.cache.iterator.sources_total"] = fmt.Sprintf("%d", db.iteratorSourcesTotal.Load())
+	stats["treedb.cache.iterator.sources_max"] = fmt.Sprintf("%d", db.iteratorSourcesMax.Load())
+	stats["treedb.cache.iterator.queue_len_max"] = fmt.Sprintf("%d", db.iteratorQueueLenMax.Load())
 	stats["treedb.cache.flush_apply.coordinator.active"] = fmt.Sprintf("%d", db.flushCoordinatorActive.Load())
 	stats["treedb.cache.flush_apply.coordinator.active_workers"] = fmt.Sprintf("%d", db.flushCoordinatorActiveWorkers.Load())
 	stats["treedb.cache.flush_apply.coordinator.in_flight_bytes"] = fmt.Sprintf("%d", db.flushCoordinatorInFlightBytes.Load())
@@ -32293,6 +32303,7 @@ func (db *DB) Drain() error {
 
 // Iterator implements DB.Iterator
 func (db *DB) Iterator(start, end []byte) (merging.Iterator, error) {
+	db.iteratorCallsTotal.Add(1)
 	db.noteRead()
 	if err := db.ensureBackendRange(); err != nil {
 		return nil, err
@@ -32329,6 +32340,7 @@ func (db *DB) Iterator(start, end []byte) (merging.Iterator, error) {
 			db.mu.Unlock()
 			return nil, err
 		}
+		db.iteratorSnapshotRotationsTotal.Add(1)
 	}
 
 	backendRangeKnown := db.backendRangeKnown
@@ -32354,6 +32366,7 @@ func (db *DB) Iterator(start, end []byte) (merging.Iterator, error) {
 			view = nil
 		}
 		decorate := func(it merging.Iterator, sourcesUsed int) merging.Iterator {
+			db.observeIteratorShape(0, sourcesUsed)
 			if iteratorDebugEnabled.Load() {
 				it = &debugIterator{Iterator: it, queueLen: 0, sourcesUsed: sourcesUsed}
 			}
@@ -32417,6 +32430,7 @@ func (db *DB) Iterator(start, end []byte) (merging.Iterator, error) {
 	queueLen := len(queue)
 	hasMemSource := false
 	decorateIterator := func(it merging.Iterator, sourcesUsed int) merging.Iterator {
+		db.observeIteratorShape(queueLen, sourcesUsed)
 		if iteratorDebugEnabled.Load() {
 			it = &debugIterator{Iterator: it, queueLen: queueLen, sourcesUsed: sourcesUsed}
 		}
@@ -32525,6 +32539,16 @@ func (db *DB) Iterator(start, end []byte) (merging.Iterator, error) {
 
 	out := merging.NewMergingIterator(sources, start, end)
 	return decorateIterator(out, len(sources)), nil
+}
+
+func (db *DB) observeIteratorShape(queueLen, sourcesUsed int) {
+	if queueLen >= 0 {
+		updateAtomicMaxUint64(&db.iteratorQueueLenMax, uint64(queueLen))
+	}
+	if sourcesUsed >= 0 {
+		db.iteratorSourcesTotal.Add(uint64(sourcesUsed))
+		updateAtomicMaxUint64(&db.iteratorSourcesMax, uint64(sourcesUsed))
+	}
 }
 
 type debugIterator struct {

--- a/TreeDB/mvcc/mvcc_bench_test.go
+++ b/TreeDB/mvcc/mvcc_bench_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	treedb "github.com/snissn/gomap/TreeDB"
+	"github.com/snissn/gomap/TreeDB/caching"
 	"github.com/snissn/gomap/TreeDB/internal/mvcckey"
 )
 
@@ -95,6 +96,8 @@ func BenchmarkGetAt(b *testing.B) {
 // rows above. Each iteration writes a new version and immediately performs a
 // point lookup, exposing snapshot rotations and source accumulation.
 func BenchmarkCommitAtGetAtInterleaved(b *testing.B) {
+	caching.SetIteratorDebug(true)
+	b.Cleanup(func() { caching.SetIteratorDebug(false) })
 	db := openBenchDB(b)
 	store := New(db)
 	key := []byte("benchmark-key")

--- a/TreeDB/mvcc/mvcc_bench_test.go
+++ b/TreeDB/mvcc/mvcc_bench_test.go
@@ -91,6 +91,57 @@ func BenchmarkGetAt(b *testing.B) {
 	}
 }
 
+// BenchmarkCommitAtGetAtInterleaved complements the preloaded read-only depth
+// rows above. Each iteration writes a new version and immediately performs a
+// point lookup, exposing snapshot rotations and source accumulation.
+func BenchmarkCommitAtGetAtInterleaved(b *testing.B) {
+	db := openBenchDB(b)
+	store := New(db)
+	key := []byte("benchmark-key")
+	mutation := []Mutation{{Key: key, Value: []byte("value")}}
+	if err := store.CommitAt(1, mutation, CommitRelaxed); err != nil {
+		b.Fatalf("seed CommitAt: %v", err)
+	}
+	before := db.Stats()
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		timestamp := uint64(i + 2)
+		if err := store.CommitAt(timestamp, mutation, CommitRelaxed); err != nil {
+			b.Fatalf("CommitAt(%d): %v", timestamp, err)
+		}
+		result, err := store.GetAt(key, timestamp)
+		if err != nil || result.State != Present {
+			b.Fatalf("GetAt(%d) result=%+v err=%v", timestamp, result, err)
+		}
+	}
+	b.StopTimer()
+	after := db.Stats()
+	reportMVCCBenchCounter(b, before, after, "treedb.cache.iterator.snapshot_rotations_total", "iterator_snapshot_rotations/op")
+	reportMVCCBenchCounter(b, before, after, "treedb.cache.iterator.sources_total", "iterator_sources/op")
+	reportMVCCBenchGauge(b, after, "treedb.cache.iterator.sources_max", "iterator_sources_max")
+	reportMVCCBenchGauge(b, after, "treedb.cache.iterator.queue_len_max", "iterator_queue_len_max")
+	reportMVCCBenchGauge(b, after, "treedb.cache.queue_len", "iterator_queue_len_end")
+}
+
+func reportMVCCBenchCounter(b *testing.B, before, after map[string]string, key, name string) {
+	var start, end uint64
+	if _, err := fmt.Sscanf(before[key], "%d", &start); err != nil {
+		return
+	}
+	if _, err := fmt.Sscanf(after[key], "%d", &end); err != nil || end < start || b.N == 0 {
+		return
+	}
+	b.ReportMetric(float64(end-start)/float64(b.N), name)
+}
+
+func reportMVCCBenchGauge(b *testing.B, stats map[string]string, key, name string) {
+	var value uint64
+	if _, err := fmt.Sscanf(stats[key], "%d", &value); err == nil {
+		b.ReportMetric(float64(value), name)
+	}
+}
+
 func prepareGetAtBench(b *testing.B, depth int) (*treedb.DB, []byte) {
 	b.Helper()
 	db := openBenchDB(b)

--- a/benchmarks/dgraph_durability/README.md
+++ b/benchmarks/dgraph_durability/README.md
@@ -34,6 +34,67 @@ GOWORK=off go test ./benchmarks/dgraph_durability \
   -run '^$' -bench '^BenchmarkDgraphShaped' -benchmem -count=5
 ```
 
+## Stable attribution rows
+
+The fixed mixed rows are seeded deterministically and create a fresh database
+per trial. Database open, the 256-key seed commit, stats collection, and close
+are outside the timer. Run them with exactly one fixed-work trial per repeat:
+
+```sh
+GOWORK=off go test ./benchmarks/dgraph_durability \
+  -run '^$' -bench '^BenchmarkDgraphShapedMixedFixed' \
+  -benchmem -benchtime=1x -count=2
+```
+
+Rows are emitted for 50k, 100k, 250k, and 500k operations. The standard Go
+`B/op` and `allocs/op` columns are per fixed-work *trial*; use the explicit
+`workload_B/op` and `workload_allocs/op` metrics for per-operation allocation.
+`operations/trial=...` and `fixture_seed=1` make this boundary machine-readable.
+
+The concurrent durable matrix has concurrency 1/2/4/8/16, values 128 B/4 KiB,
+and commit batches 1/16:
+
+```sh
+GOWORK=off go test ./benchmarks/dgraph_durability \
+  -run '^$' -bench '^BenchmarkDgraphShapedConcurrentDurable' \
+  -benchmem -benchtime=100x -count=5
+```
+
+It reports per-acknowledgement p50/p95/p99 latency. TreeDB rows additionally
+report command-WAL flush/sync, aggregate value-log sync, checkpoint, iterator
+rotation/source, and queue metrics where the public `Stats` map exposes them.
+`command_wal_syncs/write_commit` is also the inverse attribution needed to
+derive acknowledged commits per command-WAL sync. The current implementation
+has no production group-commit counter, so the harness does not invent one.
+
+The MVCC package has a separately named write/read-alternating row:
+
+```sh
+GOWORK=off go test ./TreeDB/mvcc -run '^$' \
+  -bench '^BenchmarkCommitAtGetAtInterleaved$' -benchmem -count=5
+```
+
+This is distinct from `BenchmarkGetAt`, whose history is preloaded before the
+timer and whose timed phase is read-only.
+
+### Result schema and acceptance
+
+The schema is `dgraph-durability-v2`. Archive the raw Go benchmark output with:
+
+- repository SHA and dirty state;
+- exact command and repeat count;
+- Go version, `goos`, `goarch`, package, and CPU;
+- host kernel and filesystem type for the temporary database path;
+- fixture seed, operation count, value size, batch size, concurrency, and
+  durability class encoded in each row name;
+- raw repeats. Use the median only after retaining every repeat and recording
+  any exclusion with a concrete environmental or correctness reason.
+
+Never exclude a slow run solely because it is slow. Do not aggregate relaxed
+and durable rows, or fixed-work and adaptively sized rows. Profile artifacts use
+`<backend>_<class>_<shape>_<sha>.{cpu,mem,block,mutex,trace}` so attribution can
+be matched back to the exact candidate.
+
 For syscall attribution on Linux, select one row at a time (Go benchmark names
 are slash-separated regular expressions):
 

--- a/benchmarks/dgraph_durability/benchmark_schema_test.go
+++ b/benchmarks/dgraph_durability/benchmark_schema_test.go
@@ -26,11 +26,11 @@ func TestConcurrentDurableMatrix(t *testing.T) {
 
 func TestCounterSchemaIncludesAttributionBoundaries(t *testing.T) {
 	want := map[string]bool{
-		"iterator_snapshot_rotations/write_commit": false,
-		"iterator_sources/lookup":                  false,
-		"command_wal_syncs/write_commit":           false,
-		"value_log_syncs/write_commit":             false,
-		"checkpoints/write_commit":                 false,
+		"iterator_snapshot_rotations/lookup": false,
+		"iterator_sources/lookup":            false,
+		"command_wal_syncs/write_commit":     false,
+		"value_log_syncs/write_commit":       false,
+		"checkpoints/write_commit":           false,
 	}
 	for _, metric := range storeCounterMetrics {
 		if _, ok := want[metric.name]; ok {

--- a/benchmarks/dgraph_durability/benchmark_schema_test.go
+++ b/benchmarks/dgraph_durability/benchmark_schema_test.go
@@ -1,6 +1,8 @@
 package dgraphdurability
 
 import (
+	"bytes"
+	"os"
 	"reflect"
 	"testing"
 )
@@ -41,5 +43,15 @@ func TestCounterSchemaIncludesAttributionBoundaries(t *testing.T) {
 		if !found {
 			t.Errorf("missing attribution metric %q", name)
 		}
+	}
+}
+
+func TestRunnerRecordsWorkspaceIsolationForEveryCommand(t *testing.T) {
+	script, err := os.ReadFile("run.sh")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got, want := bytes.Count(script, []byte("GOWORK=off")), 6; got != want {
+		t.Fatalf("run.sh GOWORK=off occurrences=%d want %d (three recorded and three executed commands)", got, want)
 	}
 }

--- a/benchmarks/dgraph_durability/benchmark_schema_test.go
+++ b/benchmarks/dgraph_durability/benchmark_schema_test.go
@@ -1,0 +1,45 @@
+package dgraphdurability
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestFixedMixedOperationCounts(t *testing.T) {
+	want := []int{50_000, 100_000, 250_000, 500_000}
+	if !reflect.DeepEqual(fixedMixedOperationCounts, want) {
+		t.Fatalf("fixedMixedOperationCounts=%v want %v", fixedMixedOperationCounts, want)
+	}
+}
+
+func TestConcurrentDurableMatrix(t *testing.T) {
+	if !reflect.DeepEqual(concurrentDurableConcurrencies, []int{1, 2, 4, 8, 16}) {
+		t.Fatalf("concurrencies=%v", concurrentDurableConcurrencies)
+	}
+	if !reflect.DeepEqual(concurrentDurableBatchSizes, []int{1, 16}) {
+		t.Fatalf("batch sizes=%v", concurrentDurableBatchSizes)
+	}
+	if !reflect.DeepEqual(concurrentDurableValueSizes, []int{128, 4096}) {
+		t.Fatalf("value sizes=%v", concurrentDurableValueSizes)
+	}
+}
+
+func TestCounterSchemaIncludesAttributionBoundaries(t *testing.T) {
+	want := map[string]bool{
+		"iterator_snapshot_rotations/write_commit": false,
+		"iterator_sources/lookup":                  false,
+		"command_wal_syncs/write_commit":           false,
+		"value_log_syncs/write_commit":             false,
+		"checkpoints/write_commit":                 false,
+	}
+	for _, metric := range storeCounterMetrics {
+		if _, ok := want[metric.name]; ok {
+			want[metric.name] = true
+		}
+	}
+	for name, found := range want {
+		if !found {
+			t.Errorf("missing attribution metric %q", name)
+		}
+	}
+}

--- a/benchmarks/dgraph_durability/benchmark_test.go
+++ b/benchmarks/dgraph_durability/benchmark_test.go
@@ -298,12 +298,14 @@ func benchmarkConcurrentDurable(b *testing.B, profile benchmarkProfile, concurre
 	var nextTimestamp atomic.Uint64
 	nextTimestamp.Store(benchmarkWarmupCommits)
 	var wg sync.WaitGroup
+	start := make(chan struct{})
 	wg.Add(concurrency)
 	b.ReportAllocs()
-	b.ResetTimer()
+	b.StopTimer()
 	for worker := 0; worker < concurrency; worker++ {
 		go func() {
 			defer wg.Done()
+			<-start
 			for index := range jobs {
 				started := time.Now()
 				timestamp := nextTimestamp.Add(1)
@@ -314,6 +316,9 @@ func benchmarkConcurrentDurable(b *testing.B, profile benchmarkProfile, concurre
 			}
 		}()
 	}
+	b.ResetTimer()
+	b.StartTimer()
+	close(start)
 	for i := 0; i < b.N; i++ {
 		jobs <- i
 	}

--- a/benchmarks/dgraph_durability/benchmark_test.go
+++ b/benchmarks/dgraph_durability/benchmark_test.go
@@ -5,7 +5,12 @@ import (
 	"encoding/binary"
 	"fmt"
 	"math"
+	"runtime"
+	"sort"
+	"sync"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/dgraph-io/badger/v4"
 	treedb "github.com/snissn/gomap/TreeDB"
@@ -13,6 +18,13 @@ import (
 )
 
 const benchmarkWarmupCommits = 16
+
+var (
+	fixedMixedOperationCounts      = []int{50_000, 100_000, 250_000, 500_000}
+	concurrentDurableConcurrencies = []int{1, 2, 4, 8, 16}
+	concurrentDurableBatchSizes    = []int{1, 16}
+	concurrentDurableValueSizes    = []int{128, 4096}
+)
 
 type mutation struct {
 	key    []byte
@@ -71,6 +83,46 @@ func BenchmarkDgraphShapedMixed(b *testing.B) {
 	}
 }
 
+// BenchmarkDgraphShapedMixedFixed makes duration-dependent source growth
+// visible without relying on the benchmark driver's adaptive operation count.
+// Run with -benchtime=1x so each row is one fresh, fixed-size trial.
+func BenchmarkDgraphShapedMixedFixed(b *testing.B) {
+	for _, operations := range fixedMixedOperationCounts {
+		operations := operations
+		for _, profile := range benchmarkProfiles {
+			if profile.class != "relaxed" {
+				continue
+			}
+			profile := profile
+			b.Run(fmt.Sprintf("relaxed/%s/operations=%d/seed=1", profile.name, operations), func(b *testing.B) {
+				benchmarkMixedFixed(b, profile, operations)
+			})
+		}
+	}
+}
+
+// BenchmarkDgraphShapedConcurrentDurable measures independently acknowledged
+// durable commits with per-acknowledgement latency and matching sync counters.
+func BenchmarkDgraphShapedConcurrentDurable(b *testing.B) {
+	for _, profile := range benchmarkProfiles {
+		if profile.class != "durable" {
+			continue
+		}
+		profile := profile
+		for _, concurrency := range concurrentDurableConcurrencies {
+			for _, batchSize := range concurrentDurableBatchSizes {
+				for _, valueSize := range concurrentDurableValueSizes {
+					concurrency, batchSize, valueSize := concurrency, batchSize, valueSize
+					name := fmt.Sprintf("durable/%s/concurrency=%d/batch=%d/value=%d", profile.name, concurrency, batchSize, valueSize)
+					b.Run(name, func(b *testing.B) {
+						benchmarkConcurrentDurable(b, profile, concurrency, batchSize, valueSize)
+					})
+				}
+			}
+		}
+	}
+}
+
 func benchmarkCommit(b *testing.B, profile benchmarkProfile, batchSize, valueSize int) {
 	store := profile.open(b, b.TempDir())
 	mutations := benchmarkMutations(batchSize, valueSize)
@@ -89,7 +141,7 @@ func benchmarkCommit(b *testing.B, profile benchmarkProfile, batchSize, valueSiz
 	}
 	b.StopTimer()
 	reportRates(b, batchSize)
-	reportStoreCounters(b, before, store.stats(), b.N)
+	reportStoreCounters(b, before, store.stats(), b.N, 0)
 	if err := store.close(); err != nil {
 		b.Fatalf("close: %v", err)
 	}
@@ -143,9 +195,165 @@ func benchmarkMixed(b *testing.B, profile benchmarkProfile) {
 		b.ReportMetric(float64(b.N)/elapsed.Seconds(), "operations/s")
 		b.ReportMetric(float64(writeCommits)/elapsed.Seconds(), "write_commits/s")
 	}
-	reportStoreCounters(b, before, store.stats(), writeCommits)
+	reportStoreCounters(b, before, store.stats(), writeCommits, b.N-writeCommits)
 	if err := store.close(); err != nil {
 		b.Fatalf("close: %v", err)
+	}
+}
+
+func benchmarkMixedFixed(b *testing.B, profile benchmarkProfile, operations int) {
+	var totalWrites, totalReads int
+	var totalAllocatedBytes, totalMallocs uint64
+	b.ReportAllocs()
+	b.ResetTimer()
+	for trial := 0; trial < b.N; trial++ {
+		b.StopTimer()
+		store, keys, value := prepareMixedStore(b, profile)
+		before := store.stats()
+		timestamp := uint64(1)
+		var memoryBefore, memoryAfter runtime.MemStats
+		runtime.ReadMemStats(&memoryBefore)
+		b.StartTimer()
+		writes, reads := runMixedOperations(b, store, keys, value, &timestamp, operations)
+		b.StopTimer()
+		runtime.ReadMemStats(&memoryAfter)
+		totalAllocatedBytes += memoryAfter.TotalAlloc - memoryBefore.TotalAlloc
+		totalMallocs += memoryAfter.Mallocs - memoryBefore.Mallocs
+		totalWrites += writes
+		totalReads += reads
+		reportStoreCounters(b, before, store.stats(), writes, reads)
+		if err := store.close(); err != nil {
+			b.Fatalf("close: %v", err)
+		}
+	}
+	if elapsed := b.Elapsed(); elapsed > 0 {
+		b.ReportMetric(float64(b.N*operations)/elapsed.Seconds(), "operations/s")
+		b.ReportMetric(float64(totalWrites)/elapsed.Seconds(), "write_commits/s")
+	}
+	b.ReportMetric(float64(operations), "operations/trial")
+	b.ReportMetric(1, "fixture_seed")
+	totalOperations := uint64(b.N * operations)
+	if totalOperations > 0 {
+		b.ReportMetric(float64(totalAllocatedBytes)/float64(totalOperations), "workload_B/op")
+		b.ReportMetric(float64(totalMallocs)/float64(totalOperations), "workload_allocs/op")
+	}
+}
+
+func prepareMixedStore(tb testing.TB, profile benchmarkProfile) (versionedStore, [][]byte, []byte) {
+	store := profile.open(tb, tb.TempDir())
+	const keyCount = 256
+	keys := make([][]byte, keyCount)
+	seed := make([]mutation, keyCount)
+	for i := range keys {
+		keys[i] = benchmarkKey(i)
+		seed[i] = mutation{key: keys[i], value: benchmarkValue(128)}
+	}
+	if err := store.commitAt(1, seed); err != nil {
+		tb.Fatalf("seed: %v", err)
+	}
+	return store, keys, benchmarkValue(128)
+}
+
+func runMixedOperations(tb testing.TB, store versionedStore, keys [][]byte, value []byte, timestamp *uint64, operations int) (writes, reads int) {
+	for i := 0; i < operations; i++ {
+		key := keys[(i*131)%len(keys)]
+		switch i % 10 {
+		case 0, 1, 2, 3, 4, 5:
+			got, present, err := store.getAt(key, *timestamp)
+			if err != nil {
+				tb.Fatalf("read %d: %v", i, err)
+			}
+			if present && len(got) == 0 {
+				tb.Fatalf("read %d returned an empty present value", i)
+			}
+			reads++
+		case 6, 7:
+			(*timestamp)++
+			if err := store.commitAt(*timestamp, []mutation{{key: key, value: value}}); err != nil {
+				tb.Fatalf("write %d: %v", i, err)
+			}
+			writes++
+		case 8, 9:
+			(*timestamp)++
+			if err := store.commitAt(*timestamp, []mutation{{key: key, delete: true}}); err != nil {
+				tb.Fatalf("delete %d: %v", i, err)
+			}
+			writes++
+		}
+	}
+	return writes, reads
+}
+
+func benchmarkConcurrentDurable(b *testing.B, profile benchmarkProfile, concurrency, batchSize, valueSize int) {
+	store := profile.open(b, b.TempDir())
+	mutations := benchmarkMutations(batchSize, valueSize)
+	for i := 0; i < benchmarkWarmupCommits; i++ {
+		if err := store.commitAt(uint64(i+1), mutations); err != nil {
+			b.Fatalf("warmup commit %d: %v", i+1, err)
+		}
+	}
+	before := store.stats()
+	latencies := make([]time.Duration, b.N)
+	jobs := make(chan int)
+	var nextTimestamp atomic.Uint64
+	nextTimestamp.Store(benchmarkWarmupCommits)
+	var wg sync.WaitGroup
+	wg.Add(concurrency)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for worker := 0; worker < concurrency; worker++ {
+		go func() {
+			defer wg.Done()
+			for index := range jobs {
+				started := time.Now()
+				timestamp := nextTimestamp.Add(1)
+				if err := commitConcurrent(store, timestamp, mutations); err != nil {
+					b.Errorf("commit %d: %v", index, err)
+				}
+				latencies[index] = time.Since(started)
+			}
+		}()
+	}
+	for i := 0; i < b.N; i++ {
+		jobs <- i
+	}
+	close(jobs)
+	wg.Wait()
+	b.StopTimer()
+	reportRates(b, batchSize)
+	reportLatencyPercentiles(b, latencies)
+	reportStoreCounters(b, before, store.stats(), b.N, 0)
+	b.ReportMetric(float64(concurrency), "workers")
+	if err := store.close(); err != nil {
+		b.Fatalf("close: %v", err)
+	}
+}
+
+func commitConcurrent(store versionedStore, timestamp uint64, mutations []mutation) error {
+	if tree, ok := store.(*treeDBStore); ok {
+		converted := make([]mvcc.Mutation, len(mutations))
+		for i, mutation := range mutations {
+			converted[i] = mvcc.Mutation{Key: mutation.key, Value: mutation.value, Delete: mutation.delete}
+		}
+		return tree.mvcc.CommitAt(timestamp, converted, tree.mode)
+	}
+	return store.commitAt(timestamp, mutations)
+}
+
+func reportLatencyPercentiles(b *testing.B, latencies []time.Duration) {
+	if len(latencies) == 0 {
+		return
+	}
+	sort.Slice(latencies, func(i, j int) bool { return latencies[i] < latencies[j] })
+	for _, percentile := range []struct {
+		name string
+		p    float64
+	}{{"p50_ack_ms", .50}, {"p95_ack_ms", .95}, {"p99_ack_ms", .99}} {
+		index := int(math.Ceil(float64(len(latencies))*percentile.p)) - 1
+		if index < 0 {
+			index = 0
+		}
+		b.ReportMetric(float64(latencies[index])/float64(time.Millisecond), percentile.name)
 	}
 }
 
@@ -295,23 +503,45 @@ func (s *treeDBStore) getAt(key []byte, timestamp uint64) ([]byte, bool, error) 
 func (s *treeDBStore) stats() map[string]string { return s.db.Stats() }
 func (s *treeDBStore) close() error             { return s.db.Close() }
 
-func reportStoreCounters(b *testing.B, before, after map[string]string, writeCommits int) {
+type storeCounterMetric struct {
+	key         string
+	name        string
+	denominator string
+}
+
+var storeCounterMetrics = []storeCounterMetric{
+	{key: "treedb.command_wal.sync.count_total", name: "command_wal_syncs/write_commit", denominator: "writes"},
+	{key: "treedb.command_wal.flush.count_total", name: "command_wal_flushes/write_commit", denominator: "writes"},
+	{key: "treedb.cache.value_log.sync.calls_total", name: "value_log_syncs/write_commit", denominator: "writes"},
+	{key: "treedb.cache.checkpoint.runs", name: "checkpoints/write_commit", denominator: "writes"},
+	{key: "treedb.cache.iterator.snapshot_rotations_total", name: "iterator_snapshot_rotations/lookup", denominator: "lookups"},
+	{key: "treedb.cache.iterator.sources_total", name: "iterator_sources/lookup", denominator: "lookups"},
+	{key: "treedb.cache.iterator.calls_total", name: "iterator_calls/lookup", denominator: "lookups"},
+}
+
+func reportStoreCounters(b *testing.B, before, after map[string]string, writeCommits, lookups int) {
 	b.Helper()
-	if writeCommits == 0 {
-		return
-	}
-	for _, metric := range []struct {
-		key  string
-		name string
-	}{
-		{key: "treedb.command_wal.sync.count_total", name: "command_wal_syncs/write_commit"},
-		{key: "treedb.command_wal.flush.count_total", name: "command_wal_flushes/write_commit"},
-		{key: "treedb.cache.checkpoint.runs", name: "checkpoints/write_commit"},
-	} {
+	for _, metric := range storeCounterMetrics {
+		denominator := writeCommits
+		if metric.denominator == "lookups" {
+			denominator = lookups
+		}
+		if denominator == 0 {
+			continue
+		}
 		start, startOK := parseCounter(before, metric.key)
 		end, endOK := parseCounter(after, metric.key)
 		if startOK && endOK && end >= start {
-			b.ReportMetric(float64(end-start)/float64(writeCommits), metric.name)
+			b.ReportMetric(float64(end-start)/float64(denominator), metric.name)
+		}
+	}
+	for _, metric := range []struct{ key, name string }{
+		{"treedb.cache.iterator.sources_max", "iterator_sources_max"},
+		{"treedb.cache.iterator.queue_len_max", "iterator_queue_len_max"},
+		{"treedb.cache.queue_len", "iterator_queue_len_end"},
+	} {
+		if value, ok := parseCounter(after, metric.key); ok {
+			b.ReportMetric(float64(value), metric.name)
 		}
 	}
 }
@@ -344,6 +574,23 @@ func TestDgraphShapedProfilesRoundTrip(t *testing.T) {
 			}
 			if got, present, err := store.getAt(key, 12); err != nil || present || got != nil {
 				t.Fatalf("get tombstone present=%t got=%x err=%v", present, got, err)
+			}
+			if profile.backend == "treedb" {
+				stats := store.stats()
+				for _, key := range []string{
+					"treedb.cache.iterator.calls_total",
+					"treedb.cache.iterator.snapshot_rotations_total",
+					"treedb.cache.iterator.sources_total",
+					"treedb.cache.iterator.sources_max",
+					"treedb.cache.iterator.queue_len_max",
+				} {
+					if _, ok := stats[key]; !ok {
+						t.Errorf("missing TreeDB attribution stat %q", key)
+					}
+				}
+				if calls, ok := parseCounter(stats, "treedb.cache.iterator.calls_total"); !ok || calls < 2 {
+					t.Errorf("iterator calls=%d ok=%t want >=2", calls, ok)
+				}
 			}
 			if err := store.close(); err != nil {
 				t.Fatalf("close: %v", err)

--- a/benchmarks/dgraph_durability/benchmark_test.go
+++ b/benchmarks/dgraph_durability/benchmark_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/dgraph-io/badger/v4"
 	treedb "github.com/snissn/gomap/TreeDB"
+	"github.com/snissn/gomap/TreeDB/caching"
 	"github.com/snissn/gomap/TreeDB/mvcc"
 )
 
@@ -470,6 +471,8 @@ func openTreeDBDurable(tb testing.TB, dir string) versionedStore {
 
 func openTreeDB(tb testing.TB, dir string, profile treedb.Profile, mode mvcc.CommitMode) versionedStore {
 	tb.Helper()
+	caching.SetIteratorDebug(true)
+	tb.Cleanup(func() { caching.SetIteratorDebug(false) })
 	opts := treedb.OptionsFor(profile, dir)
 	db, err := treedb.Open(opts)
 	if err != nil {

--- a/benchmarks/dgraph_durability/run.sh
+++ b/benchmarks/dgraph_durability/run.sh
@@ -39,12 +39,15 @@ fixed_cmd=(go test ./benchmarks/dgraph_durability -run '^$' -bench '^BenchmarkDg
 concurrent_cmd=(go test ./benchmarks/dgraph_durability -run '^$' -bench '^BenchmarkDgraphShapedConcurrentDurable' -benchmem -benchtime="${concurrent_commits}x" -count="$repeats")
 mvcc_cmd=(go test ./TreeDB/mvcc -run '^$' -bench '^BenchmarkCommitAtGetAtInterleaved$' -benchmem -count="$repeats")
 
-printf '%q ' "${fixed_cmd[@]}" >"$out/commands.txt"
-printf '\n' >>"$out/commands.txt"
-printf '%q ' "${concurrent_cmd[@]}" >>"$out/commands.txt"
-printf '\n' >>"$out/commands.txt"
-printf '%q ' "${mvcc_cmd[@]}" >>"$out/commands.txt"
-printf '\n' >>"$out/commands.txt"
+{
+  printf 'GOWORK=off '
+  printf '%q ' "${fixed_cmd[@]}"
+  printf '\nGOWORK=off '
+  printf '%q ' "${concurrent_cmd[@]}"
+  printf '\nGOWORK=off '
+  printf '%q ' "${mvcc_cmd[@]}"
+  printf '\n'
+} >"$out/commands.txt"
 
 GOWORK=off "${fixed_cmd[@]}" | tee "$out/fixed_mixed.txt"
 GOWORK=off "${concurrent_cmd[@]}" | tee "$out/concurrent_durable.txt"

--- a/benchmarks/dgraph_durability/run.sh
+++ b/benchmarks/dgraph_durability/run.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+out=${1:?usage: run.sh OUTPUT_DIR}
+repeats=${REPEATS:-2}
+concurrent_commits=${CONCURRENT_COMMITS:-32}
+tmp_root=${TMPDIR:-/tmp}
+mkdir -p "$out"
+
+sha=$(git rev-parse HEAD)
+dirty=false
+if [[ -n $(git status --porcelain) ]]; then
+  dirty=true
+fi
+filesystem=unknown
+if command -v findmnt >/dev/null 2>&1; then
+  filesystem=$(findmnt -n -o FSTYPE -T "$tmp_root" 2>/dev/null || true)
+  filesystem=${filesystem:-unknown}
+fi
+
+{
+  echo 'schema=dgraph-durability-v2'
+  echo "sha=$sha"
+  echo "dirty=$dirty"
+  echo "go_version=$(go version)"
+  echo "kernel=$(uname -srmo)"
+  echo "host=$(hostname)"
+  echo "tmp_root=$tmp_root"
+  echo "filesystem=$filesystem"
+  echo "repeats=$repeats"
+  echo 'fixed_fixture_seed=1'
+  echo 'fixed_timer_boundary=operations_only'
+  echo 'durability_classes=relaxed,durable'
+  echo 'accepted_runs=all_correctness-passing_repeats'
+  echo 'excluded_runs=none'
+} >"$out/metadata.env"
+
+fixed_cmd=(go test ./benchmarks/dgraph_durability -run '^$' -bench '^BenchmarkDgraphShapedMixedFixed' -benchmem -benchtime=1x -count="$repeats")
+concurrent_cmd=(go test ./benchmarks/dgraph_durability -run '^$' -bench '^BenchmarkDgraphShapedConcurrentDurable' -benchmem -benchtime="${concurrent_commits}x" -count="$repeats")
+mvcc_cmd=(go test ./TreeDB/mvcc -run '^$' -bench '^BenchmarkCommitAtGetAtInterleaved$' -benchmem -count="$repeats")
+
+printf '%q ' "${fixed_cmd[@]}" >"$out/commands.txt"
+printf '\n' >>"$out/commands.txt"
+printf '%q ' "${concurrent_cmd[@]}" >>"$out/commands.txt"
+printf '\n' >>"$out/commands.txt"
+printf '%q ' "${mvcc_cmd[@]}" >>"$out/commands.txt"
+printf '\n' >>"$out/commands.txt"
+
+GOWORK=off "${fixed_cmd[@]}" | tee "$out/fixed_mixed.txt"
+GOWORK=off "${concurrent_cmd[@]}" | tee "$out/concurrent_durable.txt"
+GOWORK=off "${mvcc_cmd[@]}" | tee "$out/mvcc_interleaved.txt"


### PR DESCRIPTION
Closes #3727

Parent: #3726

## What changed

- adds deterministic fixed-work relaxed mixed rows at 50k/100k/250k/500k operations;
- adds a separately named interleaved MVCC `CommitAt`/`GetAt` benchmark;
- adds the durable concurrency 1/2/4/8/16, batch 1/16, value 128 B/4 KiB matrix with acknowledgement percentiles;
- exposes narrow cumulative/max iterator rotation, source, and queue attribution through the existing TreeDB `Stats` map;
- reports command-WAL, aggregate value-log sync, checkpoint, iterator, and queue boundaries without inventing unavailable group-commit counters;
- documents the `dgraph-durability-v2` schema and adds a metadata-preserving runner.

This PR is instrumentation-only. It does not optimize `GetAt`, iterators, WAL/value-log synchronization, or change a production durability profile.

## Test-first evidence

Commit `ff4b17099` added schema characterization tests first. They failed to compile because the fixed-work matrix, concurrent matrix, and counter schema did not yet exist. The subsequent implementation makes those tests pass.

## Validation

Exact focused commands on Linux/amd64, Go 1.26.0:

```sh
GOWORK=off go test ./benchmarks/dgraph_durability ./TreeDB/mvcc ./TreeDB/caching
GOWORK=off go test -race ./benchmarks/dgraph_durability
GOWORK=off go vet ./benchmarks/dgraph_durability ./TreeDB/mvcc ./TreeDB/caching
bash -n benchmarks/dgraph_durability/run.sh
```

All passed locally.

Representative benchmark smoke:

```sh
GOWORK=off go test ./benchmarks/dgraph_durability -run '^$' \
  -bench '^BenchmarkDgraphShapedMixedFixed$/^relaxed$/^TreeDB-command-WAL$/^operations=50000$/^seed=1$' \
  -benchmem -benchtime=1x -count=1

GOWORK=off go test ./benchmarks/dgraph_durability -run '^$' \
  -bench '^BenchmarkDgraphShapedConcurrentDurable$/^durable$/^TreeDB-command-WAL$/^concurrency=16$/^batch=1$/^value=128$' \
  -benchtime=100x -count=1

GOWORK=off go test ./TreeDB/mvcc -run '^$' \
  -bench '^BenchmarkCommitAtGetAtInterleaved$' -benchmem -benchtime=100x -count=1
```

Observed attribution:

| Row | Result |
| --- | --- |
| fixed relaxed TreeDB 50k | 73.7k operations/s; 1.965 iterator sources/lookup; 153 queue high-water |
| durable TreeDB c=16, 1x128 B | 153.7 commits/s; 1.000 command-WAL sync/commit; 104.0 ms p50, 117.3 ms p99 |
| interleaved MVCC 100x | 44.6 us/op; 1.000 snapshot rotation/op; 6.860 sources/op |

The fixed row reports standard Go allocation columns per trial and explicit `workload_B/op` and `workload_allocs/op` per logical operation. The durable smoke is attribution evidence, not a throughput-improvement claim.

## Scope and risk

- Performance classification: performance-sensitive instrumentation, with repeatability/attribution as the exit gate rather than speedup.
- Iterator stats add atomic cumulative/max observations only while the existing benchmarking/diagnostic iterator toggle is enabled; production defaults remain uninstrumented. No storage or public API contract changes.
- The current implementation has no production group-commit counter. The benchmark reports syncs per acknowledged commit, from which commits per sync can be derived, and explicitly documents the unavailable direct group-size metric.
- Existing `BenchmarkDgraphShapedCommit` and `BenchmarkDgraphShapedMixed` row names remain unchanged.
