### PR TITLE
TreeDB: harden dictionary authority closeout

### DIFF
--- a/TreeDB/db/leaf_generation_pack_authority.go
+++ b/TreeDB/db/leaf_generation_pack_authority.go
@@ -1,6 +1,7 @@
 package db
 
 import (
+	"context"
 	"crypto/sha256"
 	"encoding/binary"
 	"errors"
@@ -47,11 +48,11 @@ type leafGenerationPackPromotionAuthority struct {
 	moveNoReplace         func(*os.File, *os.File, string, *os.File, string) (bool, error)
 }
 
-func (authority *leafGenerationPackPromotionAuthority) captureDictionary(dictID uint64, dictionary []byte) error {
+func (authority *leafGenerationPackPromotionAuthority) captureDictionary(ctx context.Context, dictID uint64, dictionary []byte) error {
 	if authority == nil || authority.released || authority.dictionaryResources != nil || len(authority.segments) != 0 {
 		return rootpublication.ErrResourceOwnership
 	}
-	resources, err := captureStableDictionaryResources(authority.db.stableDictionaryResourceProvider(), dictID, dictionary)
+	resources, err := captureStableDictionaryResources(ctx, authority.db.stableDictionaryResourceProvider(), dictID, dictionary)
 	if err != nil {
 		return err
 	}

--- a/TreeDB/db/leaf_generation_pack_authority_test.go
+++ b/TreeDB/db/leaf_generation_pack_authority_test.go
@@ -210,7 +210,7 @@ func TestLeafGenerationPackPromotionAuthorityMergesAndOwnsDictionaryClosure(t *t
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := authority.captureDictionary(dictID, dictionary); err != nil {
+	if err := authority.captureDictionary(context.Background(), dictID, dictionary); err != nil {
 		t.Fatal(err)
 	}
 	if err := authority.capture([]rewriteCreatedSegment{fixture.created}, []page.LeafLogPtr{fixture.pointer}); err != nil {
@@ -253,7 +253,7 @@ func TestLeafGenerationPackPromotionAuthorityRetainsDictionaryAcrossPostLinkPois
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := authority.captureDictionary(dictID, dictionary); err != nil {
+	if err := authority.captureDictionary(context.Background(), dictID, dictionary); err != nil {
 		t.Fatal(err)
 	}
 	if err := authority.capture([]rewriteCreatedSegment{fixture.created}, []page.LeafLogPtr{fixture.pointer}); err != nil {

--- a/TreeDB/db/leaf_generation_pack_rewrite.go
+++ b/TreeDB/db/leaf_generation_pack_rewrite.go
@@ -1200,7 +1200,7 @@ func (db *DB) rewriteLeafRefsOnline(ctx context.Context, writer *rewriteWriter, 
 	if err != nil {
 		return 0, 0, fmt.Errorf("vlog-rewrite: prepare packed promotion authority: %w", err)
 	}
-	if err := authority.captureDictionary(writer.leafDictID, writer.leafDict); err != nil {
+	if err := authority.captureDictionary(ctx, writer.leafDictID, writer.leafDict); err != nil {
 		_ = authority.release()
 		return 0, 0, fmt.Errorf("vlog-rewrite: capture packed dictionary authority: %w", err)
 	}

--- a/TreeDB/db/stable_dictionary_test.go
+++ b/TreeDB/db/stable_dictionary_test.go
@@ -19,6 +19,35 @@ type testStableDictionaryProvider struct {
 	releaseCalls atomic.Int32
 }
 
+type canceledContextStableDictionaryProvider struct {
+	sawCanceled atomic.Bool
+}
+
+func (provider *canceledContextStableDictionaryProvider) CaptureDictionaryResources(ctx context.Context, _ uint64) (*rootpublication.StableResourceSet, error) {
+	if ctx.Err() == context.Canceled {
+		provider.sawCanceled.Store(true)
+		return nil, ctx.Err()
+	}
+	return nil, fmt.Errorf("dictionary capture received uncanceled context")
+}
+
+func TestLeafGenerationPackPromotionAuthorityPropagatesCaptureContext(t *testing.T) {
+	database := &DB{}
+	provider := &canceledContextStableDictionaryProvider{}
+	database.SetStableDictionaryResourceProvider(provider)
+	authority := &leafGenerationPackPromotionAuthority{db: database}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	err := authority.captureDictionary(ctx, 7400, []byte("canceled packed dictionary authority"))
+	if err != context.Canceled {
+		t.Fatalf("capture error=%v want context.Canceled", err)
+	}
+	if !provider.sawCanceled.Load() {
+		t.Fatal("packed dictionary provider did not receive operation cancellation")
+	}
+}
+
 func newTestStableDictionaryProvider(t *testing.T, dictID uint64, dictionary []byte) *testStableDictionaryProvider {
 	t.Helper()
 	file, err := os.CreateTemp(t.TempDir(), "dictionary-authority-")

--- a/TreeDB/db/stable_leaf_rewrite.go
+++ b/TreeDB/db/stable_leaf_rewrite.go
@@ -1,6 +1,7 @@
 package db
 
 import (
+	"context"
 	"fmt"
 	"path/filepath"
 
@@ -34,7 +35,7 @@ func newRewriteStableOuterLeafCapture(writer *rewriteWriter) (*rewriteStableOute
 	if writer.stableDictionaryResourceProvider != nil {
 		dictionaryProvider = writer.stableDictionaryResourceProvider()
 	}
-	dictionaryResources, err := captureStableDictionaryResources(dictionaryProvider, writer.leafDictID, writer.leafDict)
+	dictionaryResources, err := captureStableDictionaryResources(context.Background(), dictionaryProvider, writer.leafDictID, writer.leafDict)
 	if err != nil {
 		capture.abandon()
 		return nil, err

--- a/TreeDB/db/stable_resource.go
+++ b/TreeDB/db/stable_resource.go
@@ -79,14 +79,17 @@ func (db *DB) stableDictionaryResourceProvider() StableDictionaryResourceProvide
 	return provider
 }
 
-func captureStableDictionaryResources(provider StableDictionaryResourceProvider, dictID uint64, dictionary []byte) (*rootpublication.StableResourceSet, error) {
+func captureStableDictionaryResources(ctx context.Context, provider StableDictionaryResourceProvider, dictID uint64, dictionary []byte) (*rootpublication.StableResourceSet, error) {
 	if dictID == 0 || len(dictionary) == 0 {
 		return nil, nil
 	}
 	if provider == nil {
 		return nil, fmt.Errorf("%w: dictionary %d lacks stable resource provider", rootpublication.ErrUnresolvedResource, dictID)
 	}
-	resources, err := provider.CaptureDictionaryResources(context.Background(), dictID)
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	resources, err := provider.CaptureDictionaryResources(ctx, dictID)
 	if err != nil {
 		return nil, err
 	}

--- a/TreeDB/internal/dictdb/stable_resource_capture_test.go
+++ b/TreeDB/internal/dictdb/stable_resource_capture_test.go
@@ -6,8 +6,12 @@ import (
 	"bytes"
 	"context"
 	"crypto/sha256"
+	"encoding/binary"
 	"errors"
+	"os"
+	"reflect"
 	"testing"
+	"time"
 
 	"github.com/snissn/gomap/TreeDB/db"
 	"github.com/snissn/gomap/TreeDB/internal/rootpublication"
@@ -192,5 +196,251 @@ func TestCaptureDictionaryResourcesInlineDefinitionNeedsOnlyPinnedIndexGeneratio
 	tokens := resources.Tokens()
 	if len(tokens) != 1 || tokens[0].DiagnosticPath() != "index.db" {
 		t.Fatalf("inline closure tokens=%v want index.db", tokens)
+	}
+}
+
+func TestCaptureDictionaryResourcesUnionMultiplePointerIDsIsDeterministic(t *testing.T) {
+	store, err := Open(t.TempDir(), db.Options{ChunkSize: 64 * 1024})
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer store.Close()
+
+	firstPayload := bytes.Repeat([]byte("first-shared-dictionary-"), 256)
+	secondPayload := bytes.Repeat([]byte("second-shared-dictionary-"), 256)
+	put := func(payload []byte) uint64 {
+		t.Helper()
+		id, err := store.PutDictBytes(context.Background(), payload)
+		if err != nil {
+			t.Fatalf("put dictionary: %v", err)
+		}
+		return id
+	}
+	firstID, secondID := put(firstPayload), put(secondPayload)
+	capture := func(id uint64) *rootpublication.StableResourceSet {
+		t.Helper()
+		resources, err := store.CaptureDictionaryResources(context.Background(), id)
+		if err != nil {
+			t.Fatalf("capture dictionary %d: %v", id, err)
+		}
+		return resources
+	}
+	firstForward, secondForward := capture(firstID), capture(secondID)
+	firstReverse, secondReverse := capture(firstID), capture(secondID)
+	defer firstForward.Release()
+	defer secondForward.Release()
+	defer firstReverse.Release()
+	defer secondReverse.Release()
+
+	union := func(first, second *rootpublication.StableResourceSet) *rootpublication.StableResourceSet {
+		t.Helper()
+		builder := rootpublication.NewStableResourceSetBuilder(rootpublication.ReachabilityDictionaryGeneration)
+		defer builder.Abandon()
+		if err := builder.Merge(first); err != nil {
+			t.Fatalf("merge first dictionary: %v", err)
+		}
+		if err := builder.Merge(second); err != nil {
+			t.Fatalf("merge second dictionary sharing physical storage: %v", err)
+		}
+		resources, err := builder.Freeze()
+		if err != nil {
+			t.Fatalf("freeze dictionary union: %v", err)
+		}
+		return resources
+	}
+	forward := union(firstForward, secondForward)
+	reverse := union(secondReverse, firstReverse)
+	defer forward.Release()
+	defer reverse.Release()
+	if got := forward.Len(); got != 2 {
+		t.Fatalf("forward union physical resources=%d want one index and one shared value-log segment", got)
+	}
+	if got := reverse.Len(); got != 2 {
+		t.Fatalf("reverse union physical resources=%d want one index and one shared value-log segment", got)
+	}
+	if !reflect.DeepEqual(forward.Descriptors(), reverse.Descriptors()) {
+		t.Fatalf("dictionary union descriptors depend on merge order:\nforward=%+v\nreverse=%+v", forward.Descriptors(), reverse.Descriptors())
+	}
+
+	want := map[uint64][32]byte{
+		firstID:  sha256.Sum256(firstPayload),
+		secondID: sha256.Sum256(secondPayload),
+	}
+	for _, descriptor := range forward.Descriptors() {
+		obligations := descriptor.LogicalObligations()
+		if len(obligations) != len(want) {
+			t.Fatalf("descriptor generation %d obligations=%d want %d", descriptor.Generation(), len(obligations), len(want))
+		}
+		seen := make(map[uint64]struct{}, len(obligations))
+		for _, obligation := range obligations {
+			digest, ok := want[obligation.Generation]
+			if !ok || obligation.FileID != obligation.Generation || obligation.Digest != digest ||
+				obligation.Reachability != rootpublication.ReachabilityDictionaryGeneration {
+				t.Fatalf("union lost or changed dictionary obligation: %+v", obligation)
+			}
+			seen[obligation.Generation] = struct{}{}
+		}
+		if len(seen) != len(want) {
+			t.Fatalf("descriptor generation %d retained %d dictionary IDs want %d", descriptor.Generation(), len(seen), len(want))
+		}
+	}
+
+	forward.Release()
+	reverse.Release()
+	firstForward.Release()
+	secondForward.Release()
+	firstReverse.Release()
+	secondReverse.Release()
+	if got := store.backend.StableResourceIdentityPinRegistry().ActivePins(); got != 0 {
+		t.Fatalf("dictionary union release left active value-log pins=%d", got)
+	}
+	if err := store.backend.VacuumIndexOnline(context.Background()); err != nil {
+		t.Fatalf("dictionary union release left online-vacuum fence: %v", err)
+	}
+}
+
+func TestCaptureDictionaryResourcesDedupeDoesNotGrowPinsOrDescriptors(t *testing.T) {
+	const iterations = 320
+	store, err := Open(t.TempDir(), db.Options{ChunkSize: 64 * 1024})
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer store.Close()
+	payload := bytes.Repeat([]byte("dedupe-resource-plateau-"), 256)
+	dictID, err := store.PutDictBytes(context.Background(), payload)
+	if err != nil {
+		t.Fatalf("put: %v", err)
+	}
+	warm, err := store.CaptureDictionaryResources(context.Background(), dictID)
+	if err != nil {
+		t.Fatalf("warm capture: %v", err)
+	}
+	if got := warm.Len(); got != 2 {
+		warm.Release()
+		t.Fatalf("warm resources=%d want index+value-log closure", got)
+	}
+	warm.Release()
+	registry := store.backend.StableResourceIdentityPinRegistry()
+	if got := registry.ActivePins(); got != 0 {
+		t.Fatalf("warm release left active pins=%d", got)
+	}
+
+	beforeFDs, fdErr := os.ReadDir("/dev/fd")
+	checkFDs := fdErr == nil
+	for i := 0; i < iterations; i++ {
+		reusedID, err := store.PutDictBytes(context.Background(), payload)
+		if err != nil {
+			t.Fatalf("dedupe put %d: %v", i, err)
+		}
+		if reusedID != dictID {
+			t.Fatalf("dedupe put %d id=%d want %d", i, reusedID, dictID)
+		}
+		resources, err := store.CaptureDictionaryResources(context.Background(), reusedID)
+		if err != nil {
+			t.Fatalf("dedupe capture %d: %v", i, err)
+		}
+		if got := resources.Len(); got != 2 {
+			resources.Release()
+			t.Fatalf("dedupe %d resources=%d want index+value-log closure", i, got)
+		}
+		if got := registry.ActivePins(); got != 1 {
+			resources.Release()
+			t.Fatalf("dedupe %d active value-log pins=%d want 1", i, got)
+		}
+		resources.Release()
+		if got := registry.ActivePins(); got != 0 {
+			t.Fatalf("dedupe %d left active pins=%d", i, got)
+		}
+	}
+	if checkFDs {
+		afterFDs, err := os.ReadDir("/dev/fd")
+		if err != nil {
+			t.Fatalf("read descriptor directory after stress: %v", err)
+		}
+		if len(afterFDs) > len(beforeFDs)+2 {
+			t.Fatalf("descriptor count grew from %d to %d after %d captures", len(beforeFDs), len(afterFDs), iterations)
+		}
+	}
+	if err := store.backend.VacuumIndexOnline(context.Background()); err != nil {
+		t.Fatalf("dedupe release left online-vacuum fence: %v", err)
+	}
+}
+
+func BenchmarkCaptureDictionaryResources(b *testing.B) {
+	ctx := context.Background()
+	cases := []struct {
+		name    string
+		payload []byte
+		unique  bool
+	}{
+		{name: "inline-dedupe", payload: []byte("bench-inline-dictionary")},
+		{name: "pointer-dedupe", payload: bytes.Repeat([]byte("bench-pointer-dictionary-"), 256)},
+		{name: "pointer-create", payload: bytes.Repeat([]byte("bench-pointer-create-"), 256), unique: true},
+	}
+	for _, benchmark := range cases {
+		b.Run(benchmark.name, func(b *testing.B) {
+			store, err := Open(b.TempDir(), db.Options{ChunkSize: 64 * 1024})
+			if err != nil {
+				b.Fatal(err)
+			}
+			defer store.Close()
+			warmID, err := store.PutDictBytes(ctx, benchmark.payload)
+			if err != nil {
+				b.Fatal(err)
+			}
+			warm, err := store.CaptureDictionaryResources(ctx, warmID)
+			if err != nil {
+				b.Fatal(err)
+			}
+			resourcesPerOp := warm.Len()
+			var pinHighWater uint64
+			for _, stats := range warm.Stats(time.Now()) {
+				if stats.PinHighWater > pinHighWater {
+					pinHighWater = stats.PinHighWater
+				}
+			}
+			warm.Release()
+			var beforeFileSyncs, beforeNamespaceSyncs uint64
+			if store.vlog != nil {
+				stats := store.vlog.DurabilityStats()
+				beforeFileSyncs = stats.FileSyncCalls
+				beforeNamespaceSyncs = stats.DirectorySyncCalls
+			}
+
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				payload := benchmark.payload
+				if benchmark.unique {
+					payload = make([]byte, len(benchmark.payload)+8)
+					copy(payload, benchmark.payload)
+					binary.LittleEndian.PutUint64(payload[len(benchmark.payload):], uint64(i+1))
+				}
+				dictID, err := store.PutDictBytes(ctx, payload)
+				if err != nil {
+					b.Fatal(err)
+				}
+				resources, err := store.CaptureDictionaryResources(ctx, dictID)
+				if err != nil {
+					b.Fatal(err)
+				}
+				if resources.Len() != resourcesPerOp {
+					resources.Release()
+					b.Fatalf("dictionary closure resources=%d want %d", resources.Len(), resourcesPerOp)
+				}
+				resources.Release()
+			}
+			b.StopTimer()
+			b.ReportMetric(float64(resourcesPerOp), "descriptors/op")
+			b.ReportMetric(float64(pinHighWater), "pin_high_water")
+			if store.vlog != nil {
+				stats := store.vlog.DurabilityStats()
+				b.ReportMetric(float64(stats.FileSyncCalls-beforeFileSyncs)/float64(b.N), "vlog_file_syncs/op")
+				b.ReportMetric(float64(stats.DirectorySyncCalls-beforeNamespaceSyncs)/float64(b.N), "vlog_namespace_syncs/op")
+			} else {
+				b.ReportMetric(0, "vlog_file_syncs/op")
+				b.ReportMetric(0, "vlog_namespace_syncs/op")
+			}
+		})
 	}
 }


### PR DESCRIPTION
## Summary

- propagate the packed rewrite operation context into dictionary-resource capture, so cancellation reaches the provider before promotion authority is assembled
- make the raw rewrite's lack of an operation context explicit at its capture boundary
- prove deterministic transitive union for two dictionary IDs that share one physical index generation and value-log segment
- add a 320-cycle dedupe stress case that checks exact descriptor and pin counts, release-to-zero behavior, descriptor plateau, and post-release online vacuum
- add end-to-end dictionary production-and-capture benchmarks with physical-descriptor, pin-high-water, and durability-sync counters

## Why this is a follow-up

PR #3768 merged at `ec0b0130` while this already-validated follow-up was being fast-forwarded to its branch. This PR contains only the narrow context and closeout-evidence delta on top of the identical #3768 merge tree.

## Correctness and lifecycle evidence

- packed promotion now passes its normalized, cancellation-checked `ctx` through `captureDictionary` into `CaptureDictionaryResources`; a focused test proves a canceled operation is observed by the provider
- raw rewrite has no operation context in its producer API, so it explicitly uses `context.Background()` rather than hiding that policy inside the shared helper
- two pointer-backed dictionary generations coalesce to exactly two physical descriptors (one index generation and one shared value-log segment), independent of merge order, while both logical obligations remain on each descriptor
- 320 repeated dedupe capture/release cycles hold exactly two descriptors per capture, one active value-log identity pin while live, zero after release, no monotonic `/dev/fd` growth beyond the two-descriptor allowance, and successful online vacuum after release
- this dictionary-only unit adds no rotation boundary: live raw/packed producers capture the dictionary child closure before the existing writer mutation/promotion boundary; outer-leaf rotation latency remains owned by the already-merged outer-leaf authority units

## Benchmark evidence

Apple M3, `-benchtime=20x -count=5 -benchmem`:

| Case | Time range | Bytes/op | Allocs/op | Descriptors | Pin HWM | Vlog file syncs/op | Namespace syncs/op |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| inline dedupe | 20.302-45.404 us | 4,992-4,999 | 39 | 1 | 1 | 0 | 0 |
| pointer dedupe | 45.027-64.873 us | 22,448-22,450 | 57 | 2 | 2 | 0 | 0 |
| pointer create | 9.509-9.744 ms | 60,912-60,915 | 141 | 2 | 2 | 1 | 0 |

Each case measures `PutDictBytes` plus resource capture/release. Pointer creation performs the required value-log content sync and no per-record namespace sync. Dedupe production/capture adds neither file nor namespace syncs.

## Validation

- `GOWORK=off go test ./TreeDB/db ./TreeDB/caching ./TreeDB/internal/dictdb ./TreeDB/internal/rootpublication ./TreeDB/internal/authorityinventory ./TreeDB/internal/valuelog ./TreeDB/pager -count=1`
- focused dictionary-union, 320-cycle plateau, and packed-context tests
- focused dictionary/raw/packed suites under `-race`
- `GOWORK=off go vet ./TreeDB/caching ./TreeDB/db ./TreeDB/internal/dictdb ./TreeDB/internal/rootpublication ./TreeDB/internal/authorityinventory ./TreeDB/internal/valuelog ./TreeDB/pager`
- Windows amd64 compile-only checks for db, caching, and dictdb
- `GOWORK=off go generate ./TreeDB/internal/authorityinventory` plus `git diff --check`

Part of #3677.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Dictionary resource captures now respect cancellation and request context, allowing interrupted operations to stop promptly.
  - Preserved existing validation and resource-ownership behavior.

- **Tests**
  - Added coverage for cancellation propagation.
  - Added reliability checks for deterministic resource merging, pin and descriptor cleanup, deduplication, and vacuum behavior.
  - Added performance benchmarking for dictionary resource capture scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->