### PR TITLE
TreeDB: pool retained semantic-stream encoders

### DIFF
--- a/TreeDB/collections/column_retained_semantic_stream.go
+++ b/TreeDB/collections/column_retained_semantic_stream.go
@@ -47,6 +47,80 @@ var (
 
 var columnRetainedSemanticStreamV1RawBlockScratchPool = make(chan []byte, columnRetainedSemanticStreamV1RawBlockScratchPoolSlots)
 
+// The pool retains at most one encoder per preparation worker. Each idle
+// encoder retains at most columnRetainedSemanticStreamV1RawBlockScratchMaxRetainedBytes
+// of raw scratch, so the total retained scratch is bounded by the worker cap.
+var columnRetainedSemanticStreamV1StoredBlockEncoderPool = newColumnRetainedSemanticStreamV1EncoderPool(
+	columnRetainedSemanticStreamV1PrepareMaxWorkers,
+	newColumnRetainedSemanticStreamV1StoredBlockEncoder,
+	func(encoder *columnRetainedSemanticStreamV1StoredBlockEncoder) { encoder.close() },
+)
+
+type columnRetainedSemanticStreamV1EncoderPool[T any] struct {
+	slots chan struct{}
+
+	mu    sync.Mutex
+	idle  []T
+	new   func() (T, error)
+	close func(T)
+}
+
+func newColumnRetainedSemanticStreamV1EncoderPool[T any](max int, newEncoder func() (T, error), closeEncoder func(T)) *columnRetainedSemanticStreamV1EncoderPool[T] {
+	return &columnRetainedSemanticStreamV1EncoderPool[T]{
+		slots: make(chan struct{}, max),
+		idle:  make([]T, 0, max),
+		new:   newEncoder,
+		close: closeEncoder,
+	}
+}
+
+func (p *columnRetainedSemanticStreamV1EncoderPool[T]) borrow() (T, time.Duration, error) {
+	p.slots <- struct{}{}
+	p.mu.Lock()
+	if n := len(p.idle); n > 0 {
+		encoder := p.idle[n-1]
+		p.idle = p.idle[:n-1]
+		p.mu.Unlock()
+		return encoder, 0, nil
+	}
+	p.mu.Unlock()
+	setupStart := time.Now()
+	encoder, err := p.new()
+	if err != nil {
+		<-p.slots
+		var zero T
+		return zero, 0, err
+	}
+	return encoder, time.Since(setupStart), nil
+}
+
+func (p *columnRetainedSemanticStreamV1EncoderPool[T]) release(encoder T, reusable bool) {
+	if reusable {
+		p.mu.Lock()
+		p.idle = append(p.idle, encoder)
+		p.mu.Unlock()
+	} else {
+		p.close(encoder)
+	}
+	<-p.slots
+}
+
+func (p *columnRetainedSemanticStreamV1EncoderPool[T]) idleCount() int {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return len(p.idle)
+}
+
+func (p *columnRetainedSemanticStreamV1EncoderPool[T]) closeIdle() {
+	p.mu.Lock()
+	idle := p.idle
+	p.idle = nil
+	p.mu.Unlock()
+	for _, encoder := range idle {
+		p.close(encoder)
+	}
+}
+
 type columnRetainedSemanticStreamPath struct {
 	segments                []string
 	rows                    []uint64
@@ -623,6 +697,32 @@ func prepareColumnRetainedSemanticStreamV1StorageBlockWithIDs(
 	declaredPathTrie *columnRetainedSemanticStreamV1DeclaredPathTrie,
 	useSemanticParserDeclaredRows bool,
 ) (columnRetainedSemanticStreamV1PreparedBlock, error) {
+	storedBlockEncoder, encoderSetup, err := columnRetainedSemanticStreamV1StoredBlockEncoderPool.borrow()
+	if err != nil {
+		return columnRetainedSemanticStreamV1PreparedBlock{}, err
+	}
+	reusable := false
+	defer func() { columnRetainedSemanticStreamV1StoredBlockEncoderPool.release(storedBlockEncoder, reusable) }()
+	prepared, err := prepareColumnRetainedSemanticStreamV1StorageBlockWithEncoderAndIDs(cfg, ids, documents, start, end, rootPlan, useRootFastPath, retainedSkipTrie, declaredPathTrie, useSemanticParserDeclaredRows, storedBlockEncoder, encoderSetup)
+	if err != nil {
+		return columnRetainedSemanticStreamV1PreparedBlock{}, err
+	}
+	reusable = true
+	return prepared, nil
+}
+
+func prepareColumnRetainedSemanticStreamV1StorageBlockWithEncoderAndIDs(
+	cfg ColumnStoreConfig,
+	ids, documents [][]byte,
+	start, end int,
+	rootPlan columnRetainedSemanticStreamV1RootFastPathPlan,
+	useRootFastPath bool,
+	retainedSkipTrie *columnRetainedSemanticStreamV1RetainedSkipTrie,
+	declaredPathTrie *columnRetainedSemanticStreamV1DeclaredPathTrie,
+	useSemanticParserDeclaredRows bool,
+	storedBlockEncoder *columnRetainedSemanticStreamV1StoredBlockEncoder,
+	encoderSetup time.Duration,
+) (columnRetainedSemanticStreamV1PreparedBlock, error) {
 	rows := end - start
 	var metrics columnRetainedSemanticStreamV1PrepareMetrics
 	streams := newColumnRetainedSemanticStreamStreams()
@@ -678,13 +778,7 @@ func prepareColumnRetainedSemanticStreamV1StorageBlockWithIDs(
 		}
 	}
 	metrics.BlockCollect = time.Since(collectStart)
-	encoderStart := time.Now()
-	storedBlockEncoder, err := newColumnRetainedSemanticStreamV1StoredBlockEncoder()
-	if err != nil {
-		return columnRetainedSemanticStreamV1PreparedBlock{}, err
-	}
-	metrics.BlockEncoderSetup = time.Since(encoderStart)
-	defer storedBlockEncoder.close()
+	metrics.BlockEncoderSetup = encoderSetup
 	block, rawEncode, storedEncode, err := encodeColumnRetainedSemanticStreamV1BlockFromStreamsWithEncoderMeasured(rows, streams, storedBlockEncoder)
 	if err != nil {
 		return columnRetainedSemanticStreamV1PreparedBlock{}, err

--- a/TreeDB/collections/column_retained_vlog_placement_test.go
+++ b/TreeDB/collections/column_retained_vlog_placement_test.go
@@ -11,6 +11,8 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
+	"sync/atomic"
 	"testing"
 
 	backenddb "github.com/snissn/gomap/TreeDB/db"
@@ -477,6 +479,227 @@ func TestColumnRetainedPayloadSemanticStreamV1StoredBlockEncoderReuse(t *testing
 		if !bytes.Equal(decoded, raw) {
 			t.Fatalf("decoded reused block %s differs from raw block", name)
 		}
+	}
+}
+
+func TestColumnRetainedSemanticStreamV1StoredBlockEncoderPoolLifecycle(t *testing.T) {
+	type pooledState struct {
+		inUse   atomic.Bool
+		scratch []byte
+	}
+
+	newPool := func() (*columnRetainedSemanticStreamV1EncoderPool[*pooledState], *atomic.Int32, *atomic.Int32) {
+		var constructed atomic.Int32
+		var closed atomic.Int32
+		return newColumnRetainedSemanticStreamV1EncoderPool(
+			columnRetainedSemanticStreamV1PrepareMaxWorkers,
+			func() (*pooledState, error) {
+				constructed.Add(1)
+				return &pooledState{scratch: make([]byte, 16)}, nil
+			},
+			func(*pooledState) { closed.Add(1) },
+		), &constructed, &closed
+	}
+
+	runCanonicalPreparation := func(pool *columnRetainedSemanticStreamV1EncoderPool[*pooledState], failBlock int) error {
+		var started sync.WaitGroup
+		started.Add(4)
+		return columnRetainedSemanticStreamV1RunPrepareWorkers(4, 4, func(blockIdx int) (err error) {
+			state, _, err := pool.borrow()
+			if err != nil {
+				return err
+			}
+			if !state.inUse.CompareAndSwap(false, true) {
+				pool.release(state, false)
+				return errors.New("pooled encoder shared concurrently")
+			}
+			defer func() {
+				state.inUse.Store(false)
+				pool.release(state, err == nil)
+			}()
+			started.Done()
+			started.Wait()
+			if blockIdx == failBlock {
+				return errors.New("injected block error")
+			}
+			return nil
+		})
+	}
+
+	t.Run("sequential canonical preparations reuse four encoders", func(t *testing.T) {
+		pool, constructed, closed := newPool()
+		if err := runCanonicalPreparation(pool, -1); err != nil {
+			t.Fatalf("first canonical preparation: %v", err)
+		}
+		if err := runCanonicalPreparation(pool, -1); err != nil {
+			t.Fatalf("second canonical preparation: %v", err)
+		}
+		if got := constructed.Load(); got != 4 {
+			t.Fatalf("constructed encoders=%d want four reused across two four-block preparations, not eight", got)
+		}
+		if got := pool.idleCount(); got != 4 {
+			t.Fatalf("idle pool occupancy=%d want 4", got)
+		}
+		if got := closed.Load(); got != 0 {
+			t.Fatalf("closed encoders=%d want 0 after successful returns", got)
+		}
+		if got := pool.idleCount() * 16; got != 4*16 {
+			t.Fatalf("idle scratch capacity=%d want bounded 64", got)
+		}
+	})
+
+	t.Run("error discards and replaces encoder", func(t *testing.T) {
+		pool, constructed, closed := newPool()
+		err := runCanonicalPreparation(pool, 0)
+		if err == nil || !strings.Contains(err.Error(), "injected block error") {
+			t.Fatalf("canonical preparation error=%v want injected block error", err)
+		}
+		if got := pool.idleCount(); got != 3 {
+			t.Fatalf("idle pool occupancy after error=%d want 3", got)
+		}
+		if got := closed.Load(); got != 1 {
+			t.Fatalf("closed encoders after error=%d want 1 discarded encoder", got)
+		}
+		if err := runCanonicalPreparation(pool, -1); err != nil {
+			t.Fatalf("replacement canonical preparation: %v", err)
+		}
+		if got := constructed.Load(); got != 5 {
+			t.Fatalf("constructed encoders after replacement=%d want 5", got)
+		}
+		if got := pool.idleCount(); got != 4 {
+			t.Fatalf("idle pool occupancy after replacement=%d want 4", got)
+		}
+	})
+
+	t.Run("concurrent preparations remain within pool capacity", func(t *testing.T) {
+		pool, constructed, _ := newPool()
+		var wg sync.WaitGroup
+		errs := make(chan error, 2)
+		for range 2 {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				errs <- runCanonicalPreparation(pool, -1)
+			}()
+		}
+		wg.Wait()
+		close(errs)
+		for err := range errs {
+			if err != nil {
+				t.Fatalf("concurrent canonical preparation: %v", err)
+			}
+		}
+		if got := constructed.Load(); got > columnRetainedSemanticStreamV1PrepareMaxWorkers {
+			t.Fatalf("constructed encoders=%d exceeds pool capacity=%d", got, columnRetainedSemanticStreamV1PrepareMaxWorkers)
+		}
+		if got := pool.idleCount(); got > columnRetainedSemanticStreamV1PrepareMaxWorkers {
+			t.Fatalf("idle pool occupancy=%d exceeds pool capacity=%d", got, columnRetainedSemanticStreamV1PrepareMaxWorkers)
+		}
+	})
+
+	t.Run("constructor failure releases its slot", func(t *testing.T) {
+		var attempts atomic.Int32
+		pool := newColumnRetainedSemanticStreamV1EncoderPool(
+			1,
+			func() (*pooledState, error) {
+				if attempts.Add(1) == 1 {
+					return nil, errors.New("injected constructor error")
+				}
+				return &pooledState{}, nil
+			},
+			func(*pooledState) {},
+		)
+		if _, _, err := pool.borrow(); err == nil || !strings.Contains(err.Error(), "injected constructor error") {
+			t.Fatalf("first borrow error=%v want injected constructor error", err)
+		}
+		state, _, err := pool.borrow()
+		if err != nil {
+			t.Fatalf("borrow after constructor failure: %v", err)
+		}
+		pool.release(state, true)
+		if got := attempts.Load(); got != 2 {
+			t.Fatalf("constructor attempts=%d want 2", got)
+		}
+	})
+}
+
+func TestColumnRetainedPayloadSemanticStreamV1StoredBlockEncoderPoolAcrossPreparations(t *testing.T) {
+	previousPool := columnRetainedSemanticStreamV1StoredBlockEncoderPool
+	var constructed atomic.Int32
+	pool := newColumnRetainedSemanticStreamV1EncoderPool(
+		columnRetainedSemanticStreamV1PrepareMaxWorkers,
+		func() (*columnRetainedSemanticStreamV1StoredBlockEncoder, error) {
+			constructed.Add(1)
+			return newColumnRetainedSemanticStreamV1StoredBlockEncoder()
+		},
+		func(encoder *columnRetainedSemanticStreamV1StoredBlockEncoder) { encoder.close() },
+	)
+	columnRetainedSemanticStreamV1StoredBlockEncoderPool = pool
+	t.Cleanup(func() {
+		pool.closeIdle()
+		columnRetainedSemanticStreamV1StoredBlockEncoderPool = previousPool
+	})
+
+	cfg := ColumnStoreConfig{
+		Enabled: true,
+		Columns: []ColumnStoreColumn{
+			{Name: "row_id", Path: "row_id", ValueType: ColumnStoreValueInt64, Owner: TypedStorageOwnerRowAsset},
+			{Name: "kind", Path: "kind", ValueType: ColumnStoreValueString, Owner: TypedStorageOwnerColumnPart, Dictionary: true},
+		},
+		RetainedPayload:         ColumnRetainedPayloadNonColumn,
+		RetainedPayloadEncoding: ColumnRetainedPayloadEncodingSemanticStreamV1,
+		Reconstruction:          ColumnReconstructionRetainedPayloadAndColumns,
+	}
+	ids, docs := retainedSemanticStreamDocuments(columnRetainedSemanticStreamV1BlockRows * 4)
+	for preparation := 0; preparation < 2; preparation++ {
+		prepared, err := prepareColumnRetainedPayloadInsertBatchStorageDocumentsWithIDs(cfg, ids, docs, nil)
+		if err != nil {
+			t.Fatalf("prepare canonical batch %d: %v", preparation, err)
+		}
+		resetCollectionRunTable(prepared.semanticStreamBlocks)
+	}
+	if got := constructed.Load(); got != 4 {
+		t.Fatalf("constructed encoders=%d want four reused across two canonical preparations", got)
+	}
+	if got := pool.idleCount(); got != 4 {
+		t.Fatalf("idle pool occupancy=%d want 4", got)
+	}
+}
+
+func TestColumnRetainedPayloadSemanticStreamV1StoredBlockEncoderPoolRawFallbackOwnership(t *testing.T) {
+	pool := newColumnRetainedSemanticStreamV1EncoderPool(
+		1,
+		newColumnRetainedSemanticStreamV1StoredBlockEncoder,
+		func(encoder *columnRetainedSemanticStreamV1StoredBlockEncoder) { encoder.close() },
+	)
+	defer pool.closeIdle()
+	_, docsA := retainedSemanticStreamDocuments(96)
+	_, docsB := retainedSemanticStreamDocumentsFrom(96, 96)
+	streamsA := retainedSemanticStreamTestStreamsFromDocuments(t, docsA)
+	streamsB := retainedSemanticStreamTestStreamsFromDocuments(t, docsB)
+
+	encoder, _, err := pool.borrow()
+	if err != nil {
+		t.Fatalf("borrow encoder A: %v", err)
+	}
+	blockA, err := encoder.encodeStreamsWithRawLimit(len(docsA), streamsA, 1)
+	pool.release(encoder, err == nil)
+	if err != nil {
+		t.Fatalf("encode raw fallback A: %v", err)
+	}
+	blockACopy := append([]byte(nil), blockA...)
+
+	encoder, _, err = pool.borrow()
+	if err != nil {
+		t.Fatalf("borrow encoder B: %v", err)
+	}
+	_, err = encoder.encodeStreamsWithRawLimit(len(docsB), streamsB, 1)
+	pool.release(encoder, err == nil)
+	if err != nil {
+		t.Fatalf("encode raw fallback B: %v", err)
+	}
+	if !bytes.Equal(blockA, blockACopy) {
+		t.Fatal("raw fallback output aliases pooled encoder scratch after release")
 	}
 }
 


### PR DESCRIPTION
Closes #3755

Parent: #3099

## Scope and claim boundary

Adds a bounded retained semantic-stream stored-block encoder pool for insert/load preparation only. Each block worker borrows one thread-confined encoder and returns it only after the block output is complete. The pool is capped at the existing preparation-worker cap (8), which also bounds idle raw scratch to 8 x 8 MiB maximum. On an encode failure the encoder is closed and discarded; constructor failure releases its slot.

No on-disk wrapper, locator, compression setting, reconstruction, validity, durability, WAL/value-log, GC, query, or public-API behavior changes.

`BlockEncoderSetup` remains semantically constructor time: pool hits report zero rather than borrow/wait time.

## Red-first evidence

Before the pool seam existed:

```sh
GOWORK=off go test ./TreeDB/collections -run '^TestColumnRetainedSemanticStreamV1StoredBlockEncoderPoolLifecycle$' -count=1
```

failed to build with undefined `columnRetainedSemanticStreamV1EncoderPool` / `newColumnRetainedSemanticStreamV1EncoderPool`.

The added lifecycle coverage proves sequential canonical four-block preparation reuse, no concurrent sharing, bounded concurrent occupancy, success return, block-error discard/replacement, and constructor-failure slot release. The real preparation-path test counts four constructors across two sequential 16,384-row preparations. Pooled raw-fallback ownership coverage keeps the first block unchanged after reuse.

## Focused performance evidence

Artifacts: `/mnt/fast4tb/gomap_graph_3099/worker_evidence_pool`

Exact baseline: `3ef7f881b750db7045e773be5316e97083504e01`; candidate worktree was based on that exact head before commit `ba8d7ab29`.

```sh
GOWORK=off go test ./TreeDB/collections -run '^$' -bench '^BenchmarkColumnRetainedPayloadSemanticStreamV1PrepareRootFastPathMultiBlock$' -benchmem -count=8
```

| Metric | Baseline | Candidate | Change |
| --- | ---: | ---: | ---: |
| median ns/op | 17.52 ms | 17.25 ms | -1.5% |
| B/op | ~22.84 MB | ~15.78 MB | -30.9% |
| allocs/op | ~681 | ~430 | -36.9% |
| stored_block_B/op | 89,816 | 89,816 | unchanged |
| stored/input | 0.01683 | 0.01683 | unchanged |

Host had unrelated load, so throughput is provisional; it improved in this sample. Alloc-space profiles (`*_multiblock_alloc_space_top.txt`) show zstd `ensureHist` dropping from 95.57 MB to 5.03 MB over the profile run, consistent with setup/history amortization.

## Correctness and race checks

```sh
GOWORK=off go test -race ./TreeDB/collections -run 'TestColumnRetainedSemanticStreamV1StoredBlockEncoderPoolLifecycle|TestColumnRetainedPayloadSemanticStreamV1StoredBlockEncoderPoolAcrossPreparations|TestColumnRetainedPayloadSemanticStreamV1StoredBlockEncoderPoolRawFallbackOwnership' -count=1
GOWORK=off go test ./TreeDB/collections -run 'TestColumnRetainedPayloadSemanticStreamV1StoredBlockEncoderReuse|TestColumnRetainedPayloadSemanticStreamV1StoredBlockEncoderRawFallbackDoesNotAliasScratch3221|TestColumnRetainedPayloadSemanticStreamV1|Test.*(RetainedPayload|SemanticStream|Reconstruction).*' -count=1
GOWORK=off go test ./TreeDB/collections -count=1
GOWORK=off go test ./cmd/unified_bench -count=1
git diff --check
```

All passed locally.

Coordinator-owned gates still pending: paired/interleaved 1M JSONBench evidence, peak RSS and durable storage measurements, CI, latest-head AI review, and merge readiness. This PR does not claim #3099 is closed.
