### PR TITLE
perf(mvcc): add snapshot-safe point successor reads

### DIFF
--- a/TreeDB/caching/db.go
+++ b/TreeDB/caching/db.go
@@ -30008,6 +30008,10 @@ func (db *DB) Stats() map[string]string {
 	stats["treedb.cache.point_successor.backend_probes_total"] = fmt.Sprintf("%d", db.pointSuccessorBackendProbesTotal.Load())
 	stats["treedb.cache.point_successor.sources_total"] = fmt.Sprintf("%d", db.pointSuccessorSourcesTotal.Load())
 	stats["treedb.cache.point_successor.sources_max"] = fmt.Sprintf("%d", db.pointSuccessorSourcesMax.Load())
+	// This metric is an invariant sentinel for SeekGE, not a global iterator
+	// construction counter. It must stay zero because the point-successor path
+	// has no general-merge fallback; any future fallback must increment it at
+	// the construction site.
 	stats["treedb.cache.point_successor.general_merge_iterators_total"] = fmt.Sprintf("%d", db.pointSuccessorGeneralMergeIteratorsTotal.Load())
 	stats["treedb.cache.flush_apply.coordinator.active"] = fmt.Sprintf("%d", db.flushCoordinatorActive.Load())
 	stats["treedb.cache.flush_apply.coordinator.active_workers"] = fmt.Sprintf("%d", db.flushCoordinatorActiveWorkers.Load())

--- a/TreeDB/caching/db.go
+++ b/TreeDB/caching/db.go
@@ -8970,6 +8970,14 @@ type DB struct {
 	iteratorSourcesTotal                                         atomic.Uint64
 	iteratorSourcesMax                                           atomic.Uint64
 	iteratorQueueLenMax                                          atomic.Uint64
+	pointSuccessorCallsTotal                                     atomic.Uint64
+	pointSuccessorHitsTotal                                      atomic.Uint64
+	pointSuccessorMutableProbesTotal                             atomic.Uint64
+	pointSuccessorQueueProbesTotal                               atomic.Uint64
+	pointSuccessorBackendProbesTotal                             atomic.Uint64
+	pointSuccessorSourcesTotal                                   atomic.Uint64
+	pointSuccessorSourcesMax                                     atomic.Uint64
+	pointSuccessorGeneralMergeIteratorsTotal                     atomic.Uint64
 	checkpointTotalNs                                            atomic.Uint64
 	checkpointMaxNs                                              atomic.Uint64
 	checkpointNoopSkips                                          atomic.Uint64
@@ -29993,6 +30001,14 @@ func (db *DB) Stats() map[string]string {
 	stats["treedb.cache.iterator.sources_total"] = fmt.Sprintf("%d", db.iteratorSourcesTotal.Load())
 	stats["treedb.cache.iterator.sources_max"] = fmt.Sprintf("%d", db.iteratorSourcesMax.Load())
 	stats["treedb.cache.iterator.queue_len_max"] = fmt.Sprintf("%d", db.iteratorQueueLenMax.Load())
+	stats["treedb.cache.point_successor.calls_total"] = fmt.Sprintf("%d", db.pointSuccessorCallsTotal.Load())
+	stats["treedb.cache.point_successor.hits_total"] = fmt.Sprintf("%d", db.pointSuccessorHitsTotal.Load())
+	stats["treedb.cache.point_successor.mutable_probes_total"] = fmt.Sprintf("%d", db.pointSuccessorMutableProbesTotal.Load())
+	stats["treedb.cache.point_successor.queue_probes_total"] = fmt.Sprintf("%d", db.pointSuccessorQueueProbesTotal.Load())
+	stats["treedb.cache.point_successor.backend_probes_total"] = fmt.Sprintf("%d", db.pointSuccessorBackendProbesTotal.Load())
+	stats["treedb.cache.point_successor.sources_total"] = fmt.Sprintf("%d", db.pointSuccessorSourcesTotal.Load())
+	stats["treedb.cache.point_successor.sources_max"] = fmt.Sprintf("%d", db.pointSuccessorSourcesMax.Load())
+	stats["treedb.cache.point_successor.general_merge_iterators_total"] = fmt.Sprintf("%d", db.pointSuccessorGeneralMergeIteratorsTotal.Load())
 	stats["treedb.cache.flush_apply.coordinator.active"] = fmt.Sprintf("%d", db.flushCoordinatorActive.Load())
 	stats["treedb.cache.flush_apply.coordinator.active_workers"] = fmt.Sprintf("%d", db.flushCoordinatorActiveWorkers.Load())
 	stats["treedb.cache.flush_apply.coordinator.in_flight_bytes"] = fmt.Sprintf("%d", db.flushCoordinatorInFlightBytes.Load())

--- a/TreeDB/caching/point_successor.go
+++ b/TreeDB/caching/point_successor.go
@@ -117,6 +117,16 @@ func (db *DB) pointSuccessorDiskIterator(view *memtableView, start, end []byte) 
 		}
 		return it, func() { _ = it.Close() }, nil
 	}
+	if err := db.ensureBackendRange(); err != nil {
+		return nil, func() {}, err
+	}
+	db.mu.RLock()
+	backendRangeKnown := db.backendRangeKnown
+	backendRange := db.backendRange
+	db.mu.RUnlock()
+	if backendRangeKnown && !overlapsQuery(start, end, backendRange) {
+		return nil, func() {}, nil
+	}
 	if provider, ok := db.backend.(backendSnapshotProvider); ok {
 		snap := provider.AcquireSnapshot()
 		if snap == nil {
@@ -177,15 +187,17 @@ func (db *DB) SeekGE(start, end []byte) (key, value []byte, found bool, err erro
 	// CommitAt/GetAt normally asks for the exact physical version just written.
 	// Its mutable shard has absolute precedence and no key can sort before an
 	// exact lower-bound hit, so avoid acquiring a backend cursor in this case.
+	initialTarget := -1
+	initialCandidate := pointSuccessorCandidate{}
 	if len(mutables) > 0 {
-		target := db.shardIndex(start)
-		if target >= 0 && target < len(mutables) {
-			candidate := seekPointSuccessorTable(mutables[target], start, end, nil, 0, 0)
+		initialTarget = db.shardIndex(start)
+		if initialTarget >= 0 && initialTarget < len(mutables) {
+			initialCandidate = seekPointSuccessorTable(mutables[initialTarget], start, end, nil, 0, 0)
 			db.pointSuccessorMutableProbesTotal.Add(1)
-			if candidate.found && bytes.Equal(candidate.key, start) && candidate.flags&node.FlagTombstone == 0 {
+			if initialCandidate.found && bytes.Equal(initialCandidate.key, start) && initialCandidate.flags&node.FlagTombstone == 0 {
 				db.pointSuccessorSourcesTotal.Add(1)
 				updateAtomicMaxUint64(&db.pointSuccessorSourcesMax, 1)
-				return db.materializePointSuccessor(candidate)
+				return db.materializePointSuccessor(initialCandidate)
 			}
 		}
 	}
@@ -204,8 +216,11 @@ func (db *DB) SeekGE(start, end []byte) (key, value []byte, found bool, err erro
 		if len(mutables) > 0 {
 			target := db.shardIndex(lower)
 			if target >= 0 && target < len(mutables) {
-				candidate := seekPointSuccessorTable(mutables[target], lower, end, nil, 0, priority)
-				db.pointSuccessorMutableProbesTotal.Add(1)
+				candidate := initialCandidate
+				if target != initialTarget || !bytes.Equal(lower, start) {
+					candidate = seekPointSuccessorTable(mutables[target], lower, end, nil, 0, priority)
+					db.pointSuccessorMutableProbesTotal.Add(1)
+				}
 				probes++
 				best = choosePointSuccessor(best, candidate)
 				priority++

--- a/TreeDB/caching/point_successor.go
+++ b/TreeDB/caching/point_successor.go
@@ -104,6 +104,9 @@ func seekPointSuccessorIterator(it iterator.UnsafeIterator, start, end []byte, s
 			continue
 		}
 		value, ptr, flags, revision := iterator.UnsafeEntryWithRevision(it)
+		if err := it.Error(); err != nil {
+			return pointSuccessorCandidate{}, err
+		}
 		return pointSuccessorCandidate{key: key, value: value, ptr: ptr, flags: flags, revision: revision, priority: priority, found: true}, nil
 	}
 	return pointSuccessorCandidate{}, it.Error()

--- a/TreeDB/caching/point_successor.go
+++ b/TreeDB/caching/point_successor.go
@@ -184,6 +184,11 @@ func (db *DB) SeekGE(start, end []byte) (key, value []byte, found bool, err erro
 			queue = snap.immutables
 		}
 	}
+	var callSources uint64
+	defer func() {
+		db.pointSuccessorSourcesTotal.Add(callSources)
+		updateAtomicMaxUint64(&db.pointSuccessorSourcesMax, callSources)
+	}()
 	// CommitAt/GetAt normally asks for the exact physical version just written.
 	// Its mutable shard has absolute precedence and no key can sort before an
 	// exact lower-bound hit, so avoid acquiring a backend cursor in this case.
@@ -194,9 +199,8 @@ func (db *DB) SeekGE(start, end []byte) (key, value []byte, found bool, err erro
 		if initialTarget >= 0 && initialTarget < len(mutables) {
 			initialCandidate = seekPointSuccessorTable(mutables[initialTarget], start, end, nil, 0, 0)
 			db.pointSuccessorMutableProbesTotal.Add(1)
+			callSources++
 			if initialCandidate.found && bytes.Equal(initialCandidate.key, start) && initialCandidate.flags&node.FlagTombstone == 0 {
-				db.pointSuccessorSourcesTotal.Add(1)
-				updateAtomicMaxUint64(&db.pointSuccessorSourcesMax, 1)
 				return db.materializePointSuccessor(initialCandidate)
 			}
 		}
@@ -212,7 +216,6 @@ func (db *DB) SeekGE(start, end []byte) (key, value []byte, found bool, err erro
 	for end == nil || bytes.Compare(lower, end) < 0 {
 		best := pointSuccessorCandidate{}
 		priority := 0
-		probes := 0
 		if len(mutables) > 0 {
 			target := db.shardIndex(lower)
 			if target >= 0 && target < len(mutables) {
@@ -220,13 +223,11 @@ func (db *DB) SeekGE(start, end []byte) (key, value []byte, found bool, err erro
 				if target != initialTarget || !bytes.Equal(lower, start) {
 					candidate = seekPointSuccessorTable(mutables[target], lower, end, nil, 0, priority)
 					db.pointSuccessorMutableProbesTotal.Add(1)
+					callSources++
 				}
-				probes++
 				best = choosePointSuccessor(best, candidate)
 				priority++
 				if candidate.found && bytes.Equal(candidate.key, lower) && candidate.flags&node.FlagTombstone == 0 {
-					db.pointSuccessorSourcesTotal.Add(uint64(probes))
-					updateAtomicMaxUint64(&db.pointSuccessorSourcesMax, uint64(probes))
 					return db.materializePointSuccessor(candidate)
 				}
 			}
@@ -236,25 +237,25 @@ func (db *DB) SeekGE(start, end []byte) (key, value []byte, found bool, err erro
 				}
 				best = choosePointSuccessor(best, seekPointSuccessorTable(mt, lower, end, nil, 0, priority))
 				db.pointSuccessorMutableProbesTotal.Add(1)
-				probes++
+				callSources++
 				priority++
 			}
 		}
 		for i := len(queue) - 1; i >= 0; i-- {
 			best = choosePointSuccessor(best, seekPointSuccessorTable(queue[i], lower, end, spans, i+1, priority))
 			db.pointSuccessorQueueProbesTotal.Add(1)
-			probes++
+			callSources++
 			priority++
 		}
-		candidate, probeErr := seekPointSuccessorIterator(disk, lower, end, spans, priority)
-		db.pointSuccessorBackendProbesTotal.Add(1)
-		probes++
-		if probeErr != nil {
-			return nil, nil, false, probeErr
+		if disk != nil {
+			candidate, probeErr := seekPointSuccessorIterator(disk, lower, end, spans, priority)
+			db.pointSuccessorBackendProbesTotal.Add(1)
+			callSources++
+			if probeErr != nil {
+				return nil, nil, false, probeErr
+			}
+			best = choosePointSuccessor(best, candidate)
 		}
-		best = choosePointSuccessor(best, candidate)
-		db.pointSuccessorSourcesTotal.Add(uint64(probes))
-		updateAtomicMaxUint64(&db.pointSuccessorSourcesMax, uint64(probes))
 		if !best.found {
 			return nil, nil, false, nil
 		}

--- a/TreeDB/caching/point_successor.go
+++ b/TreeDB/caching/point_successor.go
@@ -1,0 +1,272 @@
+package caching
+
+import (
+	"bytes"
+
+	"github.com/snissn/gomap/TreeDB/batch"
+	backenddb "github.com/snissn/gomap/TreeDB/db"
+	"github.com/snissn/gomap/TreeDB/internal/iterator"
+	"github.com/snissn/gomap/TreeDB/internal/memtable"
+	"github.com/snissn/gomap/TreeDB/node"
+	"github.com/snissn/gomap/TreeDB/page"
+)
+
+type pointSuccessorCandidate struct {
+	key      []byte
+	value    []byte
+	ptr      page.ValuePtr
+	flags    byte
+	revision page.EntryRevision
+	priority int
+	found    bool
+}
+
+func choosePointSuccessor(best, candidate pointSuccessorCandidate) pointSuccessorCandidate {
+	if !candidate.found {
+		return best
+	}
+	if !best.found {
+		return candidate
+	}
+	cmp := bytes.Compare(candidate.key, best.key)
+	if cmp < 0 || (cmp == 0 && candidate.priority < best.priority) {
+		return candidate
+	}
+	return best
+}
+
+func pointSuccessorAfter(key []byte) []byte {
+	return append(append([]byte(nil), key...), 0)
+}
+
+func pointSuccessorMaskEnd(layers [][]batch.DeleteRange, firstLayer int, key []byte) (next []byte, masked bool) {
+	for i := firstLayer; i < len(layers); i++ {
+		for _, span := range layers[i] {
+			if !batch.DeleteRangeContainsKey(span, key) {
+				continue
+			}
+			masked = true
+			if span.End == nil {
+				return nil, true
+			}
+			if next == nil || bytes.Compare(span.End, next) > 0 {
+				next = span.End
+			}
+		}
+	}
+	return next, masked
+}
+
+func seekPointSuccessorTable(mt memtable.Table, start, end []byte, spans [][]batch.DeleteRange, firstNewerLayer, priority int) pointSuccessorCandidate {
+	for mt != nil && (end == nil || bytes.Compare(start, end) < 0) {
+		seeker, ok := mt.(memtable.SuccessorTable)
+		if !ok {
+			return pointSuccessorCandidate{}
+		}
+		key, value, ptr, flags, revision, found := seeker.SeekGE(start, end)
+		if !found {
+			return pointSuccessorCandidate{}
+		}
+		next, masked := pointSuccessorMaskEnd(spans, firstNewerLayer, key)
+		if !masked {
+			return pointSuccessorCandidate{key: key, value: value, ptr: ptr, flags: flags, revision: revision, priority: priority, found: true}
+		}
+		if next == nil {
+			return pointSuccessorCandidate{}
+		}
+		if bytes.Compare(next, key) <= 0 {
+			next = pointSuccessorAfter(key)
+		}
+		start = next
+	}
+	return pointSuccessorCandidate{}
+}
+
+func seekPointSuccessorIterator(it iterator.UnsafeIterator, start, end []byte, spans [][]batch.DeleteRange, priority int) (pointSuccessorCandidate, error) {
+	if it == nil {
+		return pointSuccessorCandidate{}, nil
+	}
+	it.Seek(start)
+	for it.Valid() {
+		key := it.UnsafeKey()
+		if end != nil && bytes.Compare(key, end) >= 0 {
+			return pointSuccessorCandidate{}, nil
+		}
+		next, masked := pointSuccessorMaskEnd(spans, 0, key)
+		if masked {
+			if next == nil {
+				return pointSuccessorCandidate{}, nil
+			}
+			if bytes.Compare(next, key) <= 0 {
+				next = pointSuccessorAfter(key)
+			}
+			it.Seek(next)
+			continue
+		}
+		value, ptr, flags, revision := iterator.UnsafeEntryWithRevision(it)
+		return pointSuccessorCandidate{key: key, value: value, ptr: ptr, flags: flags, revision: revision, priority: priority, found: true}, nil
+	}
+	return pointSuccessorCandidate{}, it.Error()
+}
+
+func (db *DB) pointSuccessorDiskIterator(view *memtableView, start, end []byte) (iterator.UnsafeIterator, func(), error) {
+	if snap, ok := liveIteratorRootDomainSnapshot(view); ok && rootDomainSnapshotHasPublishedState(snap) {
+		it, exists, err := db.livePublishedRootIterator(snap, start, end, false)
+		if err != nil || !exists || it == nil {
+			return it, func() {}, err
+		}
+		return it, func() { _ = it.Close() }, nil
+	}
+	if provider, ok := db.backend.(backendSnapshotProvider); ok {
+		snap := provider.AcquireSnapshot()
+		if snap == nil {
+			return nil, func() {}, backenddb.ErrClosed
+		}
+		lookup := backendSnapshotLookup{db: db, snapshot: snap}
+		if state, ok := snap.StateToken(); ok {
+			lookup.rootID = state.RootPageID
+		}
+		it, err := lookup.Iterator(start, end)
+		if err != nil {
+			_ = snap.Close()
+			return nil, func() {}, err
+		}
+		return it, func() { _ = it.Close(); _ = snap.Close() }, nil
+	}
+	it, err := db.backend.Iterator(start, end)
+	if err != nil {
+		return nil, func() {}, err
+	}
+	return it, func() { _ = it.Close() }, nil
+}
+
+// SeekGE returns an owned copy of the first visible physical key/value in
+// [start,end). It captures mutable and immutable state without rotating the
+// mutable memtables and never constructs a general merging iterator.
+func (db *DB) SeekGE(start, end []byte) (key, value []byte, found bool, err error) {
+	if db == nil || db.backend == nil {
+		return nil, nil, false, backenddb.ErrClosed
+	}
+	if end != nil && bytes.Compare(start, end) >= 0 {
+		return nil, nil, false, nil
+	}
+	db.pointSuccessorCallsTotal.Add(1)
+	db.noteRead()
+
+	db.writeMu.Lock()
+	defer db.writeMu.Unlock()
+	if db.closing.Load() {
+		return nil, nil, false, backenddb.ErrClosed
+	}
+	view := db.retainMemtableView()
+	if view != nil {
+		defer db.releaseMemtableView(view)
+	}
+
+	var mutables []memtable.Table
+	var queue []memtable.Table
+	var spans [][]batch.DeleteRange
+	if view != nil {
+		mutables = view.mutables
+		queue = view.queue
+		spans = view.queueRangeSpans
+		if snap, ok := liveIteratorRootDomainSnapshot(view); ok && len(snap.immutables) > 0 {
+			queue = snap.immutables
+		}
+	}
+	// CommitAt/GetAt normally asks for the exact physical version just written.
+	// Its mutable shard has absolute precedence and no key can sort before an
+	// exact lower-bound hit, so avoid acquiring a backend cursor in this case.
+	if len(mutables) > 0 {
+		target := db.shardIndex(start)
+		if target >= 0 && target < len(mutables) {
+			candidate := seekPointSuccessorTable(mutables[target], start, end, nil, 0, 0)
+			db.pointSuccessorMutableProbesTotal.Add(1)
+			if candidate.found && bytes.Equal(candidate.key, start) && candidate.flags&node.FlagTombstone == 0 {
+				db.pointSuccessorSourcesTotal.Add(1)
+				updateAtomicMaxUint64(&db.pointSuccessorSourcesMax, 1)
+				return db.materializePointSuccessor(candidate)
+			}
+		}
+	}
+
+	disk, closeDisk, err := db.pointSuccessorDiskIterator(view, start, end)
+	if err != nil {
+		return nil, nil, false, err
+	}
+	defer closeDisk()
+
+	lower := start
+	for end == nil || bytes.Compare(lower, end) < 0 {
+		best := pointSuccessorCandidate{}
+		priority := 0
+		probes := 0
+		if len(mutables) > 0 {
+			target := db.shardIndex(lower)
+			if target >= 0 && target < len(mutables) {
+				candidate := seekPointSuccessorTable(mutables[target], lower, end, nil, 0, priority)
+				db.pointSuccessorMutableProbesTotal.Add(1)
+				probes++
+				best = choosePointSuccessor(best, candidate)
+				priority++
+				if candidate.found && bytes.Equal(candidate.key, lower) && candidate.flags&node.FlagTombstone == 0 {
+					db.pointSuccessorSourcesTotal.Add(uint64(probes))
+					updateAtomicMaxUint64(&db.pointSuccessorSourcesMax, uint64(probes))
+					return db.materializePointSuccessor(candidate)
+				}
+			}
+			for i, mt := range mutables {
+				if i == target {
+					continue
+				}
+				best = choosePointSuccessor(best, seekPointSuccessorTable(mt, lower, end, nil, 0, priority))
+				db.pointSuccessorMutableProbesTotal.Add(1)
+				probes++
+				priority++
+			}
+		}
+		for i := len(queue) - 1; i >= 0; i-- {
+			best = choosePointSuccessor(best, seekPointSuccessorTable(queue[i], lower, end, spans, i+1, priority))
+			db.pointSuccessorQueueProbesTotal.Add(1)
+			probes++
+			priority++
+		}
+		candidate, probeErr := seekPointSuccessorIterator(disk, lower, end, spans, priority)
+		db.pointSuccessorBackendProbesTotal.Add(1)
+		probes++
+		if probeErr != nil {
+			return nil, nil, false, probeErr
+		}
+		best = choosePointSuccessor(best, candidate)
+		db.pointSuccessorSourcesTotal.Add(uint64(probes))
+		updateAtomicMaxUint64(&db.pointSuccessorSourcesMax, uint64(probes))
+		if !best.found {
+			return nil, nil, false, nil
+		}
+		if best.flags&node.FlagTombstone == 0 {
+			return db.materializePointSuccessor(best)
+		}
+		lower = pointSuccessorAfter(best.key)
+	}
+	return nil, nil, false, nil
+}
+
+func (db *DB) materializePointSuccessor(candidate pointSuccessorCandidate) ([]byte, []byte, bool, error) {
+	if !candidate.found || candidate.flags&node.FlagTombstone != 0 {
+		return nil, nil, false, nil
+	}
+	key := append([]byte(nil), candidate.key...)
+	var value []byte
+	if candidate.flags&node.FlagPointer != 0 && candidate.value == nil {
+		var err error
+		value, err = db.readValueLog(key, candidate.ptr)
+		if err != nil {
+			return nil, nil, false, err
+		}
+		value = append([]byte(nil), value...)
+	} else {
+		value = append([]byte(nil), candidate.value...)
+	}
+	db.pointSuccessorHitsTotal.Add(1)
+	return key, value, true, nil
+}

--- a/TreeDB/caching/point_successor_test.go
+++ b/TreeDB/caching/point_successor_test.go
@@ -9,7 +9,28 @@ import (
 
 	"github.com/snissn/gomap/TreeDB/batch"
 	backenddb "github.com/snissn/gomap/TreeDB/db"
+	"github.com/snissn/gomap/TreeDB/internal/iterator"
+	"github.com/snissn/gomap/TreeDB/page"
 )
+
+type pointSuccessorEntryErrorIterator struct {
+	iterator.UnsafeIterator
+	err       error
+	entryRead bool
+}
+
+func (it *pointSuccessorEntryErrorIterator) UnsafeEntry() ([]byte, page.ValuePtr, byte) {
+	value, ptr, flags := it.UnsafeIterator.UnsafeEntry()
+	it.entryRead = true
+	return value, ptr, flags
+}
+
+func (it *pointSuccessorEntryErrorIterator) Error() error {
+	if it.entryRead {
+		return it.err
+	}
+	return it.UnsafeIterator.Error()
+}
 
 func openPointSuccessorTestDB(t *testing.T, backend *MockBackend) *DB {
 	t.Helper()
@@ -68,6 +89,26 @@ func TestSeekGE_SourcePrecedenceTombstonesAndBounds(t *testing.T) {
 	requireSeekGE(t, db, []byte("d"), []byte("e"), []byte("d"), []byte("queued-d"))
 	if key, value, found, err := db.SeekGE([]byte("e"), []byte("f")); err != nil || found || key != nil || value != nil {
 		t.Fatalf("bounded miss = (%q,%q,%t,%v), want nil,nil,false,nil", key, value, found, err)
+	}
+}
+
+func TestSeekPointSuccessorIteratorReturnsLazyEntryError(t *testing.T) {
+	wantErr := errors.New("lazy entry decode")
+	backend := NewMockBackend()
+	backend.Set([]byte("k"), []byte("value"))
+	base, err := backend.Iterator(nil, nil)
+	if err != nil {
+		t.Fatalf("Iterator: %v", err)
+	}
+	t.Cleanup(func() { _ = base.Close() })
+	it := &pointSuccessorEntryErrorIterator{UnsafeIterator: base, err: wantErr}
+
+	candidate, gotErr := seekPointSuccessorIterator(it, []byte("k"), nil, nil, 0)
+	if !errors.Is(gotErr, wantErr) {
+		t.Fatalf("seekPointSuccessorIterator error = %v, want %v", gotErr, wantErr)
+	}
+	if candidate.found {
+		t.Fatalf("candidate found after lazy entry error: %+v", candidate)
 	}
 }
 

--- a/TreeDB/caching/point_successor_test.go
+++ b/TreeDB/caching/point_successor_test.go
@@ -73,7 +73,7 @@ func TestSeekGE_SourcePrecedenceTombstonesAndBounds(t *testing.T) {
 
 func TestSeekGE_SourceCountersSpanTombstoneRounds(t *testing.T) {
 	backend := NewMockBackend()
-	backend.Set([]byte("z"), []byte("disjoint"))
+	backend.Set([]byte("c"), []byte("older-visible"))
 	db, err := Open(t.TempDir(), backend, Options{
 		FlushThreshold:     1 << 30,
 		MemtableShards:     1,

--- a/TreeDB/caching/point_successor_test.go
+++ b/TreeDB/caching/point_successor_test.go
@@ -1,0 +1,129 @@
+package caching
+
+import (
+	"bytes"
+	"strconv"
+	"testing"
+
+	"github.com/snissn/gomap/TreeDB/batch"
+)
+
+func openPointSuccessorTestDB(t *testing.T, backend *MockBackend) *DB {
+	t.Helper()
+	db, err := Open(t.TempDir(), backend, Options{
+		FlushThreshold:     1 << 30,
+		MemtableShards:     4,
+		MaxQueuedMemtables: -1,
+		AllowUnsafe:        true,
+	})
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	return db
+}
+
+func requireSeekGE(t *testing.T, db *DB, start, end []byte, wantKey, wantValue []byte) {
+	t.Helper()
+	key, value, found, err := db.SeekGE(start, end)
+	if err != nil {
+		t.Fatalf("SeekGE(%q,%q): %v", start, end, err)
+	}
+	if !found || !bytes.Equal(key, wantKey) || !bytes.Equal(value, wantValue) {
+		t.Fatalf("SeekGE(%q,%q) = (%q,%q,%t), want (%q,%q,true)", start, end, key, value, found, wantKey, wantValue)
+	}
+}
+
+func rotatePointSuccessorMemtables(t *testing.T, db *DB) {
+	t.Helper()
+	db.mu.Lock()
+	defer db.mu.Unlock()
+	if err := db.rotateMemtableLocked(false); err != nil {
+		t.Fatalf("rotateMemtableLocked: %v", err)
+	}
+}
+
+func TestSeekGE_SourcePrecedenceTombstonesAndBounds(t *testing.T) {
+	backend := NewMockBackend()
+	backend.Set([]byte("b"), []byte("backend-b"))
+	backend.Set([]byte("c"), []byte("backend-c"))
+	backend.Set([]byte("f"), []byte("backend-f"))
+	db := openPointSuccessorTestDB(t, backend)
+
+	if err := db.Set([]byte("d"), []byte("queued-d")); err != nil {
+		t.Fatalf("Set queued d: %v", err)
+	}
+	if err := db.Delete([]byte("b")); err != nil {
+		t.Fatalf("Delete queued b: %v", err)
+	}
+	rotatePointSuccessorMemtables(t, db)
+	if err := db.Set([]byte("c"), []byte("mutable-c")); err != nil {
+		t.Fatalf("Set mutable c: %v", err)
+	}
+
+	requireSeekGE(t, db, []byte("b"), []byte("e"), []byte("c"), []byte("mutable-c"))
+	requireSeekGE(t, db, []byte("d"), []byte("e"), []byte("d"), []byte("queued-d"))
+	if key, value, found, err := db.SeekGE([]byte("e"), []byte("f")); err != nil || found || key != nil || value != nil {
+		t.Fatalf("bounded miss = (%q,%q,%t,%v), want nil,nil,false,nil", key, value, found, err)
+	}
+}
+
+func TestSeekGE_NewerRangeSpanMasksOlderCandidate(t *testing.T) {
+	backend := NewMockBackend()
+	backend.Set([]byte("b"), []byte("masked"))
+	backend.Set([]byte("d"), []byte("visible"))
+	db := openPointSuccessorTestDB(t, backend)
+
+	if err := db.Set([]byte("z"), []byte("span carrier")); err != nil {
+		t.Fatalf("Set: %v", err)
+	}
+	rotatePointSuccessorMemtables(t, db)
+	db.mu.Lock()
+	db.queueRangeSpans[len(db.queueRangeSpans)-1] = []batch.DeleteRange{{Start: []byte("a"), End: []byte("c")}}
+	db.publishMemtablesLocked()
+	db.mu.Unlock()
+
+	requireSeekGE(t, db, []byte("a"), []byte("e"), []byte("d"), []byte("visible"))
+}
+
+func TestSeekGE_DoesNotRotateOrCreateGeneralIterator(t *testing.T) {
+	SetIteratorDebug(true)
+	t.Cleanup(func() { SetIteratorDebug(false) })
+	backend := NewMockBackend()
+	db := openPointSuccessorTestDB(t, backend)
+	if err := db.Set([]byte("k"), []byte("v")); err != nil {
+		t.Fatalf("Set: %v", err)
+	}
+
+	before := db.Stats()
+	requireSeekGE(t, db, []byte("k"), []byte("l"), []byte("k"), []byte("v"))
+	after := db.Stats()
+	for _, name := range []string{
+		"treedb.cache.iterator.calls_total",
+		"treedb.cache.iterator.snapshot_rotations_total",
+	} {
+		if before[name] != after[name] {
+			t.Fatalf("%s changed across SeekGE: %q -> %q", name, before[name], after[name])
+		}
+	}
+	if before["treedb.cache.queue_len"] != after["treedb.cache.queue_len"] {
+		t.Fatalf("queue length changed across SeekGE: %q -> %q", before["treedb.cache.queue_len"], after["treedb.cache.queue_len"])
+	}
+	if calls, err := strconv.ParseUint(after["treedb.cache.point_successor.calls_total"], 10, 64); err != nil || calls != 1 {
+		t.Fatalf("point successor calls = %q (%v), want 1", after["treedb.cache.point_successor.calls_total"], err)
+	}
+}
+
+func TestSeekGE_ReturnsOwnedBytes(t *testing.T) {
+	backend := NewMockBackend()
+	db := openPointSuccessorTestDB(t, backend)
+	if err := db.Set([]byte("k"), []byte("value")); err != nil {
+		t.Fatalf("Set: %v", err)
+	}
+	key, value, found, err := db.SeekGE([]byte("k"), nil)
+	if err != nil || !found {
+		t.Fatalf("SeekGE: found=%t err=%v", found, err)
+	}
+	key[0], value[0] = 'x', 'X'
+	requireSeekGE(t, db, []byte("k"), nil, []byte("k"), []byte("value"))
+}

--- a/TreeDB/caching/point_successor_test.go
+++ b/TreeDB/caching/point_successor_test.go
@@ -71,6 +71,113 @@ func TestSeekGE_SourcePrecedenceTombstonesAndBounds(t *testing.T) {
 	}
 }
 
+func TestSeekGE_SourceCountersSpanTombstoneRounds(t *testing.T) {
+	backend := NewMockBackend()
+	backend.Set([]byte("z"), []byte("disjoint"))
+	db, err := Open(t.TempDir(), backend, Options{
+		FlushThreshold:     1 << 30,
+		MemtableShards:     1,
+		MaxQueuedMemtables: -1,
+		AllowUnsafe:        true,
+	})
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+
+	if err := db.Delete([]byte("b")); err != nil {
+		t.Fatalf("Delete b: %v", err)
+	}
+	if err := db.Set([]byte("c"), []byte("visible")); err != nil {
+		t.Fatalf("Set c: %v", err)
+	}
+
+	before := db.Stats()
+	requireSeekGE(t, db, []byte("b"), []byte("d"), []byte("c"), []byte("visible"))
+	after := db.Stats()
+	parse := func(name string, stats map[string]string) uint64 {
+		t.Helper()
+		value, err := strconv.ParseUint(stats[name], 10, 64)
+		if err != nil {
+			t.Fatalf("parse %s=%q: %v", name, stats[name], err)
+		}
+		return value
+	}
+
+	const sourcesTotal = "treedb.cache.point_successor.sources_total"
+	if got := parse(sourcesTotal, after) - parse(sourcesTotal, before); got != 4 {
+		t.Fatalf("sources inspected = %d, want 4 across two sources and two rounds", got)
+	}
+	const sourcesMax = "treedb.cache.point_successor.sources_max"
+	if got := parse(sourcesMax, after); got != 4 {
+		t.Fatalf("sources max = %d, want 4 for the whole SeekGE call", got)
+	}
+	const backendProbes = "treedb.cache.point_successor.backend_probes_total"
+	if got := parse(backendProbes, after) - parse(backendProbes, before); got != 2 {
+		t.Fatalf("backend probes = %d, want 2 across both rounds", got)
+	}
+}
+
+func TestSeekGE_SourceCountersSkipDisjointNilBackend(t *testing.T) {
+	backend := NewMockBackend()
+	backend.Set([]byte("z"), []byte("disjoint"))
+	db, err := Open(t.TempDir(), backend, Options{
+		FlushThreshold:     1 << 30,
+		MemtableShards:     1,
+		MaxQueuedMemtables: -1,
+		AllowUnsafe:        true,
+	})
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+
+	if err := db.Delete([]byte("b")); err != nil {
+		t.Fatalf("Delete b: %v", err)
+	}
+	if err := db.Set([]byte("c"), []byte("visible")); err != nil {
+		t.Fatalf("Set c: %v", err)
+	}
+
+	// Remove the published-root shortcut from this isolated view so SeekGE uses
+	// the known backend range and returns a nil disk cursor for [b,d).
+	db.writeMu.Lock()
+	view := db.memtables.Load()
+	view.rootIterator.published = nil
+	view.rootIterator.publishedRootID = 0
+	db.writeMu.Unlock()
+	db.mu.Lock()
+	db.backendRangeKnown = true
+	db.backendRange = keyRange{valid: true, min: []byte("z"), max: []byte("z")}
+	db.mu.Unlock()
+	db.backendRangeInit.Do(func() {})
+
+	before := db.Stats()
+	requireSeekGE(t, db, []byte("b"), []byte("d"), []byte("c"), []byte("visible"))
+	after := db.Stats()
+	parse := func(name string, stats map[string]string) uint64 {
+		t.Helper()
+		value, err := strconv.ParseUint(stats[name], 10, 64)
+		if err != nil {
+			t.Fatalf("parse %s=%q: %v", name, stats[name], err)
+		}
+		return value
+	}
+
+	const sourcesTotal = "treedb.cache.point_successor.sources_total"
+	if got := parse(sourcesTotal, after) - parse(sourcesTotal, before); got != 2 {
+		t.Fatalf("sources inspected = %d, want 2 mutable probes across both rounds", got)
+	}
+	const sourcesMax = "treedb.cache.point_successor.sources_max"
+	if got := parse(sourcesMax, after); got != 2 {
+		t.Fatalf("sources max = %d, want 2 for the whole SeekGE call", got)
+	}
+	const backendProbes = "treedb.cache.point_successor.backend_probes_total"
+	if got := parse(backendProbes, after) - parse(backendProbes, before); got != 0 {
+		t.Fatalf("backend probes = %d, want 0 for disjoint nil cursor", got)
+	}
+}
+
 func TestSeekGE_NewerRangeSpanMasksOlderCandidate(t *testing.T) {
 	backend := NewMockBackend()
 	backend.Set([]byte("b"), []byte("masked"))

--- a/TreeDB/caching/point_successor_test.go
+++ b/TreeDB/caching/point_successor_test.go
@@ -216,7 +216,15 @@ func TestSeekGE_ConcurrentCommitSnapshotIsCoherent(t *testing.T) {
 
 func TestSeekGE_AfterCloseFailsClosed(t *testing.T) {
 	backend := NewMockBackend()
-	db := openPointSuccessorTestDB(t, backend)
+	db, err := Open(t.TempDir(), backend, Options{
+		FlushThreshold:     1 << 30,
+		MemtableShards:     4,
+		MaxQueuedMemtables: -1,
+		AllowUnsafe:        true,
+	})
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
 	if err := db.Close(); err != nil {
 		t.Fatalf("Close: %v", err)
 	}

--- a/TreeDB/caching/point_successor_test.go
+++ b/TreeDB/caching/point_successor_test.go
@@ -2,10 +2,13 @@ package caching
 
 import (
 	"bytes"
+	"errors"
 	"strconv"
+	"sync"
 	"testing"
 
 	"github.com/snissn/gomap/TreeDB/batch"
+	backenddb "github.com/snissn/gomap/TreeDB/db"
 )
 
 func openPointSuccessorTestDB(t *testing.T, backend *MockBackend) *DB {
@@ -112,6 +115,9 @@ func TestSeekGE_DoesNotRotateOrCreateGeneralIterator(t *testing.T) {
 	if calls, err := strconv.ParseUint(after["treedb.cache.point_successor.calls_total"], 10, 64); err != nil || calls != 1 {
 		t.Fatalf("point successor calls = %q (%v), want 1", after["treedb.cache.point_successor.calls_total"], err)
 	}
+	if merges := after["treedb.cache.point_successor.general_merge_iterators_total"]; merges != "0" {
+		t.Fatalf("point successor general merge iterators = %q, want 0", merges)
+	}
 }
 
 func TestSeekGE_ReturnsOwnedBytes(t *testing.T) {
@@ -126,4 +132,95 @@ func TestSeekGE_ReturnsOwnedBytes(t *testing.T) {
 	}
 	key[0], value[0] = 'x', 'X'
 	requireSeekGE(t, db, []byte("k"), nil, []byte("k"), []byte("value"))
+}
+
+func TestSeekGE_CompetingVersionsAcrossMutableQueuedAndPublishedSources(t *testing.T) {
+	backend := NewMockBackend()
+	backend.Set([]byte("k"), []byte("published"))
+	backend.Set([]byte("z"), []byte("published-z"))
+	db := openPointSuccessorTestDB(t, backend)
+
+	for _, value := range []string{"queued-old", "queued-new"} {
+		if err := db.Set([]byte("k"), []byte(value)); err != nil {
+			t.Fatalf("Set %s: %v", value, err)
+		}
+		rotatePointSuccessorMemtables(t, db)
+	}
+	if err := db.Set([]byte("k"), []byte("mutable")); err != nil {
+		t.Fatalf("Set mutable: %v", err)
+	}
+	requireSeekGE(t, db, []byte("k"), nil, []byte("k"), []byte("mutable"))
+
+	if err := db.Delete([]byte("k")); err != nil {
+		t.Fatalf("Delete mutable: %v", err)
+	}
+	requireSeekGE(t, db, []byte("k"), nil, []byte("z"), []byte("published-z"))
+}
+
+func TestSeekGE_FlushPublicationPreservesAnswer(t *testing.T) {
+	backend := NewMockBackend()
+	db := openPointSuccessorTestDB(t, backend)
+	db.flushMu.Lock()
+	for _, item := range []struct{ key, value string }{{"b", "bee"}, {"d", "dee"}} {
+		if err := db.Set([]byte(item.key), []byte(item.value)); err != nil {
+			db.flushMu.Unlock()
+			t.Fatalf("Set %s: %v", item.key, err)
+		}
+		rotatePointSuccessorMemtables(t, db)
+	}
+	requireSeekGE(t, db, []byte("a"), []byte("c"), []byte("b"), []byte("bee"))
+	db.flushMu.Unlock()
+	db.flushAll(false)
+	requireSeekGE(t, db, []byte("a"), []byte("c"), []byte("b"), []byte("bee"))
+}
+
+func TestSeekGE_ConcurrentCommitSnapshotIsCoherent(t *testing.T) {
+	backend := NewMockBackend()
+	db := openPointSuccessorTestDB(t, backend)
+	if err := db.Set([]byte("k"), []byte("0")); err != nil {
+		t.Fatalf("seed Set: %v", err)
+	}
+
+	var wg sync.WaitGroup
+	errCh := make(chan error, 2)
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		for i := 1; i <= 200; i++ {
+			if err := db.Set([]byte("k"), []byte(strconv.Itoa(i))); err != nil {
+				errCh <- err
+				return
+			}
+		}
+	}()
+	go func() {
+		defer wg.Done()
+		for i := 0; i < 200; i++ {
+			key, value, found, err := db.SeekGE([]byte("k"), []byte("l"))
+			if err != nil || !found || !bytes.Equal(key, []byte("k")) {
+				errCh <- errors.New("incoherent point-successor snapshot")
+				return
+			}
+			if _, err := strconv.Atoi(string(value)); err != nil {
+				errCh <- err
+				return
+			}
+		}
+	}()
+	wg.Wait()
+	close(errCh)
+	for err := range errCh {
+		t.Fatal(err)
+	}
+}
+
+func TestSeekGE_AfterCloseFailsClosed(t *testing.T) {
+	backend := NewMockBackend()
+	db := openPointSuccessorTestDB(t, backend)
+	if err := db.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	if _, _, found, err := db.SeekGE(nil, nil); !errors.Is(err, backenddb.ErrClosed) || found {
+		t.Fatalf("SeekGE after close: found=%t err=%v, want false ErrClosed", found, err)
+	}
 }

--- a/TreeDB/internal/memtable/append_only.go
+++ b/TreeDB/internal/memtable/append_only.go
@@ -2120,6 +2120,112 @@ func (m *AppendOnly) GetEntryWithRevision(key []byte) ([]byte, page.ValuePtr, by
 	}
 }
 
+func appendOnlyEntryInRange(ent *appendOnlyEntry, start, end []byte) bool {
+	if ent == nil {
+		return false
+	}
+	key := appendOnlyEntryKey(ent)
+	return bytes.Compare(key, start) >= 0 && (end == nil || bytes.Compare(key, end) < 0)
+}
+
+func (m *AppendOnly) seekGEEntryLocked(start, end []byte) *appendOnlyEntry {
+	if m.count == 0 || (end != nil && bytes.Compare(start, end) >= 0) {
+		return nil
+	}
+	active := m.entries[:m.count]
+	if m.ordered {
+		idx := sort.Search(len(active), func(i int) bool {
+			return bytes.Compare(appendOnlyEntryKey(&active[i]), start) >= 0
+		})
+		if idx < len(active) && appendOnlyEntryInRange(&active[idx], start, end) {
+			return &active[idx]
+		}
+		return nil
+	}
+	if len(m.sortedRuns) > 0 {
+		var best *appendOnlyEntry
+		bestRun := -1
+		for runIdx, run := range m.sortedRuns {
+			if !appendOnlySortedRunValid(run, len(active)) {
+				continue
+			}
+			pos := sort.Search(run.end-run.start, func(i int) bool {
+				return bytes.Compare(appendOnlyEntryKey(&active[run.start+i]), start) >= 0
+			})
+			if pos >= run.end-run.start {
+				continue
+			}
+			ent := &active[run.start+pos]
+			if !appendOnlyEntryInRange(ent, start, end) {
+				continue
+			}
+			if best == nil || bytes.Compare(appendOnlyEntryKey(ent), appendOnlyEntryKey(best)) < 0 ||
+				(bytes.Equal(appendOnlyEntryKey(ent), appendOnlyEntryKey(best)) && runIdx > bestRun) {
+				best, bestRun = ent, runIdx
+			}
+		}
+		return best
+	}
+	// The unordered fallback keeps only a latest-key hash index. Scan those
+	// indices without allocating; exact-start hits remain O(1) in GetAt's common
+	// commit-then-read path, while arbitrary successors remain correct.
+	var best *appendOnlyEntry
+	consider := func(idx int) {
+		if idx < 0 || idx >= len(active) {
+			return
+		}
+		ent := &active[idx]
+		if !appendOnlyEntryInRange(ent, start, end) {
+			return
+		}
+		if best == nil || bytes.Compare(appendOnlyEntryKey(ent), appendOnlyEntryKey(best)) < 0 {
+			best = ent
+		}
+	}
+	for _, idx := range m.latest {
+		consider(idx)
+	}
+	for _, idx := range m.latest64 {
+		consider(idx)
+	}
+	return best
+}
+
+func (m *AppendOnly) SeekGE(start, end []byte) ([]byte, []byte, page.ValuePtr, byte, page.EntryRevision, bool) {
+	if end != nil && bytes.Compare(start, end) >= 0 {
+		return nil, nil, page.ValuePtr{}, 0, page.LegacyEntryRevision, false
+	}
+	if val, ptr, flags, revision, found := m.GetEntryWithRevision(start); found {
+		return start, val, ptr, flags, revision, true
+	}
+	for {
+		m.mu.RLock()
+		if !m.ordered && len(m.sortedRuns) == 0 && m.latestDirty {
+			m.mu.RUnlock()
+			m.mu.Lock()
+			if !m.ordered && len(m.sortedRuns) == 0 && m.latestDirty {
+				m.rebuildLatestIndexLocked()
+			}
+			m.mu.Unlock()
+			continue
+		}
+		ent := m.seekGEEntryLocked(start, end)
+		if ent == nil {
+			m.mu.RUnlock()
+			return nil, nil, page.ValuePtr{}, 0, page.LegacyEntryRevision, false
+		}
+		key, val, ptr, flags, revision := appendOnlyEntryKey(ent), ent.value, ent.ptr, ent.flags, ent.revision
+		m.mu.RUnlock()
+		if flags&node.FlagTombstone != 0 {
+			return key, nil, page.ValuePtr{}, flags, revision, true
+		}
+		if flags&node.FlagPointer == 0 {
+			ptr = page.ValuePtr{}
+		}
+		return key, val, ptr, flags, revision, true
+	}
+}
+
 func (m *AppendOnly) Size() int64 {
 	m.mu.RLock()
 	defer m.mu.RUnlock()

--- a/TreeDB/internal/memtable/append_only.go
+++ b/TreeDB/internal/memtable/append_only.go
@@ -2044,6 +2044,38 @@ func (m *AppendOnly) GetEntry(key []byte) ([]byte, page.ValuePtr, byte, bool) {
 	return val, ptr, flags, found
 }
 
+func (m *AppendOnly) lookupEntryLocked(key []byte) *appendOnlyEntry {
+	if ent := m.orderedLookupEntryLocked(key); ent != nil {
+		return ent
+	}
+	if m.ordered {
+		return nil
+	}
+	if len(m.sortedRuns) > 0 {
+		return m.lookupSortedRunsEntryLocked(key)
+	}
+	if m.latestDirty {
+		return nil
+	}
+	if k64, ok := appendOnlyKeyU64(key); ok && m.latest64 != nil {
+		if idx, ok := m.latest64[k64]; ok && idx >= 0 && idx < m.count {
+			ent := &m.entries[idx]
+			if bytes.Equal(appendOnlyEntryKey(ent), key) {
+				return ent
+			}
+		}
+	}
+	if m.latest != nil {
+		if idx, ok := m.latest[appendOnlyKeyString(key)]; ok && idx >= 0 && idx < m.count {
+			ent := &m.entries[idx]
+			if bytes.Equal(appendOnlyEntryKey(ent), key) {
+				return ent
+			}
+		}
+	}
+	return nil
+}
+
 func (m *AppendOnly) GetEntryWithRevision(key []byte) ([]byte, page.ValuePtr, byte, page.EntryRevision, bool) {
 	if m.frozenFast.Load() {
 		val, ptr, flags, revision, found, ok := m.getEntryFrozen(key)
@@ -2053,7 +2085,7 @@ func (m *AppendOnly) GetEntryWithRevision(key []byte) ([]byte, page.ValuePtr, by
 	}
 	for {
 		m.mu.RLock()
-		if ent := m.orderedLookupEntryLocked(key); ent != nil {
+		if ent := m.lookupEntryLocked(key); ent != nil {
 			val := ent.value
 			ptr := ent.ptr
 			flags := ent.flags
@@ -2061,51 +2093,7 @@ func (m *AppendOnly) GetEntryWithRevision(key []byte) ([]byte, page.ValuePtr, by
 			m.mu.RUnlock()
 			return val, ptr, flags, revision, true
 		}
-		if m.ordered {
-			m.mu.RUnlock()
-			return nil, page.ValuePtr{}, 0, page.LegacyEntryRevision, false
-		}
-
-		if len(m.sortedRuns) > 0 {
-			if ent := m.lookupSortedRunsEntryLocked(key); ent != nil {
-				val := ent.value
-				ptr := ent.ptr
-				flags := ent.flags
-				revision := ent.revision
-				m.mu.RUnlock()
-				return val, ptr, flags, revision, true
-			}
-			m.mu.RUnlock()
-			return nil, page.ValuePtr{}, 0, page.LegacyEntryRevision, false
-		}
-
-		if !m.latestDirty {
-			if k64, ok := appendOnlyKeyU64(key); ok && m.latest64 != nil {
-				if idx, ok := m.latest64[k64]; ok && idx >= 0 && idx < m.count {
-					ent := &m.entries[idx]
-					if bytes.Equal(appendOnlyEntryKey(ent), key) {
-						val := ent.value
-						ptr := ent.ptr
-						flags := ent.flags
-						revision := ent.revision
-						m.mu.RUnlock()
-						return val, ptr, flags, revision, true
-					}
-				}
-			}
-			if m.latest != nil {
-				if idx, ok := m.latest[appendOnlyKeyString(key)]; ok && idx >= 0 && idx < m.count {
-					ent := &m.entries[idx]
-					if bytes.Equal(appendOnlyEntryKey(ent), key) {
-						val := ent.value
-						ptr := ent.ptr
-						flags := ent.flags
-						revision := ent.revision
-						m.mu.RUnlock()
-						return val, ptr, flags, revision, true
-					}
-				}
-			}
+		if m.ordered || len(m.sortedRuns) > 0 || !m.latestDirty {
 			m.mu.RUnlock()
 			return nil, page.ValuePtr{}, 0, page.LegacyEntryRevision, false
 		}
@@ -2195,8 +2183,10 @@ func (m *AppendOnly) SeekGE(start, end []byte) ([]byte, []byte, page.ValuePtr, b
 	if end != nil && bytes.Compare(start, end) >= 0 {
 		return nil, nil, page.ValuePtr{}, 0, page.LegacyEntryRevision, false
 	}
-	if val, ptr, flags, revision, found := m.GetEntryWithRevision(start); found {
-		return start, val, ptr, flags, revision, true
+	if m.frozenFast.Load() {
+		if val, ptr, flags, revision, found, _ := m.getEntryFrozen(start); found {
+			return start, val, ptr, flags, revision, true
+		}
 	}
 	for {
 		m.mu.RLock()
@@ -2209,7 +2199,10 @@ func (m *AppendOnly) SeekGE(start, end []byte) ([]byte, []byte, page.ValuePtr, b
 			m.mu.Unlock()
 			continue
 		}
-		ent := m.seekGEEntryLocked(start, end)
+		ent := m.lookupEntryLocked(start)
+		if ent == nil {
+			ent = m.seekGEEntryLocked(start, end)
+		}
 		if ent == nil {
 			m.mu.RUnlock()
 			return nil, nil, page.ValuePtr{}, 0, page.LegacyEntryRevision, false

--- a/TreeDB/internal/memtable/btree.go
+++ b/TreeDB/internal/memtable/btree.go
@@ -1,6 +1,7 @@
 package memtable
 
 import (
+	"bytes"
 	"strings"
 	"sync"
 
@@ -358,6 +359,30 @@ func (m *BTree) GetEntryWithRevision(key []byte) ([]byte, page.ValuePtr, byte, p
 		return canonicalizeBTreePointerValue(val.flags, val.value), val.ptr, val.flags, val.revision, true
 	}
 	return val.value, page.ValuePtr{}, val.flags, val.revision, true
+}
+
+func (m *BTree) SeekGE(start, end []byte) ([]byte, []byte, page.ValuePtr, byte, page.EntryRevision, bool) {
+	if end != nil && bytes.Compare(start, end) >= 0 {
+		return nil, nil, page.ValuePtr{}, 0, page.LegacyEntryRevision, false
+	}
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	it := m.tree.Iter()
+	if !it.Seek(bytesToStringNoCopy(start)) {
+		return nil, nil, page.ValuePtr{}, 0, page.LegacyEntryRevision, false
+	}
+	key := stringToBytesNoCopy(it.Key())
+	if end != nil && bytes.Compare(key, end) >= 0 {
+		return nil, nil, page.ValuePtr{}, 0, page.LegacyEntryRevision, false
+	}
+	ent := it.Value()
+	if ent.flags&node.FlagTombstone != 0 {
+		return key, nil, page.ValuePtr{}, ent.flags, ent.revision, true
+	}
+	if ent.flags&node.FlagPointer != 0 {
+		return key, ent.value, ent.ptr, ent.flags, ent.revision, true
+	}
+	return key, ent.value, page.ValuePtr{}, ent.flags, ent.revision, true
 }
 
 func (m *BTree) Size() int64 {

--- a/TreeDB/internal/memtable/hash_sorted.go
+++ b/TreeDB/internal/memtable/hash_sorted.go
@@ -559,6 +559,47 @@ func (m *HashSorted) GetEntryWithRevision(key []byte) ([]byte, page.ValuePtr, by
 	return ent.value, page.ValuePtr{}, ent.flags, ent.revision, true
 }
 
+func (m *HashSorted) SeekGE(start, end []byte) ([]byte, []byte, page.ValuePtr, byte, page.EntryRevision, bool) {
+	if end != nil && bytes.Compare(start, end) >= 0 {
+		return nil, nil, page.ValuePtr{}, 0, page.LegacyEntryRevision, false
+	}
+	m.mu.RLock()
+	frozen := m.frozen
+	finalizeDone := m.finalizeDone
+	m.mu.RUnlock()
+	if frozen && finalizeDone != nil {
+		<-finalizeDone
+		m.ensureIndexFrozen()
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if !m.sortedValid {
+		m.ensureSortedLocked()
+	}
+	idx := sort.SearchStrings(m.sortedKeys, bytesToStringNoCopy(start))
+	if idx >= len(m.sortedKeys) {
+		return nil, nil, page.ValuePtr{}, 0, page.LegacyEntryRevision, false
+	}
+	keyString := m.sortedKeys[idx]
+	key := stringToBytesNoCopy(keyString)
+	if end != nil && bytes.Compare(key, end) >= 0 {
+		return nil, nil, page.ValuePtr{}, 0, page.LegacyEntryRevision, false
+	}
+	entryIdx, ok := m.items[keyString]
+	if !ok || int(entryIdx) >= len(m.entries) {
+		return nil, nil, page.ValuePtr{}, 0, page.LegacyEntryRevision, false
+	}
+	ent := m.entries[entryIdx]
+	if ent.flags&node.FlagTombstone != 0 {
+		return key, nil, page.ValuePtr{}, ent.flags, ent.revision, true
+	}
+	if ent.flags&node.FlagPointer != 0 {
+		return key, ent.value, ent.ptr, ent.flags, ent.revision, true
+	}
+	return key, ent.value, page.ValuePtr{}, ent.flags, ent.revision, true
+}
+
 func (m *HashSorted) Size() int64 {
 	m.mu.RLock()
 	defer m.mu.RUnlock()

--- a/TreeDB/internal/memtable/hash_sorted.go
+++ b/TreeDB/internal/memtable/hash_sorted.go
@@ -574,6 +574,13 @@ func (m *HashSorted) SeekGE(start, end []byte) ([]byte, []byte, page.ValuePtr, b
 
 	m.mu.Lock()
 	defer m.mu.Unlock()
+	// CommitAt/GetAt commonly seeks the physical key it just wrote. Resolve that
+	// exact hit from the hash index before rebuilding sortedKeys: every new key
+	// invalidates the sorted index, so sorting here would turn an interleaved
+	// write/read workload into an O(n log n) rebuild per read.
+	if ent, ok := m.entryForReadLocked(bytesToStringNoCopy(start)); ok {
+		return hashSortedSeekResult(start, ent)
+	}
 	if !m.sortedValid {
 		m.ensureSortedLocked()
 	}
@@ -586,11 +593,14 @@ func (m *HashSorted) SeekGE(start, end []byte) ([]byte, []byte, page.ValuePtr, b
 	if end != nil && bytes.Compare(key, end) >= 0 {
 		return nil, nil, page.ValuePtr{}, 0, page.LegacyEntryRevision, false
 	}
-	entryIdx, ok := m.items[keyString]
-	if !ok || int(entryIdx) >= len(m.entries) {
+	ent, ok := m.entryForReadLocked(keyString)
+	if !ok {
 		return nil, nil, page.ValuePtr{}, 0, page.LegacyEntryRevision, false
 	}
-	ent := m.entries[entryIdx]
+	return hashSortedSeekResult(key, ent)
+}
+
+func hashSortedSeekResult(key []byte, ent hashEntry) ([]byte, []byte, page.ValuePtr, byte, page.EntryRevision, bool) {
 	if ent.flags&node.FlagTombstone != 0 {
 		return key, nil, page.ValuePtr{}, ent.flags, ent.revision, true
 	}

--- a/TreeDB/internal/memtable/memtable.go
+++ b/TreeDB/internal/memtable/memtable.go
@@ -78,6 +78,12 @@ type Table interface {
 	Freeze()
 }
 
+// SuccessorTable is the native point-successor seam used by bounded point
+// reads. Returned key/value slices alias table storage.
+type SuccessorTable interface {
+	SeekGE(start, end []byte) (key, val []byte, ptr page.ValuePtr, flags byte, revision page.EntryRevision, found bool)
+}
+
 // RevisionTable is implemented by memtables that carry native entry revisions
 // beside value/pointer/flags metadata.
 type RevisionTable interface {
@@ -358,6 +364,19 @@ func (m *Memtable) GetEntryWithRevision(key []byte) ([]byte, page.ValuePtr, byte
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 	return m.sl.GetEntryWithRevision(key)
+}
+
+func (m *Memtable) SeekGE(start, end []byte) ([]byte, []byte, page.ValuePtr, byte, page.EntryRevision, bool) {
+	if end != nil && bytes.Compare(start, end) >= 0 {
+		return nil, nil, page.ValuePtr{}, 0, page.LegacyEntryRevision, false
+	}
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	key, val, ptr, flags, revision, found := m.sl.SeekGEEntryWithRevision(start)
+	if !found || (end != nil && bytes.Compare(key, end) >= 0) {
+		return nil, nil, page.ValuePtr{}, 0, page.LegacyEntryRevision, false
+	}
+	return key, val, ptr, flags, revision, true
 }
 
 // Size returns the total memory usage (arena size).

--- a/TreeDB/internal/memtable/successor_test.go
+++ b/TreeDB/internal/memtable/successor_test.go
@@ -41,3 +41,43 @@ func TestTableSeekGE_ModeMatrix(t *testing.T) {
 		})
 	}
 }
+
+func TestHashSortedSeekGE_ExactDoesNotRebuildSortedKeys(t *testing.T) {
+	m := NewHashSorted()
+	m.Set([]byte("a"), []byte("aye"))
+	m.Set([]byte("c"), []byte("see"))
+
+	// Establish a sorted index, then invalidate it with an interleaved write.
+	if key, _, _, _, _, found := m.SeekGE([]byte("b"), nil); !found || !bytes.Equal(key, []byte("c")) {
+		t.Fatalf("SeekGE(b) key=%q found=%t, want c,true", key, found)
+	}
+	ptr := page.ValuePtr{FileID: 42, Offset: 7, Length: 3}
+	m.SetEntryWithRevision([]byte("b"), []byte("raw"), ptr, node.FlagPointer, 11)
+
+	m.mu.RLock()
+	if m.sortedValid {
+		m.mu.RUnlock()
+		t.Fatal("interleaved write did not invalidate sorted keys")
+	}
+	before := append([]string(nil), m.sortedKeys...)
+	m.mu.RUnlock()
+
+	key, value, gotPtr, flags, revision, found := m.SeekGE([]byte("b"), []byte("c"))
+	if !found || !bytes.Equal(key, []byte("b")) || !bytes.Equal(value, []byte("raw")) || gotPtr != ptr || flags != node.FlagPointer || revision != 11 {
+		t.Fatalf("SeekGE(b,c) = (%q,%q,%+v,%#x,%d,%t), want pointer b@11", key, value, gotPtr, flags, revision, found)
+	}
+
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	if m.sortedValid {
+		t.Fatal("exact SeekGE rebuilt the invalid sorted-key index")
+	}
+	if len(m.sortedKeys) != len(before) {
+		t.Fatalf("exact SeekGE changed sorted-key length from %d to %d", len(before), len(m.sortedKeys))
+	}
+	for i := range before {
+		if m.sortedKeys[i] != before[i] {
+			t.Fatalf("exact SeekGE changed sorted key %d from %q to %q", i, before[i], m.sortedKeys[i])
+		}
+	}
+}

--- a/TreeDB/internal/memtable/successor_test.go
+++ b/TreeDB/internal/memtable/successor_test.go
@@ -23,15 +23,19 @@ func TestTableSeekGE_ModeMatrix(t *testing.T) {
 			revisioned.SetEntryWithRevision([]byte("d"), nil, page.ValuePtr{}, node.FlagTombstone, 9)
 			mt.Freeze()
 
-			key, val, ptr, flags, revision, found := mt.SeekGE([]byte("c"), []byte("e"))
+			seeker, ok := mt.(SuccessorTable)
+			if !ok {
+				t.Fatal("memtable does not implement SuccessorTable")
+			}
+			key, val, ptr, flags, revision, found := seeker.SeekGE([]byte("c"), []byte("e"))
 			if !found || !bytes.Equal(key, []byte("d")) || val != nil || ptr != (page.ValuePtr{}) || flags&node.FlagTombstone == 0 || revision != 9 {
 				t.Fatalf("SeekGE(c,e) = (%q,%q,%+v,%#x,%d,%t), want tombstone d@9", key, val, ptr, flags, revision, found)
 			}
 
-			if _, _, _, _, _, found := mt.SeekGE([]byte("d"), []byte("d")); found {
+			if _, _, _, _, _, found := seeker.SeekGE([]byte("d"), []byte("d")); found {
 				t.Fatal("SeekGE accepted an empty range")
 			}
-			if _, _, _, _, _, found := mt.SeekGE([]byte("e"), nil); found {
+			if _, _, _, _, _, found := seeker.SeekGE([]byte("e"), nil); found {
 				t.Fatal("SeekGE returned a key past the table maximum")
 			}
 		})

--- a/TreeDB/internal/memtable/successor_test.go
+++ b/TreeDB/internal/memtable/successor_test.go
@@ -1,0 +1,39 @@
+package memtable
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/snissn/gomap/TreeDB/node"
+	"github.com/snissn/gomap/TreeDB/page"
+)
+
+func TestTableSeekGE_ModeMatrix(t *testing.T) {
+	for _, mode := range []Mode{ModeSkiplist, ModeHashSorted, ModeBTree, ModeAppendOnly} {
+		t.Run(mode.String(), func(t *testing.T) {
+			mt, err := NewWithCapacityMode(64<<10, mode)
+			if err != nil {
+				t.Fatalf("NewWithCapacityMode: %v", err)
+			}
+			revisioned, ok := mt.(RevisionTable)
+			if !ok {
+				t.Fatal("memtable does not implement RevisionTable")
+			}
+			revisioned.SetEntryWithRevision([]byte("b"), []byte("bee"), page.ValuePtr{}, node.FlagInline, 7)
+			revisioned.SetEntryWithRevision([]byte("d"), nil, page.ValuePtr{}, node.FlagTombstone, 9)
+			mt.Freeze()
+
+			key, val, ptr, flags, revision, found := mt.SeekGE([]byte("c"), []byte("e"))
+			if !found || !bytes.Equal(key, []byte("d")) || val != nil || ptr != (page.ValuePtr{}) || flags&node.FlagTombstone == 0 || revision != 9 {
+				t.Fatalf("SeekGE(c,e) = (%q,%q,%+v,%#x,%d,%t), want tombstone d@9", key, val, ptr, flags, revision, found)
+			}
+
+			if _, _, _, _, _, found := mt.SeekGE([]byte("d"), []byte("d")); found {
+				t.Fatal("SeekGE accepted an empty range")
+			}
+			if _, _, _, _, _, found := mt.SeekGE([]byte("e"), nil); found {
+				t.Fatal("SeekGE returned a key past the table maximum")
+			}
+		})
+	}
+}

--- a/TreeDB/internal/skiplist/skiplist.go
+++ b/TreeDB/internal/skiplist/skiplist.go
@@ -623,6 +623,28 @@ func (s *SkipList) seekGE(key []byte) uint32 {
 	return s.getNext(x, 0)
 }
 
+// SeekGEEntryWithRevision returns the first physical entry whose key is greater
+// than or equal to key. Returned slices alias skiplist storage.
+func (s *SkipList) SeekGEEntryWithRevision(key []byte) (entryKey, value []byte, ptr page.ValuePtr, flags byte, revision page.EntryRevision, found bool) {
+	curr := s.seekGE(key)
+	if curr == 0 {
+		return nil, nil, page.ValuePtr{}, 0, page.LegacyEntryRevision, false
+	}
+	entryKey = s.getKey(curr)
+	value = s.getValue(curr)
+	flags = s.getFlags(curr)
+	revision = s.getRevision(curr)
+	if flags&flagPointer != 0 {
+		if len(value) >= page.ValuePtrSize {
+			ptr = page.DecodeValuePtr(value[:page.ValuePtrSize])
+			value = value[page.ValuePtrSize:]
+		}
+	} else if flags&flagDeleted != 0 {
+		value = nil
+	}
+	return entryKey, value, ptr, flags, revision, true
+}
+
 func (s *SkipList) findLessThan(key []byte) uint32 {
 	if key == nil {
 		last := s.tail[0]

--- a/TreeDB/mvcc/mvcc.go
+++ b/TreeDB/mvcc/mvcc.go
@@ -77,6 +77,10 @@ type treeDB interface {
 	DurabilityMode() string
 }
 
+type pointSuccessorDB interface {
+	SeekGE(start, end []byte) (key, value []byte, found bool, err error)
+}
+
 // Store owns the external-version namespace of one TreeDB handle.
 type Store struct {
 	db treeDB
@@ -227,6 +231,17 @@ func (s *Store) GetAt(logical []byte, timestamp uint64) (result Result, err erro
 		s.mu.RUnlock()
 		return Result{}, fmt.Errorf("%w: read timestamp %d is at or below floor %d", ErrReadBeforeDiscardFloor, timestamp, floor)
 	}
+	if seeker, ok := s.db.(pointSuccessorDB); ok {
+		physical, record, found, seekErr := seeker.SeekGE(lower, upper)
+		s.mu.RUnlock()
+		if seekErr != nil {
+			return Result{}, storageError("seek version", seekErr)
+		}
+		if !found {
+			return Result{State: Absent}, nil
+		}
+		return decodePointResult(logical, timestamp, physical, record)
+	}
 	it, err := s.db.Iterator(lower, upper)
 	s.mu.RUnlock()
 	if err != nil {
@@ -246,16 +261,20 @@ func (s *Store) GetAt(logical []byte, timestamp uint64) (result Result, err erro
 	}
 
 	physical := it.Key()
+	record := it.Value()
+	if iterErr := it.Error(); iterErr != nil {
+		return Result{}, storageError("read value", iterErr)
+	}
+	return decodePointResult(logical, timestamp, physical, record)
+}
+
+func decodePointResult(logical []byte, timestamp uint64, physical, record []byte) (Result, error) {
 	decoded, version, decodeErr := mvcckey.Decode(physical)
 	if decodeErr != nil || !bytes.Equal(decoded, logical) || version > timestamp {
 		if decodeErr == nil {
 			decodeErr = errors.New("decoded key or timestamp is outside requested bound")
 		}
 		return Result{}, fmt.Errorf("%w: %w", ErrMalformedRecord, decodeErr)
-	}
-	record := it.Value()
-	if iterErr := it.Error(); iterErr != nil {
-		return Result{}, storageError("read value", iterErr)
 	}
 	if len(record) == 0 {
 		return Result{}, fmt.Errorf("%w: empty value envelope", ErrMalformedRecord)

--- a/TreeDB/mvcc/mvcc_bench_test.go
+++ b/TreeDB/mvcc/mvcc_bench_test.go
@@ -125,6 +125,12 @@ func BenchmarkCommitAtGetAtInterleaved(b *testing.B) {
 	reportMVCCBenchGauge(b, after, "treedb.cache.iterator.sources_max", "iterator_sources_max")
 	reportMVCCBenchGauge(b, after, "treedb.cache.iterator.queue_len_max", "iterator_queue_len_max")
 	reportMVCCBenchGauge(b, after, "treedb.cache.queue_len", "iterator_queue_len_end")
+	reportMVCCBenchCounter(b, before, after, "treedb.cache.point_successor.calls_total", "point_successor_calls/op")
+	reportMVCCBenchCounter(b, before, after, "treedb.cache.point_successor.sources_total", "point_successor_sources/op")
+	reportMVCCBenchCounter(b, before, after, "treedb.cache.point_successor.mutable_probes_total", "point_successor_mutable_probes/op")
+	reportMVCCBenchCounter(b, before, after, "treedb.cache.point_successor.backend_probes_total", "point_successor_backend_probes/op")
+	reportMVCCBenchGauge(b, after, "treedb.cache.point_successor.sources_max", "point_successor_sources_max")
+	reportMVCCBenchGauge(b, after, "treedb.cache.point_successor.general_merge_iterators_total", "point_successor_general_merge_iterators")
 }
 
 func reportMVCCBenchCounter(b *testing.B, before, after map[string]string, key, name string) {

--- a/TreeDB/mvcc/mvcc_bench_test.go
+++ b/TreeDB/mvcc/mvcc_bench_test.go
@@ -16,6 +16,23 @@ func openBenchDB(b *testing.B) *treedb.DB {
 	return db
 }
 
+func openBenchDBWithMemtableMode(b *testing.B, mode string) *treedb.DB {
+	b.Helper()
+	db, err := treedb.Open(treedb.Options{
+		Dir:                          b.TempDir(),
+		Durability:                   treedb.DurabilityWALOffRelaxed,
+		CommandWAL:                   false,
+		DisableSideStores:            true,
+		BackgroundCheckpointInterval: -1,
+		MemtableMode:                 mode,
+	})
+	if err != nil {
+		b.Fatalf("Open memtable mode %q: %v", mode, err)
+	}
+	b.Cleanup(func() { _ = db.Close() })
+	return db
+}
+
 func BenchmarkCommitAt(b *testing.B) {
 	for _, batchSize := range []int{1, 32} {
 		b.Run(fmt.Sprintf("DirectTreeDB/%d", batchSize), func(b *testing.B) {
@@ -131,6 +148,31 @@ func BenchmarkCommitAtGetAtInterleaved(b *testing.B) {
 	reportMVCCBenchCounter(b, before, after, "treedb.cache.point_successor.backend_probes_total", "point_successor_backend_probes/op")
 	reportMVCCBenchGauge(b, after, "treedb.cache.point_successor.sources_max", "point_successor_sources_max")
 	reportMVCCBenchGauge(b, after, "treedb.cache.point_successor.general_merge_iterators_total", "point_successor_general_merge_iterators")
+}
+
+// BenchmarkCommitAtGetAtInterleavedHashSorted guards the exact-successor hash
+// lookup used by write-then-read workloads. New physical MVCC versions
+// invalidate HashSorted's ordered index; exact GetAt must not rebuild it.
+func BenchmarkCommitAtGetAtInterleavedHashSorted(b *testing.B) {
+	db := openBenchDBWithMemtableMode(b, "hash_sorted")
+	store := New(db)
+	key := []byte("benchmark-key")
+	mutation := []Mutation{{Key: key, Value: []byte("value")}}
+	if err := store.CommitAt(1, mutation, CommitRelaxed); err != nil {
+		b.Fatalf("seed CommitAt: %v", err)
+	}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		timestamp := uint64(i + 2)
+		if err := store.CommitAt(timestamp, mutation, CommitRelaxed); err != nil {
+			b.Fatalf("CommitAt(%d): %v", timestamp, err)
+		}
+		result, err := store.GetAt(key, timestamp)
+		if err != nil || result.State != Present {
+			b.Fatalf("GetAt(%d) result=%+v err=%v", timestamp, result, err)
+		}
+	}
 }
 
 func reportMVCCBenchCounter(b *testing.B, before, after map[string]string, key, name string) {

--- a/TreeDB/mvcc/mvcc_test.go
+++ b/TreeDB/mvcc/mvcc_test.go
@@ -104,6 +104,63 @@ func TestGetAtUsesPointSuccessorWithoutIteratorRotation(t *testing.T) {
 	}
 }
 
+func TestGetAtPointSuccessorValueLogCheckpointAndReopen(t *testing.T) {
+	dir := t.TempDir()
+	open := func() *treedb.DB {
+		db, err := treedb.Open(treedb.Options{
+			Dir:                          dir,
+			Durability:                   treedb.DurabilityWALOffRelaxed,
+			DisableSideStores:            true,
+			BackgroundCheckpointInterval: -1,
+			ForceValueLogPointers:        true,
+			ValueLogPointerThreshold:     1,
+		})
+		if err != nil {
+			t.Fatalf("Open: %v", err)
+		}
+		return db
+	}
+	db := open()
+	store := New(db)
+	value := bytes.Repeat([]byte("v"), 4096)
+	if err := store.CommitAt(7, []Mutation{{Key: []byte("k"), Value: value}}, CommitRelaxed); err != nil {
+		t.Fatalf("CommitAt: %v", err)
+	}
+	requireResult(t, store, []byte("k"), 9, Present, 7, value)
+	if err := db.Checkpoint(); err != nil {
+		t.Fatalf("Checkpoint: %v", err)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	db = open()
+	defer db.Close()
+	requireResult(t, New(db), []byte("k"), 9, Present, 7, value)
+}
+
+func TestGetAtPointSuccessorDiscardFloorAndPruneBoundary(t *testing.T) {
+	db := openTestDB(t, t.TempDir(), treedb.DurabilityWALOffRelaxed)
+	defer db.Close()
+	store := New(db)
+	for ts := uint64(1); ts <= 5; ts++ {
+		if err := store.CommitAt(ts, []Mutation{{Key: []byte("k"), Value: []byte(strconv.FormatUint(ts, 10))}}, CommitRelaxed); err != nil {
+			t.Fatalf("CommitAt(%d): %v", ts, err)
+		}
+	}
+	if err := store.AdvanceDiscardFloor(4, CommitRelaxed); err != nil {
+		t.Fatalf("AdvanceDiscardFloor: %v", err)
+	}
+	if _, err := store.GetAt([]byte("k"), 3); !errors.Is(err, ErrReadBeforeDiscardFloor) {
+		t.Fatalf("GetAt below floor error = %v", err)
+	}
+	if _, err := store.PruneVersions(PruneOptions{BatchSize: 1, Mode: CommitRelaxed}); err != nil {
+		t.Fatalf("PruneVersions: %v", err)
+	}
+	requireResult(t, store, []byte("k"), 4, Present, 4, []byte("4"))
+	requireResult(t, store, []byte("k"), 5, Present, 5, []byte("5"))
+}
+
 func TestCommitAtMultiKeyAtomicAndDuplicatePolicy(t *testing.T) {
 	db := openTestDB(t, t.TempDir(), treedb.DurabilityDurable)
 	defer db.Close()

--- a/TreeDB/mvcc/mvcc_test.go
+++ b/TreeDB/mvcc/mvcc_test.go
@@ -112,8 +112,10 @@ func TestGetAtPointSuccessorValueLogCheckpointAndReopen(t *testing.T) {
 			Durability:                   treedb.DurabilityWALOffRelaxed,
 			DisableSideStores:            true,
 			BackgroundCheckpointInterval: -1,
-			ForceValueLogPointers:        true,
-			ValueLogPointerThreshold:     1,
+			ValueLog: treedb.ValueLogOptions{
+				ForcePointers:    true,
+				PointerThreshold: 1,
+			},
 		})
 		if err != nil {
 			t.Fatalf("Open: %v", err)
@@ -157,7 +159,9 @@ func TestGetAtPointSuccessorDiscardFloorAndPruneBoundary(t *testing.T) {
 	if _, err := store.PruneVersions(PruneOptions{BatchSize: 1, Mode: CommitRelaxed}); err != nil {
 		t.Fatalf("PruneVersions: %v", err)
 	}
-	requireResult(t, store, []byte("k"), 4, Present, 4, []byte("4"))
+	if _, err := store.GetAt([]byte("k"), 4); !errors.Is(err, ErrReadBeforeDiscardFloor) {
+		t.Fatalf("GetAt at floor error = %v", err)
+	}
 	requireResult(t, store, []byte("k"), 5, Present, 5, []byte("5"))
 }
 

--- a/TreeDB/mvcc/mvcc_test.go
+++ b/TreeDB/mvcc/mvcc_test.go
@@ -81,6 +81,29 @@ func TestCommitAtGetAtGoldenHistories(t *testing.T) {
 	requireResult(t, store, key, 30, Present, 30, []byte("thirty-replaced"))
 }
 
+func TestGetAtUsesPointSuccessorWithoutIteratorRotation(t *testing.T) {
+	db := openTestDB(t, t.TempDir(), treedb.DurabilityWALOffRelaxed)
+	defer db.Close()
+	store := New(db)
+	if err := store.CommitAt(7, []Mutation{{Key: []byte("k"), Value: []byte("seven")}}, CommitRelaxed); err != nil {
+		t.Fatalf("CommitAt: %v", err)
+	}
+	before := db.Stats()
+	requireResult(t, store, []byte("k"), 9, Present, 7, []byte("seven"))
+	after := db.Stats()
+	for _, name := range []string{
+		"treedb.cache.iterator.calls_total",
+		"treedb.cache.iterator.snapshot_rotations_total",
+	} {
+		if before[name] != after[name] {
+			t.Fatalf("%s changed across GetAt: %q -> %q", name, before[name], after[name])
+		}
+	}
+	if before["treedb.cache.queue_len"] != after["treedb.cache.queue_len"] {
+		t.Fatalf("queue length changed across GetAt: %q -> %q", before["treedb.cache.queue_len"], after["treedb.cache.queue_len"])
+	}
+}
+
 func TestCommitAtMultiKeyAtomicAndDuplicatePolicy(t *testing.T) {
 	db := openTestDB(t, t.TempDir(), treedb.DurabilityDurable)
 	defer db.Close()

--- a/TreeDB/public.go
+++ b/TreeDB/public.go
@@ -2131,6 +2131,26 @@ func (db *DB) Iterator(start, end []byte) (Iterator, error) {
 	return db.backend.Iterator(start, end)
 }
 
+// SeekGE returns owned copies of the first visible physical key and value in
+// [start,end). A miss returns nil, nil, false, nil.
+func (db *DB) SeekGE(start, end []byte) ([]byte, []byte, bool, error) {
+	if err := db.ensureOpen(); err != nil {
+		return nil, nil, false, err
+	}
+	if db.cached != nil {
+		return db.cached.SeekGE(start, end)
+	}
+	it, err := db.backend.Iterator(start, end)
+	if err != nil {
+		return nil, nil, false, err
+	}
+	defer it.Close()
+	if !it.Valid() {
+		return nil, nil, false, it.Error()
+	}
+	return it.KeyCopy(nil), it.ValueCopy(nil), true, it.Error()
+}
+
 // ReverseIterator returns a reverse iterator over the range [start, end).
 func (db *DB) ReverseIterator(start, end []byte) (Iterator, error) {
 	if err := db.ensureOpen(); err != nil {

--- a/benchmarks/dgraph_durability/benchmark_test.go
+++ b/benchmarks/dgraph_durability/benchmark_test.go
@@ -525,6 +525,10 @@ var storeCounterMetrics = []storeCounterMetric{
 	{key: "treedb.cache.iterator.snapshot_rotations_total", name: "iterator_snapshot_rotations/lookup", denominator: "lookups"},
 	{key: "treedb.cache.iterator.sources_total", name: "iterator_sources/lookup", denominator: "lookups"},
 	{key: "treedb.cache.iterator.calls_total", name: "iterator_calls/lookup", denominator: "lookups"},
+	{key: "treedb.cache.point_successor.calls_total", name: "point_successor_calls/lookup", denominator: "lookups"},
+	{key: "treedb.cache.point_successor.hits_total", name: "point_successor_hits/lookup", denominator: "lookups"},
+	{key: "treedb.cache.point_successor.sources_total", name: "point_successor_sources/lookup", denominator: "lookups"},
+	{key: "treedb.cache.point_successor.general_merge_iterators_total", name: "point_successor_general_merges/lookup", denominator: "lookups"},
 }
 
 func reportStoreCounters(b *testing.B, before, after map[string]string, writeCommits, lookups int) {
@@ -547,6 +551,7 @@ func reportStoreCounters(b *testing.B, before, after map[string]string, writeCom
 		{"treedb.cache.iterator.sources_max", "iterator_sources_max"},
 		{"treedb.cache.iterator.queue_len_max", "iterator_queue_len_max"},
 		{"treedb.cache.queue_len", "iterator_queue_len_end"},
+		{"treedb.cache.point_successor.sources_max", "point_successor_sources_max"},
 	} {
 		if value, ok := parseCounter(after, metric.key); ok {
 			b.ReportMetric(float64(value), metric.name)
@@ -591,13 +596,31 @@ func TestDgraphShapedProfilesRoundTrip(t *testing.T) {
 					"treedb.cache.iterator.sources_total",
 					"treedb.cache.iterator.sources_max",
 					"treedb.cache.iterator.queue_len_max",
+					"treedb.cache.point_successor.calls_total",
+					"treedb.cache.point_successor.hits_total",
+					"treedb.cache.point_successor.sources_total",
+					"treedb.cache.point_successor.sources_max",
+					"treedb.cache.point_successor.general_merge_iterators_total",
 				} {
 					if _, ok := stats[key]; !ok {
 						t.Errorf("missing TreeDB attribution stat %q", key)
 					}
 				}
-				if calls, ok := parseCounter(stats, "treedb.cache.iterator.calls_total"); !ok || calls < 2 {
-					t.Errorf("iterator calls=%d ok=%t want >=2", calls, ok)
+				for _, want := range []struct {
+					key   string
+					value uint64
+				}{
+					{key: "treedb.cache.iterator.calls_total", value: 1},
+					{key: "treedb.cache.iterator.snapshot_rotations_total", value: 0},
+					{key: "treedb.cache.point_successor.calls_total", value: 2},
+					{key: "treedb.cache.point_successor.hits_total", value: 2},
+					{key: "treedb.cache.point_successor.sources_total", value: 2},
+					{key: "treedb.cache.point_successor.sources_max", value: 1},
+					{key: "treedb.cache.point_successor.general_merge_iterators_total", value: 0},
+				} {
+					if got, ok := parseCounter(stats, want.key); !ok || got != want.value {
+						t.Errorf("%s=%d ok=%t want %d", want.key, got, ok, want.value)
+					}
 				}
 			}
 			if err := store.close(); err != nil {


### PR DESCRIPTION
## Objective

Add a snapshot-correct bounded `SeekGE` path and route MVCC `GetAt` through it so point reads no longer rotate mutable memtables or construct a general merging iterator.

Fixes #3728
Parent: #3726

## Context

The former `GetAt -> DB.Iterator` path rotated non-empty mutable state, retained an increasing source set, and merged every overlapping source. In the fixed 500k interleaved workload that reached 78.2 us/op, 199 allocs/op, and 266 KB/op on the exact causal base.

The test-first sequence is preserved in the commit history: the initial red commits (`b8d567f3b`, `2442ef02e`, `14d365223`) precede implementation (`ca72bf30f`, `4b55316ad`). Review-found regressions also preserve red/green boundaries: HashSorted exact lookup (`1cdbf9b01` -> `c5113faf1`), whole-call source accounting (`4f737f718` -> `74b6a73a1`), and lazy iterator entry-error propagation (`7b59ba622` -> `9df1f8660`). `78ea60102` adds the explicit HashSorted benchmark, and `6b5ed01b0` updates the Dgraph attribution contract exposed by CI.

## Non-goals

- No command-WAL, durability, root-publication, storage-format, or general iterator semantic changes.
- No synchronous flush/checkpoint workaround and no weakening of snapshot isolation.
- No changes to #3718, Dgraph adapter behavior, or conditional residual allocation issues #3589/#3512.
- No queue/backpressure semantic changes. In particular, this PR does not impose a new global immutable-queue cap.

## Design

- Add public `(*treedb.DB).SeekGE(start, end)` returning owned key/value copies for the first visible physical entry in `[start,end)`.
- Add an optional native memtable successor contract implemented by skiplist, B-tree, hash-sorted, and append-only modes, preserving value-pointer, tombstone, and revision metadata.
- Capture one retained memtable view under the exclusive write fence, arbitrate mutable shards, the immutable snapshot queue, range tombstones, and at most one published/backend cursor using existing source precedence, and release everything at return.
- Fast-return exact non-tombstone hits in the target mutable shard before acquiring a backend cursor. Reuse the first target probe for non-exact arbitration and skip backend cursor creation when the backend range is disjoint.
- Route MVCC `GetAt` through the optional successor seam while retaining the iterator fallback for alternate/test backends.
- Export calls/hits, mutable/queue/backend probes, and whole-call total/max source inspections. `general_merge_iterators_total` is explicitly an invariant sentinel owned by this path, not a global iterator-construction counter; it must remain zero because `SeekGE` has no general-merge fallback.

The per-arbitration source width is snapshot-relative: `len(snapshot.mutables) + len(snapshot.queue) + zero-or-one backend cursor`. Native tables are probed directly; the path does not create one cursor per table and retains no source state across calls. Counters record every real inspection across the entire call, so point tombstones that require another arbitration round are counted again. This is not a global constant when callers set `MaxQueuedMemtables=-1` and flushing stalls.

In the final 500k run, one lookup crossed a write-triggered rotation/publication boundary. Its retained snapshot contained 16 mutable shards + 16 immutable tables, while the backend-range check returned no cursor, so the accurate observed max is 32; an actual backend cursor would make that round 33. The remaining exact mutable hits inspected one source, average inspections remained 1.000/op, and backend probes were zero. Dedicated tests prove two tombstone/visible rounds report four inspections with a real backend cursor, while a disjoint nil-cursor case reports two mutable inspections and zero backend probes.

## Scope

- Includes: TreeDB public/caching `SeekGE`, native memtable successor primitives, MVCC `GetAt` routing, point-successor counters, tests, and benchmark counter reporting.
- Excludes: general forward/reverse iterator implementation, durability/format/config behavior, Dgraph code, and queue semantics.

## Correctness

Latest-main validation head: `9df1f8660`, rebased directly onto current `origin/main` `9d81a02d1206802333ae59d6e01dfe9d23f22d05`.

Commands passed:

```text
make fmt
git diff --check
GOWORK=off go vet ./TreeDB/internal/memtable ./TreeDB/caching ./TreeDB/mvcc ./TreeDB
GOWORK=off go test ./TreeDB/internal/memtable ./TreeDB/caching ./TreeDB/mvcc -count=1
GOWORK=off go test ./TreeDB -count=1
GOWORK=off go test -race ./TreeDB/internal/memtable ./TreeDB/caching ./TreeDB/mvcc -run 'Test(TableSeekGE|HashSortedSeekGE|SeekGE|SeekPointSuccessor|GetAt|CommitAtGetAt)' -count=1
GOWORK=off go test ./TreeDB/mvcc -run 'TestGetAtPointSuccessorValueLogCheckpointAndReopen|TestGetAtPointSuccessorDiscardFloorAndPruneBoundary|TestGetAtUsesPointSuccessorWithoutIteratorRotation' -count=1
GOWORK=off go test ./benchmarks/dgraph_durability -count=1
```

Coverage includes:

- source precedence across mutable shards, multiple immutable layers, and published/backend state;
- point and range tombstones, bounds, and owned return bytes;
- concurrent commits under one coherent snapshot;
- zero iterator-triggered rotation and zero general merge construction;
- flush/publication, forced value-log pointers, checkpoint/close/reopen;
- discard-floor and pruning boundaries;
- all four configured memtable modes, including a deterministic assertion that exact HashSorted reads do not rebuild `sortedKeys`;
- whole-call source accounting across tombstone rounds and nil backend cursors;
- lazy iterator entry/decode errors returned before a candidate can escape;
- Dgraph durability-harness attribution: one setup iterator, two point-successor calls/hits, zero rotations, and zero point-successor general merges.

The repository-wide `go test ./...` was not run; the affected packages plus the top-level TreeDB package, focused race suite, reopen coverage, formatting, and vet were run.

## Performance

Machine: Intel i5-11400F, Linux amd64, `-12`. Durability: WAL-off relaxed, identical fixed-work harness from #3727.

Causal A/B base is deliberately fixed at `b7154c7cab83e4129e8138f864411e6b8d6976d7`. The candidate matrix below was rerun on `6b5ed01b0`, directly based on current main. Final head `9df1f8660` adds only lazy iterator entry-error propagation; its latest-head 500k/profile row was rerun separately below.

```text
for n in 50000 100000 250000 500000; do
  GOWORK=off go test ./TreeDB/mvcc -run '^$' \
    -bench '^BenchmarkCommitAtGetAtInterleaved$' -benchmem -count=1 \
    -benchtime=${n}x
done
```

| Work | Base ops/s | Head ops/s | Speedup | Base B/op | Head B/op | Base allocs | Head allocs | Base rotations/op | Head rotations/op | Head merges | Head sources avg/max | Head backend probes/op |
|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|
| 50k | 32.4k | 224.3k | 6.9x | 57,345 | 7,541 | 129 | 14 | 1.000 | 0 | 0 | 1.000 / 1 | 0 |
| 100k | 26.8k | 248.5k | 9.3x | 85,912 | 7,451 | 141 | 14 | 1.000 | 0 | 0 | 1.000 / 1 | 0 |
| 250k | 18.0k | 231.6k | 12.9x | 164,618 | 7,611 | 172 | 14 | 1.000 | 0 | 0 | 1.000 / 1 | 0 |
| 500k | 12.8k | 235.5k | 18.4x | 265,996 | 7,700 | 199 | 14 | 1.000 | 0 | 0 | 1.000 / 32 | 0 |

The final-head 500k matrix row is 6.6x the issue's historical ~35.9k ops/s gate. B/op and allocs/op remain flat from 50k to 500k instead of growing with retained iterator sources.

Latest-head decisive rerun at `9df1f8660`:

```text
GOWORK=off go test ./TreeDB/mvcc -run '^$' \
  -bench '^BenchmarkCommitAtGetAtInterleaved$' -benchmem -count=1 \
  -benchtime=500000x \
  -cpuprofile=/mnt/fast4tb/gomap-3728-9df1f8660-cpu.pprof \
  -memprofile=/mnt/fast4tb/gomap-3728-9df1f8660-mem.pprof
```

Result: 3,912 ns/op (255.6k ops/s), 7,692 B/op, 14 allocs/op; rotations 0, general-merge sentinel 0, calls 1/op, mutable probes 1/op, source inspections 1/op average / 32 max, backend probes 0.

CPU profile attribution for `mvcc.(*Store).GetAt`: 0.36 s cumulative, with 0.21 s in `TreeDB.(*DB).SeekGE`; there is no `GetAt -> DB.Iterator` or merging-iterator edge. Heap allocation remains commit-dominated: `CommitAt` accounts for 3.59 GB (94.60% cumulative), while point-successor materialization is 21.5 MB (0.57%).

Explicit HashSorted fixed-work guard:

| Work | ns/op | ops/s | B/op | allocs/op |
|---:|---:|---:|---:|---:|
| 50k | 4,655 | 214.8k | 7,428 | 14 |
| 100k | 4,248 | 235.4k | 7,496 | 14 |
| 250k | 3,831 | 261.0k | 7,419 | 14 |
| 500k | 3,686 | 271.3k | 7,399 | 14 |

The HashSorted path remains flat because exact starts use the hash index and leave the invalid ordered index untouched; only a true non-exact successor builds `sortedKeys`.

Regression checks:

- Ten-run preloaded `GetAt` medians: depth 1 is 1,207 vs 1,129 ns/op (+6.9%) while falling from 632 to 128 B/op and 12 to 6 allocs/op; depth 8 is 1,817 vs 2,611 ns/op (-30.4%); depth 64 is 4,903 vs 5,122 ns/op (-4.3%). The small depth-1 latency tradeoff is explicit and accepted here for an ~80% byte reduction, 50% allocation reduction, and removal of scale growth.
- Seven-run commit-only medians show no material regression: Direct/1 +0.1%, MVCC/1 +1.7%, Direct/32 +1.3%, MVCC/32 faster within a noisy row; allocation counts are unchanged.
- Fixed 100-iteration largest version-iteration rows are within roughly +/-2% with identical allocation counts.
- Fixed 100-iteration prune median is 1.690 ms head vs 1.702 ms base with identical 160 KB/op and 522 allocs/op.
- General `DirectSeek` iterator rows remain in the same band with unchanged allocation counts; the general iterator implementation is untouched.

## Rollout / Toggle Plan

- Default: MVCC uses the optional successor seam when the TreeDB handle exposes it; alternate/test backends retain the existing iterator fallback.
- No new knob or format migration. A revert restores the former iterator path.
- Effectiveness is visible through `treedb.cache.point_successor.*` and existing iterator rotation/source counters.

## Follow-ups

- Post-fix profiling leaves #3589 and #3512 inactive for parent #3726: `getAppendOnlyEntries` is 6.12% of allocation space, fixed-scale allocation efficiency is flat, and span-native prepare/zipper work is not a top limiter.
- If the final Dgraph relaxed gate still misses, route the newly measured limiter through #3726 rather than broadening this PR.
- Mature AI reviews have been requested at the exact head; merge remains gated on their latest-head artifacts and all latest-head CI.

## Checklist

- [x] Single point-successor objective; no durability or format bundle.
- [x] Deterministic regression tests committed before implementation.
- [x] Concurrency state and snapshot/source bounds documented.
- [x] Relevant fixed-work benchmark and counters updated.
- [x] Before/after results, allocations, profiles, and non-target regressions reported.
- [x] No new mmap, length field, compression, config knob, or storage format.
- [x] Affected packages, top-level TreeDB, focused race/reopen, format, and vet pass locally.
- [x] Latest-head GitHub CI: all 28 checks passed on `9df1f8660`.


