### PR TITLE
treedb: fence value-log deletion by stable identity

### DIFF
--- a/TreeDB/caching/db.go
+++ b/TreeDB/caching/db.go
@@ -5169,24 +5169,19 @@ func (db *DB) cleanupOrphanedRetainedValueLogExpected(path string, expected root
 	if err != nil {
 		return false
 	}
-	if expected != (rootpublication.StableIdentity{}) {
-		file, err := os.Open(path)
-		if err != nil {
-			return os.IsNotExist(err) && db.cleanupMissingRetainedValueLog(path)
-		}
-		identity, identityErr := rootpublication.StableIdentityFromFile(file)
-		closeErr := file.Close()
-		if identityErr != nil || closeErr != nil || !rootpublication.SamePhysicalIdentity(expected, identity) {
-			return false
-		}
-	}
 	if err := db.valueLogReader.RegisterSegment(path, id); err != nil {
 		if os.IsNotExist(err) {
 			return db.cleanupMissingRetainedValueLog(path)
 		}
 		return false
 	}
-	if err := db.valueLogReader.RemoveSegment(id); err != nil {
+	var removeErr error
+	if expected != (rootpublication.StableIdentity{}) {
+		removeErr = db.valueLogReader.RemoveSegmentExpectedIdentity(id, expected)
+	} else {
+		removeErr = db.valueLogReader.RemoveSegment(id)
+	}
+	if removeErr != nil {
 		return false
 	}
 	if _, err := os.Stat(path); err == nil || !os.IsNotExist(err) {

--- a/TreeDB/caching/db.go
+++ b/TreeDB/caching/db.go
@@ -36,6 +36,7 @@ import (
 	"github.com/snissn/gomap/TreeDB/internal/memtable"
 	"github.com/snissn/gomap/TreeDB/internal/merging"
 	"github.com/snissn/gomap/TreeDB/internal/outerleaf"
+	"github.com/snissn/gomap/TreeDB/internal/rootpublication"
 	"github.com/snissn/gomap/TreeDB/internal/valuelog"
 	"github.com/snissn/gomap/TreeDB/node"
 	"github.com/snissn/gomap/TreeDB/page"
@@ -5153,38 +5154,42 @@ func (db *DB) cleanupMissingRetainedValueLog(path string) bool {
 }
 
 func (db *DB) cleanupOrphanedRetainedValueLog(path string) bool {
-	if path == "" {
+	return db.cleanupOrphanedRetainedValueLogExpected(path, rootpublication.StableIdentity{})
+}
+
+func (db *DB) cleanupOrphanedRetainedValueLogExpected(path string, expected rootpublication.StableIdentity) bool {
+	if path == "" || db.valueLogReader == nil {
 		return false
 	}
-	if db.valueLogReader != nil {
-		laneID, seq, valueLog, ok := parseLogSeq(filepath.Base(path))
-		if ok && valueLog && laneID >= 0 {
-			if id, err := valuelog.EncodeFileID(uint32(laneID), uint32(seq)); err == nil {
-				var removeErr error
-				backoff := 25 * time.Millisecond
-				for i := 0; i < 40; i++ {
-					removeErr = db.valueLogReader.RemoveSegment(id)
-					if removeErr == nil || errors.Is(removeErr, valuelog.ErrFileNotFound) {
-						break
-					}
-					if runtime.GOOS != "windows" {
-						return false
-					}
-					if !isWindowsSharingViolationError(removeErr) {
-						return false
-					}
-					time.Sleep(backoff)
-					if backoff < 200*time.Millisecond {
-						backoff *= 2
-					}
-				}
-				if removeErr != nil && !errors.Is(removeErr, valuelog.ErrFileNotFound) {
-					return false
-				}
-			}
+	laneID, seq, valueLog, ok := parseLogSeq(filepath.Base(path))
+	if !ok || !valueLog || laneID < 0 {
+		return false
+	}
+	id, err := valuelog.EncodeFileID(uint32(laneID), uint32(seq))
+	if err != nil {
+		return false
+	}
+	if expected != (rootpublication.StableIdentity{}) {
+		file, err := os.Open(path)
+		if err != nil {
+			return os.IsNotExist(err) && db.cleanupMissingRetainedValueLog(path)
+		}
+		identity, identityErr := rootpublication.StableIdentityFromFile(file)
+		closeErr := file.Close()
+		if identityErr != nil || closeErr != nil || !rootpublication.SamePhysicalIdentity(expected, identity) {
+			return false
 		}
 	}
-	if err := db.removeFileRetry(path); err != nil {
+	if err := db.valueLogReader.RegisterSegment(path, id); err != nil {
+		if os.IsNotExist(err) {
+			return db.cleanupMissingRetainedValueLog(path)
+		}
+		return false
+	}
+	if err := db.valueLogReader.RemoveSegment(id); err != nil {
+		return false
+	}
+	if _, err := os.Stat(path); err == nil || !os.IsNotExist(err) {
 		return false
 	}
 	db.mu.Lock()
@@ -6947,11 +6952,13 @@ func (db *DB) pruneRetainedValueLogsWithObservedContextOptions(ctx context.Conte
 			}
 
 			if marker, ok := db.backend.(valueLogZombieMarker); ok {
+				var expectedIdentity rootpublication.StableIdentity
 				if db.valueLogReader != nil {
+					expectedIdentity, _ = db.valueLogReader.StableSegmentIdentity(id)
 					_ = db.valueLogReader.EvictSegment(id)
 				}
 				if err := marker.MarkValueLogZombie(id); err != nil {
-					if errors.Is(err, valuelog.ErrFileNotFound) && db.cleanupOrphanedRetainedValueLog(path) {
+					if errors.Is(err, valuelog.ErrFileNotFound) && db.cleanupOrphanedRetainedValueLogExpected(path, expectedIdentity) {
 						removed = true
 						out.RemovedSegments++
 						if size > 0 {
@@ -6986,9 +6993,7 @@ func (db *DB) pruneRetainedValueLogsWithObservedContextOptions(ctx context.Conte
 					out.ObservedSourceZombieMarkedBytes += size
 				}
 				marked = true
-			} else {
-				db.dropValueLogSegment(path)
-				_ = db.removeFileRetry(path)
+			} else if db.cleanupOrphanedRetainedValueLog(path) {
 				db.mu.Lock()
 				db.untrackValueLogSegmentLocked(path)
 				db.mu.Unlock()
@@ -7001,6 +7006,8 @@ func (db *DB) pruneRetainedValueLogsWithObservedContextOptions(ctx context.Conte
 				if size > 0 {
 					out.ObservedSourceRemovedBytes += size
 				}
+			} else {
+				continue
 			}
 			db.forgetValueLogRetain(path)
 		}
@@ -7088,11 +7095,13 @@ func (db *DB) pruneRetainedValueLogsWithObservedContextOptions(ctx context.Conte
 		}
 
 		if marker, ok := db.backend.(valueLogZombieMarker); ok {
+			var expectedIdentity rootpublication.StableIdentity
 			if db.valueLogReader != nil {
+				expectedIdentity, _ = db.valueLogReader.StableSegmentIdentity(id)
 				_ = db.valueLogReader.EvictSegment(id)
 			}
 			if err := marker.MarkValueLogZombie(id); err != nil {
-				if errors.Is(err, valuelog.ErrFileNotFound) && db.cleanupOrphanedRetainedValueLog(path) {
+				if errors.Is(err, valuelog.ErrFileNotFound) && db.cleanupOrphanedRetainedValueLogExpected(path, expectedIdentity) {
 					removed = true
 					out.RemovedSegments++
 					if size > 0 {
@@ -7133,9 +7142,7 @@ func (db *DB) pruneRetainedValueLogsWithObservedContextOptions(ctx context.Conte
 				}
 			}
 			marked = true
-		} else {
-			db.dropValueLogSegment(path)
-			_ = db.removeFileRetry(path)
+		} else if db.cleanupOrphanedRetainedValueLog(path) {
 			db.mu.Lock()
 			db.untrackValueLogSegmentLocked(path)
 			db.mu.Unlock()
@@ -7150,6 +7157,8 @@ func (db *DB) pruneRetainedValueLogsWithObservedContextOptions(ctx context.Conte
 					out.ObservedSourceRemovedBytes += size
 				}
 			}
+		} else {
+			continue
 		}
 		db.forgetValueLogRetain(path)
 	}
@@ -8071,6 +8080,19 @@ type BackendDB interface {
 	Stats() map[string]string
 }
 
+type valueLogIdentityPinRegistryProvider interface {
+	ValueLogIdentityPinRegistry() *rootpublication.IdentityPinRegistry
+}
+
+// ValueLogIdentityPinRegistry lets nested wrappers share the same physical
+// deletion gate as the backend and cache value-log managers.
+func (db *DB) ValueLogIdentityPinRegistry() *rootpublication.IdentityPinRegistry {
+	if db == nil {
+		return nil
+	}
+	return db.valueLogIdentityPins
+}
+
 type backendStateReader interface {
 	State() *backenddb.DBState
 }
@@ -8762,6 +8784,7 @@ type DB struct {
 	valueLogRewriteTriggerChurn    int64
 	valueLogRewriteMinSegmentAge   time.Duration
 	valueLogReader                 *valuelog.Manager
+	valueLogIdentityPins           *rootpublication.IdentityPinRegistry
 	valueLogHotLanes               []int
 	valueLogWarmLanes              []int
 	valueLogColdLanes              []int
@@ -12318,7 +12341,13 @@ func Open(dir string, backend BackendDB, opts Options) (*DB, error) {
 		}
 		mutableShards[i] = memShard{mem: mt}
 	}
-	reader, err := valuelog.NewManager(valueLogDir)
+	valueLogIdentityPins := rootpublication.NewIdentityPinRegistry()
+	if provider, ok := backend.(valueLogIdentityPinRegistryProvider); ok {
+		if shared := provider.ValueLogIdentityPinRegistry(); shared != nil {
+			valueLogIdentityPins = shared
+		}
+	}
+	reader, err := valuelog.NewManagerWithStableResourcePinRegistry(valueLogDir, valueLogIdentityPins)
 	if err != nil {
 		return nil, err
 	}
@@ -12610,6 +12639,7 @@ func Open(dir string, backend BackendDB, opts Options) (*DB, error) {
 		memtableValueLogPointers:                   true,
 		indexOuterLeavesInValueLog:                 opts.IndexOuterLeavesInValueLog,
 		valueLogReader:                             valueLogReader,
+		valueLogIdentityPins:                       valueLogIdentityPins,
 		valueLogRetain:                             retained,
 		debugFlushPointers:                         debugFlushPointers,
 		debugFlushTiming:                           debugFlushTiming,

--- a/TreeDB/caching/stable_resource_registry_test.go
+++ b/TreeDB/caching/stable_resource_registry_test.go
@@ -1,0 +1,156 @@
+package caching
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	backenddb "github.com/snissn/gomap/TreeDB/db"
+	"github.com/snissn/gomap/TreeDB/internal/rootpublication"
+	"github.com/snissn/gomap/TreeDB/internal/valuelog"
+)
+
+func TestOpenSharesBackendValueLogIdentityPinRegistry(t *testing.T) {
+	dir := t.TempDir()
+	backend, err := backenddb.Open(backenddb.Options{Dir: dir})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer backend.Close()
+
+	database, err := Open(dir, backend, Options{
+		DisableWAL:     true,
+		AllowUnsafe:    true,
+		FlushThreshold: 1 << 20,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer database.Close()
+
+	registry := backend.ValueLogIdentityPinRegistry()
+	if registry == nil {
+		t.Fatal("backend has no value-log identity pin registry")
+	}
+	if got := database.ValueLogIdentityPinRegistry(); got != registry {
+		t.Fatalf("cached DB registry = %p, backend registry = %p", got, registry)
+	}
+	if got := database.valueLogReader.StableResourcePinRegistry(); got != registry {
+		t.Fatalf("cached value-log reader registry = %p, backend registry = %p", got, registry)
+	}
+}
+
+func TestCleanupOrphanedRetainedValueLogRejectsReboundPathAfterEvict(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Windows does not permit replacing an open segment path")
+	}
+	dir := t.TempDir()
+	backend, err := backenddb.Open(backenddb.Options{Dir: dir})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer backend.Close()
+	database, err := Open(dir, backend, Options{DisableWAL: true, AllowUnsafe: true, FlushThreshold: 1 << 20})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer database.Close()
+	fileID, err := valuelog.EncodeFileID(0, 2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(database.valueLogDir, valueLogName(0, 2))
+	writer, err := valuelog.NewWriter(path, fileID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := writer.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := database.valueLogReader.RegisterSegment(path, fileID); err != nil {
+		t.Fatal(err)
+	}
+	expected, ok := database.valueLogReader.StableSegmentIdentity(fileID)
+	if !ok {
+		t.Fatal("manager did not capture segment identity")
+	}
+	if err := database.valueLogReader.EvictSegment(fileID); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Rename(path, path+".old"); err != nil {
+		t.Fatal(err)
+	}
+	const replacement = "replacement survives retained cleanup"
+	if err := os.WriteFile(path, []byte(replacement), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if database.cleanupOrphanedRetainedValueLogExpected(path, expected) {
+		t.Fatal("cleanup removed a rebound pathname")
+	}
+	got, err := os.ReadFile(path)
+	if err != nil || string(got) != replacement {
+		t.Fatalf("replacement changed: got=%q err=%v", got, err)
+	}
+}
+
+func TestCleanupOrphanedRetainedValueLogPreservesStablePinnedSegment(t *testing.T) {
+	dir := t.TempDir()
+	backend, err := backenddb.Open(backenddb.Options{Dir: dir})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer backend.Close()
+	database, err := Open(dir, backend, Options{DisableWAL: true, AllowUnsafe: true, FlushThreshold: 1 << 20})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer database.Close()
+
+	fileID, err := valuelog.EncodeFileID(0, 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(database.valueLogDir, valueLogName(0, 1))
+	writer, err := valuelog.NewWriter(path, fileID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := writer.Append(0, nil, 1, []byte("stable retained value")); err != nil {
+		t.Fatal(err)
+	}
+	if err := writer.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := database.valueLogReader.RegisterSegment(path, fileID); err != nil {
+		t.Fatal(err)
+	}
+	database.markValueLogRetain(path)
+	token, err := database.valueLogReader.StableResourceToken(fileID, valuelog.StableResourceRegistration{
+		Kind: rootpublication.ResourceValueLog, LogicalLane: "0", Generation: 1,
+		DiagnosticPath: "value_vlog/" + filepath.Base(path), Digest: [32]byte{1},
+		Reachability: rootpublication.ReachabilityValueLogPointer,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if database.cleanupOrphanedRetainedValueLog(path) {
+		t.Fatal("cleanup reported removal while stable token was live")
+	}
+	if _, err := os.Stat(path); err != nil {
+		t.Fatalf("stable-pinned retained file disappeared: %v", err)
+	}
+	database.valueLogMu.Lock()
+	_, retained := database.valueLogRetain[path]
+	database.valueLogMu.Unlock()
+	if !retained {
+		t.Fatal("stable-pinned retained file was forgotten")
+	}
+	token.Release()
+	if !database.cleanupOrphanedRetainedValueLog(path) {
+		t.Fatal("cleanup did not remove retained file after stable token release")
+	}
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Fatalf("retained file still exists after release: %v", err)
+	}
+}

--- a/TreeDB/caching/stable_resource_registry_test.go
+++ b/TreeDB/caching/stable_resource_registry_test.go
@@ -85,8 +85,24 @@ func TestCleanupOrphanedRetainedValueLogRejectsReboundPathAfterEvict(t *testing.
 	if err := os.WriteFile(path, []byte(replacement), 0o600); err != nil {
 		t.Fatal(err)
 	}
+	replacementFile, err := os.Open(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	replacementIdentity, err := rootpublication.StableIdentityFromFile(replacementFile)
+	closeErr := replacementFile.Close()
+	if err != nil || closeErr != nil {
+		t.Fatalf("capture replacement identity: identity=%v close=%v", err, closeErr)
+	}
 	if database.cleanupOrphanedRetainedValueLogExpected(path, expected) {
 		t.Fatal("cleanup removed a rebound pathname")
+	}
+	registered, ok := database.valueLogReader.StableSegmentIdentity(fileID)
+	if !ok {
+		t.Fatal("cleanup did not register the rebound segment")
+	}
+	if !rootpublication.SamePhysicalIdentity(registered, replacementIdentity) {
+		t.Fatal("cleanup registered an unexpected replacement identity")
 	}
 	got, err := os.ReadFile(path)
 	if err != nil || string(got) != replacement {

--- a/TreeDB/db/compact_storage.go
+++ b/TreeDB/db/compact_storage.go
@@ -1609,6 +1609,12 @@ func (db *DB) pruneZeroByteValueLogFiles(protectedPaths []string) (int, error) {
 		}
 		if db.valueLogManager != nil {
 			if fileID, ok := compactStorageValueLogFileID(name); ok {
+				if err := db.valueLogManager.RegisterSegment(path, fileID); err != nil {
+					if os.IsNotExist(err) {
+						continue
+					}
+					return deleted, err
+				}
 				tracked, _, err := db.valueLogManager.MarkZombieIfTracked(fileID)
 				if err != nil {
 					return deleted, err

--- a/TreeDB/db/db.go
+++ b/TreeDB/db/db.go
@@ -21,6 +21,7 @@ import (
 	"github.com/snissn/gomap/TreeDB/internal/durabilitycut"
 	"github.com/snissn/gomap/TreeDB/internal/keyupdate"
 	"github.com/snissn/gomap/TreeDB/internal/lockfile"
+	"github.com/snissn/gomap/TreeDB/internal/rootpublication"
 	"github.com/snissn/gomap/TreeDB/internal/valuelog"
 	"github.com/snissn/gomap/TreeDB/lifecycle"
 	"github.com/snissn/gomap/TreeDB/node"
@@ -86,6 +87,7 @@ type snapshotView struct {
 
 type DB struct {
 	valueLogManager                *valuelog.Manager
+	valueLogIdentityPins           *rootpublication.IdentityPinRegistry
 	snapshotViewRO                 atomic.Pointer[snapshotView]
 	snapshotAcquireRO              [snapshotAcquireShardCount]atomic.Int32
 	snapshotAcquireEpoch           atomic.Uint64
@@ -1872,7 +1874,8 @@ func openWithLock(opts Options, lock *lockfile.Lock) (*DB, error) {
 	p.SetVerifyOnRead(opts.VerifyOnRead)
 
 	layout := resolveStorageLayout(opts.Dir)
-	vm, err := valuelog.NewManager(layout.valueVLogDir)
+	valueLogIdentityPins := rootpublication.NewIdentityPinRegistry()
+	vm, err := valuelog.NewManagerWithStableResourcePinRegistry(layout.valueVLogDir, valueLogIdentityPins)
 	if err != nil {
 		p.Close()
 		return nil, err
@@ -1905,6 +1908,7 @@ func openWithLock(opts Options, lock *lockfile.Lock) (*DB, error) {
 
 	db := &DB{
 		valueLogManager:                vm,
+		valueLogIdentityPins:           valueLogIdentityPins,
 		valueLogRefTracker:             newValueLogRefTrackerForOptions(opts),
 		lock:                           lock,
 		adaptive:                       adaptiveCtrl,

--- a/TreeDB/db/leaf_generation_pack_cleanup_test.go
+++ b/TreeDB/db/leaf_generation_pack_cleanup_test.go
@@ -7,8 +7,64 @@ import (
 	"testing"
 
 	"github.com/snissn/gomap/TreeDB/internal/durabilitycut"
+	"github.com/snissn/gomap/TreeDB/internal/rootpublication"
 	"github.com/snissn/gomap/TreeDB/internal/valuelog"
 )
+
+func TestCleanupRewriteCreatedSegmentRespectsStableIdentityPin(t *testing.T) {
+	dir := t.TempDir()
+	fileID, err := valuelog.EncodeFileID(42, 1)
+	if err != nil {
+		t.Fatalf("EncodeFileID: %v", err)
+	}
+	path := valuelog.SegmentPath(dir, fileID)
+	writer, err := valuelog.NewWriter(path, fileID)
+	if err != nil {
+		t.Fatalf("NewWriter: %v", err)
+	}
+	if _, err := writer.Append(0, nil, 1, []byte("rewrite-created")); err != nil {
+		_ = writer.Close()
+		t.Fatalf("Append: %v", err)
+	}
+	if err := writer.Close(); err != nil {
+		t.Fatalf("Close writer: %v", err)
+	}
+
+	mgr, err := valuelog.NewManagerWithStableResourcePinRegistry(dir, rootpublication.NewIdentityPinRegistry())
+	if err != nil {
+		t.Fatalf("NewManager: %v", err)
+	}
+	defer func() { _ = mgr.Close() }()
+	token, err := mgr.StableResourceToken(fileID, valuelog.StableResourceRegistration{
+		Kind:           rootpublication.ResourceValueLog,
+		LogicalLane:    "rewrite",
+		Generation:     1,
+		DiagnosticPath: filepath.Base(path),
+		Reachability:   rootpublication.ReachabilityValueLogPointer,
+		Digest:         [32]byte{1},
+	})
+	if err != nil {
+		t.Fatalf("StableResourceToken: %v", err)
+	}
+
+	database := &DB{valueLogManager: mgr}
+	created := []rewriteCreatedSegment{{path: path, fileID: fileID}}
+	err = database.cleanupRewriteCreatedSegments(created)
+	if !errors.Is(err, valuelog.ErrFilePinned) || !errors.Is(err, ErrRecoveryRequired) {
+		t.Fatalf("cleanup while pinned error=%v, want ErrFilePinned and ErrRecoveryRequired", err)
+	}
+	if _, err := os.Stat(path); err != nil {
+		t.Fatalf("stable-pinned rewrite segment removed: %v", err)
+	}
+
+	token.Release()
+	if err := database.cleanupRewriteCreatedSegments(created); err != nil {
+		t.Fatalf("cleanup after release: %v", err)
+	}
+	if _, err := os.Stat(path); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("rewrite segment remains after pin release: %v", err)
+	}
+}
 
 func TestCleanupRewriteCreatedManagerSegmentPostUnlinkCutRequiresRecovery(t *testing.T) {
 	dir := t.TempDir()

--- a/TreeDB/db/leaf_generation_pack_cleanup_test.go
+++ b/TreeDB/db/leaf_generation_pack_cleanup_test.go
@@ -67,7 +67,10 @@ func TestCleanupRewriteCreatedSegmentRespectsStableIdentityPin(t *testing.T) {
 }
 
 func TestCleanupRewriteCreatedManagerSegmentPostUnlinkCutRequiresRecovery(t *testing.T) {
-	dir := t.TempDir()
+	dir := filepath.Join(t.TempDir(), leafVLogDirName)
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		t.Fatalf("MkdirAll leaf_vlog: %v", err)
+	}
 	fileID, err := valuelog.EncodeFileID(42, 1)
 	if err != nil {
 		t.Fatalf("EncodeFileID: %v", err)
@@ -86,7 +89,7 @@ func TestCleanupRewriteCreatedManagerSegmentPostUnlinkCutRequiresRecovery(t *tes
 	wantErr := errors.New("injected post-unlink cut")
 	restore := durabilitycut.Install(func(event durabilitycut.Event) error {
 		if event.Namespace == durabilitycut.NamespaceUnlink &&
-			event.Resource == durabilitycut.ResourceValueLog &&
+			event.Resource == durabilitycut.ResourceOuterLeaf &&
 			filepath.Clean(event.OldPath) == filepath.Clean(path) {
 			return wantErr
 		}

--- a/TreeDB/db/leaf_generation_pack_rewrite.go
+++ b/TreeDB/db/leaf_generation_pack_rewrite.go
@@ -113,7 +113,11 @@ func (db *DB) cleanupRewriteCreatedSegments(createdSegments []rewriteCreatedSegm
 		if seg.fileID == 0 || seg.path == "" {
 			continue
 		}
-		if db != nil && db.valueLogManager != nil && db.valueLogManager.HasSegment(seg.fileID) {
+		if db != nil && db.valueLogManager != nil {
+			if err := db.valueLogManager.RegisterSegment(seg.path, seg.fileID); err != nil {
+				errs = append(errs, fmt.Errorf("register rewrite-created segment %d for removal: %w", seg.fileID, err))
+				continue
+			}
 			if err := db.valueLogManager.RemoveSegmentForce(seg.fileID); err != nil {
 				errs = append(errs, fmt.Errorf("remove rewrite-created segment %d: %w", seg.fileID, errors.Join(err, ErrRecoveryRequired)))
 			}

--- a/TreeDB/db/open_readonly.go
+++ b/TreeDB/db/open_readonly.go
@@ -8,6 +8,7 @@ import (
 	"github.com/snissn/gomap/TreeDB/freelist"
 	"github.com/snissn/gomap/TreeDB/internal/collectionwal"
 	"github.com/snissn/gomap/TreeDB/internal/lockfile"
+	"github.com/snissn/gomap/TreeDB/internal/rootpublication"
 	"github.com/snissn/gomap/TreeDB/internal/valuelog"
 	"github.com/snissn/gomap/TreeDB/page"
 	"github.com/snissn/gomap/TreeDB/pager"
@@ -51,7 +52,8 @@ func openReadOnly(opts Options) (*DB, error) {
 	p.SetVerifyOnRead(opts.VerifyOnRead)
 
 	layout := resolveStorageLayout(opts.Dir)
-	vm, err := valuelog.NewManager(layout.valueVLogDir)
+	valueLogIdentityPins := rootpublication.NewIdentityPinRegistry()
+	vm, err := valuelog.NewManagerWithStableResourcePinRegistry(layout.valueVLogDir, valueLogIdentityPins)
 	if err != nil {
 		_ = p.Close()
 		_ = lock.Close()
@@ -81,6 +83,7 @@ func openReadOnly(opts Options) (*DB, error) {
 		readOnly:                       true,
 		durability:                     opts.Durability,
 		valueLogManager:                vm,
+		valueLogIdentityPins:           valueLogIdentityPins,
 		lock:                           lock,
 		adaptive:                       adaptiveCtrl,
 		flushAdmission:                 FlushAdmissionDecisionForOptions(opts),
@@ -202,7 +205,8 @@ func openReadOnlyNoLock(opts Options) (*DB, error) {
 	p.SetVerifyOnRead(opts.VerifyOnRead)
 
 	layout := resolveStorageLayout(opts.Dir)
-	vm, err := valuelog.NewManager(layout.valueVLogDir)
+	valueLogIdentityPins := rootpublication.NewIdentityPinRegistry()
+	vm, err := valuelog.NewManagerWithStableResourcePinRegistry(layout.valueVLogDir, valueLogIdentityPins)
 	if err != nil {
 		_ = p.Close()
 		return nil, err
@@ -230,6 +234,7 @@ func openReadOnlyNoLock(opts Options) (*DB, error) {
 		readOnly:                       true,
 		durability:                     opts.Durability,
 		valueLogManager:                vm,
+		valueLogIdentityPins:           valueLogIdentityPins,
 		adaptive:                       adaptiveCtrl,
 		flushAdmission:                 FlushAdmissionDecisionForOptions(opts),
 		keepRecent:                     opts.KeepRecent,

--- a/TreeDB/db/open_readonly.go
+++ b/TreeDB/db/open_readonly.go
@@ -15,6 +15,13 @@ import (
 	"github.com/snissn/gomap/TreeDB/zipper"
 )
 
+func wrapReadOnlyValueLogRecoveryError(err error) error {
+	if errors.Is(err, rootpublication.ErrRecoveryRequired) {
+		return errors.Join(err, ErrRecoveryRequired)
+	}
+	return err
+}
+
 func openReadOnly(opts Options) (*DB, error) {
 	if err := applyReadOnlyDefaults(&opts); err != nil {
 		return nil, err
@@ -53,17 +60,17 @@ func openReadOnly(opts Options) (*DB, error) {
 
 	layout := resolveStorageLayout(opts.Dir)
 	valueLogIdentityPins := rootpublication.NewIdentityPinRegistry()
-	vm, err := valuelog.NewManagerWithStableResourcePinRegistry(layout.valueVLogDir, valueLogIdentityPins)
+	vm, err := valuelog.NewReadOnlyManagerWithStableResourcePinRegistry(layout.valueVLogDir, valueLogIdentityPins)
 	if err != nil {
 		_ = p.Close()
 		_ = lock.Close()
-		return nil, err
+		return nil, wrapReadOnlyValueLogRecoveryError(err)
 	}
 	if err := vm.AddScanDir(layout.leafVLogDir); err != nil {
 		_ = vm.Close()
 		_ = p.Close()
 		_ = lock.Close()
-		return nil, err
+		return nil, wrapReadOnlyValueLogRecoveryError(err)
 	}
 	vm.SetDisableReadChecksum(opts.ValueLog.ReadIntegrity == IntegritySkipChecksums)
 	vm.SetCurrentWritableMmapEnabled(opts.ValueLog.CurrentWritableMmap)
@@ -206,15 +213,15 @@ func openReadOnlyNoLock(opts Options) (*DB, error) {
 
 	layout := resolveStorageLayout(opts.Dir)
 	valueLogIdentityPins := rootpublication.NewIdentityPinRegistry()
-	vm, err := valuelog.NewManagerWithStableResourcePinRegistry(layout.valueVLogDir, valueLogIdentityPins)
+	vm, err := valuelog.NewReadOnlyManagerWithStableResourcePinRegistry(layout.valueVLogDir, valueLogIdentityPins)
 	if err != nil {
 		_ = p.Close()
-		return nil, err
+		return nil, wrapReadOnlyValueLogRecoveryError(err)
 	}
 	if err := vm.AddScanDir(layout.leafVLogDir); err != nil {
 		_ = vm.Close()
 		_ = p.Close()
-		return nil, err
+		return nil, wrapReadOnlyValueLogRecoveryError(err)
 	}
 	vm.SetDisableReadChecksum(opts.ValueLog.ReadIntegrity == IntegritySkipChecksums)
 	vm.SetCurrentWritableMmapEnabled(opts.ValueLog.CurrentWritableMmap)

--- a/TreeDB/db/readonly_open_test.go
+++ b/TreeDB/db/readonly_open_test.go
@@ -39,6 +39,42 @@ func TestReadOnlyRejectsWrites(t *testing.T) {
 	}
 }
 
+func TestReadOnlyOpenRejectsStableDeleteQuarantineWithoutMutation(t *testing.T) {
+	dir := t.TempDir()
+	w, err := Open(Options{Dir: dir})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := w.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	valueLogDir := resolveStorageLayout(dir).valueVLogDir
+	quarantineDir := filepath.Join(valueLogDir, ".value-l0-000001.log.delete-0000000000000001-00000000000000000000000000000001")
+	if err := os.MkdirAll(quarantineDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+
+	openers := []struct {
+		name string
+		open func(Options) (*DB, error)
+	}{
+		{name: "shared_lock", open: func(opts Options) (*DB, error) { return Open(opts) }},
+		{name: "no_lock", open: openReadOnlyNoLock},
+	}
+	for _, opener := range openers {
+		t.Run(opener.name, func(t *testing.T) {
+			got, err := opener.open(Options{Dir: dir, ReadOnly: true})
+			if got != nil || !errors.Is(err, ErrRecoveryRequired) {
+				t.Fatalf("read-only open with pending stable delete=(%v, %v), want (nil, ErrRecoveryRequired)", got, err)
+			}
+			if _, err := os.Stat(quarantineDir); err != nil {
+				t.Fatalf("read-only open changed quarantine: %v", err)
+			}
+		})
+	}
+}
+
 func TestReadOnlyOpenDoesNotAcquireCommandJournalOwner(t *testing.T) {
 	dir := t.TempDir()
 

--- a/TreeDB/db/stable_resource.go
+++ b/TreeDB/db/stable_resource.go
@@ -6,6 +6,15 @@ import (
 	"github.com/snissn/gomap/TreeDB/internal/rootpublication"
 )
 
+// ValueLogIdentityPinRegistry exposes the DB-scoped physical deletion gate to
+// wrappers that manage the same value-log namespace.
+func (db *DB) ValueLogIdentityPinRegistry() *rootpublication.IdentityPinRegistry {
+	if db == nil {
+		return nil
+	}
+	return db.valueLogIdentityPins
+}
+
 // NewStableDBResourceToken registers the exact already-open index handle.
 // Meta/root publication stays adjacent (#3679), while freelist/COW publication
 // stays adjacent (#3678); neither has an independent external identity here.

--- a/TreeDB/db/stable_resource_test.go
+++ b/TreeDB/db/stable_resource_test.go
@@ -27,3 +27,19 @@ func TestStableDBAdjacentPublicationIssueRouting(t *testing.T) {
 		})
 	}
 }
+
+func TestOpenSharesValueLogIdentityPinRegistryWithManager(t *testing.T) {
+	database, err := Open(Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer database.Close()
+
+	registry := database.ValueLogIdentityPinRegistry()
+	if registry == nil {
+		t.Fatal("opened DB has no value-log identity pin registry")
+	}
+	if got := database.valueLogManager.StableResourcePinRegistry(); got != registry {
+		t.Fatalf("value-log manager registry = %p, DB registry = %p", got, registry)
+	}
+}

--- a/TreeDB/db/vlog_gc_test.go
+++ b/TreeDB/db/vlog_gc_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/snissn/gomap/TreeDB/internal/rootpublication"
 	"github.com/snissn/gomap/TreeDB/internal/valuelog"
 	"github.com/snissn/gomap/TreeDB/page"
 )
@@ -309,6 +310,84 @@ func TestValueLogGC_RemovesUnreferencedSegment(t *testing.T) {
 	}
 	if _, err := os.Stat(path2); err != nil {
 		t.Fatalf("expected segment2 to remain, err=%v", err)
+	}
+}
+
+func TestValueLogGC_StableIdentityPinDefersUnreferencedSegmentDelete(t *testing.T) {
+	dir := t.TempDir()
+	database, err := Open(Options{Dir: dir, DisableBackgroundPrune: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer database.Close()
+	fileID, err := valuelog.EncodeFileID(0, 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(ValueLogDirPath(dir), "value-l0-000001.log")
+	writer, err := valuelog.NewWriter(path, fileID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := writer.Append(0, nil, 1, []byte("unreferenced stable value")); err != nil {
+		t.Fatal(err)
+	}
+	if err := writer.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := database.valueLogManager.RegisterSegment(path, fileID); err != nil {
+		t.Fatal(err)
+	}
+	activeID, err := valuelog.EncodeFileID(0, 2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	activePath := filepath.Join(ValueLogDirPath(dir), "value-l0-000002.log")
+	activeWriter, err := valuelog.NewWriter(activePath, activeID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := activeWriter.Append(0, nil, 2, []byte("active value")); err != nil {
+		t.Fatal(err)
+	}
+	if err := activeWriter.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := database.valueLogManager.RegisterSegment(activePath, activeID); err != nil {
+		t.Fatal(err)
+	}
+	token, err := database.valueLogManager.StableResourceToken(fileID, valuelog.StableResourceRegistration{
+		Kind: rootpublication.ResourceValueLog, LogicalLane: "0", Generation: 1,
+		DiagnosticPath: "value_vlog/" + filepath.Base(path), Digest: [32]byte{1},
+		Reachability: rootpublication.ReachabilityValueLogPointer,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	stats, err := database.ValueLogGC(context.Background(), ValueLogGCOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if stats.SegmentsEligible == 0 {
+		t.Fatalf("target segment was not eligible: %+v", stats)
+	}
+	if _, err := os.Stat(path); err != nil {
+		t.Fatalf("GC removed stable-pinned segment: %v", err)
+	}
+	token.Release()
+	deadline := time.Now().Add(5 * time.Second)
+	for {
+		_, err := os.Stat(path)
+		if os.IsNotExist(err) {
+			break
+		}
+		if err != nil {
+			t.Fatal(err)
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("GC zombie was not removed after stable token release")
+		}
+		time.Sleep(10 * time.Millisecond)
 	}
 }
 

--- a/TreeDB/internal/rootpublication/pin_registry.go
+++ b/TreeDB/internal/rootpublication/pin_registry.go
@@ -93,9 +93,15 @@ func (registry *IdentityPinRegistry) Pin(identity StableIdentity) (*IdentityPin,
 	}
 	registry.mu.Lock()
 	defer registry.mu.Unlock()
-	state := registry.stateLocked(identity)
+	state := registry.states[identity]
+	if state == nil {
+		return nil, ErrResourceConflict
+	}
 	if state.deleting {
 		return nil, ErrResourceDeletionInProgress
+	}
+	if state.observers == 0 {
+		return nil, ErrResourceConflict
 	}
 	if state.retired {
 		return nil, ErrResourceConflict

--- a/TreeDB/internal/rootpublication/pin_registry.go
+++ b/TreeDB/internal/rootpublication/pin_registry.go
@@ -1,0 +1,319 @@
+package rootpublication
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"sync"
+)
+
+var (
+	ErrUnbalancedResourcePin      = errors.New("stable resource release without a matching pin")
+	ErrResourceDeletionInProgress = errors.New("stable resource deletion in progress")
+)
+
+// IdentityPinRegistry is a DB-scoped gate shared by every producer and
+// deleter that can reach the same physical files. Logical generations are not
+// part of this key: deleting an inode must be blocked by every alias of it.
+type IdentityPinRegistry struct {
+	mu         sync.Mutex
+	states     map[StableIdentity]*identityPinState
+	namespaces map[string]bool
+	activePins uint64
+}
+
+type identityPinState struct {
+	pins      uint64
+	observers uint64
+	deleting  bool
+	retired   bool
+	zero      chan struct{}
+}
+
+// IdentityDeleteLease excludes later pins until deletion commits or aborts.
+type IdentityDeleteLease struct {
+	registry  *IdentityPinRegistry
+	identity  StableIdentity
+	namespace string
+	once      sync.Once
+}
+
+// IdentityPin owns one registry reference and is safe to release repeatedly.
+type IdentityPin struct {
+	registry *IdentityPinRegistry
+	identity StableIdentity
+	once     sync.Once
+}
+
+func NewIdentityPinRegistry() *IdentityPinRegistry {
+	return &IdentityPinRegistry{
+		states:     make(map[StableIdentity]*identityPinState),
+		namespaces: make(map[string]bool),
+	}
+}
+
+func physicalStableIdentity(identity StableIdentity) StableIdentity {
+	identity.Generation = 0
+	return identity
+}
+
+// StableIdentityFromFile captures the physical identity of an already-open
+// handle. Callers must not substitute a pathname lookup: the pathname can be
+// rebound between discovery and deletion.
+func StableIdentityFromFile(file *os.File) (StableIdentity, error) {
+	if file == nil {
+		return StableIdentity{}, fmt.Errorf("%w: nil stable resource handle", ErrUnresolvedResource)
+	}
+	return stableIdentityFromFile(file)
+}
+
+// SamePhysicalIdentity reports whether two identities name the same physical
+// object, deliberately ignoring their logical generations.
+func SamePhysicalIdentity(left, right StableIdentity) bool {
+	left, leftErr := validateRegistryIdentity(left)
+	right, rightErr := validateRegistryIdentity(right)
+	return leftErr == nil && rightErr == nil && left == right
+}
+
+func validateRegistryIdentity(identity StableIdentity) (StableIdentity, error) {
+	identity = physicalStableIdentity(identity)
+	if !identity.valid() {
+		return StableIdentity{}, fmt.Errorf("%w: invalid physical identity", ErrUnresolvedResource)
+	}
+	return identity, nil
+}
+
+func (registry *IdentityPinRegistry) Pin(identity StableIdentity) (*IdentityPin, error) {
+	identity, err := validateRegistryIdentity(identity)
+	if err != nil {
+		return nil, err
+	}
+	if registry == nil {
+		return nil, fmt.Errorf("%w: nil identity pin registry", ErrUnresolvedResource)
+	}
+	registry.mu.Lock()
+	defer registry.mu.Unlock()
+	state := registry.stateLocked(identity)
+	if state.deleting {
+		return nil, ErrResourceDeletionInProgress
+	}
+	if state.retired {
+		return nil, ErrResourceConflict
+	}
+	state.pins++
+	registry.activePins++
+	return &IdentityPin{registry: registry, identity: identity}, nil
+}
+
+func (registry *IdentityPinRegistry) release(identity StableIdentity) error {
+	identity, err := validateRegistryIdentity(identity)
+	if err != nil {
+		return err
+	}
+	if registry == nil {
+		return fmt.Errorf("%w: nil identity pin registry", ErrUnresolvedResource)
+	}
+	registry.mu.Lock()
+	defer registry.mu.Unlock()
+	state := registry.states[identity]
+	if state == nil || state.pins == 0 {
+		return ErrUnbalancedResourcePin
+	}
+	state.pins--
+	registry.activePins--
+	if state.pins == 0 {
+		if state.zero != nil {
+			close(state.zero)
+			state.zero = nil
+		}
+		registry.deleteIdleStateLocked(identity, state)
+	}
+	return nil
+}
+
+func (pin *IdentityPin) Release() {
+	if pin == nil || pin.registry == nil {
+		return
+	}
+	pin.once.Do(func() { _ = pin.registry.release(pin.identity) })
+}
+
+func (registry *IdentityPinRegistry) Observe(identity StableIdentity) error {
+	identity, err := validateRegistryIdentity(identity)
+	if err != nil {
+		return err
+	}
+	if registry == nil {
+		return fmt.Errorf("%w: nil identity pin registry", ErrUnresolvedResource)
+	}
+	registry.mu.Lock()
+	defer registry.mu.Unlock()
+	state := registry.stateLocked(identity)
+	if state.retired || state.deleting {
+		return ErrResourceConflict
+	}
+	state.observers++
+	return nil
+}
+
+func (registry *IdentityPinRegistry) Unobserve(identity StableIdentity) error {
+	identity, err := validateRegistryIdentity(identity)
+	if err != nil {
+		return err
+	}
+	if registry == nil {
+		return fmt.Errorf("%w: nil identity pin registry", ErrUnresolvedResource)
+	}
+	registry.mu.Lock()
+	defer registry.mu.Unlock()
+	state := registry.states[identity]
+	if state == nil || state.observers == 0 {
+		return ErrUnbalancedResourcePin
+	}
+	state.observers--
+	registry.deleteIdleStateLocked(identity, state)
+	return nil
+}
+
+func (registry *IdentityPinRegistry) BeginDelete(identity StableIdentity) (*IdentityDeleteLease, error) {
+	return registry.beginDelete(identity, "")
+}
+
+func (registry *IdentityPinRegistry) BeginDeleteAt(identity StableIdentity, namespace string) (*IdentityDeleteLease, error) {
+	if namespace == "" {
+		return nil, fmt.Errorf("%w: empty delete namespace", ErrUnresolvedResource)
+	}
+	return registry.beginDelete(identity, namespace)
+}
+
+func (registry *IdentityPinRegistry) beginDelete(identity StableIdentity, namespace string) (*IdentityDeleteLease, error) {
+	identity, err := validateRegistryIdentity(identity)
+	if err != nil {
+		return nil, err
+	}
+	if registry == nil {
+		return nil, fmt.Errorf("%w: nil identity pin registry", ErrUnresolvedResource)
+	}
+	registry.mu.Lock()
+	defer registry.mu.Unlock()
+	state := registry.stateLocked(identity)
+	if state.pins != 0 || state.deleting || (namespace != "" && registry.namespaces[namespace]) {
+		return nil, ErrResourcePinned
+	}
+	if state.retired {
+		return nil, ErrResourceConflict
+	}
+	state.deleting = true
+	if namespace != "" {
+		registry.namespaces[namespace] = true
+	}
+	return &IdentityDeleteLease{registry: registry, identity: identity, namespace: namespace}, nil
+}
+
+func (registry *IdentityPinRegistry) WaitUnpinned(identity StableIdentity) <-chan struct{} {
+	ready := make(chan struct{})
+	identity, err := validateRegistryIdentity(identity)
+	if registry == nil || err != nil {
+		close(ready)
+		return ready
+	}
+	registry.mu.Lock()
+	state := registry.states[identity]
+	if state == nil || state.pins == 0 {
+		registry.mu.Unlock()
+		close(ready)
+		return ready
+	}
+	if state.zero == nil {
+		state.zero = make(chan struct{})
+	}
+	zero := state.zero
+	registry.mu.Unlock()
+	return zero
+}
+
+func (registry *IdentityPinRegistry) PinCount(identity StableIdentity) uint64 {
+	identity, err := validateRegistryIdentity(identity)
+	if registry == nil || err != nil {
+		return 0
+	}
+	registry.mu.Lock()
+	defer registry.mu.Unlock()
+	if state := registry.states[identity]; state != nil {
+		return state.pins
+	}
+	return 0
+}
+
+func (registry *IdentityPinRegistry) ActivePins() uint64 {
+	if registry == nil {
+		return 0
+	}
+	registry.mu.Lock()
+	defer registry.mu.Unlock()
+	return registry.activePins
+}
+
+// ActiveIdentities reports live registry state for leak/stress gates.
+func (registry *IdentityPinRegistry) ActiveIdentities() int {
+	if registry == nil {
+		return 0
+	}
+	registry.mu.Lock()
+	defer registry.mu.Unlock()
+	return len(registry.states)
+}
+
+func (registry *IdentityPinRegistry) stateLocked(identity StableIdentity) *identityPinState {
+	if registry.states == nil {
+		registry.states = make(map[StableIdentity]*identityPinState)
+	}
+	state := registry.states[identity]
+	if state == nil {
+		state = &identityPinState{}
+		registry.states[identity] = state
+	}
+	return state
+}
+
+func (registry *IdentityPinRegistry) deleteIdleStateLocked(identity StableIdentity, state *identityPinState) {
+	if state != nil && state.pins == 0 && state.observers == 0 && !state.deleting {
+		delete(registry.states, identity)
+	}
+}
+
+func (lease *IdentityDeleteLease) Abort() {
+	if lease == nil || lease.registry == nil {
+		return
+	}
+	lease.once.Do(func() {
+		registry := lease.registry
+		registry.mu.Lock()
+		state := registry.states[lease.identity]
+		if state != nil {
+			state.deleting = false
+			registry.deleteIdleStateLocked(lease.identity, state)
+		}
+		delete(registry.namespaces, lease.namespace)
+		registry.mu.Unlock()
+	})
+}
+
+func (lease *IdentityDeleteLease) CommitDeleted() {
+	if lease == nil || lease.registry == nil {
+		return
+	}
+	lease.once.Do(func() {
+		registry := lease.registry
+		registry.mu.Lock()
+		state := registry.stateLocked(lease.identity)
+		state.deleting = false
+		state.retired = true
+		registry.deleteIdleStateLocked(lease.identity, state)
+		delete(registry.namespaces, lease.namespace)
+		registry.mu.Unlock()
+	})
+}
+
+// Commit is the deletion-owner spelling used after a successful unlink.
+func (lease *IdentityDeleteLease) Commit() { lease.CommitDeleted() }

--- a/TreeDB/internal/rootpublication/pin_registry_test.go
+++ b/TreeDB/internal/rootpublication/pin_registry_test.go
@@ -57,6 +57,10 @@ func TestIdentityPinRegistryCoalescesLogicalGenerations(t *testing.T) {
 	registry := NewIdentityPinRegistry()
 	first := testStableIdentity(1)
 	second := testStableIdentity(2)
+	if err := registry.Observe(first); err != nil {
+		t.Fatalf("Observe: %v", err)
+	}
+	defer registry.Unobserve(first)
 	pin, err := registry.Pin(first)
 	if err != nil {
 		t.Fatalf("Pin generation 1: %v", err)
@@ -68,6 +72,35 @@ func TestIdentityPinRegistryCoalescesLogicalGenerations(t *testing.T) {
 		t.Fatalf("BeginDelete generation 2 = %v, want physical ErrResourcePinned", err)
 	}
 	pin.Release()
+}
+
+func TestIdentityPinRegistryRejectsUnobservedPin(t *testing.T) {
+	registry := NewIdentityPinRegistry()
+	if _, err := registry.Pin(testStableIdentity(1)); !errors.Is(err, ErrResourceConflict) {
+		t.Fatalf("Pin without producer observation = %v, want ErrResourceConflict", err)
+	}
+}
+
+func TestIdentityPinRegistryRejectsLatePinAfterFinalObserverRetires(t *testing.T) {
+	registry := NewIdentityPinRegistry()
+	identity := testStableIdentity(1)
+	if err := registry.Observe(identity); err != nil {
+		t.Fatal(err)
+	}
+	lease, err := registry.BeginDelete(identity)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := registry.Unobserve(identity); err != nil {
+		t.Fatal(err)
+	}
+	lease.Commit()
+	if _, err := registry.Pin(identity); !errors.Is(err, ErrResourceConflict) {
+		t.Fatalf("Pin after final observer retired = %v, want ErrResourceConflict", err)
+	}
+	if got := registry.ActiveIdentities(); got != 0 {
+		t.Fatalf("active identities after retirement = %d, want 0", got)
+	}
 }
 
 func TestIdentityPinRegistrySerializesDeleteNamespace(t *testing.T) {
@@ -157,6 +190,14 @@ func TestStableResourceTokenPinsIdentityRegistryUntilExactRelease(t *testing.T) 
 	}
 
 	registry := NewIdentityPinRegistry()
+	identity, err := StableIdentityFromFile(file)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := registry.Observe(identity); err != nil {
+		t.Fatal(err)
+	}
+	defer registry.Unobserve(identity)
 	var userReleases atomic.Uint64
 	token, err := NewStableResourceToken(StableResourceSpec{
 		Kind: ResourceValueLog, LogicalLane: "main", ResourceID: "1", Generation: 1,

--- a/TreeDB/internal/rootpublication/pin_registry_test.go
+++ b/TreeDB/internal/rootpublication/pin_registry_test.go
@@ -211,3 +211,34 @@ func BenchmarkIdentityPinRegistryPinRelease(b *testing.B) {
 		pin.Release()
 	}
 }
+
+func BenchmarkStableResourceTokenConstructionWithIdentityPinRegistry(b *testing.B) {
+	dir := b.TempDir()
+	file := writeStableResourceFixture(b, dir, "bench-pinned.vlog", "benchmark-resource")
+	identity, err := StableIdentityFromFile(file)
+	if err != nil {
+		b.Fatal(err)
+	}
+	registry := NewIdentityPinRegistry()
+	if err := registry.Observe(identity); err != nil {
+		b.Fatal(err)
+	}
+	b.Cleanup(func() {
+		if err := registry.Unobserve(identity); err != nil {
+			b.Error(err)
+		}
+	})
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		token, err := NewStableResourceToken(StableResourceSpec{
+			Kind: ResourceValueLog, LogicalLane: "main", ResourceID: "bench", Generation: uint64(i + 1),
+			DiagnosticPath: "bench-pinned.vlog", File: file, Frontier: DurableFrontier{Bytes: 4},
+			Reachability: ReachabilityValueLogPointer, PinRegistry: registry,
+		})
+		if err != nil {
+			b.Fatal(err)
+		}
+		token.Release()
+	}
+}

--- a/TreeDB/internal/rootpublication/pin_registry_test.go
+++ b/TreeDB/internal/rootpublication/pin_registry_test.go
@@ -1,0 +1,213 @@
+package rootpublication
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"sync/atomic"
+	"testing"
+)
+
+func testStableIdentity(generation uint64) StableIdentity {
+	return StableIdentity{
+		Platform:   "test",
+		VolumeID:   7,
+		ObjectID:   [16]byte{1, 2, 3, 4},
+		Generation: generation,
+	}
+}
+
+func TestIdentityPinRegistrySerializesPinAndDelete(t *testing.T) {
+	registry := NewIdentityPinRegistry()
+	identity := testStableIdentity(11)
+	if err := registry.Observe(identity); err != nil {
+		t.Fatalf("Observe: %v", err)
+	}
+	pin, err := registry.Pin(identity)
+	if err != nil {
+		t.Fatalf("Pin: %v", err)
+	}
+	zero := registry.WaitUnpinned(identity)
+	if _, err := registry.BeginDelete(identity); !errors.Is(err, ErrResourcePinned) {
+		t.Fatalf("BeginDelete while pinned = %v, want ErrResourcePinned", err)
+	}
+	select {
+	case <-zero:
+		t.Fatal("WaitUnpinned closed before Release")
+	default:
+	}
+	pin.Release()
+	<-zero
+	lease, err := registry.BeginDelete(identity)
+	if err != nil {
+		t.Fatalf("BeginDelete after release: %v", err)
+	}
+	if _, err := registry.Pin(identity); !errors.Is(err, ErrResourceDeletionInProgress) {
+		t.Fatalf("Pin during deletion = %v, want ErrResourceDeletionInProgress", err)
+	}
+	lease.Abort()
+	pin, err = registry.Pin(identity)
+	if err != nil {
+		t.Fatalf("Pin after abort: %v", err)
+	}
+	pin.Release()
+}
+
+func TestIdentityPinRegistryCoalescesLogicalGenerations(t *testing.T) {
+	registry := NewIdentityPinRegistry()
+	first := testStableIdentity(1)
+	second := testStableIdentity(2)
+	pin, err := registry.Pin(first)
+	if err != nil {
+		t.Fatalf("Pin generation 1: %v", err)
+	}
+	if got := registry.PinCount(second); got != 1 {
+		t.Fatalf("PinCount generation 2 = %d, want physical count 1", got)
+	}
+	if _, err := registry.BeginDelete(second); !errors.Is(err, ErrResourcePinned) {
+		t.Fatalf("BeginDelete generation 2 = %v, want physical ErrResourcePinned", err)
+	}
+	pin.Release()
+}
+
+func TestIdentityPinRegistrySerializesDeleteNamespace(t *testing.T) {
+	registry := NewIdentityPinRegistry()
+	first := testStableIdentity(1)
+	second := testStableIdentity(2)
+	second.ObjectID[0] = 9
+	lease, err := registry.BeginDeleteAt(first, "value_vlog/value-l1-000001.log")
+	if err != nil {
+		t.Fatalf("BeginDeleteAt first: %v", err)
+	}
+	if _, err := registry.BeginDeleteAt(second, "value_vlog/value-l1-000001.log"); !errors.Is(err, ErrResourcePinned) {
+		t.Fatalf("BeginDeleteAt same namespace = %v, want ErrResourcePinned", err)
+	}
+	lease.Abort()
+	secondLease, err := registry.BeginDeleteAt(second, "value_vlog/value-l1-000001.log")
+	if err != nil {
+		t.Fatalf("BeginDeleteAt after abort: %v", err)
+	}
+	secondLease.Abort()
+}
+
+func TestIdentityPinRegistryRejectsUnbalancedRelease(t *testing.T) {
+	registry := NewIdentityPinRegistry()
+	if err := registry.release(testStableIdentity(1)); !errors.Is(err, ErrUnbalancedResourcePin) {
+		t.Fatalf("Release without pin = %v, want ErrUnbalancedResourcePin", err)
+	}
+}
+
+func TestIdentityPinRegistryRejectsLatePinAfterCommittedDelete(t *testing.T) {
+	registry := NewIdentityPinRegistry()
+	identity := testStableIdentity(1)
+	if err := registry.Observe(identity); err != nil {
+		t.Fatal(err)
+	}
+	lease, err := registry.BeginDelete(identity)
+	if err != nil {
+		t.Fatal(err)
+	}
+	lease.Commit()
+	if _, err := registry.Pin(testStableIdentity(2)); !errors.Is(err, ErrResourceConflict) {
+		t.Fatalf("Pin after committed delete = %v, want ErrResourceConflict", err)
+	}
+	if err := registry.Unobserve(identity); err != nil {
+		t.Fatal(err)
+	}
+	if got := registry.ActiveIdentities(); got != 0 {
+		t.Fatalf("active identities after final observer = %d, want 0", got)
+	}
+}
+
+func TestIdentityPinRegistryDeletionStressDoesNotRetainState(t *testing.T) {
+	registry := NewIdentityPinRegistry()
+	for i := 0; i < 10_000; i++ {
+		identity := testStableIdentity(1)
+		identity.ObjectID[4] = byte(i)
+		identity.ObjectID[5] = byte(i >> 8)
+		if err := registry.Observe(identity); err != nil {
+			t.Fatalf("Observe %d: %v", i, err)
+		}
+		lease, err := registry.BeginDelete(identity)
+		if err != nil {
+			t.Fatalf("BeginDelete %d: %v", i, err)
+		}
+		lease.Commit()
+		if err := registry.Unobserve(identity); err != nil {
+			t.Fatalf("Unobserve %d: %v", i, err)
+		}
+	}
+	if got := registry.ActivePins(); got != 0 {
+		t.Fatalf("active pins after stress = %d, want 0", got)
+	}
+	if got := registry.ActiveIdentities(); got != 0 {
+		t.Fatalf("active identities after stress = %d, want 0", got)
+	}
+}
+
+func TestStableResourceTokenPinsIdentityRegistryUntilExactRelease(t *testing.T) {
+	dir := t.TempDir()
+	file, err := os.OpenFile(filepath.Join(dir, "resource.vlog"), os.O_CREATE|os.O_RDWR, 0o600)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer file.Close()
+	if _, err := file.Write([]byte("stable-resource")); err != nil {
+		t.Fatal(err)
+	}
+
+	registry := NewIdentityPinRegistry()
+	var userReleases atomic.Uint64
+	token, err := NewStableResourceToken(StableResourceSpec{
+		Kind: ResourceValueLog, LogicalLane: "main", ResourceID: "1", Generation: 1,
+		DiagnosticPath: "value_vlog/resource.vlog", File: file,
+		Frontier: DurableFrontier{Bytes: uint64(len("stable-resource"))},
+		Digest:   [32]byte{1}, Reachability: ReachabilityValueLogPointer,
+		PinRegistry: registry, OnRelease: func() { userReleases.Add(1) },
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := registry.PinCount(token.Identity()); got != 1 {
+		t.Fatalf("pin count=%d want 1", got)
+	}
+	if _, err := registry.BeginDelete(token.Identity()); !errors.Is(err, ErrResourcePinned) {
+		t.Fatalf("delete while token live error=%v want %v", err, ErrResourcePinned)
+	}
+
+	token.Release()
+	token.Release()
+	if got := registry.PinCount(token.Identity()); got != 0 {
+		t.Fatalf("pin count after release=%d want 0", got)
+	}
+	if got := userReleases.Load(); got != 1 {
+		t.Fatalf("user release callbacks=%d want 1", got)
+	}
+	lease, err := registry.BeginDelete(token.Identity())
+	if err != nil {
+		t.Fatalf("begin delete after token release: %v", err)
+	}
+	lease.Abort()
+}
+
+func BenchmarkIdentityPinRegistryPinRelease(b *testing.B) {
+	registry := NewIdentityPinRegistry()
+	identity := testStableIdentity(1)
+	if err := registry.Observe(identity); err != nil {
+		b.Fatal(err)
+	}
+	b.Cleanup(func() {
+		if err := registry.Unobserve(identity); err != nil {
+			b.Error(err)
+		}
+	})
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		pin, err := registry.Pin(identity)
+		if err != nil {
+			b.Fatal(err)
+		}
+		pin.Release()
+	}
+}

--- a/TreeDB/internal/rootpublication/resource_token.go
+++ b/TreeDB/internal/rootpublication/resource_token.go
@@ -313,6 +313,9 @@ type StableResourceSpec struct {
 	// must still execute SyncThrough on the pinned identity.
 	ContentSynced bool
 	OnRelease     func()
+	// PinRegistry is the DB-scoped physical deletion gate. When set, token
+	// construction acquires a pin for the exact handle identity before return.
+	PinRegistry *IdentityPinRegistry
 
 	// StableIdentityOverride exists for deterministic platform-adapter and
 	// conflict tests. Production producers leave it zero and use handle identity.
@@ -346,6 +349,7 @@ type StableResourceToken struct {
 	syncedFrontier     DurableFrontier
 	hasSyncedFrontier  bool
 	onRelease          func()
+	identityPin        *IdentityPin
 	owner              atomic.Uint32
 	released           atomic.Bool
 	metrics            resourceTokenMetrics
@@ -397,6 +401,18 @@ func NewStableResourceToken(spec StableResourceSpec) (*StableResourceToken, erro
 		return nil, fmt.Errorf("%w: identity generation %d differs from resource generation %d", ErrResourceConflict, identity.Generation, spec.Generation)
 	}
 	identity.Generation = spec.Generation
+	var identityPin *IdentityPin
+	if spec.PinRegistry != nil {
+		identityPin, err = spec.PinRegistry.Pin(identity)
+		if err != nil {
+			return nil, fmt.Errorf("pin stable resource identity: %w", err)
+		}
+		defer func() {
+			if closeOnError {
+				identityPin.Release()
+			}
+		}()
+	}
 	if err := spec.Namespace.validateLinkedResource(identity); err != nil {
 		return nil, err
 	}
@@ -417,7 +433,7 @@ func NewStableResourceToken(spec StableResourceSpec) (*StableResourceToken, erro
 		identity: identity, frontier: cloneDurableFrontier(spec.Frontier), digest: spec.Digest,
 		reachability: spec.Reachability, logicalObligations: logicalObligations,
 		stability: stability, namespace: spec.Namespace, pinned: pinned,
-		flush: flush, sync: syncThrough, onRelease: spec.OnRelease,
+		flush: flush, sync: syncThrough, onRelease: spec.OnRelease, identityPin: identityPin,
 	}
 	if spec.ContentSynced {
 		token.syncedFrontier = cloneDurableFrontier(spec.Frontier)
@@ -558,6 +574,7 @@ func (token *StableResourceToken) releasePinned() {
 	if token.namespace != nil {
 		token.namespace.release()
 	}
+	token.identityPin.Release()
 	if token.onRelease != nil {
 		token.onRelease()
 	}

--- a/TreeDB/internal/valuelog/errors.go
+++ b/TreeDB/internal/valuelog/errors.go
@@ -11,6 +11,10 @@ var ErrFileNotFound = errors.New("valuelog: file not found")
 // snapshot and cannot be removed yet.
 var ErrFilePinned = errors.New("valuelog: file pinned")
 
+// ErrStableDeleteRecoveryRequired reports an interrupted identity-gated
+// segment deletion that must be reconciled by a read-write manager.
+var ErrStableDeleteRecoveryRequired = errors.New("valuelog: stable delete recovery required")
+
 type fileNotFoundError struct {
 	id         uint32
 	inSnapshot bool

--- a/TreeDB/internal/valuelog/identity_pin_manager_test.go
+++ b/TreeDB/internal/valuelog/identity_pin_manager_test.go
@@ -530,8 +530,12 @@ func TestManagerStableIdentityPinBlocksSecondManagerDelete(t *testing.T) {
 func TestManagerStableDeleteEmitsCanonicalUnlinkCutBeforeQuarantineUnlink(t *testing.T) {
 	dir := t.TempDir()
 	fileID, path := writeIdentityPinTestSegment(t, dir)
-	identity := identityPinTestIdentity(t, path)
 	registry := rootpublication.NewIdentityPinRegistry()
+	producer, err := NewManagerWithStableResourcePinRegistry(dir, registry)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer producer.Close()
 	deleter, err := NewManagerWithStableResourcePinRegistry(dir, registry)
 	if err != nil {
 		t.Fatal(err)
@@ -567,7 +571,11 @@ func TestManagerStableDeleteEmitsCanonicalUnlinkCutBeforeQuarantineUnlink(t *tes
 		t.Fatalf("post-unlink cut path stat=%v, want removed", statErr)
 	}
 
-	token, pinErr := registry.Pin(identity)
+	token, pinErr := producer.StableResourceToken(fileID, StableResourceRegistration{
+		Kind: rootpublication.ResourceValueLog, LogicalLane: "main", Generation: 2,
+		DiagnosticPath: "value_vlog/" + filepath.Base(path),
+		Digest:         [32]byte{2}, Reachability: rootpublication.ReachabilityValueLogPointer,
+	})
 	if token != nil {
 		token.Release()
 	}

--- a/TreeDB/internal/valuelog/identity_pin_manager_test.go
+++ b/TreeDB/internal/valuelog/identity_pin_manager_test.go
@@ -75,6 +75,72 @@ func TestManagerStartupCompletesMatchingStableDeleteQuarantine(t *testing.T) {
 	}
 }
 
+func TestReadOnlyManagerRejectsStableDeleteQuarantineWithoutMutation(t *testing.T) {
+	dir := t.TempDir()
+	_, path := writeIdentityPinTestSegment(t, dir)
+	identity := identityPinTestIdentity(t, path)
+	quarantineDir, quarantinePath, err := stableDeleteQuarantinePaths(path, identity)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Mkdir(quarantineDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Rename(path, quarantinePath); err != nil {
+		t.Fatal(err)
+	}
+
+	manager, err := NewReadOnlyManagerWithStableResourcePinRegistry(dir, rootpublication.NewIdentityPinRegistry())
+	if manager != nil || !errors.Is(err, ErrStableDeleteRecoveryRequired) || !errors.Is(err, rootpublication.ErrRecoveryRequired) {
+		t.Fatalf("NewReadOnlyManager=(%v, %v), want specific and shared recovery errors", manager, err)
+	}
+	if _, err := os.Stat(path); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("read-only open restored canonical path: %v", err)
+	}
+	if _, err := os.Stat(quarantinePath); err != nil {
+		t.Fatalf("read-only open changed quarantine inode: %v", err)
+	}
+	if _, err := os.Stat(quarantineDir); err != nil {
+		t.Fatalf("read-only open changed quarantine directory: %v", err)
+	}
+}
+
+func TestReadOnlyManagerRefreshRejectsNewStableDeleteQuarantineWithoutMutation(t *testing.T) {
+	dir := t.TempDir()
+	manager, err := NewReadOnlyManagerWithStableResourcePinRegistry(dir, rootpublication.NewIdentityPinRegistry())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer manager.Close()
+
+	_, path := writeIdentityPinTestSegment(t, dir)
+	identity := identityPinTestIdentity(t, path)
+	quarantineDir, quarantinePath, err := stableDeleteQuarantinePaths(path, identity)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Mkdir(quarantineDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Rename(path, quarantinePath); err != nil {
+		t.Fatal(err)
+	}
+
+	err = manager.Refresh()
+	if !errors.Is(err, ErrStableDeleteRecoveryRequired) || !errors.Is(err, rootpublication.ErrRecoveryRequired) {
+		t.Fatalf("Refresh() error = %v, want specific and shared recovery errors", err)
+	}
+	if _, err := os.Stat(path); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("read-only refresh restored canonical path: %v", err)
+	}
+	if _, err := os.Stat(quarantinePath); err != nil {
+		t.Fatalf("read-only refresh changed quarantine inode: %v", err)
+	}
+	if _, err := os.Stat(quarantineDir); err != nil {
+		t.Fatalf("read-only refresh changed quarantine directory: %v", err)
+	}
+}
+
 func TestManagerStartupRestoresUnexpectedStableDeleteQuarantineIdentity(t *testing.T) {
 	dir := t.TempDir()
 	fileID, path := writeIdentityPinTestSegment(t, dir)

--- a/TreeDB/internal/valuelog/identity_pin_manager_test.go
+++ b/TreeDB/internal/valuelog/identity_pin_manager_test.go
@@ -1,0 +1,299 @@
+package valuelog
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+	"time"
+
+	"github.com/snissn/gomap/TreeDB/internal/rootpublication"
+)
+
+func writeIdentityPinTestSegment(t *testing.T, dir string) (uint32, string) {
+	t.Helper()
+	fileID, err := EncodeFileID(1, 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	path := SegmentPath(dir, fileID)
+	writer, err := NewWriter(path, fileID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := writer.Append(0, nil, 1, []byte("stable value")); err != nil {
+		t.Fatal(err)
+	}
+	if err := writer.Close(); err != nil {
+		t.Fatal(err)
+	}
+	return fileID, path
+}
+
+func TestManagerZombieDeleteWaitsForStableIdentityPin(t *testing.T) {
+	dir := t.TempDir()
+	fileID, path := writeIdentityPinTestSegment(t, dir)
+	manager, err := NewManagerWithStableResourcePinRegistry(dir, rootpublication.NewIdentityPinRegistry())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer manager.Close()
+	token := stableManagerToken(t, manager, fileID)
+	set := manager.CurrentSetNoRefresh()
+	if err := manager.MarkZombie(fileID); err != nil {
+		t.Fatal(err)
+	}
+	if err := manager.Release(set); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(path); err != nil {
+		t.Fatalf("zombie removed while stable-pinned: %v", err)
+	}
+	token.Release()
+	deadline := time.Now().Add(5 * time.Second)
+	for {
+		_, err := os.Stat(path)
+		if errors.Is(err, os.ErrNotExist) {
+			break
+		}
+		if err != nil {
+			t.Fatal(err)
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("zombie was not removed after stable pin release")
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}
+
+func TestManagerRetryZombieDeleteClosesOwnHandleBeforeUnlink(t *testing.T) {
+	dir := t.TempDir()
+	fileID, path := writeIdentityPinTestSegment(t, dir)
+	manager, err := NewManagerWithStableResourcePinRegistry(dir, rootpublication.NewIdentityPinRegistry())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer manager.Close()
+	if err := manager.MarkZombie(fileID); err != nil {
+		t.Fatal(err)
+	}
+	manager.mu.RLock()
+	file := manager.files[fileID]
+	manager.mu.RUnlock()
+	if file == nil {
+		t.Fatal("manager lost zombie before retry")
+	}
+
+	originalRemove := removeSegmentPath
+	removeSegmentPath = func(removePath string) error {
+		if _, statErr := file.File.Stat(); statErr == nil {
+			return errors.New("unlink attempted before closing manager handle")
+		}
+		return os.Remove(removePath)
+	}
+	t.Cleanup(func() { removeSegmentPath = originalRemove })
+
+	file.retryDeletePending.Store(true)
+	manager.retryZombieDelete(file)
+	if _, err := os.Stat(path); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("zombie remains after close-first retry: %v", err)
+	}
+	if manager.HasSegment(fileID) {
+		t.Fatal("manager retained deleted zombie")
+	}
+}
+
+func TestManagerZombieDeleteCommitsSuccessfulUnlinkAfterCloseError(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "value-l1-000001.log")
+	handle, err := os.OpenFile(path, os.O_CREATE|os.O_RDWR, 0o600)
+	if err != nil {
+		t.Fatal(err)
+	}
+	identity, err := rootpublication.StableIdentityFromFile(handle)
+	if err != nil {
+		handle.Close()
+		t.Fatal(err)
+	}
+	namespace, err := stableDeleteNamespace(path)
+	if err != nil {
+		handle.Close()
+		t.Fatal(err)
+	}
+	if err := handle.Close(); err != nil {
+		t.Fatal(err)
+	}
+	registry := rootpublication.NewIdentityPinRegistry()
+	if err := registry.Observe(identity); err != nil {
+		t.Fatal(err)
+	}
+	file := &File{
+		ID: 1, Path: path, File: handle,
+		stableIdentity: identity, stableNamespace: namespace, stableObserved: true,
+	}
+	file.IsZombie.Store(true)
+	manager := &Manager{
+		files: map[uint32]*File{file.ID: file}, stableResourcePins: registry,
+	}
+	if err := manager.deleteZombieFile(file); err == nil {
+		t.Fatal("deleteZombieFile returned nil, want the already-closed handle error")
+	}
+	if _, err := os.Stat(path); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("successfully unlinked zombie remains: %v", err)
+	}
+	if manager.HasSegment(file.ID) {
+		t.Fatal("manager retained zombie after successful unlink")
+	}
+	if got := registry.ActiveIdentities(); got != 0 {
+		t.Fatalf("identity registry retained %d entries after successful unlink", got)
+	}
+}
+
+func stableManagerToken(t *testing.T, manager *Manager, fileID uint32) *rootpublication.StableResourceToken {
+	t.Helper()
+	token, err := manager.StableResourceToken(fileID, StableResourceRegistration{
+		Kind: rootpublication.ResourceValueLog, LogicalLane: "main", Generation: 1,
+		DiagnosticPath: "value_vlog/" + filepath.Base(manager.SegmentPath(fileID)),
+		Digest:         [32]byte{1}, Reachability: rootpublication.ReachabilityValueLogPointer,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return token
+}
+
+func TestManagerStableIdentityPinBlocksSecondManagerDelete(t *testing.T) {
+	dir := t.TempDir()
+	fileID, path := writeIdentityPinTestSegment(t, dir)
+	registry := rootpublication.NewIdentityPinRegistry()
+	first, err := NewManagerWithStableResourcePinRegistry(dir, registry)
+	if err != nil {
+		t.Fatal(err)
+	}
+	second, err := NewManagerWithStableResourcePinRegistry(dir, registry)
+	if err != nil {
+		first.Close()
+		t.Fatal(err)
+	}
+	defer second.Close()
+	if first.StableResourcePinRegistry() != second.StableResourcePinRegistry() {
+		t.Fatal("managers do not share one identity registry")
+	}
+	token := stableManagerToken(t, first, fileID)
+	removed, err := second.RemoveSegmentIfUnpinned(fileID)
+	if err != nil {
+		t.Fatalf("RemoveSegmentIfUnpinned while stable-pinned: %v", err)
+	}
+	if removed {
+		t.Fatal("stable-pinned segment was removed")
+	}
+	if _, err := os.Stat(path); err != nil {
+		t.Fatalf("stable-pinned segment disappeared: %v", err)
+	}
+	token.Release()
+	if err := first.Close(); err != nil {
+		t.Fatal(err)
+	}
+	removed, err = second.RemoveSegmentIfUnpinned(fileID)
+	if err != nil || !removed {
+		t.Fatalf("RemoveSegmentIfUnpinned after release = (%v, %v), want (true, nil)", removed, err)
+	}
+	if _, err := os.Stat(path); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("segment remains after delete: %v", err)
+	}
+}
+
+func TestManagerStableIdentityPinBlocksExplicitDeleteModes(t *testing.T) {
+	for _, mode := range []string{"remove", "force"} {
+		t.Run(mode, func(t *testing.T) {
+			dir := t.TempDir()
+			fileID, path := writeIdentityPinTestSegment(t, dir)
+			registry := rootpublication.NewIdentityPinRegistry()
+			producer, err := NewManagerWithStableResourcePinRegistry(dir, registry)
+			if err != nil {
+				t.Fatal(err)
+			}
+			deleter, err := NewManagerWithStableResourcePinRegistry(dir, registry)
+			if err != nil {
+				producer.Close()
+				t.Fatal(err)
+			}
+			defer deleter.Close()
+			token := stableManagerToken(t, producer, fileID)
+			remove := deleter.RemoveSegment
+			if mode == "force" {
+				remove = deleter.RemoveSegmentForce
+			}
+			if err := remove(fileID); !errors.Is(err, ErrFilePinned) {
+				t.Fatalf("delete while stable-pinned = %v, want ErrFilePinned", err)
+			}
+			if _, err := os.Stat(path); err != nil {
+				t.Fatalf("stable-pinned segment disappeared: %v", err)
+			}
+			token.Release()
+			if err := producer.Close(); err != nil {
+				t.Fatal(err)
+			}
+			if err := remove(fileID); err != nil {
+				t.Fatalf("delete after release: %v", err)
+			}
+			if _, err := os.Stat(path); !errors.Is(err, os.ErrNotExist) {
+				t.Fatalf("segment remains after delete: %v", err)
+			}
+		})
+	}
+}
+
+func TestManagerStableDeleteRejectsReplacedPath(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Windows does not permit replacing an open segment path")
+	}
+	dir := t.TempDir()
+	fileID, path := writeIdentityPinTestSegment(t, dir)
+	manager, err := NewManager(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer manager.Close()
+	if err := manager.SetStableResourcePinRegistry(rootpublication.NewIdentityPinRegistry()); err != nil {
+		t.Fatal(err)
+	}
+	oldPath := path + ".old"
+	if err := os.Rename(path, oldPath); err != nil {
+		t.Fatal(err)
+	}
+	const replacement = "replacement must survive"
+	if err := os.WriteFile(path, []byte(replacement), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := manager.RemoveSegment(fileID); !errors.Is(err, rootpublication.ErrResourceConflict) {
+		t.Fatalf("RemoveSegment replaced path = %v, want ErrResourceConflict", err)
+	}
+	got, err := os.ReadFile(path)
+	if err != nil || string(got) != replacement {
+		t.Fatalf("replacement changed: got=%q err=%v", got, err)
+	}
+}
+
+func TestManagerRegisterSegmentRejectsSameIDReboundPath(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Windows does not permit replacing an open segment path")
+	}
+	dir := t.TempDir()
+	fileID, path := writeIdentityPinTestSegment(t, dir)
+	manager, err := NewManagerWithStableResourcePinRegistry(dir, rootpublication.NewIdentityPinRegistry())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer manager.Close()
+	if err := os.Rename(path, path+".old"); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte("replacement"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := manager.RegisterSegment(path, fileID); !errors.Is(err, rootpublication.ErrResourceConflict) {
+		t.Fatalf("RegisterSegment rebound path = %v, want ErrResourceConflict", err)
+	}
+}

--- a/TreeDB/internal/valuelog/identity_pin_manager_test.go
+++ b/TreeDB/internal/valuelog/identity_pin_manager_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/snissn/gomap/TreeDB/internal/durabilitycut"
 	"github.com/snissn/gomap/TreeDB/internal/rootpublication"
 )
 
@@ -201,6 +202,52 @@ func TestManagerStableIdentityPinBlocksSecondManagerDelete(t *testing.T) {
 	}
 	if _, err := os.Stat(path); !errors.Is(err, os.ErrNotExist) {
 		t.Fatalf("segment remains after delete: %v", err)
+	}
+}
+
+func TestManagerStableDeleteCommitsUnlinkBeforePostUnlinkCut(t *testing.T) {
+	dir := t.TempDir()
+	fileID, path := writeIdentityPinTestSegment(t, dir)
+	registry := rootpublication.NewIdentityPinRegistry()
+	producer, err := NewManagerWithStableResourcePinRegistry(dir, registry)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer producer.Close()
+	deleter, err := NewManagerWithStableResourcePinRegistry(dir, registry)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer deleter.Close()
+
+	wantErr := errors.New("injected post-unlink cut")
+	restore := durabilitycut.Install(func(event durabilitycut.Event) error {
+		if event.Namespace == durabilitycut.NamespaceUnlink &&
+			event.Resource == durabilitycut.ResourceValueLog &&
+			filepath.Clean(event.OldPath) == filepath.Clean(path) {
+			return wantErr
+		}
+		return nil
+	})
+	err = deleter.RemoveSegment(fileID)
+	restore()
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("RemoveSegment error=%v, want post-unlink cut", err)
+	}
+	if _, statErr := os.Stat(path); !errors.Is(statErr, os.ErrNotExist) {
+		t.Fatalf("post-unlink cut path stat=%v, want removed", statErr)
+	}
+
+	token, pinErr := producer.StableResourceToken(fileID, StableResourceRegistration{
+		Kind: rootpublication.ResourceValueLog, LogicalLane: "main", Generation: 2,
+		DiagnosticPath: "value_vlog/" + filepath.Base(path),
+		Digest:         [32]byte{2}, Reachability: rootpublication.ReachabilityValueLogPointer,
+	})
+	if token != nil {
+		token.Release()
+	}
+	if !errors.Is(pinErr, rootpublication.ErrResourceConflict) {
+		t.Fatalf("late pin after committed unlink error=%v, want ErrResourceConflict", pinErr)
 	}
 }
 

--- a/TreeDB/internal/valuelog/identity_pin_manager_test.go
+++ b/TreeDB/internal/valuelog/identity_pin_manager_test.go
@@ -246,7 +246,7 @@ func TestManagerStableIdentityPinBlocksSecondManagerDelete(t *testing.T) {
 	}
 }
 
-func TestManagerStableDeleteCommitsUnlinkBeforePostUnlinkCut(t *testing.T) {
+func TestManagerStableDeleteEmitsCanonicalUnlinkCutBeforeQuarantineUnlink(t *testing.T) {
 	dir := t.TempDir()
 	fileID, path := writeIdentityPinTestSegment(t, dir)
 	registry := rootpublication.NewIdentityPinRegistry()
@@ -260,6 +260,14 @@ func TestManagerStableDeleteCommitsUnlinkBeforePostUnlinkCut(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer deleter.Close()
+
+	originalRemove := removeSegmentPath
+	quarantineUnlinked := false
+	removeSegmentPath = func(removePath string) error {
+		quarantineUnlinked = true
+		return originalRemove(removePath)
+	}
+	t.Cleanup(func() { removeSegmentPath = originalRemove })
 
 	wantErr := errors.New("injected post-unlink cut")
 	restore := durabilitycut.Install(func(event durabilitycut.Event) error {
@@ -275,6 +283,9 @@ func TestManagerStableDeleteCommitsUnlinkBeforePostUnlinkCut(t *testing.T) {
 	if !errors.Is(err, wantErr) {
 		t.Fatalf("RemoveSegment error=%v, want post-unlink cut", err)
 	}
+	if quarantineUnlinked {
+		t.Fatal("stable delete unlinked the quarantined inode before emitting the canonical-name cut")
+	}
 	if _, statErr := os.Stat(path); !errors.Is(statErr, os.ErrNotExist) {
 		t.Fatalf("post-unlink cut path stat=%v, want removed", statErr)
 	}
@@ -289,6 +300,40 @@ func TestManagerStableDeleteCommitsUnlinkBeforePostUnlinkCut(t *testing.T) {
 	}
 	if !errors.Is(pinErr, rootpublication.ErrResourceConflict) {
 		t.Fatalf("late pin after committed unlink error=%v, want ErrResourceConflict", pinErr)
+	}
+}
+
+func TestManagerStableDeleteRestoreCompensatesCanonicalUnlink(t *testing.T) {
+	dir := t.TempDir()
+	fileID, path := writeIdentityPinTestSegment(t, dir)
+	manager, err := NewManagerWithStableResourcePinRegistry(dir, rootpublication.NewIdentityPinRegistry())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer manager.Close()
+
+	wantErr := errors.New("injected quarantine unlink failure")
+	originalRemove := removeSegmentPath
+	removeSegmentPath = func(string) error { return wantErr }
+	t.Cleanup(func() { removeSegmentPath = originalRemove })
+
+	var operations []durabilitycut.NamespaceOperation
+	restore := durabilitycut.Install(func(event durabilitycut.Event) error {
+		if filepath.Clean(event.OldPath) == filepath.Clean(path) || filepath.Clean(event.NewPath) == filepath.Clean(path) {
+			operations = append(operations, event.Namespace)
+		}
+		return nil
+	})
+	err = manager.RemoveSegment(fileID)
+	restore()
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("RemoveSegment error=%v, want quarantine unlink failure", err)
+	}
+	if _, err := os.Stat(path); err != nil {
+		t.Fatalf("restored segment stat: %v", err)
+	}
+	if len(operations) != 2 || operations[0] != durabilitycut.NamespaceUnlink || operations[1] != durabilitycut.NamespaceCreate {
+		t.Fatalf("namespace operations=%v, want [unlink create]", operations)
 	}
 }
 

--- a/TreeDB/internal/valuelog/identity_pin_manager_test.go
+++ b/TreeDB/internal/valuelog/identity_pin_manager_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/snissn/gomap/TreeDB/internal/durabilitycut"
 	"github.com/snissn/gomap/TreeDB/internal/rootpublication"
+	templ "github.com/snissn/gomap/TreeDB/template"
 )
 
 func writeIdentityPinTestSegment(t *testing.T, dir string) (uint32, string) {
@@ -102,6 +103,46 @@ func TestManagerRetryZombieDeleteClosesOwnHandleBeforeUnlink(t *testing.T) {
 	}
 	if manager.HasSegment(fileID) {
 		t.Fatal("manager retained deleted zombie")
+	}
+}
+
+func TestManagerStableDeletePreservesReplacementCreatedAtUnlink(t *testing.T) {
+	dir := t.TempDir()
+	fileID, path := writeIdentityPinTestSegment(t, dir)
+	manager, err := NewManagerWithStableResourcePinRegistry(dir, rootpublication.NewIdentityPinRegistry())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer manager.Close()
+
+	const replacement = "replacement created after quarantine rename"
+	originalRemove := removeSegmentPath
+	removeSegmentPath = func(quarantinePath string) error {
+		if filepath.Clean(quarantinePath) == filepath.Clean(path) {
+			t.Fatal("stable delete passed the original pathname to unlink")
+		}
+		if err := os.WriteFile(path, []byte(replacement), 0o600); err != nil {
+			return err
+		}
+		return os.Remove(quarantinePath)
+	}
+	t.Cleanup(func() { removeSegmentPath = originalRemove })
+
+	if err := manager.RemoveSegment(fileID); err != nil {
+		t.Fatalf("RemoveSegment: %v", err)
+	}
+	got, err := os.ReadFile(path)
+	if err != nil || string(got) != replacement {
+		t.Fatalf("replacement changed: got=%q err=%v", got, err)
+	}
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, entry := range entries {
+		if entry.IsDir() {
+			t.Fatalf("stable delete left quarantine directory %q", entry.Name())
+		}
 	}
 }
 
@@ -342,5 +383,58 @@ func TestManagerRegisterSegmentRejectsSameIDReboundPath(t *testing.T) {
 	}
 	if err := manager.RegisterSegment(path, fileID); !errors.Is(err, rootpublication.ErrResourceConflict) {
 		t.Fatalf("RegisterSegment rebound path = %v, want ErrResourceConflict", err)
+	}
+}
+
+func TestNewManagerRefreshFailureReleasesObservedIdentities(t *testing.T) {
+	dir := t.TempDir()
+	for seq := uint32(1); seq <= 2; seq++ {
+		fileID, err := EncodeFileID(1, seq)
+		if err != nil {
+			t.Fatal(err)
+		}
+		writer, err := NewWriter(SegmentPath(dir, fileID), fileID)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if _, err := writer.Append(0, nil, uint64(seq), []byte("constructor cleanup")); err != nil {
+			writer.Close()
+			t.Fatal(err)
+		}
+		if err := writer.Close(); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	originalOpen := currentOpenSegmentFile()
+	openCalls := 0
+	var firstOpened *File
+	wantErr := errors.New("injected second segment open failure")
+	swapOpenSegmentFileForTest(func(path string, id uint32, dictLookup DictLookup, templateLookup TemplateLookup, templateOpts templ.DecodeOptions, templateCache *templateDefCache) (*File, error) {
+		openCalls++
+		if openCalls == 2 {
+			return nil, wantErr
+		}
+		file, err := originalOpen(path, id, dictLookup, templateLookup, templateOpts, templateCache)
+		if err == nil {
+			firstOpened = file
+		}
+		return file, err
+	})
+	t.Cleanup(func() { swapOpenSegmentFileForTest(originalOpen) })
+
+	registry := rootpublication.NewIdentityPinRegistry()
+	manager, err := NewManagerWithStableResourcePinRegistry(dir, registry)
+	if manager != nil || !errors.Is(err, wantErr) {
+		t.Fatalf("NewManager = (%v, %v), want (nil, injected error)", manager, err)
+	}
+	if firstOpened == nil {
+		t.Fatal("constructor did not open the first segment")
+	}
+	if _, err := firstOpened.File.Stat(); err == nil {
+		t.Fatal("partially initialized manager left its first handle open")
+	}
+	if got := registry.ActiveIdentities(); got != 0 {
+		t.Fatalf("registry retained %d constructor observers", got)
 	}
 }

--- a/TreeDB/internal/valuelog/identity_pin_manager_test.go
+++ b/TreeDB/internal/valuelog/identity_pin_manager_test.go
@@ -33,6 +33,221 @@ func writeIdentityPinTestSegment(t *testing.T, dir string) (uint32, string) {
 	return fileID, path
 }
 
+func identityPinTestIdentity(t *testing.T, path string) rootpublication.StableIdentity {
+	t.Helper()
+	file, err := os.Open(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer file.Close()
+	identity, err := rootpublication.StableIdentityFromFile(file)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return identity
+}
+
+func TestManagerStartupCompletesMatchingStableDeleteQuarantine(t *testing.T) {
+	dir := t.TempDir()
+	fileID, path := writeIdentityPinTestSegment(t, dir)
+	identity := identityPinTestIdentity(t, path)
+	quarantineDir, quarantinePath, err := stableDeleteQuarantinePaths(path, identity)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Mkdir(quarantineDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Rename(path, quarantinePath); err != nil {
+		t.Fatal(err)
+	}
+
+	manager, err := NewManagerWithStableResourcePinRegistry(dir, rootpublication.NewIdentityPinRegistry())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer manager.Close()
+	if manager.HasSegment(fileID) {
+		t.Fatal("manager registered a segment whose stable deletion had committed")
+	}
+	if _, err := os.Stat(quarantineDir); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("matching quarantine remains after startup recovery: %v", err)
+	}
+}
+
+func TestManagerStartupRestoresUnexpectedStableDeleteQuarantineIdentity(t *testing.T) {
+	dir := t.TempDir()
+	fileID, path := writeIdentityPinTestSegment(t, dir)
+	intendedIdentity := identityPinTestIdentity(t, path)
+	replacementDir := filepath.Join(dir, "replacement")
+	if err := os.Mkdir(replacementDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	_, replacementPath := writeIdentityPinTestSegment(t, replacementDir)
+	replacementIdentity := identityPinTestIdentity(t, replacementPath)
+	if err := os.Remove(path); err != nil {
+		t.Fatal(err)
+	}
+	if rootpublication.SamePhysicalIdentity(intendedIdentity, replacementIdentity) {
+		t.Fatal("replacement unexpectedly reused the intended physical identity")
+	}
+	quarantineDir, quarantinePath, err := stableDeleteQuarantinePaths(path, intendedIdentity)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Mkdir(quarantineDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Rename(replacementPath, quarantinePath); err != nil {
+		t.Fatal(err)
+	}
+
+	manager, err := NewManagerWithStableResourcePinRegistry(dir, rootpublication.NewIdentityPinRegistry())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer manager.Close()
+	if !manager.HasSegment(fileID) {
+		t.Fatal("manager did not register the conservatively restored segment")
+	}
+	gotIdentity := identityPinTestIdentity(t, path)
+	if !rootpublication.SamePhysicalIdentity(gotIdentity, replacementIdentity) {
+		t.Fatal("startup recovery restored the wrong physical identity")
+	}
+	if _, err := os.Stat(quarantineDir); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("unexpected-identity quarantine remains after restore: %v", err)
+	}
+}
+
+func TestManagerStartupRollsBackPartialStableDeleteRestore(t *testing.T) {
+	dir := t.TempDir()
+	fileID, path := writeIdentityPinTestSegment(t, dir)
+	identity := identityPinTestIdentity(t, path)
+	quarantineDir, quarantinePath, err := stableDeleteQuarantinePaths(path, identity)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Mkdir(quarantineDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Link(path, quarantinePath); err != nil {
+		t.Fatal(err)
+	}
+
+	manager, err := NewManagerWithStableResourcePinRegistry(dir, rootpublication.NewIdentityPinRegistry())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer manager.Close()
+	if !manager.HasSegment(fileID) {
+		t.Fatal("manager lost the canonical segment after partial restore recovery")
+	}
+	if _, err := os.Stat(quarantineDir); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("partial-restore quarantine remains after startup recovery: %v", err)
+	}
+}
+
+func TestManagerStartupCompletesQuarantineAndPreservesReplacement(t *testing.T) {
+	dir := t.TempDir()
+	fileID, path := writeIdentityPinTestSegment(t, dir)
+	identity := identityPinTestIdentity(t, path)
+	quarantineDir, quarantinePath, err := stableDeleteQuarantinePaths(path, identity)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Mkdir(quarantineDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Rename(path, quarantinePath); err != nil {
+		t.Fatal(err)
+	}
+	replacementDir := filepath.Join(dir, "replacement")
+	if err := os.Mkdir(replacementDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	_, replacementPath := writeIdentityPinTestSegment(t, replacementDir)
+	replacementIdentity := identityPinTestIdentity(t, replacementPath)
+	if err := os.Rename(replacementPath, path); err != nil {
+		t.Fatal(err)
+	}
+
+	manager, err := NewManagerWithStableResourcePinRegistry(dir, rootpublication.NewIdentityPinRegistry())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer manager.Close()
+	if !manager.HasSegment(fileID) {
+		t.Fatal("manager did not register the replacement segment")
+	}
+	if got := identityPinTestIdentity(t, path); !rootpublication.SamePhysicalIdentity(got, replacementIdentity) {
+		t.Fatal("startup recovery changed the replacement identity")
+	}
+	if _, err := os.Stat(quarantineDir); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("matching quarantine remains after replacement recovery: %v", err)
+	}
+}
+
+func TestManagerStartupRejectsAmbiguousStableDeleteQuarantine(t *testing.T) {
+	dir := t.TempDir()
+	_, path := writeIdentityPinTestSegment(t, dir)
+	intendedIdentity := identityPinTestIdentity(t, path)
+	quarantineDir, quarantinePath, err := stableDeleteQuarantinePaths(path, intendedIdentity)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Mkdir(quarantineDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	replacementDir := filepath.Join(dir, "replacement")
+	if err := os.Mkdir(replacementDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	_, replacementPath := writeIdentityPinTestSegment(t, replacementDir)
+	if err := os.Rename(replacementPath, quarantinePath); err != nil {
+		t.Fatal(err)
+	}
+
+	manager, err := NewManagerWithStableResourcePinRegistry(dir, rootpublication.NewIdentityPinRegistry())
+	if manager != nil || !errors.Is(err, rootpublication.ErrResourceConflict) {
+		t.Fatalf("NewManager ambiguous quarantine=(%v, %v), want (nil, ErrResourceConflict)", manager, err)
+	}
+	if _, err := os.Stat(path); err != nil {
+		t.Fatalf("canonical segment changed after fail-closed recovery: %v", err)
+	}
+	if _, err := os.Stat(quarantinePath); err != nil {
+		t.Fatalf("ambiguous quarantine changed after fail-closed recovery: %v", err)
+	}
+}
+
+func TestStableDeleteRetryPreservesReplacementBesideCommittedQuarantine(t *testing.T) {
+	dir := t.TempDir()
+	_, path := writeIdentityPinTestSegment(t, dir)
+	identity := identityPinTestIdentity(t, path)
+	quarantineDir, quarantinePath, err := stableDeleteQuarantinePaths(path, identity)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Mkdir(quarantineDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Rename(path, quarantinePath); err != nil {
+		t.Fatal(err)
+	}
+	const replacement = "replacement after committed canonical unlink"
+	if err := os.WriteFile(path, []byte(replacement), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	removed, err := removeStableSegmentFileOnce(path, identity)
+	if err != nil || !removed {
+		t.Fatalf("stable delete retry = (%v, %v), want (true, nil)", removed, err)
+	}
+	got, err := os.ReadFile(path)
+	if err != nil || string(got) != replacement {
+		t.Fatalf("replacement changed during stable delete retry: got=%q err=%v", got, err)
+	}
+}
+
 func TestManagerZombieDeleteWaitsForStableIdentityPin(t *testing.T) {
 	dir := t.TempDir()
 	fileID, path := writeIdentityPinTestSegment(t, dir)

--- a/TreeDB/internal/valuelog/identity_pin_manager_test.go
+++ b/TreeDB/internal/valuelog/identity_pin_manager_test.go
@@ -690,6 +690,33 @@ func TestManagerStableDeleteRejectsReplacedPath(t *testing.T) {
 	}
 }
 
+func TestManagerRemoveSegmentExpectedIdentityRejectsRegisteredReplacement(t *testing.T) {
+	dir := t.TempDir()
+	fileID, path := writeIdentityPinTestSegment(t, dir)
+	expected := identityPinTestIdentity(t, path)
+	if err := os.Rename(path, path+".old"); err != nil {
+		t.Fatal(err)
+	}
+	_, replacementPath := writeIdentityPinTestSegment(t, dir)
+	replacement := identityPinTestIdentity(t, replacementPath)
+	if rootpublication.SamePhysicalIdentity(expected, replacement) {
+		t.Fatal("replacement unexpectedly reused the original physical identity")
+	}
+
+	manager, err := NewManagerWithStableResourcePinRegistry(dir, rootpublication.NewIdentityPinRegistry())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer manager.Close()
+	if err := manager.RemoveSegmentExpectedIdentity(fileID, expected); !errors.Is(err, rootpublication.ErrResourceConflict) {
+		t.Fatalf("RemoveSegmentExpectedIdentity replacement error = %v, want ErrResourceConflict", err)
+	}
+	got := identityPinTestIdentity(t, replacementPath)
+	if !rootpublication.SamePhysicalIdentity(got, replacement) {
+		t.Fatal("expected-identity removal changed the registered replacement")
+	}
+}
+
 func TestManagerRegisterSegmentRejectsSameIDReboundPath(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("Windows does not permit replacing an open segment path")

--- a/TreeDB/internal/valuelog/identity_pin_manager_test.go
+++ b/TreeDB/internal/valuelog/identity_pin_manager_test.go
@@ -530,12 +530,8 @@ func TestManagerStableIdentityPinBlocksSecondManagerDelete(t *testing.T) {
 func TestManagerStableDeleteEmitsCanonicalUnlinkCutBeforeQuarantineUnlink(t *testing.T) {
 	dir := t.TempDir()
 	fileID, path := writeIdentityPinTestSegment(t, dir)
+	identity := identityPinTestIdentity(t, path)
 	registry := rootpublication.NewIdentityPinRegistry()
-	producer, err := NewManagerWithStableResourcePinRegistry(dir, registry)
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer producer.Close()
 	deleter, err := NewManagerWithStableResourcePinRegistry(dir, registry)
 	if err != nil {
 		t.Fatal(err)
@@ -571,11 +567,7 @@ func TestManagerStableDeleteEmitsCanonicalUnlinkCutBeforeQuarantineUnlink(t *tes
 		t.Fatalf("post-unlink cut path stat=%v, want removed", statErr)
 	}
 
-	token, pinErr := producer.StableResourceToken(fileID, StableResourceRegistration{
-		Kind: rootpublication.ResourceValueLog, LogicalLane: "main", Generation: 2,
-		DiagnosticPath: "value_vlog/" + filepath.Base(path),
-		Digest:         [32]byte{2}, Reachability: rootpublication.ReachabilityValueLogPointer,
-	})
+	token, pinErr := registry.Pin(identity)
 	if token != nil {
 		token.Release()
 	}

--- a/TreeDB/internal/valuelog/manager.go
+++ b/TreeDB/internal/valuelog/manager.go
@@ -2542,10 +2542,17 @@ func (m *Manager) RemoveSegmentForce(id uint32) error {
 
 var removeSegmentPath = os.Remove
 
+func segmentNamespaceResource(path string) durabilitycut.Resource {
+	if filepath.Base(filepath.Dir(filepath.Clean(path))) == "leaf_vlog" {
+		return durabilitycut.ResourceOuterLeaf
+	}
+	return durabilitycut.ResourceValueLog
+}
+
 func removeSegmentFileOnce(path string) (bool, error) {
 	err := removeSegmentPath(path)
 	if err == nil {
-		return true, durabilitycut.EmitNamespace(durabilitycut.NamespaceUnlink, durabilitycut.ResourceValueLog, filepath.Dir(path), path, "")
+		return true, durabilitycut.EmitNamespace(durabilitycut.NamespaceUnlink, segmentNamespaceResource(path), filepath.Dir(path), path, "")
 	}
 	if os.IsNotExist(err) {
 		return true, nil

--- a/TreeDB/internal/valuelog/manager.go
+++ b/TreeDB/internal/valuelog/manager.go
@@ -1262,19 +1262,20 @@ type Manager struct {
 
 	refreshScans atomic.Uint64
 
-	disableReadChecksum        bool
-	dictLookup                 DictLookup
-	templateLookup             TemplateLookup
-	templateDecodeOpts         templ.DecodeOptions
-	templateDefCache           *templateDefCache
-	groupedFrameCacheEntries   int
-	groupedFrameCacheMaxRaw    int
-	groupedFrameCacheMaxBytes  int64
-	groupedFrameCacheBudget    *groupedFrameCacheBudget
-	currentWritableMmap        atomic.Bool
-	currentWritableReadBarrier atomic.Value
-	stableResourcePins         *rootpublication.IdentityPinRegistry
-	recoveredStableDeleteDirs  map[string]bool
+	disableReadChecksum         bool
+	dictLookup                  DictLookup
+	templateLookup              TemplateLookup
+	templateDecodeOpts          templ.DecodeOptions
+	templateDefCache            *templateDefCache
+	groupedFrameCacheEntries    int
+	groupedFrameCacheMaxRaw     int
+	groupedFrameCacheMaxBytes   int64
+	groupedFrameCacheBudget     *groupedFrameCacheBudget
+	currentWritableMmap         atomic.Bool
+	currentWritableReadBarrier  atomic.Value
+	stableResourcePins          *rootpublication.IdentityPinRegistry
+	recoveredStableDeleteDirs   map[string]bool
+	stableDeleteRecoveryEnabled bool
 }
 
 func NewManager(dir string) (*Manager, error) {
@@ -1285,15 +1286,27 @@ func NewManager(dir string) (*Manager, error) {
 // identity gate before the initial directory scan, so every tracked handle is
 // observed from the moment it becomes deletable.
 func NewManagerWithStableResourcePinRegistry(dir string, registry *rootpublication.IdentityPinRegistry) (*Manager, error) {
+	return newManagerWithStableResourcePinRegistry(dir, registry, true)
+}
+
+// NewReadOnlyManagerWithStableResourcePinRegistry opens segment handles
+// without reconciling interrupted stable deletions. Pending quarantine intents
+// fail with ErrStableDeleteRecoveryRequired and are left untouched.
+func NewReadOnlyManagerWithStableResourcePinRegistry(dir string, registry *rootpublication.IdentityPinRegistry) (*Manager, error) {
+	return newManagerWithStableResourcePinRegistry(dir, registry, false)
+}
+
+func newManagerWithStableResourcePinRegistry(dir string, registry *rootpublication.IdentityPinRegistry, recoverStableDeletes bool) (*Manager, error) {
 	m := &Manager{
-		dir:                       dir,
-		files:                     make(map[uint32]*File),
-		currentWritableByLane:     make(map[uint32]uint32),
-		groupedFrameCacheEntries:  defaultGroupedFrameCacheEntries,
-		groupedFrameCacheMaxRaw:   defaultGroupedFrameCacheMaxRawBytes,
-		groupedFrameCacheMaxBytes: defaultGroupedFrameCacheMaxBytes,
-		stableResourcePins:        registry,
-		recoveredStableDeleteDirs: make(map[string]bool),
+		dir:                         dir,
+		files:                       make(map[uint32]*File),
+		currentWritableByLane:       make(map[uint32]uint32),
+		groupedFrameCacheEntries:    defaultGroupedFrameCacheEntries,
+		groupedFrameCacheMaxRaw:     defaultGroupedFrameCacheMaxRawBytes,
+		groupedFrameCacheMaxBytes:   defaultGroupedFrameCacheMaxBytes,
+		stableResourcePins:          registry,
+		recoveredStableDeleteDirs:   make(map[string]bool),
+		stableDeleteRecoveryEnabled: recoverStableDeletes,
 	}
 	m.groupedFrameCacheBudget = newGroupedFrameCacheBudget(defaultGroupedFrameCacheMaxBytes)
 	if err := m.Refresh(); err != nil {
@@ -1581,7 +1594,11 @@ func (m *Manager) Refresh() error {
 	}
 	m.mu.RUnlock()
 	for _, dir := range dirs {
-		if err := m.recoverStableDeleteDirOnce(dir); err != nil {
+		if m.stableDeleteRecoveryEnabled {
+			if err := m.recoverStableDeleteDirOnce(dir); err != nil {
+				return err
+			}
+		} else if err := requireNoStableDeleteQuarantines(dir); err != nil {
 			return err
 		}
 		segments, err := currentScanSegmentPaths()(dir)

--- a/TreeDB/internal/valuelog/manager.go
+++ b/TreeDB/internal/valuelog/manager.go
@@ -2476,6 +2476,13 @@ func (m *Manager) DecodeScratchStats() DecodeScratchStats {
 }
 
 func (m *Manager) RemoveSegment(id uint32) error {
+	return m.RemoveSegmentExpectedIdentity(id, rootpublication.StableIdentity{})
+}
+
+// RemoveSegmentExpectedIdentity removes id only when the manager-observed
+// physical identity matches expected. A zero expected identity preserves the
+// ordinary RemoveSegment behavior.
+func (m *Manager) RemoveSegmentExpectedIdentity(id uint32, expected rootpublication.StableIdentity) error {
 	m.mu.Lock()
 	f, ok := m.files[id]
 	if !ok {
@@ -2485,6 +2492,21 @@ func (m *Manager) RemoveSegment(id uint32) error {
 	if f.RefCount.Load() != 0 {
 		m.mu.Unlock()
 		return &filePinnedError{id: id, op: "remove"}
+	}
+	if expected != (rootpublication.StableIdentity{}) {
+		actual := f.stableIdentity
+		if actual == (rootpublication.StableIdentity{}) {
+			var err error
+			actual, err = rootpublication.StableIdentityFromFile(f.File)
+			if err != nil {
+				m.mu.Unlock()
+				return err
+			}
+		}
+		if !rootpublication.SamePhysicalIdentity(expected, actual) {
+			m.mu.Unlock()
+			return fmt.Errorf("%w: value-log file id %d identity changed", rootpublication.ErrResourceConflict, id)
+		}
 	}
 	lease, err := m.stableDeleteLease(f)
 	if err != nil {

--- a/TreeDB/internal/valuelog/manager.go
+++ b/TreeDB/internal/valuelog/manager.go
@@ -1295,7 +1295,7 @@ func NewManagerWithStableResourcePinRegistry(dir string, registry *rootpublicati
 	}
 	m.groupedFrameCacheBudget = newGroupedFrameCacheBudget(defaultGroupedFrameCacheMaxBytes)
 	if err := m.Refresh(); err != nil {
-		return nil, err
+		return nil, errors.Join(err, m.Close())
 	}
 	return m, nil
 }
@@ -2583,9 +2583,7 @@ func removeSegmentFileWithRetry(path string) (bool, error) {
 
 func removeSegmentFileOnceStable(path string, identity rootpublication.StableIdentity, stable bool) (bool, error) {
 	if stable {
-		if err := validateStableDeletePathIdentity(path, identity); err != nil {
-			return false, err
-		}
+		return removeStableSegmentFileOnce(path, identity)
 	}
 	return removeSegmentFileOnce(path)
 }

--- a/TreeDB/internal/valuelog/manager.go
+++ b/TreeDB/internal/valuelog/manager.go
@@ -1274,6 +1274,7 @@ type Manager struct {
 	currentWritableMmap        atomic.Bool
 	currentWritableReadBarrier atomic.Value
 	stableResourcePins         *rootpublication.IdentityPinRegistry
+	recoveredStableDeleteDirs  map[string]bool
 }
 
 func NewManager(dir string) (*Manager, error) {
@@ -1292,6 +1293,7 @@ func NewManagerWithStableResourcePinRegistry(dir string, registry *rootpublicati
 		groupedFrameCacheMaxRaw:   defaultGroupedFrameCacheMaxRawBytes,
 		groupedFrameCacheMaxBytes: defaultGroupedFrameCacheMaxBytes,
 		stableResourcePins:        registry,
+		recoveredStableDeleteDirs: make(map[string]bool),
 	}
 	m.groupedFrameCacheBudget = newGroupedFrameCacheBudget(defaultGroupedFrameCacheMaxBytes)
 	if err := m.Refresh(); err != nil {
@@ -1579,6 +1581,9 @@ func (m *Manager) Refresh() error {
 	}
 	m.mu.RUnlock()
 	for _, dir := range dirs {
+		if err := m.recoverStableDeleteDirOnce(dir); err != nil {
+			return err
+		}
 		segments, err := currentScanSegmentPaths()(dir)
 		if err != nil {
 			return err
@@ -1598,6 +1603,26 @@ func (m *Manager) Refresh() error {
 		}
 		m.mu.Unlock()
 	}
+	return nil
+}
+
+func (m *Manager) recoverStableDeleteDirOnce(dir string) error {
+	if m == nil {
+		return nil
+	}
+	dir = filepath.Clean(dir)
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.recoveredStableDeleteDirs == nil {
+		m.recoveredStableDeleteDirs = make(map[string]bool)
+	}
+	if m.recoveredStableDeleteDirs[dir] {
+		return nil
+	}
+	if err := recoverStableDeleteQuarantines(dir); err != nil {
+		return err
+	}
+	m.recoveredStableDeleteDirs[dir] = true
 	return nil
 }
 

--- a/TreeDB/internal/valuelog/manager.go
+++ b/TreeDB/internal/valuelog/manager.go
@@ -2542,25 +2542,28 @@ func (m *Manager) RemoveSegmentForce(id uint32) error {
 
 var removeSegmentPath = os.Remove
 
-func removeSegmentFileOnce(path string) error {
+func removeSegmentFileOnce(path string) (bool, error) {
 	err := removeSegmentPath(path)
 	if err == nil {
-		return durabilitycut.EmitNamespace(durabilitycut.NamespaceUnlink, durabilitycut.ResourceValueLog, filepath.Dir(path), path, "")
+		return true, durabilitycut.EmitNamespace(durabilitycut.NamespaceUnlink, durabilitycut.ResourceValueLog, filepath.Dir(path), path, "")
 	}
 	if os.IsNotExist(err) {
-		return nil
+		return true, nil
 	}
-	return err
+	return false, err
 }
 
-func removeSegmentFileWithRetry(path string) error {
+func removeSegmentFileWithRetry(path string) (bool, error) {
 	const attempts = 40
 	backoff := 25 * time.Millisecond
 	var lastErr error
 	for i := 0; i < attempts; i++ {
-		err := removeSegmentFileOnce(path)
+		removed, err := removeSegmentFileOnce(path)
+		if removed {
+			return true, err
+		}
 		if err == nil {
-			return nil
+			return false, nil
 		}
 		lastErr = err
 		// On non-Windows, or on the final retry attempt, stop retrying.
@@ -2575,26 +2578,29 @@ func removeSegmentFileWithRetry(path string) error {
 			backoff *= 2
 		}
 	}
-	return lastErr
+	return false, lastErr
 }
 
-func removeSegmentFileOnceStable(path string, identity rootpublication.StableIdentity, stable bool) error {
+func removeSegmentFileOnceStable(path string, identity rootpublication.StableIdentity, stable bool) (bool, error) {
 	if stable {
 		if err := validateStableDeletePathIdentity(path, identity); err != nil {
-			return err
+			return false, err
 		}
 	}
 	return removeSegmentFileOnce(path)
 }
 
-func removeSegmentFileWithRetryStable(path string, identity rootpublication.StableIdentity) error {
+func removeSegmentFileWithRetryStable(path string, identity rootpublication.StableIdentity) (bool, error) {
 	const attempts = 40
 	backoff := 25 * time.Millisecond
 	var lastErr error
 	for i := 0; i < attempts; i++ {
-		err := removeSegmentFileOnceStable(path, identity, true)
+		removed, err := removeSegmentFileOnceStable(path, identity, true)
+		if removed {
+			return true, err
+		}
 		if err == nil {
-			return nil
+			return false, nil
 		}
 		lastErr = err
 		if runtime.GOOS != "windows" || i >= attempts-1 || !isWindowsSharingViolationError(err) {
@@ -2605,7 +2611,7 @@ func removeSegmentFileWithRetryStable(path string, identity rootpublication.Stab
 			backoff *= 2
 		}
 	}
-	return lastErr
+	return false, lastErr
 }
 
 func isWindowsSharingViolationError(err error) bool {

--- a/TreeDB/internal/valuelog/manager.go
+++ b/TreeDB/internal/valuelog/manager.go
@@ -142,7 +142,7 @@ func (f *File) appendMaybeDecodeLeafLogPayload(dst, payload []byte) ([]byte, err
 }
 
 func openFile(path string, id uint32, dictLookup DictLookup, templateLookup TemplateLookup, templateOpts templ.DecodeOptions, templateCache *templateDefCache) (*File, error) {
-	f, err := os.Open(path)
+	f, err := openSegmentReadHandle(path)
 	if err != nil {
 		return nil, err
 	}

--- a/TreeDB/internal/valuelog/manager.go
+++ b/TreeDB/internal/valuelog/manager.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/snissn/gomap/TreeDB/internal/durabilitycut"
 	"github.com/snissn/gomap/TreeDB/internal/limits"
+	"github.com/snissn/gomap/TreeDB/internal/rootpublication"
 	"github.com/snissn/gomap/TreeDB/page"
 	templ "github.com/snissn/gomap/TreeDB/template"
 )
@@ -49,6 +50,9 @@ type File struct {
 	RefCount           atomic.Int64
 	IsZombie           atomic.Bool
 	retryDeletePending atomic.Bool
+	stableIdentity     rootpublication.StableIdentity
+	stableNamespace    string
+	stableObserved     bool
 	currentWritable    atomic.Bool
 	dictLookup         DictLookup
 	templateLookup     TemplateLookup
@@ -1269,9 +1273,17 @@ type Manager struct {
 	groupedFrameCacheBudget    *groupedFrameCacheBudget
 	currentWritableMmap        atomic.Bool
 	currentWritableReadBarrier atomic.Value
+	stableResourcePins         *rootpublication.IdentityPinRegistry
 }
 
 func NewManager(dir string) (*Manager, error) {
+	return NewManagerWithStableResourcePinRegistry(dir, nil)
+}
+
+// NewManagerWithStableResourcePinRegistry installs the DB-scoped physical
+// identity gate before the initial directory scan, so every tracked handle is
+// observed from the moment it becomes deletable.
+func NewManagerWithStableResourcePinRegistry(dir string, registry *rootpublication.IdentityPinRegistry) (*Manager, error) {
 	m := &Manager{
 		dir:                       dir,
 		files:                     make(map[uint32]*File),
@@ -1279,6 +1291,7 @@ func NewManager(dir string) (*Manager, error) {
 		groupedFrameCacheEntries:  defaultGroupedFrameCacheEntries,
 		groupedFrameCacheMaxRaw:   defaultGroupedFrameCacheMaxRawBytes,
 		groupedFrameCacheMaxBytes: defaultGroupedFrameCacheMaxBytes,
+		stableResourcePins:        registry,
 	}
 	m.groupedFrameCacheBudget = newGroupedFrameCacheBudget(defaultGroupedFrameCacheMaxBytes)
 	if err := m.Refresh(); err != nil {
@@ -1494,8 +1507,11 @@ func (m *Manager) Close() error {
 	defer m.mu.Unlock()
 	var err error
 	for _, f := range m.files {
+		if e := m.unobserveStableFileLocked(f); e != nil {
+			err = errors.Join(err, e)
+		}
 		if e := f.Close(); e != nil {
-			err = e
+			err = errors.Join(err, e)
 		}
 	}
 	m.files = nil
@@ -1615,7 +1631,18 @@ func (m *Manager) registerSegmentLocked(path string, id uint32) error {
 	if m.files == nil {
 		m.files = make(map[uint32]*File, 16)
 	}
-	if _, ok := m.files[id]; ok {
+	if existing, ok := m.files[id]; ok {
+		if filepath.Clean(existing.Path) != filepath.Clean(path) {
+			return fmt.Errorf("%w: value-log file id %d already names %q, not %q", rootpublication.ErrResourceConflict, id, existing.Path, path)
+		}
+		openInfo, openErr := existing.File.Stat()
+		pathInfo, pathErr := os.Stat(path)
+		if openErr != nil || pathErr != nil {
+			return errors.Join(openErr, pathErr)
+		}
+		if !os.SameFile(openInfo, pathInfo) {
+			return fmt.Errorf("%w: value-log file id %d path was rebound", rootpublication.ErrResourceConflict, id)
+		}
 		return nil
 	}
 	f, err := currentOpenSegmentFile()(path, id, m.dictLookup, m.templateLookup, m.templateDecodeOpts, m.templateDefCache)
@@ -1627,6 +1654,10 @@ func (m *Manager) registerSegmentLocked(path string, id uint32) error {
 	f.setGroupedFrameCacheMaxBytes(m.groupedFrameCacheMaxBytes)
 	f.setGroupedFrameCacheEntries(m.groupedFrameCacheEntries)
 	f.setGroupedFrameCacheMaxRawBytes(m.groupedFrameCacheMaxRaw)
+	if err := m.observeStableFileLocked(f); err != nil {
+		_ = f.Close()
+		return err
+	}
 	m.files[id] = f
 	return nil
 }
@@ -1942,33 +1973,8 @@ func (m *Manager) Release(set *Set) error {
 	for _, f := range set.Files {
 		newRef := f.RefCount.Add(-1)
 		if newRef == 0 && f.IsZombie.Load() {
-			shouldRemove := false
-			m.mu.Lock()
-			if f.RefCount.Load() == 0 {
-				if cur, exists := m.files[f.ID]; exists && cur == f {
-					shouldRemove = true
-				}
-			}
-			m.mu.Unlock()
-			if shouldRemove {
-				if e := f.Close(); e != nil {
-					err = e
-				}
-				if e := removeSegmentFileWithRetry(f.Path); e != nil {
-					if isWindowsSharingViolationError(e) {
-						if f.retryDeletePending.CompareAndSwap(false, true) {
-							go m.retryZombieDelete(f)
-						}
-						continue
-					}
-					err = e
-					continue
-				}
-				m.mu.Lock()
-				if cur, exists := m.files[f.ID]; exists && cur == f && f.RefCount.Load() == 0 && f.IsZombie.Load() {
-					delete(m.files, f.ID)
-				}
-				m.mu.Unlock()
+			if e := m.deleteZombieFile(f); e != nil {
+				err = errors.Join(err, e)
 			}
 		}
 	}
@@ -1990,18 +1996,48 @@ func (m *Manager) retryZombieDelete(f *File) {
 		if !keepRetrying {
 			return
 		}
+		lease, leaseErr := m.stableDeleteLease(f)
+		if errors.Is(leaseErr, ErrFilePinned) {
+			// The conflict can be either an identity pin or a different identity
+			// holding the pathname lease. Backoff handles both without spinning on
+			// an already-ready per-identity pin channel.
+			time.Sleep(backoff)
+			if backoff < 2*time.Second {
+				backoff *= 2
+			}
+			continue
+		}
+		if leaseErr != nil {
+			log.Printf("valuelog: retry zombie delete gate failed for %s: %v", f.Path, leaseErr)
+			return
+		}
+		if lease != nil {
+			if err := validateStableDeletePathIdentity(f.Path, f.stableIdentity); err != nil {
+				abortStableDeleteLease(lease)
+				log.Printf("valuelog: retry zombie delete path validation failed for %s: %v", f.Path, err)
+				return
+			}
+		}
 
-		if err := removeSegmentFileOnce(f.Path); err == nil {
+		deleted, removeErr := closeAndRemoveStableSegmentFileResult(f, lease != nil)
+		if deleted {
+			commitStableDeleteLease(lease)
 			m.mu.Lock()
 			if cur, exists := m.files[f.ID]; exists && cur == f && f.RefCount.Load() == 0 && f.IsZombie.Load() {
 				delete(m.files, f.ID)
+				_ = m.unobserveStableFileLocked(f)
 			}
 			m.mu.Unlock()
+			if removeErr != nil {
+				log.Printf("valuelog: removed retired zombie %s after close error: %v", f.Path, removeErr)
+			}
 			return
-		} else if !isWindowsSharingViolationError(err) {
-			log.Printf("valuelog: retry zombie delete failed for %s: %v", f.Path, err)
+		} else if !isWindowsSharingViolationError(removeErr) {
+			abortStableDeleteLease(lease)
+			log.Printf("valuelog: retry zombie delete failed for %s: %v", f.Path, removeErr)
 			return
 		}
+		abortStableDeleteLease(lease)
 
 		time.Sleep(backoff)
 		if backoff < 2*time.Second {
@@ -2052,8 +2088,9 @@ func (m *Manager) EvictSegment(id uint32) error {
 		return &filePinnedError{id: id, op: "evict"}
 	}
 	delete(m.files, id)
+	unobserveErr := m.unobserveStableFileLocked(f)
 	m.mu.Unlock()
-	return f.Close()
+	return errors.Join(unobserveErr, f.Close())
 }
 
 // RemapStats reports aggregate remap executions and tracked dead mappings.
@@ -2407,10 +2444,25 @@ func (m *Manager) RemoveSegment(id uint32) error {
 		m.mu.Unlock()
 		return &filePinnedError{id: id, op: "remove"}
 	}
+	lease, err := m.stableDeleteLease(f)
+	if err != nil {
+		m.mu.Unlock()
+		return err
+	}
+	if lease != nil {
+		if err := validateStableDeletePath(f); err != nil {
+			abortStableDeleteLease(lease)
+			m.mu.Unlock()
+			return err
+		}
+	}
 	delete(m.files, id)
+	unobserveErr := m.unobserveStableFileLocked(f)
 	m.mu.Unlock()
 
-	return closeAndRemoveSegmentFile(f)
+	deleted, removeErr := closeAndRemoveStableSegmentFileResult(f, lease != nil)
+	finishStableDeleteLease(lease, deleted)
+	return errors.Join(unobserveErr, removeErr)
 }
 
 // RemoveSegmentIfUnpinned removes a tracked segment only when no live snapshot
@@ -2430,10 +2482,32 @@ func (m *Manager) RemoveSegmentIfUnpinned(id uint32) (bool, error) {
 		m.mu.Unlock()
 		return false, nil
 	}
+	lease, err := m.stableDeleteLease(f)
+	if errors.Is(err, ErrFilePinned) {
+		m.mu.Unlock()
+		if f.IsZombie.Load() && f.retryDeletePending.CompareAndSwap(false, true) {
+			go m.retryZombieDelete(f)
+		}
+		return false, nil
+	}
+	if err != nil {
+		m.mu.Unlock()
+		return false, err
+	}
+	if lease != nil {
+		if err := validateStableDeletePath(f); err != nil {
+			abortStableDeleteLease(lease)
+			m.mu.Unlock()
+			return false, err
+		}
+	}
 	delete(m.files, id)
+	unobserveErr := m.unobserveStableFileLocked(f)
 	m.mu.Unlock()
 
-	return true, closeAndRemoveSegmentFile(f)
+	deleted, removeErr := closeAndRemoveStableSegmentFileResult(f, lease != nil)
+	finishStableDeleteLease(lease, deleted)
+	return true, errors.Join(unobserveErr, removeErr)
 }
 
 // RemoveSegmentForce removes a segment without refcount checks.
@@ -2445,20 +2519,28 @@ func (m *Manager) RemoveSegmentForce(id uint32) error {
 		m.mu.Unlock()
 		return nil
 	}
+	lease, err := m.stableDeleteLease(f)
+	if err != nil {
+		m.mu.Unlock()
+		return err
+	}
+	if lease != nil {
+		if err := validateStableDeletePath(f); err != nil {
+			abortStableDeleteLease(lease)
+			m.mu.Unlock()
+			return err
+		}
+	}
 	delete(m.files, id)
+	unobserveErr := m.unobserveStableFileLocked(f)
 	m.mu.Unlock()
 
-	return closeAndRemoveSegmentFile(f)
+	deleted, removeErr := closeAndRemoveStableSegmentFileResult(f, lease != nil)
+	finishStableDeleteLease(lease, deleted)
+	return errors.Join(unobserveErr, removeErr)
 }
 
 var removeSegmentPath = os.Remove
-
-func closeAndRemoveSegmentFile(f *File) error {
-	if f == nil {
-		return nil
-	}
-	return errors.Join(f.Close(), removeSegmentFileWithRetry(f.Path))
-}
 
 func removeSegmentFileOnce(path string) error {
 	err := removeSegmentPath(path)
@@ -2486,6 +2568,36 @@ func removeSegmentFileWithRetry(path string) error {
 			break
 		}
 		if !isWindowsSharingViolationError(err) {
+			break
+		}
+		time.Sleep(backoff)
+		if backoff < 200*time.Millisecond {
+			backoff *= 2
+		}
+	}
+	return lastErr
+}
+
+func removeSegmentFileOnceStable(path string, identity rootpublication.StableIdentity, stable bool) error {
+	if stable {
+		if err := validateStableDeletePathIdentity(path, identity); err != nil {
+			return err
+		}
+	}
+	return removeSegmentFileOnce(path)
+}
+
+func removeSegmentFileWithRetryStable(path string, identity rootpublication.StableIdentity) error {
+	const attempts = 40
+	backoff := 25 * time.Millisecond
+	var lastErr error
+	for i := 0; i < attempts; i++ {
+		err := removeSegmentFileOnceStable(path, identity, true)
+		if err == nil {
+			return nil
+		}
+		lastErr = err
+		if runtime.GOOS != "windows" || i >= attempts-1 || !isWindowsSharingViolationError(err) {
 			break
 		}
 		time.Sleep(backoff)

--- a/TreeDB/internal/valuelog/namespace_instrumentation_test.go
+++ b/TreeDB/internal/valuelog/namespace_instrumentation_test.go
@@ -25,8 +25,12 @@ func TestRemoveSegmentFileOnceEmitsUnlink(t *testing.T) {
 	})
 	defer restore()
 
-	if err := removeSegmentFileOnce(path); err != nil {
+	removed, err := removeSegmentFileOnce(path)
+	if err != nil {
 		t.Fatalf("removeSegmentFileOnce: %v", err)
+	}
+	if !removed {
+		t.Fatal("removeSegmentFileOnce reported no removal")
 	}
 	want := []durabilitycut.Event{{
 		Resource:  durabilitycut.ResourceValueLog,

--- a/TreeDB/internal/valuelog/segment_open_other.go
+++ b/TreeDB/internal/valuelog/segment_open_other.go
@@ -1,0 +1,9 @@
+//go:build !windows
+
+package valuelog
+
+import "os"
+
+func openSegmentReadHandle(path string) (*os.File, error) {
+	return os.Open(path)
+}

--- a/TreeDB/internal/valuelog/segment_open_windows.go
+++ b/TreeDB/internal/valuelog/segment_open_windows.go
@@ -1,0 +1,39 @@
+//go:build windows
+
+package valuelog
+
+import (
+	"errors"
+	"os"
+
+	"golang.org/x/sys/windows"
+)
+
+// openSegmentReadHandle allows another manager to quarantine a sealed segment
+// while this read handle remains open. Identity leases still decide whether the
+// rename is permitted; FILE_SHARE_DELETE only removes the Windows pathname
+// restriction after that decision has been made.
+func openSegmentReadHandle(path string) (*os.File, error) {
+	pathp, err := windows.UTF16PtrFromString(path)
+	if err != nil {
+		return nil, &os.PathError{Op: "open", Path: path, Err: err}
+	}
+	handle, err := windows.CreateFile(
+		pathp,
+		windows.GENERIC_READ,
+		windows.FILE_SHARE_READ|windows.FILE_SHARE_WRITE|windows.FILE_SHARE_DELETE,
+		nil,
+		windows.OPEN_EXISTING,
+		windows.FILE_ATTRIBUTE_NORMAL,
+		0,
+	)
+	if err != nil {
+		return nil, &os.PathError{Op: "open", Path: path, Err: err}
+	}
+	file := os.NewFile(uintptr(handle), path)
+	if file == nil {
+		_ = windows.CloseHandle(handle)
+		return nil, &os.PathError{Op: "open", Path: path, Err: errors.New("invalid Windows file handle")}
+	}
+	return file, nil
+}

--- a/TreeDB/internal/valuelog/segment_open_windows_test.go
+++ b/TreeDB/internal/valuelog/segment_open_windows_test.go
@@ -1,0 +1,44 @@
+//go:build windows
+
+package valuelog
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestOpenSegmentReadHandleAllowsQuarantineRename(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "value-l0-000001.log")
+	if err := os.WriteFile(path, []byte("sealed segment"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	first, err := openSegmentReadHandle(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer first.Close()
+	second, err := openSegmentReadHandle(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer second.Close()
+
+	quarantine := filepath.Join(dir, ".value-l0-000001.log.delete-test")
+	if err := os.Rename(path, quarantine); err != nil {
+		t.Fatalf("rename with manager read handles open: %v", err)
+	}
+	if _, err := os.Stat(path); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("canonical path stat after rename = %v, want not exist", err)
+	}
+	buf := make([]byte, len("sealed segment"))
+	if _, err := first.ReadAt(buf, 0); err != nil {
+		t.Fatalf("read through renamed segment handle: %v", err)
+	}
+	if string(buf) != "sealed segment" {
+		t.Fatalf("read through renamed segment = %q", buf)
+	}
+}

--- a/TreeDB/internal/valuelog/stable_resource.go
+++ b/TreeDB/internal/valuelog/stable_resource.go
@@ -14,6 +14,297 @@ import (
 var newValueLogStableNamespaceToken = rootpublication.NewStableNamespaceToken
 var openStableValueLogParent = os.Open
 
+// SetStableResourcePinRegistry installs the DB-scoped physical identity gate
+// used by every manager that can delete these segment files.
+func (m *Manager) SetStableResourcePinRegistry(registry *rootpublication.IdentityPinRegistry) error {
+	if m == nil || registry == nil {
+		return errors.New("valuelog: nil stable resource pin registry")
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.stableResourcePins != nil && m.stableResourcePins != registry {
+		return errors.New("valuelog: stable resource pin registry already installed")
+	}
+	if m.stableResourcePins == registry {
+		return nil
+	}
+	observed := make([]*File, 0, len(m.files))
+	for _, file := range m.files {
+		if err := m.observeStableFileWithRegistryLocked(file, registry); err != nil {
+			for _, prior := range observed {
+				_ = registry.Unobserve(prior.stableIdentity)
+				prior.stableObserved = false
+			}
+			return err
+		}
+		observed = append(observed, file)
+	}
+	m.stableResourcePins = registry
+	return nil
+}
+
+// StableResourcePinRegistry returns the deletion gate installed before this
+// manager's files became eligible for removal.
+func (m *Manager) StableResourcePinRegistry() *rootpublication.IdentityPinRegistry {
+	if m == nil {
+		return nil
+	}
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	return m.stableResourcePins
+}
+
+// StableSegmentIdentity returns the immutable physical identity captured when
+// the manager opened fileID. Callers can carry it across an intentional evict
+// and reject a pathname replacement before fallback cleanup.
+func (m *Manager) StableSegmentIdentity(fileID uint32) (rootpublication.StableIdentity, bool) {
+	if m == nil {
+		return rootpublication.StableIdentity{}, false
+	}
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	file := m.files[fileID]
+	if file == nil || file.stableIdentity == (rootpublication.StableIdentity{}) {
+		return rootpublication.StableIdentity{}, false
+	}
+	return file.stableIdentity, true
+}
+
+// StableResourceToken captures a checked token from a manager-owned exact
+// handle while holding the manager read lock. The registry is supplied by the
+// manager and cannot be omitted or substituted by the caller.
+func (m *Manager) StableResourceToken(fileID uint32, registration StableResourceRegistration) (*rootpublication.StableResourceToken, error) {
+	if m == nil {
+		return nil, errors.New("valuelog: nil manager")
+	}
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	file := m.files[fileID]
+	if file == nil {
+		return nil, &fileNotFoundError{id: fileID}
+	}
+	if m.stableResourcePins == nil {
+		return nil, fmt.Errorf("%w: manager has no stable identity registry", rootpublication.ErrUnresolvedResource)
+	}
+	registration.PinRegistry = m.stableResourcePins
+	namespace, err := stableValueLogNamespaceToken(file.File, registration)
+	if err != nil {
+		return nil, err
+	}
+	defer namespace.Release()
+	return stableValueLogResourceToken(file.File, fileID, registration, namespace, false)
+}
+
+func (m *Manager) observeStableFileLocked(file *File) error {
+	if m == nil || m.stableResourcePins == nil {
+		return nil
+	}
+	return m.observeStableFileWithRegistryLocked(file, m.stableResourcePins)
+}
+
+func (m *Manager) observeStableFileWithRegistryLocked(file *File, registry *rootpublication.IdentityPinRegistry) error {
+	if file == nil || registry == nil || file.stableObserved {
+		return nil
+	}
+	identity, err := rootpublication.StableIdentityFromFile(file.File)
+	if err != nil {
+		return err
+	}
+	if err := registry.Observe(identity); err != nil {
+		return err
+	}
+	namespace, err := stableDeleteNamespace(file.Path)
+	if err != nil {
+		_ = registry.Unobserve(identity)
+		return err
+	}
+	file.stableIdentity = identity
+	file.stableNamespace = namespace
+	file.stableObserved = true
+	return nil
+}
+
+func (m *Manager) unobserveStableFileLocked(file *File) error {
+	if m == nil || m.stableResourcePins == nil || file == nil || !file.stableObserved {
+		return nil
+	}
+	file.stableObserved = false
+	return m.stableResourcePins.Unobserve(file.stableIdentity)
+}
+
+func (m *Manager) stableDeleteLease(file *File) (*rootpublication.IdentityDeleteLease, error) {
+	if m == nil || file == nil || m.stableResourcePins == nil {
+		return nil, nil
+	}
+	identity := file.stableIdentity
+	if identity == (rootpublication.StableIdentity{}) {
+		var err error
+		identity, err = rootpublication.StableIdentityFromFile(file.File)
+		if err != nil {
+			return nil, err
+		}
+	}
+	namespace := file.stableNamespace
+	if namespace == "" {
+		var err error
+		namespace, err = stableDeleteNamespace(file.Path)
+		if err != nil {
+			return nil, err
+		}
+	}
+	lease, err := m.stableResourcePins.BeginDeleteAt(identity, namespace)
+	if errors.Is(err, rootpublication.ErrResourcePinned) {
+		return nil, &filePinnedError{id: file.ID, op: "delete stable resource"}
+	}
+	return lease, err
+}
+
+func stableDeleteNamespace(path string) (string, error) {
+	if path == "" {
+		return "", fmt.Errorf("%w: empty value-log path", rootpublication.ErrUnresolvedResource)
+	}
+	parent, err := os.Open(filepath.Dir(path))
+	if err != nil {
+		return "", err
+	}
+	defer parent.Close()
+	identity, err := rootpublication.StableIdentityFromFile(parent)
+	if err != nil {
+		return "", err
+	}
+	return fmt.Sprintf("%s:%d:%x/%s", identity.Platform, identity.VolumeID, identity.ObjectID, filepath.Base(path)), nil
+}
+
+func validateStableDeletePath(file *File) error {
+	if file == nil || file.File == nil || file.Path == "" {
+		return fmt.Errorf("%w: invalid value-log delete target", rootpublication.ErrUnresolvedResource)
+	}
+	identity := file.stableIdentity
+	if identity == (rootpublication.StableIdentity{}) {
+		var err error
+		identity, err = rootpublication.StableIdentityFromFile(file.File)
+		if err != nil {
+			return err
+		}
+	}
+	return validateStableDeletePathIdentity(file.Path, identity)
+}
+
+func validateStableDeletePathIdentity(path string, identity rootpublication.StableIdentity) error {
+	linked, err := os.Open(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return err
+	}
+	defer linked.Close()
+	linkedIdentity, err := rootpublication.StableIdentityFromFile(linked)
+	if err != nil {
+		return err
+	}
+	if !rootpublication.SamePhysicalIdentity(identity, linkedIdentity) {
+		return fmt.Errorf("%w: value-log path no longer names captured identity", rootpublication.ErrResourceConflict)
+	}
+	return nil
+}
+
+func abortStableDeleteLease(lease *rootpublication.IdentityDeleteLease) {
+	if lease != nil {
+		lease.Abort()
+	}
+}
+
+func commitStableDeleteLease(lease *rootpublication.IdentityDeleteLease) {
+	if lease != nil {
+		lease.Commit()
+	}
+}
+
+func finishStableDeleteLease(lease *rootpublication.IdentityDeleteLease, deleted bool) {
+	if deleted {
+		commitStableDeleteLease(lease)
+	} else {
+		abortStableDeleteLease(lease)
+	}
+}
+
+// closeAndRemoveStableSegmentFileResult closes the manager's own handle before
+// unlink (required on Windows), then revalidates that the path still names the
+// identity captured before close. The registry lease excludes process-local
+// pin and delete races across this boundary.
+func closeAndRemoveStableSegmentFileResult(file *File, validateIdentity bool) (bool, error) {
+	if file == nil {
+		return true, nil
+	}
+	identity := file.stableIdentity
+	if validateIdentity && identity == (rootpublication.StableIdentity{}) {
+		var err error
+		identity, err = rootpublication.StableIdentityFromFile(file.File)
+		if err != nil {
+			return false, err
+		}
+	}
+	closeErr := file.Close()
+	var removeErr error
+	if validateIdentity {
+		removeErr = removeSegmentFileWithRetryStable(file.Path, identity)
+	} else {
+		removeErr = removeSegmentFileWithRetry(file.Path)
+	}
+	return removeErr == nil, errors.Join(closeErr, removeErr)
+}
+
+func (m *Manager) deleteZombieFile(file *File) error {
+	if m == nil || file == nil {
+		return nil
+	}
+	m.mu.Lock()
+	current, exists := m.files[file.ID]
+	if !exists || current != file || file.RefCount.Load() != 0 || !file.IsZombie.Load() {
+		m.mu.Unlock()
+		return nil
+	}
+	lease, err := m.stableDeleteLease(file)
+	if errors.Is(err, ErrFilePinned) {
+		m.mu.Unlock()
+		if file.retryDeletePending.CompareAndSwap(false, true) {
+			go m.retryZombieDelete(file)
+		}
+		return nil
+	}
+	if err != nil {
+		m.mu.Unlock()
+		return err
+	}
+	if lease != nil {
+		if err := validateStableDeletePath(file); err != nil {
+			abortStableDeleteLease(lease)
+			m.mu.Unlock()
+			return err
+		}
+	}
+	m.mu.Unlock()
+
+	deleted, unlinkErr := closeAndRemoveStableSegmentFileResult(file, lease != nil)
+	if !deleted {
+		abortStableDeleteLease(lease)
+		if isWindowsSharingViolationError(unlinkErr) && file.retryDeletePending.CompareAndSwap(false, true) {
+			go m.retryZombieDelete(file)
+			return nil
+		}
+		return unlinkErr
+	}
+	commitStableDeleteLease(lease)
+	m.mu.Lock()
+	if current, exists := m.files[file.ID]; exists && current == file && file.RefCount.Load() == 0 && file.IsZombie.Load() {
+		delete(m.files, file.ID)
+		_ = m.unobserveStableFileLocked(file)
+	}
+	m.mu.Unlock()
+	return unlinkErr
+}
+
 func captureStableValueLogParent(path string, resource *os.File) (*os.File, error) {
 	parent, err := openStableValueLogParent(filepath.Dir(path))
 	if err != nil {
@@ -65,6 +356,7 @@ type StableResourceRegistration struct {
 	OldName            string
 	NewName            string
 	NamespaceParent    *os.File
+	PinRegistry        *rootpublication.IdentityPinRegistry
 }
 
 // StableResourceRotation retains exact handles for the segment closed by a
@@ -147,7 +439,7 @@ func stableValueLogResourceToken(file *os.File, fileID uint32, registration Stab
 		ResourceID: strconv.FormatUint(uint64(fileID), 10), Generation: registration.Generation,
 		DiagnosticPath: registration.DiagnosticPath, File: file, Frontier: frontier,
 		Digest: registration.Digest, Reachability: registration.Reachability, Namespace: namespace,
-		ContentSynced: contentSynced,
+		ContentSynced: contentSynced, PinRegistry: registration.PinRegistry,
 	}
 	switch domain {
 	case rootpublication.StableProducerValueLog:

--- a/TreeDB/internal/valuelog/stable_resource.go
+++ b/TreeDB/internal/valuelog/stable_resource.go
@@ -1,11 +1,14 @@
 package valuelog
 
 import (
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strconv"
+	"strings"
 
 	"github.com/snissn/gomap/TreeDB/internal/durabilitycut"
 	"github.com/snissn/gomap/TreeDB/internal/rootpublication"
@@ -313,6 +316,130 @@ func closeAndRemoveStableSegmentFileResult(file *File, validateIdentity bool) (b
 	return removed, errors.Join(closeErr, removeErr)
 }
 
+const stableDeleteQuarantineMarker = ".delete-"
+
+func stableDeleteQuarantinePaths(path string, identity rootpublication.StableIdentity) (string, string, error) {
+	base := filepath.Base(path)
+	if path == "" || base == "." || base == string(filepath.Separator) || identity.Platform == "" || identity.ObjectID == [16]byte{} {
+		return "", "", fmt.Errorf("%w: invalid stable delete quarantine intent", rootpublication.ErrUnresolvedResource)
+	}
+	name := fmt.Sprintf(".%s%s%016x-%032x", base, stableDeleteQuarantineMarker, identity.VolumeID, identity.ObjectID)
+	dir := filepath.Join(filepath.Dir(path), name)
+	return dir, filepath.Join(dir, base), nil
+}
+
+func parseStableDeleteQuarantineName(name string) (string, rootpublication.StableIdentity, bool) {
+	marker := strings.LastIndex(name, stableDeleteQuarantineMarker)
+	if !strings.HasPrefix(name, ".") || marker <= 1 {
+		return "", rootpublication.StableIdentity{}, false
+	}
+	base := name[1:marker]
+	encoded := name[marker+len(stableDeleteQuarantineMarker):]
+	if filepath.Base(base) != base || len(encoded) != 49 || encoded[16] != '-' {
+		return "", rootpublication.StableIdentity{}, false
+	}
+	volumeID, err := strconv.ParseUint(encoded[:16], 16, 64)
+	if err != nil {
+		return "", rootpublication.StableIdentity{}, false
+	}
+	objectBytes, err := hex.DecodeString(encoded[17:])
+	if err != nil || len(objectBytes) != 16 {
+		return "", rootpublication.StableIdentity{}, false
+	}
+	var objectID [16]byte
+	copy(objectID[:], objectBytes)
+	if objectID == [16]byte{} {
+		return "", rootpublication.StableIdentity{}, false
+	}
+	return base, rootpublication.StableIdentity{Platform: runtime.GOOS, VolumeID: volumeID, ObjectID: objectID}, true
+}
+
+func stableIdentityAtPath(path string) (rootpublication.StableIdentity, error) {
+	file, err := os.Open(path)
+	if err != nil {
+		return rootpublication.StableIdentity{}, err
+	}
+	defer file.Close()
+	return rootpublication.StableIdentityFromFile(file)
+}
+
+// recoverStableDeleteQuarantines reconciles deterministic same-parent delete
+// intents before the manager exposes any segment from that directory. A
+// matching quarantined inode is the delete target and can be finished. An
+// unexpected inode is conservatively restored when the canonical name is
+// absent, while ambiguous two-inode states fail closed.
+func recoverStableDeleteQuarantines(parent string) error {
+	entries, err := os.ReadDir(parent)
+	if os.IsNotExist(err) {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+	for _, entry := range entries {
+		base, expected, ok := parseStableDeleteQuarantineName(entry.Name())
+		if !ok || !entry.IsDir() {
+			continue
+		}
+		if _, err := recoverStableDeleteQuarantine(parent, entry.Name(), base, expected); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func recoverStableDeleteQuarantine(parent, quarantineName, base string, expected rootpublication.StableIdentity) (bool, error) {
+	quarantineDir := filepath.Join(parent, quarantineName)
+	entries, err := os.ReadDir(quarantineDir)
+	if os.IsNotExist(err) {
+		return false, nil
+	}
+	if err != nil {
+		return false, err
+	}
+	if len(entries) == 0 {
+		return false, os.Remove(quarantineDir)
+	}
+	if len(entries) != 1 || entries[0].Name() != base || entries[0].IsDir() {
+		return false, fmt.Errorf("%w: stable delete quarantine %q contains unexpected entries", rootpublication.ErrResourceConflict, quarantineDir)
+	}
+	quarantinePath := filepath.Join(quarantineDir, base)
+	quarantinedIdentity, err := stableIdentityAtPath(quarantinePath)
+	if err != nil {
+		return false, err
+	}
+	originalPath := filepath.Join(parent, base)
+	originalIdentity, originalErr := stableIdentityAtPath(originalPath)
+	originalExists := originalErr == nil
+	if originalErr != nil && !os.IsNotExist(originalErr) {
+		return false, originalErr
+	}
+
+	if rootpublication.SamePhysicalIdentity(quarantinedIdentity, expected) {
+		if err := os.Remove(quarantinePath); err != nil && !os.IsNotExist(err) {
+			return false, err
+		}
+		if err := os.Remove(quarantineDir); err != nil && !os.IsNotExist(err) {
+			return false, err
+		}
+		// If originalExists names the same inode, this merely removes a partial
+		// rollback hard link. If it names a replacement, the replacement remains.
+		completed := !originalExists || !rootpublication.SamePhysicalIdentity(originalIdentity, quarantinedIdentity)
+		return completed, nil
+	}
+
+	if originalExists {
+		return false, fmt.Errorf("%w: stable delete quarantine %q and canonical path %q name different unexpected identities", rootpublication.ErrResourceConflict, quarantinePath, originalPath)
+	}
+	if err := os.Rename(quarantinePath, originalPath); err != nil {
+		return false, err
+	}
+	if err := durabilitycut.EmitNamespace(durabilitycut.NamespaceCreate, segmentNamespaceResource(originalPath), parent, "", originalPath); err != nil {
+		return false, err
+	}
+	return false, os.Remove(quarantineDir)
+}
+
 // removeStableSegmentFileOnce first moves the linked name into a private
 // same-directory quarantine and records that completed canonical-name unlink.
 // It then validates and unlinks the renamed object. A replacement created at
@@ -320,11 +447,34 @@ func closeAndRemoveStableSegmentFileResult(file *File, validateIdentity bool) (b
 func removeStableSegmentFileOnce(path string, identity rootpublication.StableIdentity) (bool, error) {
 	parent := filepath.Dir(path)
 	resource := segmentNamespaceResource(path)
-	quarantineDir, err := os.MkdirTemp(parent, "."+filepath.Base(path)+".delete-")
+	quarantineDir, quarantinePath, err := stableDeleteQuarantinePaths(path, identity)
 	if err != nil {
 		return false, err
 	}
-	quarantinePath := filepath.Join(quarantineDir, filepath.Base(path))
+	if err := os.Mkdir(quarantineDir, 0o700); err != nil {
+		if !os.IsExist(err) {
+			return false, err
+		}
+		base, expected, ok := parseStableDeleteQuarantineName(filepath.Base(quarantineDir))
+		if !ok {
+			return false, fmt.Errorf("%w: invalid existing stable delete quarantine %q", rootpublication.ErrResourceConflict, quarantineDir)
+		}
+		completed, err := recoverStableDeleteQuarantine(parent, filepath.Base(quarantineDir), base, expected)
+		if err != nil {
+			return false, err
+		}
+		if completed {
+			return true, nil
+		}
+		if _, err := os.Stat(path); os.IsNotExist(err) {
+			return true, nil
+		} else if err != nil {
+			return false, err
+		}
+		if err := os.Mkdir(quarantineDir, 0o700); err != nil {
+			return false, err
+		}
+	}
 	if err := os.Rename(path, quarantinePath); err != nil {
 		_ = os.Remove(quarantineDir)
 		if os.IsNotExist(err) {

--- a/TreeDB/internal/valuelog/stable_resource.go
+++ b/TreeDB/internal/valuelog/stable_resource.go
@@ -14,6 +14,63 @@ import (
 var newValueLogStableNamespaceToken = rootpublication.NewStableNamespaceToken
 var openStableValueLogParent = os.Open
 
+func observeStableWriterFile(file *os.File, registry *rootpublication.IdentityPinRegistry) (rootpublication.StableIdentity, error) {
+	if registry == nil {
+		return rootpublication.StableIdentity{}, nil
+	}
+	identity, err := rootpublication.StableIdentityFromFile(file)
+	if err != nil {
+		return rootpublication.StableIdentity{}, err
+	}
+	if err := registry.Observe(identity); err != nil {
+		return rootpublication.StableIdentity{}, err
+	}
+	return identity, nil
+}
+
+func (w *Writer) observeStableResourceFile(file *os.File, registry *rootpublication.IdentityPinRegistry) error {
+	if w == nil || registry == nil {
+		return nil
+	}
+	identity, err := observeStableWriterFile(file, registry)
+	if err != nil {
+		return err
+	}
+	w.stableResourcePins = registry
+	w.stableResourceIdentity = identity
+	w.stableResourceObserved = true
+	return nil
+}
+
+func (w *Writer) releaseStableResourceObservation() error {
+	if w == nil || !w.stableResourceObserved || w.stableResourcePins == nil {
+		return nil
+	}
+	err := w.stableResourcePins.Unobserve(w.stableResourceIdentity)
+	w.stableResourceIdentity = rootpublication.StableIdentity{}
+	w.stableResourceObserved = false
+	return err
+}
+
+func (w *Writer) bindStableResourcePinRegistry(registration *StableResourceRegistration) error {
+	if w == nil || registration == nil {
+		return nil
+	}
+	if registration.PinRegistry != nil {
+		if w.stableResourcePins == nil || !w.stableResourceObserved {
+			return fmt.Errorf("%w: writer registry must be installed before the file becomes deletable", rootpublication.ErrUnresolvedResource)
+		}
+		if registration.PinRegistry != w.stableResourcePins {
+			return fmt.Errorf("%w: writer stable identity registry differs from registration", rootpublication.ErrResourceConflict)
+		}
+		return nil
+	}
+	if w.stableResourcePins != nil {
+		registration.PinRegistry = w.stableResourcePins
+	}
+	return nil
+}
+
 // SetStableResourcePinRegistry installs the DB-scoped physical identity gate
 // used by every manager that can delete these segment files.
 func (m *Manager) SetStableResourcePinRegistry(registry *rootpublication.IdentityPinRegistry) error {
@@ -257,11 +314,12 @@ func closeAndRemoveStableSegmentFileResult(file *File, validateIdentity bool) (b
 }
 
 // removeStableSegmentFileOnce first moves the linked name into a private
-// same-directory quarantine, then validates and unlinks that renamed object.
-// A replacement created at the original name after the rename is never passed
-// to the unlink syscall.
+// same-directory quarantine and records that completed canonical-name unlink.
+// It then validates and unlinks the renamed object. A replacement created at
+// the original name after the rename is never passed to the unlink syscall.
 func removeStableSegmentFileOnce(path string, identity rootpublication.StableIdentity) (bool, error) {
 	parent := filepath.Dir(path)
+	resource := segmentNamespaceResource(path)
 	quarantineDir, err := os.MkdirTemp(parent, "."+filepath.Base(path)+".delete-")
 	if err != nil {
 		return false, err
@@ -274,11 +332,19 @@ func removeStableSegmentFileOnce(path string, identity rootpublication.StableIde
 		}
 		return false, err
 	}
+	if err := durabilitycut.EmitNamespace(durabilitycut.NamespaceUnlink, resource, parent, path, ""); err != nil {
+		// The canonical name is already gone. Commit the identity deletion even
+		// though the injected cut deliberately leaves the private inode behind.
+		return true, err
+	}
 	restore := func() error {
 		if err := os.Link(quarantinePath, path); err != nil {
 			return err
 		}
-		return os.Remove(quarantinePath)
+		if err := os.Remove(quarantinePath); err != nil {
+			return err
+		}
+		return durabilitycut.EmitNamespace(durabilitycut.NamespaceCreate, resource, parent, "", path)
 	}
 	if err := validateStableDeletePathIdentity(quarantinePath, identity); err != nil {
 		restoreErr := restore()
@@ -296,8 +362,7 @@ func removeStableSegmentFileOnce(path string, identity rootpublication.StableIde
 		return false, removeErr
 	}
 	cleanupErr := os.Remove(quarantineDir)
-	cutErr := durabilitycut.EmitNamespace(durabilitycut.NamespaceUnlink, segmentNamespaceResource(path), parent, path, "")
-	return true, errors.Join(cleanupErr, cutErr)
+	return true, cleanupErr
 }
 
 func (m *Manager) deleteZombieFile(file *File) error {
@@ -447,6 +512,9 @@ func (w *Writer) StableResourceToken(registration StableResourceRegistration) (*
 	if w == nil || w.f == nil {
 		return nil, errors.New("valuelog: stable resource requires file-backed writer")
 	}
+	if err := w.bindStableResourcePinRegistry(&registration); err != nil {
+		return nil, err
+	}
 	if err := w.Flush(); err != nil {
 		return nil, err
 	}
@@ -567,6 +635,12 @@ func (w *Writer) RotateToWithStableResources(path string, fileID uint32, syncCur
 	if active.NamespaceOperation == rootpublication.NamespaceNone {
 		return nil, errors.New("valuelog: stable rotation requires active namespace operation")
 	}
+	if err := w.bindStableResourcePinRegistry(&closed); err != nil {
+		return nil, err
+	}
+	if err := w.bindStableResourcePinRegistry(&active); err != nil {
+		return nil, err
+	}
 	if err := w.Flush(); err != nil {
 		return nil, err
 	}
@@ -591,10 +665,22 @@ func (w *Writer) RotateToWithStableResources(path string, fileID uint32, syncCur
 		closedToken.Release()
 		return nil, err
 	}
+	preparedIdentity, err := observeStableWriterFile(prepared, w.stableResourcePins)
+	if err != nil {
+		closedToken.Release()
+		_ = prepared.Close()
+		_ = rootpublication.RemoveStableChildFile(w.stableParent, filepath.Base(path))
+		_ = w.stableParent.Sync()
+		return nil, err
+	}
+	preparedObserved := w.stableResourcePins != nil
 	installed := false
 	defer func() {
 		if installed {
 			return
+		}
+		if preparedObserved {
+			_ = w.stableResourcePins.Unobserve(preparedIdentity)
 		}
 		validateErr := rootpublication.ValidateStableChildLink(w.stableParent, prepared, filepath.Base(path))
 		closeErr := prepared.Close()
@@ -633,11 +719,19 @@ func (w *Writer) RotateToWithStableResources(path string, fileID uint32, syncCur
 	}
 	old := w.f
 	if err := old.Close(); err != nil {
+		observeErr := w.releaseStableResourceObservation()
 		activeToken.Release()
 		closedToken.Release()
 		w.f = nil
 		w.bw = nil
-		return nil, fmt.Errorf("valuelog: close old writer during stable rotation: %w", err)
+		return nil, fmt.Errorf("valuelog: close old writer during stable rotation: %w", errors.Join(err, observeErr))
+	}
+	if err := w.releaseStableResourceObservation(); err != nil {
+		activeToken.Release()
+		closedToken.Release()
+		w.f = nil
+		w.bw = nil
+		return nil, fmt.Errorf("valuelog: release old writer observation during stable rotation: %w", err)
 	}
 	w.f = prepared
 	w.bw = nil
@@ -646,6 +740,11 @@ func (w *Writer) RotateToWithStableResources(path string, fileID uint32, syncCur
 	w.appendMax = defaultBufferSize
 	w.appendBuf = w.appendBuf[:0]
 	w.trimTransientScratchBuffers()
+	if preparedObserved {
+		w.stableResourceIdentity = preparedIdentity
+		w.stableResourceObserved = true
+		preparedObserved = false
+	}
 	installed = true
 	return &StableResourceRotation{Closed: closedToken, Active: activeToken}, nil
 }

--- a/TreeDB/internal/valuelog/stable_resource.go
+++ b/TreeDB/internal/valuelog/stable_resource.go
@@ -256,6 +256,50 @@ func closeAndRemoveStableSegmentFileResult(file *File, validateIdentity bool) (b
 	return removed, errors.Join(closeErr, removeErr)
 }
 
+// removeStableSegmentFileOnce first moves the linked name into a private
+// same-directory quarantine, then validates and unlinks that renamed object.
+// A replacement created at the original name after the rename is never passed
+// to the unlink syscall.
+func removeStableSegmentFileOnce(path string, identity rootpublication.StableIdentity) (bool, error) {
+	parent := filepath.Dir(path)
+	quarantineDir, err := os.MkdirTemp(parent, "."+filepath.Base(path)+".delete-")
+	if err != nil {
+		return false, err
+	}
+	quarantinePath := filepath.Join(quarantineDir, filepath.Base(path))
+	if err := os.Rename(path, quarantinePath); err != nil {
+		_ = os.Remove(quarantineDir)
+		if os.IsNotExist(err) {
+			return true, nil
+		}
+		return false, err
+	}
+	restore := func() error {
+		if err := os.Link(quarantinePath, path); err != nil {
+			return err
+		}
+		return os.Remove(quarantinePath)
+	}
+	if err := validateStableDeletePathIdentity(quarantinePath, identity); err != nil {
+		restoreErr := restore()
+		if restoreErr == nil {
+			restoreErr = os.Remove(quarantineDir)
+		}
+		return false, errors.Join(err, restoreErr)
+	}
+	removeErr := removeSegmentPath(quarantinePath)
+	if removeErr != nil && !os.IsNotExist(removeErr) {
+		if restoreErr := restore(); restoreErr != nil {
+			return false, fmt.Errorf("%w: stable delete failed (%v) and quarantine restore failed: %v", rootpublication.ErrResourceConflict, removeErr, restoreErr)
+		}
+		_ = os.Remove(quarantineDir)
+		return false, removeErr
+	}
+	cleanupErr := os.Remove(quarantineDir)
+	cutErr := durabilitycut.EmitNamespace(durabilitycut.NamespaceUnlink, durabilitycut.ResourceValueLog, parent, path, "")
+	return true, errors.Join(cleanupErr, cutErr)
+}
+
 func (m *Manager) deleteZombieFile(file *File) error {
 	if m == nil || file == nil {
 		return nil

--- a/TreeDB/internal/valuelog/stable_resource.go
+++ b/TreeDB/internal/valuelog/stable_resource.go
@@ -296,7 +296,7 @@ func removeStableSegmentFileOnce(path string, identity rootpublication.StableIde
 		return false, removeErr
 	}
 	cleanupErr := os.Remove(quarantineDir)
-	cutErr := durabilitycut.EmitNamespace(durabilitycut.NamespaceUnlink, durabilitycut.ResourceValueLog, parent, path, "")
+	cutErr := durabilitycut.EmitNamespace(durabilitycut.NamespaceUnlink, segmentNamespaceResource(path), parent, path, "")
 	return true, errors.Join(cleanupErr, cutErr)
 }
 

--- a/TreeDB/internal/valuelog/stable_resource.go
+++ b/TreeDB/internal/valuelog/stable_resource.go
@@ -388,6 +388,22 @@ func recoverStableDeleteQuarantines(parent string) error {
 	return nil
 }
 
+func requireNoStableDeleteQuarantines(parent string) error {
+	entries, err := os.ReadDir(parent)
+	if os.IsNotExist(err) {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+	for _, entry := range entries {
+		if _, _, ok := parseStableDeleteQuarantineName(entry.Name()); ok && entry.IsDir() {
+			return fmt.Errorf("%w: %w: pending quarantine %q", ErrStableDeleteRecoveryRequired, rootpublication.ErrRecoveryRequired, filepath.Join(parent, entry.Name()))
+		}
+	}
+	return nil
+}
+
 func recoverStableDeleteQuarantine(parent, quarantineName, base string, expected rootpublication.StableIdentity) (bool, error) {
 	quarantineDir := filepath.Join(parent, quarantineName)
 	entries, err := os.ReadDir(quarantineDir)

--- a/TreeDB/internal/valuelog/stable_resource.go
+++ b/TreeDB/internal/valuelog/stable_resource.go
@@ -246,13 +246,14 @@ func closeAndRemoveStableSegmentFileResult(file *File, validateIdentity bool) (b
 		}
 	}
 	closeErr := file.Close()
+	var removed bool
 	var removeErr error
 	if validateIdentity {
-		removeErr = removeSegmentFileWithRetryStable(file.Path, identity)
+		removed, removeErr = removeSegmentFileWithRetryStable(file.Path, identity)
 	} else {
-		removeErr = removeSegmentFileWithRetry(file.Path)
+		removed, removeErr = removeSegmentFileWithRetry(file.Path)
 	}
-	return removeErr == nil, errors.Join(closeErr, removeErr)
+	return removed, errors.Join(closeErr, removeErr)
 }
 
 func (m *Manager) deleteZombieFile(file *File) error {

--- a/TreeDB/internal/valuelog/stable_resource_test.go
+++ b/TreeDB/internal/valuelog/stable_resource_test.go
@@ -290,6 +290,63 @@ func TestRotateToWithStableResourcesRetainsClosedAndActiveIdentities(t *testing.
 	}
 }
 
+func TestRotateToWithStableResourcesOwnsRegistryObservations(t *testing.T) {
+	requireStableValueLogNamespace(t)
+	dir := t.TempDir()
+	registry := rootpublication.NewIdentityPinRegistry()
+	writer, err := NewWriterWithStableResourcePinRegistry(filepath.Join(dir, "000001.vlog"), 1, registry)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := writer.Append(0, nil, 1, []byte("first")); err != nil {
+		t.Fatal(err)
+	}
+	rotation, err := writer.RotateToWithStableResources(filepath.Join(dir, "000002.vlog"), 2, true,
+		StableResourceRegistration{
+			LogicalLane: "main", Generation: 1, DiagnosticPath: "maindb/value_vlog/000001.vlog",
+			Reachability: rootpublication.ReachabilityValueLogPointer, PinRegistry: registry,
+		},
+		StableResourceRegistration{
+			LogicalLane: "main", Generation: 2, DiagnosticPath: "maindb/value_vlog/000002.vlog",
+			Reachability: rootpublication.ReachabilityValueLogPointer, PinRegistry: registry,
+			ParentGeneration: 1, NamespaceOperation: rootpublication.NamespaceCreate,
+		})
+	if err != nil {
+		_ = writer.Close()
+		t.Fatal(err)
+	}
+	if got := registry.ActivePins(); got != 2 {
+		t.Fatalf("rotation active pins=%d want 2", got)
+	}
+	rotation.Release()
+	if got := registry.ActivePins(); got != 0 {
+		t.Fatalf("rotation active pins after release=%d want 0", got)
+	}
+	if err := writer.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if got := registry.ActiveIdentities(); got != 0 {
+		t.Fatalf("writer registry retained %d identities after close", got)
+	}
+}
+
+func TestWriterRejectsLateRegistryInjection(t *testing.T) {
+	dir := t.TempDir()
+	writer, err := NewWriter(filepath.Join(dir, "000001.vlog"), 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer writer.Close()
+	_, err = writer.StableResourceToken(StableResourceRegistration{
+		LogicalLane: "main", Generation: 1, DiagnosticPath: "maindb/value_vlog/000001.vlog",
+		Reachability: rootpublication.ReachabilityValueLogPointer,
+		PinRegistry:  rootpublication.NewIdentityPinRegistry(),
+	})
+	if !errors.Is(err, rootpublication.ErrUnresolvedResource) {
+		t.Fatalf("late registry injection error=%v want ErrUnresolvedResource", err)
+	}
+}
+
 func TestStableValueLogRotationNamespaceFailureKeepsOldWriterActive(t *testing.T) {
 	requireStableValueLogNamespace(t)
 	dir := t.TempDir()

--- a/TreeDB/internal/valuelog/stable_resource_test.go
+++ b/TreeDB/internal/valuelog/stable_resource_test.go
@@ -535,75 +535,90 @@ func TestStableValueLogRegistrationRejectsForeignProducerField(t *testing.T) {
 
 func BenchmarkStableValueLogRotation(b *testing.B) {
 	requireStableValueLogNamespace(b)
-	for _, syncCurrent := range []bool{false, true} {
-		b.Run(fmt.Sprintf("sync_current=%t", syncCurrent), func(b *testing.B) {
-			dir := b.TempDir()
-			writer, err := NewWriter(filepath.Join(dir, "000001.vlog"), 1)
-			if err != nil {
-				b.Fatal(err)
+	for _, withRegistry := range []bool{false, true} {
+		b.Run(fmt.Sprintf("with_registry=%t", withRegistry), func(b *testing.B) {
+			for _, syncCurrent := range []bool{false, true} {
+				b.Run(fmt.Sprintf("sync_current=%t", syncCurrent), func(b *testing.B) {
+					dir := b.TempDir()
+					var registry *rootpublication.IdentityPinRegistry
+					var writer *Writer
+					var err error
+					if withRegistry {
+						registry = rootpublication.NewIdentityPinRegistry()
+						writer, err = NewWriterWithStableResourcePinRegistry(filepath.Join(dir, "000001.vlog"), 1, registry)
+					} else {
+						writer, err = NewWriter(filepath.Join(dir, "000001.vlog"), 1)
+					}
+					if err != nil {
+						b.Fatal(err)
+					}
+					b.Cleanup(func() { _ = writer.Close() })
+					beforeContentSyncs := writer.DurabilityStats().FileSyncCalls
+					var namespaceSyncs uint64
+					b.ReportAllocs()
+					b.ResetTimer()
+					for i := 0; i < b.N; i++ {
+						b.StopTimer()
+						if _, err := writer.Append(0, nil, uint64(i+1), []byte("rotation-benchmark-value")); err != nil {
+							b.Fatal(err)
+						}
+						closedID := writer.FileID()
+						activeID := closedID + 1
+						activeName := fmt.Sprintf("%06d.vlog", activeID)
+						b.StartTimer()
+						rotation, err := writer.RotateToWithStableResources(filepath.Join(dir, activeName), activeID, syncCurrent,
+							StableResourceRegistration{
+								LogicalLane: "main", Generation: uint64(closedID), DiagnosticPath: filepath.Join("maindb", "value_vlog", fmt.Sprintf("%06d.vlog", closedID)),
+								Reachability: rootpublication.ReachabilityValueLogPointer,
+							},
+							StableResourceRegistration{
+								LogicalLane: "main", Generation: uint64(activeID), DiagnosticPath: filepath.Join("maindb", "value_vlog", activeName),
+								Reachability: rootpublication.ReachabilityValueLogPointer, ParentGeneration: uint64(activeID),
+								NamespaceOperation: rootpublication.NamespaceCreate,
+							})
+						b.StopTimer()
+						if err != nil {
+							b.Fatal(err)
+						}
+						builder := rootpublication.NewStableResourceSetBuilder(rootpublication.ReachabilityValueLogPointer)
+						if err := builder.Add(rotation.TakeClosed()); err != nil {
+							rotation.Release()
+							b.Fatal(err)
+						}
+						if err := builder.Add(rotation.TakeActive()); err != nil {
+							rotation.Release()
+							b.Fatal(err)
+						}
+						set, err := builder.Freeze()
+						if err != nil {
+							rotation.Release()
+							b.Fatal(err)
+						}
+						rotation.Release()
+						stats := set.Stats(time.Now())
+						if len(stats) != 1 || stats[0].PendingCount != 2 || stats[0].NamespaceSyncs != 1 {
+							set.Release()
+							b.Fatalf("stable rotation operation counts=%+v", stats)
+						}
+						namespaceSyncs += stats[0].NamespaceSyncs
+						set.Release()
+						b.StartTimer()
+					}
+					contentSyncs := writer.DurabilityStats().FileSyncCalls - beforeContentSyncs
+					wantContentSyncs := uint64(0)
+					if syncCurrent {
+						wantContentSyncs = uint64(b.N)
+					}
+					if namespaceSyncs != uint64(b.N) || contentSyncs != wantContentSyncs {
+						b.Fatalf("rotation counters namespace=%d content=%d want namespace=%d content=%d", namespaceSyncs, contentSyncs, b.N, wantContentSyncs)
+					}
+					if registry != nil && (registry.ActivePins() != 0 || registry.ActiveIdentities() != 1) {
+						b.Fatalf("rotation registry pins=%d identities=%d, want 0 pins and one active writer", registry.ActivePins(), registry.ActiveIdentities())
+					}
+					b.ReportMetric(float64(namespaceSyncs)/float64(b.N), "stable-token-namespace-sync/op")
+					b.ReportMetric(float64(contentSyncs)/float64(b.N), "producer-content-sync/op")
+				})
 			}
-			b.Cleanup(func() { _ = writer.Close() })
-			beforeContentSyncs := writer.DurabilityStats().FileSyncCalls
-			var namespaceSyncs uint64
-			b.ReportAllocs()
-			b.ResetTimer()
-			for i := 0; i < b.N; i++ {
-				b.StopTimer()
-				if _, err := writer.Append(0, nil, uint64(i+1), []byte("rotation-benchmark-value")); err != nil {
-					b.Fatal(err)
-				}
-				closedID := writer.FileID()
-				activeID := closedID + 1
-				activeName := fmt.Sprintf("%06d.vlog", activeID)
-				b.StartTimer()
-				rotation, err := writer.RotateToWithStableResources(filepath.Join(dir, activeName), activeID, syncCurrent,
-					StableResourceRegistration{
-						LogicalLane: "main", Generation: uint64(closedID), DiagnosticPath: filepath.Join("maindb", "value_vlog", fmt.Sprintf("%06d.vlog", closedID)),
-						Reachability: rootpublication.ReachabilityValueLogPointer,
-					},
-					StableResourceRegistration{
-						LogicalLane: "main", Generation: uint64(activeID), DiagnosticPath: filepath.Join("maindb", "value_vlog", activeName),
-						Reachability: rootpublication.ReachabilityValueLogPointer, ParentGeneration: uint64(activeID),
-						NamespaceOperation: rootpublication.NamespaceCreate,
-					})
-				b.StopTimer()
-				if err != nil {
-					b.Fatal(err)
-				}
-				builder := rootpublication.NewStableResourceSetBuilder(rootpublication.ReachabilityValueLogPointer)
-				if err := builder.Add(rotation.TakeClosed()); err != nil {
-					rotation.Release()
-					b.Fatal(err)
-				}
-				if err := builder.Add(rotation.TakeActive()); err != nil {
-					rotation.Release()
-					b.Fatal(err)
-				}
-				set, err := builder.Freeze()
-				if err != nil {
-					rotation.Release()
-					b.Fatal(err)
-				}
-				rotation.Release()
-				stats := set.Stats(time.Now())
-				if len(stats) != 1 || stats[0].PendingCount != 2 || stats[0].NamespaceSyncs != 1 {
-					set.Release()
-					b.Fatalf("stable rotation operation counts=%+v", stats)
-				}
-				namespaceSyncs += stats[0].NamespaceSyncs
-				set.Release()
-				b.StartTimer()
-			}
-			contentSyncs := writer.DurabilityStats().FileSyncCalls - beforeContentSyncs
-			wantContentSyncs := uint64(0)
-			if syncCurrent {
-				wantContentSyncs = uint64(b.N)
-			}
-			if namespaceSyncs != uint64(b.N) || contentSyncs != wantContentSyncs {
-				b.Fatalf("rotation counters namespace=%d content=%d want namespace=%d content=%d", namespaceSyncs, contentSyncs, b.N, wantContentSyncs)
-			}
-			b.ReportMetric(float64(namespaceSyncs)/float64(b.N), "stable-token-namespace-sync/op")
-			b.ReportMetric(float64(contentSyncs)/float64(b.N), "producer-content-sync/op")
 		})
 	}
 }

--- a/TreeDB/internal/valuelog/writer.go
+++ b/TreeDB/internal/valuelog/writer.go
@@ -16,6 +16,7 @@ import (
 	"github.com/snissn/gomap/TreeDB/internal/crc"
 	"github.com/snissn/gomap/TreeDB/internal/durabilitycut"
 	"github.com/snissn/gomap/TreeDB/internal/limits"
+	"github.com/snissn/gomap/TreeDB/internal/rootpublication"
 	"github.com/snissn/gomap/TreeDB/page"
 )
 
@@ -85,6 +86,9 @@ type Writer struct {
 	f                      *os.File
 	stableParent           *os.File
 	stableParentErr        error
+	stableResourcePins     *rootpublication.IdentityPinRegistry
+	stableResourceIdentity rootpublication.StableIdentity
+	stableResourceObserved bool
 	bw                     *bufio.Writer
 	size                   int64
 	fileID                 uint32
@@ -621,7 +625,17 @@ func shouldUseEncodeAllParts(records []Record, rawPayloadBytes int) bool {
 }
 
 func NewWriter(path string, fileID uint32) (*Writer, error) {
-	return newFileWriter(path, fileID, true, func(file *os.File) error { return file.Sync() })
+	return newFileWriter(path, fileID, true, func(file *os.File) error { return file.Sync() }, nil)
+}
+
+// NewWriterWithStableResourcePinRegistry observes the writer's exact file
+// identity before it can race a registry-gated deletion owner. The observation
+// follows ordinary and stable rotations and is released when the writer closes.
+func NewWriterWithStableResourcePinRegistry(path string, fileID uint32, registry *rootpublication.IdentityPinRegistry) (*Writer, error) {
+	if registry == nil {
+		return nil, errors.New("valuelog: nil stable resource pin registry")
+	}
+	return newFileWriter(path, fileID, true, func(file *os.File) error { return file.Sync() }, registry)
 }
 
 // NewStagingWriter creates a writer for an unreferenced temporary file whose
@@ -629,10 +643,10 @@ func NewWriter(path string, fileID uint32) (*Writer, error) {
 // directory; callers must sync the file, rename it into its durable namespace,
 // and sync the destination directory before publishing a reference.
 func NewStagingWriter(path string, fileID uint32) (*Writer, error) {
-	return newFileWriter(path, fileID, false, syncStagingFileData)
+	return newFileWriter(path, fileID, false, syncStagingFileData, nil)
 }
 
-func newFileWriter(path string, fileID uint32, syncDirectory bool, syncFn func(*os.File) error) (*Writer, error) {
+func newFileWriter(path string, fileID uint32, syncDirectory bool, syncFn func(*os.File) error, registry *rootpublication.IdentityPinRegistry) (*Writer, error) {
 	f, err := openLogFile(path)
 	if err != nil {
 		return nil, err
@@ -673,6 +687,14 @@ func newFileWriter(path string, fileID uint32, syncDirectory bool, syncFn func(*
 	w.blockCodec = BlockCodecSnappy
 	w.clock = RealClock{}
 	w.keepSafetyMargin = DefaultKeepSafetyMargin
+	if err := w.observeStableResourceFile(f, registry); err != nil {
+		_ = f.Close()
+		if w.stableParent != nil {
+			_ = w.stableParent.Close()
+			w.stableParent = nil
+		}
+		return nil, err
+	}
 	return w, nil
 }
 
@@ -974,8 +996,15 @@ func (w *Writer) RotateToWithSync(path string, fileID uint32, syncCurrent bool) 
 			_ = f.Close()
 			return err
 		}
+		newIdentity, err := observeStableWriterFile(f, w.stableResourcePins)
+		if err != nil {
+			_ = f.Close()
+			return err
+		}
+		newObserved := w.stableResourcePins != nil
 		stableParent, stableParentErr := captureStableValueLogParent(path, f)
 		oldStableParent := w.stableParent
+		oldObserveErr := w.releaseStableResourceObservation()
 		w.f = f
 		w.stableParent = stableParent
 		w.stableParentErr = stableParentErr
@@ -986,10 +1015,17 @@ func (w *Writer) RotateToWithSync(path string, fileID uint32, syncCurrent bool) 
 		w.appendMax = defaultBufferSize
 		w.appendBuf = w.appendBuf[:0]
 		w.trimTransientScratchBuffers()
+		if newObserved {
+			w.stableResourceIdentity = newIdentity
+			w.stableResourceObserved = true
+		}
 		if oldStableParent != nil {
 			if err := w.closeRotatedResource(oldStableParent); err != nil {
-				return rotationInstalledError{err: err}
+				return rotationInstalledError{err: errors.Join(oldObserveErr, err)}
 			}
+		}
+		if oldObserveErr != nil {
+			return rotationInstalledError{err: oldObserveErr}
 		}
 		return nil
 	}
@@ -1018,6 +1054,12 @@ func (w *Writer) RotateToWithSync(path string, fileID uint32, syncCurrent bool) 
 			return err
 		}
 	}
+	newIdentity, err := observeStableWriterFile(f, w.stableResourcePins)
+	if err != nil {
+		_ = f.Close()
+		return err
+	}
+	newObserved := w.stableResourcePins != nil
 	old := w.f
 	oldStableParent := w.stableParent
 	if w.bw != nil {
@@ -1037,12 +1079,17 @@ func (w *Writer) RotateToWithSync(path string, fileID uint32, syncCurrent bool) 
 	w.fileID = fileID
 	w.appendBuf = w.appendBuf[:0]
 	closeErr := w.closeRotatedResource(old)
+	observeErr := w.releaseStableResourceObservation()
+	if newObserved {
+		w.stableResourceIdentity = newIdentity
+		w.stableResourceObserved = true
+	}
 	var closeParentErr error
 	if oldStableParent != nil {
 		closeParentErr = w.closeRotatedResource(oldStableParent)
 	}
 	w.trimTransientScratchBuffers()
-	if err := errors.Join(closeErr, closeParentErr); err != nil {
+	if err := errors.Join(closeErr, closeParentErr, observeErr); err != nil {
 		return rotationInstalledError{err: err}
 	}
 	return nil
@@ -2505,10 +2552,11 @@ func (w *Writer) Sync() error {
 	return nil
 }
 
-func (w *Writer) Close() error {
+func (w *Writer) Close() (retErr error) {
 	if w == nil {
 		return nil
 	}
+	defer func() { retErr = errors.Join(retErr, w.releaseStableResourceObservation()) }()
 	defer w.releaseDictEncoder()
 	defer w.releaseAppendBuf()
 	defer w.releaseTransientScratchBuffers()


### PR DESCRIPTION
## Objective

Land the next #3677 merge unit: one DB-scoped physical-identity registry shared by every live value-log manager, and consume its pins in persistent value-log deletion paths so GC/rewrite cannot unlink a resource still carried by a stable publication token.

Part of #3677. This does not close the parent or unblock descendants yet.

## Context

PR #3745 established exact-handle stable resource tokens but deliberately left real deletion owners unconnected. The remaining race was bidirectional: a live token did not stop another manager from unlinking the same inode, while pathname-only Windows retries could later remove a replacement file.

## Non-goals

- Root/meta publication consumption (#3679).
- Command-WAL prefix debt (#3718).
- Outer-leaf, dictionary/template, column/vector/text producer/deleter families still remaining in #3677.
- Offline/exclusive staging cleanup, which owns a private unpublished namespace.
- New durability syncs, file formats, or user-facing configuration.

## Design

- `IdentityPinRegistry` keys physical identities without logical generation, requires a live producer observation before pin admission, and serializes pin/delete plus parent-identity/basename namespace leases.
- DB, read-only DB, backend, and cache managers receive the registry before their initial directory scan; caching reuses the backend's exact pointer.
- Manager-opened files are observed by exact handle identity. A checked manager capture API supplies the registry itself, so callers cannot omit or substitute it.
- Every manager removal mode, zombie release/retry, value-log GC/rewrite cleanup, compact zero-file cleanup, and cached retained-file fallback goes through the same deletion lease.
- Delete retries cache the pre-close identity, close the manager handle before Windows removal, rename the linked name into a private same-directory quarantine, validate the quarantined object, and unlink only that exact object. A replacement at the original name is never passed to unlink.
- Same-file-ID registration is idempotent only when the path still names the original open identity.
- Committed identity tombstones remain only while another observed handle can still capture a token; the 10,000-identity stress gate returns registry state to zero.

Lock order is producer/manager lock -> registry lock. Registry release never calls back into a manager while holding the registry lock.

## Scope

Includes:

- `TreeDB/internal/rootpublication`: physical pin/delete registry and token pin ownership.
- `TreeDB/internal/valuelog`: checked capture, manager observation, exact deletion funnel, Windows retry.
- `TreeDB/db`: pre-scan injection and online GC/rewrite/compact cleanup consumption.
- `TreeDB/caching`: backend/cache registry sharing and retained-file fallback preservation.

Excludes all other #3677 producer/deleter families.

## Correctness

Covered regressions include:

- pin-before-delete and delete-before-pin serialization;
- logical generations coalescing onto one physical identity;
- two managers sharing one directory/registry;
- `RemoveSegment`, `RemoveSegmentIfUnpinned`, `RemoveSegmentForce`, zombie release, and retry;
- close-before-unlink Windows behavior;
- successful unlink plus close-error ownership completion;
- rename/recreate preservation, replacement-at-unlink preservation, and same-ID rebound registration rejection;
- DB `ValueLogGC` deferral followed by automatic reclaim on token release;
- rewrite-created cleanup respecting stable pins;
- cached retained cleanup preserving pins/bookkeeping and rejecting a replacement after intentional evict;
- exact-once release, initial-refresh rollback with zero leaked observations, and 10,000-identity no-growth stress.

Local commands:

- `GOWORK=off go test ./TreeDB/internal/rootpublication ./TreeDB/internal/valuelog ./TreeDB/db ./TreeDB/caching -count=1`
- `GOWORK=off go test -race ./TreeDB/internal/rootpublication ./TreeDB/internal/valuelog ./TreeDB/db ./TreeDB/caching -run 'TestIdentityPinRegistry|TestStableResourceTokenPinsIdentityRegistryUntilExactRelease|TestManagerStable|TestManagerZombie|TestCleanupOrphanedRetainedValueLog|TestValueLogGC_StableIdentityPin|TestCleanupRewriteCreatedSegmentRespectsStableIdentityPin|TestOpenShares' -count=1`
- `GOWORK=off go vet ./TreeDB/internal/rootpublication ./TreeDB/internal/valuelog ./TreeDB/db ./TreeDB/caching`
- `GOWORK=off env GOOS=windows GOARCH=amd64 go test -exec /bin/true ./TreeDB/internal/rootpublication ./TreeDB/internal/valuelog ./TreeDB/db ./TreeDB/caching -run '^$'`
- `git diff --check`

Focused race, vet, Windows compilation, and all targeted regression suites pass locally. The full affected-package run is also the latest-head CI gate.

## Performance

Command:

`GOWORK=off go test ./TreeDB/internal/rootpublication -run '^$' -bench 'BenchmarkStableResourceTokenConstruction($|WithIdentityPinRegistry)|BenchmarkIdentityPinRegistryPinRelease' -benchmem -count=5`

Median of five on i5-11400F, linux/amd64:

| Shape | ns/op | B/op | allocs/op |
|---|---:|---:|---:|
| Token without registry | 1,671 | 912 | 6 |
| Token with DB registry | 1,835 | 1,024 | 7 |
| Isolated pin/release | 110.5 | 80 | 1 |

The registry adds about 164 ns, 112 bytes, and one allocation per captured token. Lazy waiter-channel creation reduced the initial pin/release candidate from roughly 900 ns, 192 B, 2 allocs to 111 ns, 80 B, 1 alloc. Ordinary record writes add no work or namespace sync; the cost occurs only when an exact stable token is captured.

## Rollout / Toggle Plan

The fence is an invariant for live DB managers and has no unsafe bypass toggle. Revert this PR as a unit if a platform issue appears. No format or on-disk compatibility change is involved.

## Follow-ups

Continue #3677 with the remaining real producer/deleter families and the all-kind closeout before #3718/#3729 can advance.

### AI Review Loop

- Independent exact-head review: prior blockers fixed; exact-head re-review in progress.
- Codex latest-head review: required after the final meaningful push.
- Unresolved review threads: must be zero before merge.
- Latest-head CI: must be green before merge.

