### PR TITLE
fix(treedb): release covered command-WAL pins before unlink

### DIFF
--- a/TreeDB/db/command_wal_debt.go
+++ b/TreeDB/db/command_wal_debt.go
@@ -279,6 +279,34 @@ func (debt *CommandWALDependencyDebt) releaseThrough(lsn uint64) {
 	}
 }
 
+// releasePhysicalThrough releases physical resources that have already crossed
+// the unlink preparation durability barrier, while retaining their logical LSN
+// debt entries until the corresponding segment unlink completes.
+func (debt *CommandWALDependencyDebt) releasePhysicalThrough(lsn uint64) {
+	if debt == nil || lsn == 0 {
+		return
+	}
+	debt.mu.Lock()
+	var resources []*rootpublication.StableResourceSet
+	var rotationFiles []*rootpublication.StableResourceToken
+	for i := range debt.entries {
+		if debt.entries[i].firstLSN > lsn {
+			break
+		}
+		resources = append(resources, debt.entries[i].resources...)
+		rotationFiles = append(rotationFiles, debt.entries[i].rotationFiles...)
+		debt.entries[i].resources = nil
+		debt.entries[i].rotationFiles = nil
+	}
+	debt.mu.Unlock()
+	for _, resource := range resources {
+		resource.Release()
+	}
+	for _, token := range rotationFiles {
+		token.Release()
+	}
+}
+
 func (debt *CommandWALDependencyDebt) releaseAll() {
 	if debt == nil {
 		return

--- a/TreeDB/db/command_wal_debt.go
+++ b/TreeDB/db/command_wal_debt.go
@@ -87,22 +87,70 @@ func (debt *CommandWALDependencyDebt) hasPhysicalDependenciesThrough(lsn uint64)
 	return false
 }
 
+func commandWALRotationTokenMatchesPath(token *rootpublication.StableResourceToken, walDir, path string) bool {
+	if token == nil || walDir == "" || path == "" {
+		return false
+	}
+	tokenName := filepath.Base(filepath.Clean(token.DiagnosticPath()))
+	if tokenName == "." || tokenName == string(filepath.Separator) {
+		return false
+	}
+	// Stable command-WAL diagnostics are rooted at the logical "maindb/wal"
+	// label, while walDir is the exact physical directory for this DB. Resolve
+	// the registered segment name under that directory before comparing; a
+	// basename match outside walDir must not release this ledger's token.
+	tokenPath, err := filepath.Abs(filepath.Join(walDir, tokenName))
+	if err != nil {
+		return false
+	}
+	unlinkPath, err := filepath.Abs(path)
+	return err == nil && filepath.Clean(tokenPath) == filepath.Clean(unlinkPath)
+}
+
+// hasPhysicalDependenciesForUnlink extends the covered LSN prefix with the
+// exact closed-segment token selected for unlink. An automatic rotation is
+// recorded on the successor frame's LSN, so the predecessor token may live
+// beyond the predecessor segment's own max LSN.
+func (debt *CommandWALDependencyDebt) hasPhysicalDependenciesForUnlink(lsn uint64, walDir, path string) bool {
+	if debt == nil {
+		return false
+	}
+	debt.mu.Lock()
+	defer debt.mu.Unlock()
+	for _, entry := range debt.entries {
+		if entry.firstLSN <= lsn && (len(entry.resources) != 0 || len(entry.rotationFiles) != 0) {
+			return true
+		}
+		for _, token := range entry.rotationFiles {
+			if commandWALRotationTokenMatchesPath(token, walDir, path) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
 // rotationFileViewThrough returns a deterministic, exact-handle view of the
 // command-WAL files retained by relaxed rotations. These tokens deliberately
 // remain outside StableResourceSet until their namespace-create obligations
 // have crossed a directory barrier: normal root-publication resource sets are
 // only valid after namespaces are stable.
 func (debt *CommandWALDependencyDebt) rotationFileViewThrough(lsn uint64) ([]*rootpublication.StableResourceToken, error) {
+	return debt.rotationFileViewForUnlink(lsn, "", "")
+}
+
+func (debt *CommandWALDependencyDebt) rotationFileViewForUnlink(lsn uint64, walDir, path string) ([]*rootpublication.StableResourceToken, error) {
 	if debt == nil {
 		return nil, nil
 	}
 	debt.mu.Lock()
 	var tokens []*rootpublication.StableResourceToken
 	for _, entry := range debt.entries {
-		if entry.firstLSN > lsn {
-			break
+		for _, token := range entry.rotationFiles {
+			if entry.firstLSN <= lsn || commandWALRotationTokenMatchesPath(token, walDir, path) {
+				tokens = append(tokens, token)
+			}
 		}
-		tokens = append(tokens, entry.rotationFiles...)
 	}
 	debt.mu.Unlock()
 
@@ -146,7 +194,11 @@ func (debt *CommandWALDependencyDebt) rotationFileViewThrough(lsn uint64) ([]*ro
 }
 
 func (debt *CommandWALDependencyDebt) syncRotationFilesThrough(root, walDir string, lsn uint64) error {
-	tokens, err := debt.rotationFileViewThrough(lsn)
+	return debt.syncRotationFilesForUnlink(root, walDir, lsn, "")
+}
+
+func (debt *CommandWALDependencyDebt) syncRotationFilesForUnlink(root, walDir string, lsn uint64, unlinkPath string) error {
+	tokens, err := debt.rotationFileViewForUnlink(lsn, walDir, unlinkPath)
 	if err != nil {
 		return err
 	}
@@ -166,16 +218,21 @@ func (debt *CommandWALDependencyDebt) syncRotationFilesThrough(root, walDir stri
 }
 
 func (debt *CommandWALDependencyDebt) stabilizeRotationNamespacesThrough(root, walDir string, lsn uint64) error {
+	return debt.stabilizeRotationNamespacesForUnlink(root, walDir, lsn, "")
+}
+
+func (debt *CommandWALDependencyDebt) stabilizeRotationNamespacesForUnlink(root, walDir string, lsn uint64, unlinkPath string) error {
 	if debt == nil {
 		return nil
 	}
 	debt.mu.Lock()
 	var tokens []*rootpublication.StableResourceToken
 	for _, entry := range debt.entries {
-		if entry.firstLSN > lsn {
-			break
+		for _, token := range entry.rotationFiles {
+			if entry.firstLSN <= lsn || commandWALRotationTokenMatchesPath(token, walDir, unlinkPath) {
+				tokens = append(tokens, token)
+			}
 		}
-		tokens = append(tokens, entry.rotationFiles...)
 	}
 	debt.mu.Unlock()
 	compact := tokens[:0]
@@ -237,6 +294,29 @@ func (debt *CommandWALDependencyDebt) noteRetryThrough(lsn uint64) {
 	}
 }
 
+func (debt *CommandWALDependencyDebt) noteRetryForUnlink(lsn uint64, walDir, path string) {
+	if debt == nil {
+		return
+	}
+	debt.mu.Lock()
+	defer debt.mu.Unlock()
+	for i := range debt.entries {
+		entry := &debt.entries[i]
+		matches := entry.firstLSN <= lsn
+		if !matches {
+			for _, token := range entry.rotationFiles {
+				if commandWALRotationTokenMatchesPath(token, walDir, path) {
+					matches = true
+					break
+				}
+			}
+		}
+		if matches {
+			entry.retries++
+		}
+	}
+}
+
 func (debt *CommandWALDependencyDebt) releaseThrough(lsn uint64) {
 	if debt == nil || lsn == 0 {
 		return
@@ -283,20 +363,35 @@ func (debt *CommandWALDependencyDebt) releaseThrough(lsn uint64) {
 // the unlink preparation durability barrier, while retaining their logical LSN
 // debt entries until the corresponding segment unlink completes.
 func (debt *CommandWALDependencyDebt) releasePhysicalThrough(lsn uint64) {
-	if debt == nil || lsn == 0 {
+	debt.releasePhysicalForUnlink(lsn, "", "")
+}
+
+func (debt *CommandWALDependencyDebt) releasePhysicalForUnlink(lsn uint64, walDir, path string) {
+	if debt == nil || (lsn == 0 && path == "") {
 		return
 	}
 	debt.mu.Lock()
 	var resources []*rootpublication.StableResourceSet
 	var rotationFiles []*rootpublication.StableResourceToken
 	for i := range debt.entries {
-		if debt.entries[i].firstLSN > lsn {
-			break
+		entry := &debt.entries[i]
+		if entry.firstLSN <= lsn {
+			resources = append(resources, entry.resources...)
+			rotationFiles = append(rotationFiles, entry.rotationFiles...)
+			entry.resources = nil
+			entry.rotationFiles = nil
+			continue
 		}
-		resources = append(resources, debt.entries[i].resources...)
-		rotationFiles = append(rotationFiles, debt.entries[i].rotationFiles...)
-		debt.entries[i].resources = nil
-		debt.entries[i].rotationFiles = nil
+		kept := entry.rotationFiles[:0]
+		for _, token := range entry.rotationFiles {
+			if commandWALRotationTokenMatchesPath(token, walDir, path) {
+				rotationFiles = append(rotationFiles, token)
+				continue
+			}
+			kept = append(kept, token)
+		}
+		clear(entry.rotationFiles[len(kept):])
+		entry.rotationFiles = kept
 	}
 	debt.mu.Unlock()
 	for _, resource := range resources {

--- a/TreeDB/db/command_wal_publish.go
+++ b/TreeDB/db/command_wal_publish.go
@@ -439,14 +439,29 @@ func scanCommandWALSegmentsCoveredByAppliedLSN(dir string, appliedLSN uint64, ma
 	return decisions, nil
 }
 
+var removeCommandWALSegmentFn = os.Remove
+
 func removeCoveredCommandWALSegments(decisions []commandWALSegmentCleanupDecision) ([]commandWALSegmentCleanupDecision, error) {
+	return removeCoveredCommandWALSegmentsWithHooks(decisions, nil, nil)
+}
+
+func removeCoveredCommandWALSegmentsWithHooks(
+	decisions []commandWALSegmentCleanupDecision,
+	beforeUnlink func(commandWALSegmentCleanupDecision) error,
+	afterUnlink func(commandWALSegmentCleanupDecision),
+) ([]commandWALSegmentCleanupDecision, error) {
 	for i := range decisions {
 		decision := &decisions[i]
 		if decision.Covered && !decision.Active {
 			if err := durabilitycut.EmitPath(durabilitycut.BeforeWALOrAssetUnlink, durabilitycut.ResourceCommandWAL, "", decision.Path); err != nil {
 				return decisions, err
 			}
-			removeErr := os.Remove(decision.Path)
+			if beforeUnlink != nil {
+				if err := beforeUnlink(*decision); err != nil {
+					return decisions, err
+				}
+			}
+			removeErr := removeCommandWALSegmentFn(decision.Path)
 			if removeErr != nil && !os.IsNotExist(removeErr) {
 				return decisions, removeErr
 			}
@@ -462,6 +477,9 @@ func removeCoveredCommandWALSegments(decisions []commandWALSegmentCleanupDecisio
 			// Preserve the completed namespace mutation in the returned decisions
 			// even when the post-unlink observer reports a simulated crash cut.
 			decision.Removed = true
+			if afterUnlink != nil {
+				afterUnlink(*decision)
+			}
 			if err := durabilitycut.Emit(after); err != nil {
 				if removeErr == nil {
 					return decisions, errors.Join(err, ErrRecoveryRequired)

--- a/TreeDB/db/command_wal_publish_test.go
+++ b/TreeDB/db/command_wal_publish_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/snissn/gomap/TreeDB/internal/commitlog"
 	"github.com/snissn/gomap/TreeDB/internal/durabilitycut"
+	"github.com/snissn/gomap/TreeDB/internal/rootpublication"
 	"github.com/snissn/gomap/TreeDB/node"
 	"github.com/snissn/gomap/TreeDB/page"
 )
@@ -928,6 +929,109 @@ func TestCommandWALCheckpointCleanupDeletesOnlyCoveredSegments(t *testing.T) {
 	}
 	if _, err := os.Stat(filepath.Join(WALDirPath(dir), "commit-l0-000002.log")); err != nil {
 		t.Fatalf("uncovered segment stat=%v, want present", err)
+	}
+}
+
+func TestCommandWALCheckpointCleanupReleasesCoveredDebtBeforeUnlink(t *testing.T) {
+	dir := t.TempDir()
+	writeCommandWALFrame(t, dir, 1, 1)
+	writeCommandWALFrame(t, dir, 2, 2)
+
+	newToken := func(name string, generation uint64, released *bool) *rootpublication.StableResourceToken {
+		t.Helper()
+		file, err := os.Open(filepath.Join(WALDirPath(dir), name))
+		if err != nil {
+			t.Fatalf("open %s: %v", name, err)
+		}
+		token, err := rootpublication.NewStableResourceToken(rootpublication.StableResourceSpec{
+			Kind:           rootpublication.ResourceCommandWAL,
+			LogicalLane:    "0",
+			ResourceID:     name,
+			Generation:     generation,
+			DiagnosticPath: filepath.ToSlash(filepath.Join("wal", name)),
+			File:           file,
+			Frontier:       rootpublication.DurableFrontier{Bytes: 1, MaxLSN: generation},
+			Reachability:   rootpublication.ReachabilityCommandWALRotated,
+			ContentSynced:  true,
+			OnRelease: func() {
+				*released = true
+			},
+		})
+		if err != nil {
+			_ = file.Close()
+			t.Fatalf("new stable token %s: %v", name, err)
+		}
+		_ = file.Close()
+		return token
+	}
+
+	coveredReleased := false
+	coveredResourceReleased := false
+	laterReleased := false
+	covered := newToken("commit-l0-000001.log", 1, &coveredReleased)
+	coveredResource := newToken("commit-l0-000001.log", 3, &coveredResourceReleased)
+	resourceBuilder := rootpublication.NewStableResourceSetBuilder(rootpublication.ReachabilityCommandWALRotated)
+	if err := resourceBuilder.Add(coveredResource); err != nil {
+		covered.Release()
+		coveredResource.Release()
+		later := newToken("commit-l0-000002.log", 2, &laterReleased)
+		later.Release()
+		t.Fatalf("add covered resource: %v", err)
+	}
+	coveredResources, err := resourceBuilder.Freeze()
+	if err != nil {
+		covered.Release()
+		resourceBuilder.Abandon()
+		t.Fatalf("freeze covered resource: %v", err)
+	}
+	later := newToken("commit-l0-000002.log", 2, &laterReleased)
+	db := &DB{dir: dir, commandWAL: true, durability: DurabilityDurable}
+	db.state.Store(&DBState{AppliedCommandLSN: 1})
+	if err := db.commandWALDebt.add(1, []*rootpublication.StableResourceToken{covered}, coveredResources); err != nil {
+		covered.Release()
+		coveredResources.Release()
+		later.Release()
+		t.Fatalf("add covered debt: %v", err)
+	}
+	if err := db.commandWALDebt.add(2, []*rootpublication.StableResourceToken{later}); err != nil {
+		db.commandWALDebt.releaseAll()
+		t.Fatalf("add later debt: %v", err)
+	}
+	t.Cleanup(db.commandWALDebt.releaseAll)
+
+	restoreObserver := durabilitycut.Install(func(event durabilitycut.Event) error {
+		if event.Point == durabilitycut.BeforeWALOrAssetUnlink && filepath.Base(event.Path) == "commit-l0-000001.log" {
+			if !coveredReleased {
+				t.Error("covered command-WAL rotation debt remained pinned at its segment unlink")
+			}
+			if !coveredResourceReleased {
+				t.Error("covered command-WAL resource debt remained pinned at its segment unlink")
+			}
+			if laterReleased {
+				t.Error("later command-WAL debt was released before its applied prefix")
+			}
+		}
+		return nil
+	})
+	defer restoreObserver()
+
+	if err := db.CleanupCommandWALCoveredSegments(true); err != nil {
+		t.Fatalf("CleanupCommandWALCoveredSegments: %v", err)
+	}
+	if !coveredReleased {
+		t.Fatal("covered command-WAL rotation debt was not released")
+	}
+	if !coveredResourceReleased {
+		t.Fatal("covered command-WAL resource debt was not released")
+	}
+	if laterReleased {
+		t.Fatal("later command-WAL debt was released")
+	}
+	db.commandWALDebt.mu.Lock()
+	pending := len(db.commandWALDebt.entries)
+	db.commandWALDebt.mu.Unlock()
+	if pending != 1 {
+		t.Fatalf("pending debt entries=%d, want 1 for later LSN", pending)
 	}
 }
 

--- a/TreeDB/db/command_wal_publish_test.go
+++ b/TreeDB/db/command_wal_publish_test.go
@@ -1258,6 +1258,135 @@ func TestCommandWALCheckpointCleanupReleasesCoveredDebtBeforeUnlink(t *testing.T
 	}
 }
 
+func TestCommandWALCheckpointCleanupReleasesPredecessorTokenOwnedBySuccessorLSN(t *testing.T) {
+	dir := t.TempDir()
+	writeCommandWALFrame(t, dir, 1, 10)
+	writeCommandWALFrame(t, dir, 2, 11)
+
+	newToken := func(name string, generation, maxLSN uint64, released *bool) *rootpublication.StableResourceToken {
+		t.Helper()
+		file, err := os.Open(filepath.Join(WALDirPath(dir), name))
+		if err != nil {
+			t.Fatalf("open %s: %v", name, err)
+		}
+		token, err := rootpublication.NewStableResourceToken(rootpublication.StableResourceSpec{
+			Kind:           rootpublication.ResourceCommandWAL,
+			LogicalLane:    "0",
+			ResourceID:     name,
+			Generation:     generation,
+			DiagnosticPath: filepath.Join("maindb", "wal", name),
+			File:           file,
+			Frontier:       rootpublication.DurableFrontier{Bytes: 1, MaxLSN: maxLSN},
+			Reachability:   rootpublication.ReachabilityCommandWALRotated,
+			ContentSynced:  true,
+			OnRelease: func() {
+				*released = true
+			},
+		})
+		if err != nil {
+			_ = file.Close()
+			t.Fatalf("new stable token %s: %v", name, err)
+		}
+		_ = file.Close()
+		return token
+	}
+
+	closedReleased := false
+	activeReleased := false
+	closed := newToken("commit-l0-000001.log", 1, 10, &closedReleased)
+	active := newToken("commit-l0-000002.log", 2, 11, &activeReleased)
+	if !commandWALRotationTokenMatchesPath(closed, WALDirPath(dir), filepath.Join(WALDirPath(dir), "commit-l0-000001.log")) {
+		closed.Release()
+		active.Release()
+		t.Fatal("predecessor token did not match its exact command-WAL path")
+	}
+	if commandWALRotationTokenMatchesPath(closed, WALDirPath(dir), filepath.Join(dir, "other-wal", "commit-l0-000001.log")) {
+		closed.Release()
+		active.Release()
+		t.Fatal("predecessor token matched the same basename outside its command-WAL directory")
+	}
+	pathOnlyReleased := false
+	pathOnly := newToken("commit-l0-000002.log", 3, 11, &pathOnlyReleased)
+	var pathOnlyDebt CommandWALDependencyDebt
+	if err := pathOnlyDebt.add(12, []*rootpublication.StableResourceToken{pathOnly}); err != nil {
+		closed.Release()
+		active.Release()
+		pathOnly.Release()
+		t.Fatalf("add path-only debt: %v", err)
+	}
+	pathOnlyDebt.releasePhysicalForUnlink(0, WALDirPath(dir), filepath.Join(WALDirPath(dir), "commit-l0-000002.log"))
+	if !pathOnlyReleased || len(pathOnlyDebt.entries) != 1 || len(pathOnlyDebt.entries[0].rotationFiles) != 0 {
+		closed.Release()
+		active.Release()
+		pathOnlyDebt.releaseAll()
+		t.Fatalf("path-only release=(released=%t entries=%+v), want released physical token with logical entry retained", pathOnlyReleased, pathOnlyDebt.entries)
+	}
+	pathOnlyDebt.releaseAll()
+	db := &DB{dir: dir, commandWALDir: WALDirPath(dir), commandWAL: true, durability: DurabilityDurable}
+	db.state.Store(&DBState{AppliedCommandLSN: 10})
+	// Automatic rotation ownership is transferred after the successor frame is
+	// appended, so both tokens belong to LSN 11 even though the predecessor's
+	// final frame is LSN 10.
+	if err := db.commandWALDebt.add(11, []*rootpublication.StableResourceToken{closed, active}); err != nil {
+		closed.Release()
+		active.Release()
+		t.Fatalf("add successor-owned rotation debt: %v", err)
+	}
+	t.Cleanup(db.commandWALDebt.releaseAll)
+
+	decisions, err := scanCommandWALSegmentsCoveredByAppliedLSN(dir, 10, 0)
+	if err != nil {
+		t.Fatalf("scan covered command WAL segments: %v", err)
+	}
+	var predecessor commandWALSegmentCleanupDecision
+	for _, decision := range decisions {
+		if filepath.Base(decision.Path) == "commit-l0-000001.log" {
+			predecessor = decision
+			break
+		}
+	}
+	if !predecessor.Covered || predecessor.Active || predecessor.MaxLSN != 10 {
+		t.Fatalf("predecessor decision=%+v, want covered non-active max LSN 10", predecessor)
+	}
+
+	originalRemove := removeCommandWALSegmentFn
+	removeCommandWALSegmentFn = func(path string) error {
+		if filepath.Base(path) == "commit-l0-000001.log" {
+			if !closedReleased {
+				t.Error("predecessor token from successor LSN remained pinned at unlink")
+			}
+			if activeReleased {
+				t.Error("successor token was released while its LSN remained unapplied")
+			}
+		}
+		return originalRemove(path)
+	}
+	defer func() { removeCommandWALSegmentFn = originalRemove }()
+
+	if err := db.CleanupCommandWALCoveredSegments(false); err != nil {
+		t.Fatalf("CleanupCommandWALCoveredSegments: %v", err)
+	}
+	if !closedReleased {
+		t.Fatal("predecessor token owned by successor LSN was not released")
+	}
+	if activeReleased {
+		t.Fatal("successor token was released before LSN 11 became applied")
+	}
+	if _, err := os.Stat(filepath.Join(WALDirPath(dir), "commit-l0-000001.log")); !os.IsNotExist(err) {
+		t.Fatalf("predecessor segment stat=%v, want removed", err)
+	}
+	if _, err := os.Stat(filepath.Join(WALDirPath(dir), "commit-l0-000002.log")); err != nil {
+		t.Fatalf("successor segment stat=%v, want retained", err)
+	}
+	db.commandWALDebt.mu.Lock()
+	defer db.commandWALDebt.mu.Unlock()
+	if len(db.commandWALDebt.entries) != 1 || db.commandWALDebt.entries[0].firstLSN != 11 ||
+		len(db.commandWALDebt.entries[0].rotationFiles) != 1 ||
+		!commandWALRotationTokenMatchesPath(db.commandWALDebt.entries[0].rotationFiles[0], WALDirPath(dir), filepath.Join(WALDirPath(dir), "commit-l0-000002.log")) {
+		t.Fatalf("successor logical debt after predecessor unlink=%+v, want LSN 11 with only successor token", db.commandWALDebt.entries)
+	}
+}
+
 func TestCommandWALCleanupDoesNotEmitAfterDeletionSyncOnSyncFailure(t *testing.T) {
 	dir := t.TempDir()
 	writeCommandWALFrame(t, dir, 1, 1)

--- a/TreeDB/db/command_wal_publish_test.go
+++ b/TreeDB/db/command_wal_publish_test.go
@@ -933,105 +933,109 @@ func TestCommandWALCheckpointCleanupDeletesOnlyCoveredSegments(t *testing.T) {
 }
 
 func TestCommandWALCheckpointCleanupReleasesCoveredDebtBeforeUnlink(t *testing.T) {
-	dir := t.TempDir()
-	writeCommandWALFrame(t, dir, 1, 1)
-	writeCommandWALFrame(t, dir, 2, 2)
+	for _, sync := range []bool{false, true} {
+		t.Run(fmt.Sprintf("sync=%t", sync), func(t *testing.T) {
+			dir := t.TempDir()
+			writeCommandWALFrame(t, dir, 1, 1)
+			writeCommandWALFrame(t, dir, 2, 2)
 
-	newToken := func(name string, generation uint64, released *bool) *rootpublication.StableResourceToken {
-		t.Helper()
-		file, err := os.Open(filepath.Join(WALDirPath(dir), name))
-		if err != nil {
-			t.Fatalf("open %s: %v", name, err)
-		}
-		token, err := rootpublication.NewStableResourceToken(rootpublication.StableResourceSpec{
-			Kind:           rootpublication.ResourceCommandWAL,
-			LogicalLane:    "0",
-			ResourceID:     name,
-			Generation:     generation,
-			DiagnosticPath: filepath.ToSlash(filepath.Join("wal", name)),
-			File:           file,
-			Frontier:       rootpublication.DurableFrontier{Bytes: 1, MaxLSN: generation},
-			Reachability:   rootpublication.ReachabilityCommandWALRotated,
-			ContentSynced:  true,
-			OnRelease: func() {
-				*released = true
-			},
-		})
-		if err != nil {
-			_ = file.Close()
-			t.Fatalf("new stable token %s: %v", name, err)
-		}
-		_ = file.Close()
-		return token
-	}
+			newToken := func(name string, generation uint64, released *bool) *rootpublication.StableResourceToken {
+				t.Helper()
+				file, err := os.Open(filepath.Join(WALDirPath(dir), name))
+				if err != nil {
+					t.Fatalf("open %s: %v", name, err)
+				}
+				token, err := rootpublication.NewStableResourceToken(rootpublication.StableResourceSpec{
+					Kind:           rootpublication.ResourceCommandWAL,
+					LogicalLane:    "0",
+					ResourceID:     name,
+					Generation:     generation,
+					DiagnosticPath: filepath.ToSlash(filepath.Join("wal", name)),
+					File:           file,
+					Frontier:       rootpublication.DurableFrontier{Bytes: 1, MaxLSN: generation},
+					Reachability:   rootpublication.ReachabilityCommandWALRotated,
+					ContentSynced:  true,
+					OnRelease: func() {
+						*released = true
+					},
+				})
+				if err != nil {
+					_ = file.Close()
+					t.Fatalf("new stable token %s: %v", name, err)
+				}
+				_ = file.Close()
+				return token
+			}
 
-	coveredReleased := false
-	coveredResourceReleased := false
-	laterReleased := false
-	covered := newToken("commit-l0-000001.log", 1, &coveredReleased)
-	coveredResource := newToken("commit-l0-000001.log", 3, &coveredResourceReleased)
-	resourceBuilder := rootpublication.NewStableResourceSetBuilder(rootpublication.ReachabilityCommandWALRotated)
-	if err := resourceBuilder.Add(coveredResource); err != nil {
-		covered.Release()
-		coveredResource.Release()
-		later := newToken("commit-l0-000002.log", 2, &laterReleased)
-		later.Release()
-		t.Fatalf("add covered resource: %v", err)
-	}
-	coveredResources, err := resourceBuilder.Freeze()
-	if err != nil {
-		covered.Release()
-		resourceBuilder.Abandon()
-		t.Fatalf("freeze covered resource: %v", err)
-	}
-	later := newToken("commit-l0-000002.log", 2, &laterReleased)
-	db := &DB{dir: dir, commandWAL: true, durability: DurabilityDurable}
-	db.state.Store(&DBState{AppliedCommandLSN: 1})
-	if err := db.commandWALDebt.add(1, []*rootpublication.StableResourceToken{covered}, coveredResources); err != nil {
-		covered.Release()
-		coveredResources.Release()
-		later.Release()
-		t.Fatalf("add covered debt: %v", err)
-	}
-	if err := db.commandWALDebt.add(2, []*rootpublication.StableResourceToken{later}); err != nil {
-		db.commandWALDebt.releaseAll()
-		t.Fatalf("add later debt: %v", err)
-	}
-	t.Cleanup(db.commandWALDebt.releaseAll)
+			coveredReleased := false
+			coveredResourceReleased := false
+			laterReleased := false
+			covered := newToken("commit-l0-000001.log", 1, &coveredReleased)
+			coveredResource := newToken("commit-l0-000001.log", 3, &coveredResourceReleased)
+			resourceBuilder := rootpublication.NewStableResourceSetBuilder(rootpublication.ReachabilityCommandWALRotated)
+			if err := resourceBuilder.Add(coveredResource); err != nil {
+				covered.Release()
+				coveredResource.Release()
+				later := newToken("commit-l0-000002.log", 2, &laterReleased)
+				later.Release()
+				t.Fatalf("add covered resource: %v", err)
+			}
+			coveredResources, err := resourceBuilder.Freeze()
+			if err != nil {
+				covered.Release()
+				resourceBuilder.Abandon()
+				t.Fatalf("freeze covered resource: %v", err)
+			}
+			later := newToken("commit-l0-000002.log", 2, &laterReleased)
+			db := &DB{dir: dir, commandWAL: true, durability: DurabilityDurable}
+			db.state.Store(&DBState{AppliedCommandLSN: 1})
+			if err := db.commandWALDebt.add(1, []*rootpublication.StableResourceToken{covered}, coveredResources); err != nil {
+				covered.Release()
+				coveredResources.Release()
+				later.Release()
+				t.Fatalf("add covered debt: %v", err)
+			}
+			if err := db.commandWALDebt.add(2, []*rootpublication.StableResourceToken{later}); err != nil {
+				db.commandWALDebt.releaseAll()
+				t.Fatalf("add later debt: %v", err)
+			}
+			t.Cleanup(db.commandWALDebt.releaseAll)
 
-	restoreObserver := durabilitycut.Install(func(event durabilitycut.Event) error {
-		if event.Point == durabilitycut.BeforeWALOrAssetUnlink && filepath.Base(event.Path) == "commit-l0-000001.log" {
+			restoreObserver := durabilitycut.Install(func(event durabilitycut.Event) error {
+				if event.Point == durabilitycut.BeforeWALOrAssetUnlink && filepath.Base(event.Path) == "commit-l0-000001.log" {
+					if !coveredReleased {
+						t.Error("covered command-WAL rotation debt remained pinned at its segment unlink")
+					}
+					if !coveredResourceReleased {
+						t.Error("covered command-WAL resource debt remained pinned at its segment unlink")
+					}
+					if laterReleased {
+						t.Error("later command-WAL debt was released before its applied prefix")
+					}
+				}
+				return nil
+			})
+			defer restoreObserver()
+
+			if err := db.CleanupCommandWALCoveredSegments(sync); err != nil {
+				t.Fatalf("CleanupCommandWALCoveredSegments: %v", err)
+			}
 			if !coveredReleased {
-				t.Error("covered command-WAL rotation debt remained pinned at its segment unlink")
+				t.Fatal("covered command-WAL rotation debt was not released")
 			}
 			if !coveredResourceReleased {
-				t.Error("covered command-WAL resource debt remained pinned at its segment unlink")
+				t.Fatal("covered command-WAL resource debt was not released")
 			}
 			if laterReleased {
-				t.Error("later command-WAL debt was released before its applied prefix")
+				t.Fatal("later command-WAL debt was released")
 			}
-		}
-		return nil
-	})
-	defer restoreObserver()
-
-	if err := db.CleanupCommandWALCoveredSegments(true); err != nil {
-		t.Fatalf("CleanupCommandWALCoveredSegments: %v", err)
-	}
-	if !coveredReleased {
-		t.Fatal("covered command-WAL rotation debt was not released")
-	}
-	if !coveredResourceReleased {
-		t.Fatal("covered command-WAL resource debt was not released")
-	}
-	if laterReleased {
-		t.Fatal("later command-WAL debt was released")
-	}
-	db.commandWALDebt.mu.Lock()
-	pending := len(db.commandWALDebt.entries)
-	db.commandWALDebt.mu.Unlock()
-	if pending != 1 {
-		t.Fatalf("pending debt entries=%d, want 1 for later LSN", pending)
+			db.commandWALDebt.mu.Lock()
+			pending := len(db.commandWALDebt.entries)
+			db.commandWALDebt.mu.Unlock()
+			if pending != 1 {
+				t.Fatalf("pending debt entries=%d, want 1 for later LSN", pending)
+			}
+		})
 	}
 }
 

--- a/TreeDB/db/command_wal_publish_test.go
+++ b/TreeDB/db/command_wal_publish_test.go
@@ -1001,14 +1001,60 @@ func TestCommandWALCheckpointCleanupReleasesCoveredDebtBeforeUnlink(t *testing.T
 			}
 			t.Cleanup(db.commandWALDebt.releaseAll)
 
+			wantErr := errors.New("injected pre-unlink cut")
+			restoreFailure := durabilitycut.Install(func(event durabilitycut.Event) error {
+				if event.Point == durabilitycut.BeforeWALOrAssetUnlink && filepath.Base(event.Path) == "commit-l0-000001.log" {
+					return wantErr
+				}
+				return nil
+			})
+			err = db.CleanupCommandWALCoveredSegments(sync)
+			restoreFailure()
+			if !errors.Is(err, wantErr) {
+				t.Fatalf("CleanupCommandWALCoveredSegments pre-unlink error=%v, want %v", err, wantErr)
+			}
+			if coveredReleased || coveredResourceReleased || laterReleased {
+				t.Fatalf("pre-unlink failure released debt: rotation=%t resource=%t later=%t", coveredReleased, coveredResourceReleased, laterReleased)
+			}
+			db.commandWALDebt.mu.Lock()
+			pendingAfterFailure := len(db.commandWALDebt.entries)
+			db.commandWALDebt.mu.Unlock()
+			if pendingAfterFailure != 2 {
+				t.Fatalf("pending debt entries after pre-unlink failure=%d, want 2", pendingAfterFailure)
+			}
+
+			wantRemoveErr := errors.New("injected segment remove failure")
+			originalRemove := removeCommandWALSegmentFn
+			removeCommandWALSegmentFn = func(path string) error {
+				if filepath.Base(path) == "commit-l0-000001.log" {
+					if !coveredReleased || !coveredResourceReleased {
+						t.Errorf("remove failure saw covered pins rotation=%t resource=%t, want released", coveredReleased, coveredResourceReleased)
+					}
+					if laterReleased {
+						t.Error("remove failure released later command-WAL debt")
+					}
+					return wantRemoveErr
+				}
+				return originalRemove(path)
+			}
+			err = db.CleanupCommandWALCoveredSegments(sync)
+			removeCommandWALSegmentFn = originalRemove
+			if !errors.Is(err, wantRemoveErr) {
+				t.Fatalf("CleanupCommandWALCoveredSegments remove error=%v, want %v", err, wantRemoveErr)
+			}
+			if _, statErr := os.Stat(filepath.Join(WALDirPath(dir), "commit-l0-000001.log")); statErr != nil {
+				t.Fatalf("covered segment stat after injected remove failure=%v, want present", statErr)
+			}
+			db.commandWALDebt.mu.Lock()
+			pendingAfterRemoveFailure := len(db.commandWALDebt.entries)
+			coveredPhysicalReleased := len(db.commandWALDebt.entries[0].resources) == 0 && len(db.commandWALDebt.entries[0].rotationFiles) == 0
+			db.commandWALDebt.mu.Unlock()
+			if pendingAfterRemoveFailure != 2 || !coveredPhysicalReleased {
+				t.Fatalf("remove failure debt entries=%d coveredPhysicalReleased=%t, want 2 and true", pendingAfterRemoveFailure, coveredPhysicalReleased)
+			}
+
 			restoreObserver := durabilitycut.Install(func(event durabilitycut.Event) error {
 				if event.Point == durabilitycut.BeforeWALOrAssetUnlink && filepath.Base(event.Path) == "commit-l0-000001.log" {
-					if !coveredReleased {
-						t.Error("covered command-WAL rotation debt remained pinned at its segment unlink")
-					}
-					if !coveredResourceReleased {
-						t.Error("covered command-WAL resource debt remained pinned at its segment unlink")
-					}
 					if laterReleased {
 						t.Error("later command-WAL debt was released before its applied prefix")
 					}
@@ -1016,6 +1062,19 @@ func TestCommandWALCheckpointCleanupReleasesCoveredDebtBeforeUnlink(t *testing.T
 				return nil
 			})
 			defer restoreObserver()
+			originalRemove = removeCommandWALSegmentFn
+			removeCommandWALSegmentFn = func(path string) error {
+				if filepath.Base(path) == "commit-l0-000001.log" {
+					if !coveredReleased {
+						t.Error("covered command-WAL rotation debt remained pinned at its segment unlink")
+					}
+					if !coveredResourceReleased {
+						t.Error("covered command-WAL resource debt remained pinned at its segment unlink")
+					}
+				}
+				return originalRemove(path)
+			}
+			defer func() { removeCommandWALSegmentFn = originalRemove }()
 
 			if err := db.CleanupCommandWALCoveredSegments(sync); err != nil {
 				t.Fatalf("CleanupCommandWALCoveredSegments: %v", err)

--- a/TreeDB/db/command_wal_publish_test.go
+++ b/TreeDB/db/command_wal_publish_test.go
@@ -1047,7 +1047,7 @@ func TestCommandWALCheckpointCleanupReleasesCoveredDebtBeforeUnlink(t *testing.T
 			}
 			db.commandWALDebt.mu.Lock()
 			pendingAfterRemoveFailure := len(db.commandWALDebt.entries)
-			coveredPhysicalReleased := len(db.commandWALDebt.entries[0].resources) == 0 && len(db.commandWALDebt.entries[0].rotationFiles) == 0
+			coveredPhysicalReleased := pendingAfterRemoveFailure > 0 && len(db.commandWALDebt.entries[0].resources) == 0 && len(db.commandWALDebt.entries[0].rotationFiles) == 0
 			db.commandWALDebt.mu.Unlock()
 			if pendingAfterRemoveFailure != 2 || !coveredPhysicalReleased {
 				t.Fatalf("remove failure debt entries=%d coveredPhysicalReleased=%t, want 2 and true", pendingAfterRemoveFailure, coveredPhysicalReleased)

--- a/TreeDB/db/command_wal_raw.go
+++ b/TreeDB/db/command_wal_raw.go
@@ -480,12 +480,18 @@ func (db *DB) CleanupCommandWALCoveredSegments(sync bool) error {
 		db.commandWALCleanupScanNs.Add(scanNs)
 	}
 	if err == nil {
-		// Covered dependency pins can retain handles to inactive segments. Drop
-		// them before unlinking those segments so Windows can remove them as
-		// well as Unix-like platforms. Pin release is independent of the
-		// optional deletion-directory fsync below.
-		db.releaseCommandWALDurablePrefixPinsThrough(state.AppliedCommandLSN)
-		decisions, err = removeCoveredCommandWALSegments(decisions)
+		// After the pre-unlink cut succeeds, make the physical dependencies
+		// durable before releasing their pins for Windows unlink. Logical debt
+		// remains until the unlink completes, so a failed cleanup cannot weaken
+		// a later explicit durability barrier.
+		decisions, err = removeCoveredCommandWALSegmentsWithHooks(decisions,
+			func(decision commandWALSegmentCleanupDecision) error {
+				return db.prepareCommandWALDependencyDebtForUnlink(decision.MaxLSN)
+			},
+			func(decision commandWALSegmentCleanupDecision) {
+				db.commandWALDebt.releaseThrough(decision.MaxLSN)
+			},
+		)
 	}
 	removed := uint64(0)
 	removedBytes := uint64(0)
@@ -539,11 +545,29 @@ func (db *DB) CleanupCommandWALCoveredSegments(sync bool) error {
 	return err
 }
 
-func (db *DB) releaseCommandWALDurablePrefixPinsThrough(lsn uint64) {
-	if db == nil || lsn == 0 {
-		return
+func (db *DB) prepareCommandWALDependencyDebtForUnlink(lsn uint64) error {
+	if db == nil || lsn == 0 || !db.commandWALDebt.hasPhysicalDependenciesThrough(lsn) {
+		return nil
 	}
-	db.commandWALDebt.releaseThrough(lsn)
+	view, err := db.commandWALDebt.resourceViewThrough(lsn)
+	if err == nil {
+		err = view.SyncThrough()
+	}
+	if err == nil {
+		err = db.commandWALDebt.syncRotationFilesThrough(db.dir, db.commandWALDir, lsn)
+	}
+	if err == nil {
+		err = stabilizeCommandWALResourceNamespaces(view)
+	}
+	if err == nil {
+		err = db.commandWALDebt.stabilizeRotationNamespacesThrough(db.dir, db.commandWALDir, lsn)
+	}
+	if err != nil {
+		db.commandWALDebt.noteRetryThrough(lsn)
+		return err
+	}
+	db.commandWALDebt.releasePhysicalThrough(lsn)
+	return nil
 }
 
 func (db *DB) closeCommandWALDurablePrefixThrough(lsn uint64) {

--- a/TreeDB/db/command_wal_raw.go
+++ b/TreeDB/db/command_wal_raw.go
@@ -480,6 +480,12 @@ func (db *DB) CleanupCommandWALCoveredSegments(sync bool) error {
 		db.commandWALCleanupScanNs.Add(scanNs)
 	}
 	if err == nil {
+		// Covered dependency pins can retain handles to inactive segments. Drop
+		// the durable prefix before unlinking those segments so Windows can
+		// remove them as well as Unix-like platforms.
+		if sync {
+			db.closeCommandWALDurablePrefixThrough(state.AppliedCommandLSN)
+		}
 		decisions, err = removeCoveredCommandWALSegments(decisions)
 	}
 	removed := uint64(0)
@@ -527,9 +533,6 @@ func (db *DB) CleanupCommandWALCoveredSegments(sync bool) error {
 				return errors.Join(syncErr, ErrRecoveryRequired)
 			}
 		}
-	}
-	if err == nil && sync {
-		db.closeCommandWALDurablePrefixThrough(state.AppliedCommandLSN)
 	}
 	return err
 }

--- a/TreeDB/db/command_wal_raw.go
+++ b/TreeDB/db/command_wal_raw.go
@@ -481,11 +481,10 @@ func (db *DB) CleanupCommandWALCoveredSegments(sync bool) error {
 	}
 	if err == nil {
 		// Covered dependency pins can retain handles to inactive segments. Drop
-		// the durable prefix before unlinking those segments so Windows can
-		// remove them as well as Unix-like platforms.
-		if sync {
-			db.closeCommandWALDurablePrefixThrough(state.AppliedCommandLSN)
-		}
+		// them before unlinking those segments so Windows can remove them as
+		// well as Unix-like platforms. Pin release is independent of the
+		// optional deletion-directory fsync below.
+		db.releaseCommandWALDurablePrefixPinsThrough(state.AppliedCommandLSN)
 		decisions, err = removeCoveredCommandWALSegments(decisions)
 	}
 	removed := uint64(0)
@@ -534,7 +533,17 @@ func (db *DB) CleanupCommandWALCoveredSegments(sync bool) error {
 			}
 		}
 	}
+	if err == nil && sync {
+		db.closeCommandWALDurablePrefixThrough(state.AppliedCommandLSN)
+	}
 	return err
+}
+
+func (db *DB) releaseCommandWALDurablePrefixPinsThrough(lsn uint64) {
+	if db == nil || lsn == 0 {
+		return
+	}
+	db.commandWALDebt.releaseThrough(lsn)
 }
 
 func (db *DB) closeCommandWALDurablePrefixThrough(lsn uint64) {

--- a/TreeDB/db/command_wal_raw.go
+++ b/TreeDB/db/command_wal_raw.go
@@ -486,7 +486,7 @@ func (db *DB) CleanupCommandWALCoveredSegments(sync bool) error {
 		// a later explicit durability barrier.
 		decisions, err = removeCoveredCommandWALSegmentsWithHooks(decisions,
 			func(decision commandWALSegmentCleanupDecision) error {
-				return db.prepareCommandWALDependencyDebtForUnlink(decision.MaxLSN)
+				return db.prepareCommandWALDependencyDebtForUnlink(decision.MaxLSN, decision.Path)
 			},
 			func(decision commandWALSegmentCleanupDecision) {
 				db.commandWALDebt.releaseThrough(decision.MaxLSN)
@@ -545,8 +545,8 @@ func (db *DB) CleanupCommandWALCoveredSegments(sync bool) error {
 	return err
 }
 
-func (db *DB) prepareCommandWALDependencyDebtForUnlink(lsn uint64) error {
-	if db == nil || lsn == 0 || !db.commandWALDebt.hasPhysicalDependenciesThrough(lsn) {
+func (db *DB) prepareCommandWALDependencyDebtForUnlink(lsn uint64, path string) error {
+	if db == nil || (lsn == 0 && path == "") || !db.commandWALDebt.hasPhysicalDependenciesForUnlink(lsn, db.commandWALDir, path) {
 		return nil
 	}
 	view, err := db.commandWALDebt.resourceViewThrough(lsn)
@@ -554,19 +554,19 @@ func (db *DB) prepareCommandWALDependencyDebtForUnlink(lsn uint64) error {
 		err = view.SyncThrough()
 	}
 	if err == nil {
-		err = db.commandWALDebt.syncRotationFilesThrough(db.dir, db.commandWALDir, lsn)
+		err = db.commandWALDebt.syncRotationFilesForUnlink(db.dir, db.commandWALDir, lsn, path)
 	}
 	if err == nil {
 		err = stabilizeCommandWALResourceNamespaces(view)
 	}
 	if err == nil {
-		err = db.commandWALDebt.stabilizeRotationNamespacesThrough(db.dir, db.commandWALDir, lsn)
+		err = db.commandWALDebt.stabilizeRotationNamespacesForUnlink(db.dir, db.commandWALDir, lsn, path)
 	}
 	if err != nil {
-		db.commandWALDebt.noteRetryThrough(lsn)
+		db.commandWALDebt.noteRetryForUnlink(lsn, db.commandWALDir, path)
 		return err
 	}
-	db.commandWALDebt.releasePhysicalThrough(lsn)
+	db.commandWALDebt.releasePhysicalForUnlink(lsn, db.commandWALDir, path)
 	return nil
 }
 


### PR DESCRIPTION
Closes #3778
Part of #3776

## Scope

Release covered command-WAL physical dependency pins only after the pre-unlink durability cut succeeds and the exact covered physical dependencies have been synced and namespace-stabilized. This happens before each actual inactive-segment unlink in both `sync=false` and `sync=true` cleanup.

Automatic size rotation records both the closed predecessor and active successor tokens on the successor frame's LSN. Cleanup therefore prepares the covered LSN prefix plus the exact predecessor token selected by the unlink path. It releases that predecessor handle before unlink while retaining the successor LSN's logical entry, unrelated resources, and active-successor token.

Logical debt is retained until unlink succeeds. A pre-unlink failure preserves untouched debt; an `os.Remove` failure leaves durable logical debt after its physical dependencies have crossed the preparation barrier, so a later explicit barrier cannot miss unsynced external references.

## Non-goals

- No on-disk format, recovery, public API, rotation-policy, Raft, or CI workflow changes.
- No Windows-specific retries, suppressed sharing errors, timeout changes, or #3682 cleanup-proof redesign.

## Evidence

Latest head: `fc0340abb5672c5e7d25d48a2ccb157d78dafca4`, based on `main@56a98f286756287d6863339efe8c0db794076df8`.

The deterministic regressions prove:

- pre-unlink injected failure preserves resource, rotation, and later-LSN debt;
- injected remove failure occurs after covered pins are released, retains the segment and logical debt, and preserves later debt;
- segment 1 at max LSN 10 releases its closed token even though rotation ownership is attached to segment 2's first LSN 11;
- segment 2's token and LSN 11 logical debt remain pinned/unapplied;
- the same basename outside the exact command-WAL directory cannot match;
- successful retry retires only debt covered by the actual unlink.

Coordinator validation on the exact head:

- `GOWORK=off go test ./TreeDB/db -run 'TestCommandWALCheckpointCleanup(ReleasesCoveredDebtBeforeUnlink|ReleasesPredecessorTokenOwnedBySuccessorLSN)$' -count=20`
- `GOWORK=off go test ./TreeDB/db -run 'TestCommandWAL.*Cleanup' -count=5`
- `GOWORK=off go test -race ./TreeDB/db -run 'TestCommandWALCheckpointCleanup(ReleasesCoveredDebtBeforeUnlink|ReleasesPredecessorTokenOwnedBySuccessorLSN)$' -count=5`
- `GOWORK=off go test ./TreeDB/collections -run '^TestCollectionCommandWALBSONYCSBPointLookupAfterLoad$' -count=3`
- `GOWORK=off go test ./TreeDB/db -count=1` (passed in 553.583s)
- `git diff --check origin/main...HEAD`

All passed locally. Fresh exact-head hosted CI and Codex review remain merge gates.

## Performance rationale

This remains cleanup-only. Ordinary command append, append sync, allocation, and namespace-sync paths are unchanged. Cleanup performs path-aware physical-durability preparation only for a covered segment being unlinked; no benchmark is applicable.

## Risks

Preparation failures retain selected debt and increment retry accounting. An unlink failure retains logical debt after physical dependencies are durable; successful retry or a later explicit close can retire it. Latest-head hosted Windows cleanup remains required.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved command WAL cleanup to safely handle files with linked dependency resources.
  * Ensured dependency data is synchronized and stabilized before WAL files are removed.
  * Prevented dependency tokens from being released prematurely when cleanup or file removal fails.
  * Added retry handling for interrupted cleanup operations.
  * Improved unlink behavior for rotation files and related resources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->