### PR TITLE
treedb: stabilize leaf-generation manifest replacement

### DIFF
--- a/TreeDB/db/db.go
+++ b/TreeDB/db/db.go
@@ -177,6 +177,7 @@ type DB struct {
 	pendingValueLogAppendMu         sync.Mutex
 	pendingValueLogAppendFileIDRefs map[uint32]int
 	pendingValueLogAppendPtrRefs    map[page.ValuePtr]int
+	leafGenerationManifestStableMu  sync.Mutex
 	updateLocks                     keyupdate.Locks
 	maintenanceMu                   sync.Mutex
 	combineMu                       sync.RWMutex

--- a/TreeDB/db/leaf_generation_gc.go
+++ b/TreeDB/db/leaf_generation_gc.go
@@ -307,7 +307,7 @@ func (db *DB) leafGenerationGCApplyScan(basis leafGenerationGCScanBasis, liveGen
 	}
 
 	if decision.intermediateChanged {
-		if err := saveLeafGenerationManifest(LeafLogDirPath(db.dir), manifest); err != nil {
+		if err := db.saveLeafGenerationManifestDurable(manifest); err != nil {
 			return stats, err
 		}
 		db.leafGenerationManifest = manifest
@@ -328,7 +328,7 @@ func (db *DB) leafGenerationGCApplyScan(basis leafGenerationGCScanBasis, liveGen
 	}
 	stats.GenerationsDeleted = countPrunedLeafGenerations(prePrune, manifest)
 	stats.FilesDeleted = filesDeleted
-	if err := saveLeafGenerationManifest(LeafLogDirPath(db.dir), manifest); err != nil {
+	if err := db.saveLeafGenerationManifestDurable(manifest); err != nil {
 		return stats, err
 	}
 	db.leafGenerationManifest = manifest

--- a/TreeDB/db/leaf_generation_manifest.go
+++ b/TreeDB/db/leaf_generation_manifest.go
@@ -16,7 +16,7 @@ import (
 
 const (
 	leafGenerationManifestFileName = "manifest.json"
-	leafGenerationManifestVersion  = 1
+	leafGenerationManifestVersion  = 2
 
 	leafGenerationStateWritable = "writable"
 	leafGenerationStateSealed   = "sealed"
@@ -26,6 +26,7 @@ const (
 
 type leafGenerationManifest struct {
 	Version             int                    `json:"version"`
+	Revision            uint64                 `json:"revision"`
 	CurrentGenerationID uint64                 `json:"current_generation_id"`
 	NextGenerationID    uint64                 `json:"next_generation_id"`
 	Generations         []leafGenerationRecord `json:"generations"`
@@ -52,6 +53,7 @@ func leafGenerationManifestPath(leafDir string) string {
 func newLeafGenerationManifest(commitSeq uint64) *leafGenerationManifest {
 	return &leafGenerationManifest{
 		Version:             leafGenerationManifestVersion,
+		Revision:            1,
 		CurrentGenerationID: 1,
 		NextGenerationID:    2,
 		Generations: []leafGenerationRecord{{
@@ -284,6 +286,7 @@ func (m *leafGenerationManifest) clone() *leafGenerationManifest {
 	}
 	out := &leafGenerationManifest{
 		Version:             m.Version,
+		Revision:            m.Revision,
 		CurrentGenerationID: m.CurrentGenerationID,
 		NextGenerationID:    m.NextGenerationID,
 		Generations:         make([]leafGenerationRecord, len(m.Generations)),
@@ -666,7 +669,7 @@ func (db *DB) noteLeafGenerationWritableFileIDs(fileIDs []uint32, commitSeq uint
 	if !changedAny {
 		return nil
 	}
-	if err := saveLeafGenerationManifest(LeafLogDirPath(db.dir), nextManifest); err != nil {
+	if err := db.saveLeafGenerationManifestDurable(nextManifest); err != nil {
 		return err
 	}
 	db.mu.Lock()
@@ -715,6 +718,9 @@ func loadLeafGenerationManifest(leafDir string) (*leafGenerationManifest, bool, 
 	if err := json.Unmarshal(data, &manifest); err != nil {
 		return nil, false, fmt.Errorf("treedb: decode %s: %w", filepath.Base(path), err)
 	}
+	if manifest.Revision == 0 {
+		return nil, false, fmt.Errorf("treedb: %s revision must be non-zero", filepath.Base(path))
+	}
 	if err := validateLeafGenerationManifest(&manifest); err != nil {
 		return nil, false, err
 	}
@@ -729,11 +735,37 @@ func saveLeafGenerationManifest(leafDir string, manifest *leafGenerationManifest
 	if err := validateLeafGenerationManifest(manifest); err != nil {
 		return err
 	}
-	data, err := json.MarshalIndent(manifest, "", "  ")
+	persisted := manifest.clone()
+	currentData, readErr := os.ReadFile(path)
+	switch {
+	case readErr == nil:
+		var current leafGenerationManifest
+		if err := json.Unmarshal(currentData, &current); err != nil {
+			return fmt.Errorf("treedb: decode current %s revision: %w", filepath.Base(path), err)
+		}
+		if current.Revision > persisted.Revision {
+			persisted.Revision = current.Revision
+		}
+		if persisted.Revision == ^uint64(0) {
+			return fmt.Errorf("treedb: %s revision exhausted", filepath.Base(path))
+		}
+		persisted.Revision++
+	case os.IsNotExist(readErr):
+		if persisted.Revision == 0 {
+			persisted.Revision = 1
+		}
+	default:
+		return readErr
+	}
+	data, err := json.MarshalIndent(persisted, "", "  ")
 	if err != nil {
 		return err
 	}
-	return writeFileAtomic(path, data, 0o600)
+	if err := writeFileAtomic(path, data, 0o600); err != nil {
+		return err
+	}
+	manifest.Revision = persisted.Revision
+	return nil
 }
 
 type leafGenerationBootstrapFile struct {
@@ -1059,7 +1091,7 @@ func (db *DB) reconcileLeafGenerationManifestWithDirLocked(commitSeq uint64) (bo
 	if err != nil || !changed {
 		return false, err
 	}
-	if err := saveLeafGenerationManifest(leafDir, reconciled); err != nil {
+	if err := db.saveLeafGenerationManifestDurable(reconciled); err != nil {
 		return false, err
 	}
 	db.mu.Lock()

--- a/TreeDB/db/leaf_generation_manifest_revision_test.go
+++ b/TreeDB/db/leaf_generation_manifest_revision_test.go
@@ -1,0 +1,32 @@
+package db
+
+import (
+	"os"
+	"testing"
+)
+
+func TestSaveLeafGenerationManifestAdvancesPersistentRevision(t *testing.T) {
+	leafDir := t.TempDir()
+	manifest := newLeafGenerationManifest(1)
+	if err := saveLeafGenerationManifest(leafDir, manifest); err != nil {
+		t.Fatal(err)
+	}
+	firstRevision := manifest.Revision
+	manifest.NextGenerationID++
+	if err := saveLeafGenerationManifest(leafDir, manifest); err != nil {
+		t.Fatal(err)
+	}
+	if manifest.Revision <= firstRevision {
+		t.Fatalf("revision=%d want > %d", manifest.Revision, firstRevision)
+	}
+	loaded, ok, err := loadLeafGenerationManifest(leafDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !ok || loaded.Revision != manifest.Revision {
+		t.Fatalf("loaded revision=%d ok=%t want %d", loaded.Revision, ok, manifest.Revision)
+	}
+	if _, err := os.Stat(leafGenerationManifestPath(leafDir)); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/TreeDB/db/leaf_generation_manifest_stable.go
+++ b/TreeDB/db/leaf_generation_manifest_stable.go
@@ -1,0 +1,256 @@
+package db
+
+import (
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+
+	"github.com/snissn/gomap/TreeDB/internal/durabilitycut"
+	"github.com/snissn/gomap/TreeDB/internal/rootpublication"
+)
+
+const leafGenerationManifestResourceID = "leaf-generation-manifest"
+
+func nextLeafGenerationManifestRevision(current *os.File, requested uint64) (uint64, error) {
+	currentRevision := uint64(0)
+	if current != nil {
+		if _, err := current.Seek(0, io.SeekStart); err != nil {
+			return 0, err
+		}
+		data, err := io.ReadAll(current)
+		if err != nil {
+			return 0, err
+		}
+		var disk leafGenerationManifest
+		if err := json.Unmarshal(data, &disk); err != nil {
+			return 0, fmt.Errorf("treedb: decode current %s revision: %w", leafGenerationManifestFileName, err)
+		}
+		currentRevision = disk.Revision
+	}
+	if requested > currentRevision {
+		currentRevision = requested
+	}
+	if currentRevision == ^uint64(0) {
+		return 0, fmt.Errorf("treedb: %s revision exhausted", leafGenerationManifestFileName)
+	}
+	return currentRevision + 1, nil
+}
+
+func openStableManifestTemp(parent *os.File) (*os.File, string, error) {
+	for attempt := 0; attempt < 32; attempt++ {
+		var suffix [8]byte
+		if _, err := rand.Read(suffix[:]); err != nil {
+			return nil, "", err
+		}
+		name := leafGenerationManifestFileName + ".tmp." + hex.EncodeToString(suffix[:])
+		file, err := rootpublication.OpenStableChildFile(parent, name, os.O_CREATE|os.O_EXCL|os.O_RDWR, 0o600)
+		if err == nil {
+			return file, name, nil
+		}
+		if !errors.Is(err, os.ErrExist) {
+			return nil, "", err
+		}
+	}
+	return nil, "", fmt.Errorf("treedb: allocate unique %s temporary file", leafGenerationManifestFileName)
+}
+
+func (db *DB) manifestPostRenameError(err error) error {
+	if db != nil {
+		db.publicationPoisoned.Store(true)
+	}
+	return errors.Join(err, ErrRecoveryRequired)
+}
+
+// saveLeafGenerationManifestWithStableResource replaces the generation
+// manifest through one retained parent handle and returns a token for the exact
+// installed inode. The returned token is already content- and namespace-stable
+// but remains pinned for a future publication candidate to consume.
+func (db *DB) saveLeafGenerationManifestWithStableResource(
+	manifest *leafGenerationManifest,
+	reachability rootpublication.ReachabilityField,
+) (*rootpublication.StableResourceToken, error) {
+	if db == nil || db.closing.Load() {
+		return nil, ErrClosed
+	}
+	if err := db.publicationPoisonedError(); err != nil {
+		return nil, err
+	}
+	if db.valueLogIdentityPins == nil {
+		return nil, fmt.Errorf("%w: DB has no stable identity registry", rootpublication.ErrUnresolvedResource)
+	}
+	if reachability != rootpublication.ReachabilityOuterLeafGeneration {
+		return nil, fmt.Errorf("%w: manifest reachability %q", rootpublication.ErrUnresolvedResource, reachability)
+	}
+	if err := validateLeafGenerationManifest(manifest); err != nil {
+		return nil, err
+	}
+
+	db.leafGenerationManifestStableMu.Lock()
+	defer db.leafGenerationManifestStableMu.Unlock()
+
+	leafDir := LeafLogDirPath(db.dir)
+	parent, err := os.Open(leafDir)
+	if err != nil {
+		return nil, err
+	}
+	defer parent.Close()
+	targetName := leafGenerationManifestFileName
+	namespaceKey, err := rootpublication.StableChildNamespace(parent, targetName)
+	if err != nil {
+		return nil, err
+	}
+
+	var (
+		current         *os.File
+		currentIdentity rootpublication.StableIdentity
+		currentObserved bool
+		deleteLease     *rootpublication.IdentityDeleteLease
+	)
+	current, err = rootpublication.OpenStableChildFile(parent, targetName, os.O_RDONLY, 0)
+	if err != nil && !errors.Is(err, os.ErrNotExist) {
+		return nil, err
+	}
+	if current != nil {
+		defer current.Close()
+		currentIdentity, err = rootpublication.StableIdentityFromFile(current)
+		if err != nil {
+			return nil, err
+		}
+		if err := db.valueLogIdentityPins.Observe(currentIdentity); err != nil {
+			return nil, err
+		}
+		currentObserved = true
+		defer func() {
+			if currentObserved {
+				_ = db.valueLogIdentityPins.Unobserve(currentIdentity)
+			}
+		}()
+		deleteLease, err = db.valueLogIdentityPins.BeginDeleteAt(currentIdentity, namespaceKey)
+		if err != nil {
+			return nil, err
+		}
+		defer func() {
+			if deleteLease != nil {
+				deleteLease.Abort()
+			}
+		}()
+	}
+
+	revision, err := nextLeafGenerationManifestRevision(current, manifest.Revision)
+	if err != nil {
+		return nil, err
+	}
+	persisted := manifest.clone()
+	persisted.Revision = revision
+	data, err := json.MarshalIndent(persisted, "", "  ")
+	if err != nil {
+		return nil, err
+	}
+	digest := sha256.Sum256(data)
+
+	temp, tempName, err := openStableManifestTemp(parent)
+	if err != nil {
+		return nil, err
+	}
+	tempLinked := true
+	defer func() {
+		_ = temp.Close()
+		if tempLinked {
+			_ = rootpublication.RemoveStableChildFile(parent, tempName)
+		}
+	}()
+	if _, err := temp.Write(data); err != nil {
+		return nil, err
+	}
+	diagnosticPath := filepath.ToSlash(filepath.Join(leafVLogDirName, targetName))
+	if err := durabilitycut.EmitPath(durabilitycut.BeforeDependencyFileSync, durabilitycut.ResourceOuterLeaf, db.dir, diagnosticPath); err != nil {
+		return nil, err
+	}
+	if err := temp.Sync(); err != nil {
+		return nil, err
+	}
+	if err := durabilitycut.EmitPath(durabilitycut.AfterDependencyFileSync, durabilitycut.ResourceOuterLeaf, db.dir, diagnosticPath); err != nil {
+		return nil, err
+	}
+
+	newIdentity, err := rootpublication.StableIdentityFromFile(temp)
+	if err != nil {
+		return nil, err
+	}
+	if err := db.valueLogIdentityPins.Observe(newIdentity); err != nil {
+		return nil, err
+	}
+	newObserved := true
+	defer func() {
+		if newObserved {
+			_ = db.valueLogIdentityPins.Unobserve(newIdentity)
+		}
+	}()
+
+	if err := rootpublication.RenameStableChildFile(parent, tempName, targetName); err != nil {
+		return nil, err
+	}
+	tempLinked = false
+	if deleteLease != nil {
+		deleteLease.Commit()
+		deleteLease = nil
+		_ = db.valueLogIdentityPins.Unobserve(currentIdentity)
+		currentObserved = false
+	}
+	targetPath := filepath.Join(leafDir, targetName)
+	if err := observeNamespaceMutation(durabilitycut.NamespaceRename, durabilitycut.ResourceOuterLeaf, leafDir, filepath.Join(leafDir, tempName), targetPath); err != nil {
+		return nil, db.manifestPostRenameError(err)
+	}
+
+	namespace, err := rootpublication.NewStableNamespaceToken(rootpublication.StableNamespaceSpec{
+		Parent: parent, LinkedResource: temp, ParentGeneration: revision,
+		Operation: rootpublication.NamespaceRename, OldName: tempName, NewName: targetName,
+		DiagnosticPath: leafVLogDirName,
+	})
+	if err != nil {
+		return nil, db.manifestPostRenameError(err)
+	}
+	defer namespace.Release()
+	token, err := NewStableOuterLeafResourceToken(rootpublication.StableResourceSpec{
+		Kind: rootpublication.ResourceOuterLeafManifest, LogicalLane: leafVLogDirName,
+		ResourceID: leafGenerationManifestResourceID, Generation: revision,
+		DiagnosticPath: diagnosticPath, File: temp,
+		Frontier: rootpublication.DurableFrontier{Bytes: uint64(len(data))}, Digest: digest,
+		Reachability: reachability, Namespace: namespace, ContentSynced: true,
+		PinRegistry: db.valueLogIdentityPins,
+		OnRelease:   func() { _ = db.valueLogIdentityPins.Unobserve(newIdentity) },
+	})
+	if err != nil {
+		return nil, db.manifestPostRenameError(err)
+	}
+	newObserved = false
+	if err := durabilitycut.EmitPath(durabilitycut.BeforeNewFileDirectorySync, durabilitycut.ResourceOuterLeaf, db.dir, leafDir); err != nil {
+		token.Release()
+		return nil, db.manifestPostRenameError(err)
+	}
+	if err := token.Namespace().Stabilize(); err != nil {
+		token.Release()
+		return nil, db.manifestPostRenameError(err)
+	}
+	if err := durabilitycut.EmitPath(durabilitycut.AfterNewFileDirectorySync, durabilitycut.ResourceOuterLeaf, db.dir, leafDir); err != nil {
+		token.Release()
+		return nil, db.manifestPostRenameError(err)
+	}
+	manifest.Revision = revision
+	return token, nil
+}
+
+func (db *DB) saveLeafGenerationManifestDurable(manifest *leafGenerationManifest) error {
+	token, err := db.saveLeafGenerationManifestWithStableResource(manifest, rootpublication.ReachabilityOuterLeafGeneration)
+	if err != nil {
+		return err
+	}
+	token.Release()
+	return nil
+}

--- a/TreeDB/db/leaf_generation_manifest_stable_test.go
+++ b/TreeDB/db/leaf_generation_manifest_stable_test.go
@@ -1,0 +1,192 @@
+//go:build darwin || linux || freebsd || netbsd || openbsd
+
+package db
+
+import (
+	"crypto/sha256"
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/snissn/gomap/TreeDB/internal/durabilitycut"
+	"github.com/snissn/gomap/TreeDB/internal/rootpublication"
+)
+
+func openStableManifestTestDB(t *testing.T) *DB {
+	t.Helper()
+	db, err := Open(Options{
+		Dir: t.TempDir(), Durability: DurabilityWALOffRelaxed,
+		DisableBackgroundPrune: true, IndexOuterLeavesInValueLog: true,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	return db
+}
+
+func TestLeafGenerationManifestStableResourceBindsRevisionDigestAndExactHandle(t *testing.T) {
+	db := openStableManifestTestDB(t)
+	manifest := db.leafGenerationManifest.clone()
+	manifest.NextGenerationID++
+	token, err := db.saveLeafGenerationManifestWithStableResource(manifest, rootpublication.ReachabilityOuterLeafGeneration)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer token.Release()
+
+	path := leafGenerationManifestPath(LeafLogDirPath(db.dir))
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var persisted leafGenerationManifest
+	if err := json.Unmarshal(data, &persisted); err != nil {
+		t.Fatal(err)
+	}
+	if persisted.Revision == 0 || token.Generation() != persisted.Revision {
+		t.Fatalf("persisted revision=%d token generation=%d", persisted.Revision, token.Generation())
+	}
+	if got, want := token.Digest(), sha256.Sum256(data); got != want {
+		t.Fatalf("token digest=%x want %x", got, want)
+	}
+	if token.Kind() != rootpublication.ResourceOuterLeafManifest || token.Reachability() != rootpublication.ReachabilityOuterLeafGeneration {
+		t.Fatalf("token kind/reachability=%s/%s", token.Kind(), token.Reachability())
+	}
+	if token.Namespace() == nil || token.Namespace().Operation() != rootpublication.NamespaceRename {
+		t.Fatalf("namespace=%v, want retained rename", token.Namespace())
+	}
+	current, err := os.Open(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer current.Close()
+	identity, err := rootpublication.StableIdentityFromFile(current)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !rootpublication.SamePhysicalIdentity(token.Identity(), identity) {
+		t.Fatal("token was not bound to the installed manifest inode")
+	}
+	if err := token.SyncThrough(); err != nil {
+		t.Fatalf("retained token sync: %v", err)
+	}
+}
+
+func TestLeafGenerationManifestStableResourceBlocksPinnedDestinationReplacement(t *testing.T) {
+	db := openStableManifestTestDB(t)
+	first := db.leafGenerationManifest.clone()
+	first.NextGenerationID++
+	token, err := db.saveLeafGenerationManifestWithStableResource(first, rootpublication.ReachabilityOuterLeafGeneration)
+	if err != nil {
+		t.Fatal(err)
+	}
+	second := first.clone()
+	second.NextGenerationID++
+	if _, err := db.saveLeafGenerationManifestWithStableResource(second, rootpublication.ReachabilityOuterLeafGeneration); !errors.Is(err, rootpublication.ErrResourcePinned) {
+		t.Fatalf("replacement error=%v want ErrResourcePinned", err)
+	}
+	token.Release()
+	next, err := db.saveLeafGenerationManifestWithStableResource(second, rootpublication.ReachabilityOuterLeafGeneration)
+	if err != nil {
+		t.Fatal(err)
+	}
+	next.Release()
+}
+
+func TestLeafGenerationManifestStableResourcePostRenameFailurePoisonsHandle(t *testing.T) {
+	db := openStableManifestTestDB(t)
+	manifest := db.leafGenerationManifest.clone()
+	manifest.NextGenerationID++
+	cutErr := errors.New("manifest rename cut")
+	restore := durabilitycut.Install(func(event durabilitycut.Event) error {
+		if event.Namespace == durabilitycut.NamespaceRename && filepath.Base(event.NewPath) == leafGenerationManifestFileName {
+			return cutErr
+		}
+		return nil
+	})
+	token, err := db.saveLeafGenerationManifestWithStableResource(manifest, rootpublication.ReachabilityOuterLeafGeneration)
+	restore()
+	if token != nil {
+		token.Release()
+	}
+	if !errors.Is(err, cutErr) || !errors.Is(err, ErrRecoveryRequired) {
+		t.Fatalf("save error=%v want cut and ErrRecoveryRequired", err)
+	}
+	if !db.publicationPoisoned.Load() {
+		t.Fatal("post-rename failure did not poison DB")
+	}
+	if _, statErr := os.Stat(leafGenerationManifestPath(LeafLogDirPath(db.dir))); statErr != nil {
+		t.Fatalf("renamed manifest missing after ambiguous cut: %v", statErr)
+	}
+}
+
+func TestLeafGenerationManifestStableResourceExactSyncCountsAndNoPinGrowth(t *testing.T) {
+	db := openStableManifestTestDB(t)
+	baselinePins := db.valueLogIdentityPins.ActivePins()
+	baselineIdentities := db.valueLogIdentityPins.ActiveIdentities()
+	var contentBefore, contentAfter, namespaceBefore, namespaceAfter, renames int
+	restore := durabilitycut.Install(func(event durabilitycut.Event) error {
+		switch {
+		case event.Point == durabilitycut.BeforeDependencyFileSync && event.Resource == durabilitycut.ResourceOuterLeaf:
+			contentBefore++
+		case event.Point == durabilitycut.AfterDependencyFileSync && event.Resource == durabilitycut.ResourceOuterLeaf:
+			contentAfter++
+		case event.Point == durabilitycut.BeforeNewFileDirectorySync && event.Resource == durabilitycut.ResourceOuterLeaf:
+			namespaceBefore++
+		case event.Point == durabilitycut.AfterNewFileDirectorySync && event.Resource == durabilitycut.ResourceOuterLeaf:
+			namespaceAfter++
+		case event.Namespace == durabilitycut.NamespaceRename && filepath.Base(event.NewPath) == leafGenerationManifestFileName:
+			renames++
+		}
+		return nil
+	})
+	const replacements = 32
+	for i := 0; i < replacements; i++ {
+		manifest := db.leafGenerationManifest.clone()
+		manifest.NextGenerationID += uint64(i + 1)
+		token, err := db.saveLeafGenerationManifestWithStableResource(manifest, rootpublication.ReachabilityOuterLeafGeneration)
+		if err != nil {
+			restore()
+			t.Fatalf("replacement %d: %v", i, err)
+		}
+		token.Release()
+		db.leafGenerationManifest = manifest
+	}
+	restore()
+	if contentBefore != replacements || contentAfter != replacements ||
+		namespaceBefore != replacements || namespaceAfter != replacements || renames != replacements {
+		t.Fatalf("events content=%d/%d namespace=%d/%d renames=%d want %d each",
+			contentBefore, contentAfter, namespaceBefore, namespaceAfter, renames, replacements)
+	}
+	if got := db.valueLogIdentityPins.ActivePins(); got != baselinePins {
+		t.Fatalf("active pins=%d want baseline %d", got, baselinePins)
+	}
+	if got := db.valueLogIdentityPins.ActiveIdentities(); got != baselineIdentities {
+		t.Fatalf("active identities=%d want baseline %d", got, baselineIdentities)
+	}
+}
+
+func BenchmarkLeafGenerationManifestStableReplace(b *testing.B) {
+	db, err := Open(Options{
+		Dir: b.TempDir(), Durability: DurabilityWALOffRelaxed,
+		DisableBackgroundPrune: true, IndexOuterLeavesInValueLog: true,
+	})
+	if err != nil {
+		b.Fatal(err)
+	}
+	b.Cleanup(func() { _ = db.Close() })
+	manifest := db.leafGenerationManifest.clone()
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		manifest.NextGenerationID++
+		token, err := db.saveLeafGenerationManifestWithStableResource(manifest, rootpublication.ReachabilityOuterLeafGeneration)
+		if err != nil {
+			b.Fatal(err)
+		}
+		token.Release()
+	}
+}

--- a/TreeDB/db/leaf_generation_pack.go
+++ b/TreeDB/db/leaf_generation_pack.go
@@ -597,7 +597,7 @@ func (db *DB) persistLeafGenerationManifestAndRecordLengthIndexes(manifest *leaf
 		return nil
 	}
 	rawFileIDs = dedupeLeafGenerationRawFileIDs(rawFileIDs)
-	if err := saveLeafGenerationManifest(LeafLogDirPath(db.dir), manifest); err != nil {
+	if err := db.saveLeafGenerationManifestDurable(manifest); err != nil {
 		return err
 	}
 	var firstErr error

--- a/TreeDB/internal/rootpublication/resource_identity_other.go
+++ b/TreeDB/internal/rootpublication/resource_identity_other.go
@@ -12,6 +12,10 @@ func removeStableChildFile(*os.File, string) error {
 	return ErrNamespacePersistenceUnsupported
 }
 
+func renameStableChildFile(*os.File, string, string) error {
+	return ErrNamespacePersistenceUnsupported
+}
+
 func duplicateStableFile(*os.File) (*os.File, error) {
 	return nil, ErrStableIdentityUnsupported
 }

--- a/TreeDB/internal/rootpublication/resource_identity_unix.go
+++ b/TreeDB/internal/rootpublication/resource_identity_unix.go
@@ -37,6 +37,21 @@ func removeStableChildFile(parent *os.File, name string) error {
 	}
 }
 
+func renameStableChildFile(parent *os.File, oldName, newName string) error {
+	if parent == nil {
+		return os.ErrInvalid
+	}
+	for {
+		err := unix.Renameat(int(parent.Fd()), oldName, int(parent.Fd()), newName)
+		if err == nil {
+			return nil
+		}
+		if err != unix.EINTR {
+			return err
+		}
+	}
+}
+
 func duplicateStableFile(file *os.File) (*os.File, error) {
 	if file == nil {
 		return nil, os.ErrInvalid

--- a/TreeDB/internal/rootpublication/resource_identity_unix_test.go
+++ b/TreeDB/internal/rootpublication/resource_identity_unix_test.go
@@ -93,6 +93,45 @@ func TestRemoveStableChildFileUsesCapturedParentAfterPathReplacement(t *testing.
 	}
 }
 
+func TestRenameStableChildFileUsesCapturedParentAfterPathReplacement(t *testing.T) {
+	root := t.TempDir()
+	originalDir := filepath.Join(root, "segments")
+	if err := os.Mkdir(originalDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	parent, err := os.Open(originalDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer parent.Close()
+	child, err := OpenStableChildFile(parent, "manifest.tmp", os.O_CREATE|os.O_EXCL|os.O_RDWR, 0o600)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := child.Close(); err != nil {
+		t.Fatal(err)
+	}
+	movedDir := filepath.Join(root, "segments-moved")
+	if err := os.Rename(originalDir, movedDir); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Mkdir(originalDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(originalDir, "manifest.tmp"), []byte("replacement"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := RenameStableChildFile(parent, "manifest.tmp", "manifest.json"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(filepath.Join(movedDir, "manifest.json")); err != nil {
+		t.Fatalf("captured-parent target: %v", err)
+	}
+	if got, err := os.ReadFile(filepath.Join(originalDir, "manifest.tmp")); err != nil || string(got) != "replacement" {
+		t.Fatalf("replacement child changed: data=%q err=%v", got, err)
+	}
+}
+
 func TestStableNamespaceRejectsChildReplacementBeforeStabilize(t *testing.T) {
 	dir := t.TempDir()
 	parent, err := os.Open(dir)

--- a/TreeDB/internal/rootpublication/resource_identity_windows.go
+++ b/TreeDB/internal/rootpublication/resource_identity_windows.go
@@ -19,6 +19,10 @@ func removeStableChildFile(*os.File, string) error {
 	return fmt.Errorf("%w: relative directory-handle unlink is unavailable", ErrNamespacePersistenceUnsupported)
 }
 
+func renameStableChildFile(*os.File, string, string) error {
+	return fmt.Errorf("%w: relative directory-handle rename is unavailable", ErrNamespacePersistenceUnsupported)
+}
+
 type stableWindowsFileIDInfo struct {
 	VolumeSerialNumber uint64
 	FileID             [16]byte

--- a/TreeDB/internal/rootpublication/resource_identity_windows_test.go
+++ b/TreeDB/internal/rootpublication/resource_identity_windows_test.go
@@ -31,6 +31,17 @@ func TestOpenStableChildFileFailsTypedWhenRelativePrimitiveUnavailable(t *testin
 	}
 }
 
+func TestRenameStableChildFileFailsTypedWhenRelativePrimitiveUnavailable(t *testing.T) {
+	parent, err := os.Open(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer parent.Close()
+	if err := RenameStableChildFile(parent, "old", "new"); !errors.Is(err, ErrNamespacePersistenceUnsupported) {
+		t.Fatalf("RenameStableChildFile error=%v want ErrNamespacePersistenceUnsupported", err)
+	}
+}
+
 func TestStableNamespaceRegistrationFailsTypedBeforeCertification(t *testing.T) {
 	dir := t.TempDir()
 	parent, err := os.Open(dir)

--- a/TreeDB/internal/rootpublication/resource_token.go
+++ b/TreeDB/internal/rootpublication/resource_token.go
@@ -778,6 +778,30 @@ func RemoveStableChildFile(parent *os.File, name string) error {
 	return removeStableChildFile(parent, name)
 }
 
+// RenameStableChildFile atomically renames one child to another through the
+// exact already-open parent directory. It never resolves Parent.Name().
+func RenameStableChildFile(parent *os.File, oldName, newName string) error {
+	if parent == nil || oldName == "" || newName == "" ||
+		filepath.Base(oldName) != oldName || filepath.Base(newName) != newName ||
+		oldName == "." || oldName == ".." || newName == "." || newName == ".." {
+		return fmt.Errorf("%w: stable child rename requires base names and an exact parent handle", ErrUnresolvedResource)
+	}
+	return renameStableChildFile(parent, oldName, newName)
+}
+
+// StableChildNamespace returns the physical parent/name key used to serialize
+// deletion and replacement of one directory entry.
+func StableChildNamespace(parent *os.File, name string) (string, error) {
+	if parent == nil || name == "" || filepath.Base(name) != name || name == "." || name == ".." {
+		return "", fmt.Errorf("%w: stable child namespace requires a base name and exact parent handle", ErrUnresolvedResource)
+	}
+	identity, err := StableIdentityFromFile(parent)
+	if err != nil {
+		return "", err
+	}
+	return fmt.Sprintf("%s:%d:%x/%s", identity.Platform, identity.VolumeID, identity.ObjectID, name), nil
+}
+
 func validateStableChildLink(parent, resource *os.File, name string) error {
 	resourceIdentity, err := stableIdentityFromFile(resource)
 	if err != nil {

--- a/docs/TREEDB_STORAGE_FORMAT.md
+++ b/docs/TREEDB_STORAGE_FORMAT.md
@@ -34,7 +34,7 @@ TreeDB creates/manages two sub-databases under the root directory:
 - `Dir/maindb/index.db`: memory-mapped pager file containing B+Tree pages + metadata.
 - `Dir/maindb/wal/`: redo journal segments named `commit-l<lane>-<seq>.log`.
 - `Dir/maindb/value_vlog/`: persistent large-value segments named `value-l<lane>-<seq>.log`.
-- `Dir/maindb/leaf_vlog/`: optional persistent outer-leaf generation segments named `value-l<lane>-<seq>.log`.
+- `Dir/maindb/leaf_vlog/`: optional persistent outer-leaf generation segments named `value-l<lane>-<seq>.log`. Its version-2 `manifest.json` carries a monotonic revision; live replacement syncs the exact temporary inode and retained parent-directory namespace before the revision is usable.
 - `Dir/maindb/column_assets/`: compatibility directory name for the isolated typed asset manager root used by typed-storage physical assets.
 - `Dir/maindb/LOCK`: cross-process exclusive-open lock for the main DB.
 


### PR DESCRIPTION
Part of #3677. This is the bounded leaf-generation manifest merge unit; it does not close #3677 or unblock descendants.

## Contract

- Add exact-parent `RenameStableChildFile` and stable child namespace keys to the shared root-publication substrate.
- Replace live `leaf_vlog/manifest.json` mutations through one retained directory handle: open destination, acquire its identity deletion lease, create/write/sync an exact temp child, rename by directory FD, validate the installed child identity, and sync the parent namespace.
- Return an already-stable `StableResourceToken` for the exact installed manifest inode with `ReachabilityOuterLeafGeneration`, SHA-256 content digest, byte frontier, DB-scoped identity pin, and retained rename token.
- Block replacement while the destination identity is pinned. Release observations and pins exactly once; repeated replacements return to the baseline identity/pin counts.
- Treat every post-rename failure as ambiguous: retain the installed target, poison the DB handle, and return `ErrRecoveryRequired`.
- Route live commit, GC, pack, and in-place reconciliation writes through the durable helper. Bootstrap/read-only/offline standalone writes remain separate because they do not own a live DB registry.

## On-disk format

`leaf_vlog/manifest.json` advances to format version 2 and adds a persistent monotonic `revision`. TreeDB is pre-alpha and intentionally does not add migration scaffolding; old directories must be rebuilt. `docs/TREEDB_STORAGE_FORMAT.md` records the new boundary.

## TDD and failure witnesses

- exact-parent rename still targets the captured directory after its diagnostic pathname is replaced;
- unsupported platforms fail with `ErrNamespacePersistenceUnsupported` before certification;
- token revision/digest/identity match the installed manifest bytes and inode;
- a retained token blocks destination replacement with `ErrResourcePinned`;
- an injected post-rename observation failure returns the injected error plus `ErrRecoveryRequired`, poisons the handle, and retains the renamed manifest;
- 32 repeated replacements produce exactly one content-sync pair, one directory-sync pair, and one rename event each, then return to baseline active pins and identities;
- standalone saves advance and reload the persistent revision.

## Local evidence on `9e2e066c1`

- `GOWORK=off go test ./TreeDB/internal/rootpublication ./TreeDB/db -run 'Test.*(LeafGeneration|StableChildFile|StableNamespace)' -count=1`
- `GOWORK=off go test -race ./TreeDB/db -run 'TestLeafGenerationManifestStableResource|TestLeafGenerationGC|TestLeafGenerationPack' -count=1`
- `GOWORK=off go test ./TreeDB/internal/rootpublication -count=1`
- `GOWORK=off go vet ./TreeDB/internal/rootpublication ./TreeDB/db`
- Windows compile: rootpublication and db test binaries with `GOOS=windows GOARCH=amd64`
- `git diff --check`

## Performance gate

`BenchmarkLeafGenerationManifestStableReplace`, `-benchtime=20x -count=3`:

| run | ns/op | B/op | allocs/op |
| --- | ---: | ---: | ---: |
| 1 | 10,647,882 | 5,412 | 65 |
| 2 | 15,980,694 | 5,412 | 65 |
| 3 | 12,725,152 | 5,413 | 65 |

Latency is filesystem-sync dominated and intentionally reported as a range under host contention. The hard gates are stable 65 allocs/op, approximately 5.4 KiB/op, exactly one content fsync and one parent-directory fsync per manifest replacement, no structural sync on ordinary record writes, and no monotonic descriptor/pin/registry growth.

## Boundaries

Root-candidate consumption/order remains #3679. Raw outer-leaf append/rotation capture and packed-output capture/deletion fencing remain subsequent #3677 units.
