### PR TITLE
treedb: capture raw outer-leaf durability resources

### DIFF
--- a/TreeDB/caching/db.go
+++ b/TreeDB/caching/db.go
@@ -16794,18 +16794,36 @@ func (db *DB) prepareAppendFrames(
 }
 
 func (db *DB) appendValueLog(l *lane, dictID uint64, dict []byte, records []valuelog.Record, durability journalDurability) ([]page.ValuePtr, error) {
+	ptrs, _, err := db.appendValueLogInternal(l, dictID, dict, records, durability, nil)
+	return ptrs, err
+}
+
+func (db *DB) appendValueLogWithStableResources(l *lane, dictID uint64, dict []byte, records []valuelog.Record, durability journalDurability) ([]page.ValuePtr, *rootpublication.StableResourceSet, error) {
+	capture := newStableOuterLeafCapture(db, l)
+	ptrs, resources, err := db.appendValueLogInternal(l, dictID, dict, records, durability, capture)
+	if err != nil {
+		capture.abandon()
+	}
+	return ptrs, resources, err
+}
+
+func (db *DB) appendValueLogInternal(l *lane, dictID uint64, dict []byte, records []valuelog.Record, durability journalDurability, capture *stableOuterLeafCapture) ([]page.ValuePtr, *rootpublication.StableResourceSet, error) {
 	if !db.splitValueLogEnabled() {
-		return nil, errWALUnavailable
+		return nil, nil, errWALUnavailable
 	}
 	if len(records) == 0 {
-		return nil, nil
+		if capture == nil {
+			return nil, nil, nil
+		}
+		resources, err := capture.freeze(nil)
+		return nil, resources, err
 	}
 	if l == nil {
-		return nil, errWALUnavailable
+		return nil, nil, errWALUnavailable
 	}
 	select {
 	case <-db.closeCh:
-		return nil, errWALClosed
+		return nil, nil, errWALClosed
 	default:
 	}
 	wallStart := time.Time{}
@@ -17068,7 +17086,7 @@ func (db *DB) appendValueLog(l *lane, dictID uint64, dict []byte, records []valu
 		wallStart,
 	)
 	if prepareErr != nil {
-		return nil, prepareErr
+		return nil, nil, prepareErr
 	}
 	if prepEncodeWallNs > 0 && leafLogAppend {
 		db.observeFlushApplyLeafLogEncodeCompress(time.Duration(prepEncodeWallNs))
@@ -17100,12 +17118,12 @@ func (db *DB) appendValueLog(l *lane, dictID uint64, dict []byte, records []valu
 	}
 	if err := db.ensureValueLogWriterMuHeld(l); err != nil {
 		l.vlogMu.Unlock()
-		return nil, err
+		return nil, nil, err
 	}
 	w := l.vlog
 	if w == nil {
 		l.vlogMu.Unlock()
-		return nil, errWALUnavailable
+		return nil, nil, errWALUnavailable
 	}
 	firstPath := l.vlogPath
 	var retainPaths []string
@@ -17124,9 +17142,9 @@ func (db *DB) appendValueLog(l *lane, dictID uint64, dict []byte, records []valu
 			retainPaths = append(retainPaths, path)
 		}
 	}
-	if rotateErr := db.rotateValueLogForMaxSegmentMuHeld(l, w); rotateErr != nil {
+	if rotateErr := db.rotateValueLogForMaxSegmentMuHeldCapture(l, w, capture); rotateErr != nil {
 		l.vlogMu.Unlock()
-		return nil, rotateErr
+		return nil, nil, rotateErr
 	}
 	if l.vlogPath != firstPath {
 		noteRotatePath(l.vlogPath)
@@ -17135,7 +17153,7 @@ func (db *DB) appendValueLog(l *lane, dictID uint64, dict []byte, records []valu
 	w = l.vlog
 	if w == nil {
 		l.vlogMu.Unlock()
-		return nil, errWALUnavailable
+		return nil, nil, errWALUnavailable
 	}
 	if l.vlogCaps.writer != w {
 		l.vlogCaps = computeVlogWriterCaps(w)
@@ -17185,9 +17203,9 @@ func (db *DB) appendValueLog(l *lane, dictID uint64, dict []byte, records []valu
 				est = 0
 			}
 			if est > 0 && w.Size() > maxBytes-est {
-				if rotateErr := db.rotateValueLogMuHeld(l); rotateErr != nil {
+				if rotateErr := db.rotateValueLogMuHeldCapture(l, capture); rotateErr != nil {
 					l.vlogMu.Unlock()
-					return nil, rotateErr
+					return nil, nil, rotateErr
 				}
 				noteRotatePath(l.vlogPath)
 				// Reload writer after rotation so subsequent appends go to the new
@@ -17195,7 +17213,7 @@ func (db *DB) appendValueLog(l *lane, dictID uint64, dict []byte, records []valu
 				w = l.vlog
 				if w == nil {
 					l.vlogMu.Unlock()
-					return nil, errWALUnavailable
+					return nil, nil, errWALUnavailable
 				}
 				if l.vlogCaps.writer != w {
 					l.vlogCaps = computeVlogWriterCaps(w)
@@ -17224,7 +17242,7 @@ func (db *DB) appendValueLog(l *lane, dictID uint64, dict []byte, records []valu
 				if delta := w.Size() - segmentStartSize; delta > 0 {
 					bytesWrittenTotal += delta
 				}
-				if rotateErr := db.rotateValueLogMuHeld(l); rotateErr != nil {
+				if rotateErr := db.rotateValueLogMuHeldCapture(l, capture); rotateErr != nil {
 					err = rotateErr
 					break
 				}
@@ -17302,7 +17320,7 @@ func (db *DB) appendValueLog(l *lane, dictID uint64, dict []byte, records []valu
 	}
 	if err == nil && !rawBatchUsed {
 		for i := 0; i < len(records); i += k {
-			if i > 0 && i%4096 == 0 {
+			if capture == nil && i > 0 && i%4096 == 0 {
 				if leafLogAppend {
 					appendHold += time.Since(lockHoldStart)
 				}
@@ -17329,7 +17347,7 @@ func (db *DB) appendValueLog(l *lane, dictID uint64, dict []byte, records []valu
 				if w == nil {
 					l.vlogMu.Unlock()
 					putValueLogPtrs(ptrs)
-					return nil, errWALUnavailable
+					return nil, nil, errWALUnavailable
 				}
 				if l.vlogCaps.writer != w {
 					l.vlogCaps = computeVlogWriterCaps(w)
@@ -17346,7 +17364,7 @@ func (db *DB) appendValueLog(l *lane, dictID uint64, dict []byte, records []valu
 					if delta := w.Size() - segmentStartSize; delta > 0 {
 						bytesWrittenTotal += delta
 					}
-					if rotateErr := db.rotateValueLogMuHeld(l); rotateErr != nil {
+					if rotateErr := db.rotateValueLogMuHeldCapture(l, capture); rotateErr != nil {
 						err = rotateErr
 						break
 					}
@@ -17474,6 +17492,14 @@ func (db *DB) appendValueLog(l *lane, dictID uint64, dict []byte, records []valu
 			retainPath = l.vlogPath
 		}
 	}
+	if err == nil && capture != nil {
+		fileID, encodeErr := valuelog.EncodeFileID(uint32(l.id), uint32(l.vlogSeq))
+		if encodeErr != nil {
+			err = encodeErr
+		} else {
+			err = capture.captureCurrent(w, l.vlogPath, fileID)
+		}
+	}
 	if db.testBeforeVlogUnlock != nil {
 		db.testBeforeVlogUnlock(int(l.id))
 	}
@@ -17491,12 +17517,12 @@ func (db *DB) appendValueLog(l *lane, dictID uint64, dict []byte, records []valu
 	}
 	if err != nil {
 		putValueLogPtrs(ptrs)
-		return nil, err
+		return nil, nil, err
 	}
 	for i := range ptrs {
 		if !page.IsValueLogFileID(ptrs[i].FileID) {
 			putValueLogPtrs(ptrs)
-			return nil, fmt.Errorf("cachingdb: appendValueLog produced invalid pointer idx=%d ptr=%+v", i, ptrs[i])
+			return nil, nil, fmt.Errorf("cachingdb: appendValueLog produced invalid pointer idx=%d ptr=%+v", i, ptrs[i])
 		}
 	}
 	if framesTotal > 0 {
@@ -17614,7 +17640,15 @@ func (db *DB) appendValueLog(l *lane, dictID uint64, dict []byte, records []valu
 		}
 		db.valueLogAutotuneMetrics.observe(wallStart, rawPayloadBytes, storedForMetrics, encodeNsTotal, encodeRawBytes)
 	}
-	return ptrs, nil
+	if capture == nil {
+		return ptrs, nil, nil
+	}
+	resources, err := capture.freeze(ptrs)
+	if err != nil {
+		putValueLogPtrs(ptrs)
+		return nil, nil, err
+	}
+	return ptrs, resources, nil
 }
 
 func (db *DB) appendValueLogOne(l *lane, dictID uint64, dict []byte, rid uint64, value []byte, durability journalDurability) (page.ValuePtr, string, error) {
@@ -27021,14 +27055,18 @@ func (db *DB) rotateValueLogLocked(l *lane) error {
 }
 
 func (db *DB) rotateValueLogMuHeld(l *lane) error {
+	return db.rotateValueLogMuHeldCapture(l, nil)
+}
+
+func (db *DB) rotateValueLogMuHeldCapture(l *lane, capture *stableOuterLeafCapture) error {
 	if db.isLeafLogAppendLane(l) {
 		nextSeq, err := db.nextLeafLogAppendSeq()
 		if err != nil {
 			return err
 		}
-		return db.rotateValueLogMuHeldToSeq(l, nextSeq)
+		return db.rotateValueLogMuHeldToSeqCapture(l, nextSeq, capture)
 	}
-	return db.rotateValueLogMuHeldToSeq(l, l.vlogSeq+1)
+	return db.rotateValueLogMuHeldToSeqCapture(l, l.vlogSeq+1, capture)
 }
 
 func (db *DB) ensureValueLogWriterMuHeld(l *lane) error {
@@ -27045,6 +27083,10 @@ func (db *DB) ensureValueLogWriterMuHeld(l *lane) error {
 }
 
 func (db *DB) rotateValueLogMuHeldToSeq(l *lane, nextSeq int) error {
+	return db.rotateValueLogMuHeldToSeqCapture(l, nextSeq, nil)
+}
+
+func (db *DB) rotateValueLogMuHeldToSeqCapture(l *lane, nextSeq int, capture *stableOuterLeafCapture) error {
 	if l == nil {
 		return errWALUnavailable
 	}
@@ -27058,9 +27100,10 @@ func (db *DB) rotateValueLogMuHeldToSeq(l *lane, nextSeq int) error {
 	oldPath := l.vlogPath
 	oldLiveBytes := l.vlogLiveBytes.Load()
 	var (
-		closedPrev    int64
-		hadClosedPrev bool
-		rotationErr   error
+		closedPrev      int64
+		hadClosedPrev   bool
+		rotationErr     error
+		stableInstalled bool
 	)
 	name := valueLogName(l.id, nextSeq)
 	path := filepath.Join(db.valueLogDirForLane(l), name)
@@ -27071,8 +27114,37 @@ func (db *DB) rotateValueLogMuHeldToSeq(l *lane, nextSeq int) error {
 
 	if l.vlog != nil {
 		oldSize := l.vlog.Size()
-		if err := l.vlog.RotateToWithSync(path, fileID, !db.relaxedSync); err != nil {
-			if !valuelog.RotationInstalled(err) {
+		var rotateErr error
+		if capture == nil {
+			rotateErr = l.vlog.RotateToWithSync(path, fileID, !db.relaxedSync)
+		} else {
+			stableWriter, ok := l.vlog.(stableValueWriter)
+			if !ok {
+				return fmt.Errorf("%w: outer-leaf writer lacks stable rotation", rootpublication.ErrUnresolvedResource)
+			}
+			oldFileID, encodeErr := valuelog.EncodeFileID(uint32(l.id), uint32(oldSeq))
+			if encodeErr != nil {
+				return encodeErr
+			}
+			closed, registrationErr := capture.registration(oldPath, oldFileID, rootpublication.NamespaceNone)
+			if registrationErr != nil {
+				return registrationErr
+			}
+			active, registrationErr := capture.registration(path, fileID, rootpublication.NamespaceCreate)
+			if registrationErr != nil {
+				return registrationErr
+			}
+			rotation, stableErr := stableWriter.RotateToWithStableResources(path, fileID, !db.relaxedSync, closed, active)
+			if stableErr == nil {
+				stableInstalled = true
+				stableErr = capture.addRotation(rotation)
+			} else if rotation != nil {
+				rotation.Release()
+			}
+			rotateErr = stableErr
+		}
+		if err := rotateErr; err != nil {
+			if !stableInstalled && !valuelog.RotationInstalled(err) {
 				return err
 			}
 			rotationErr = err
@@ -27106,7 +27178,12 @@ func (db *DB) rotateValueLogMuHeldToSeq(l *lane, nextSeq int) error {
 			}
 		}
 	} else {
-		w, err := valuelog.NewWriter(path, fileID)
+		var w *valuelog.Writer
+		if db.isLeafLogAppendLane(l) {
+			w, err = valuelog.NewWriterWithStableResourcePinRegistry(path, fileID, db.valueLogIdentityPins)
+		} else {
+			w, err = valuelog.NewWriter(path, fileID)
+		}
 		if err != nil {
 			return err
 		}
@@ -27182,7 +27259,12 @@ func (db *DB) restoreValueLogWriterMuHeld(l *lane, path string, seq int) error {
 	if err != nil {
 		return err
 	}
-	w, err := valuelog.NewWriter(path, fileID)
+	var w *valuelog.Writer
+	if db.isLeafLogAppendLane(l) {
+		w, err = valuelog.NewWriterWithStableResourcePinRegistry(path, fileID, db.valueLogIdentityPins)
+	} else {
+		w, err = valuelog.NewWriter(path, fileID)
+	}
 	if err != nil {
 		return err
 	}
@@ -27239,6 +27321,10 @@ func (db *DB) registerValueLogSegmentReplacing(path string, fileID, previousFile
 }
 
 func (db *DB) rotateValueLogForMaxSegmentMuHeld(l *lane, w valueWriter) error {
+	return db.rotateValueLogForMaxSegmentMuHeldCapture(l, w, nil)
+}
+
+func (db *DB) rotateValueLogForMaxSegmentMuHeldCapture(l *lane, w valueWriter, capture *stableOuterLeafCapture) error {
 	if db == nil || l == nil || w == nil {
 		return nil
 	}
@@ -27249,7 +27335,7 @@ func (db *DB) rotateValueLogForMaxSegmentMuHeld(l *lane, w valueWriter) error {
 	if w.Size() <= maxBytes {
 		return nil
 	}
-	return db.rotateValueLogMuHeld(l)
+	return db.rotateValueLogMuHeldCapture(l, capture)
 }
 
 func (db *DB) untrackWALSegmentLocked(path string) {

--- a/TreeDB/caching/db.go
+++ b/TreeDB/caching/db.go
@@ -17125,6 +17125,20 @@ func (db *DB) appendValueLogInternal(l *lane, dictID uint64, dict []byte, record
 		l.vlogMu.Unlock()
 		return nil, nil, errWALUnavailable
 	}
+	if capture != nil {
+		stableWriter, ok := w.(stableValueWriter)
+		if !ok {
+			l.vlogMu.Unlock()
+			return nil, nil, fmt.Errorf("%w: outer-leaf writer lacks stable capture", rootpublication.ErrUnresolvedResource)
+		}
+		// Relaxed ordinary rotation intentionally defers its one namespace sync.
+		// Pay that debt before max-segment rotation or any append can mutate the
+		// newly-created segment.
+		if err := stableWriter.CertifyStableCreationNamespace(); err != nil {
+			l.vlogMu.Unlock()
+			return nil, nil, err
+		}
+	}
 	firstPath := l.vlogPath
 	var retainPaths []string
 	noteRotatePath := func(path string) {
@@ -27122,11 +27136,22 @@ func (db *DB) rotateValueLogMuHeldToSeqCapture(l *lane, nextSeq int, capture *st
 			if !ok {
 				return fmt.Errorf("%w: outer-leaf writer lacks stable rotation", rootpublication.ErrUnresolvedResource)
 			}
+			if err := capture.bindParentGeneration(stableWriter); err != nil {
+				return err
+			}
 			oldFileID, encodeErr := valuelog.EncodeFileID(uint32(l.id), uint32(oldSeq))
 			if encodeErr != nil {
 				return encodeErr
 			}
-			closed, registrationErr := capture.registration(oldPath, oldFileID, rootpublication.NamespaceNone)
+			closedOperation := rootpublication.NamespaceNone
+			creationPending, pendingErr := stableWriter.StableCreationNamespacePending()
+			if pendingErr != nil {
+				return pendingErr
+			}
+			if creationPending {
+				closedOperation = rootpublication.NamespaceCreate
+			}
+			closed, registrationErr := capture.registration(oldPath, oldFileID, closedOperation)
 			if registrationErr != nil {
 				return registrationErr
 			}

--- a/TreeDB/caching/leaf_page_log.go
+++ b/TreeDB/caching/leaf_page_log.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	backenddb "github.com/snissn/gomap/TreeDB/db"
+	"github.com/snissn/gomap/TreeDB/internal/rootpublication"
 	"github.com/snissn/gomap/TreeDB/internal/valuelog"
 	"github.com/snissn/gomap/TreeDB/page"
 )
@@ -17,6 +18,11 @@ type cachingLeafPageLog struct {
 
 var _ backenddb.LeafPageLog = (*cachingLeafPageLog)(nil)
 var _ backenddb.LeafPageBatchLog = (*cachingLeafPageLog)(nil)
+var _ backenddb.LeafPageStableLog = (*cachingLeafPageLog)(nil)
+var _ backenddb.LeafPageStableBatchLog = (*cachingLeafPageLog)(nil)
+var _ backenddb.LeafPagePreparedStableLog = (*cachingLeafPageLog)(nil)
+var _ backenddb.LeafPagePreparedStableBatchLog = (*cachingLeafPageLog)(nil)
+var _ backenddb.LeafPagePreparedChildRefStableBatchLog = (*cachingLeafPageLog)(nil)
 var _ backenddb.LeafPageLogCompactStorageHandoff = (*cachingLeafPageLog)(nil)
 
 var compactLeafLogPayloadScratchPool sync.Pool
@@ -197,24 +203,45 @@ func (l *cachingLeafPageLog) AppendLeafPage(leafPage []byte) (page.LeafLogPtr, e
 	return leafPtr, nil
 }
 
+func (l *cachingLeafPageLog) AppendLeafPageWithStableResources(leafPage []byte) (page.LeafLogPtr, *rootpublication.StableResourceSet, error) {
+	ptrs, resources, err := l.appendLeafPages([][]byte{leafPage}, true)
+	if err != nil {
+		return page.LeafLogPtr{}, nil, err
+	}
+	if len(ptrs) != 1 {
+		resources.Release()
+		return page.LeafLogPtr{}, nil, fmt.Errorf("cachingdb: stable leaf append returned %d pointers", len(ptrs))
+	}
+	return ptrs[0], resources, nil
+}
+
 func (l *cachingLeafPageLog) AppendLeafPages(leafPages [][]byte) ([]page.LeafLogPtr, error) {
+	ptrs, _, err := l.appendLeafPages(leafPages, false)
+	return ptrs, err
+}
+
+func (l *cachingLeafPageLog) AppendLeafPagesWithStableResources(leafPages [][]byte) ([]page.LeafLogPtr, *rootpublication.StableResourceSet, error) {
+	return l.appendLeafPages(leafPages, true)
+}
+
+func (l *cachingLeafPageLog) appendLeafPages(leafPages [][]byte, stable bool) ([]page.LeafLogPtr, *rootpublication.StableResourceSet, error) {
 	if l == nil || l.db == nil || l.lane == nil {
-		return nil, errWALUnavailable
+		return nil, nil, errWALUnavailable
 	}
 	if len(leafPages) == 0 {
-		return nil, nil
+		return nil, nil, nil
 	}
-	if len(leafPages) == 1 {
+	if len(leafPages) == 1 && !stable {
 		ptr, err := l.AppendLeafPage(leafPages[0])
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
-		return []page.LeafLogPtr{ptr}, nil
+		return []page.LeafLogPtr{ptr}, nil, nil
 	}
 
 	startRID, err := l.db.ReserveValueLogRIDs(len(leafPages))
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	records := getValueLogRecordsCap(len(leafPages))
 	records = records[:len(leafPages)]
@@ -246,7 +273,7 @@ func (l *cachingLeafPageLog) AppendLeafPages(leafPages [][]byte) ([]page.LeafLog
 		if err != nil {
 			putCompactLeafLogPayloadScratch(scratch)
 			observeEncode()
-			return nil, err
+			return nil, nil, err
 		}
 		if compacted {
 			if scratchRef == nil {
@@ -265,25 +292,38 @@ func (l *cachingLeafPageLog) AppendLeafPages(leafPages [][]byte) ([]page.LeafLog
 	}
 	observeEncode()
 
-	valuePtrs, err := l.db.appendValueLog(l.lane, 0, nil, records, journalDurabilityNone)
+	var resources *rootpublication.StableResourceSet
+	var valuePtrs []page.ValuePtr
+	if stable {
+		valuePtrs, resources, err = l.db.appendValueLogWithStableResources(l.lane, 0, nil, records, journalDurabilityNone)
+	} else {
+		valuePtrs, err = l.db.appendValueLog(l.lane, 0, nil, records, journalDurabilityNone)
+	}
 	if err != nil {
 		l.db.observeLeafLogLaneAppend(l.lane, 0, 0, 0, 0, err)
-		return nil, err
+		return nil, nil, err
 	}
+	releaseResources := true
+	defer func() {
+		if releaseResources {
+			resources.Release()
+		}
+	}()
 	defer putValueLogPtrs(valuePtrs)
 	if len(valuePtrs) != len(leafPages) {
-		return nil, fmt.Errorf("cachingdb: leaf page batch returned %d ptrs for %d leaf pages", len(valuePtrs), len(leafPages))
+		return nil, nil, fmt.Errorf("cachingdb: leaf page batch returned %d ptrs for %d leaf pages", len(valuePtrs), len(leafPages))
 	}
 	leafPtrs := make([]page.LeafLogPtr, len(valuePtrs))
 	for i, ptr := range valuePtrs {
 		leafPtr, convErr := page.LeafLogPtrFromValuePtr(ptr)
 		if convErr != nil {
-			return nil, convErr
+			return nil, nil, convErr
 		}
 		leafPtrs[i] = leafPtr
 		l.db.noteLeafGenerationRecordLength(ptr)
 	}
-	return leafPtrs, nil
+	releaseResources = false
+	return leafPtrs, resources, nil
 }
 
 func (l *cachingLeafPageLog) AppendPreparedLeafPage(leafPage []byte, preparedPayload []byte) (page.LeafLogPtr, error) {
@@ -310,26 +350,47 @@ func (l *cachingLeafPageLog) AppendPreparedLeafPage(leafPage []byte, preparedPay
 	return leafPtr, nil
 }
 
+func (l *cachingLeafPageLog) AppendPreparedLeafPageWithStableResources(leafPage []byte, preparedPayload []byte) (page.LeafLogPtr, *rootpublication.StableResourceSet, error) {
+	ptrs, resources, err := l.appendPreparedLeafPages([][]byte{leafPage}, [][]byte{preparedPayload}, true)
+	if err != nil {
+		return page.LeafLogPtr{}, nil, err
+	}
+	if len(ptrs) != 1 {
+		resources.Release()
+		return page.LeafLogPtr{}, nil, fmt.Errorf("cachingdb: stable prepared leaf append returned %d pointers", len(ptrs))
+	}
+	return ptrs[0], resources, nil
+}
+
 func (l *cachingLeafPageLog) AppendPreparedLeafPages(leafPages [][]byte, preparedPayloads [][]byte) ([]page.LeafLogPtr, error) {
+	ptrs, _, err := l.appendPreparedLeafPages(leafPages, preparedPayloads, false)
+	return ptrs, err
+}
+
+func (l *cachingLeafPageLog) AppendPreparedLeafPagesWithStableResources(leafPages [][]byte, preparedPayloads [][]byte) ([]page.LeafLogPtr, *rootpublication.StableResourceSet, error) {
+	return l.appendPreparedLeafPages(leafPages, preparedPayloads, true)
+}
+
+func (l *cachingLeafPageLog) appendPreparedLeafPages(leafPages [][]byte, preparedPayloads [][]byte, stable bool) ([]page.LeafLogPtr, *rootpublication.StableResourceSet, error) {
 	if l == nil || l.db == nil || l.lane == nil {
-		return nil, errWALUnavailable
+		return nil, nil, errWALUnavailable
 	}
 	if len(leafPages) == 0 {
-		return nil, nil
+		return nil, nil, nil
 	}
 	if len(preparedPayloads) != len(leafPages) {
-		return nil, fmt.Errorf("cachingdb: prepared leaf page batch has %d payloads for %d leaf pages", len(preparedPayloads), len(leafPages))
+		return nil, nil, fmt.Errorf("cachingdb: prepared leaf page batch has %d payloads for %d leaf pages", len(preparedPayloads), len(leafPages))
 	}
-	if len(leafPages) == 1 {
+	if len(leafPages) == 1 && !stable {
 		ptr, err := l.AppendPreparedLeafPage(leafPages[0], preparedPayloads[0])
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
-		return []page.LeafLogPtr{ptr}, nil
+		return []page.LeafLogPtr{ptr}, nil, nil
 	}
 	startRID, err := l.db.ReserveValueLogRIDs(len(leafPages))
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	records := getValueLogRecordsCap(len(leafPages))
 	records = records[:len(leafPages)]
@@ -341,55 +402,77 @@ func (l *cachingLeafPageLog) AppendPreparedLeafPages(leafPages [][]byte, prepare
 	}()
 	for i := range leafPages {
 		if len(leafPages[i]) != page.PageSize {
-			return nil, fmt.Errorf("cachingdb: prepared leaf page %d has invalid size: got=%dB want=%dB", i, len(leafPages[i]), page.PageSize)
+			return nil, nil, fmt.Errorf("cachingdb: prepared leaf page %d has invalid size: got=%dB want=%dB", i, len(leafPages[i]), page.PageSize)
 		}
 		records[i] = valuelog.Record{
 			RID:   startRID + uint64(i),
 			Value: preparedPayloads[i],
 		}
 	}
-	valuePtrs, err := l.db.appendValueLog(l.lane, 0, nil, records, journalDurabilityNone)
+	var resources *rootpublication.StableResourceSet
+	var valuePtrs []page.ValuePtr
+	if stable {
+		valuePtrs, resources, err = l.db.appendValueLogWithStableResources(l.lane, 0, nil, records, journalDurabilityNone)
+	} else {
+		valuePtrs, err = l.db.appendValueLog(l.lane, 0, nil, records, journalDurabilityNone)
+	}
 	if err != nil {
 		l.db.observeLeafLogLaneAppend(l.lane, 0, 0, 0, 0, err)
-		return nil, err
+		return nil, nil, err
 	}
+	releaseResources := true
+	defer func() {
+		if releaseResources {
+			resources.Release()
+		}
+	}()
 	defer putValueLogPtrs(valuePtrs)
 	if len(valuePtrs) != len(leafPages) {
-		return nil, fmt.Errorf("cachingdb: prepared leaf page batch returned %d ptrs for %d leaf pages", len(valuePtrs), len(leafPages))
+		return nil, nil, fmt.Errorf("cachingdb: prepared leaf page batch returned %d ptrs for %d leaf pages", len(valuePtrs), len(leafPages))
 	}
 	leafPtrs := make([]page.LeafLogPtr, len(valuePtrs))
 	for i, ptr := range valuePtrs {
 		leafPtr, convErr := page.LeafLogPtrFromValuePtr(ptr)
 		if convErr != nil {
-			return nil, convErr
+			return nil, nil, convErr
 		}
 		leafPtrs[i] = leafPtr
 		l.db.noteLeafGenerationRecordLength(ptr)
 	}
-	return leafPtrs, nil
+	releaseResources = false
+	return leafPtrs, resources, nil
 }
 
 func (l *cachingLeafPageLog) AppendPreparedLeafPageChildRefs(leafPages [][]byte, preparedPayloads [][]byte, refs []page.ChildRef) ([]page.ChildRef, error) {
+	refs, _, err := l.appendPreparedLeafPageChildRefs(leafPages, preparedPayloads, refs, false)
+	return refs, err
+}
+
+func (l *cachingLeafPageLog) AppendPreparedLeafPageChildRefsWithStableResources(leafPages [][]byte, preparedPayloads [][]byte, refs []page.ChildRef) ([]page.ChildRef, *rootpublication.StableResourceSet, error) {
+	return l.appendPreparedLeafPageChildRefs(leafPages, preparedPayloads, refs, true)
+}
+
+func (l *cachingLeafPageLog) appendPreparedLeafPageChildRefs(leafPages [][]byte, preparedPayloads [][]byte, refs []page.ChildRef, stable bool) ([]page.ChildRef, *rootpublication.StableResourceSet, error) {
 	refs = refs[:0]
 	if l == nil || l.db == nil || l.lane == nil {
-		return nil, errWALUnavailable
+		return nil, nil, errWALUnavailable
 	}
 	if len(leafPages) == 0 {
-		return refs, nil
+		return refs, nil, nil
 	}
 	if len(preparedPayloads) != len(leafPages) {
-		return nil, fmt.Errorf("cachingdb: prepared leaf page child-ref batch has %d payloads for %d leaf pages", len(preparedPayloads), len(leafPages))
+		return nil, nil, fmt.Errorf("cachingdb: prepared leaf page child-ref batch has %d payloads for %d leaf pages", len(preparedPayloads), len(leafPages))
 	}
-	if len(leafPages) == 1 {
+	if len(leafPages) == 1 && !stable {
 		ptr, err := l.AppendPreparedLeafPage(leafPages[0], preparedPayloads[0])
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
-		return append(refs, page.LeafLogChildRef(ptr)), nil
+		return append(refs, page.LeafLogChildRef(ptr)), nil, nil
 	}
 	startRID, err := l.db.ReserveValueLogRIDs(len(leafPages))
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	records := getValueLogRecordsCap(len(leafPages))
 	records = records[:len(leafPages)]
@@ -401,21 +484,33 @@ func (l *cachingLeafPageLog) AppendPreparedLeafPageChildRefs(leafPages [][]byte,
 	}()
 	for i := range leafPages {
 		if len(leafPages[i]) != page.PageSize {
-			return nil, fmt.Errorf("cachingdb: prepared leaf page %d has invalid size: got=%dB want=%dB", i, len(leafPages[i]), page.PageSize)
+			return nil, nil, fmt.Errorf("cachingdb: prepared leaf page %d has invalid size: got=%dB want=%dB", i, len(leafPages[i]), page.PageSize)
 		}
 		records[i] = valuelog.Record{
 			RID:   startRID + uint64(i),
 			Value: preparedPayloads[i],
 		}
 	}
-	valuePtrs, err := l.db.appendValueLog(l.lane, 0, nil, records, journalDurabilityNone)
+	var resources *rootpublication.StableResourceSet
+	var valuePtrs []page.ValuePtr
+	if stable {
+		valuePtrs, resources, err = l.db.appendValueLogWithStableResources(l.lane, 0, nil, records, journalDurabilityNone)
+	} else {
+		valuePtrs, err = l.db.appendValueLog(l.lane, 0, nil, records, journalDurabilityNone)
+	}
 	if err != nil {
 		l.db.observeLeafLogLaneAppend(l.lane, 0, 0, 0, 0, err)
-		return nil, err
+		return nil, nil, err
 	}
+	releaseResources := true
+	defer func() {
+		if releaseResources && resources != nil {
+			resources.Release()
+		}
+	}()
 	defer putValueLogPtrs(valuePtrs)
 	if len(valuePtrs) != len(leafPages) {
-		return nil, fmt.Errorf("cachingdb: prepared leaf page child-ref batch returned %d ptrs for %d leaf pages", len(valuePtrs), len(leafPages))
+		return nil, nil, fmt.Errorf("cachingdb: prepared leaf page child-ref batch returned %d ptrs for %d leaf pages", len(valuePtrs), len(leafPages))
 	}
 	if cap(refs) < len(valuePtrs) {
 		refs = make([]page.ChildRef, len(valuePtrs))
@@ -425,12 +520,13 @@ func (l *cachingLeafPageLog) AppendPreparedLeafPageChildRefs(leafPages [][]byte,
 	for i, ptr := range valuePtrs {
 		leafPtr, convErr := page.LeafLogPtrFromValuePtr(ptr)
 		if convErr != nil {
-			return nil, convErr
+			return nil, nil, convErr
 		}
 		refs[i] = page.LeafLogChildRef(leafPtr)
 		l.db.noteLeafGenerationRecordLength(ptr)
 	}
-	return refs, nil
+	releaseResources = false
+	return refs, resources, nil
 }
 
 func getCompactLeafLogPayloadScratch() *compactLeafLogPayloadScratch {

--- a/TreeDB/caching/leaf_page_log.go
+++ b/TreeDB/caching/leaf_page_log.go
@@ -444,15 +444,70 @@ func (l *cachingLeafPageLog) appendPreparedLeafPages(leafPages [][]byte, prepare
 }
 
 func (l *cachingLeafPageLog) AppendPreparedLeafPageChildRefs(leafPages [][]byte, preparedPayloads [][]byte, refs []page.ChildRef) ([]page.ChildRef, error) {
-	refs, _, err := l.appendPreparedLeafPageChildRefs(leafPages, preparedPayloads, refs, false)
-	return refs, err
+	refs = refs[:0]
+	if l == nil || l.db == nil || l.lane == nil {
+		return nil, errWALUnavailable
+	}
+	if len(leafPages) == 0 {
+		return refs, nil
+	}
+	if len(preparedPayloads) != len(leafPages) {
+		return nil, fmt.Errorf("cachingdb: prepared leaf page child-ref batch has %d payloads for %d leaf pages", len(preparedPayloads), len(leafPages))
+	}
+	if len(leafPages) == 1 {
+		ptr, err := l.AppendPreparedLeafPage(leafPages[0], preparedPayloads[0])
+		if err != nil {
+			return nil, err
+		}
+		return append(refs, page.LeafLogChildRef(ptr)), nil
+	}
+	startRID, err := l.db.ReserveValueLogRIDs(len(leafPages))
+	if err != nil {
+		return nil, err
+	}
+	records := getValueLogRecordsCap(len(leafPages))
+	records = records[:len(leafPages)]
+	defer func() {
+		for i := range records {
+			records[i] = valuelog.Record{}
+		}
+		putValueLogRecordsNoClear(records)
+	}()
+	for i := range leafPages {
+		if len(leafPages[i]) != page.PageSize {
+			return nil, fmt.Errorf("cachingdb: prepared leaf page %d has invalid size: got=%dB want=%dB", i, len(leafPages[i]), page.PageSize)
+		}
+		records[i] = valuelog.Record{
+			RID:   startRID + uint64(i),
+			Value: preparedPayloads[i],
+		}
+	}
+	valuePtrs, err := l.db.appendValueLog(l.lane, 0, nil, records, journalDurabilityNone)
+	if err != nil {
+		l.db.observeLeafLogLaneAppend(l.lane, 0, 0, 0, 0, err)
+		return nil, err
+	}
+	defer putValueLogPtrs(valuePtrs)
+	if len(valuePtrs) != len(leafPages) {
+		return nil, fmt.Errorf("cachingdb: prepared leaf page child-ref batch returned %d ptrs for %d leaf pages", len(valuePtrs), len(leafPages))
+	}
+	if cap(refs) < len(valuePtrs) {
+		refs = make([]page.ChildRef, len(valuePtrs))
+	} else {
+		refs = refs[:len(valuePtrs)]
+	}
+	for i, ptr := range valuePtrs {
+		leafPtr, convErr := page.LeafLogPtrFromValuePtr(ptr)
+		if convErr != nil {
+			return nil, convErr
+		}
+		refs[i] = page.LeafLogChildRef(leafPtr)
+		l.db.noteLeafGenerationRecordLength(ptr)
+	}
+	return refs, nil
 }
 
 func (l *cachingLeafPageLog) AppendPreparedLeafPageChildRefsWithStableResources(leafPages [][]byte, preparedPayloads [][]byte, refs []page.ChildRef) ([]page.ChildRef, *rootpublication.StableResourceSet, error) {
-	return l.appendPreparedLeafPageChildRefs(leafPages, preparedPayloads, refs, true)
-}
-
-func (l *cachingLeafPageLog) appendPreparedLeafPageChildRefs(leafPages [][]byte, preparedPayloads [][]byte, refs []page.ChildRef, stable bool) ([]page.ChildRef, *rootpublication.StableResourceSet, error) {
 	refs = refs[:0]
 	if l == nil || l.db == nil || l.lane == nil {
 		return nil, nil, errWALUnavailable
@@ -462,13 +517,6 @@ func (l *cachingLeafPageLog) appendPreparedLeafPageChildRefs(leafPages [][]byte,
 	}
 	if len(preparedPayloads) != len(leafPages) {
 		return nil, nil, fmt.Errorf("cachingdb: prepared leaf page child-ref batch has %d payloads for %d leaf pages", len(preparedPayloads), len(leafPages))
-	}
-	if len(leafPages) == 1 && !stable {
-		ptr, err := l.AppendPreparedLeafPage(leafPages[0], preparedPayloads[0])
-		if err != nil {
-			return nil, nil, err
-		}
-		return append(refs, page.LeafLogChildRef(ptr)), nil, nil
 	}
 	startRID, err := l.db.ReserveValueLogRIDs(len(leafPages))
 	if err != nil {
@@ -491,13 +539,7 @@ func (l *cachingLeafPageLog) appendPreparedLeafPageChildRefs(leafPages [][]byte,
 			Value: preparedPayloads[i],
 		}
 	}
-	var resources *rootpublication.StableResourceSet
-	var valuePtrs []page.ValuePtr
-	if stable {
-		valuePtrs, resources, err = l.db.appendValueLogWithStableResources(l.lane, 0, nil, records, journalDurabilityNone)
-	} else {
-		valuePtrs, err = l.db.appendValueLog(l.lane, 0, nil, records, journalDurabilityNone)
-	}
+	valuePtrs, resources, err := l.db.appendValueLogWithStableResources(l.lane, 0, nil, records, journalDurabilityNone)
 	if err != nil {
 		l.db.observeLeafLogLaneAppend(l.lane, 0, 0, 0, 0, err)
 		return nil, nil, err

--- a/TreeDB/caching/leaf_page_log_lanes.go
+++ b/TreeDB/caching/leaf_page_log_lanes.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 
 	backenddb "github.com/snissn/gomap/TreeDB/db"
+	"github.com/snissn/gomap/TreeDB/internal/rootpublication"
 	"github.com/snissn/gomap/TreeDB/page"
 )
 
@@ -13,9 +14,14 @@ type cachingLeafPageLogGroup struct {
 
 var _ backenddb.LeafPageLog = (*cachingLeafPageLogGroup)(nil)
 var _ backenddb.LeafPageBatchLog = (*cachingLeafPageLogGroup)(nil)
+var _ backenddb.LeafPageStableLog = (*cachingLeafPageLogGroup)(nil)
+var _ backenddb.LeafPageStableBatchLog = (*cachingLeafPageLogGroup)(nil)
 var _ backenddb.LeafPagePreparedLog = (*cachingLeafPageLogGroup)(nil)
+var _ backenddb.LeafPagePreparedStableLog = (*cachingLeafPageLogGroup)(nil)
 var _ backenddb.LeafPagePreparedBatchLog = (*cachingLeafPageLogGroup)(nil)
+var _ backenddb.LeafPagePreparedStableBatchLog = (*cachingLeafPageLogGroup)(nil)
 var _ backenddb.LeafPagePreparedChildRefBatchLog = (*cachingLeafPageLogGroup)(nil)
+var _ backenddb.LeafPagePreparedChildRefStableBatchLog = (*cachingLeafPageLogGroup)(nil)
 var _ backenddb.LeafPageConcurrentAppendLog = (*cachingLeafPageLogGroup)(nil)
 var _ backenddb.LeafPageLogCreatedSegmentProvider = (*cachingLeafPageLogGroup)(nil)
 var _ backenddb.LeafPageLogCurrentSegmentProvider = (*cachingLeafPageLogGroup)(nil)
@@ -69,12 +75,36 @@ func (g *cachingLeafPageLogGroup) AppendLeafPages(leafPages [][]byte) ([]page.Le
 	return log.AppendLeafPages(leafPages)
 }
 
+func (g *cachingLeafPageLogGroup) AppendLeafPageWithStableResources(leafPage []byte) (page.LeafLogPtr, *rootpublication.StableResourceSet, error) {
+	log := g.defaultLog()
+	if log == nil {
+		return page.LeafLogPtr{}, nil, errors.New("cachingdb: leaf page log unavailable")
+	}
+	return log.AppendLeafPageWithStableResources(leafPage)
+}
+
+func (g *cachingLeafPageLogGroup) AppendLeafPagesWithStableResources(leafPages [][]byte) ([]page.LeafLogPtr, *rootpublication.StableResourceSet, error) {
+	log := g.defaultLog()
+	if log == nil {
+		return nil, nil, errors.New("cachingdb: leaf page log unavailable")
+	}
+	return log.AppendLeafPagesWithStableResources(leafPages)
+}
+
 func (g *cachingLeafPageLogGroup) AppendPreparedLeafPage(leafPage []byte, preparedPayload []byte) (page.LeafLogPtr, error) {
 	log := g.defaultLog()
 	if log == nil {
 		return page.LeafLogPtr{}, errors.New("cachingdb: leaf page log unavailable")
 	}
 	return log.AppendPreparedLeafPage(leafPage, preparedPayload)
+}
+
+func (g *cachingLeafPageLogGroup) AppendPreparedLeafPageWithStableResources(leafPage []byte, preparedPayload []byte) (page.LeafLogPtr, *rootpublication.StableResourceSet, error) {
+	log := g.defaultLog()
+	if log == nil {
+		return page.LeafLogPtr{}, nil, errors.New("cachingdb: leaf page log unavailable")
+	}
+	return log.AppendPreparedLeafPageWithStableResources(leafPage, preparedPayload)
 }
 
 func (g *cachingLeafPageLogGroup) AppendPreparedLeafPages(leafPages [][]byte, preparedPayloads [][]byte) ([]page.LeafLogPtr, error) {
@@ -85,12 +115,28 @@ func (g *cachingLeafPageLogGroup) AppendPreparedLeafPages(leafPages [][]byte, pr
 	return log.AppendPreparedLeafPages(leafPages, preparedPayloads)
 }
 
+func (g *cachingLeafPageLogGroup) AppendPreparedLeafPagesWithStableResources(leafPages [][]byte, preparedPayloads [][]byte) ([]page.LeafLogPtr, *rootpublication.StableResourceSet, error) {
+	log := g.defaultLog()
+	if log == nil {
+		return nil, nil, errors.New("cachingdb: leaf page log unavailable")
+	}
+	return log.AppendPreparedLeafPagesWithStableResources(leafPages, preparedPayloads)
+}
+
 func (g *cachingLeafPageLogGroup) AppendPreparedLeafPageChildRefs(leafPages [][]byte, preparedPayloads [][]byte, refs []page.ChildRef) ([]page.ChildRef, error) {
 	log := g.defaultLog()
 	if log == nil {
 		return nil, errors.New("cachingdb: leaf page log unavailable")
 	}
 	return log.AppendPreparedLeafPageChildRefs(leafPages, preparedPayloads, refs)
+}
+
+func (g *cachingLeafPageLogGroup) AppendPreparedLeafPageChildRefsWithStableResources(leafPages [][]byte, preparedPayloads [][]byte, refs []page.ChildRef) ([]page.ChildRef, *rootpublication.StableResourceSet, error) {
+	log := g.defaultLog()
+	if log == nil {
+		return nil, nil, errors.New("cachingdb: leaf page log unavailable")
+	}
+	return log.AppendPreparedLeafPageChildRefsWithStableResources(leafPages, preparedPayloads, refs)
 }
 
 func (g *cachingLeafPageLogGroup) ConcurrentLeafPageAppends() bool { return true }

--- a/TreeDB/caching/leaf_page_log_test.go
+++ b/TreeDB/caching/leaf_page_log_test.go
@@ -245,11 +245,11 @@ func TestCompactLeafLogPayloadScratchPtrRefClearedForPooling(t *testing.T) {
 	putCompactLeafLogPayloadScratchPtrRef(got, got.ptrs)
 }
 
-func buildSparseLeafPageForLeafLogTest(t *testing.T) []byte {
+func buildSparseLeafPageForLeafLogTest(t testing.TB) []byte {
 	return buildSparseLeafPageForLeafLogTestWithTag(t, 'x')
 }
 
-func buildSparseLeafPageForLeafLogTestWithTag(t *testing.T, tag byte) []byte {
+func buildSparseLeafPageForLeafLogTestWithTag(t testing.TB, tag byte) []byte {
 	t.Helper()
 	buf := make([]byte, page.PageSize)
 	b := node.NewBuilderWithOptions(buf, page.PageTypeLeaf, node.BuilderOptions{

--- a/TreeDB/caching/leaf_page_stable_resource_test.go
+++ b/TreeDB/caching/leaf_page_stable_resource_test.go
@@ -1,0 +1,92 @@
+//go:build !windows
+
+package caching
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"testing"
+
+	backenddb "github.com/snissn/gomap/TreeDB/db"
+	"github.com/snissn/gomap/TreeDB/internal/rootpublication"
+	"github.com/snissn/gomap/TreeDB/page"
+)
+
+func TestCachingLeafPageLogStableBatchPinsExactRawSegment(t *testing.T) {
+	dir := t.TempDir()
+	backend, err := backenddb.Open(backenddb.Options{Dir: dir, IndexOuterLeavesInValueLog: true})
+	if err != nil {
+		t.Fatalf("open backend: %v", err)
+	}
+	cached, err := Open(dir, backend, Options{
+		IndexOuterLeavesInValueLog: true,
+		RelaxedSync:                true,
+		AllowUnsafe:                true,
+	})
+	if err != nil {
+		_ = backend.Close()
+		t.Fatalf("open cache: %v", err)
+	}
+	defer func() { _ = cached.Close() }()
+
+	stable, ok := newCachingLeafPageLog(cached, &cached.leafLog).(backenddb.LeafPageStableBatchLog)
+	if !ok {
+		t.Fatal("cached leaf-page log does not expose stable batch capture")
+	}
+	pages := [][]byte{
+		buildSparseLeafPageForLeafLogTestWithTag(t, 's'),
+		buildSparseLeafPageForLeafLogTestWithTag(t, 't'),
+	}
+	ptrs, resources, err := stable.AppendLeafPagesWithStableResources(pages)
+	if err != nil {
+		t.Fatalf("stable append: %v", err)
+	}
+	if resources == nil {
+		t.Fatal("stable append returned nil resources")
+	}
+	defer resources.Release()
+	if len(ptrs) != len(pages) {
+		t.Fatalf("pointer count=%d want %d", len(ptrs), len(pages))
+	}
+	descriptors := resources.Descriptors()
+	if len(descriptors) != 1 {
+		t.Fatalf("resource count=%d want 1", len(descriptors))
+	}
+	descriptor := descriptors[0]
+	if descriptor.Kind() != rootpublication.ResourceOuterLeafLog {
+		t.Fatalf("kind=%q want %q", descriptor.Kind(), rootpublication.ResourceOuterLeafLog)
+	}
+	fields := descriptor.ReachabilityFields()
+	if len(fields) != 1 || fields[0] != rootpublication.ReachabilityOuterLeafRawPointer {
+		t.Fatalf("reachability=%v", fields)
+	}
+	if descriptor.Frontier().Bytes == 0 {
+		t.Fatal("captured frontier is empty")
+	}
+
+	segmentPath, _, ok := newCachingLeafPageLog(cached, &cached.leafLog).(interface {
+		CurrentValueLogSegment() (string, uint32, bool)
+	}).CurrentValueLogSegment()
+	if !ok {
+		t.Fatal("missing current leaf segment")
+	}
+	moved := segmentPath + ".moved"
+	if err := os.Rename(segmentPath, moved); err != nil {
+		t.Fatalf("rename captured segment: %v", err)
+	}
+	if err := os.WriteFile(segmentPath, bytes.Repeat([]byte{0xee}, page.PageSize), 0o600); err != nil {
+		t.Fatalf("create path replacement: %v", err)
+	}
+	token := resources.Tokens()[0]
+	got := make([]byte, 8)
+	if _, err := token.ReadAt(got, int64(ptrs[0].Offset)); err != nil {
+		t.Fatalf("read pinned segment after path replacement: %v", err)
+	}
+	if bytes.Equal(got, bytes.Repeat([]byte{0xee}, len(got))) {
+		t.Fatal("stable token reopened the replacement pathname")
+	}
+	if filepath.Clean(token.DiagnosticPath()) == filepath.Clean(segmentPath) {
+		t.Fatal("diagnostic path must be DB-relative")
+	}
+}

--- a/TreeDB/caching/leaf_page_stable_resource_test.go
+++ b/TreeDB/caching/leaf_page_stable_resource_test.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	backenddb "github.com/snissn/gomap/TreeDB/db"
+	"github.com/snissn/gomap/TreeDB/internal/durabilitycut"
 	"github.com/snissn/gomap/TreeDB/internal/rootpublication"
 	"github.com/snissn/gomap/TreeDB/internal/valuelog"
 	"github.com/snissn/gomap/TreeDB/page"
@@ -175,8 +176,8 @@ func TestCachingLeafPageLogStablePreparedBatchCapturesEveryReferencedSegment(t *
 			namespaceTokens++
 		}
 	}
-	if namespaceTokens != len(descriptors)-1 {
-		t.Fatalf("namespace-bearing tokens=%d descriptors=%d want created segments plus one existing segment", namespaceTokens, len(descriptors))
+	if namespaceTokens != len(descriptors) {
+		t.Fatalf("namespace-bearing tokens=%d descriptors=%d want exact create evidence for every newly created referenced segment", namespaceTokens, len(descriptors))
 	}
 	stats := resources.Stats(time.Now())
 	if len(stats) != 1 || stats[0].NamespaceSyncs != uint64(namespaceTokens) {
@@ -313,6 +314,86 @@ func TestCachingLeafPageLogStableCaptureExcludesFollowingConcurrentRotation(t *t
 	descriptors := stable.resources.Descriptors()
 	if len(descriptors) != 1 || uint32(descriptors[0].Generation()) != stable.ptr.ValueLogFileID() {
 		t.Fatalf("stable descriptors=%v want only file_id=%d", descriptors, stable.ptr.ValueLogFileID())
+	}
+}
+
+func TestCachingLeafPageLogStableCertifiesRelaxedOrdinaryRotationBeforeAppend(t *testing.T) {
+	dir := t.TempDir()
+	backend, err := backenddb.Open(backenddb.Options{Dir: dir, IndexOuterLeavesInValueLog: true})
+	if err != nil {
+		t.Fatalf("open backend: %v", err)
+	}
+	cached, err := Open(dir, backend, Options{
+		IndexOuterLeavesInValueLog: true,
+		RelaxedSync:                true,
+		AllowUnsafe:                true,
+	})
+	if err != nil {
+		_ = backend.Close()
+		t.Fatalf("open cache: %v", err)
+	}
+	defer func() { _ = cached.Close() }()
+
+	log := newCachingLeafPageLog(cached, &cached.leafLog)
+	stable := log.(backenddb.LeafPageStableLog)
+	first, firstResources, err := stable.AppendLeafPageWithStableResources(buildSparseLeafPageForLeafLogTestWithTag(t, 'u'))
+	if err != nil {
+		t.Fatalf("first stable append: %v", err)
+	}
+	firstResources.Release()
+
+	cached.leafLog.vlogMu.Lock()
+	err = cached.rotateValueLogMuHeld(&cached.leafLog)
+	rotatedWriter := cached.leafLog.vlog
+	rotatedSize := rotatedWriter.Size()
+	cached.leafLog.vlogMu.Unlock()
+	if err != nil {
+		t.Fatalf("relaxed ordinary rotation: %v", err)
+	}
+	if rotatedSize != 0 {
+		t.Fatalf("relaxed successor size=%d want 0", rotatedSize)
+	}
+
+	fail := errors.New("injected creation certification failure")
+	restore := durabilitycut.Install(func(event durabilitycut.Event) error {
+		if event.Resource == durabilitycut.ResourceOuterLeaf && event.Point == durabilitycut.BeforeNewFileDirectorySync {
+			return fail
+		}
+		return nil
+	})
+	_, rejectedResources, err := stable.AppendLeafPageWithStableResources(buildSparseLeafPageForLeafLogTestWithTag(t, 'v'))
+	restore()
+	if !errors.Is(err, fail) {
+		t.Fatalf("stable append after relaxed rotation error=%v want injected failure", err)
+	}
+	if rejectedResources != nil {
+		rejectedResources.Release()
+		t.Fatal("failed certification returned stable resources")
+	}
+	if got := rotatedWriter.Size(); got != rotatedSize {
+		t.Fatalf("failed certification mutated successor size: before=%d after=%d", rotatedSize, got)
+	}
+
+	beforeSyncs := rotatedWriter.(interface {
+		DurabilityStats() valuelog.DurabilityStats
+	}).DurabilityStats().DirectorySyncCalls
+	second, secondResources, err := stable.AppendLeafPageWithStableResources(buildSparseLeafPageForLeafLogTestWithTag(t, 'w'))
+	if err != nil {
+		t.Fatalf("retry stable append: %v", err)
+	}
+	defer secondResources.Release()
+	afterSyncs := rotatedWriter.(interface {
+		DurabilityStats() valuelog.DurabilityStats
+	}).DurabilityStats().DirectorySyncCalls
+	if afterSyncs != beforeSyncs+1 {
+		t.Fatalf("retry namespace syncs: before=%d after=%d want +1", beforeSyncs, afterSyncs)
+	}
+	if second.FileID == first.FileID {
+		t.Fatalf("ordinary rotation did not advance leaf segment: first=%d second=%d", first.FileID, second.FileID)
+	}
+	descriptors := secondResources.Descriptors()
+	if len(descriptors) != 1 || descriptors[0].Generation() != uint64(second.ValueLogFileID()) {
+		t.Fatalf("retry resources=%v want exact generation %d", descriptors, second.ValueLogFileID())
 	}
 }
 

--- a/TreeDB/caching/leaf_page_stable_resource_test.go
+++ b/TreeDB/caching/leaf_page_stable_resource_test.go
@@ -4,12 +4,16 @@ package caching
 
 import (
 	"bytes"
+	"errors"
 	"os"
 	"path/filepath"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	backenddb "github.com/snissn/gomap/TreeDB/db"
 	"github.com/snissn/gomap/TreeDB/internal/rootpublication"
+	"github.com/snissn/gomap/TreeDB/internal/valuelog"
 	"github.com/snissn/gomap/TreeDB/page"
 )
 
@@ -64,6 +68,13 @@ func TestCachingLeafPageLogStableBatchPinsExactRawSegment(t *testing.T) {
 	if descriptor.Frontier().Bytes == 0 {
 		t.Fatal("captured frontier is empty")
 	}
+	if _, err := cached.valueLogIdentityPins.BeginDelete(descriptor.Identity()); !errors.Is(err, rootpublication.ErrResourcePinned) {
+		t.Fatalf("delete pinned raw segment error=%v want ErrResourcePinned", err)
+	}
+	stats := resources.Stats(time.Now())
+	if len(stats) != 1 || stats[0].NamespaceSyncs != 1 {
+		t.Fatalf("stable resource stats=%+v want one creation namespace sync", stats)
+	}
 
 	segmentPath, _, ok := newCachingLeafPageLog(cached, &cached.leafLog).(interface {
 		CurrentValueLogSegment() (string, uint32, bool)
@@ -88,5 +99,219 @@ func TestCachingLeafPageLogStableBatchPinsExactRawSegment(t *testing.T) {
 	}
 	if filepath.Clean(token.DiagnosticPath()) == filepath.Clean(segmentPath) {
 		t.Fatal("diagnostic path must be DB-relative")
+	}
+	if got, want := filepath.Dir(filepath.FromSlash(token.DiagnosticPath())), "leaf_vlog"; got != want {
+		t.Fatalf("diagnostic directory=%q want %q", got, want)
+	}
+}
+
+func TestCachingLeafPageLogStablePreparedBatchCapturesEveryReferencedSegment(t *testing.T) {
+	dir := t.TempDir()
+	backend, err := backenddb.Open(backenddb.Options{Dir: dir, IndexOuterLeavesInValueLog: true})
+	if err != nil {
+		t.Fatalf("open backend: %v", err)
+	}
+	cached, err := Open(dir, backend, Options{
+		IndexOuterLeavesInValueLog: true,
+		FlushApplyConcurrency:      4,
+		ValueLogCompression:        uint8(vlogCompressionBlock),
+		ValueLogMaxSegmentBytes:    512,
+		RelaxedSync:                true,
+		AllowUnsafe:                true,
+	})
+	if err != nil {
+		_ = backend.Close()
+		t.Fatalf("open cache: %v", err)
+	}
+	defer func() { _ = cached.Close() }()
+
+	const count = valuelog.MaxFrameK*2 + 8
+	pages := make([][]byte, count)
+	prepared := make([][]byte, count)
+	for i := range pages {
+		pages[i] = buildSparseLeafPageForLeafLogTestWithTag(t, byte(i))
+		encoded, _, encodeErr := valuelog.MaybeCompactLeafLogPayloadTo(nil, pages[i])
+		if encodeErr != nil {
+			t.Fatalf("prepare leaf %d: %v", i, encodeErr)
+		}
+		prepared[i] = encoded
+	}
+	stable := newCachingLeafPageLog(cached, &cached.leafLog).(backenddb.LeafPagePreparedStableBatchLog)
+	ptrs, resources, err := stable.AppendPreparedLeafPagesWithStableResources(pages, prepared)
+	if err != nil {
+		t.Fatalf("stable prepared append: %v", err)
+	}
+	if resources == nil {
+		t.Fatal("stable prepared append returned nil resources")
+	}
+	defer resources.Release()
+	if len(ptrs) != count {
+		t.Fatalf("pointer count=%d want %d", len(ptrs), count)
+	}
+	referenced := make(map[uint32]struct{})
+	for _, ptr := range ptrs {
+		referenced[ptr.ValueLogFileID()] = struct{}{}
+	}
+	if len(referenced) < 2 {
+		t.Fatalf("batch referenced %d segments; test did not exercise rotation", len(referenced))
+	}
+	descriptors := resources.Descriptors()
+	if len(descriptors) != len(referenced) {
+		t.Fatalf("captured descriptors=%d referenced segments=%d", len(descriptors), len(referenced))
+	}
+	for _, descriptor := range descriptors {
+		fileID := uint32(descriptor.Generation())
+		if _, ok := referenced[fileID]; !ok {
+			t.Fatalf("captured unrelated segment file_id=%d referenced=%v", fileID, referenced)
+		}
+		delete(referenced, fileID)
+	}
+	if len(referenced) != 0 {
+		t.Fatalf("missing captured segment IDs: %v", referenced)
+	}
+	namespaceTokens := 0
+	for _, token := range resources.Tokens() {
+		if token.Namespace() != nil {
+			namespaceTokens++
+		}
+	}
+	if namespaceTokens != len(descriptors)-1 {
+		t.Fatalf("namespace-bearing tokens=%d descriptors=%d want created segments plus one existing segment", namespaceTokens, len(descriptors))
+	}
+	stats := resources.Stats(time.Now())
+	if len(stats) != 1 || stats[0].NamespaceSyncs != uint64(namespaceTokens) {
+		t.Fatalf("stable multi-segment stats=%+v want %d namespace syncs", stats, namespaceTokens)
+	}
+}
+
+func TestCachingLeafPageLogStablePreparedChildRefsReturnOwnedResources(t *testing.T) {
+	dir := t.TempDir()
+	backend, err := backenddb.Open(backenddb.Options{Dir: dir, IndexOuterLeavesInValueLog: true})
+	if err != nil {
+		t.Fatalf("open backend: %v", err)
+	}
+	cached, err := Open(dir, backend, Options{IndexOuterLeavesInValueLog: true, RelaxedSync: true, AllowUnsafe: true})
+	if err != nil {
+		_ = backend.Close()
+		t.Fatalf("open cache: %v", err)
+	}
+	defer func() { _ = cached.Close() }()
+
+	pages := [][]byte{
+		buildSparseLeafPageForLeafLogTestWithTag(t, 'c'),
+		buildSparseLeafPageForLeafLogTestWithTag(t, 'd'),
+	}
+	prepared := make([][]byte, len(pages))
+	for i := range pages {
+		encoded, _, encodeErr := valuelog.MaybeCompactLeafLogPayloadTo(nil, pages[i])
+		if encodeErr != nil {
+			t.Fatal(encodeErr)
+		}
+		prepared[i] = encoded
+	}
+	stable := newCachingLeafPageLog(cached, &cached.leafLog).(backenddb.LeafPagePreparedChildRefStableBatchLog)
+	refs, resources, err := stable.AppendPreparedLeafPageChildRefsWithStableResources(pages, prepared, make([]page.ChildRef, 0, len(pages)))
+	if err != nil {
+		t.Fatalf("stable prepared child refs: %v", err)
+	}
+	if resources == nil || resources.Len() == 0 {
+		t.Fatal("stable prepared child refs returned no resources")
+	}
+	defer resources.Release()
+	if len(refs) != len(pages) {
+		t.Fatalf("ref count=%d want %d", len(refs), len(pages))
+	}
+	for i, ref := range refs {
+		if !ref.IsLeafLog() || ref.Log.FileID == 0 {
+			t.Fatalf("ref %d=%+v is not a leaf-log reference", i, ref)
+		}
+	}
+}
+
+func TestCachingLeafPageLogStableCaptureExcludesFollowingConcurrentRotation(t *testing.T) {
+	dir := t.TempDir()
+	backend, err := backenddb.Open(backenddb.Options{Dir: dir, IndexOuterLeavesInValueLog: true})
+	if err != nil {
+		t.Fatalf("open backend: %v", err)
+	}
+	cached, err := Open(dir, backend, Options{
+		IndexOuterLeavesInValueLog: true,
+		ValueLogMaxSegmentBytes:    1,
+		RelaxedSync:                true,
+		AllowUnsafe:                true,
+	})
+	if err != nil {
+		_ = backend.Close()
+		t.Fatalf("open cache: %v", err)
+	}
+	defer func() { _ = cached.Close() }()
+
+	entered := make(chan struct{})
+	release := make(chan struct{})
+	var first atomic.Bool
+	cached.testBeforeVlogUnlock = func(laneID int) {
+		if laneID != leafLogLaneID || !first.CompareAndSwap(false, true) {
+			return
+		}
+		close(entered)
+		<-release
+	}
+	stableResult := make(chan struct {
+		ptr       page.LeafLogPtr
+		resources *rootpublication.StableResourceSet
+		err       error
+	}, 1)
+	log := newCachingLeafPageLog(cached, &cached.leafLog)
+	stablePage := buildSparseLeafPageForLeafLogTestWithTag(t, 'q')
+	ordinaryPage := buildSparseLeafPageForLeafLogTestWithTag(t, 'r')
+	go func() {
+		ptr, resources, appendErr := log.(backenddb.LeafPageStableLog).AppendLeafPageWithStableResources(stablePage)
+		stableResult <- struct {
+			ptr       page.LeafLogPtr
+			resources *rootpublication.StableResourceSet
+			err       error
+		}{ptr: ptr, resources: resources, err: appendErr}
+	}()
+	select {
+	case <-entered:
+	case <-time.After(5 * time.Second):
+		t.Fatal("stable append did not reach capture boundary")
+	}
+	ordinaryResult := make(chan struct {
+		ptr page.LeafLogPtr
+		err error
+	}, 1)
+	go func() {
+		ptr, appendErr := log.AppendLeafPage(ordinaryPage)
+		ordinaryResult <- struct {
+			ptr page.LeafLogPtr
+			err error
+		}{ptr: ptr, err: appendErr}
+	}()
+	select {
+	case result := <-ordinaryResult:
+		close(release)
+		t.Fatalf("ordinary append crossed stable capture mutex: ptr=%+v err=%v", result.ptr, result.err)
+	case <-time.After(50 * time.Millisecond):
+	}
+	close(release)
+	stable := <-stableResult
+	if stable.err != nil {
+		t.Fatalf("stable append: %v", stable.err)
+	}
+	if stable.resources == nil {
+		t.Fatal("stable append returned nil resources")
+	}
+	defer stable.resources.Release()
+	ordinary := <-ordinaryResult
+	if ordinary.err != nil {
+		t.Fatalf("ordinary append: %v", ordinary.err)
+	}
+	if ordinary.ptr.FileID == stable.ptr.FileID {
+		t.Fatalf("ordinary append did not rotate: stable=%d ordinary=%d", stable.ptr.FileID, ordinary.ptr.FileID)
+	}
+	descriptors := stable.resources.Descriptors()
+	if len(descriptors) != 1 || uint32(descriptors[0].Generation()) != stable.ptr.ValueLogFileID() {
+		t.Fatalf("stable descriptors=%v want only file_id=%d", descriptors, stable.ptr.ValueLogFileID())
 	}
 }

--- a/TreeDB/caching/leaf_page_stable_resource_test.go
+++ b/TreeDB/caching/leaf_page_stable_resource_test.go
@@ -179,8 +179,8 @@ func TestCachingLeafPageLogStablePreparedBatchCapturesEveryReferencedSegment(t *
 			namespaceTokens++
 		}
 	}
-	if namespaceTokens != len(descriptors)-1 {
-		t.Fatalf("namespace-bearing tokens=%d descriptors=%d want created segments plus one existing segment", namespaceTokens, len(descriptors))
+	if namespaceTokens != len(descriptors) {
+		t.Fatalf("namespace-bearing tokens=%d descriptors=%d want one exact creation witness per fresh segment", namespaceTokens, len(descriptors))
 	}
 	stats := resources.Stats(time.Now())
 	if len(stats) != 1 || stats[0].NamespaceSyncs != uint64(namespaceTokens) {

--- a/TreeDB/caching/leaf_page_stable_resource_test.go
+++ b/TreeDB/caching/leaf_page_stable_resource_test.go
@@ -315,3 +315,96 @@ func TestCachingLeafPageLogStableCaptureExcludesFollowingConcurrentRotation(t *t
 		t.Fatalf("stable descriptors=%v want only file_id=%d", descriptors, stable.ptr.ValueLogFileID())
 	}
 }
+
+func TestCachingLeafPageLogStableSteadyAppendHasNoPinOrNamespaceGrowth(t *testing.T) {
+	dir := t.TempDir()
+	backend, err := backenddb.Open(backenddb.Options{Dir: dir, IndexOuterLeavesInValueLog: true})
+	if err != nil {
+		t.Fatalf("open backend: %v", err)
+	}
+	cached, err := Open(dir, backend, Options{IndexOuterLeavesInValueLog: true, RelaxedSync: true, AllowUnsafe: true})
+	if err != nil {
+		_ = backend.Close()
+		t.Fatalf("open cache: %v", err)
+	}
+	defer func() { _ = cached.Close() }()
+
+	stable := newCachingLeafPageLog(cached, &cached.leafLog).(backenddb.LeafPageStableBatchLog)
+	pages := [][]byte{
+		buildSparseLeafPageForLeafLogTestWithTag(t, 'g'),
+		buildSparseLeafPageForLeafLogTestWithTag(t, 'h'),
+	}
+	_, warmResources, err := stable.AppendLeafPagesWithStableResources(pages)
+	if err != nil {
+		t.Fatalf("warm stable append: %v", err)
+	}
+	warmResources.Release()
+	writer, ok := cached.leafLog.vlog.(interface {
+		DurabilityStats() valuelog.DurabilityStats
+	})
+	if !ok {
+		t.Fatal("leaf writer does not expose durability counters")
+	}
+	baselineSyncs := writer.DurabilityStats().DirectorySyncCalls
+	baselineIdentities := cached.valueLogIdentityPins.ActiveIdentities()
+	for iteration := 0; iteration < 100; iteration++ {
+		_, resources, appendErr := stable.AppendLeafPagesWithStableResources(pages)
+		if appendErr != nil {
+			t.Fatalf("stable append %d: %v", iteration, appendErr)
+		}
+		resources.Release()
+		if pins := cached.valueLogIdentityPins.ActivePins(); pins != 0 {
+			t.Fatalf("stable append %d left %d active pins", iteration, pins)
+		}
+		if identities := cached.valueLogIdentityPins.ActiveIdentities(); identities != baselineIdentities {
+			t.Fatalf("stable append %d identities=%d want baseline %d", iteration, identities, baselineIdentities)
+		}
+	}
+	if syncs := writer.DurabilityStats().DirectorySyncCalls; syncs != baselineSyncs {
+		t.Fatalf("steady stable appends added directory syncs: before=%d after=%d", baselineSyncs, syncs)
+	}
+}
+
+func BenchmarkCachingLeafPageLogStableBatch(b *testing.B) {
+	for _, stable := range []bool{false, true} {
+		name := "ordinary"
+		if stable {
+			name = "stable"
+		}
+		b.Run(name, func(b *testing.B) {
+			dir := b.TempDir()
+			backend, err := backenddb.Open(backenddb.Options{Dir: dir, IndexOuterLeavesInValueLog: true})
+			if err != nil {
+				b.Fatal(err)
+			}
+			cached, err := Open(dir, backend, Options{IndexOuterLeavesInValueLog: true, RelaxedSync: true, AllowUnsafe: true})
+			if err != nil {
+				_ = backend.Close()
+				b.Fatal(err)
+			}
+			defer func() { _ = cached.Close() }()
+			pages := [][]byte{
+				buildSparseLeafPageForLeafLogTestWithTag(b, 'i'),
+				buildSparseLeafPageForLeafLogTestWithTag(b, 'j'),
+				buildSparseLeafPageForLeafLogTestWithTag(b, 'k'),
+				buildSparseLeafPageForLeafLogTestWithTag(b, 'l'),
+			}
+			log := newCachingLeafPageLog(cached, &cached.leafLog)
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				if stable {
+					_, resources, appendErr := log.(backenddb.LeafPageStableBatchLog).AppendLeafPagesWithStableResources(pages)
+					if appendErr != nil {
+						b.Fatal(appendErr)
+					}
+					resources.Release()
+					continue
+				}
+				if _, appendErr := log.(backenddb.LeafPageBatchLog).AppendLeafPages(pages); appendErr != nil {
+					b.Fatal(appendErr)
+				}
+			}
+		})
+	}
+}

--- a/TreeDB/caching/leaf_page_stable_resource_test.go
+++ b/TreeDB/caching/leaf_page_stable_resource_test.go
@@ -76,9 +76,13 @@ func TestCachingLeafPageLogStableBatchPinsExactRawSegment(t *testing.T) {
 		t.Fatalf("stable resource stats=%+v want one creation namespace sync", stats)
 	}
 
-	segmentPath, _, ok := newCachingLeafPageLog(cached, &cached.leafLog).(interface {
+	segmentLog, ok := newCachingLeafPageLog(cached, &cached.leafLog).(interface {
 		CurrentValueLogSegment() (string, uint32, bool)
-	}).CurrentValueLogSegment()
+	})
+	if !ok {
+		t.Fatal("cached leaf-page log does not expose current segment lookup")
+	}
+	segmentPath, _, ok := segmentLog.CurrentValueLogSegment()
 	if !ok {
 		t.Fatal("missing current leaf segment")
 	}
@@ -262,10 +266,14 @@ func TestCachingLeafPageLogStableCaptureExcludesFollowingConcurrentRotation(t *t
 		err       error
 	}, 1)
 	log := newCachingLeafPageLog(cached, &cached.leafLog)
+	stableLog, ok := log.(backenddb.LeafPageStableLog)
+	if !ok {
+		t.Fatal("cached leaf-page log does not implement stable append")
+	}
 	stablePage := buildSparseLeafPageForLeafLogTestWithTag(t, 'q')
 	ordinaryPage := buildSparseLeafPageForLeafLogTestWithTag(t, 'r')
 	go func() {
-		ptr, resources, appendErr := log.(backenddb.LeafPageStableLog).AppendLeafPageWithStableResources(stablePage)
+		ptr, resources, appendErr := stableLog.AppendLeafPageWithStableResources(stablePage)
 		stableResult <- struct {
 			ptr       page.LeafLogPtr
 			resources *rootpublication.StableResourceSet
@@ -390,18 +398,26 @@ func BenchmarkCachingLeafPageLogStableBatch(b *testing.B) {
 				buildSparseLeafPageForLeafLogTestWithTag(b, 'l'),
 			}
 			log := newCachingLeafPageLog(cached, &cached.leafLog)
+			stableLog, stableOK := log.(backenddb.LeafPageStableBatchLog)
+			batchLog, batchOK := log.(backenddb.LeafPageBatchLog)
+			if stable && !stableOK {
+				b.Fatal("cached leaf-page log does not implement stable batch append")
+			}
+			if !stable && !batchOK {
+				b.Fatal("cached leaf-page log does not implement batch append")
+			}
 			b.ReportAllocs()
 			b.ResetTimer()
 			for i := 0; i < b.N; i++ {
 				if stable {
-					_, resources, appendErr := log.(backenddb.LeafPageStableBatchLog).AppendLeafPagesWithStableResources(pages)
+					_, resources, appendErr := stableLog.AppendLeafPagesWithStableResources(pages)
 					if appendErr != nil {
 						b.Fatal(appendErr)
 					}
 					resources.Release()
 					continue
 				}
-				if _, appendErr := log.(backenddb.LeafPageBatchLog).AppendLeafPages(pages); appendErr != nil {
+				if _, appendErr := batchLog.AppendLeafPages(pages); appendErr != nil {
 					b.Fatal(appendErr)
 				}
 			}

--- a/TreeDB/caching/stable_leaf_resource.go
+++ b/TreeDB/caching/stable_leaf_resource.go
@@ -36,7 +36,7 @@ func (capture *stableOuterLeafCapture) registration(path string, fileID uint32, 
 	if capture == nil || capture.db == nil || capture.lane == nil || path == "" || fileID == 0 {
 		return valuelog.StableResourceRegistration{}, fmt.Errorf("%w: incomplete outer-leaf stable registration", rootpublication.ErrUnresolvedResource)
 	}
-	diagnosticPath, err := filepath.Rel(capture.db.dir, path)
+	diagnosticPath, err := filepath.Rel(filepath.Dir(capture.db.dir), path)
 	if err != nil || diagnosticPath == "." || filepath.IsAbs(diagnosticPath) {
 		return valuelog.StableResourceRegistration{}, fmt.Errorf("%w: outer-leaf diagnostic path: %v", rootpublication.ErrUnresolvedResource, err)
 	}

--- a/TreeDB/caching/stable_leaf_resource.go
+++ b/TreeDB/caching/stable_leaf_resource.go
@@ -1,0 +1,161 @@
+package caching
+
+import (
+	"fmt"
+	"path/filepath"
+
+	"github.com/snissn/gomap/TreeDB/internal/rootpublication"
+	"github.com/snissn/gomap/TreeDB/internal/valuelog"
+	"github.com/snissn/gomap/TreeDB/page"
+)
+
+const outerLeafNamespaceGeneration uint64 = 1
+
+type stableValueWriter interface {
+	valueWriter
+	StableResourceToken(valuelog.StableResourceRegistration) (*rootpublication.StableResourceToken, error)
+	RotateToWithStableResources(path string, fileID uint32, syncCurrent bool, closed, active valuelog.StableResourceRegistration) (*valuelog.StableResourceRotation, error)
+	StableCreationNamespacePending() (bool, error)
+}
+
+type stableOuterLeafCapture struct {
+	db      *DB
+	lane    *lane
+	builder *rootpublication.StableResourceSetBuilder
+	tokens  []*rootpublication.StableResourceToken
+}
+
+func newStableOuterLeafCapture(db *DB, lane *lane) *stableOuterLeafCapture {
+	return &stableOuterLeafCapture{
+		db: db, lane: lane,
+		builder: rootpublication.NewStableResourceSetBuilder(rootpublication.ReachabilityOuterLeafRawPointer),
+	}
+}
+
+func (capture *stableOuterLeafCapture) registration(path string, fileID uint32, namespace rootpublication.NamespaceOperation) (valuelog.StableResourceRegistration, error) {
+	if capture == nil || capture.db == nil || capture.lane == nil || path == "" || fileID == 0 {
+		return valuelog.StableResourceRegistration{}, fmt.Errorf("%w: incomplete outer-leaf stable registration", rootpublication.ErrUnresolvedResource)
+	}
+	diagnosticPath, err := filepath.Rel(capture.db.dir, path)
+	if err != nil || diagnosticPath == "." || filepath.IsAbs(diagnosticPath) {
+		return valuelog.StableResourceRegistration{}, fmt.Errorf("%w: outer-leaf diagnostic path: %v", rootpublication.ErrUnresolvedResource, err)
+	}
+	registration := valuelog.StableResourceRegistration{
+		Kind:               rootpublication.ResourceOuterLeafLog,
+		LogicalLane:        fmt.Sprintf("outer-leaf-%d", capture.lane.id),
+		Generation:         uint64(fileID),
+		DiagnosticPath:     filepath.ToSlash(diagnosticPath),
+		Reachability:       rootpublication.ReachabilityOuterLeafRawPointer,
+		ParentGeneration:   outerLeafNamespaceGeneration,
+		NamespaceOperation: namespace,
+		PinRegistry:        capture.db.valueLogIdentityPins,
+	}
+	if namespace != rootpublication.NamespaceNone {
+		registration.NewName = filepath.Base(path)
+	}
+	return registration, nil
+}
+
+func (capture *stableOuterLeafCapture) addToken(token *rootpublication.StableResourceToken) error {
+	if capture == nil || capture.builder == nil || token == nil {
+		return rootpublication.ErrResourceOwnership
+	}
+	capture.tokens = append(capture.tokens, token)
+	return nil
+}
+
+func (capture *stableOuterLeafCapture) addRotation(rotation *valuelog.StableResourceRotation) error {
+	if rotation == nil {
+		return rootpublication.ErrResourceOwnership
+	}
+	defer rotation.Release()
+	if token := rotation.TakeClosed(); token != nil {
+		if err := capture.addToken(token); err != nil {
+			token.Release()
+			return err
+		}
+	}
+	if token := rotation.TakeActive(); token != nil {
+		if err := capture.addToken(token); err != nil {
+			token.Release()
+			return err
+		}
+	}
+	return nil
+}
+
+func (capture *stableOuterLeafCapture) captureCurrent(writer valueWriter, path string, fileID uint32) error {
+	stableWriter, ok := writer.(stableValueWriter)
+	if !ok {
+		return fmt.Errorf("%w: outer-leaf writer lacks stable capture", rootpublication.ErrUnresolvedResource)
+	}
+	created, err := stableWriter.StableCreationNamespacePending()
+	if err != nil {
+		return err
+	}
+	namespace := rootpublication.NamespaceNone
+	if created {
+		namespace = rootpublication.NamespaceCreate
+	}
+	registration, err := capture.registration(path, fileID, namespace)
+	if err != nil {
+		return err
+	}
+	token, err := stableWriter.StableResourceToken(registration)
+	if err != nil {
+		return err
+	}
+	if err := capture.addToken(token); err != nil {
+		token.Release()
+		return err
+	}
+	return nil
+}
+
+func (capture *stableOuterLeafCapture) freeze(ptrs []page.ValuePtr) (*rootpublication.StableResourceSet, error) {
+	if capture == nil || capture.builder == nil {
+		return nil, rootpublication.ErrResourceOwnership
+	}
+	required := make(map[uint64]struct{}, len(ptrs))
+	for _, ptr := range ptrs {
+		required[uint64(ptr.FileID)] = struct{}{}
+	}
+	for _, token := range capture.tokens {
+		if _, ok := required[token.Generation()]; !ok {
+			token.Release()
+			continue
+		}
+		if err := capture.builder.Add(token); err != nil {
+			token.Release()
+			capture.builder.Abandon()
+			capture.releaseTokens()
+			capture.builder = nil
+			return nil, err
+		}
+	}
+	capture.tokens = nil
+	set, err := capture.builder.Freeze()
+	if err != nil {
+		capture.builder.Abandon()
+	}
+	capture.builder = nil
+	return set, err
+}
+
+func (capture *stableOuterLeafCapture) abandon() {
+	if capture == nil {
+		return
+	}
+	if capture.builder != nil {
+		capture.builder.Abandon()
+	}
+	capture.releaseTokens()
+	capture.builder = nil
+}
+
+func (capture *stableOuterLeafCapture) releaseTokens() {
+	for _, token := range capture.tokens {
+		token.Release()
+	}
+	capture.tokens = nil
+}

--- a/TreeDB/caching/stable_leaf_resource.go
+++ b/TreeDB/caching/stable_leaf_resource.go
@@ -9,20 +9,21 @@ import (
 	"github.com/snissn/gomap/TreeDB/page"
 )
 
-const outerLeafNamespaceGeneration uint64 = 1
-
 type stableValueWriter interface {
 	valueWriter
+	CertifyStableCreationNamespace() error
 	StableResourceToken(valuelog.StableResourceRegistration) (*rootpublication.StableResourceToken, error)
 	RotateToWithStableResources(path string, fileID uint32, syncCurrent bool, closed, active valuelog.StableResourceRegistration) (*valuelog.StableResourceRotation, error)
 	StableCreationNamespacePending() (bool, error)
+	StableNamespaceParentGeneration() (uint64, error)
 }
 
 type stableOuterLeafCapture struct {
-	db      *DB
-	lane    *lane
-	builder *rootpublication.StableResourceSetBuilder
-	tokens  []*rootpublication.StableResourceToken
+	db               *DB
+	lane             *lane
+	builder          *rootpublication.StableResourceSetBuilder
+	tokens           []*rootpublication.StableResourceToken
+	parentGeneration uint64
 }
 
 func newStableOuterLeafCapture(db *DB, lane *lane) *stableOuterLeafCapture {
@@ -46,7 +47,7 @@ func (capture *stableOuterLeafCapture) registration(path string, fileID uint32, 
 		Generation:         uint64(fileID),
 		DiagnosticPath:     filepath.ToSlash(diagnosticPath),
 		Reachability:       rootpublication.ReachabilityOuterLeafRawPointer,
-		ParentGeneration:   outerLeafNamespaceGeneration,
+		ParentGeneration:   capture.parentGeneration,
 		NamespaceOperation: namespace,
 		PinRegistry:        capture.db.valueLogIdentityPins,
 	}
@@ -54,6 +55,24 @@ func (capture *stableOuterLeafCapture) registration(path string, fileID uint32, 
 		registration.NewName = filepath.Base(path)
 	}
 	return registration, nil
+}
+
+func (capture *stableOuterLeafCapture) bindParentGeneration(writer stableValueWriter) error {
+	if capture == nil || writer == nil {
+		return rootpublication.ErrResourceOwnership
+	}
+	if capture.parentGeneration != 0 {
+		return nil
+	}
+	generation, err := writer.StableNamespaceParentGeneration()
+	if err != nil {
+		return err
+	}
+	if generation == 0 {
+		return fmt.Errorf("%w: outer-leaf namespace parent has zero generation", rootpublication.ErrUnresolvedResource)
+	}
+	capture.parentGeneration = generation
+	return nil
 }
 
 func (capture *stableOuterLeafCapture) addToken(token *rootpublication.StableResourceToken) error {
@@ -88,6 +107,9 @@ func (capture *stableOuterLeafCapture) captureCurrent(writer valueWriter, path s
 	stableWriter, ok := writer.(stableValueWriter)
 	if !ok {
 		return fmt.Errorf("%w: outer-leaf writer lacks stable capture", rootpublication.ErrUnresolvedResource)
+	}
+	if err := capture.bindParentGeneration(stableWriter); err != nil {
+		return err
 	}
 	created, err := stableWriter.StableCreationNamespacePending()
 	if err != nil {

--- a/TreeDB/db/leaf_generation_pack_stage_stats_test.go
+++ b/TreeDB/db/leaf_generation_pack_stage_stats_test.go
@@ -34,7 +34,10 @@ func TestLeafGenerationPack_ApplyStageAccounting(t *testing.T) {
 	if publishAttributed > stats.PublishHoldNanos {
 		t.Fatalf("exclusive publish stages=%d exceed publish hold=%d: %+v", publishAttributed, stats.PublishHoldNanos, stages)
 	}
-	if stages.DirectorySyncWaitTimeNanos > stages.DirectorySyncTimeNanos {
+	// Windows can quantize a sub-tick directory-sync operation wall to zero
+	// while the overlapping channel wait crosses a clock tick. Preserve the
+	// subset invariant whenever the operation wall is observable.
+	if stages.DirectorySyncTimeNanos > 0 && stages.DirectorySyncWaitTimeNanos > stages.DirectorySyncTimeNanos {
 		t.Fatalf("directory sync wait=%d exceeds operation wall=%d", stages.DirectorySyncWaitTimeNanos, stages.DirectorySyncTimeNanos)
 	}
 	if stats.RetryApplyStages != (LeafGenerationPackApplyStageStats{}) {

--- a/TreeDB/db/leaf_generation_pack_stage_stats_test.go
+++ b/TreeDB/db/leaf_generation_pack_stage_stats_test.go
@@ -34,12 +34,12 @@ func TestLeafGenerationPack_ApplyStageAccounting(t *testing.T) {
 	if publishAttributed > stats.PublishHoldNanos {
 		t.Fatalf("exclusive publish stages=%d exceed publish hold=%d: %+v", publishAttributed, stats.PublishHoldNanos, stages)
 	}
-	// Windows can quantize a sub-tick directory-sync operation wall to zero
-	// while the overlapping channel wait crosses a clock tick. Preserve the
-	// subset invariant whenever the operation wall is observable.
-	if stages.DirectorySyncTimeNanos > 0 && stages.DirectorySyncWaitTimeNanos > stages.DirectorySyncTimeNanos {
-		t.Fatalf("directory sync wait=%d exceeds operation wall=%d", stages.DirectorySyncWaitTimeNanos, stages.DirectorySyncTimeNanos)
-	}
+	// DirectorySyncTimeNanos is measured inside the async worker, while the
+	// wait includes channel delivery and timer quantization. In particular,
+	// Windows can report a zero operation duration for a sub-millisecond sync,
+	// and scheduler delay can make the measured receive wait exceed a small
+	// non-zero operation duration. The publish-hold assertion above is the
+	// meaningful additive bound for the non-overlapping wait.
 	if stats.RetryApplyStages != (LeafGenerationPackApplyStageStats{}) {
 		t.Fatalf("successful first attempt reported retry stages: %+v", stats.RetryApplyStages)
 	}

--- a/TreeDB/db/leaf_page_log.go
+++ b/TreeDB/db/leaf_page_log.go
@@ -31,13 +31,18 @@ type LeafPageBatchLog interface {
 	AppendLeafPages(leafPages [][]byte) ([]page.LeafLogPtr, error)
 }
 
-// LeafPageStableLog is the identity-pinned counterpart to LeafPageLog. The
-// returned set is unclaimed builder-owned authority for every raw outer-leaf
-// segment referenced by the returned pointer.
+// LeafPageStableLog is the identity-pinned counterpart to LeafPageLog. On a
+// successful non-empty append, the returned set is non-nil unclaimed
+// builder-owned authority for exactly the raw outer-leaf segments referenced
+// by the returned pointer. Ownership transfers to the caller, which must
+// transfer or release it exactly once. On error, implementations must release
+// acquired authority and return a nil set.
 type LeafPageStableLog interface {
 	AppendLeafPageWithStableResources(leafPage []byte) (page.LeafLogPtr, *rootpublication.StableResourceSet, error)
 }
 
+// LeafPageStableBatchLog has the same success/error ownership contract as
+// LeafPageStableLog, covering every unique segment in the returned batch.
 type LeafPageStableBatchLog interface {
 	AppendLeafPagesWithStableResources(leafPages [][]byte) ([]page.LeafLogPtr, *rootpublication.StableResourceSet, error)
 }
@@ -49,6 +54,8 @@ type LeafPagePreparedLog interface {
 	AppendPreparedLeafPage(leafPage []byte, preparedPayload []byte) (page.LeafLogPtr, error)
 }
 
+// LeafPagePreparedStableLog has the same success/error ownership contract as
+// LeafPageStableLog for a caller-prepared payload.
 type LeafPagePreparedStableLog interface {
 	AppendPreparedLeafPageWithStableResources(leafPage []byte, preparedPayload []byte) (page.LeafLogPtr, *rootpublication.StableResourceSet, error)
 }
@@ -73,6 +80,8 @@ type LeafPagePreparedBatchLog interface {
 	AppendPreparedLeafPages(leafPages [][]byte, preparedPayloads [][]byte) ([]page.LeafLogPtr, error)
 }
 
+// LeafPagePreparedStableBatchLog has the same success/error ownership contract
+// as LeafPageStableLog, covering every unique segment in the returned batch.
 type LeafPagePreparedStableBatchLog interface {
 	AppendPreparedLeafPagesWithStableResources(leafPages [][]byte, preparedPayloads [][]byte) ([]page.LeafLogPtr, *rootpublication.StableResourceSet, error)
 }
@@ -84,8 +93,66 @@ type LeafPagePreparedChildRefBatchLog interface {
 	AppendPreparedLeafPageChildRefs(leafPages [][]byte, preparedPayloads [][]byte, refs []page.ChildRef) ([]page.ChildRef, error)
 }
 
+// LeafPagePreparedChildRefStableBatchLog has the same success/error ownership
+// contract as LeafPageStableLog, covering every unique segment referenced by
+// the returned leaf-log child refs.
 type LeafPagePreparedChildRefStableBatchLog interface {
 	AppendPreparedLeafPageChildRefsWithStableResources(leafPages [][]byte, preparedPayloads [][]byte, refs []page.ChildRef) ([]page.ChildRef, *rootpublication.StableResourceSet, error)
+}
+
+func validateLeafPageStableResources(ptrs []page.LeafLogPtr, resources *rootpublication.StableResourceSet) error {
+	if len(ptrs) == 0 {
+		if resources != nil && resources.Len() != 0 {
+			return fmt.Errorf("%w: empty leaf append returned stable resources", rootpublication.ErrResourceConflict)
+		}
+		return nil
+	}
+	if resources == nil {
+		return fmt.Errorf("%w: leaf append returned nil stable resources", rootpublication.ErrUnresolvedResource)
+	}
+	if resources.Owner() != rootpublication.ResourceOwnerBuilder {
+		return fmt.Errorf("%w: leaf append returned resources owned by %v", rootpublication.ErrResourceOwnership, resources.Owner())
+	}
+	required := make(map[uint64]uint64, len(ptrs))
+	for i, ptr := range ptrs {
+		if ptr.FileID == 0 {
+			return fmt.Errorf("%w: leaf append returned zero file ID at %d", rootpublication.ErrUnresolvedResource, i)
+		}
+		generation := uint64(ptr.ValueLogFileID())
+		recordLength := uint64(ptr.RecordLength())
+		if recordLength == 0 || ptr.Offset > ^uint64(0)-recordLength {
+			return fmt.Errorf("%w: leaf append returned invalid record frontier at %d", rootpublication.ErrUnresolvedResource, i)
+		}
+		minimumBytes := ptr.Offset + recordLength
+		if minimumBytes > required[generation] {
+			required[generation] = minimumBytes
+		}
+	}
+	descriptors := resources.Descriptors()
+	if len(descriptors) != len(required) {
+		return fmt.Errorf("%w: leaf append returned %d stable descriptors for %d referenced segments", rootpublication.ErrResourceConflict, len(descriptors), len(required))
+	}
+	for _, descriptor := range descriptors {
+		if descriptor.Kind() != rootpublication.ResourceOuterLeafLog {
+			return fmt.Errorf("%w: leaf append returned stable kind %q", rootpublication.ErrResourceConflict, descriptor.Kind())
+		}
+		fields := descriptor.ReachabilityFields()
+		if len(fields) != 1 || fields[0] != rootpublication.ReachabilityOuterLeafRawPointer {
+			return fmt.Errorf("%w: leaf append returned stable reachability %v", rootpublication.ErrResourceConflict, fields)
+		}
+		minimumBytes, ok := required[descriptor.Generation()]
+		if !ok {
+			return fmt.Errorf("%w: leaf append returned unreferenced stable generation %d", rootpublication.ErrResourceConflict, descriptor.Generation())
+		}
+		if descriptor.Frontier().Bytes < minimumBytes {
+			return fmt.Errorf("%w: leaf append stable generation %d frontier %d does not cover pointer end %d", rootpublication.ErrUnresolvedResource, descriptor.Generation(), descriptor.Frontier().Bytes, minimumBytes)
+		}
+		delete(required, descriptor.Generation())
+	}
+	if len(required) != 0 {
+		return fmt.Errorf("%w: leaf append omitted stable generations %v", rootpublication.ErrUnresolvedResource, required)
+	}
+	return nil
 }
 
 type LeafPageLogSegment struct {
@@ -148,6 +215,10 @@ type leafPageLogProtectedRootPairSnapshotProvider interface {
 	ProtectedLeafGenerationRootIDPairSnapshot() (rootIDs []uint64, systemRootIDs []uint64, version uint64)
 }
 
+type leafPageLogStableRegistryBinder interface {
+	bindStableResourcePinRegistry(*rootpublication.IdentityPinRegistry) error
+}
+
 type leafPageLogRecordLengthProvider interface {
 	LastLeafPageRecordLength() uint32
 }
@@ -193,6 +264,15 @@ func (l *leafPageLogWithRecordLengthHints) AppendLeafPageWithStableResources(lea
 	}
 	ptr, resources, err := stable.AppendLeafPageWithStableResources(leafPage)
 	if err != nil {
+		if resources != nil {
+			resources.Release()
+		}
+		return page.LeafLogPtr{}, nil, err
+	}
+	if err := validateLeafPageStableResources([]page.LeafLogPtr{ptr}, resources); err != nil {
+		if resources != nil {
+			resources.Release()
+		}
 		return page.LeafLogPtr{}, nil, err
 	}
 	if err := l.emitDependencyAppend(durabilitycut.AfterDependencyAppend, ptr); err != nil {
@@ -282,7 +362,20 @@ func (l *leafPageLogWithRecordLengthHints) AppendLeafPagesWithStableResources(le
 	}
 	ptrs, resources, err := stable.AppendLeafPagesWithStableResources(leafPages)
 	if err != nil {
+		if resources != nil {
+			resources.Release()
+		}
 		return nil, nil, err
+	}
+	if err := validateLeafPageStableResources(ptrs, resources); err != nil {
+		if resources != nil {
+			resources.Release()
+		}
+		return nil, nil, err
+	}
+	if len(ptrs) != len(leafPages) {
+		resources.Release()
+		return nil, nil, fmt.Errorf("stable leaf batch returned %d ptrs for %d pages", len(ptrs), len(leafPages))
 	}
 	if err := l.emitDependencyAppend(durabilitycut.AfterDependencyAppend, ptrs...); err != nil {
 		resources.Release()
@@ -323,13 +416,22 @@ func (l *leafPageLogWithRecordLengthHints) AppendPreparedLeafPageWithStableResou
 	}
 	stable, ok := l.inner.(LeafPagePreparedStableLog)
 	if !ok {
-		return page.LeafLogPtr{}, nil, fmt.Errorf("%w: leaf page log lacks stable prepared append", rootpublication.ErrUnresolvedResource)
+		return l.AppendLeafPageWithStableResources(leafPage)
 	}
 	if err := l.emitDependencyAppend(durabilitycut.BeforeDependencyAppend); err != nil {
 		return page.LeafLogPtr{}, nil, err
 	}
 	ptr, resources, err := stable.AppendPreparedLeafPageWithStableResources(leafPage, preparedPayload)
 	if err != nil {
+		if resources != nil {
+			resources.Release()
+		}
+		return page.LeafLogPtr{}, nil, err
+	}
+	if err := validateLeafPageStableResources([]page.LeafLogPtr{ptr}, resources); err != nil {
+		if resources != nil {
+			resources.Release()
+		}
 		return page.LeafLogPtr{}, nil, err
 	}
 	if err := l.emitDependencyAppend(durabilitycut.AfterDependencyAppend, ptr); err != nil {
@@ -382,14 +484,27 @@ func (l *leafPageLogWithRecordLengthHints) AppendPreparedLeafPagesWithStableReso
 	}
 	stable, ok := l.inner.(LeafPagePreparedStableBatchLog)
 	if !ok {
-		return nil, nil, fmt.Errorf("%w: leaf page log lacks stable prepared batch append", rootpublication.ErrUnresolvedResource)
+		return l.AppendLeafPagesWithStableResources(leafPages)
 	}
 	if err := l.emitDependencyAppend(durabilitycut.BeforeDependencyAppend); err != nil {
 		return nil, nil, err
 	}
 	ptrs, resources, err := stable.AppendPreparedLeafPagesWithStableResources(leafPages, preparedPayloads)
 	if err != nil {
+		if resources != nil {
+			resources.Release()
+		}
 		return nil, nil, err
+	}
+	if err := validateLeafPageStableResources(ptrs, resources); err != nil {
+		if resources != nil {
+			resources.Release()
+		}
+		return nil, nil, err
+	}
+	if len(ptrs) != len(leafPages) {
+		resources.Release()
+		return nil, nil, fmt.Errorf("stable prepared leaf batch returned %d ptrs for %d pages", len(ptrs), len(leafPages))
 	}
 	if err := l.emitDependencyAppend(durabilitycut.AfterDependencyAppend, ptrs...); err != nil {
 		resources.Release()
@@ -469,13 +584,28 @@ func (l *leafPageLogWithRecordLengthHints) AppendPreparedLeafPageChildRefsWithSt
 	}
 	stable, ok := l.inner.(LeafPagePreparedChildRefStableBatchLog)
 	if !ok {
-		return nil, nil, fmt.Errorf("%w: leaf page log lacks stable prepared child-ref append", rootpublication.ErrUnresolvedResource)
+		ptrs, resources, err := l.AppendPreparedLeafPagesWithStableResources(leafPages, preparedPayloads)
+		if err != nil {
+			return nil, nil, err
+		}
+		if cap(refs) < len(ptrs) {
+			refs = make([]page.ChildRef, len(ptrs))
+		} else {
+			refs = refs[:len(ptrs)]
+		}
+		for i, ptr := range ptrs {
+			refs[i] = page.LeafLogChildRef(ptr)
+		}
+		return refs, resources, nil
 	}
 	if err := l.emitDependencyAppend(durabilitycut.BeforeDependencyAppend); err != nil {
 		return nil, nil, err
 	}
 	out, resources, err := stable.AppendPreparedLeafPageChildRefsWithStableResources(leafPages, preparedPayloads, refs)
 	if err != nil {
+		if resources != nil {
+			resources.Release()
+		}
 		return nil, nil, err
 	}
 	if len(out) != len(leafPages) {
@@ -490,6 +620,12 @@ func (l *leafPageLogWithRecordLengthHints) AppendPreparedLeafPageChildRefsWithSt
 		}
 		ptrs[i] = ref.Log
 		l.noteLeafPagePointer(leafPages[i], ref.Log)
+	}
+	if err := validateLeafPageStableResources(ptrs, resources); err != nil {
+		if resources != nil {
+			resources.Release()
+		}
+		return nil, nil, err
 	}
 	if err := l.emitDependencyAppend(durabilitycut.AfterDependencyAppend, ptrs...); err != nil {
 		resources.Release()
@@ -812,6 +948,12 @@ func (db *DB) setLeafPageLogRaw(log LeafPageLog) {
 func (db *DB) setLeafPageLog(log LeafPageLog, wrap bool) {
 	if db == nil {
 		return
+	}
+	if binder, ok := log.(leafPageLogStableRegistryBinder); ok {
+		// SetLeafPageLog predates stable capture and cannot return an error. The
+		// producer records a typed late-bind failure so ordinary compatibility
+		// may continue while every stable sibling fails closed.
+		_ = binder.bindStableResourcePinRegistry(db.valueLogIdentityPins)
 	}
 	installed := log
 	if wrap {

--- a/TreeDB/db/leaf_page_log.go
+++ b/TreeDB/db/leaf_page_log.go
@@ -489,11 +489,13 @@ func (l *leafPageLogWithRecordLengthHints) AppendPreparedLeafPageChildRefsWithSt
 			return nil, nil, fmt.Errorf("leaf page prepared stable child-ref batch returned non-leaf-log ref at %d", i)
 		}
 		ptrs[i] = ref.Log
-		l.noteLeafPagePointer(leafPages[i], ref.Log)
 	}
 	if err := l.emitDependencyAppend(durabilitycut.AfterDependencyAppend, ptrs...); err != nil {
 		resources.Release()
 		return nil, nil, err
+	}
+	for i, ptr := range ptrs {
+		l.noteLeafPagePointer(leafPages[i], ptr)
 	}
 	return out, resources, nil
 }

--- a/TreeDB/db/leaf_page_log.go
+++ b/TreeDB/db/leaf_page_log.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 
 	"github.com/snissn/gomap/TreeDB/internal/durabilitycut"
+	"github.com/snissn/gomap/TreeDB/internal/rootpublication"
 	"github.com/snissn/gomap/TreeDB/internal/valuelog"
 	"github.com/snissn/gomap/TreeDB/page"
 )
@@ -30,11 +31,26 @@ type LeafPageBatchLog interface {
 	AppendLeafPages(leafPages [][]byte) ([]page.LeafLogPtr, error)
 }
 
+// LeafPageStableLog is the identity-pinned counterpart to LeafPageLog. The
+// returned set is unclaimed builder-owned authority for every raw outer-leaf
+// segment referenced by the returned pointer.
+type LeafPageStableLog interface {
+	AppendLeafPageWithStableResources(leafPage []byte) (page.LeafLogPtr, *rootpublication.StableResourceSet, error)
+}
+
+type LeafPageStableBatchLog interface {
+	AppendLeafPagesWithStableResources(leafPages [][]byte) ([]page.LeafLogPtr, *rootpublication.StableResourceSet, error)
+}
+
 type LeafPagePreparedLog interface {
 	// AppendPreparedLeafPage appends one caller-prepared leaf-log payload. The
 	// original leafPage is used for read-cache population and integrity checks;
 	// preparedPayload contains the already-compacted value-log record payload.
 	AppendPreparedLeafPage(leafPage []byte, preparedPayload []byte) (page.LeafLogPtr, error)
+}
+
+type LeafPagePreparedStableLog interface {
+	AppendPreparedLeafPageWithStableResources(leafPage []byte, preparedPayload []byte) (page.LeafLogPtr, *rootpublication.StableResourceSet, error)
 }
 
 type LeafPagePreparedAppendLog interface {
@@ -57,11 +73,19 @@ type LeafPagePreparedBatchLog interface {
 	AppendPreparedLeafPages(leafPages [][]byte, preparedPayloads [][]byte) ([]page.LeafLogPtr, error)
 }
 
+type LeafPagePreparedStableBatchLog interface {
+	AppendPreparedLeafPagesWithStableResources(leafPages [][]byte, preparedPayloads [][]byte) ([]page.LeafLogPtr, *rootpublication.StableResourceSet, error)
+}
+
 type LeafPagePreparedChildRefBatchLog interface {
 	// AppendPreparedLeafPageChildRefs is the ChildRef-returning counterpart to
 	// AppendPreparedLeafPages. It lets hot paths avoid allocating an intermediate
 	// []LeafLogPtr when the caller ultimately needs ChildRefs.
 	AppendPreparedLeafPageChildRefs(leafPages [][]byte, preparedPayloads [][]byte, refs []page.ChildRef) ([]page.ChildRef, error)
+}
+
+type LeafPagePreparedChildRefStableBatchLog interface {
+	AppendPreparedLeafPageChildRefsWithStableResources(leafPages [][]byte, preparedPayloads [][]byte, refs []page.ChildRef) ([]page.ChildRef, *rootpublication.StableResourceSet, error)
 }
 
 type LeafPageLogSegment struct {
@@ -156,6 +180,29 @@ func (l *leafPageLogWithRecordLengthHints) AppendLeafPage(leafPage []byte) (page
 	return ptr, nil
 }
 
+func (l *leafPageLogWithRecordLengthHints) AppendLeafPageWithStableResources(leafPage []byte) (page.LeafLogPtr, *rootpublication.StableResourceSet, error) {
+	if l == nil || l.inner == nil {
+		return page.LeafLogPtr{}, nil, errors.New("leaf page log unavailable")
+	}
+	stable, ok := l.inner.(LeafPageStableLog)
+	if !ok {
+		return page.LeafLogPtr{}, nil, fmt.Errorf("%w: leaf page log lacks stable append", rootpublication.ErrUnresolvedResource)
+	}
+	if err := l.emitDependencyAppend(durabilitycut.BeforeDependencyAppend); err != nil {
+		return page.LeafLogPtr{}, nil, err
+	}
+	ptr, resources, err := stable.AppendLeafPageWithStableResources(leafPage)
+	if err != nil {
+		return page.LeafLogPtr{}, nil, err
+	}
+	if err := l.emitDependencyAppend(durabilitycut.AfterDependencyAppend, ptr); err != nil {
+		resources.Release()
+		return page.LeafLogPtr{}, nil, err
+	}
+	l.noteLeafPagePointer(leafPage, ptr)
+	return ptr, resources, nil
+}
+
 func (l *leafPageLogWithRecordLengthHints) ConcurrentLeafPageAppends() bool {
 	if l == nil || l.inner == nil {
 		return false
@@ -219,6 +266,35 @@ func (l *leafPageLogWithRecordLengthHints) AppendLeafPages(leafPages [][]byte) (
 	return ptrs, nil
 }
 
+func (l *leafPageLogWithRecordLengthHints) AppendLeafPagesWithStableResources(leafPages [][]byte) ([]page.LeafLogPtr, *rootpublication.StableResourceSet, error) {
+	if l == nil || l.inner == nil {
+		return nil, nil, errors.New("leaf page log unavailable")
+	}
+	if len(leafPages) == 0 {
+		return nil, nil, nil
+	}
+	stable, ok := l.inner.(LeafPageStableBatchLog)
+	if !ok {
+		return nil, nil, fmt.Errorf("%w: leaf page log lacks stable batch append", rootpublication.ErrUnresolvedResource)
+	}
+	if err := l.emitDependencyAppend(durabilitycut.BeforeDependencyAppend); err != nil {
+		return nil, nil, err
+	}
+	ptrs, resources, err := stable.AppendLeafPagesWithStableResources(leafPages)
+	if err != nil {
+		return nil, nil, err
+	}
+	if err := l.emitDependencyAppend(durabilitycut.AfterDependencyAppend, ptrs...); err != nil {
+		resources.Release()
+		return nil, nil, err
+	}
+	if err := l.noteLeafPageBatchPointers(leafPages, ptrs); err != nil {
+		resources.Release()
+		return nil, nil, err
+	}
+	return ptrs, resources, nil
+}
+
 func (l *leafPageLogWithRecordLengthHints) AppendPreparedLeafPage(leafPage []byte, preparedPayload []byte) (page.LeafLogPtr, error) {
 	if l == nil || l.inner == nil {
 		return page.LeafLogPtr{}, errors.New("leaf page log unavailable")
@@ -239,6 +315,29 @@ func (l *leafPageLogWithRecordLengthHints) AppendPreparedLeafPage(leafPage []byt
 	}
 	l.noteLeafPagePointer(leafPage, ptr)
 	return ptr, nil
+}
+
+func (l *leafPageLogWithRecordLengthHints) AppendPreparedLeafPageWithStableResources(leafPage []byte, preparedPayload []byte) (page.LeafLogPtr, *rootpublication.StableResourceSet, error) {
+	if l == nil || l.inner == nil {
+		return page.LeafLogPtr{}, nil, errors.New("leaf page log unavailable")
+	}
+	stable, ok := l.inner.(LeafPagePreparedStableLog)
+	if !ok {
+		return page.LeafLogPtr{}, nil, fmt.Errorf("%w: leaf page log lacks stable prepared append", rootpublication.ErrUnresolvedResource)
+	}
+	if err := l.emitDependencyAppend(durabilitycut.BeforeDependencyAppend); err != nil {
+		return page.LeafLogPtr{}, nil, err
+	}
+	ptr, resources, err := stable.AppendPreparedLeafPageWithStableResources(leafPage, preparedPayload)
+	if err != nil {
+		return page.LeafLogPtr{}, nil, err
+	}
+	if err := l.emitDependencyAppend(durabilitycut.AfterDependencyAppend, ptr); err != nil {
+		resources.Release()
+		return page.LeafLogPtr{}, nil, err
+	}
+	l.noteLeafPagePointer(leafPage, ptr)
+	return ptr, resources, nil
 }
 
 func (l *leafPageLogWithRecordLengthHints) AppendPreparedLeafPages(leafPages [][]byte, preparedPayloads [][]byte) ([]page.LeafLogPtr, error) {
@@ -269,6 +368,38 @@ func (l *leafPageLogWithRecordLengthHints) AppendPreparedLeafPages(leafPages [][
 		return nil, err
 	}
 	return ptrs, nil
+}
+
+func (l *leafPageLogWithRecordLengthHints) AppendPreparedLeafPagesWithStableResources(leafPages [][]byte, preparedPayloads [][]byte) ([]page.LeafLogPtr, *rootpublication.StableResourceSet, error) {
+	if l == nil || l.inner == nil {
+		return nil, nil, errors.New("leaf page log unavailable")
+	}
+	if len(leafPages) == 0 {
+		return nil, nil, nil
+	}
+	if len(preparedPayloads) != len(leafPages) {
+		return nil, nil, fmt.Errorf("leaf page prepared stable batch has %d payloads for %d leaf pages", len(preparedPayloads), len(leafPages))
+	}
+	stable, ok := l.inner.(LeafPagePreparedStableBatchLog)
+	if !ok {
+		return nil, nil, fmt.Errorf("%w: leaf page log lacks stable prepared batch append", rootpublication.ErrUnresolvedResource)
+	}
+	if err := l.emitDependencyAppend(durabilitycut.BeforeDependencyAppend); err != nil {
+		return nil, nil, err
+	}
+	ptrs, resources, err := stable.AppendPreparedLeafPagesWithStableResources(leafPages, preparedPayloads)
+	if err != nil {
+		return nil, nil, err
+	}
+	if err := l.emitDependencyAppend(durabilitycut.AfterDependencyAppend, ptrs...); err != nil {
+		resources.Release()
+		return nil, nil, err
+	}
+	if err := l.noteLeafPageBatchPointers(leafPages, ptrs); err != nil {
+		resources.Release()
+		return nil, nil, err
+	}
+	return ptrs, resources, nil
 }
 
 func (l *leafPageLogWithRecordLengthHints) AppendPreparedLeafPageChildRefs(leafPages [][]byte, preparedPayloads [][]byte, refs []page.ChildRef) ([]page.ChildRef, error) {
@@ -323,6 +454,48 @@ func (l *leafPageLogWithRecordLengthHints) AppendPreparedLeafPageChildRefs(leafP
 		refs[i] = page.LeafLogChildRef(ptr)
 	}
 	return refs, nil
+}
+
+func (l *leafPageLogWithRecordLengthHints) AppendPreparedLeafPageChildRefsWithStableResources(leafPages [][]byte, preparedPayloads [][]byte, refs []page.ChildRef) ([]page.ChildRef, *rootpublication.StableResourceSet, error) {
+	refs = refs[:0]
+	if l == nil || l.inner == nil {
+		return nil, nil, errors.New("leaf page log unavailable")
+	}
+	if len(leafPages) == 0 {
+		return refs, nil, nil
+	}
+	if len(preparedPayloads) != len(leafPages) {
+		return nil, nil, fmt.Errorf("leaf page prepared stable child-ref batch has %d payloads for %d leaf pages", len(preparedPayloads), len(leafPages))
+	}
+	stable, ok := l.inner.(LeafPagePreparedChildRefStableBatchLog)
+	if !ok {
+		return nil, nil, fmt.Errorf("%w: leaf page log lacks stable prepared child-ref append", rootpublication.ErrUnresolvedResource)
+	}
+	if err := l.emitDependencyAppend(durabilitycut.BeforeDependencyAppend); err != nil {
+		return nil, nil, err
+	}
+	out, resources, err := stable.AppendPreparedLeafPageChildRefsWithStableResources(leafPages, preparedPayloads, refs)
+	if err != nil {
+		return nil, nil, err
+	}
+	if len(out) != len(leafPages) {
+		resources.Release()
+		return nil, nil, fmt.Errorf("leaf page prepared stable child-ref batch returned %d refs for %d leaf pages", len(out), len(leafPages))
+	}
+	ptrs := make([]page.LeafLogPtr, len(out))
+	for i, ref := range out {
+		if !ref.IsLeafLog() {
+			resources.Release()
+			return nil, nil, fmt.Errorf("leaf page prepared stable child-ref batch returned non-leaf-log ref at %d", i)
+		}
+		ptrs[i] = ref.Log
+		l.noteLeafPagePointer(leafPages[i], ref.Log)
+	}
+	if err := l.emitDependencyAppend(durabilitycut.AfterDependencyAppend, ptrs...); err != nil {
+		resources.Release()
+		return nil, nil, err
+	}
+	return out, resources, nil
 }
 
 func (l *leafPageLogWithRecordLengthHints) emitDependencyAppend(point durabilitycut.Point, ptrs ...page.LeafLogPtr) error {

--- a/TreeDB/db/leaf_page_log_lanes.go
+++ b/TreeDB/db/leaf_page_log_lanes.go
@@ -6,6 +6,7 @@ import (
 	"sync"
 	"sync/atomic"
 
+	"github.com/snissn/gomap/TreeDB/internal/rootpublication"
 	"github.com/snissn/gomap/TreeDB/internal/valuelog"
 	"github.com/snissn/gomap/TreeDB/page"
 )
@@ -186,6 +187,14 @@ func (g *leafPageLogLaneGroup) AppendLeafPages(leafPages [][]byte) ([]page.LeafL
 	return g.appendLeafPagesAt(0, leafPages)
 }
 
+func (g *leafPageLogLaneGroup) AppendLeafPageWithStableResources(leafPage []byte) (page.LeafLogPtr, *rootpublication.StableResourceSet, error) {
+	return g.appendLeafPageStableAt(0, leafPage)
+}
+
+func (g *leafPageLogLaneGroup) AppendLeafPagesWithStableResources(leafPages [][]byte) ([]page.LeafLogPtr, *rootpublication.StableResourceSet, error) {
+	return g.appendLeafPagesStableAt(0, leafPages)
+}
+
 func (g *leafPageLogLaneGroup) Flush() error {
 	return g.forEachLane(func(lane LeafPageLog) error { return lane.Flush() })
 }
@@ -320,6 +329,20 @@ func (h *leafPageLogLaneHandle) AppendLeafPages(leafPages [][]byte) ([]page.Leaf
 	return h.group.appendLeafPagesAt(h.index, leafPages)
 }
 
+func (h *leafPageLogLaneHandle) AppendLeafPageWithStableResources(leafPage []byte) (page.LeafLogPtr, *rootpublication.StableResourceSet, error) {
+	if h == nil || h.group == nil {
+		return page.LeafLogPtr{}, nil, errors.New("leaf page log unavailable")
+	}
+	return h.group.appendLeafPageStableAt(h.index, leafPage)
+}
+
+func (h *leafPageLogLaneHandle) AppendLeafPagesWithStableResources(leafPages [][]byte) ([]page.LeafLogPtr, *rootpublication.StableResourceSet, error) {
+	if h == nil || h.group == nil {
+		return nil, nil, errors.New("leaf page log unavailable")
+	}
+	return h.group.appendLeafPagesStableAt(h.index, leafPages)
+}
+
 func (h *leafPageLogLaneHandle) Flush() error {
 	if h == nil || h.group == nil {
 		return nil
@@ -393,6 +416,73 @@ func (g *leafPageLogLaneGroup) appendLeafPagesAt(index int, leafPages [][]byte) 
 		g.noteAppendedLeafPtr(ptr)
 	}
 	return ptrs, nil
+}
+
+func (g *leafPageLogLaneGroup) appendLeafPageStableAt(index int, leafPage []byte) (page.LeafLogPtr, *rootpublication.StableResourceSet, error) {
+	var ptr page.LeafLogPtr
+	var resources *rootpublication.StableResourceSet
+	err := g.withLane(index, func(lane LeafPageLog) error {
+		stable, ok := lane.(LeafPageStableLog)
+		if !ok {
+			return fmt.Errorf("%w: leaf page lane lacks stable append", rootpublication.ErrUnresolvedResource)
+		}
+		var err error
+		ptr, resources, err = stable.AppendLeafPageWithStableResources(leafPage)
+		return err
+	})
+	if err != nil {
+		if resources != nil {
+			resources.Release()
+		}
+		return page.LeafLogPtr{}, nil, err
+	}
+	if resources == nil {
+		return page.LeafLogPtr{}, nil, fmt.Errorf("%w: stable leaf lane returned no resource authority", rootpublication.ErrUnresolvedResource)
+	}
+	if err := validateLeafPageStableResources([]page.LeafLogPtr{ptr}, resources); err != nil {
+		resources.Release()
+		return page.LeafLogPtr{}, nil, err
+	}
+	g.noteAppendedLeafPtr(ptr)
+	return ptr, resources, nil
+}
+
+func (g *leafPageLogLaneGroup) appendLeafPagesStableAt(index int, leafPages [][]byte) ([]page.LeafLogPtr, *rootpublication.StableResourceSet, error) {
+	if len(leafPages) == 0 {
+		return nil, nil, nil
+	}
+	var ptrs []page.LeafLogPtr
+	var resources *rootpublication.StableResourceSet
+	err := g.withLane(index, func(lane LeafPageLog) error {
+		stable, ok := lane.(LeafPageStableBatchLog)
+		if !ok {
+			return fmt.Errorf("%w: leaf page lane lacks stable batch append", rootpublication.ErrUnresolvedResource)
+		}
+		var err error
+		ptrs, resources, err = stable.AppendLeafPagesWithStableResources(leafPages)
+		return err
+	})
+	if err != nil {
+		if resources != nil {
+			resources.Release()
+		}
+		return nil, nil, err
+	}
+	if resources == nil {
+		return nil, nil, fmt.Errorf("%w: stable leaf lane batch returned no resource authority", rootpublication.ErrUnresolvedResource)
+	}
+	if len(ptrs) != len(leafPages) {
+		resources.Release()
+		return nil, nil, fmt.Errorf("leaf page stable batch log returned %d ptrs for %d leaf pages", len(ptrs), len(leafPages))
+	}
+	if err := validateLeafPageStableResources(ptrs, resources); err != nil {
+		resources.Release()
+		return nil, nil, err
+	}
+	for _, ptr := range ptrs {
+		g.noteAppendedLeafPtr(ptr)
+	}
+	return ptrs, resources, nil
 }
 
 func (g *leafPageLogLaneGroup) withLane(index int, fn func(LeafPageLog) error) error {

--- a/TreeDB/db/leaf_page_read_cache_test.go
+++ b/TreeDB/db/leaf_page_read_cache_test.go
@@ -9,6 +9,8 @@ import (
 	"time"
 
 	"github.com/pierrec/lz4/v4"
+	"github.com/snissn/gomap/TreeDB/internal/durabilitycut"
+	"github.com/snissn/gomap/TreeDB/internal/rootpublication"
 	"github.com/snissn/gomap/TreeDB/page"
 )
 
@@ -1527,6 +1529,64 @@ func TestLeafPageLogRejectsBatchPtrCountMismatch(t *testing.T) {
 	}
 	if stats := db.leafPageReadCache.stats(); stats.Stores != 0 {
 		t.Fatalf("cache stores=%d, want 0 after rejected batch", stats.Stores)
+	}
+}
+
+type leafPageCacheStableChildRefTestLog struct {
+	ptr       page.LeafLogPtr
+	resources *rootpublication.StableResourceSet
+}
+
+func (l *leafPageCacheStableChildRefTestLog) AppendLeafPage([]byte) (page.LeafLogPtr, error) {
+	return l.ptr, nil
+}
+
+func (l *leafPageCacheStableChildRefTestLog) AppendPreparedLeafPageChildRefsWithStableResources(_ [][]byte, _ [][]byte, refs []page.ChildRef) ([]page.ChildRef, *rootpublication.StableResourceSet, error) {
+	return append(refs[:0], page.LeafLogChildRef(l.ptr)), l.resources, nil
+}
+
+func (*leafPageCacheStableChildRefTestLog) Flush() error { return nil }
+func (*leafPageCacheStableChildRefTestLog) Sync() error  { return nil }
+
+func TestLeafPageLogStableChildRefsDoNotCacheBeforeDependencyAppendSucceeds(t *testing.T) {
+	resources, err := rootpublication.NewStableResourceSetBuilder().Freeze()
+	if err != nil {
+		t.Fatalf("freeze empty resource set: %v", err)
+	}
+	ptr := page.LeafLogPtr{FileID: 11, Offset: 256, RecordLengthHint: 4096}
+	db := &DB{dir: t.TempDir(), leafPageReadCache: newLeafPageReadCache(8)}
+	inner := &leafPageCacheStableChildRefTestLog{ptr: ptr, resources: resources}
+	log := &leafPageLogWithRecordLengthHints{db: db, inner: inner}
+	wantErr := errors.New("reject dependency append")
+	restore := durabilitycut.Install(func(event durabilitycut.Event) error {
+		if event.Resource == durabilitycut.ResourceOuterLeaf && event.Point == durabilitycut.AfterDependencyAppend {
+			return wantErr
+		}
+		return nil
+	})
+	_, gotResources, err := log.AppendPreparedLeafPageChildRefsWithStableResources(
+		[][]byte{bytes.Repeat([]byte{0x7a}, page.PageSize)},
+		[][]byte{{0x01}},
+		nil,
+	)
+	restore()
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("append error=%v want %v", err, wantErr)
+	}
+	if gotResources != nil {
+		t.Fatalf("resources=%v want nil after rejected append", gotResources)
+	}
+	if owner := resources.Owner(); owner != rootpublication.ResourceOwnerReleased {
+		t.Fatalf("resource owner=%v want released", owner)
+	}
+	if stats := db.leafPageReadCache.stats(); stats.Stores != 0 {
+		t.Fatalf("cache stores=%d want 0 after rejected dependency append", stats.Stores)
+	}
+	db.leafGenerationRecordLengthMu.Lock()
+	indexedFiles := len(db.leafGenerationRecordLengthByFile)
+	db.leafGenerationRecordLengthMu.Unlock()
+	if indexedFiles != 0 {
+		t.Fatalf("record-length indexes=%d want 0 after rejected dependency append", indexedFiles)
 	}
 }
 

--- a/TreeDB/db/leaf_page_stable_contract_test.go
+++ b/TreeDB/db/leaf_page_stable_contract_test.go
@@ -1,0 +1,221 @@
+package db
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/snissn/gomap/TreeDB/internal/rootpublication"
+	"github.com/snissn/gomap/TreeDB/page"
+)
+
+type stableContractTestLeafLog struct {
+	ptrs      []page.LeafLogPtr
+	resources *rootpublication.StableResourceSet
+	err       error
+}
+
+func (log *stableContractTestLeafLog) AppendLeafPage([]byte) (page.LeafLogPtr, error) {
+	return log.ptrs[0], log.err
+}
+
+func (log *stableContractTestLeafLog) AppendLeafPages([][]byte) ([]page.LeafLogPtr, error) {
+	return log.ptrs, log.err
+}
+
+func (log *stableContractTestLeafLog) AppendLeafPageWithStableResources([]byte) (page.LeafLogPtr, *rootpublication.StableResourceSet, error) {
+	return log.ptrs[0], log.resources, log.err
+}
+
+func (log *stableContractTestLeafLog) AppendLeafPagesWithStableResources([][]byte) ([]page.LeafLogPtr, *rootpublication.StableResourceSet, error) {
+	return log.ptrs, log.resources, log.err
+}
+
+func (log *stableContractTestLeafLog) AppendPreparedLeafPageWithStableResources([]byte, []byte) (page.LeafLogPtr, *rootpublication.StableResourceSet, error) {
+	return log.ptrs[0], log.resources, log.err
+}
+
+func (log *stableContractTestLeafLog) AppendPreparedLeafPagesWithStableResources([][]byte, [][]byte) ([]page.LeafLogPtr, *rootpublication.StableResourceSet, error) {
+	return log.ptrs, log.resources, log.err
+}
+
+func (log *stableContractTestLeafLog) AppendPreparedLeafPageChildRefsWithStableResources(_ [][]byte, _ [][]byte, refs []page.ChildRef) ([]page.ChildRef, *rootpublication.StableResourceSet, error) {
+	refs = refs[:0]
+	for _, ptr := range log.ptrs {
+		refs = append(refs, page.LeafLogChildRef(ptr))
+	}
+	return refs, log.resources, log.err
+}
+
+func (*stableContractTestLeafLog) Flush() error { return nil }
+func (*stableContractTestLeafLog) Sync() error  { return nil }
+
+type stableContractDescriptor struct {
+	generation   uint64
+	kind         rootpublication.ResourceKind
+	reachability rootpublication.ReachabilityField
+	frontier     uint64
+}
+
+func stableContractResourceSet(t *testing.T, descriptors ...stableContractDescriptor) *rootpublication.StableResourceSet {
+	t.Helper()
+	if len(descriptors) == 0 {
+		return nil
+	}
+	builder := rootpublication.NewStableResourceSetBuilder(descriptors[0].reachability)
+	for i, descriptor := range descriptors {
+		file, err := os.CreateTemp(t.TempDir(), "stable-leaf-*")
+		if err != nil {
+			t.Fatalf("create stable resource %d: %v", i, err)
+		}
+		if err := file.Truncate(4096); err != nil {
+			_ = file.Close()
+			t.Fatalf("truncate stable resource %d: %v", i, err)
+		}
+		t.Cleanup(func() { _ = file.Close() })
+		token, err := rootpublication.NewStableResourceToken(rootpublication.StableResourceSpec{
+			Kind: descriptor.kind, LogicalLane: "test-leaf", ResourceID: fmt.Sprintf("segment-%d", i),
+			Generation: descriptor.generation, DiagnosticPath: fmt.Sprintf("leaf_vlog/test-%d.vlog", i),
+			File: file, Frontier: rootpublication.DurableFrontier{Bytes: descriptor.frontier},
+			Reachability: descriptor.reachability,
+		})
+		if err != nil {
+			t.Fatalf("create stable token %d: %v", i, err)
+		}
+		if err := builder.Add(token); err != nil {
+			token.Release()
+			t.Fatalf("add stable token %d: %v", i, err)
+		}
+	}
+	set, err := builder.Freeze()
+	if err != nil {
+		builder.Abandon()
+		t.Fatalf("freeze stable resources: %v", err)
+	}
+	return set
+}
+
+func TestLeafPageStableWrapperRejectsMalformedProviderAuthority(t *testing.T) {
+	ptrs := []page.LeafLogPtr{
+		{FileID: 11, Offset: 32, RecordLengthHint: 16},
+		{FileID: 12, Offset: 64, RecordLengthHint: 16},
+	}
+	outer := func(generation uint64, frontier uint64) stableContractDescriptor {
+		return stableContractDescriptor{
+			generation: generation, kind: rootpublication.ResourceOuterLeafLog,
+			reachability: rootpublication.ReachabilityOuterLeafRawPointer, frontier: frontier,
+		}
+	}
+	tests := []struct {
+		name      string
+		resources func(*testing.T) *rootpublication.StableResourceSet
+	}{
+		{name: "nil", resources: func(*testing.T) *rootpublication.StableResourceSet { return nil }},
+		{name: "partial", resources: func(t *testing.T) *rootpublication.StableResourceSet {
+			return stableContractResourceSet(t, outer(uint64(ptrs[0].ValueLogFileID()), 4096))
+		}},
+		{name: "extra", resources: func(t *testing.T) *rootpublication.StableResourceSet {
+			return stableContractResourceSet(t,
+				outer(uint64(ptrs[0].ValueLogFileID()), 4096),
+				outer(uint64(ptrs[1].ValueLogFileID()), 4096),
+				outer(uint64(page.ValueLogFileID(13)), 4096))
+		}},
+		{name: "wrong-generation", resources: func(t *testing.T) *rootpublication.StableResourceSet {
+			return stableContractResourceSet(t,
+				outer(uint64(ptrs[0].ValueLogFileID()), 4096),
+				outer(uint64(page.ValueLogFileID(13)), 4096))
+		}},
+		{name: "wrong-reachability", resources: func(t *testing.T) *rootpublication.StableResourceSet {
+			return stableContractResourceSet(t,
+				stableContractDescriptor{generation: uint64(ptrs[0].ValueLogFileID()), kind: rootpublication.ResourceValueLog, reachability: rootpublication.ReachabilityValueLogPointer, frontier: 4096},
+				stableContractDescriptor{generation: uint64(ptrs[1].ValueLogFileID()), kind: rootpublication.ResourceValueLog, reachability: rootpublication.ReachabilityValueLogPointer, frontier: 4096})
+		}},
+		{name: "frontier-before-pointer", resources: func(t *testing.T) *rootpublication.StableResourceSet {
+			return stableContractResourceSet(t,
+				outer(uint64(ptrs[0].ValueLogFileID()), ptrs[0].Offset),
+				outer(uint64(ptrs[1].ValueLogFileID()), 4096))
+		}},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			resources := test.resources(t)
+			log := &leafPageLogWithRecordLengthHints{inner: &stableContractTestLeafLog{ptrs: ptrs, resources: resources}}
+			_, returned, err := log.AppendLeafPagesWithStableResources([][]byte{{1}, {2}})
+			if err == nil {
+				if returned != nil {
+					returned.Release()
+				}
+				t.Fatal("malformed provider authority was accepted")
+			}
+			if returned != nil {
+				returned.Release()
+				t.Fatal("rejected provider authority was returned")
+			}
+			if resources != nil && resources.Owner() != rootpublication.ResourceOwnerReleased {
+				t.Fatalf("rejected resources owner=%v want released", resources.Owner())
+			}
+		})
+	}
+}
+
+func TestLeafPageStableWrappersValidateEveryInterface(t *testing.T) {
+	ptr := page.LeafLogPtr{FileID: 21, Offset: 32, RecordLengthHint: 16}
+	pageBytes := []byte{1}
+	prepared := []byte{2}
+	providerErr := errors.New("provider failed")
+	tests := []struct {
+		name string
+		call func(*leafPageLogWithRecordLengthHints) (*rootpublication.StableResourceSet, error)
+	}{
+		{name: "single", call: func(log *leafPageLogWithRecordLengthHints) (*rootpublication.StableResourceSet, error) {
+			_, resources, err := log.AppendLeafPageWithStableResources(pageBytes)
+			return resources, err
+		}},
+		{name: "batch", call: func(log *leafPageLogWithRecordLengthHints) (*rootpublication.StableResourceSet, error) {
+			_, resources, err := log.AppendLeafPagesWithStableResources([][]byte{pageBytes})
+			return resources, err
+		}},
+		{name: "prepared-single", call: func(log *leafPageLogWithRecordLengthHints) (*rootpublication.StableResourceSet, error) {
+			_, resources, err := log.AppendPreparedLeafPageWithStableResources(pageBytes, prepared)
+			return resources, err
+		}},
+		{name: "prepared-batch", call: func(log *leafPageLogWithRecordLengthHints) (*rootpublication.StableResourceSet, error) {
+			_, resources, err := log.AppendPreparedLeafPagesWithStableResources([][]byte{pageBytes}, [][]byte{prepared})
+			return resources, err
+		}},
+		{name: "prepared-child-refs", call: func(log *leafPageLogWithRecordLengthHints) (*rootpublication.StableResourceSet, error) {
+			_, resources, err := log.AppendPreparedLeafPageChildRefsWithStableResources([][]byte{pageBytes}, [][]byte{prepared}, nil)
+			return resources, err
+		}},
+	}
+	for _, test := range tests {
+		t.Run(test.name+"/nil-success", func(t *testing.T) {
+			log := &leafPageLogWithRecordLengthHints{inner: &stableContractTestLeafLog{ptrs: []page.LeafLogPtr{ptr}}}
+			resources, err := test.call(log)
+			if err == nil || resources != nil {
+				if resources != nil {
+					resources.Release()
+				}
+				t.Fatalf("nil authority result resources=%v err=%v", resources, err)
+			}
+		})
+		t.Run(test.name+"/error-release", func(t *testing.T) {
+			resources := stableContractResourceSet(t, stableContractDescriptor{
+				generation: uint64(ptr.ValueLogFileID()), kind: rootpublication.ResourceOuterLeafLog,
+				reachability: rootpublication.ReachabilityOuterLeafRawPointer, frontier: 4096,
+			})
+			log := &leafPageLogWithRecordLengthHints{inner: &stableContractTestLeafLog{ptrs: []page.LeafLogPtr{ptr}, resources: resources, err: providerErr}}
+			returned, err := test.call(log)
+			if !errors.Is(err, providerErr) || returned != nil {
+				if returned != nil {
+					returned.Release()
+				}
+				t.Fatalf("provider error result resources=%v err=%v", returned, err)
+			}
+			if resources.Owner() != rootpublication.ResourceOwnerReleased {
+				t.Fatalf("provider error resources owner=%v want released", resources.Owner())
+			}
+		})
+	}
+}

--- a/TreeDB/db/stable_leaf_rewrite.go
+++ b/TreeDB/db/stable_leaf_rewrite.go
@@ -1,0 +1,214 @@
+package db
+
+import (
+	"fmt"
+	"path/filepath"
+
+	"github.com/snissn/gomap/TreeDB/internal/rootpublication"
+	"github.com/snissn/gomap/TreeDB/internal/valuelog"
+	"github.com/snissn/gomap/TreeDB/page"
+)
+
+type rewriteStableOuterLeafCapture struct {
+	writer           *rewriteWriter
+	builder          *rootpublication.StableResourceSetBuilder
+	tokens           []*rootpublication.StableResourceToken
+	parentGeneration uint64
+}
+
+func newRewriteStableOuterLeafCapture(writer *rewriteWriter) (*rewriteStableOuterLeafCapture, error) {
+	if writer == nil || writer.leafDir == "" || writer.leafStaging {
+		return nil, fmt.Errorf("%w: rewrite writer is not an authoritative raw outer-leaf producer", rootpublication.ErrUnresolvedResource)
+	}
+	if writer.stableRegistryErr != nil {
+		return nil, writer.stableRegistryErr
+	}
+	if writer.stableResourcePins == nil {
+		return nil, fmt.Errorf("%w: raw outer-leaf producer lacks the DB-scoped pin registry", rootpublication.ErrUnresolvedResource)
+	}
+	return &rewriteStableOuterLeafCapture{
+		writer:  writer,
+		builder: rootpublication.NewStableResourceSetBuilder(rootpublication.ReachabilityOuterLeafRawPointer),
+	}, nil
+}
+
+func (capture *rewriteStableOuterLeafCapture) bindParentGeneration(writer *valuelog.Writer) error {
+	if capture == nil || writer == nil {
+		return rootpublication.ErrResourceOwnership
+	}
+	if capture.parentGeneration != 0 {
+		return nil
+	}
+	generation, err := writer.StableNamespaceParentGeneration()
+	if err != nil {
+		return err
+	}
+	if generation == 0 {
+		return fmt.Errorf("%w: raw outer-leaf parent has zero generation", rootpublication.ErrUnresolvedResource)
+	}
+	capture.parentGeneration = generation
+	return nil
+}
+
+func (capture *rewriteStableOuterLeafCapture) registration(path string, fileID uint32, operation rootpublication.NamespaceOperation) (valuelog.StableResourceRegistration, error) {
+	if capture == nil || capture.writer == nil || path == "" || fileID == 0 || capture.parentGeneration == 0 {
+		return valuelog.StableResourceRegistration{}, fmt.Errorf("%w: incomplete standalone outer-leaf registration", rootpublication.ErrUnresolvedResource)
+	}
+	diagnosticPath, err := filepath.Rel(filepath.Dir(capture.writer.leafDir), path)
+	if err != nil || diagnosticPath == "." || filepath.IsAbs(diagnosticPath) {
+		return valuelog.StableResourceRegistration{}, fmt.Errorf("%w: standalone outer-leaf diagnostic path: %v", rootpublication.ErrUnresolvedResource, err)
+	}
+	registration := valuelog.StableResourceRegistration{
+		Kind:               rootpublication.ResourceOuterLeafLog,
+		LogicalLane:        fmt.Sprintf("outer-leaf-%d", capture.writer.leafLane),
+		Generation:         uint64(fileID),
+		DiagnosticPath:     filepath.ToSlash(diagnosticPath),
+		Reachability:       rootpublication.ReachabilityOuterLeafRawPointer,
+		ParentGeneration:   capture.parentGeneration,
+		NamespaceOperation: operation,
+		PinRegistry:        capture.writer.stableResourcePins,
+	}
+	if operation != rootpublication.NamespaceNone {
+		registration.NewName = filepath.Base(path)
+	}
+	return registration, nil
+}
+
+func (capture *rewriteStableOuterLeafCapture) add(token *rootpublication.StableResourceToken) error {
+	if capture == nil || capture.builder == nil || token == nil {
+		return rootpublication.ErrResourceOwnership
+	}
+	capture.tokens = append(capture.tokens, token)
+	return nil
+}
+
+func (capture *rewriteStableOuterLeafCapture) addRotation(rotation *valuelog.StableResourceRotation) error {
+	if rotation == nil {
+		return rootpublication.ErrResourceOwnership
+	}
+	defer rotation.Release()
+	if token := rotation.TakeClosed(); token != nil {
+		if err := capture.add(token); err != nil {
+			token.Release()
+			return err
+		}
+	}
+	if token := rotation.TakeActive(); token != nil {
+		if err := capture.add(token); err != nil {
+			token.Release()
+			return err
+		}
+	}
+	return nil
+}
+
+func (capture *rewriteStableOuterLeafCapture) captureRotation(writer *valuelog.Writer, nextPath string, nextFileID uint32, syncCurrent bool) (bool, error) {
+	if err := capture.bindParentGeneration(writer); err != nil {
+		return false, err
+	}
+	closedOperation := rootpublication.NamespaceNone
+	created, err := writer.StableCreationNamespacePending()
+	if err != nil {
+		return false, err
+	}
+	if created {
+		closedOperation = rootpublication.NamespaceCreate
+	}
+	closed, err := capture.registration(capture.writer.leafCurrentPath, capture.writer.leafCurrentFileID, closedOperation)
+	if err != nil {
+		return false, err
+	}
+	active, err := capture.registration(nextPath, nextFileID, rootpublication.NamespaceCreate)
+	if err != nil {
+		return false, err
+	}
+	rotation, err := writer.RotateToWithStableResources(nextPath, nextFileID, syncCurrent, closed, active)
+	if err != nil {
+		if rotation != nil {
+			rotation.Release()
+		}
+		return valuelog.RotationInstalled(err), err
+	}
+	if err := capture.addRotation(rotation); err != nil {
+		return true, err
+	}
+	return true, nil
+}
+
+func (capture *rewriteStableOuterLeafCapture) captureCurrent() error {
+	if capture == nil || capture.writer == nil || capture.writer.leafW == nil {
+		return fmt.Errorf("%w: standalone outer-leaf writer unavailable", rootpublication.ErrUnresolvedResource)
+	}
+	if err := capture.bindParentGeneration(capture.writer.leafW); err != nil {
+		return err
+	}
+	operation := rootpublication.NamespaceNone
+	created, err := capture.writer.leafW.StableCreationNamespacePending()
+	if err != nil {
+		return err
+	}
+	if created {
+		operation = rootpublication.NamespaceCreate
+	}
+	registration, err := capture.registration(capture.writer.leafCurrentPath, capture.writer.leafCurrentFileID, operation)
+	if err != nil {
+		return err
+	}
+	token, err := capture.writer.leafW.StableResourceToken(registration)
+	if err != nil {
+		return err
+	}
+	if err := capture.add(token); err != nil {
+		token.Release()
+		return err
+	}
+	return nil
+}
+
+func (capture *rewriteStableOuterLeafCapture) freeze(ptrs []page.LeafLogPtr) (*rootpublication.StableResourceSet, error) {
+	if capture == nil || capture.builder == nil {
+		return nil, rootpublication.ErrResourceOwnership
+	}
+	required := make(map[uint64]struct{}, len(ptrs))
+	for _, ptr := range ptrs {
+		required[uint64(ptr.ValueLogFileID())] = struct{}{}
+	}
+	for _, token := range capture.tokens {
+		if _, ok := required[token.Generation()]; !ok {
+			token.Release()
+			continue
+		}
+		if err := capture.builder.Add(token); err != nil {
+			token.Release()
+			capture.builder.Abandon()
+			capture.releaseTokens()
+			capture.builder = nil
+			return nil, err
+		}
+	}
+	capture.tokens = nil
+	set, err := capture.builder.Freeze()
+	if err != nil {
+		capture.builder.Abandon()
+	}
+	capture.builder = nil
+	return set, err
+}
+
+func (capture *rewriteStableOuterLeafCapture) abandon() {
+	if capture == nil {
+		return
+	}
+	if capture.builder != nil {
+		capture.builder.Abandon()
+	}
+	capture.releaseTokens()
+	capture.builder = nil
+}
+
+func (capture *rewriteStableOuterLeafCapture) releaseTokens() {
+	for _, token := range capture.tokens {
+		token.Release()
+	}
+	capture.tokens = nil
+}

--- a/TreeDB/db/standalone_leaf_page_stable_resource_test.go
+++ b/TreeDB/db/standalone_leaf_page_stable_resource_test.go
@@ -1,0 +1,156 @@
+//go:build !windows
+
+package db
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/snissn/gomap/TreeDB/internal/rootpublication"
+	"github.com/snissn/gomap/TreeDB/internal/valuelog"
+	"github.com/snissn/gomap/TreeDB/page"
+)
+
+func standaloneStableLeafPages(count, size int) [][]byte {
+	pages := make([][]byte, count)
+	for i := range pages {
+		page := make([]byte, size)
+		for j := range page {
+			page[j] = byte((i*37 + j*131 + j/7) % 251)
+		}
+		pages[i] = page
+	}
+	return pages
+}
+
+func TestStandaloneLeafPageLogStableBatchCapturesExactRotatedSegments(t *testing.T) {
+	dir := t.TempDir()
+	db, err := Open(Options{Dir: dir, IndexOuterLeavesInValueLog: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	log, err := NewStandaloneLeafPageLog(dir, StandaloneLeafPageLogOptions{
+		MaxSegmentBytes: 512,
+		Compression:     ValueLogCompressionOff,
+	})
+	if err != nil {
+		_ = db.Close()
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		_ = db.Close()
+		_ = log.Close()
+	})
+	db.SetLeafPageLog(log)
+
+	stable, ok := db.leafPageLog.(LeafPageStableBatchLog)
+	if !ok {
+		t.Fatalf("installed standalone leaf log %T erased stable batch capture", db.leafPageLog)
+	}
+	pages := standaloneStableLeafPages(valuelog.MaxFrameK*2+8, page.PageSize)
+	ptrs, resources, err := stable.AppendLeafPagesWithStableResources(pages)
+	if err != nil {
+		t.Fatalf("stable batch: %v", err)
+	}
+	if resources == nil {
+		t.Fatal("stable batch returned nil resource authority")
+	}
+	defer resources.Release()
+	if len(ptrs) != len(pages) {
+		t.Fatalf("ptrs=%d want %d", len(ptrs), len(pages))
+	}
+
+	referenced := make(map[uint64]struct{}, len(ptrs))
+	for _, ptr := range ptrs {
+		referenced[uint64(ptr.ValueLogFileID())] = struct{}{}
+	}
+	if len(referenced) < 2 {
+		t.Fatalf("referenced segments=%d want rotation", len(referenced))
+	}
+	descriptors := resources.Descriptors()
+	if len(descriptors) != len(referenced) {
+		t.Fatalf("descriptors=%d referenced=%d", len(descriptors), len(referenced))
+	}
+	for _, descriptor := range descriptors {
+		if descriptor.Kind() != rootpublication.ResourceOuterLeafLog {
+			t.Fatalf("kind=%q", descriptor.Kind())
+		}
+		if _, ok := referenced[descriptor.Generation()]; !ok {
+			t.Fatalf("captured unrelated generation=%d", descriptor.Generation())
+		}
+		delete(referenced, descriptor.Generation())
+		if _, err := db.valueLogIdentityPins.BeginDelete(descriptor.Identity()); !errors.Is(err, rootpublication.ErrResourcePinned) {
+			t.Fatalf("delete captured generation %d error=%v want ErrResourcePinned", descriptor.Generation(), err)
+		}
+	}
+	if len(referenced) != 0 {
+		t.Fatalf("missing referenced generations: %v", referenced)
+	}
+	namespaceTokens := 0
+	for _, token := range resources.Tokens() {
+		if token.Namespace() != nil {
+			namespaceTokens++
+		}
+	}
+	if namespaceTokens != len(descriptors) {
+		t.Fatalf("namespace tokens=%d descriptors=%d", namespaceTokens, len(descriptors))
+	}
+	stats := resources.Stats(time.Now())
+	if len(stats) != 1 || stats[0].NamespaceSyncs != uint64(namespaceTokens) {
+		t.Fatalf("resource stats=%+v", stats)
+	}
+}
+
+func TestStandaloneLeafPageLogStableCaptureSurvivesLaneClone(t *testing.T) {
+	db, log := openLeafPageLogLaneTestDB(t)
+	t.Cleanup(func() {
+		_ = db.Close()
+		_ = log.Close()
+	})
+	lane, ok := db.leafPageLogLaneForWorkerIndex(1)
+	if !ok {
+		t.Fatal("nonzero standalone leaf lane unavailable")
+	}
+	stable, ok := lane.(LeafPageStableLog)
+	if !ok {
+		t.Fatalf("cloned lane %T erased stable capture", lane)
+	}
+	_, resources, err := stable.AppendLeafPageWithStableResources([]byte("stable cloned lane"))
+	if err != nil {
+		t.Fatalf("stable cloned lane append: %v", err)
+	}
+	if resources == nil || resources.Len() != 1 {
+		t.Fatalf("cloned lane resources=%v", resources)
+	}
+	resources.Release()
+}
+
+func TestStandaloneLeafPageLogLateRegistryBindFailsStableOnly(t *testing.T) {
+	dir := t.TempDir()
+	log, err := NewStandaloneLeafPageLog(dir, StandaloneLeafPageLogOptions{Compression: ValueLogCompressionOff})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := log.AppendLeafPage([]byte("opened before DB installation")); err != nil {
+		_ = log.Close()
+		t.Fatal(err)
+	}
+	db, err := Open(Options{Dir: dir, IndexOuterLeavesInValueLog: true})
+	if err != nil {
+		_ = log.Close()
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		_ = db.Close()
+		_ = log.Close()
+	})
+	db.SetLeafPageLog(log)
+	stable := db.leafPageLog.(LeafPageStableLog)
+	if _, resources, err := stable.AppendLeafPageWithStableResources([]byte("must fail closed")); !errors.Is(err, rootpublication.ErrUnresolvedResource) || resources != nil {
+		t.Fatalf("late-bind stable append resources=%v err=%v", resources, err)
+	}
+	if _, err := db.leafPageLog.AppendLeafPage([]byte("ordinary compatibility remains")); err != nil {
+		t.Fatalf("ordinary append after late bind: %v", err)
+	}
+}

--- a/TreeDB/db/vlog_rewrite.go
+++ b/TreeDB/db/vlog_rewrite.go
@@ -29,6 +29,7 @@ import (
 	"github.com/snissn/gomap/TreeDB/internal/lockfile"
 	"github.com/snissn/gomap/TreeDB/internal/memtable"
 	"github.com/snissn/gomap/TreeDB/internal/outerleaf"
+	"github.com/snissn/gomap/TreeDB/internal/rootpublication"
 	"github.com/snissn/gomap/TreeDB/internal/valuelog"
 	"github.com/snissn/gomap/TreeDB/node"
 	"github.com/snissn/gomap/TreeDB/page"
@@ -3388,12 +3389,14 @@ type rewriteWriter struct {
 	ridAlloc         *rewriteRIDAllocator
 	// currentPath/currentFileID cache the active writer segment identity so
 	// CurrentValueLogSegment can avoid per-call path/fileID recomputation.
-	currentPath       string
-	currentFileID     uint32
-	leafCurrentPath   string
-	leafCurrentFileID uint32
-	leafStaging       bool
-	lastLeafRecordLen uint32
+	currentPath        string
+	currentFileID      uint32
+	leafCurrentPath    string
+	leafCurrentFileID  uint32
+	stableResourcePins *rootpublication.IdentityPinRegistry
+	stableRegistryErr  error
+	leafStaging        bool
+	lastLeafRecordLen  uint32
 	// blockCompression enables per-frame block compression for dictID=0 append
 	// paths (used by online rewrite). Offline rewrites use AppendRawRecord and do
 	// not consult this setting.
@@ -3478,6 +3481,21 @@ func (w *rewriteWriter) ConfigureLeafLog(leafDir string, lane, startSeq uint32) 
 	w.leafSeq = startSeq
 }
 
+func (w *rewriteWriter) bindStableResourcePinRegistry(registry *rootpublication.IdentityPinRegistry) error {
+	if w == nil || registry == nil {
+		return fmt.Errorf("%w: standalone leaf writer requires the DB-scoped pin registry", rootpublication.ErrUnresolvedResource)
+	}
+	if w.stableResourcePins == registry && w.stableRegistryErr == nil {
+		return nil
+	}
+	if w.leafW != nil || w.stableResourcePins != nil {
+		w.stableRegistryErr = fmt.Errorf("%w: stable leaf registry installed after writer open or differs from its original registry", rootpublication.ErrUnresolvedResource)
+		return w.stableRegistryErr
+	}
+	w.stableResourcePins = registry
+	return nil
+}
+
 func (w *rewriteWriter) configureLeafStaging() {
 	if w != nil {
 		w.leafStaging = true
@@ -3529,6 +3547,8 @@ func (w *rewriteWriter) cloneLeafPageLogLane(seqAlloc *leafLogSeqAllocator, ridA
 	clone.leafStaging = w.leafStaging
 	clone.leafSeqAllocator = seqAlloc
 	clone.ridAlloc = ridAlloc
+	clone.stableResourcePins = w.stableResourcePins
+	clone.stableRegistryErr = w.stableRegistryErr
 	clone.blockCompression = w.blockCompression
 	clone.blockCodec = w.blockCodec
 	clone.leafBlockCodec = w.leafBlockCodec
@@ -3739,6 +3759,35 @@ func (w *rewriteWriter) AppendLeafPage(leafPage []byte) (page.LeafLogPtr, error)
 	return w.appendLeafPageWithRID(rid, leafPage)
 }
 
+func (w *rewriteWriter) AppendLeafPageWithStableResources(leafPage []byte) (page.LeafLogPtr, *rootpublication.StableResourceSet, error) {
+	if w == nil {
+		return page.LeafLogPtr{}, nil, errors.New("vlog-rewrite: nil writer")
+	}
+	capture, err := newRewriteStableOuterLeafCapture(w)
+	if err != nil {
+		return page.LeafLogPtr{}, nil, err
+	}
+	rid, err := w.nextRecordRID()
+	if err != nil {
+		capture.abandon()
+		return page.LeafLogPtr{}, nil, err
+	}
+	ptr, err := w.appendLeafPageWithRIDCapture(rid, leafPage, capture)
+	if err == nil {
+		err = capture.captureCurrent()
+	}
+	if err != nil {
+		capture.abandon()
+		return page.LeafLogPtr{}, nil, err
+	}
+	resources, err := capture.freeze([]page.LeafLogPtr{ptr})
+	if err != nil {
+		capture.abandon()
+		return page.LeafLogPtr{}, nil, err
+	}
+	return ptr, resources, nil
+}
+
 func (w *rewriteWriter) AppendLeafPages(leafPages [][]byte) ([]page.LeafLogPtr, error) {
 	if w == nil {
 		return nil, errors.New("vlog-rewrite: nil writer")
@@ -3751,6 +3800,38 @@ func (w *rewriteWriter) AppendLeafPages(leafPages [][]byte) ([]page.LeafLogPtr, 
 		return nil, err
 	}
 	return w.appendLeafPagesWithRIDStart(startRID, leafPages)
+}
+
+func (w *rewriteWriter) AppendLeafPagesWithStableResources(leafPages [][]byte) ([]page.LeafLogPtr, *rootpublication.StableResourceSet, error) {
+	if w == nil {
+		return nil, nil, errors.New("vlog-rewrite: nil writer")
+	}
+	if len(leafPages) == 0 {
+		return nil, nil, nil
+	}
+	capture, err := newRewriteStableOuterLeafCapture(w)
+	if err != nil {
+		return nil, nil, err
+	}
+	startRID, err := w.reserveRecordRIDs(len(leafPages))
+	if err != nil {
+		capture.abandon()
+		return nil, nil, err
+	}
+	ptrs, err := w.appendLeafPagesWithRIDStartCapture(startRID, leafPages, capture)
+	if err == nil {
+		err = capture.captureCurrent()
+	}
+	if err != nil {
+		capture.abandon()
+		return nil, nil, err
+	}
+	resources, err := capture.freeze(ptrs)
+	if err != nil {
+		capture.abandon()
+		return nil, nil, err
+	}
+	return ptrs, resources, nil
 }
 
 func (w *rewriteWriter) nextRecordRID() (uint64, error) {
@@ -3798,6 +3879,10 @@ func (w *rewriteWriter) LastLeafPageRecordLength() uint32 {
 }
 
 func (w *rewriteWriter) appendLeafPageWithRID(rid uint64, leafPage []byte) (page.LeafLogPtr, error) {
+	return w.appendLeafPageWithRIDCapture(rid, leafPage, nil)
+}
+
+func (w *rewriteWriter) appendLeafPageWithRIDCapture(rid uint64, leafPage []byte, capture *rewriteStableOuterLeafCapture) (page.LeafLogPtr, error) {
 	if w == nil {
 		return page.LeafLogPtr{}, errors.New("vlog-rewrite: nil writer")
 	}
@@ -3821,7 +3906,10 @@ func (w *rewriteWriter) appendLeafPageWithRID(rid uint64, leafPage []byte) (page
 		}
 	}
 	if w.leafDir != "" {
-		return w.appendLeafPageSplit(rid, encodedLeafPage)
+		return w.appendLeafPageSplitCapture(rid, encodedLeafPage, capture)
+	}
+	if capture != nil {
+		return page.LeafLogPtr{}, fmt.Errorf("%w: raw outer-leaf stable capture requires a split leaf log", rootpublication.ErrUnresolvedResource)
 	}
 	if w.blockCompression && w.leafDictID != 0 && len(w.leafDict) > 0 && rewriteAllowDictForSmallPayload(encodedLeafPage) {
 		ptr, err := w.appendSingleValueWithDictClass(rewriteTemplateClassOuterLeaf, w.leafDictID, w.leafDict, rid, encodedLeafPage)
@@ -3850,6 +3938,10 @@ func (w *rewriteWriter) appendLeafPageWithRID(rid uint64, leafPage []byte) (page
 }
 
 func (w *rewriteWriter) appendLeafPagesWithRIDStart(startRID uint64, leafPages [][]byte) ([]page.LeafLogPtr, error) {
+	return w.appendLeafPagesWithRIDStartCapture(startRID, leafPages, nil)
+}
+
+func (w *rewriteWriter) appendLeafPagesWithRIDStartCapture(startRID uint64, leafPages [][]byte, capture *rewriteStableOuterLeafCapture) ([]page.LeafLogPtr, error) {
 	if w == nil {
 		return nil, errors.New("vlog-rewrite: nil writer")
 	}
@@ -3857,7 +3949,7 @@ func (w *rewriteWriter) appendLeafPagesWithRIDStart(startRID uint64, leafPages [
 		return nil, nil
 	}
 	if len(leafPages) == 1 {
-		ptr, err := w.appendLeafPageWithRID(startRID, leafPages[0])
+		ptr, err := w.appendLeafPageWithRIDCapture(startRID, leafPages[0], capture)
 		if err != nil {
 			return nil, err
 		}
@@ -3870,7 +3962,7 @@ func (w *rewriteWriter) appendLeafPagesWithRIDStart(startRID uint64, leafPages [
 			if end > len(leafPages) {
 				end = len(leafPages)
 			}
-			chunkPtrs, err := w.appendLeafPagesWithRIDStart(startRID+uint64(start), leafPages[start:end])
+			chunkPtrs, err := w.appendLeafPagesWithRIDStartCapture(startRID+uint64(start), leafPages[start:end], capture)
 			if err != nil {
 				return nil, err
 			}
@@ -3879,6 +3971,9 @@ func (w *rewriteWriter) appendLeafPagesWithRIDStart(startRID uint64, leafPages [
 		return ptrs, nil
 	}
 	if w.leafDir == "" {
+		if capture != nil {
+			return nil, fmt.Errorf("%w: raw outer-leaf stable capture requires a split leaf log", rootpublication.ErrUnresolvedResource)
+		}
 		ptrs := make([]page.LeafLogPtr, len(leafPages))
 		for i, leafPage := range leafPages {
 			ptr, err := w.appendLeafPageWithRID(startRID+uint64(i), leafPage)
@@ -3889,7 +3984,7 @@ func (w *rewriteWriter) appendLeafPagesWithRIDStart(startRID uint64, leafPages [
 		}
 		return ptrs, nil
 	}
-	if err := w.ensureLeafWriter(); err != nil {
+	if err := w.ensureLeafWriterCapture(capture); err != nil {
 		return nil, err
 	}
 	if cap(w.leafBatchRecords) < len(leafPages) {
@@ -3948,7 +4043,7 @@ func (w *rewriteWriter) appendLeafPagesWithRIDStart(startRID uint64, leafPages [
 			rawPayloadBytes += len(records[i].Value)
 		}
 	}
-	if err := w.maybeRotateLeafForEstimate(rewriteDictFrameRecordLen(rawPayloadBytes, len(records))); err != nil {
+	if err := w.maybeRotateLeafForEstimateCapture(rewriteDictFrameRecordLen(rawPayloadBytes, len(records)), capture); err != nil {
 		return nil, err
 	}
 	if cap(w.leafBatchValuePtrs) < len(records) {
@@ -3983,14 +4078,18 @@ func (w *rewriteWriter) leafPagesUseCompactPayload() bool {
 }
 
 func (w *rewriteWriter) appendLeafPageSplit(rid uint64, leafPage []byte) (page.LeafLogPtr, error) {
-	if err := w.ensureLeafWriter(); err != nil {
+	return w.appendLeafPageSplitCapture(rid, leafPage, nil)
+}
+
+func (w *rewriteWriter) appendLeafPageSplitCapture(rid uint64, leafPage []byte, capture *rewriteStableOuterLeafCapture) (page.LeafLogPtr, error) {
+	if err := w.ensureLeafWriterCapture(capture); err != nil {
 		return page.LeafLogPtr{}, err
 	}
 	dictID := w.leafDictID
 	dict := w.leafDict
 	if w.blockCompression && dictID != 0 && len(dict) > 0 && rewriteAllowDictForSmallPayload(leafPage) {
 		dictID, dict, leafPage = w.applyTemplateCompression(rewriteTemplateClassOuterLeaf, dictID, dict, leafPage)
-		if err := w.maybeRotateLeafForEstimate(rewriteDictFrameRecordLen(len(leafPage), 1)); err != nil {
+		if err := w.maybeRotateLeafForEstimateCapture(rewriteDictFrameRecordLen(len(leafPage), 1), capture); err != nil {
 			return page.LeafLogPtr{}, err
 		}
 		ptr, err := w.leafW.Append(dictID, dict, rid, leafPage)
@@ -4005,7 +4104,7 @@ func (w *rewriteWriter) appendLeafPageSplit(rid uint64, leafPage []byte) (page.L
 	if dictID != 0 || len(dict) != 0 {
 		return page.LeafLogPtr{}, fmt.Errorf("vlog-rewrite: unexpected outer-leaf dict/template state")
 	}
-	if err := w.maybeRotateLeafForEstimate(int64(valuelog.HeaderSize + len(leafPage))); err != nil {
+	if err := w.maybeRotateLeafForEstimateCapture(int64(valuelog.HeaderSize+len(leafPage)), capture); err != nil {
 		return page.LeafLogPtr{}, err
 	}
 	ptr, err := w.leafW.Append(0, nil, rid, leafPage)
@@ -4100,6 +4199,10 @@ func (w *rewriteWriter) rotate() error {
 }
 
 func (w *rewriteWriter) ensureLeafWriter() error {
+	return w.ensureLeafWriterCapture(nil)
+}
+
+func (w *rewriteWriter) ensureLeafWriterCapture(capture *rewriteStableOuterLeafCapture) error {
 	if w == nil {
 		return errors.New("vlog-rewrite: nil writer")
 	}
@@ -4107,12 +4210,27 @@ func (w *rewriteWriter) ensureLeafWriter() error {
 		return w.ensureWriter()
 	}
 	if w.leafW != nil {
+		if capture != nil {
+			if w.stableRegistryErr != nil {
+				return w.stableRegistryErr
+			}
+			if w.stableResourcePins == nil {
+				return fmt.Errorf("%w: raw outer-leaf writer lacks the DB-scoped pin registry", rootpublication.ErrUnresolvedResource)
+			}
+			if err := w.leafW.CertifyStableCreationNamespace(); err != nil {
+				return err
+			}
+		}
 		return nil
 	}
-	return w.rotateLeaf()
+	return w.rotateLeafCapture(capture)
 }
 
 func (w *rewriteWriter) maybeRotateLeafForEstimate(estimate int64) error {
+	return w.maybeRotateLeafForEstimateCapture(estimate, nil)
+}
+
+func (w *rewriteWriter) maybeRotateLeafForEstimateCapture(estimate int64, capture *rewriteStableOuterLeafCapture) error {
 	if w == nil || w.leafW == nil {
 		return nil
 	}
@@ -4128,7 +4246,7 @@ func (w *rewriteWriter) maybeRotateLeafForEstimate(estimate int64) error {
 	if w.leafW.Size()+estimate <= w.maxSize {
 		return nil
 	}
-	return w.rotateLeaf()
+	return w.rotateLeafCapture(capture)
 }
 
 func (w *rewriteWriter) nextLeafSeq() (uint32, error) {
@@ -4152,6 +4270,11 @@ func (w *rewriteWriter) nextLeafSeq() (uint32, error) {
 }
 
 func (w *rewriteWriter) rotateLeaf() error {
+	return w.rotateLeafCapture(nil)
+}
+
+func (w *rewriteWriter) rotateLeafCapture(capture *rewriteStableOuterLeafCapture) error {
+	var rotationErr error
 	nextSeq, err := w.nextLeafSeq()
 	if err != nil {
 		return err
@@ -4164,7 +4287,12 @@ func (w *rewriteWriter) rotateLeaf() error {
 	if w.leafW == nil {
 		var writer *valuelog.Writer
 		if w.leafStaging {
+			if capture != nil {
+				return fmt.Errorf("%w: staging leaf writer cannot certify raw outer-leaf authority", rootpublication.ErrUnresolvedResource)
+			}
 			writer, err = valuelog.NewStagingWriter(path, fileID)
+		} else if w.stableResourcePins != nil {
+			writer, err = valuelog.NewWriterWithStableResourcePinRegistry(path, fileID, w.stableResourcePins)
 		} else {
 			writer, err = valuelog.NewWriter(path, fileID)
 		}
@@ -4184,8 +4312,16 @@ func (w *rewriteWriter) rotateLeaf() error {
 		w.leafCurrentFileID = fileID
 		return nil
 	}
-	if err := w.leafW.RotateTo(path, fileID); err != nil {
-		return err
+	if capture == nil {
+		if err := w.leafW.RotateTo(path, fileID); err != nil {
+			return err
+		}
+	} else {
+		installed, err := capture.captureRotation(w.leafW, path, fileID, true)
+		if err != nil && !installed {
+			return err
+		}
+		rotationErr = err
 	}
 	leafCodec := w.leafBlockCodec
 	if leafCodec == 0 {
@@ -4197,7 +4333,7 @@ func (w *rewriteWriter) rotateLeaf() error {
 	w.noteCreatedSegment(path, fileID)
 	w.leafCurrentPath = path
 	w.leafCurrentFileID = fileID
-	return nil
+	return rotationErr
 }
 
 func (w *rewriteWriter) SetKeepPolicy(ioNsPerStoredByte, encodeNsPerRawByte, safetyMargin float64) {

--- a/TreeDB/internal/rootpublication/producer_rotation_stress_test.go
+++ b/TreeDB/internal/rootpublication/producer_rotation_stress_test.go
@@ -49,7 +49,11 @@ func stableProducerRotationRetryResourcePlateau(t *testing.T) {
 			return rootpublication.PublishResult{Outcome: rootpublication.PublishRetryableFailure, Err: err}
 		}
 		stats := resources.Stats(time.Now())
-		if len(stats) != 1 || stats[0].PendingCount != 2 || stats[0].Flushes != 2 || stats[0].Syncs != 2 || stats[0].NamespaceSyncs != 1 {
+		wantNamespaceSyncs := uint64(1)
+		if seq > 1 && seq%2 == 1 {
+			wantNamespaceSyncs = 2
+		}
+		if len(stats) != 1 || stats[0].PendingCount != 2 || stats[0].Flushes != 2 || stats[0].Syncs != 2 || stats[0].NamespaceSyncs != wantNamespaceSyncs {
 			return rootpublication.PublishResult{Outcome: rootpublication.PublishRetryableFailure, Err: fmt.Errorf("unexpected resource operation counts: %+v", stats)}
 		}
 		return rootpublication.PublishResult{Outcome: rootpublication.PublishSucceeded}
@@ -138,7 +142,13 @@ func stableProducerRotationRetryResourcePlateau(t *testing.T) {
 			t.Fatalf("rotation %d physical pins=%d want 2", seq, set.Len())
 		}
 		stats := set.Stats(time.Now())
-		if len(stats) != 1 || stats[0].PendingCount != 2 || stats[0].NamespaceSyncs != 1 {
+		wantNamespaceSyncs := uint64(1)
+		if kind == rootpublication.ResourceValueLog && seq > 1 {
+			// Both the newly closed segment and its successor were created by
+			// this writer and retain their distinct one-sync proofs.
+			wantNamespaceSyncs = 2
+		}
+		if len(stats) != 1 || stats[0].PendingCount != 2 || stats[0].NamespaceSyncs != wantNamespaceSyncs {
 			set.Release()
 			t.Fatalf("rotation %d capture stats=%+v", seq, stats)
 		}
@@ -157,7 +167,7 @@ func stableProducerRotationRetryResourcePlateau(t *testing.T) {
 			t.Fatalf("rotation %d first publish=%v want injected retry", seq, err)
 		}
 		pending := resourceStatsForKind(t, coordinator.Stats().Resources, kind)
-		if pending.PendingCount != 2 || pending.ActivePins != 2 || pending.Flushes != 2 || pending.Syncs != 0 || pending.NamespaceSyncs != 1 {
+		if pending.PendingCount != 2 || pending.ActivePins != 2 || pending.Flushes != 2 || pending.Syncs != 0 || pending.NamespaceSyncs != wantNamespaceSyncs {
 			t.Fatalf("rotation %d retry stats=%+v", seq, pending)
 		}
 		if err := coordinator.WaitThrough(context.Background(), seq); err != nil {

--- a/TreeDB/internal/rootpublication/producer_rotation_stress_test.go
+++ b/TreeDB/internal/rootpublication/producer_rotation_stress_test.go
@@ -35,6 +35,15 @@ func stableProducerRotationRetryResourcePlateau(t *testing.T) {
 
 	retryErr := errors.New("injected pre-meta retry")
 	attempts := make(map[uint64]uint8, iterations)
+	expectedNamespaceSyncs := func(seq uint64) uint64 {
+		// The first value-log segment and every command-WAL segment contribute
+		// one creation witness. Later value-log rotations retain the closed
+		// segment's creation witness and add the newly active segment's witness.
+		if seq > 1 && seq%2 == 1 {
+			return 2
+		}
+		return 1
+	}
 	coordinator, err := rootpublication.New(rootpublication.Options{Publisher: rootpublication.PublisherFunc(func(_ context.Context, candidate *rootpublication.PreparedRootCandidate) rootpublication.PublishResult {
 		seq := candidate.Frontier().CommitSeq()
 		attempts[seq]++
@@ -49,7 +58,7 @@ func stableProducerRotationRetryResourcePlateau(t *testing.T) {
 			return rootpublication.PublishResult{Outcome: rootpublication.PublishRetryableFailure, Err: err}
 		}
 		stats := resources.Stats(time.Now())
-		if len(stats) != 1 || stats[0].PendingCount != 2 || stats[0].Flushes != 2 || stats[0].Syncs != 2 || stats[0].NamespaceSyncs != 1 {
+		if len(stats) != 1 || stats[0].PendingCount != 2 || stats[0].Flushes != 2 || stats[0].Syncs != 2 || stats[0].NamespaceSyncs != expectedNamespaceSyncs(seq) {
 			return rootpublication.PublishResult{Outcome: rootpublication.PublishRetryableFailure, Err: fmt.Errorf("unexpected resource operation counts: %+v", stats)}
 		}
 		return rootpublication.PublishResult{Outcome: rootpublication.PublishSucceeded}
@@ -138,7 +147,7 @@ func stableProducerRotationRetryResourcePlateau(t *testing.T) {
 			t.Fatalf("rotation %d physical pins=%d want 2", seq, set.Len())
 		}
 		stats := set.Stats(time.Now())
-		if len(stats) != 1 || stats[0].PendingCount != 2 || stats[0].NamespaceSyncs != 1 {
+		if len(stats) != 1 || stats[0].PendingCount != 2 || stats[0].NamespaceSyncs != expectedNamespaceSyncs(seq) {
 			set.Release()
 			t.Fatalf("rotation %d capture stats=%+v", seq, stats)
 		}
@@ -157,7 +166,7 @@ func stableProducerRotationRetryResourcePlateau(t *testing.T) {
 			t.Fatalf("rotation %d first publish=%v want injected retry", seq, err)
 		}
 		pending := resourceStatsForKind(t, coordinator.Stats().Resources, kind)
-		if pending.PendingCount != 2 || pending.ActivePins != 2 || pending.Flushes != 2 || pending.Syncs != 0 || pending.NamespaceSyncs != 1 {
+		if pending.PendingCount != 2 || pending.ActivePins != 2 || pending.Flushes != 2 || pending.Syncs != 0 || pending.NamespaceSyncs != expectedNamespaceSyncs(seq) {
 			t.Fatalf("rotation %d retry stats=%+v", seq, pending)
 		}
 		if err := coordinator.WaitThrough(context.Background(), seq); err != nil {

--- a/TreeDB/internal/rootpublication/resource_contract_test.go
+++ b/TreeDB/internal/rootpublication/resource_contract_test.go
@@ -1428,6 +1428,52 @@ func TestStableNamespaceStabilizeIsSingleFlight(t *testing.T) {
 	}
 }
 
+func TestStableNamespaceCreationProofSyncsOnceAcrossRepeatedBind(t *testing.T) {
+	dir := t.TempDir()
+	parent, err := os.Open(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer parent.Close()
+	child := writeStableResourceFixture(t, dir, "proof.vlog", "proof")
+	defer child.Close()
+	adapter := &countingNamespaceAdapter{}
+	proof, err := newStableNamespaceCreationProof(parent, child, "proof.vlog", adapter)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer proof.Release()
+	if got := adapter.syncs.Load(); got != 1 {
+		t.Fatalf("creation proof syncs=%d want 1", got)
+	}
+	for generation := uint64(1); generation <= 4; generation++ {
+		token, err := proof.Bind(parent, generation, "proof.vlog", "display-only")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got := token.syncs.Load(); got != 1 {
+			t.Fatalf("bound token generation=%d namespace syncs=%d want 1", generation, got)
+		}
+		if got := token.syncNanos.Load(); got == 0 {
+			t.Fatalf("bound token generation=%d lost namespace sync duration", generation)
+		}
+		if err := token.Stabilize(); err != nil {
+			t.Fatal(err)
+		}
+		token.Release()
+	}
+	if got := adapter.syncs.Load(); got != 1 {
+		t.Fatalf("repeated binds resynced namespace: syncs=%d", got)
+	}
+	proof.Release()
+	if token, err := proof.Bind(parent, 5, "proof.vlog", "display-only"); !errors.Is(err, ErrResourceOwnership) || token != nil {
+		if token != nil {
+			token.Release()
+		}
+		t.Fatalf("Bind after release token=%v err=%v want ErrResourceOwnership", token, err)
+	}
+}
+
 func TestStableNamespaceRegistrationAndReleaseAreSerialized(t *testing.T) {
 	for iteration := range 100 {
 		dir := t.TempDir()

--- a/TreeDB/internal/rootpublication/resource_contract_test.go
+++ b/TreeDB/internal/rootpublication/resource_contract_test.go
@@ -1465,6 +1465,12 @@ func TestStableNamespaceCreationProofSyncsOnceAcrossRepeatedBind(t *testing.T) {
 	if got := adapter.syncs.Load(); got != 1 {
 		t.Fatalf("repeated binds resynced namespace: syncs=%d", got)
 	}
+	if token, err := proof.Bind(parent, 0, "proof.vlog", "display-only"); !errors.Is(err, ErrUnresolvedResource) || token != nil {
+		if token != nil {
+			token.Release()
+		}
+		t.Fatalf("Bind with zero generation token=%v err=%v want ErrUnresolvedResource", token, err)
+	}
 	proof.Release()
 	if token, err := proof.Bind(parent, 5, "proof.vlog", "display-only"); !errors.Is(err, ErrResourceOwnership) || token != nil {
 		if token != nil {

--- a/TreeDB/internal/rootpublication/resource_identity_unix_test.go
+++ b/TreeDB/internal/rootpublication/resource_identity_unix_test.go
@@ -125,3 +125,79 @@ func TestStableNamespaceRejectsChildReplacementBeforeStabilize(t *testing.T) {
 		t.Fatalf("Stabilize after child replacement error=%v want ErrResourceConflict", err)
 	}
 }
+
+func TestStableNamespaceCreationProofRejectsReplacementBeforeBind(t *testing.T) {
+	dir := t.TempDir()
+	parent, err := os.Open(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer parent.Close()
+	original, err := OpenStableChildFile(parent, "000001.vlog", os.O_CREATE|os.O_EXCL|os.O_RDWR, 0o600)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer original.Close()
+	proof, err := NewStableNamespaceCreationProof(parent, original, "000001.vlog")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer proof.Release()
+	if err := os.Rename(filepath.Join(dir, "000001.vlog"), filepath.Join(dir, "original.vlog")); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "000001.vlog"), []byte("replacement"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	token, err := proof.Bind(parent, 1, "000001.vlog", "display-only")
+	if token != nil {
+		token.Release()
+		t.Fatal("replacement child received a bound namespace token")
+	}
+	if !errors.Is(err, ErrResourceConflict) {
+		t.Fatalf("Bind after child replacement error=%v want ErrResourceConflict", err)
+	}
+}
+
+func TestStableNamespaceCreationProofRejectsWrongParentAndName(t *testing.T) {
+	dir := t.TempDir()
+	parent, err := os.Open(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer parent.Close()
+	child, err := OpenStableChildFile(parent, "000001.vlog", os.O_CREATE|os.O_EXCL|os.O_RDWR, 0o600)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer child.Close()
+	proof, err := NewStableNamespaceCreationProof(parent, child, "000001.vlog")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer proof.Release()
+	wrongParent, err := os.Open(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer wrongParent.Close()
+	for _, tc := range []struct {
+		name   string
+		parent *os.File
+		child  string
+	}{
+		{name: "parent", parent: wrongParent, child: "000001.vlog"},
+		{name: "name", parent: parent, child: "000002.vlog"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			token, err := proof.Bind(tc.parent, 1, tc.child, "display-only")
+			if token != nil {
+				token.Release()
+				t.Fatal("mismatched proof binding returned a token")
+			}
+			if !errors.Is(err, ErrResourceConflict) {
+				t.Fatalf("Bind error=%v want ErrResourceConflict", err)
+			}
+		})
+	}
+}

--- a/TreeDB/internal/rootpublication/resource_identity_unix_test.go
+++ b/TreeDB/internal/rootpublication/resource_identity_unix_test.go
@@ -9,6 +9,44 @@ import (
 	"testing"
 )
 
+func TestStableNamespaceParentGenerationTracksExactParentIdentity(t *testing.T) {
+	firstDir := t.TempDir()
+	first, err := os.Open(firstDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer first.Close()
+	duplicate, err := duplicateStableFile(first)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer duplicate.Close()
+	second, err := os.Open(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer second.Close()
+
+	firstGeneration, err := StableNamespaceParentGeneration(first)
+	if err != nil || firstGeneration == 0 {
+		t.Fatalf("first generation=%d err=%v", firstGeneration, err)
+	}
+	duplicateGeneration, err := StableNamespaceParentGeneration(duplicate)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if duplicateGeneration != firstGeneration {
+		t.Fatalf("duplicate generation=%d first=%d", duplicateGeneration, firstGeneration)
+	}
+	secondGeneration, err := StableNamespaceParentGeneration(second)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if secondGeneration == firstGeneration {
+		t.Fatalf("distinct parent generations collided: %d", firstGeneration)
+	}
+}
+
 func TestOpenStableChildFileUsesCapturedParentAfterPathReplacement(t *testing.T) {
 	root := t.TempDir()
 	originalDir := filepath.Join(root, "segments")

--- a/TreeDB/internal/rootpublication/resource_identity_windows_test.go
+++ b/TreeDB/internal/rootpublication/resource_identity_windows_test.go
@@ -59,6 +59,28 @@ func TestStableNamespaceRegistrationFailsTypedBeforeCertification(t *testing.T) 
 	}
 }
 
+func TestStableNamespaceCreationProofFailsTypedOnWindows(t *testing.T) {
+	dir := t.TempDir()
+	parent, err := os.Open(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer parent.Close()
+	child, err := os.OpenFile(filepath.Join(dir, "child-proof"), os.O_CREATE|os.O_EXCL|os.O_RDWR, 0o600)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer child.Close()
+	proof, err := NewStableNamespaceCreationProof(parent, child, "child-proof")
+	if proof != nil {
+		proof.Release()
+		t.Fatal("unsupported namespace creation returned a proof")
+	}
+	if !errors.Is(err, ErrNamespacePersistenceUnsupported) {
+		t.Fatalf("NewStableNamespaceCreationProof error=%v want ErrNamespacePersistenceUnsupported", err)
+	}
+}
+
 func TestRenameStableChildFileFailsTypedWithoutVisibilityWindows(t *testing.T) {
 	dir := t.TempDir()
 	parent, err := os.Open(dir)

--- a/TreeDB/internal/rootpublication/resource_token.go
+++ b/TreeDB/internal/rootpublication/resource_token.go
@@ -764,8 +764,11 @@ func newStableNamespaceCreationProof(parent, child *os.File, name string, adapte
 // Bind returns an already-stable normal namespace token after proving the
 // retained parent still links the original child. It never syncs again.
 func (proof *StableNamespaceCreationProof) Bind(parent *os.File, parentGeneration uint64, name, diagnosticPath string) (*StableNamespaceToken, error) {
-	if proof == nil || parentGeneration == 0 || proof.released.Load() {
+	if proof == nil || proof.released.Load() {
 		return nil, ErrResourceOwnership
+	}
+	if parentGeneration == 0 {
+		return nil, fmt.Errorf("%w: namespace creation proof binding requires a parent generation", ErrUnresolvedResource)
 	}
 	if parent == nil || name != proof.name || !stableChildBaseName(name) {
 		return nil, fmt.Errorf("%w: namespace creation proof binding differs from the exact parent or child name", ErrResourceConflict)
@@ -806,15 +809,18 @@ func (proof *StableNamespaceCreationProof) Bind(parent *os.File, parentGeneratio
 }
 
 func (proof *StableNamespaceCreationProof) Release() {
-	if proof == nil || proof.released.Swap(true) {
+	if proof == nil {
 		return
 	}
 	proof.mu.Lock()
+	defer proof.mu.Unlock()
+	if proof.released.Swap(true) {
+		return
+	}
 	if proof.parent != nil {
 		_ = proof.parent.Close()
 		proof.parent = nil
 	}
-	proof.mu.Unlock()
 }
 
 const (

--- a/TreeDB/internal/rootpublication/resource_token.go
+++ b/TreeDB/internal/rootpublication/resource_token.go
@@ -704,6 +704,119 @@ type StableNamespaceToken struct {
 	syncNanos              atomic.Uint64
 }
 
+// StableNamespaceCreationProof is an opaque, exact-handle witness that a
+// newly-created child was linked from and durably synced through its retained
+// parent. It exists solely to carry that one creation sync to later resource
+// registration, where the logical parent generation is finally known.
+type StableNamespaceCreationProof struct {
+	parent    *os.File
+	parentID  StableIdentity
+	childID   StableIdentity
+	name      string
+	adapter   namespacePersistenceAdapter
+	released  atomic.Bool
+	syncs     atomic.Uint64
+	syncNanos atomic.Uint64
+	mu        sync.Mutex
+}
+
+// NewStableNamespaceCreationProof validates the exact parent/child link and
+// performs the sole namespace sync for a just-created child.
+func NewStableNamespaceCreationProof(parent, child *os.File, name string) (*StableNamespaceCreationProof, error) {
+	return newStableNamespaceCreationProof(parent, child, name, nativeNamespaceAdapter{})
+}
+
+func newStableNamespaceCreationProof(parent, child *os.File, name string, adapter namespacePersistenceAdapter) (*StableNamespaceCreationProof, error) {
+	if parent == nil || child == nil || !stableChildBaseName(name) {
+		return nil, fmt.Errorf("%w: incomplete namespace creation proof", ErrUnresolvedResource)
+	}
+	if adapter == nil {
+		return nil, fmt.Errorf("%w: missing namespace persistence adapter", ErrUnresolvedResource)
+	}
+	if err := adapter.ValidateLink(parent, child, name); err != nil {
+		return nil, err
+	}
+	parentID, err := adapter.Identity(parent)
+	if err != nil {
+		return nil, err
+	}
+	childID, err := adapter.Identity(child)
+	if err != nil {
+		return nil, err
+	}
+	pinned, err := duplicateStableFile(parent)
+	if err != nil {
+		return nil, fmt.Errorf("duplicate namespace proof parent: %w", err)
+	}
+	started := time.Now()
+	err = adapter.Sync(pinned)
+	syncNanos := uint64(time.Since(started))
+	if err != nil {
+		_ = pinned.Close()
+		return nil, err
+	}
+	proof := &StableNamespaceCreationProof{parent: pinned, parentID: parentID, childID: childID, name: name, adapter: adapter}
+	proof.syncs.Store(1)
+	proof.syncNanos.Store(syncNanos)
+	return proof, nil
+}
+
+// Bind returns an already-stable normal namespace token after proving the
+// retained parent still links the original child. It never syncs again.
+func (proof *StableNamespaceCreationProof) Bind(parent *os.File, parentGeneration uint64, name, diagnosticPath string) (*StableNamespaceToken, error) {
+	if proof == nil || parentGeneration == 0 || proof.released.Load() {
+		return nil, ErrResourceOwnership
+	}
+	if parent == nil || name != proof.name || !stableChildBaseName(name) {
+		return nil, fmt.Errorf("%w: namespace creation proof binding differs from the exact parent or child name", ErrResourceConflict)
+	}
+	if err := validateDiagnosticPath(diagnosticPath); err != nil {
+		return nil, err
+	}
+	proof.mu.Lock()
+	defer proof.mu.Unlock()
+	if proof.released.Load() {
+		return nil, ErrResourceOwnership
+	}
+	parentID, err := proof.adapter.Identity(parent)
+	if err != nil {
+		return nil, err
+	}
+	if !sameStableObject(parentID, proof.parentID) {
+		return nil, fmt.Errorf("%w: namespace creation proof binding names a different parent", ErrResourceConflict)
+	}
+	if err := proof.adapter.ValidateIdentity(proof.parent, proof.childID, proof.name); err != nil {
+		return nil, err
+	}
+	pinned, err := duplicateStableFile(proof.parent)
+	if err != nil {
+		return nil, err
+	}
+	parentID, err = proof.adapter.Identity(pinned)
+	if err != nil {
+		_ = pinned.Close()
+		return nil, err
+	}
+	parentID.Generation = parentGeneration
+	token := &StableNamespaceToken{parent: pinned, parentIdentity: parentID, linkedResourceIdentity: proof.childID, hasLinkedResource: true, operation: NamespaceCreate, newName: proof.name, diagnosticPath: filepath.ToSlash(diagnosticPath), adapter: proof.adapter}
+	token.state.Store(namespaceStable)
+	token.syncs.Store(proof.syncs.Load())
+	token.syncNanos.Store(proof.syncNanos.Load())
+	return token, nil
+}
+
+func (proof *StableNamespaceCreationProof) Release() {
+	if proof == nil || proof.released.Swap(true) {
+		return
+	}
+	proof.mu.Lock()
+	if proof.parent != nil {
+		_ = proof.parent.Close()
+		proof.parent = nil
+	}
+	proof.mu.Unlock()
+}
+
 const (
 	namespacePending uint32 = iota
 	namespaceStable

--- a/TreeDB/internal/rootpublication/resource_token.go
+++ b/TreeDB/internal/rootpublication/resource_token.go
@@ -685,6 +685,49 @@ type StableNamespaceSpec struct {
 	DiagnosticPath   string
 }
 
+// StableNamespaceParentGeneration derives a stable, non-zero logical
+// generation from an exact parent namespace handle. The token retains and
+// validates the full platform identity separately; this compact generation is
+// only the logical namespace epoch used by resource registration and changes
+// when the physical parent object changes.
+func StableNamespaceParentGeneration(parent *os.File) (uint64, error) {
+	if parent == nil {
+		return 0, fmt.Errorf("%w: namespace parent generation requires an exact parent handle", ErrUnresolvedResource)
+	}
+	identity, err := stableIdentityFromFile(parent)
+	if err != nil {
+		return 0, err
+	}
+	if !identity.valid() {
+		return 0, fmt.Errorf("%w: namespace parent has no stable identity", ErrUnresolvedResource)
+	}
+	// FNV-1a is sufficient here because the exact identity remains part of the
+	// token and is the authoritative conflict check. Avoid process-random or
+	// caller-invented constants so cloned producers agree on one parent epoch.
+	const (
+		offset64 = uint64(14695981039346656037)
+		prime64  = uint64(1099511628211)
+	)
+	generation := offset64
+	add := func(value byte) {
+		generation ^= uint64(value)
+		generation *= prime64
+	}
+	for i := range identity.Platform {
+		add(identity.Platform[i])
+	}
+	for shift := 0; shift < 64; shift += 8 {
+		add(byte(identity.VolumeID >> shift))
+	}
+	for _, value := range identity.ObjectID {
+		add(value)
+	}
+	if generation == 0 {
+		generation = 1
+	}
+	return generation, nil
+}
+
 type StableNamespaceToken struct {
 	parent                 *os.File
 	parentIdentity         StableIdentity

--- a/TreeDB/internal/valuelog/stable_pending_successor_supported_test.go
+++ b/TreeDB/internal/valuelog/stable_pending_successor_supported_test.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/snissn/gomap/TreeDB/internal/durabilitycut"
 	"github.com/snissn/gomap/TreeDB/internal/rootpublication"
@@ -143,8 +144,11 @@ func TestStableValueLogPendingSuccessorRejectsOrdinaryAndMismatchedRotation(t *t
 
 			injected := errors.New("injected value-log namespace-token failure")
 			originalFactory := bindValueLogStableNamespaceCreationProof
-			bindValueLogStableNamespaceCreationProof = func(*rootpublication.StableNamespaceCreationProof, *os.File, uint64, string, string) (*rootpublication.StableNamespaceToken, error) {
-				return nil, injected
+			bindValueLogStableNamespaceCreationProof = func(proof *rootpublication.StableNamespaceCreationProof, parent *os.File, generation uint64, name, diagnosticPath string) (*rootpublication.StableNamespaceToken, error) {
+				if name == filepath.Base(secondPath) {
+					return nil, injected
+				}
+				return originalFactory(proof, parent, generation, name, diagnosticPath)
 			}
 			rotation, err := writer.RotateToWithStableResources(secondPath, 2, false, closed, active)
 			bindValueLogStableNamespaceCreationProof = originalFactory
@@ -200,9 +204,11 @@ func TestStableValueLogTokenFailureRetriesExactPendingSuccessor(t *testing.T) {
 	originalFactory := bindValueLogStableNamespaceCreationProof
 	factoryCalls := 0
 	bindValueLogStableNamespaceCreationProof = func(proof *rootpublication.StableNamespaceCreationProof, parent *os.File, generation uint64, name, diagnosticPath string) (*rootpublication.StableNamespaceToken, error) {
-		factoryCalls++
-		if factoryCalls == 1 {
-			return nil, injected
+		if name == filepath.Base(secondPath) {
+			factoryCalls++
+			if factoryCalls == 1 {
+				return nil, injected
+			}
 		}
 		return originalFactory(proof, parent, generation, name, diagnosticPath)
 	}
@@ -277,6 +283,79 @@ func TestStableValueLogTokenFailureRetriesExactPendingSuccessor(t *testing.T) {
 	}
 }
 
+func TestStableValueLogClosedCreationProofBindFailurePreservesCurrentAuthority(t *testing.T) {
+	dir := t.TempDir()
+	firstPath := filepath.Join(dir, "000001.vlog")
+	secondPath := filepath.Join(dir, "000002.vlog")
+	registry := rootpublication.NewIdentityPinRegistry()
+	writer, err := NewWriterWithStableResourcePinRegistry(firstPath, 1, registry)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = writer.Close() })
+	appendStablePendingValue(t, writer, 1)
+	closed, active := stablePendingRegistrations(1, 2)
+	originalFile := writer.f
+	originalProof := writer.creationProof
+	if originalProof == nil {
+		t.Fatal("new current segment lacks retained creation proof")
+	}
+
+	injected := errors.New("injected closed creation-proof bind failure")
+	originalFactory := bindValueLogStableNamespaceCreationProof
+	bindValueLogStableNamespaceCreationProof = func(proof *rootpublication.StableNamespaceCreationProof, parent *os.File, generation uint64, name, diagnosticPath string) (*rootpublication.StableNamespaceToken, error) {
+		if name == filepath.Base(firstPath) {
+			return nil, injected
+		}
+		return originalFactory(proof, parent, generation, name, diagnosticPath)
+	}
+	rotation, err := writer.RotateToWithStableResources(secondPath, 2, false, closed, active)
+	bindValueLogStableNamespaceCreationProof = originalFactory
+	if rotation != nil {
+		rotation.Release()
+		t.Fatal("closed-proof bind failure returned owned resources")
+	}
+	if !errors.Is(err, injected) {
+		t.Fatalf("rotation error=%v want injected failure", err)
+	}
+	if writer.f != originalFile || writer.FileID() != 1 || writer.creationProof != originalProof || writer.pendingStableSuccessor != nil {
+		t.Fatalf("closed-proof failure changed authority: file=%p/%p id=%d proof=%p/%p pending=%+v", writer.f, originalFile, writer.FileID(), writer.creationProof, originalProof, writer.pendingStableSuccessor)
+	}
+	if got := registry.ActiveIdentities(); got != 1 {
+		t.Fatalf("closed-proof failure identities=%d want current writer only", got)
+	}
+	if got := registry.ActivePins(); got != 0 {
+		t.Fatalf("closed-proof failure pins=%d want 0", got)
+	}
+
+	rotation, err = writer.RotateToWithStableResources(secondPath, 2, false, closed, active)
+	if err != nil {
+		t.Fatalf("retry after closed-proof failure: %v", err)
+	}
+	builder := rootpublication.NewStableResourceSetBuilder(rootpublication.ReachabilityValueLogPointer)
+	if err := builder.Add(rotation.TakeClosed()); err != nil {
+		rotation.Release()
+		t.Fatalf("add closed rotation token: %v", err)
+	}
+	if err := builder.Add(rotation.TakeActive()); err != nil {
+		builder.Abandon()
+		rotation.Release()
+		t.Fatalf("add active rotation token: %v", err)
+	}
+	rotation.Release()
+	resources, err := builder.Freeze()
+	if err != nil {
+		builder.Abandon()
+		t.Fatalf("freeze rotation resources: %v", err)
+	}
+	stats := resources.Stats(time.Now())
+	if len(stats) != 1 || stats[0].NamespaceSyncs != 2 {
+		resources.Release()
+		t.Fatalf("rotation resource stats=%+v want two namespace syncs", stats)
+	}
+	resources.Release()
+}
+
 func TestStableValueLogAfterDirectoryCutRetryKeepsSyncedProof(t *testing.T) {
 	dir := t.TempDir()
 	writer, err := NewWriter(filepath.Join(dir, "000001.vlog"), 1)
@@ -343,8 +422,11 @@ func TestStableValueLogPendingSuccessorRejectsRegistryMismatch(t *testing.T) {
 
 	injected := errors.New("injected namespace-token failure before registry mismatch")
 	originalFactory := bindValueLogStableNamespaceCreationProof
-	bindValueLogStableNamespaceCreationProof = func(*rootpublication.StableNamespaceCreationProof, *os.File, uint64, string, string) (*rootpublication.StableNamespaceToken, error) {
-		return nil, injected
+	bindValueLogStableNamespaceCreationProof = func(proof *rootpublication.StableNamespaceCreationProof, parent *os.File, generation uint64, name, diagnosticPath string) (*rootpublication.StableNamespaceToken, error) {
+		if name == filepath.Base(secondPath) {
+			return nil, injected
+		}
+		return originalFactory(proof, parent, generation, name, diagnosticPath)
 	}
 	rotation, err := writer.RotateToWithStableResources(secondPath, 2, false, closed, active)
 	bindValueLogStableNamespaceCreationProof = originalFactory
@@ -401,10 +483,14 @@ func TestStableValueLogPendingSuccessorCloseReleasesExactOwnership(t *testing.T)
 	closed, active := stablePendingRegistrations(1, 2)
 	originalFactory := bindValueLogStableNamespaceCreationProof
 	injected := errors.New("injected token failure before close")
-	bindValueLogStableNamespaceCreationProof = func(*rootpublication.StableNamespaceCreationProof, *os.File, uint64, string, string) (*rootpublication.StableNamespaceToken, error) {
-		return nil, injected
+	secondPath := filepath.Join(dir, "000002.vlog")
+	bindValueLogStableNamespaceCreationProof = func(proof *rootpublication.StableNamespaceCreationProof, parent *os.File, generation uint64, name, diagnosticPath string) (*rootpublication.StableNamespaceToken, error) {
+		if name == filepath.Base(secondPath) {
+			return nil, injected
+		}
+		return originalFactory(proof, parent, generation, name, diagnosticPath)
 	}
-	rotation, err := writer.RotateToWithStableResources(filepath.Join(dir, "000002.vlog"), 2, false, closed, active)
+	rotation, err := writer.RotateToWithStableResources(secondPath, 2, false, closed, active)
 	bindValueLogStableNamespaceCreationProof = originalFactory
 	if rotation != nil {
 		rotation.Release()
@@ -454,9 +540,11 @@ func TestStableValueLogPendingSuccessorTransfersRegistryObservationOnRetry(t *te
 	originalFactory := bindValueLogStableNamespaceCreationProof
 	factoryCalls := 0
 	bindValueLogStableNamespaceCreationProof = func(proof *rootpublication.StableNamespaceCreationProof, parent *os.File, generation uint64, name, diagnosticPath string) (*rootpublication.StableNamespaceToken, error) {
-		factoryCalls++
-		if factoryCalls == 1 {
-			return nil, injected
+		if name == filepath.Base(secondPath) {
+			factoryCalls++
+			if factoryCalls == 1 {
+				return nil, injected
+			}
 		}
 		return originalFactory(proof, parent, generation, name, diagnosticPath)
 	}
@@ -518,8 +606,11 @@ func TestStableValueLogPendingSuccessorReleasesRegistryObservationOnClose(t *tes
 
 	injected := errors.New("injected value-log namespace-token failure")
 	originalFactory := bindValueLogStableNamespaceCreationProof
-	bindValueLogStableNamespaceCreationProof = func(*rootpublication.StableNamespaceCreationProof, *os.File, uint64, string, string) (*rootpublication.StableNamespaceToken, error) {
-		return nil, injected
+	bindValueLogStableNamespaceCreationProof = func(proof *rootpublication.StableNamespaceCreationProof, parent *os.File, generation uint64, name, diagnosticPath string) (*rootpublication.StableNamespaceToken, error) {
+		if name == filepath.Base(secondPath) {
+			return nil, injected
+		}
+		return originalFactory(proof, parent, generation, name, diagnosticPath)
 	}
 	rotation, err := writer.RotateToWithStableResources(secondPath, 2, false, closed, active)
 	bindValueLogStableNamespaceCreationProof = originalFactory

--- a/TreeDB/internal/valuelog/stable_pending_successor_supported_test.go
+++ b/TreeDB/internal/valuelog/stable_pending_successor_supported_test.go
@@ -105,6 +105,59 @@ func TestStableValueLogObserverFailureRetriesExactPendingSuccessor(t *testing.T)
 	}
 }
 
+func TestStableOuterLeafRotationClassifiesNamespaceCreateWithDirectorySync(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "leaf_vlog")
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	firstPath := filepath.Join(dir, "000001.vlog")
+	secondPath := filepath.Join(dir, "000002.vlog")
+	writer, err := NewWriter(firstPath, 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer writer.Close()
+	appendStablePendingValue(t, writer, 1)
+	closed := StableResourceRegistration{
+		Kind: rootpublication.ResourceOuterLeafLog, LogicalLane: "outer-leaf", Generation: 1,
+		DiagnosticPath: "maindb/leaf_vlog/000001.vlog", Reachability: rootpublication.ReachabilityOuterLeafRawPointer,
+	}
+	active := StableResourceRegistration{
+		Kind: rootpublication.ResourceOuterLeafLog, LogicalLane: "outer-leaf", Generation: 2,
+		DiagnosticPath: "maindb/leaf_vlog/000002.vlog", Reachability: rootpublication.ReachabilityOuterLeafRawPointer,
+		ParentGeneration: 2, NamespaceOperation: rootpublication.NamespaceCreate,
+	}
+
+	var outerCreates, valueCreates, outerBeforeSyncs, outerAfterSyncs int
+	restore := durabilitycut.Install(func(event durabilitycut.Event) error {
+		switch {
+		case event.Namespace == durabilitycut.NamespaceCreate && event.NewPath == secondPath:
+			if event.Resource == durabilitycut.ResourceOuterLeaf {
+				outerCreates++
+			}
+			if event.Resource == durabilitycut.ResourceValueLog {
+				valueCreates++
+			}
+		case event.Resource == durabilitycut.ResourceOuterLeaf && event.Point == durabilitycut.BeforeNewFileDirectorySync:
+			outerBeforeSyncs++
+		case event.Resource == durabilitycut.ResourceOuterLeaf && event.Point == durabilitycut.AfterNewFileDirectorySync:
+			outerAfterSyncs++
+		}
+		return nil
+	})
+	defer restore()
+
+	rotation, err := writer.RotateToWithStableResources(secondPath, 2, false, closed, active)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer rotation.Release()
+	if outerCreates != 1 || valueCreates != 0 || outerBeforeSyncs != 1 || outerAfterSyncs != 1 {
+		t.Fatalf("outer-leaf creation cuts create(value/outer)=%d/%d directory(before/after)=%d/%d want 0/1 and 1/1",
+			valueCreates, outerCreates, outerBeforeSyncs, outerAfterSyncs)
+	}
+}
+
 func TestStableValueLogPendingSuccessorRejectsOrdinaryAndMismatchedRotation(t *testing.T) {
 	for _, tc := range []struct {
 		name string

--- a/TreeDB/internal/valuelog/stable_pending_successor_supported_test.go
+++ b/TreeDB/internal/valuelog/stable_pending_successor_supported_test.go
@@ -142,12 +142,12 @@ func TestStableValueLogPendingSuccessorRejectsOrdinaryAndMismatchedRotation(t *t
 			oldFile := writer.f
 
 			injected := errors.New("injected value-log namespace-token failure")
-			originalFactory := newValueLogStableNamespaceToken
-			newValueLogStableNamespaceToken = func(rootpublication.StableNamespaceSpec) (*rootpublication.StableNamespaceToken, error) {
+			originalFactory := bindValueLogStableNamespaceCreationProof
+			bindValueLogStableNamespaceCreationProof = func(*rootpublication.StableNamespaceCreationProof, *os.File, uint64, string, string) (*rootpublication.StableNamespaceToken, error) {
 				return nil, injected
 			}
 			rotation, err := writer.RotateToWithStableResources(secondPath, 2, false, closed, active)
-			newValueLogStableNamespaceToken = originalFactory
+			bindValueLogStableNamespaceCreationProof = originalFactory
 			if rotation != nil {
 				rotation.Release()
 				t.Fatal("failed rotation returned owned resources")
@@ -180,24 +180,33 @@ func TestStableValueLogTokenFailureRetriesExactPendingSuccessor(t *testing.T) {
 	active.ExternalRIDs = []uint64{101, 202}
 
 	createCalls := 0
+	beforeDirectoryCuts := 0
+	afterDirectoryCuts := 0
+	beforeDirectorySyncs := writer.DurabilityStats().DirectorySyncCalls
 	restore := durabilitycut.Install(func(event durabilitycut.Event) error {
 		if event.Resource == durabilitycut.ResourceValueLog && event.Namespace == durabilitycut.NamespaceCreate {
 			createCalls++
+		}
+		if event.Resource == durabilitycut.ResourceValueLog && event.Point == durabilitycut.BeforeNewFileDirectorySync {
+			beforeDirectoryCuts++
+		}
+		if event.Resource == durabilitycut.ResourceValueLog && event.Point == durabilitycut.AfterNewFileDirectorySync {
+			afterDirectoryCuts++
 		}
 		return nil
 	})
 	defer restore()
 	injected := errors.New("injected value-log namespace-token failure")
-	originalFactory := newValueLogStableNamespaceToken
+	originalFactory := bindValueLogStableNamespaceCreationProof
 	factoryCalls := 0
-	newValueLogStableNamespaceToken = func(spec rootpublication.StableNamespaceSpec) (*rootpublication.StableNamespaceToken, error) {
+	bindValueLogStableNamespaceCreationProof = func(proof *rootpublication.StableNamespaceCreationProof, parent *os.File, generation uint64, name, diagnosticPath string) (*rootpublication.StableNamespaceToken, error) {
 		factoryCalls++
 		if factoryCalls == 1 {
 			return nil, injected
 		}
-		return originalFactory(spec)
+		return originalFactory(proof, parent, generation, name, diagnosticPath)
 	}
-	defer func() { newValueLogStableNamespaceToken = originalFactory }()
+	defer func() { bindValueLogStableNamespaceCreationProof = originalFactory }()
 
 	rotation, err := writer.RotateToWithStableResources(secondPath, 2, false, closed, active)
 	if rotation != nil {
@@ -206,6 +215,9 @@ func TestStableValueLogTokenFailureRetriesExactPendingSuccessor(t *testing.T) {
 	}
 	if !errors.Is(err, injected) {
 		t.Fatalf("first rotation error=%v want token failure", err)
+	}
+	if got := writer.DurabilityStats().DirectorySyncCalls; got != beforeDirectorySyncs+1 || beforeDirectoryCuts != 1 || afterDirectoryCuts != 1 {
+		t.Fatalf("failed bind proof sync evidence calls=%d before/after=%d/%d want %d and 1/1", got, beforeDirectoryCuts, afterDirectoryCuts, beforeDirectorySyncs+1)
 	}
 	pending := writer.pendingStableSuccessor
 	if pending == nil || !pending.stableObserved || pending.active.PinRegistry != registry {
@@ -240,6 +252,9 @@ func TestStableValueLogTokenFailureRetriesExactPendingSuccessor(t *testing.T) {
 		t.Fatalf("retry createCalls=%d factoryCalls=%d sameFile=%t, want 1/2/true",
 			createCalls, factoryCalls, os.SameFile(createdInfo, installedInfo))
 	}
+	if got := writer.DurabilityStats().DirectorySyncCalls; got != beforeDirectorySyncs+1 || beforeDirectoryCuts != 1 || afterDirectoryCuts != 1 {
+		t.Fatalf("identical retry resynced proof: calls=%d before/after=%d/%d", got, beforeDirectoryCuts, afterDirectoryCuts)
+	}
 	if writer.pendingStableSuccessor != nil || !writer.stableResourceObserved ||
 		!rootpublication.SamePhysicalIdentity(writer.stableResourceIdentity, pendingIdentity) {
 		t.Fatal("successful retry did not transfer the pending observation into the active writer")
@@ -262,6 +277,58 @@ func TestStableValueLogTokenFailureRetriesExactPendingSuccessor(t *testing.T) {
 	}
 }
 
+func TestStableValueLogAfterDirectoryCutRetryKeepsSyncedProof(t *testing.T) {
+	dir := t.TempDir()
+	writer, err := NewWriter(filepath.Join(dir, "000001.vlog"), 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer writer.Close()
+	appendStablePendingValue(t, writer, 1)
+	closed, active := stablePendingRegistrations(1, 2)
+	secondPath := filepath.Join(dir, "000002.vlog")
+	beforeSyncs := writer.DurabilityStats().DirectorySyncCalls
+	injected := errors.New("injected after-directory-sync cut")
+	beforeCuts := 0
+	afterCuts := 0
+	restore := durabilitycut.Install(func(event durabilitycut.Event) error {
+		if event.Resource != durabilitycut.ResourceValueLog {
+			return nil
+		}
+		switch event.Point {
+		case durabilitycut.BeforeNewFileDirectorySync:
+			beforeCuts++
+		case durabilitycut.AfterNewFileDirectorySync:
+			afterCuts++
+			return injected
+		}
+		return nil
+	})
+	defer restore()
+	rotation, err := writer.RotateToWithStableResources(secondPath, 2, false, closed, active)
+	if rotation != nil {
+		rotation.Release()
+		t.Fatal("failed after-cut rotation returned resources")
+	}
+	if !errors.Is(err, injected) {
+		t.Fatalf("after-cut error=%v want injected", err)
+	}
+	if writer.pendingStableSuccessor == nil || writer.pendingStableSuccessor.creationProof == nil {
+		t.Fatal("after-cut failure did not retain the already-synced exact proof")
+	}
+	if got := writer.DurabilityStats().DirectorySyncCalls; got != beforeSyncs+1 || beforeCuts != 1 || afterCuts != 1 {
+		t.Fatalf("first attempt sync evidence calls=%d cuts=%d/%d", got, beforeCuts, afterCuts)
+	}
+	rotation, err = writer.RotateToWithStableResources(secondPath, 2, false, closed, active)
+	if err != nil {
+		t.Fatalf("retry after completed directory sync: %v", err)
+	}
+	rotation.Release()
+	if got := writer.DurabilityStats().DirectorySyncCalls; got != beforeSyncs+1 || beforeCuts != 1 || afterCuts != 1 {
+		t.Fatalf("retry repeated completed directory sync: calls=%d cuts=%d/%d", got, beforeCuts, afterCuts)
+	}
+}
+
 func TestStableValueLogPendingSuccessorRejectsRegistryMismatch(t *testing.T) {
 	dir := t.TempDir()
 	registry := rootpublication.NewIdentityPinRegistry()
@@ -275,12 +342,12 @@ func TestStableValueLogPendingSuccessorRejectsRegistryMismatch(t *testing.T) {
 	secondPath := filepath.Join(dir, "000002.vlog")
 
 	injected := errors.New("injected namespace-token failure before registry mismatch")
-	originalFactory := newValueLogStableNamespaceToken
-	newValueLogStableNamespaceToken = func(rootpublication.StableNamespaceSpec) (*rootpublication.StableNamespaceToken, error) {
+	originalFactory := bindValueLogStableNamespaceCreationProof
+	bindValueLogStableNamespaceCreationProof = func(*rootpublication.StableNamespaceCreationProof, *os.File, uint64, string, string) (*rootpublication.StableNamespaceToken, error) {
 		return nil, injected
 	}
 	rotation, err := writer.RotateToWithStableResources(secondPath, 2, false, closed, active)
-	newValueLogStableNamespaceToken = originalFactory
+	bindValueLogStableNamespaceCreationProof = originalFactory
 	if rotation != nil {
 		rotation.Release()
 		t.Fatal("failed rotation returned owned resources")
@@ -332,13 +399,13 @@ func TestStableValueLogPendingSuccessorCloseReleasesExactOwnership(t *testing.T)
 	}
 	appendStablePendingValue(t, writer, 1)
 	closed, active := stablePendingRegistrations(1, 2)
-	originalFactory := newValueLogStableNamespaceToken
+	originalFactory := bindValueLogStableNamespaceCreationProof
 	injected := errors.New("injected token failure before close")
-	newValueLogStableNamespaceToken = func(rootpublication.StableNamespaceSpec) (*rootpublication.StableNamespaceToken, error) {
+	bindValueLogStableNamespaceCreationProof = func(*rootpublication.StableNamespaceCreationProof, *os.File, uint64, string, string) (*rootpublication.StableNamespaceToken, error) {
 		return nil, injected
 	}
 	rotation, err := writer.RotateToWithStableResources(filepath.Join(dir, "000002.vlog"), 2, false, closed, active)
-	newValueLogStableNamespaceToken = originalFactory
+	bindValueLogStableNamespaceCreationProof = originalFactory
 	if rotation != nil {
 		rotation.Release()
 		t.Fatal("failed rotation returned owned resources")
@@ -384,16 +451,16 @@ func TestStableValueLogPendingSuccessorTransfersRegistryObservationOnRetry(t *te
 	closed, active := stablePendingRegistrations(1, 2)
 
 	injected := errors.New("injected value-log namespace-token failure")
-	originalFactory := newValueLogStableNamespaceToken
+	originalFactory := bindValueLogStableNamespaceCreationProof
 	factoryCalls := 0
-	newValueLogStableNamespaceToken = func(spec rootpublication.StableNamespaceSpec) (*rootpublication.StableNamespaceToken, error) {
+	bindValueLogStableNamespaceCreationProof = func(proof *rootpublication.StableNamespaceCreationProof, parent *os.File, generation uint64, name, diagnosticPath string) (*rootpublication.StableNamespaceToken, error) {
 		factoryCalls++
 		if factoryCalls == 1 {
 			return nil, injected
 		}
-		return originalFactory(spec)
+		return originalFactory(proof, parent, generation, name, diagnosticPath)
 	}
-	defer func() { newValueLogStableNamespaceToken = originalFactory }()
+	defer func() { bindValueLogStableNamespaceCreationProof = originalFactory }()
 
 	rotation, err := writer.RotateToWithStableResources(secondPath, 2, false, closed, active)
 	if rotation != nil {
@@ -450,12 +517,12 @@ func TestStableValueLogPendingSuccessorReleasesRegistryObservationOnClose(t *tes
 	closed, active := stablePendingRegistrations(1, 2)
 
 	injected := errors.New("injected value-log namespace-token failure")
-	originalFactory := newValueLogStableNamespaceToken
-	newValueLogStableNamespaceToken = func(rootpublication.StableNamespaceSpec) (*rootpublication.StableNamespaceToken, error) {
+	originalFactory := bindValueLogStableNamespaceCreationProof
+	bindValueLogStableNamespaceCreationProof = func(*rootpublication.StableNamespaceCreationProof, *os.File, uint64, string, string) (*rootpublication.StableNamespaceToken, error) {
 		return nil, injected
 	}
 	rotation, err := writer.RotateToWithStableResources(secondPath, 2, false, closed, active)
-	newValueLogStableNamespaceToken = originalFactory
+	bindValueLogStableNamespaceCreationProof = originalFactory
 	if rotation != nil {
 		rotation.Release()
 		t.Fatal("failed rotation returned owned resources")

--- a/TreeDB/internal/valuelog/stable_resource.go
+++ b/TreeDB/internal/valuelog/stable_resource.go
@@ -10,12 +10,17 @@ import (
 	"slices"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/snissn/gomap/TreeDB/internal/durabilitycut"
 	"github.com/snissn/gomap/TreeDB/internal/rootpublication"
 )
 
 var newValueLogStableNamespaceToken = rootpublication.NewStableNamespaceToken
+var newValueLogStableNamespaceCreationProof = rootpublication.NewStableNamespaceCreationProof
+var bindValueLogStableNamespaceCreationProof = func(proof *rootpublication.StableNamespaceCreationProof, parent *os.File, parentGeneration uint64, name, diagnosticPath string) (*rootpublication.StableNamespaceToken, error) {
+	return proof.Bind(parent, parentGeneration, name, diagnosticPath)
+}
 var openStableValueLogParent = os.Open
 
 type pendingValueLogSuccessor struct {
@@ -27,7 +32,47 @@ type pendingValueLogSuccessor struct {
 	stableIdentity  rootpublication.StableIdentity
 	stableObserved  bool
 	observerEmitted bool
+	creationProof   *rootpublication.StableNamespaceCreationProof
 	failStop        bool
+}
+
+func (w *Writer) newStableCreationProof(parent, child *os.File, path string) (*rootpublication.StableNamespaceCreationProof, error) {
+	resource := segmentNamespaceResource(path)
+	dir := filepath.Dir(path)
+	if err := durabilitycut.EmitPath(durabilitycut.BeforeNewFileDirectorySync, resource, "", dir); err != nil {
+		return nil, err
+	}
+	started := time.Now()
+	proof, err := newValueLogStableNamespaceCreationProof(parent, child, filepath.Base(path))
+	w.directorySyncCalls.Add(1)
+	if ns := time.Since(started).Nanoseconds(); ns > 0 {
+		w.directorySyncNs.Add(uint64(ns))
+	}
+	if err != nil {
+		w.directorySyncErrors.Add(1)
+		return nil, err
+	}
+	return proof, durabilitycut.EmitPath(durabilitycut.AfterNewFileDirectorySync, resource, "", dir)
+}
+
+func (w *Writer) prepareStableCreationProof(parent, child *os.File, path string, created, syncDirectory, retainProof bool) (*rootpublication.StableNamespaceCreationProof, bool, bool, error) {
+	if created && retainProof && syncDirectory {
+		if rootpublication.StableRelativeNamespaceSupported() {
+			proof, err := w.newStableCreationProof(parent, child, path)
+			return proof, false, false, err
+		}
+		if err := syncNewFileDirectory(w, path); err != nil {
+			return nil, true, false, err
+		}
+		return nil, true, false, nil
+	}
+	if created && retainProof && !syncDirectory {
+		return nil, false, true, nil
+	}
+	if syncDirectory {
+		return nil, false, false, syncNewFileDirectory(w, path)
+	}
+	return nil, false, false, nil
 }
 
 func cloneStableResourceRegistration(registration StableResourceRegistration) StableResourceRegistration {
@@ -717,6 +762,18 @@ func (rotation *StableResourceRotation) Release() {
 	rotation.Active = nil
 }
 
+// StableCreationNamespacePending reports whether the current segment was
+// created by this writer and therefore requires NamespaceCreate evidence when
+// it is captured. Existing-file opens return false; the subsequent token
+// registration remains responsible for typed unsupported or uncertified
+// failures.
+func (w *Writer) StableCreationNamespacePending() (bool, error) {
+	if w == nil || w.f == nil {
+		return false, errors.New("valuelog: stable resource requires file-backed writer")
+	}
+	return w.creationProof != nil || w.creationUnsupported || w.creationUncertified, nil
+}
+
 // StableResourceToken flushes accepted bytes and captures a duplicate of the
 // current file descriptor. It does not fsync the file; publication owns the
 // later FlushThrough/SyncThrough boundary on the token.
@@ -737,7 +794,31 @@ func (w *Writer) stableResourceTokenAfterFlush(registration StableResourceRegist
 	if w == nil || w.f == nil {
 		return nil, errors.New("valuelog: stable resource requires file-backed writer")
 	}
-	namespace, err := stableValueLogNamespaceToken(w.f, registration)
+	var namespace *rootpublication.StableNamespaceToken
+	var err error
+	if registration.NamespaceOperation == rootpublication.NamespaceCreate {
+		if w.creationProof == nil {
+			if w.stableResourcePins != nil && !w.creationUnsupported {
+				if w.creationUncertified {
+					return nil, fmt.Errorf("%w: asynchronously created value-log segment has no stable namespace proof", rootpublication.ErrUnresolvedResource)
+				}
+				return nil, fmt.Errorf("%w: existing value-log segment has no creation namespace proof", rootpublication.ErrUnresolvedResource)
+			}
+			namespace, err = stableValueLogNamespaceToken(w.f, registration)
+		} else {
+			parent := registration.NamespaceParent
+			if parent == nil {
+				parent = w.stableParent
+			}
+			name := registration.NewName
+			if name == "" {
+				name = filepath.Base(w.f.Name())
+			}
+			namespace, err = bindValueLogStableNamespaceCreationProof(w.creationProof, parent, registration.ParentGeneration, name, filepath.Dir(registration.DiagnosticPath))
+		}
+	} else {
+		namespace, err = stableValueLogNamespaceToken(w.f, registration)
+	}
 	if err != nil {
 		return nil, err
 	}
@@ -843,6 +924,9 @@ func (w *Writer) RotateToWithStableResources(path string, fileID uint32, syncCur
 	if w == nil || w.f == nil {
 		return nil, errors.New("valuelog: stable rotation requires file-backed writer")
 	}
+	if w.creationUncertified {
+		return nil, fmt.Errorf("%w: asynchronously created current segment cannot enter a stable rotation", rootpublication.ErrUnresolvedResource)
+	}
 	if active.NamespaceOperation == rootpublication.NamespaceNone {
 		return nil, errors.New("valuelog: stable rotation requires active namespace operation")
 	}
@@ -917,12 +1001,21 @@ func (w *Writer) RotateToWithStableResources(path string, fileID uint32, syncCur
 			return nil, pendingValueLogFailure(w.stableParent, prepared, path, observeErr)
 		}
 	}
+	if pending.creationProof == nil {
+		proof, proofErr := w.newStableCreationProof(w.stableParent, prepared, path)
+		pending.creationProof = proof
+		if proofErr != nil {
+			closedToken.Release()
+			return nil, pendingValueLogFailure(w.stableParent, prepared, path, proofErr)
+		}
+	}
 	preparedInfo, err := prepared.Stat()
 	if err != nil {
 		closedToken.Release()
 		return nil, pendingValueLogFailure(w.stableParent, prepared, path, err)
 	}
-	namespace, err := stableValueLogNamespaceToken(prepared, normalizedActive)
+	namespace, err := bindValueLogStableNamespaceCreationProof(pending.creationProof, normalizedActive.NamespaceParent, normalizedActive.ParentGeneration,
+		normalizedActive.NewName, filepath.Dir(normalizedActive.DiagnosticPath))
 	if err != nil {
 		closedToken.Release()
 		return nil, pendingValueLogFailure(w.stableParent, prepared, path, err)
@@ -934,6 +1027,7 @@ func (w *Writer) RotateToWithStableResources(path string, fileID uint32, syncCur
 		return nil, err
 	}
 	old := w.f
+	oldCreationProof := w.creationProof
 	closeErr := w.closeRotatedResource(old)
 	observeErr := w.releaseStableResourceObservation()
 	if err := errors.Join(closeErr, observeErr); err != nil {
@@ -946,6 +1040,10 @@ func (w *Writer) RotateToWithStableResources(path string, fileID uint32, syncCur
 	}
 	pending.file = nil
 	w.f = prepared
+	w.creationProof = pending.creationProof
+	w.creationUnsupported = false
+	w.creationUncertified = false
+	pending.creationProof = nil
 	w.bw = nil
 	w.size = preparedInfo.Size()
 	w.fileID = fileID
@@ -956,6 +1054,9 @@ func (w *Writer) RotateToWithStableResources(path string, fileID uint32, syncCur
 		w.stableResourceIdentity = pending.stableIdentity
 		w.stableResourceObserved = true
 		pending.stableObserved = false
+	}
+	if oldCreationProof != nil {
+		oldCreationProof.Release()
 	}
 	w.pendingStableSuccessor = nil
 	return &StableResourceRotation{Closed: closedToken, Active: activeToken}, nil

--- a/TreeDB/internal/valuelog/stable_resource.go
+++ b/TreeDB/internal/valuelog/stable_resource.go
@@ -794,6 +794,10 @@ func (w *Writer) stableResourceTokenAfterFlush(registration StableResourceRegist
 	if w == nil || w.f == nil {
 		return nil, errors.New("valuelog: stable resource requires file-backed writer")
 	}
+	creationPending := w.creationProof != nil || w.creationUnsupported || w.creationUncertified
+	if creationPending && registration.NamespaceOperation != rootpublication.NamespaceCreate {
+		return nil, fmt.Errorf("%w: current value-log segment requires NamespaceCreate evidence", rootpublication.ErrNamespaceUnstable)
+	}
 	var namespace *rootpublication.StableNamespaceToken
 	var err error
 	if registration.NamespaceOperation == rootpublication.NamespaceCreate {

--- a/TreeDB/internal/valuelog/stable_resource.go
+++ b/TreeDB/internal/valuelog/stable_resource.go
@@ -1072,7 +1072,7 @@ func (w *Writer) RotateToWithStableResources(path string, fileID uint32, syncCur
 	prepared := pending.file
 	if !pending.observerEmitted {
 		pending.observerEmitted = true
-		if observeErr := durabilitycut.EmitNamespace(durabilitycut.NamespaceCreate, durabilitycut.ResourceValueLog, filepath.Dir(path), "", path); observeErr != nil {
+		if observeErr := durabilitycut.EmitNamespace(durabilitycut.NamespaceCreate, segmentNamespaceResource(path), filepath.Dir(path), "", path); observeErr != nil {
 			closedToken.Release()
 			return nil, pendingValueLogFailure(w.stableParent, prepared, path, observeErr)
 		}

--- a/TreeDB/internal/valuelog/stable_resource.go
+++ b/TreeDB/internal/valuelog/stable_resource.go
@@ -21,6 +21,12 @@ var newValueLogStableNamespaceCreationProof = rootpublication.NewStableNamespace
 var bindValueLogStableNamespaceCreationProof = func(proof *rootpublication.StableNamespaceCreationProof, parent *os.File, parentGeneration uint64, name, diagnosticPath string) (*rootpublication.StableNamespaceToken, error) {
 	return proof.Bind(parent, parentGeneration, name, diagnosticPath)
 }
+
+// Keep retained-current and pending-successor binding as separate seams so
+// failure tests can target either ownership phase without perturbing the other.
+var bindRetainedValueLogStableNamespaceCreationProof = func(proof *rootpublication.StableNamespaceCreationProof, parent *os.File, parentGeneration uint64, name, diagnosticPath string) (*rootpublication.StableNamespaceToken, error) {
+	return proof.Bind(parent, parentGeneration, name, diagnosticPath)
+}
 var openStableValueLogParent = os.Open
 
 type pendingValueLogSuccessor struct {
@@ -791,6 +797,10 @@ func (w *Writer) StableResourceToken(registration StableResourceRegistration) (*
 }
 
 func (w *Writer) stableResourceTokenAfterFlush(registration StableResourceRegistration) (*rootpublication.StableResourceToken, error) {
+	return w.stableResourceTokenAfterFlushWithContentState(registration, false)
+}
+
+func (w *Writer) stableResourceTokenAfterFlushWithContentState(registration StableResourceRegistration, contentSynced bool) (*rootpublication.StableResourceToken, error) {
 	if w == nil || w.f == nil {
 		return nil, errors.New("valuelog: stable resource requires file-backed writer")
 	}
@@ -824,7 +834,7 @@ func (w *Writer) stableResourceTokenAfterFlush(registration StableResourceRegist
 			if name == "" {
 				name = filepath.Base(w.f.Name())
 			}
-			namespace, err = bindValueLogStableNamespaceCreationProof(w.creationProof, parent, registration.ParentGeneration, name, filepath.Dir(registration.DiagnosticPath))
+			namespace, err = bindRetainedValueLogStableNamespaceCreationProof(w.creationProof, parent, registration.ParentGeneration, name, filepath.Dir(registration.DiagnosticPath))
 		}
 	} else {
 		namespace, err = stableValueLogNamespaceToken(w.f, registration)
@@ -833,7 +843,7 @@ func (w *Writer) stableResourceTokenAfterFlush(registration StableResourceRegist
 		return nil, err
 	}
 	defer namespace.Release()
-	return stableValueLogResourceToken(w.f, w.fileID, registration, namespace, false)
+	return stableValueLogResourceToken(w.f, w.fileID, registration, namespace, contentSynced)
 }
 
 func stableValueLogResourceToken(file *os.File, fileID uint32, registration StableResourceRegistration, namespace *rootpublication.StableNamespaceToken, contentSynced bool) (*rootpublication.StableResourceToken, error) {
@@ -925,8 +935,9 @@ func pendingValueLogFailure(parent, file *os.File, path string, err error) error
 }
 
 // RotateToWithStableResources pins the flushed old segment before writer state
-// switches and then pins the newly-created active segment after its namespace
-// operation has been made persistent.
+// switches, attaching any retained proof from its original creation without a
+// second directory sync. It then pins the newly-created active segment after
+// that segment's namespace operation has been made persistent.
 func (w *Writer) RotateToWithStableResources(path string, fileID uint32, syncCurrent bool, closed, active StableResourceRegistration) (*StableResourceRotation, error) {
 	if w != nil && w.pendingStableSuccessor != nil && w.pendingStableSuccessor.failStop {
 		return nil, fmt.Errorf("%w: value-log stable rotation stopped after old-writer close failure", rootpublication.ErrResourceOwnership)
@@ -958,6 +969,18 @@ func (w *Writer) RotateToWithStableResources(path string, fileID uint32, syncCur
 	if err != nil {
 		return nil, err
 	}
+	if w.creationProof != nil || w.creationUnsupported || w.creationUncertified {
+		switch closed.NamespaceOperation {
+		case rootpublication.NamespaceNone:
+			closed.NamespaceOperation = rootpublication.NamespaceCreate
+		case rootpublication.NamespaceCreate:
+		default:
+			return nil, fmt.Errorf("%w: current value-log segment creation requires NamespaceCreate evidence", rootpublication.ErrNamespaceUnstable)
+		}
+		if closed.ParentGeneration == 0 {
+			closed.ParentGeneration = normalizedActive.ParentGeneration
+		}
+	}
 	if pending := w.pendingStableSuccessor; pending != nil {
 		if pending.parent != w.stableParent || pending.path != path || pending.fileID != fileID ||
 			!sameStableResourceRegistration(pending.active, normalizedActive) {
@@ -973,7 +996,7 @@ func (w *Writer) RotateToWithStableResources(path string, fileID uint32, syncCur
 			return nil, err
 		}
 	}
-	closedToken, err := stableValueLogResourceToken(w.f, w.fileID, closed, nil, syncCurrent)
+	closedToken, err := w.stableResourceTokenAfterFlushWithContentState(closed, syncCurrent)
 	if err != nil {
 		return nil, err
 	}

--- a/TreeDB/internal/valuelog/stable_resource.go
+++ b/TreeDB/internal/valuelog/stable_resource.go
@@ -798,6 +798,9 @@ func (w *Writer) stableResourceTokenAfterFlush(registration StableResourceRegist
 	if creationPending && registration.NamespaceOperation != rootpublication.NamespaceCreate {
 		return nil, fmt.Errorf("%w: current value-log segment requires NamespaceCreate evidence", rootpublication.ErrNamespaceUnstable)
 	}
+	if registration.NamespaceOperation == rootpublication.NamespaceCreate && registration.NamespaceParent == nil {
+		registration.NamespaceParent = w.stableParent
+	}
 	var namespace *rootpublication.StableNamespaceToken
 	var err error
 	if registration.NamespaceOperation == rootpublication.NamespaceCreate {

--- a/TreeDB/internal/valuelog/stable_resource.go
+++ b/TreeDB/internal/valuelog/stable_resource.go
@@ -801,6 +801,9 @@ func (w *Writer) stableResourceTokenAfterFlush(registration StableResourceRegist
 	if registration.NamespaceOperation == rootpublication.NamespaceCreate && registration.NamespaceParent == nil {
 		registration.NamespaceParent = w.stableParent
 	}
+	if registration.NamespaceOperation == rootpublication.NamespaceCreate && w.creationUnsupported {
+		return nil, fmt.Errorf("%w: current value-log segment creation cannot be certified on this platform", rootpublication.ErrNamespacePersistenceUnsupported)
+	}
 	var namespace *rootpublication.StableNamespaceToken
 	var err error
 	if registration.NamespaceOperation == rootpublication.NamespaceCreate {

--- a/TreeDB/internal/valuelog/stable_resource.go
+++ b/TreeDB/internal/valuelog/stable_resource.go
@@ -990,8 +990,9 @@ func (w *Writer) RotateToWithStableResources(path string, fileID uint32, syncCur
 	if w.creationUncertified {
 		return nil, fmt.Errorf("%w: asynchronously created current segment cannot enter a stable rotation", rootpublication.ErrUnresolvedResource)
 	}
-	if active.NamespaceOperation == rootpublication.NamespaceNone {
-		return nil, errors.New("valuelog: stable rotation requires active namespace operation")
+	if active.NamespaceOperation != rootpublication.NamespaceCreate {
+		return nil, fmt.Errorf("%w: stable rotation creates its successor and requires active namespace operation %q, got %q",
+			rootpublication.ErrNamespaceUnstable, rootpublication.NamespaceCreate, active.NamespaceOperation)
 	}
 	if w.stableParentErr != nil || w.stableParent == nil {
 		if w.stableParentErr != nil {

--- a/TreeDB/internal/valuelog/stable_resource.go
+++ b/TreeDB/internal/valuelog/stable_resource.go
@@ -774,6 +774,48 @@ func (w *Writer) StableCreationNamespacePending() (bool, error) {
 	return w.creationProof != nil || w.creationUnsupported || w.creationUncertified, nil
 }
 
+// StableNamespaceParentGeneration returns the logical epoch derived from the
+// exact retained parent directory handle used by stable creation and rotation.
+func (w *Writer) StableNamespaceParentGeneration() (uint64, error) {
+	if w == nil || w.stableParent == nil {
+		if w != nil && w.stableParentErr != nil {
+			return 0, w.stableParentErr
+		}
+		return 0, fmt.Errorf("%w: stable value-log parent unavailable", rootpublication.ErrUnresolvedResource)
+	}
+	return rootpublication.StableNamespaceParentGeneration(w.stableParent)
+}
+
+// CertifyStableCreationNamespace converts an exact relaxed-rotation successor
+// into stable creation evidence before a stable caller appends bytes to it.
+// The writer and its retained parent remain unchanged on failure, so a caller
+// can retry without publishing an unreachable record.
+func (w *Writer) CertifyStableCreationNamespace() error {
+	if w == nil || w.f == nil {
+		return errors.New("valuelog: stable resource requires file-backed writer")
+	}
+	if !w.creationUncertified {
+		return nil
+	}
+	if w.stableParentErr != nil || w.stableParent == nil {
+		if w.stableParentErr != nil {
+			return fmt.Errorf("valuelog: stable parent unavailable: %w", w.stableParentErr)
+		}
+		return errors.New("valuelog: stable parent unavailable")
+	}
+	if w.creationProof != nil || w.creationUnsupported {
+		return fmt.Errorf("%w: inconsistent uncertified value-log creation state", rootpublication.ErrResourceConflict)
+	}
+	proof, err := w.newStableCreationProof(w.stableParent, w.f, w.f.Name())
+	if proof != nil {
+		// The parent sync may have completed before an injected after-sync cut.
+		// Retain that exact proof so retry does not repeat structural durability.
+		w.creationProof = proof
+		w.creationUncertified = false
+	}
+	return err
+}
+
 // StableResourceToken flushes accepted bytes and captures a duplicate of the
 // current file descriptor. It does not fsync the file; publication owns the
 // later FlushThrough/SyncThrough boundary on the token.
@@ -970,7 +1012,53 @@ func (w *Writer) RotateToWithStableResources(path string, fileID uint32, syncCur
 			return nil, err
 		}
 	}
-	closedToken, err := stableValueLogResourceToken(w.f, w.fileID, closed, nil, syncCurrent)
+	creationPending := w.creationProof != nil || w.creationUnsupported || w.creationUncertified
+	if creationPending {
+		// Only the writer knows that this exact current segment still carries
+		// initial-create debt. Upgrade the closed registration so callers cannot
+		// accidentally discard the retained proof during rotation.
+		closed.NamespaceOperation = rootpublication.NamespaceCreate
+		if closed.ParentGeneration == 0 {
+			closed.ParentGeneration, err = w.StableNamespaceParentGeneration()
+			if err != nil {
+				return nil, err
+			}
+		}
+		if closed.NewName == "" {
+			closed.NewName = filepath.Base(w.f.Name())
+		}
+	}
+	var closedNamespace *rootpublication.StableNamespaceToken
+	if closed.NamespaceOperation == rootpublication.NamespaceCreate {
+		if w.creationProof == nil {
+			if w.creationUncertified {
+				return nil, fmt.Errorf("%w: asynchronously created rotating value-log segment has no stable namespace proof", rootpublication.ErrUnresolvedResource)
+			}
+			if w.stableResourcePins != nil && !w.creationUnsupported {
+				return nil, fmt.Errorf("%w: existing rotating value-log segment has no creation namespace proof", rootpublication.ErrUnresolvedResource)
+			}
+			closedNamespace, err = stableValueLogNamespaceToken(w.f, closed)
+		} else {
+			parent := closed.NamespaceParent
+			if parent == nil {
+				parent = w.stableParent
+			}
+			name := closed.NewName
+			if name == "" {
+				name = filepath.Base(w.f.Name())
+			}
+			closedNamespace, err = bindValueLogStableNamespaceCreationProof(
+				w.creationProof, parent, closed.ParentGeneration, name, filepath.Dir(closed.DiagnosticPath),
+			)
+		}
+		if err != nil {
+			return nil, err
+		}
+	}
+	closedToken, err := stableValueLogResourceToken(w.f, w.fileID, closed, closedNamespace, syncCurrent)
+	if closedNamespace != nil {
+		closedNamespace.Release()
+	}
 	if err != nil {
 		return nil, err
 	}

--- a/TreeDB/internal/valuelog/stable_resource_supported_test.go
+++ b/TreeDB/internal/valuelog/stable_resource_supported_test.go
@@ -440,6 +440,65 @@ func TestStableRotationExistingClosedSegmentHasNoCreationWitness(t *testing.T) {
 	}
 }
 
+func TestStableRotationRejectsRenameBeforeMutation(t *testing.T) {
+	dir := t.TempDir()
+	firstPath := filepath.Join(dir, "000001.vlog")
+	secondPath := filepath.Join(dir, "000002.vlog")
+	registry := rootpublication.NewIdentityPinRegistry()
+	writer, err := NewWriterWithStableResourcePinRegistry(firstPath, 1, registry)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer writer.Close()
+	if _, err := writer.Append(0, nil, 1, []byte("before rejected rename")); err != nil {
+		t.Fatal(err)
+	}
+	beforeStats := writer.DurabilityStats()
+	beforePins := registry.ActivePins()
+	beforeIdentities := registry.ActiveIdentities()
+
+	rotation, err := writer.RotateToWithStableResources(secondPath, 2, true,
+		StableResourceRegistration{
+			LogicalLane: "main", Generation: 1, DiagnosticPath: "maindb/value_vlog/000001.vlog",
+			Reachability: rootpublication.ReachabilityValueLogPointer,
+		},
+		StableResourceRegistration{
+			LogicalLane: "main", Generation: 2, DiagnosticPath: "maindb/value_vlog/000002.vlog",
+			Reachability: rootpublication.ReachabilityValueLogPointer, ParentGeneration: 1,
+			NamespaceOperation: rootpublication.NamespaceRename,
+			OldName:            filepath.Base(firstPath),
+			NewName:            filepath.Base(secondPath),
+		})
+	if rotation != nil {
+		rotation.Release()
+		t.Fatal("rejected rename returned owned resources")
+	}
+	if !errors.Is(err, rootpublication.ErrNamespaceUnstable) {
+		t.Fatalf("stable rename rotation error=%v want ErrNamespaceUnstable", err)
+	}
+	if _, err := os.Stat(secondPath); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("rejected rename exposed successor: %v", err)
+	}
+	if writer.FileID() != 1 || writer.f == nil || writer.f.Name() != firstPath {
+		t.Fatalf("rejected rename changed active writer: id=%d file=%v", writer.FileID(), writer.f)
+	}
+	if got := writer.DurabilityStats(); got != beforeStats {
+		t.Fatalf("rejected rename performed durability work: before=%+v after=%+v", beforeStats, got)
+	}
+	if got := registry.ActivePins(); got != beforePins {
+		t.Fatalf("rejected rename changed active pins: before=%d after=%d", beforePins, got)
+	}
+	if got := registry.ActiveIdentities(); got != beforeIdentities {
+		t.Fatalf("rejected rename changed observed identities: before=%d after=%d", beforeIdentities, got)
+	}
+	if _, err := writer.Append(0, nil, 2, []byte("old writer remains usable")); err != nil {
+		t.Fatalf("append after rejected rename: %v", err)
+	}
+	if err := writer.Flush(); err != nil {
+		t.Fatalf("flush after rejected rename: %v", err)
+	}
+}
+
 func TestStableValueLogRotationNamespaceFailureKeepsOldWriterActive(t *testing.T) {
 	testStableValueLogRotationNamespaceFailureKeepsOldWriterActive(t)
 }

--- a/TreeDB/internal/valuelog/stable_resource_supported_test.go
+++ b/TreeDB/internal/valuelog/stable_resource_supported_test.go
@@ -360,6 +360,43 @@ func TestRotateToWithStableResourcesOwnsRegistryObservations(t *testing.T) {
 	testRotateToWithStableResourcesOwnsRegistryObservations(t)
 }
 
+func TestStableRotationExistingClosedSegmentHasNoCreationWitness(t *testing.T) {
+	dir := t.TempDir()
+	firstPath := filepath.Join(dir, "000001.vlog")
+	if err := os.WriteFile(firstPath, nil, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	registry := rootpublication.NewIdentityPinRegistry()
+	writer, err := NewWriterWithStableResourcePinRegistry(firstPath, 1, registry)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer writer.Close()
+	if pending, pendingErr := writer.StableCreationNamespacePending(); pendingErr != nil || pending {
+		t.Fatalf("existing writer creation pending=%t err=%v want false, nil", pending, pendingErr)
+	}
+	rotation, err := writer.RotateToWithStableResources(filepath.Join(dir, "000002.vlog"), 2, false,
+		StableResourceRegistration{
+			LogicalLane: "main", Generation: 1, DiagnosticPath: "maindb/value_vlog/000001.vlog",
+			Reachability: rootpublication.ReachabilityValueLogPointer, ParentGeneration: 1,
+		},
+		StableResourceRegistration{
+			LogicalLane: "main", Generation: 2, DiagnosticPath: "maindb/value_vlog/000002.vlog",
+			Reachability: rootpublication.ReachabilityValueLogPointer, ParentGeneration: 1,
+			NamespaceOperation: rootpublication.NamespaceCreate,
+		})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer rotation.Release()
+	if rotation.Closed.Namespace() != nil {
+		t.Fatal("existing closed segment fabricated a creation witness")
+	}
+	if rotation.Active.Namespace() == nil || rotation.Active.Namespace().Operation() != rootpublication.NamespaceCreate {
+		t.Fatal("new active segment is missing its creation witness")
+	}
+}
+
 func TestStableValueLogRotationNamespaceFailureKeepsOldWriterActive(t *testing.T) {
 	testStableValueLogRotationNamespaceFailureKeepsOldWriterActive(t)
 }

--- a/TreeDB/internal/valuelog/stable_resource_supported_test.go
+++ b/TreeDB/internal/valuelog/stable_resource_supported_test.go
@@ -216,6 +216,26 @@ func TestStableWriterCreationProofBindsRepeatedlyWithoutResync(t *testing.T) {
 	}
 }
 
+func TestStableWriterCreationProofCannotBeOmitted(t *testing.T) {
+	dir := t.TempDir()
+	writer, err := NewWriterWithStableResourcePinRegistry(filepath.Join(dir, "000001.vlog"), 1, rootpublication.NewIdentityPinRegistry())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer writer.Close()
+	token, err := writer.StableResourceToken(StableResourceRegistration{
+		LogicalLane: "main", Generation: 1, DiagnosticPath: "maindb/value_vlog/000001.vlog",
+		Reachability: rootpublication.ReachabilityValueLogPointer,
+	})
+	if token != nil {
+		token.Release()
+		t.Fatal("newly-created stable writer returned a token without namespace evidence")
+	}
+	if !errors.Is(err, rootpublication.ErrNamespaceUnstable) {
+		t.Fatalf("omitted create evidence error=%v want ErrNamespaceUnstable", err)
+	}
+}
+
 func TestStableWriterExistingOpenCannotClaimCreateProof(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "000001.vlog")

--- a/TreeDB/internal/valuelog/stable_resource_supported_test.go
+++ b/TreeDB/internal/valuelog/stable_resource_supported_test.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/snissn/gomap/TreeDB/internal/rootpublication"
 )
@@ -166,6 +167,152 @@ func TestOrdinaryRotationRetainedParentPlateau(t *testing.T) {
 		if _, err := oldParent.Stat(); !errors.Is(err, os.ErrClosed) {
 			t.Fatalf("rotation %d retained superseded parent: %v", id, err)
 		}
+	}
+}
+
+func TestStableWriterCreationProofBindsRepeatedlyWithoutResync(t *testing.T) {
+	dir := t.TempDir()
+	registry := rootpublication.NewIdentityPinRegistry()
+	writer, err := NewWriterWithStableResourcePinRegistry(filepath.Join(dir, "000001.vlog"), 1, registry)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer writer.Close()
+	if pending, err := writer.StableCreationNamespacePending(); err != nil || !pending {
+		t.Fatalf("new writer creation pending=%v err=%v want true, nil", pending, err)
+	}
+	if _, err := writer.Append(0, nil, 1, []byte("proof")); err != nil {
+		t.Fatal(err)
+	}
+	if got := writer.DurabilityStats().DirectorySyncCalls; got != 1 {
+		t.Fatalf("initial exact-parent syncs=%d want 1", got)
+	}
+	for generation := uint64(1); generation <= 4; generation++ {
+		token, err := writer.StableResourceToken(StableResourceRegistration{
+			LogicalLane: "main", Generation: generation, DiagnosticPath: "maindb/value_vlog/000001.vlog",
+			Reachability: rootpublication.ReachabilityValueLogPointer, ParentGeneration: generation,
+			NamespaceOperation: rootpublication.NamespaceCreate,
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		builder := rootpublication.NewStableResourceSetBuilder(rootpublication.ReachabilityValueLogPointer)
+		if err := builder.Add(token); err != nil {
+			token.Release()
+			t.Fatal(err)
+		}
+		set, err := builder.Freeze()
+		if err != nil {
+			t.Fatal(err)
+		}
+		stats := set.Stats(time.Now())
+		set.Release()
+		if len(stats) != 1 || stats[0].NamespaceSyncs != 1 {
+			t.Fatalf("capture %d namespace stats=%+v want one creation sync", generation, stats)
+		}
+	}
+	if got := writer.DurabilityStats().DirectorySyncCalls; got != 1 {
+		t.Fatalf("repeated capture resynced exact parent: calls=%d", got)
+	}
+}
+
+func TestStableWriterExistingOpenCannotClaimCreateProof(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "000001.vlog")
+	if err := os.WriteFile(path, []byte("existing"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	writer, err := NewWriterWithStableResourcePinRegistry(path, 1, rootpublication.NewIdentityPinRegistry())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer writer.Close()
+	if pending, err := writer.StableCreationNamespacePending(); err != nil || pending {
+		t.Fatalf("existing writer creation pending=%v err=%v want false, nil", pending, err)
+	}
+	token, err := writer.StableResourceToken(StableResourceRegistration{
+		LogicalLane: "main", Generation: 1, DiagnosticPath: "maindb/value_vlog/000001.vlog",
+		Reachability: rootpublication.ReachabilityValueLogPointer, ParentGeneration: 1,
+		NamespaceOperation: rootpublication.NamespaceCreate,
+	})
+	if token != nil {
+		token.Release()
+		t.Fatal("existing open returned create evidence")
+	}
+	if !errors.Is(err, rootpublication.ErrUnresolvedResource) {
+		t.Fatalf("existing create capture error=%v want ErrUnresolvedResource", err)
+	}
+}
+
+func TestStableRegistrySyncedOrdinaryRotationTransfersCreationProof(t *testing.T) {
+	dir := t.TempDir()
+	registry := rootpublication.NewIdentityPinRegistry()
+	writer, err := NewWriterWithStableResourcePinRegistry(filepath.Join(dir, "000001.vlog"), 1, registry)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer writer.Close()
+	before := writer.DurabilityStats().DirectorySyncCalls
+	if err := writer.RotateToWithSync(filepath.Join(dir, "000002.vlog"), 2, true); err != nil {
+		t.Fatal(err)
+	}
+	if writer.creationProof == nil || writer.creationUncertified {
+		t.Fatalf("synced ordinary rotation proof=%v uncertified=%t", writer.creationProof, writer.creationUncertified)
+	}
+	if got := writer.DurabilityStats().DirectorySyncCalls; got != before+1 {
+		t.Fatalf("synced ordinary rotation namespace syncs=%d want %d", got, before+1)
+	}
+	token, err := writer.StableResourceToken(StableResourceRegistration{
+		LogicalLane: "main", Generation: 2, DiagnosticPath: "maindb/value_vlog/000002.vlog",
+		Reachability: rootpublication.ReachabilityValueLogPointer, ParentGeneration: 2,
+		NamespaceOperation: rootpublication.NamespaceCreate,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	token.Release()
+	if got := writer.DurabilityStats().DirectorySyncCalls; got != before+1 {
+		t.Fatalf("capture after synced ordinary rotation resynced namespace: calls=%d", got)
+	}
+}
+
+func TestStableRotationTransfersCreationProofAcrossFourSegments(t *testing.T) {
+	dir := t.TempDir()
+	registry := rootpublication.NewIdentityPinRegistry()
+	writer, err := NewWriterWithStableResourcePinRegistry(filepath.Join(dir, "000001.vlog"), 1, registry)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer writer.Close()
+	baselineFDs, checkFDs := valueLogOpenDescriptorCount(t)
+	for activeID := uint32(2); activeID <= 5; activeID++ {
+		if _, err := writer.Append(0, nil, uint64(activeID), []byte("rotate")); err != nil {
+			t.Fatal(err)
+		}
+		closedID := activeID - 1
+		rotation, err := writer.RotateToWithStableResources(filepath.Join(dir, fmt.Sprintf("%06d.vlog", activeID)), activeID, false,
+			StableResourceRegistration{LogicalLane: "main", Generation: uint64(closedID), DiagnosticPath: fmt.Sprintf("maindb/value_vlog/%06d.vlog", closedID), Reachability: rootpublication.ReachabilityValueLogPointer},
+			StableResourceRegistration{LogicalLane: "main", Generation: uint64(activeID), DiagnosticPath: fmt.Sprintf("maindb/value_vlog/%06d.vlog", activeID), Reachability: rootpublication.ReachabilityValueLogPointer, ParentGeneration: uint64(activeID), NamespaceOperation: rootpublication.NamespaceCreate})
+		if err != nil {
+			t.Fatalf("rotation %d: %v", activeID, err)
+		}
+		if writer.creationProof == nil || writer.creationUncertified {
+			rotation.Release()
+			t.Fatalf("rotation %d did not transfer active creation proof", activeID)
+		}
+		rotation.Release()
+	}
+	if got := writer.DurabilityStats().DirectorySyncCalls; got != 5 {
+		t.Fatalf("initial plus four rotation namespace syncs=%d want 5", got)
+	}
+	if got := registry.ActivePins(); got != 0 {
+		t.Fatalf("released rotations retain %d pins", got)
+	}
+	if got := registry.ActiveIdentities(); got != 1 {
+		t.Fatalf("four rotations retain %d observed identities want 1", got)
+	}
+	if got, ok := valueLogOpenDescriptorCount(t); checkFDs && ok && got > baselineFDs+1 {
+		t.Fatalf("four rotations grew retained descriptors: baseline=%d current=%d", baselineFDs, got)
 	}
 }
 

--- a/TreeDB/internal/valuelog/stable_resource_supported_test.go
+++ b/TreeDB/internal/valuelog/stable_resource_supported_test.go
@@ -10,8 +10,51 @@ import (
 	"testing"
 	"time"
 
+	"github.com/snissn/gomap/TreeDB/internal/durabilitycut"
 	"github.com/snissn/gomap/TreeDB/internal/rootpublication"
 )
+
+func TestCertifyStableCreationNamespaceRetainsProofAfterCompletedSyncCut(t *testing.T) {
+	dir := t.TempDir()
+	registry := rootpublication.NewIdentityPinRegistry()
+	writer, err := NewWriterWithStableResourcePinRegistry(filepath.Join(dir, "000001.vlog"), 1, registry)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer writer.Close()
+	if err := writer.RotateToWithSync(filepath.Join(dir, "000002.vlog"), 2, false); err != nil {
+		t.Fatal(err)
+	}
+	if !writer.creationUncertified || writer.creationProof != nil {
+		t.Fatalf("relaxed rotation state proof=%v uncertified=%t", writer.creationProof, writer.creationUncertified)
+	}
+	before := writer.DurabilityStats().DirectorySyncCalls
+	injected := errors.New("injected after namespace sync")
+	restore := durabilitycut.Install(func(event durabilitycut.Event) error {
+		if event.Resource == durabilitycut.ResourceValueLog && event.Point == durabilitycut.AfterNewFileDirectorySync {
+			return injected
+		}
+		return nil
+	})
+	err = writer.CertifyStableCreationNamespace()
+	restore()
+	if !errors.Is(err, injected) {
+		t.Fatalf("certify error=%v want injected cut", err)
+	}
+	if writer.creationProof == nil || writer.creationUncertified {
+		t.Fatalf("completed sync proof=%v uncertified=%t", writer.creationProof, writer.creationUncertified)
+	}
+	after := writer.DurabilityStats().DirectorySyncCalls
+	if after != before+1 {
+		t.Fatalf("directory syncs before=%d after=%d want +1", before, after)
+	}
+	if err := writer.CertifyStableCreationNamespace(); err != nil {
+		t.Fatalf("certify retry: %v", err)
+	}
+	if got := writer.DurabilityStats().DirectorySyncCalls; got != after {
+		t.Fatalf("certify retry repeated sync: before=%d after=%d", after, got)
+	}
+}
 
 func TestOrdinaryRotationRefreshesStableParentBeforeStableRotation(t *testing.T) {
 	root := t.TempDir()

--- a/TreeDB/internal/valuelog/stable_resource_test.go
+++ b/TreeDB/internal/valuelog/stable_resource_test.go
@@ -327,6 +327,7 @@ func testRotateToWithStableResourcesOwnsRegistryObservations(t *testing.T) {
 	if _, err := writer.Append(0, nil, 1, []byte("first")); err != nil {
 		t.Fatal(err)
 	}
+	beforeDirectorySyncs := writer.DurabilityStats().DirectorySyncCalls
 	rotation, err := writer.RotateToWithStableResources(filepath.Join(dir, "000002.vlog"), 2, true,
 		StableResourceRegistration{
 			LogicalLane: "main", Generation: 1, DiagnosticPath: "maindb/value_vlog/000001.vlog",
@@ -343,6 +344,15 @@ func testRotateToWithStableResourcesOwnsRegistryObservations(t *testing.T) {
 	}
 	if got := registry.ActivePins(); got != 2 {
 		t.Fatalf("rotation active pins=%d want 2", got)
+	}
+	if rotation.Closed.Namespace() == nil || rotation.Closed.Namespace().Operation() != rootpublication.NamespaceCreate {
+		t.Fatal("freshly-created closed segment lost its retained creation proof")
+	}
+	if rotation.Active.Namespace() == nil || rotation.Active.Namespace().Operation() != rootpublication.NamespaceCreate {
+		t.Fatal("freshly-created active segment lost its creation proof")
+	}
+	if got := writer.DurabilityStats().DirectorySyncCalls; got != beforeDirectorySyncs+1 {
+		t.Fatalf("stable rotation directory syncs=%d want %d; binding the closed proof must not resync", got, beforeDirectorySyncs+1)
 	}
 	rotation.Release()
 	if got := registry.ActivePins(); got != 0 {
@@ -600,7 +610,11 @@ func benchmarkStableValueLogRotation(b *testing.B) {
 						}
 						rotation.Release()
 						stats := set.Stats(time.Now())
-						if len(stats) != 1 || stats[0].PendingCount != 2 || stats[0].NamespaceSyncs != 1 {
+						wantNamespaceSyncs := uint64(1)
+						if withRegistry {
+							wantNamespaceSyncs = 2
+						}
+						if len(stats) != 1 || stats[0].PendingCount != 2 || stats[0].NamespaceSyncs != wantNamespaceSyncs {
 							set.Release()
 							b.Fatalf("stable rotation operation counts=%+v", stats)
 						}
@@ -613,8 +627,12 @@ func benchmarkStableValueLogRotation(b *testing.B) {
 					if syncCurrent {
 						wantContentSyncs = uint64(b.N)
 					}
-					if namespaceSyncs != uint64(b.N) || contentSyncs != wantContentSyncs {
-						b.Fatalf("rotation counters namespace=%d content=%d want namespace=%d content=%d", namespaceSyncs, contentSyncs, b.N, wantContentSyncs)
+					wantNamespaceSyncs := uint64(b.N)
+					if withRegistry {
+						wantNamespaceSyncs *= 2
+					}
+					if namespaceSyncs != wantNamespaceSyncs || contentSyncs != wantContentSyncs {
+						b.Fatalf("rotation counters namespace=%d content=%d want namespace=%d content=%d", namespaceSyncs, contentSyncs, wantNamespaceSyncs, wantContentSyncs)
 					}
 					if registry != nil && (registry.ActivePins() != 0 || registry.ActiveIdentities() != 1) {
 						b.Fatalf("rotation registry pins=%d identities=%d, want 0 pins and one active writer", registry.ActivePins(), registry.ActiveIdentities())

--- a/TreeDB/internal/valuelog/stable_resource_test.go
+++ b/TreeDB/internal/valuelog/stable_resource_test.go
@@ -202,6 +202,57 @@ func TestStableValueLogOrdinaryAppendDoesNotSyncNamespace(t *testing.T) {
 	}
 }
 
+func TestStableRegistryRelaxedOrdinaryRotationDoesNotSyncOrClaimCreate(t *testing.T) {
+	dir := t.TempDir()
+	registry := rootpublication.NewIdentityPinRegistry()
+	writer, err := NewWriterWithStableResourcePinRegistry(filepath.Join(dir, "000001.vlog"), 1, registry)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer writer.Close()
+	before := writer.DurabilityStats().DirectorySyncCalls
+	if err := writer.RotateToWithSync(filepath.Join(dir, "000002.vlog"), 2, false); err != nil {
+		t.Fatal(err)
+	}
+	if after := writer.DurabilityStats().DirectorySyncCalls; after != before {
+		t.Fatalf("relaxed ordinary rotation namespace syncs: before=%d after=%d", before, after)
+	}
+	if writer.creationProof != nil || !writer.creationUncertified {
+		t.Fatalf("relaxed successor proof=%v uncertified=%t, want nil/true", writer.creationProof, writer.creationUncertified)
+	}
+	token, err := writer.StableResourceToken(StableResourceRegistration{
+		LogicalLane: "main", Generation: 2, DiagnosticPath: "maindb/value_vlog/000002.vlog",
+		Reachability: rootpublication.ReachabilityValueLogPointer, ParentGeneration: 2,
+		NamespaceOperation: rootpublication.NamespaceCreate,
+	})
+	if token != nil {
+		token.Release()
+		t.Fatal("uncertified relaxed successor returned a create token")
+	}
+	if !errors.Is(err, rootpublication.ErrUnresolvedResource) {
+		t.Fatalf("uncertified relaxed successor error=%v want ErrUnresolvedResource", err)
+	}
+	if after := writer.DurabilityStats().DirectorySyncCalls; after != before {
+		t.Fatalf("failed late certification added namespace syncs: before=%d after=%d", before, after)
+	}
+	rotation, rotateErr := writer.RotateToWithStableResources(filepath.Join(dir, "000003.vlog"), 3, false,
+		StableResourceRegistration{LogicalLane: "main", Generation: 2, DiagnosticPath: "maindb/value_vlog/000002.vlog", Reachability: rootpublication.ReachabilityValueLogPointer},
+		StableResourceRegistration{LogicalLane: "main", Generation: 3, DiagnosticPath: "maindb/value_vlog/000003.vlog", Reachability: rootpublication.ReachabilityValueLogPointer, ParentGeneration: 3, NamespaceOperation: rootpublication.NamespaceCreate})
+	if rotation != nil {
+		rotation.Release()
+		t.Fatal("uncertified relaxed successor entered a stable rotation")
+	}
+	if !errors.Is(rotateErr, rootpublication.ErrUnresolvedResource) {
+		t.Fatalf("uncertified stable rotation error=%v want ErrUnresolvedResource", rotateErr)
+	}
+	if _, statErr := os.Stat(filepath.Join(dir, "000003.vlog")); !errors.Is(statErr, os.ErrNotExist) {
+		t.Fatalf("uncertified stable rotation exposed successor: %v", statErr)
+	}
+	if after := writer.DurabilityStats().DirectorySyncCalls; after != before {
+		t.Fatalf("failed stable rotation added namespace syncs: before=%d after=%d", before, after)
+	}
+}
+
 func testRotateToWithStableResourcesRetainsClosedAndActiveIdentities(t *testing.T) {
 	dir := t.TempDir()
 	firstPath := filepath.Join(dir, "000001.vlog")
@@ -334,11 +385,11 @@ func testStableValueLogRotationNamespaceFailureKeepsOldWriterActive(t *testing.T
 		t.Fatal(err)
 	}
 	injected := errors.New("injected namespace failure")
-	originalFactory := newValueLogStableNamespaceToken
-	newValueLogStableNamespaceToken = func(rootpublication.StableNamespaceSpec) (*rootpublication.StableNamespaceToken, error) {
+	originalFactory := bindValueLogStableNamespaceCreationProof
+	bindValueLogStableNamespaceCreationProof = func(*rootpublication.StableNamespaceCreationProof, *os.File, uint64, string, string) (*rootpublication.StableNamespaceToken, error) {
 		return nil, injected
 	}
-	defer func() { newValueLogStableNamespaceToken = originalFactory }()
+	defer func() { bindValueLogStableNamespaceCreationProof = originalFactory }()
 	rotation, err := writer.RotateToWithStableResources(filepath.Join(dir, "000002.vlog"), 2, true,
 		StableResourceRegistration{
 			LogicalLane: "main", Generation: 1, DiagnosticPath: "maindb/value_vlog/000001.vlog",
@@ -375,8 +426,8 @@ func testStableValueLogRollbackDoesNotUnlinkReplacement(t *testing.T) {
 	}
 	defer writer.Close()
 	injected := errors.New("injected namespace failure after replacement")
-	originalFactory := newValueLogStableNamespaceToken
-	newValueLogStableNamespaceToken = func(rootpublication.StableNamespaceSpec) (*rootpublication.StableNamespaceToken, error) {
+	originalFactory := bindValueLogStableNamespaceCreationProof
+	bindValueLogStableNamespaceCreationProof = func(*rootpublication.StableNamespaceCreationProof, *os.File, uint64, string, string) (*rootpublication.StableNamespaceToken, error) {
 		if err := os.Rename(failedPath, displacedPath); err != nil {
 			t.Fatal(err)
 		}
@@ -385,7 +436,7 @@ func testStableValueLogRollbackDoesNotUnlinkReplacement(t *testing.T) {
 		}
 		return nil, injected
 	}
-	defer func() { newValueLogStableNamespaceToken = originalFactory }()
+	defer func() { bindValueLogStableNamespaceCreationProof = originalFactory }()
 
 	rotation, err := writer.RotateToWithStableResources(failedPath, 2, false,
 		StableResourceRegistration{

--- a/TreeDB/internal/valuelog/stable_resource_test.go
+++ b/TreeDB/internal/valuelog/stable_resource_test.go
@@ -9,8 +9,44 @@ import (
 	"testing"
 	"time"
 
+	"github.com/snissn/gomap/TreeDB/internal/durabilitycut"
 	"github.com/snissn/gomap/TreeDB/internal/rootpublication"
 )
+
+func TestOrdinaryOuterLeafCreationClassifiesFallbackDirectorySync(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "leaf_vlog")
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(dir, "000001.vlog")
+	var outerCreates, valueSyncs, outerBeforeSyncs, outerAfterSyncs int
+	restore := durabilitycut.Install(func(event durabilitycut.Event) error {
+		switch {
+		case event.Namespace == durabilitycut.NamespaceCreate && event.NewPath == path && event.Resource == durabilitycut.ResourceOuterLeaf:
+			outerCreates++
+		case event.Point == durabilitycut.BeforeNewFileDirectorySync && event.Resource == durabilitycut.ResourceOuterLeaf:
+			outerBeforeSyncs++
+		case event.Point == durabilitycut.AfterNewFileDirectorySync && event.Resource == durabilitycut.ResourceOuterLeaf:
+			outerAfterSyncs++
+		case (event.Point == durabilitycut.BeforeNewFileDirectorySync || event.Point == durabilitycut.AfterNewFileDirectorySync) && event.Resource == durabilitycut.ResourceValueLog:
+			valueSyncs++
+		}
+		return nil
+	})
+	defer restore()
+
+	writer, err := NewWriter(path, 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := writer.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if outerCreates != 1 || outerBeforeSyncs != 1 || outerAfterSyncs != 1 || valueSyncs != 0 {
+		t.Fatalf("ordinary outer-leaf creation cuts create=%d directory(before/after)=%d/%d value-sync=%d want 1, 1/1, 0",
+			outerCreates, outerBeforeSyncs, outerAfterSyncs, valueSyncs)
+	}
+}
 
 func testStableValueLogRenameUsesCallerCapturedParent(t *testing.T) {
 	root := t.TempDir()

--- a/TreeDB/internal/valuelog/stable_resource_test.go
+++ b/TreeDB/internal/valuelog/stable_resource_test.go
@@ -568,6 +568,7 @@ func benchmarkStableValueLogRotation(b *testing.B) {
 					}
 					b.Cleanup(func() { _ = writer.Close() })
 					beforeContentSyncs := writer.DurabilityStats().FileSyncCalls
+					beforeDirectorySyncs := writer.DurabilityStats().DirectorySyncCalls
 					var namespaceSyncs uint64
 					b.ReportAllocs()
 					b.ResetTimer()
@@ -610,9 +611,14 @@ func benchmarkStableValueLogRotation(b *testing.B) {
 						}
 						rotation.Release()
 						stats := set.Stats(time.Now())
-						wantNamespaceSyncs := uint64(1)
-						if withRegistry {
-							wantNamespaceSyncs = 2
+						// A writer opened without stable capture has no creation witness for
+						// its initial segment. Every later closed segment was created by the
+						// preceding stable rotation, so it retains that witness alongside the
+						// newly active segment. Registry-backed construction captures the
+						// initial segment as well.
+						wantNamespaceSyncs := uint64(2)
+						if !withRegistry && i == 0 {
+							wantNamespaceSyncs = 1
 						}
 						if len(stats) != 1 || stats[0].PendingCount != 2 || stats[0].NamespaceSyncs != wantNamespaceSyncs {
 							set.Release()
@@ -623,21 +629,23 @@ func benchmarkStableValueLogRotation(b *testing.B) {
 						b.StartTimer()
 					}
 					contentSyncs := writer.DurabilityStats().FileSyncCalls - beforeContentSyncs
+					physicalNamespaceSyncs := writer.DurabilityStats().DirectorySyncCalls - beforeDirectorySyncs
 					wantContentSyncs := uint64(0)
 					if syncCurrent {
 						wantContentSyncs = uint64(b.N)
 					}
-					wantNamespaceSyncs := uint64(b.N)
-					if withRegistry {
-						wantNamespaceSyncs *= 2
+					wantNamespaceSyncs := uint64(2 * b.N)
+					if !withRegistry {
+						wantNamespaceSyncs--
 					}
-					if namespaceSyncs != wantNamespaceSyncs || contentSyncs != wantContentSyncs {
-						b.Fatalf("rotation counters namespace=%d content=%d want namespace=%d content=%d", namespaceSyncs, contentSyncs, wantNamespaceSyncs, wantContentSyncs)
+					if namespaceSyncs != wantNamespaceSyncs || physicalNamespaceSyncs != uint64(b.N) || contentSyncs != wantContentSyncs {
+						b.Fatalf("rotation counters witnesses=%d physical_namespace=%d content=%d want witnesses=%d physical_namespace=%d content=%d", namespaceSyncs, physicalNamespaceSyncs, contentSyncs, wantNamespaceSyncs, b.N, wantContentSyncs)
 					}
 					if registry != nil && (registry.ActivePins() != 0 || registry.ActiveIdentities() != 1) {
 						b.Fatalf("rotation registry pins=%d identities=%d, want 0 pins and one active writer", registry.ActivePins(), registry.ActiveIdentities())
 					}
 					b.ReportMetric(float64(namespaceSyncs)/float64(b.N), "stable-token-namespace-sync/op")
+					b.ReportMetric(float64(physicalNamespaceSyncs)/float64(b.N), "producer-namespace-sync/op")
 					b.ReportMetric(float64(contentSyncs)/float64(b.N), "producer-content-sync/op")
 				})
 			}

--- a/TreeDB/internal/valuelog/stable_resource_windows_test.go
+++ b/TreeDB/internal/valuelog/stable_resource_windows_test.go
@@ -124,7 +124,8 @@ func TestUnsupportedStableRotationDoesNotLeakRegistryOwnership(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	rotation, err := writer.RotateToWithStableResources(filepath.Join(dir, "000002.vlog"), 2, false,
+	secondPath := filepath.Join(dir, "000002.vlog")
+	rotation, err := writer.RotateToWithStableResources(secondPath, 2, false,
 		StableResourceRegistration{
 			LogicalLane: "main", Generation: 1, DiagnosticPath: "maindb/value_vlog/000001.vlog",
 			Reachability: rootpublication.ReachabilityValueLogPointer,
@@ -146,6 +147,12 @@ func TestUnsupportedStableRotationDoesNotLeakRegistryOwnership(t *testing.T) {
 	}
 	if got := registry.ActiveIdentities(); got != 1 {
 		t.Fatalf("unsupported rotation identities=%d want active writer only", got)
+	}
+	if _, statErr := os.Stat(secondPath); !errors.Is(statErr, os.ErrNotExist) {
+		t.Fatalf("unsupported rotation exposed successor: %v", statErr)
+	}
+	if _, appendErr := writer.Append(0, nil, 1, []byte("writer-remains-usable")); appendErr != nil {
+		t.Fatalf("append after unsupported stable rotation: %v", appendErr)
 	}
 	if err := writer.Close(); err != nil {
 		t.Fatal(err)

--- a/TreeDB/internal/valuelog/stable_resource_windows_test.go
+++ b/TreeDB/internal/valuelog/stable_resource_windows_test.go
@@ -58,6 +58,26 @@ func TestStableValueLogRotationFailsClosedWithoutSuccessorVisibility(t *testing.
 	}
 }
 
+func TestStableValueLogCurrentCreationUsesRetainedParentAndFailsTyped(t *testing.T) {
+	writer, err := NewWriterWithStableResourcePinRegistry(filepath.Join(t.TempDir(), "000001.vlog"), 1, rootpublication.NewIdentityPinRegistry())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer writer.Close()
+	token, err := writer.StableResourceToken(StableResourceRegistration{
+		LogicalLane: "outer-leaf", Generation: 1, DiagnosticPath: "leaf_vlog/000001.vlog",
+		Reachability: rootpublication.ReachabilityOuterLeafRawPointer, ParentGeneration: 1,
+		NamespaceOperation: rootpublication.NamespaceCreate,
+	})
+	if token != nil {
+		token.Release()
+		t.Fatal("unsupported current-segment capture returned a token")
+	}
+	if !errors.Is(err, rootpublication.ErrNamespacePersistenceUnsupported) {
+		t.Fatalf("current-segment capture error=%v want ErrNamespacePersistenceUnsupported", err)
+	}
+}
+
 func TestOrdinaryValueLogRotationRemainsUsableAndStableRotationFailsClosed(t *testing.T) {
 	dir := t.TempDir()
 	secondPath := filepath.Join(dir, "000002.vlog")

--- a/TreeDB/internal/valuelog/writer.go
+++ b/TreeDB/internal/valuelog/writer.go
@@ -44,7 +44,7 @@ const (
 var syncDirFn = syncDir
 var writerAppendBufPool = make(chan []byte, writerAppendBufPoolEntries)
 
-func openLogFile(path string) (*os.File, error) {
+func openLogFile(path string) (*os.File, bool, error) {
 	// Stable-resource publication retains this exact descriptor for both
 	// durability operations and recovery validation. Keep writer descriptors
 	// read-capable so a duplicated pin can serve ReadAt without reopening by
@@ -52,16 +52,17 @@ func openLogFile(path string) (*os.File, error) {
 	const flags = os.O_RDWR | os.O_APPEND
 	created, err := os.OpenFile(path, flags|os.O_CREATE|os.O_EXCL, 0o600)
 	if err == nil {
-		if observeErr := durabilitycut.EmitNamespace(durabilitycut.NamespaceCreate, durabilitycut.ResourceValueLog, filepath.Dir(path), "", path); observeErr != nil {
+		if observeErr := durabilitycut.EmitNamespace(durabilitycut.NamespaceCreate, segmentNamespaceResource(path), filepath.Dir(path), "", path); observeErr != nil {
 			_ = created.Close()
-			return nil, observeErr
+			return nil, false, observeErr
 		}
-		return created, nil
+		return created, true, nil
 	}
 	if !errors.Is(err, os.ErrExist) {
-		return nil, err
+		return nil, false, err
 	}
-	return os.OpenFile(path, flags|os.O_CREATE, 0o600)
+	f, err := os.OpenFile(path, flags|os.O_CREATE, 0o600)
+	return f, false, err
 }
 
 func syncNewFileDirectory(w *Writer, path string) error {
@@ -87,6 +88,9 @@ type Writer struct {
 	f                      *os.File
 	stableParent           *os.File
 	stableParentErr        error
+	creationProof          *rootpublication.StableNamespaceCreationProof
+	creationUnsupported    bool
+	creationUncertified    bool
 	pendingStableSuccessor *pendingValueLogSuccessor
 	stableResourcePins     *rootpublication.IdentityPinRegistry
 	stableResourceIdentity rootpublication.StableIdentity
@@ -656,7 +660,7 @@ func NewStagingWriter(path string, fileID uint32) (*Writer, error) {
 }
 
 func newFileWriter(path string, fileID uint32, syncDirectory bool, syncFn func(*os.File) error, registry *rootpublication.IdentityPinRegistry) (*Writer, error) {
-	f, err := openLogFile(path)
+	f, created, err := openLogFile(path)
 	if err != nil {
 		return nil, err
 	}
@@ -665,22 +669,39 @@ func newFileWriter(path string, fileID uint32, syncDirectory bool, syncFn func(*
 		syncFn: syncFn,
 	}
 	w.stableParent, w.stableParentErr = captureStableValueLogParent(path, f)
-	if syncDirectory {
-		if err := syncNewFileDirectory(w, path); err != nil {
-			_ = f.Close()
-			if w.stableParent != nil {
-				_ = w.stableParent.Close()
-			}
-			return nil, err
+	if err := w.observeStableResourceFile(f, registry); err != nil {
+		_ = f.Close()
+		if w.stableParent != nil {
+			_ = w.stableParent.Close()
+			w.stableParent = nil
 		}
+		return nil, err
 	}
+	proof, unsupported, uncertified, proofErr := w.prepareStableCreationProof(w.stableParent, f, path, created, syncDirectory, registry != nil)
+	if proofErr != nil {
+		if proof != nil {
+			proof.Release()
+		}
+		_ = f.Close()
+		if w.stableParent != nil {
+			_ = w.stableParent.Close()
+		}
+		return nil, errors.Join(proofErr, w.releaseStableResourceObservation())
+	}
+	w.creationProof = proof
+	w.creationUnsupported = unsupported
+	w.creationUncertified = uncertified
 	info, err := f.Stat()
 	if err != nil {
 		_ = f.Close()
 		if w.stableParent != nil {
 			_ = w.stableParent.Close()
 		}
-		return nil, err
+		if w.creationProof != nil {
+			w.creationProof.Release()
+			w.creationProof = nil
+		}
+		return nil, errors.Join(err, w.releaseStableResourceObservation())
 	}
 	w.f = f
 	// File-backed writers use direct writes and append buffers; bufio is only
@@ -696,14 +717,6 @@ func newFileWriter(path string, fileID uint32, syncDirectory bool, syncFn func(*
 	w.blockCodec = BlockCodecSnappy
 	w.clock = RealClock{}
 	w.keepSafetyMargin = DefaultKeepSafetyMargin
-	if err := w.observeStableResourceFile(f, registry); err != nil {
-		_ = f.Close()
-		if w.stableParent != nil {
-			_ = w.stableParent.Close()
-			w.stableParent = nil
-		}
-		return nil, err
-	}
 	return w, nil
 }
 
@@ -996,33 +1009,57 @@ func (w *Writer) RotateToWithSync(path string, fileID uint32, syncCurrent bool) 
 				return err
 			}
 		}
-		f, err := openLogFile(path)
+		f, created, err := openLogFile(path)
 		if err != nil {
 			return err
 		}
-		if syncCurrent {
-			if err := syncNewFileDirectory(w, path); err != nil {
-				_ = f.Close()
-				return err
-			}
-		}
-		info, err := f.Stat()
-		if err != nil {
-			_ = f.Close()
-			return err
-		}
+		stableParent, stableParentErr := captureStableValueLogParent(path, f)
 		newIdentity, err := observeStableWriterFile(f, w.stableResourcePins)
 		if err != nil {
 			_ = f.Close()
+			if stableParent != nil {
+				_ = stableParent.Close()
+			}
 			return err
 		}
 		newObserved := w.stableResourcePins != nil
-		stableParent, stableParentErr := captureStableValueLogParent(path, f)
+		newCreationProof, newCreationUnsupported, newCreationUncertified, err := w.prepareStableCreationProof(stableParent, f, path, created, syncCurrent, w.stableResourcePins != nil)
+		if err != nil {
+			if newObserved {
+				_ = w.stableResourcePins.Unobserve(newIdentity)
+			}
+			if newCreationProof != nil {
+				newCreationProof.Release()
+			}
+			_ = f.Close()
+			if stableParent != nil {
+				_ = stableParent.Close()
+			}
+			return err
+		}
+		info, err := f.Stat()
+		if err != nil {
+			if newObserved {
+				_ = w.stableResourcePins.Unobserve(newIdentity)
+			}
+			if newCreationProof != nil {
+				newCreationProof.Release()
+			}
+			_ = f.Close()
+			if stableParent != nil {
+				_ = stableParent.Close()
+			}
+			return err
+		}
 		oldStableParent := w.stableParent
+		oldCreationProof := w.creationProof
 		oldObserveErr := w.releaseStableResourceObservation()
 		w.f = f
 		w.stableParent = stableParent
 		w.stableParentErr = stableParentErr
+		w.creationProof = newCreationProof
+		w.creationUnsupported = newCreationUnsupported
+		w.creationUncertified = newCreationUncertified
 		// File-backed writers do not use bufio; drop any sink buffer.
 		w.bw = nil
 		w.size = info.Size()
@@ -1033,6 +1070,9 @@ func (w *Writer) RotateToWithSync(path string, fileID uint32, syncCurrent bool) 
 		if newObserved {
 			w.stableResourceIdentity = newIdentity
 			w.stableResourceObserved = true
+		}
+		if oldCreationProof != nil {
+			oldCreationProof.Release()
 		}
 		if oldStableParent != nil {
 			if err := w.closeRotatedResource(oldStableParent); err != nil {
@@ -1054,39 +1094,72 @@ func (w *Writer) RotateToWithSync(path string, fileID uint32, syncCurrent bool) 
 		}
 	}
 
-	f, err := openLogFile(path)
+	f, created, err := openLogFile(path)
 	if err != nil {
+		return err
+	}
+	stableParent, stableParentErr := captureStableValueLogParent(path, f)
+	newIdentity, err := observeStableWriterFile(f, w.stableResourcePins)
+	if err != nil {
+		_ = f.Close()
+		if stableParent != nil {
+			_ = stableParent.Close()
+		}
+		return err
+	}
+	newObserved := w.stableResourcePins != nil
+	newCreationProof, newCreationUnsupported, newCreationUncertified, err := w.prepareStableCreationProof(stableParent, f, path, created, syncCurrent, w.stableResourcePins != nil)
+	if err != nil {
+		if newObserved {
+			_ = w.stableResourcePins.Unobserve(newIdentity)
+		}
+		if newCreationProof != nil {
+			newCreationProof.Release()
+		}
+		_ = f.Close()
+		if stableParent != nil {
+			_ = stableParent.Close()
+		}
 		return err
 	}
 	info, err := f.Stat()
 	if err != nil {
-		_ = f.Close()
-		return err
-	}
-	if syncCurrent {
-		if err := syncNewFileDirectory(w, path); err != nil {
-			_ = f.Close()
-			return err
+		if newObserved {
+			_ = w.stableResourcePins.Unobserve(newIdentity)
 		}
-	}
-	newIdentity, err := observeStableWriterFile(f, w.stableResourcePins)
-	if err != nil {
+		if newCreationProof != nil {
+			newCreationProof.Release()
+		}
 		_ = f.Close()
+		if stableParent != nil {
+			_ = stableParent.Close()
+		}
 		return err
 	}
-	newObserved := w.stableResourcePins != nil
 	old := w.f
 	oldStableParent := w.stableParent
+	oldCreationProof := w.creationProof
 	if w.bw != nil {
 		if err := w.bw.Flush(); err != nil {
+			if newObserved {
+				_ = w.stableResourcePins.Unobserve(newIdentity)
+			}
+			if newCreationProof != nil {
+				newCreationProof.Release()
+			}
 			_ = f.Close()
+			if stableParent != nil {
+				_ = stableParent.Close()
+			}
 			return err
 		}
 	}
-	stableParent, stableParentErr := captureStableValueLogParent(path, f)
 	w.f = f
 	w.stableParent = stableParent
 	w.stableParentErr = stableParentErr
+	w.creationProof = newCreationProof
+	w.creationUnsupported = newCreationUnsupported
+	w.creationUncertified = newCreationUncertified
 	// File-backed writers do not use bufio. Drop any leftover sink buffer
 	// rather than retargeting it across rotations.
 	w.bw = nil
@@ -1102,6 +1175,9 @@ func (w *Writer) RotateToWithSync(path string, fileID uint32, syncCurrent bool) 
 	var closeParentErr error
 	if oldStableParent != nil {
 		closeParentErr = w.closeRotatedResource(oldStableParent)
+	}
+	if oldCreationProof != nil {
+		oldCreationProof.Release()
 	}
 	w.trimTransientScratchBuffers()
 	if err := errors.Join(closeErr, closeParentErr, observeErr); err != nil {
@@ -2604,6 +2680,10 @@ func (w *Writer) Close() (retErr error) {
 		closeErrs = append(closeErrs, err)
 	}
 	if pending := w.pendingStableSuccessor; pending != nil {
+		if pending.creationProof != nil {
+			pending.creationProof.Release()
+			pending.creationProof = nil
+		}
 		if pending.file != nil {
 			closeErrs = append(closeErrs, pending.file.Close())
 			pending.file = nil
@@ -2621,6 +2701,10 @@ func (w *Writer) Close() (retErr error) {
 	if w.stableParent != nil {
 		closeErrs = append(closeErrs, w.stableParent.Close())
 		w.stableParent = nil
+	}
+	if w.creationProof != nil {
+		w.creationProof.Release()
+		w.creationProof = nil
 	}
 	return errors.Join(closeErrs...)
 }

--- a/TreeDB/internal/valuelog/writer.go
+++ b/TreeDB/internal/valuelog/writer.go
@@ -67,13 +67,14 @@ func openLogFile(path string) (*os.File, bool, error) {
 
 func syncNewFileDirectory(w *Writer, path string) error {
 	dir := filepath.Dir(path)
-	if err := durabilitycut.EmitPath(durabilitycut.BeforeNewFileDirectorySync, durabilitycut.ResourceValueLog, "", dir); err != nil {
+	resource := segmentNamespaceResource(path)
+	if err := durabilitycut.EmitPath(durabilitycut.BeforeNewFileDirectorySync, resource, "", dir); err != nil {
 		return err
 	}
 	if err := w.syncDirectory(path); err != nil {
 		return err
 	}
-	return durabilitycut.EmitPath(durabilitycut.AfterNewFileDirectorySync, durabilitycut.ResourceValueLog, "", dir)
+	return durabilitycut.EmitPath(durabilitycut.AfterNewFileDirectorySync, resource, "", dir)
 }
 
 func recordSizeExceedsMax(valueLen uint32) bool {


### PR DESCRIPTION
## Summary

Part of #3677.

This bounded merge unit makes raw outer-leaf append APIs return exact identity-pinned durability authority for every segment referenced by their pointers.

- retains exact creation evidence across initial open, ordinary/stable rotation, retry, and shutdown;
- derives namespace epochs from retained parent-directory identity;
- certifies relaxed ordinary-rotation successors before stable append mutation without repeating a completed physical namespace sync;
- captures exact closed and active raw outer-leaf segments under the lane/writer mutex for single, batch, prepared, and child-ref APIs;
- extends the same contract to standalone/CompactStorage default and cloned lanes;
- filters authority to exactly the generations referenced by returned pointers;
- uses the DB-scoped identity registry so GC/rewrite deletion fails while authority is live;
- validates exact kind, reachability, generation, frontier, and builder ownership at every DB seam and releases malformed authority;
- preserves direct ordinary hot paths and allocation contracts;
- rejects non-create stable-rotation registrations before flush, sync, pin acquisition, or successor creation;
- classifies stable and ordinary fallback `leaf_vlog` creation/directory-sync cuts consistently as outer-leaf durability events.

Returned `StableResourceSet`s are builder-owned and unclaimed. Root-candidate consumption belongs to #3679. Packed promotion and the remaining #3677 inventory are follow-on units, so this PR does not complete #3677.

## Correctness evidence

- rename/recreate at one path remains bound to the original descriptor;
- a 518-page prepared batch spans 65 segments and authority exactly matches the returned file-ID set;
- fresh segments retain exact creation witnesses while an existing open cannot fabricate one;
- standalone capture spans rotations, survives lane cloning, and fences shared-registry deletion;
- malformed providers are rejected across every stable append sibling, including partial/extra generations and short frontiers;
- an after-sync failure retains completed creation proof and retry performs no second physical namespace sync;
- concurrent ordinary append cannot cross the stable capture boundary or contaminate the returned set;
- 100 capture/release iterations return to zero pins without identity, descriptor, directory-sync, or FD growth;
- unsupported platforms fail with the typed namespace-persistence error before returning authority;
- `NamespaceRename` passed to the create-only stable rotation API fails with `ErrNamespaceUnstable`, creates no successor, performs no durability work, changes no registry state, and leaves the old writer usable;
- stable rotation emits one outer-leaf create plus one matching before/after outer-leaf directory-sync pair and no value-log create;
- ordinary/unsupported fallback creation emits one outer-leaf create plus one matching before/after outer-leaf directory-sync pair and no value-log sync cuts.

## Validation

Exact head: `8d29b6512d3a5e4acba2d55023b24347ab3f4b54`

```text
GOWORK=off go test ./TreeDB/internal/rootpublication ./TreeDB/internal/valuelog ./TreeDB/db ./TreeDB/caching -count=1
GOWORK=off go test -race ./TreeDB/internal/rootpublication ./TreeDB/internal/valuelog ./TreeDB/db ./TreeDB/caching -run 'Test.*(ProducerRotation|StableCreationNamespace|StableValueLogClosedCreationProof|LeafPageLogStable|LeafPageStableWrapper|CachingLeafPageLogStable|StandaloneLeafPageStable)' -count=1
GOWORK=off go vet ./TreeDB/internal/rootpublication ./TreeDB/internal/valuelog ./TreeDB/db ./TreeDB/caching
GOOS=windows GOARCH=amd64 GOWORK=off go test -c <each affected package>
git diff --check origin/main...HEAD
```

The reconciled four-package suite passed before the final narrow review fixes (root publication 27.939s, value log 5.770s, DB 347.062s, caching 84.800s), together with focused race, four-package vet, and Windows/amd64 compilation. Production-complete head `992275687` passes:

- `go test ./TreeDB/internal/valuelog -count=1`;
- the ordinary fallback, stable create classification, retained-witness retry, and pre-mutation rename regressions at `-count=20`;
- the same focused set under `-race -count=10`;
- `go vet ./TreeDB/internal/valuelog`;
- Windows/amd64 `go test -c`;
- the stable-rotation benchmark matrix;
- exact paired ordinary-path benchmarks and diff hygiene.

The final two commits are test-only. After two hosted Windows reproductions showed
that the async directory-sync worker can report a zero operation duration while
the receiver reports a non-zero wait, exact final head `8d29b6512` removes the
invalid cross-thread timing bound and retains the meaningful additive
publish-hold assertion. It passes the focused accounting test 100x, the same
test under race 20x, Windows/amd64 DB compile-only, and diff hygiene locally.

Hosted exact-head CI passed all 28 checks across Linux, macOS, Windows, race,
formatting, benchmark, and guardrail workflows. The initial `windows-core-2`
attempt had one unrelated nativewire setup timeout after a shared 10-second
context expired; base/main and the production-identical PR head had passed that
same test in 15.28s, 15.43s, and 15.30s. The targeted exact-head retry passed.
Hosted Codex and CodeRabbit reviews are clean on `8d29b6512`.

Review-driven fixes include typed unsupported-platform error precedence, post-admission cache bookkeeping, retained closed-segment creation witnesses, exact provider validation/release, pre-mutation certification, after-sync retry retention, direct ordinary child-ref performance restoration, physical-sync versus retained-witness accounting, exact create-only stable-rotation validation, and path-consistent outer-leaf creation and directory-sync cut classification.

## Performance

Host: Intel i5-11400F, Linux amd64. Exact base `692e50b2f`; exact head `992275687`. Separately built binaries used identical `GOMAXPROCS=1`, `-test.cpu=1`, `-test.benchtime=5000x`, and `-test.count=10` invocations.

| Ordinary shape | Base | Head | Result | B/op | allocs/op |
| --- | ---: | ---: | --- | ---: | ---: |
| prepared single | 1.290 us | 1.307 us | unchanged, p=0.079 | 0 -> 0 | 0 -> 0 |
| prepared 128-page batch | 17.75 us | 17.67 us | unchanged, p=0.353 | 3.00 KiB -> 3.00 KiB | 1 -> 1 |
| prepared 128 child refs | 16.84 us | 16.71 us | -0.77%, p=0.023 | 0 -> 0 | 0 -> 0 |

Geomean is `+0.01%`. The exact-head in-memory stable four-page batch at `2000x`, 10 samples reports ordinary 8.850 us, 197 B, 1 allocation versus stable 22.00 us, 4009 B, 41 allocations. Stable authority therefore adds about 3812 B and 40 allocations per batch; that explicit API is outside ordinary append paths.

Repeated exact-head stable rotation at `200x`, 10 samples reports exactly one physical producer namespace sync per created successor in all modes, zero or one content sync according to `sync_current`, and retained stable-token witness accounting of 2.000/op with the registry (1.995 without, reflecting the initial segment over 200 rotations). Hard gates pass: no ordinary latency, byte, or allocation regression; no second physical sync for a retained witness; zero per-record or steady-append namespace syncs; and no monotonic pin, identity, descriptor, memory, or FD growth.

## Scope boundary

This unit does not activate root publication, consume command-WAL prefix debt, promote packed generations, or cover remaining column/vector/text/dictionary/template producers. Those remain ordered behind #3677.
