### PR TITLE
fix(valuelog): require registry at manager construction

### DIFF
--- a/TreeDB/docs/spec/recovery.md
+++ b/TreeDB/docs/spec/recovery.md
@@ -9,11 +9,12 @@ Recovery is executed during `Open` for read-write handles.
 Current high-level order for non-collection cached WAL:
 
 1. recover index metadata/root state,
-2. discover value-log and commit-log segments from their canonical directories,
-3. validate reachable value-log and split leaf-log records needed by replay,
-4. replay cached commit logs if WAL mode permits,
-5. expose recovered backend roots and memtables,
-6. clean obsolete commit-log segments only after replay permits it.
+2. reconcile identity-encoded value-log delete quarantines on read-write open,
+3. discover value-log and commit-log segments from their canonical directories,
+4. validate reachable value-log and split leaf-log records needed by replay,
+5. replay cached commit logs if WAL mode permits,
+6. expose recovered backend roots and memtables,
+7. clean obsolete commit-log segments only after replay permits it.
 
 Target user-command WAL extension:
 
@@ -116,6 +117,15 @@ From chosen meta:
 - set allocator head from `FreelistHeadID`.
 
 ## 3. WAL Segment Discovery
+
+Before a writable value-log manager scans a segment directory, it reconciles
+any same-parent delete intent named
+`.<segment-name>.delete-<volume-id>-<object-id>`. If the quarantined file has
+the encoded physical identity, recovery completes its deletion. If it has a
+different identity and the canonical name is absent, recovery restores it. A
+canonical and quarantined pair with conflicting identities, or malformed
+quarantine contents, fails closed rather than guessing. Reconciliation runs
+before segment handles become visible to publication or maintenance.
 
 Commit-log segments are discovered from `<maindb>/wal` by filename parsing.
 Value-log segments are discovered from `<maindb>/value_vlog`; split leaf-log
@@ -439,6 +449,13 @@ cleaned.
 ## 7. Read-Only Open
 
 Read-only open must not perform mutating command WAL replay.
+
+Read-only open also does not reconcile value-log delete quarantines. If any
+recognized identity-encoded quarantine is present, both shared-lock and
+no-lock read-only open return public `ErrRecoveryRequired` and leave the
+canonical path, quarantine directory, and quarantined file unchanged. An
+operator may preserve/copy the directory and then use a read-write open to run
+the deterministic reconciliation.
 
 Before exposing state, read-only open must scan command WAL segment metadata,
 cleanup metadata, and `AppliedLSN` enough to determine whether any complete

--- a/TreeDB/docs/spec/storage-format.md
+++ b/TreeDB/docs/spec/storage-format.md
@@ -23,6 +23,10 @@ A TreeDB deployment uses:
 - value-log segments under `value_vlog/value-l*.log`,
 - optional split outer-leaf value-log segments under `leaf_vlog/value-l*.log`
   when `IndexOuterLeavesInValueLog` is enabled,
+- transient, crash-persistent value-log delete intents beside a segment as
+  `.<segment-name>.delete-<volume-id>-<object-id>/<segment-name>`, where the
+  fixed-width hexadecimal ids identify the exact physical object being
+  deleted,
 - typed asset manager segments under
   `column_assets/<namespace>/assets/segments/segment-*.tca` for production
   typed-storage physical assets (`column_assets` remains the compatibility
@@ -53,6 +57,12 @@ Raft provider state is separate from the main DB. The local command WAL under
 value storage managed by reachability-based GC and rewrite/compaction. The
 single-group provider/storage boundary is defined in
 `TreeDB/docs/spec/raftcluster.md`.
+
+The identity-encoded delete-intent directory is recovery state, not another
+value-log segment or an age-based retention mechanism. It may remain after an
+interrupted unlink. A writable open reconciles it before exposing segments; a
+read-only open never mutates it and reports `ErrRecoveryRequired`. Because
+TreeDB is pre-alpha, this protocol has no compatibility migration scaffold.
 
 ## 1.1 Opt-in external-version MVCC key subspace
 

--- a/TreeDB/docs/spec/value-log-lifecycle.md
+++ b/TreeDB/docs/spec/value-log-lifecycle.md
@@ -22,7 +22,24 @@ Conceptually, a value-log segment can be:
 3. eligible (unreferenced and not active),
 4. deleted/zombied.
 
-### 2.1 External-version logical pruning is not segment GC
+### 2.1 Physical-identity deletion and quarantine
+
+All managers and writers that can publish or delete segments in one live DB
+namespace share a physical-identity registry.
+The registry must be installed at construction, before the initial segment
+scan; attaching it afterward is forbidden because an already-open unregistered
+handle could otherwise resurrect an identity another manager committed as
+deleted. Stable publication pins and delete leases use the captured file-handle
+identity, not a later pathname lookup.
+
+Destructive segment removal first moves the canonical name into a private,
+same-parent, identity-encoded quarantine directory. Validation and unlink then
+operate on that exact renamed object. A replacement created at the old
+canonical name is never selected for cleanup. An interrupted quarantine is
+durable recovery state: read-write open reconciles it before scanning segments,
+while read-only open returns `ErrRecoveryRequired` without mutation.
+
+### 2.2 External-version logical pruning is not segment GC
 
 `TreeDB/mvcc.PruneVersions` deletes obsolete physical index keys only after its
 persisted external timestamp floor makes those historical reads invalid. It

--- a/TreeDB/internal/valuelog/identity_pin_manager_test.go
+++ b/TreeDB/internal/valuelog/identity_pin_manager_test.go
@@ -584,6 +584,52 @@ func TestManagerStableDeleteEmitsCanonicalUnlinkCutBeforeQuarantineUnlink(t *tes
 	}
 }
 
+func TestManagerRejectsRegistryInstallationAfterAnotherManagerCommitsDelete(t *testing.T) {
+	dir := t.TempDir()
+	fileID, path := writeIdentityPinTestSegment(t, dir)
+	late, err := NewManager(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer late.Close()
+	registry := rootpublication.NewIdentityPinRegistry()
+	deleter, err := NewManagerWithStableResourcePinRegistry(dir, registry)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := deleter.RemoveSegment(fileID); err != nil {
+		_ = deleter.Close()
+		t.Fatal(err)
+	}
+	if err := deleter.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(path); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("committed delete left path: %v", err)
+	}
+	if got := registry.ActiveIdentities(); got != 0 {
+		t.Fatalf("registry retained %d identities after committed delete", got)
+	}
+	if err := late.SetStableResourcePinRegistry(registry); !errors.Is(err, rootpublication.ErrUnresolvedResource) {
+		t.Fatalf("late registry installation error=%v want ErrUnresolvedResource", err)
+	}
+	token, err := late.StableResourceToken(fileID, StableResourceRegistration{
+		Kind: rootpublication.ResourceValueLog, LogicalLane: "main", Generation: 1,
+		DiagnosticPath: "value_vlog/" + filepath.Base(path),
+		Reachability:   rootpublication.ReachabilityValueLogPointer,
+	})
+	if token != nil {
+		token.Release()
+		t.Fatal("unregistered manager returned a stable resource token")
+	}
+	if !errors.Is(err, rootpublication.ErrUnresolvedResource) {
+		t.Fatalf("unregistered manager token error=%v want ErrUnresolvedResource", err)
+	}
+	if got := registry.ActiveIdentities(); got != 0 {
+		t.Fatalf("late installation resurrected %d identities", got)
+	}
+}
+
 func TestManagerStableDeleteRestoreCompensatesCanonicalUnlink(t *testing.T) {
 	dir := t.TempDir()
 	fileID, path := writeIdentityPinTestSegment(t, dir)

--- a/TreeDB/internal/valuelog/identity_pin_manager_test.go
+++ b/TreeDB/internal/valuelog/identity_pin_manager_test.go
@@ -711,14 +711,11 @@ func TestManagerStableDeleteRejectsReplacedPath(t *testing.T) {
 	}
 	dir := t.TempDir()
 	fileID, path := writeIdentityPinTestSegment(t, dir)
-	manager, err := NewManager(dir)
+	manager, err := NewManagerWithStableResourcePinRegistry(dir, rootpublication.NewIdentityPinRegistry())
 	if err != nil {
 		t.Fatal(err)
 	}
 	defer manager.Close()
-	if err := manager.SetStableResourcePinRegistry(rootpublication.NewIdentityPinRegistry()); err != nil {
-		t.Fatal(err)
-	}
 	oldPath := path + ".old"
 	if err := os.Rename(path, oldPath); err != nil {
 		t.Fatal(err)

--- a/TreeDB/internal/valuelog/stable_pending_successor_supported_test.go
+++ b/TreeDB/internal/valuelog/stable_pending_successor_supported_test.go
@@ -169,13 +169,15 @@ func TestStableValueLogTokenFailureRetriesExactPendingSuccessor(t *testing.T) {
 	dir := t.TempDir()
 	firstPath := filepath.Join(dir, "000001.vlog")
 	secondPath := filepath.Join(dir, "000002.vlog")
-	writer, err := NewWriter(firstPath, 1)
+	registry := rootpublication.NewIdentityPinRegistry()
+	writer, err := NewWriterWithStableResourcePinRegistry(firstPath, 1, registry)
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer writer.Close()
+	t.Cleanup(func() { _ = writer.Close() })
 	appendStablePendingValue(t, writer, 1)
 	closed, active := stablePendingRegistrations(1, 2)
+	active.ExternalRIDs = []uint64{101, 202}
 
 	createCalls := 0
 	restore := durabilitycut.Install(func(event durabilitycut.Event) error {
@@ -205,6 +207,23 @@ func TestStableValueLogTokenFailureRetriesExactPendingSuccessor(t *testing.T) {
 	if !errors.Is(err, injected) {
 		t.Fatalf("first rotation error=%v want token failure", err)
 	}
+	pending := writer.pendingStableSuccessor
+	if pending == nil || !pending.stableObserved || pending.active.PinRegistry != registry {
+		t.Fatalf("retry did not retain one registry-owned successor: %+v", pending)
+	}
+	if pending.parent != writer.stableParent || pending.path != secondPath || pending.fileID != 2 ||
+		pending.active.NamespaceParent != writer.stableParent || pending.active.NewName != filepath.Base(secondPath) {
+		t.Fatalf("retry did not retain the exact parent/path registration: %+v", pending)
+	}
+	active.ExternalRIDs[0] = 999
+	if got := pending.active.ExternalRIDs; len(got) != 2 || got[0] != 101 || got[1] != 202 {
+		t.Fatalf("pending frontier aliases caller storage: %v", got)
+	}
+	active.ExternalRIDs = []uint64{101, 202}
+	pendingIdentity := pending.stableIdentity
+	if got := registry.ActiveIdentities(); got != 2 {
+		t.Fatalf("pending retry identities=%d want old active plus exact successor", got)
+	}
 	createdInfo, err := os.Stat(secondPath)
 	if err != nil {
 		t.Fatal(err)
@@ -213,7 +232,6 @@ func TestStableValueLogTokenFailureRetriesExactPendingSuccessor(t *testing.T) {
 	if err != nil {
 		t.Fatalf("identical retry: %v", err)
 	}
-	defer rotation.Release()
 	installedInfo, err := writer.f.Stat()
 	if err != nil {
 		t.Fatal(err)
@@ -221,6 +239,135 @@ func TestStableValueLogTokenFailureRetriesExactPendingSuccessor(t *testing.T) {
 	if createCalls != 1 || factoryCalls != 2 || !os.SameFile(createdInfo, installedInfo) {
 		t.Fatalf("retry createCalls=%d factoryCalls=%d sameFile=%t, want 1/2/true",
 			createCalls, factoryCalls, os.SameFile(createdInfo, installedInfo))
+	}
+	if writer.pendingStableSuccessor != nil || !writer.stableResourceObserved ||
+		!rootpublication.SamePhysicalIdentity(writer.stableResourceIdentity, pendingIdentity) {
+		t.Fatal("successful retry did not transfer the pending observation into the active writer")
+	}
+	if got := registry.ActivePins(); got != 2 {
+		t.Fatalf("successful retry pins=%d want closed and active tokens", got)
+	}
+	rotation.Release()
+	if got := registry.ActivePins(); got != 0 {
+		t.Fatalf("released rotation pins=%d want 0", got)
+	}
+	if got := registry.ActiveIdentities(); got != 1 {
+		t.Fatalf("post-transfer identities=%d want active writer only", got)
+	}
+	if err := writer.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if got := registry.ActiveIdentities(); got != 0 {
+		t.Fatalf("closed writer retained %d identities", got)
+	}
+}
+
+func TestStableValueLogPendingSuccessorRejectsRegistryMismatch(t *testing.T) {
+	dir := t.TempDir()
+	registry := rootpublication.NewIdentityPinRegistry()
+	writer, err := NewWriterWithStableResourcePinRegistry(filepath.Join(dir, "000001.vlog"), 1, registry)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = writer.Close() })
+	appendStablePendingValue(t, writer, 1)
+	closed, active := stablePendingRegistrations(1, 2)
+	secondPath := filepath.Join(dir, "000002.vlog")
+
+	injected := errors.New("injected namespace-token failure before registry mismatch")
+	originalFactory := newValueLogStableNamespaceToken
+	newValueLogStableNamespaceToken = func(rootpublication.StableNamespaceSpec) (*rootpublication.StableNamespaceToken, error) {
+		return nil, injected
+	}
+	rotation, err := writer.RotateToWithStableResources(secondPath, 2, false, closed, active)
+	newValueLogStableNamespaceToken = originalFactory
+	if rotation != nil {
+		rotation.Release()
+		t.Fatal("failed rotation returned owned resources")
+	}
+	if !errors.Is(err, injected) {
+		t.Fatalf("first rotation error=%v want token failure", err)
+	}
+	pending := writer.pendingStableSuccessor
+	if pending == nil || !pending.stableObserved {
+		t.Fatal("token failure did not retain the observed exact successor")
+	}
+	identity := pending.stableIdentity
+	mismatched := active
+	mismatched.PinRegistry = rootpublication.NewIdentityPinRegistry()
+	rotation, err = writer.RotateToWithStableResources(secondPath, 2, false, closed, mismatched)
+	if rotation != nil {
+		rotation.Release()
+		t.Fatal("registry-mismatched retry returned owned resources")
+	}
+	if !errors.Is(err, rootpublication.ErrResourceConflict) {
+		t.Fatalf("registry-mismatched retry error=%v want ErrResourceConflict", err)
+	}
+	if writer.pendingStableSuccessor != pending || !pending.stableObserved ||
+		!rootpublication.SamePhysicalIdentity(pending.stableIdentity, identity) {
+		t.Fatal("registry-mismatched retry changed the retained exact successor")
+	}
+	if got := registry.ActiveIdentities(); got != 2 {
+		t.Fatalf("registry mismatch identities=%d want old active plus pending successor", got)
+	}
+	rotation, err = writer.RotateToWithStableResources(secondPath, 2, false, closed, active)
+	if err != nil {
+		t.Fatalf("valid retry: %v", err)
+	}
+	rotation.Release()
+	if err := writer.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if got := registry.ActiveIdentities(); got != 0 {
+		t.Fatalf("valid retry cleanup retained %d identities", got)
+	}
+}
+
+func TestStableValueLogPendingSuccessorCloseReleasesExactOwnership(t *testing.T) {
+	dir := t.TempDir()
+	registry := rootpublication.NewIdentityPinRegistry()
+	writer, err := NewWriterWithStableResourcePinRegistry(filepath.Join(dir, "000001.vlog"), 1, registry)
+	if err != nil {
+		t.Fatal(err)
+	}
+	appendStablePendingValue(t, writer, 1)
+	closed, active := stablePendingRegistrations(1, 2)
+	originalFactory := newValueLogStableNamespaceToken
+	injected := errors.New("injected token failure before close")
+	newValueLogStableNamespaceToken = func(rootpublication.StableNamespaceSpec) (*rootpublication.StableNamespaceToken, error) {
+		return nil, injected
+	}
+	rotation, err := writer.RotateToWithStableResources(filepath.Join(dir, "000002.vlog"), 2, false, closed, active)
+	newValueLogStableNamespaceToken = originalFactory
+	if rotation != nil {
+		rotation.Release()
+		t.Fatal("failed rotation returned owned resources")
+	}
+	if !errors.Is(err, injected) {
+		t.Fatalf("rotation error=%v want token failure", err)
+	}
+	oldFile := writer.f
+	pendingFile := writer.pendingStableSuccessor.file
+	parent := writer.stableParent
+	if got := registry.ActiveIdentities(); got != 2 {
+		t.Fatalf("pending close setup identities=%d want 2", got)
+	}
+	if err := writer.Close(); err != nil {
+		t.Fatal(err)
+	}
+	for name, file := range map[string]*os.File{"old": oldFile, "pending": pendingFile, "parent": parent} {
+		if err := file.Close(); !errors.Is(err, os.ErrClosed) {
+			t.Fatalf("%s handle second close=%v want os.ErrClosed", name, err)
+		}
+	}
+	if got := registry.ActivePins(); got != 0 {
+		t.Fatalf("pending close retained %d pins", got)
+	}
+	if got := registry.ActiveIdentities(); got != 0 {
+		t.Fatalf("pending close retained %d identities", got)
+	}
+	if err := writer.Close(); err != nil {
+		t.Fatalf("second writer close: %v", err)
 	}
 }
 
@@ -336,7 +483,8 @@ func TestStableValueLogPendingSuccessorReplacementFailsClosedWithoutUnlink(t *te
 	firstPath := filepath.Join(dir, "000001.vlog")
 	secondPath := filepath.Join(dir, "000002.vlog")
 	displacedPath := filepath.Join(dir, "000002-displaced.vlog")
-	writer, err := NewWriter(firstPath, 1)
+	registry := rootpublication.NewIdentityPinRegistry()
+	writer, err := NewWriterWithStableResourcePinRegistry(firstPath, 1, registry)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -375,6 +523,12 @@ func TestStableValueLogPendingSuccessorReplacementFailsClosedWithoutUnlink(t *te
 	if err := writer.Close(); err != nil {
 		t.Errorf("close writer: %v", err)
 	}
+	if got := registry.ActivePins(); got != 0 {
+		t.Errorf("replacement cleanup retained %d pins", got)
+	}
+	if got := registry.ActiveIdentities(); got != 0 {
+		t.Errorf("replacement cleanup retained %d identities", got)
+	}
 	if got, err := os.ReadFile(secondPath); err != nil || string(got) != "replacement" {
 		t.Errorf("replacement changed: data=%q err=%v", got, err)
 	}
@@ -390,7 +544,8 @@ func TestStableValueLogOldCloseFailureIsFailStop(t *testing.T) {
 	dir := t.TempDir()
 	firstPath := filepath.Join(dir, "000001.vlog")
 	secondPath := filepath.Join(dir, "000002.vlog")
-	writer, err := NewWriter(firstPath, 1)
+	registry := rootpublication.NewIdentityPinRegistry()
+	writer, err := NewWriterWithStableResourcePinRegistry(firstPath, 1, registry)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -409,6 +564,15 @@ func TestStableValueLogOldCloseFailureIsFailStop(t *testing.T) {
 	if !errors.Is(err, injected) {
 		t.Fatalf("rotation error=%v want old-close failure", err)
 	}
+	if pending := writer.pendingStableSuccessor; pending == nil || !pending.failStop || !pending.stableObserved || pending.active.PinRegistry != registry {
+		t.Fatalf("old-close failure did not retain observed fail-stop successor: %+v", pending)
+	}
+	if got := registry.ActivePins(); got != 0 {
+		t.Fatalf("old-close failure retained %d token pins", got)
+	}
+	if got := registry.ActiveIdentities(); got != 1 {
+		t.Fatalf("old-close failure identities=%d want retained successor only", got)
+	}
 	if err := writer.RotateTo(firstPath, 1); !errors.Is(err, rootpublication.ErrResourceOwnership) {
 		t.Fatalf("ordinary rotation after fail-stop error=%v want ErrResourceOwnership", err)
 	}
@@ -422,6 +586,12 @@ func TestStableValueLogOldCloseFailureIsFailStop(t *testing.T) {
 	}
 	if err := writer.Close(); err != nil {
 		t.Fatal(err)
+	}
+	if got := registry.ActiveIdentities(); got != 0 {
+		t.Fatalf("fail-stop close retained %d identities", got)
+	}
+	if err := writer.Close(); err != nil {
+		t.Fatalf("second close: %v", err)
 	}
 	if _, err := os.Stat(secondPath); err != nil {
 		t.Fatalf("fail-stop close removed created successor: %v", err)

--- a/TreeDB/internal/valuelog/stable_resource.go
+++ b/TreeDB/internal/valuelog/stable_resource.go
@@ -115,32 +115,21 @@ func (w *Writer) bindStableResourcePinRegistry(registration *StableResourceRegis
 	return nil
 }
 
-// SetStableResourcePinRegistry installs the DB-scoped physical identity gate
-// used by every manager that can delete these segment files.
+// SetStableResourcePinRegistry only accepts the registry already installed by
+// the constructor. Installing a registry after the initial directory scan can
+// resurrect an identity another manager already committed as deleted.
 func (m *Manager) SetStableResourcePinRegistry(registry *rootpublication.IdentityPinRegistry) error {
 	if m == nil || registry == nil {
 		return errors.New("valuelog: nil stable resource pin registry")
 	}
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	if m.stableResourcePins != nil && m.stableResourcePins != registry {
+	if m.stableResourcePins == nil {
+		return fmt.Errorf("%w: stable resource pin registry must be installed at manager construction", rootpublication.ErrUnresolvedResource)
+	}
+	if m.stableResourcePins != registry {
 		return errors.New("valuelog: stable resource pin registry already installed")
 	}
-	if m.stableResourcePins == registry {
-		return nil
-	}
-	observed := make([]*File, 0, len(m.files))
-	for _, file := range m.files {
-		if err := m.observeStableFileWithRegistryLocked(file, registry); err != nil {
-			for _, prior := range observed {
-				_ = registry.Unobserve(prior.stableIdentity)
-				prior.stableObserved = false
-			}
-			return err
-		}
-		observed = append(observed, file)
-	}
-	m.stableResourcePins = registry
 	return nil
 }
 

--- a/TreeDB/internal/valuelog/stable_resource_windows_test.go
+++ b/TreeDB/internal/valuelog/stable_resource_windows_test.go
@@ -96,3 +96,44 @@ func TestOrdinaryValueLogRotationRemainsUsableAndStableRotationFailsClosed(t *te
 		t.Fatalf("unsupported stable rotation exposed successor: %v", err)
 	}
 }
+
+func TestUnsupportedStableRotationDoesNotLeakRegistryOwnership(t *testing.T) {
+	dir := t.TempDir()
+	registry := rootpublication.NewIdentityPinRegistry()
+	writer, err := NewWriterWithStableResourcePinRegistry(filepath.Join(dir, "000001.vlog"), 1, registry)
+	if err != nil {
+		t.Fatal(err)
+	}
+	rotation, err := writer.RotateToWithStableResources(filepath.Join(dir, "000002.vlog"), 2, false,
+		StableResourceRegistration{
+			LogicalLane: "main", Generation: 1, DiagnosticPath: "maindb/value_vlog/000001.vlog",
+			Reachability: rootpublication.ReachabilityValueLogPointer,
+		},
+		StableResourceRegistration{
+			LogicalLane: "main", Generation: 2, DiagnosticPath: "maindb/value_vlog/000002.vlog",
+			Reachability: rootpublication.ReachabilityValueLogPointer, ParentGeneration: 2,
+			NamespaceOperation: rootpublication.NamespaceCreate,
+		})
+	if rotation != nil {
+		rotation.Release()
+		t.Fatal("unsupported stable rotation returned owned resources")
+	}
+	if !errors.Is(err, rootpublication.ErrNamespacePersistenceUnsupported) {
+		t.Fatalf("stable rotation error=%v want ErrNamespacePersistenceUnsupported", err)
+	}
+	if got := registry.ActivePins(); got != 0 {
+		t.Fatalf("unsupported rotation retained %d pins", got)
+	}
+	if got := registry.ActiveIdentities(); got != 1 {
+		t.Fatalf("unsupported rotation identities=%d want active writer only", got)
+	}
+	if err := writer.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if got := registry.ActiveIdentities(); got != 0 {
+		t.Fatalf("closed writer retained %d identities", got)
+	}
+	if err := writer.Close(); err != nil {
+		t.Fatalf("second close: %v", err)
+	}
+}


### PR DESCRIPTION
Part of #3677. Follow-up to #3747. This bounded unit leaves #3677 and all descendants active.

## Outcome

Require the DB-scoped value-log physical-identity registry at `Manager` construction time. A manager that already scanned/opened segments without the registry may not attach it later and recreate a publishable observation for an identity another manager has committed as deleted.

## Why this follow-up exists

PR #3747 merged its reviewed public head `5e1869dc` as `main@eff739dac` while a normal local reconciliation descendant was completing final review. No merged branch is rewritten. An exact tree comparison isolates seven reviewed files omitted from the public line; this branch starts from the exact merge commit and ports only those files.

## Changes

- Make `Manager.SetStableResourcePinRegistry` idempotent only for the registry already supplied at construction; a previously unregistered manager returns `ErrUnresolvedResource`.
- Prove an unregistered manager cannot survive another manager's committed deletion, attach the registry late, and resurrect the deleted physical identity.
- Preserve pending-successor registry, exact identity, cloned frontier, descriptor, parent, retry, observation-transfer, fail-stop, and exact-once close ownership witnesses.
- Add Windows no-leak coverage for unsupported stable rotation.
- Document identity-encoded persistent delete quarantine, writable reconciliation before segment discovery, read-only `ErrRecoveryRequired`, and the constructor-only registry lifecycle.

## TDD evidence

- RED `1cb3569aa919957e2e558454f0ec6231c2bfdbe2` adds only the deterministic late-manager regression. On merged `main`, it fails exactly: `late registry installation error=<nil> want ErrUnresolvedResource`.
- GREEN `33ecc0e2381407fe1f88fe947c4951af6b16a310` applies the constructor-only setter, updates the one legitimate test caller to constructor injection, and ports the remaining reviewed tests and documentation.

## Exact-head validation

Base: `eff739dac37054edd1139f450aee9802343c6ee5`

Head: `33ecc0e2381407fe1f88fe947c4951af6b16a310`

- Exact regression and focused residual ownership matrix pass.
- Full `TreeDB/internal/valuelog`, `TreeDB/internal/rootpublication`, `TreeDB/db`, `TreeDB/caching`, and `TreeDB/collections` suites pass.
- Focused race and 100x retry/fail-stop/registry stress pass.
- `go vet` passes all five relevant packages.
- Windows/amd64 test compilation passes all five relevant packages.
- `gofmt`, `git diff --check`, and clean-worktree checks pass.
- The final diff from base is exactly seven classified paths. Each final mode/type/blob/path entry equals the independently reviewed `94547290` tree; every other path equals merged `main`.
- Independent mature review of the exact RED/GREEN range found no P0-P3 issue and repeated the native, race, stress, vet, Windows, formatting, tree-boundary, and benchmark gates.

## Performance evidence

- Stable value-log rotation benchmark smoke (100 iterations): 874,556 ns/op unsynced/uncompressed; 3,170,409 ns/op synced/uncompressed; 197,571 ns/op unsynced/compressed; 2,882,448 ns/op synced/compressed.
- Registry pin/release: 180.3 ns/op. Stable token construction: 3,087 ns/op at 1,000 iterations.

## Scope boundary

#3677 remains open for raw/packed outer-leaf and manifest stable-resource capture, remaining column/typed-column/vector/text/dictionary/template producer and deletion-consumer integration, exhaustive inventory closure, and the repository-wide all-kind matrix.
