### PR TITLE
test(raftcluster): wait for a stable leader term

### DIFF
--- a/TreeDB/internal/raftcluster/hashicorp_raft_test.go
+++ b/TreeDB/internal/raftcluster/hashicorp_raft_test.go
@@ -79,7 +79,7 @@ func TestHashicorpRaftProviderThreeNodeLeaderSubmitAppliesFollowers(t *testing.T
 
 func TestHashicorpRaftProviderReadIndexReturnsProductionProofForLeader(t *testing.T) {
 	cluster := newHashicorpRaftDBCluster(t)
-	leader := cluster.waitForLeader(t)
+	leader := cluster.waitForLeaderReady(t)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
@@ -486,7 +486,7 @@ func TestHashicorpRaftProviderReadIndexRejectsTargetMismatch(t *testing.T) {
 
 func TestHashicorpRaftProviderSnapshotRejoinsLaggingFollowerAndCompactsLogs(t *testing.T) {
 	cluster := newHashicorpRaftDBCluster(t)
-	leader := cluster.waitForLeader(t)
+	leader := cluster.waitForLeaderReady(t)
 	lagging := cluster.firstFollower(t, leader.id)
 	healthy := cluster.firstFollowerExcept(t, leader.id, lagging.id)
 	cluster.disconnectNode(t, lagging.id)
@@ -1135,6 +1135,89 @@ func (c *hashicorpRaftTestCluster) waitForLeader(tb testing.TB) *hashicorpRaftTe
 	}
 	tb.Fatalf("timed out waiting for leader; states=%s", c.admissionSummary())
 	return nil
+}
+
+// waitForLeaderReady requires two leader observations in the same live term.
+// A single Leader admission observation is not sufficient: on slow hosts it
+// can be sampled while the election/current-term no-op is still settling,
+// allowing the next submit or read assertion to race leadership loss. This is
+// a test-harness barrier only; it deliberately does not retry the operation
+// under test.
+func (c *hashicorpRaftTestCluster) waitForLeaderReady(tb testing.TB) *hashicorpRaftTestNode {
+	tb.Helper()
+	deadline := time.Now().Add(15 * time.Second)
+	var previous leaderReadinessObservation
+	var lastErr error
+	for time.Now().Before(deadline) {
+		leader := c.waitForSingleLeader()
+		if leader == nil {
+			previous = leaderReadinessObservation{}
+			time.Sleep(20 * time.Millisecond)
+			continue
+		}
+		term, ok := HashicorpRaftTestLeaderTerm(leader.provider)
+		if !ok {
+			lastErr = errors.New("leader has no current term")
+			previous = leaderReadinessObservation{}
+			time.Sleep(20 * time.Millisecond)
+			continue
+		}
+		current := leaderReadinessObservation{nodeID: leader.id, term: term, valid: true}
+		if sameStableLeaderTerm(previous, current) {
+			return leader
+		}
+		previous = current
+		time.Sleep(20 * time.Millisecond)
+	}
+	tb.Fatalf("timed out waiting for leader-ready stable term; last_read_index_err=%v states=%s", lastErr, c.admissionSummary())
+	return nil
+}
+
+type leaderReadinessObservation struct {
+	nodeID NodeID
+	term   uint64
+	valid  bool
+}
+
+func sameStableLeaderTerm(previous, current leaderReadinessObservation) bool {
+	return previous.valid && current.valid && previous.nodeID == current.nodeID && previous.nodeID != "" && previous.term == current.term && current.term != 0
+}
+
+func (c *hashicorpRaftTestCluster) waitForSingleLeader() *hashicorpRaftTestNode {
+	var leader *hashicorpRaftTestNode
+	for _, node := range c.nodes {
+		if node.provider == nil {
+			continue
+		}
+		status, err := node.provider.ClusterAdmissionStatus(context.Background())
+		if err != nil || !status.Leader {
+			continue
+		}
+		if leader != nil {
+			return nil
+		}
+		leader = node
+	}
+	return leader
+}
+
+func TestHashicorpRaftLeaderReadinessRequiresConsecutiveObservationsInOneTerm(t *testing.T) {
+	ready := leaderReadinessObservation{nodeID: "node-a", term: 4, valid: true}
+	if sameStableLeaderTerm(leaderReadinessObservation{}, ready) {
+		t.Fatal("a single leader/proof observation must not satisfy the readiness barrier")
+	}
+	if sameStableLeaderTerm(ready, leaderReadinessObservation{nodeID: "node-a", term: 5, valid: true}) {
+		t.Fatal("a term transition must reset the readiness barrier")
+	}
+	if sameStableLeaderTerm(ready, leaderReadinessObservation{nodeID: "node-b", term: 4, valid: true}) {
+		t.Fatal("a leader transition must reset the readiness barrier")
+	}
+	if sameStableLeaderTerm(ready, leaderReadinessObservation{nodeID: "node-a", term: 4}) {
+		t.Fatal("an invalid observation must not satisfy the readiness barrier")
+	}
+	if !sameStableLeaderTerm(ready, ready) {
+		t.Fatal("two valid observations for the same leader term must satisfy the readiness barrier")
+	}
 }
 
 func (c *hashicorpRaftTestCluster) firstFollower(tb testing.TB, leaderID NodeID) *hashicorpRaftTestNode {

--- a/TreeDB/internal/raftcluster/hashicorp_raft_test.go
+++ b/TreeDB/internal/raftcluster/hashicorp_raft_test.go
@@ -27,7 +27,7 @@ import (
 
 func TestHashicorpRaftProviderThreeNodeLeaderSubmitAppliesFollowers(t *testing.T) {
 	cluster := newHashicorpRaftDBCluster(t)
-	leader := cluster.waitForLeaderReady(t)
+	leader := cluster.waitForLeader(t)
 
 	entry := testClusterCreateCollectionEntry(t, 7)
 	leaderCtx, leaderCancel := context.WithTimeout(context.Background(), 5*time.Second)
@@ -80,7 +80,7 @@ func TestHashicorpRaftProviderThreeNodeLeaderSubmitAppliesFollowers(t *testing.T
 
 func TestHashicorpRaftProviderReadIndexReturnsProductionProofForLeader(t *testing.T) {
 	cluster := newHashicorpRaftDBCluster(t)
-	leader := cluster.waitForLeaderReady(t)
+	leader := cluster.waitForLeader(t)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
@@ -490,7 +490,7 @@ func TestHashicorpRaftProviderSnapshotRejoinsLaggingFollowerAndCompactsLogs(t *t
 		t.Skip("Raft snapshot rejoin requires durable rename and removal namespaces")
 	}
 	cluster := newHashicorpRaftDBCluster(t)
-	leader := cluster.waitForLeaderReady(t)
+	leader := cluster.waitForLeader(t)
 	lagging := cluster.firstFollower(t, leader.id)
 	healthy := cluster.firstFollowerExcept(t, leader.id, lagging.id)
 	cluster.disconnectNode(t, lagging.id)
@@ -1112,42 +1112,13 @@ func hashicorpRaftFastTestConfig() *hraft.Config {
 	return conf
 }
 
-func (c *hashicorpRaftTestCluster) waitForLeader(tb testing.TB) *hashicorpRaftTestNode {
-	tb.Helper()
-	deadline := time.Now().Add(15 * time.Second)
-	for time.Now().Before(deadline) {
-		var leader *hashicorpRaftTestNode
-		for _, node := range c.nodes {
-			if node.provider == nil {
-				continue
-			}
-			status, err := node.provider.ClusterAdmissionStatus(context.Background())
-			if err != nil {
-				tb.Fatalf("%s ClusterAdmissionStatus: %v", node.id, err)
-			}
-			if status.Leader {
-				if leader != nil {
-					tb.Fatalf("multiple leaders: %s and %s", leader.id, node.id)
-				}
-				leader = node
-			}
-		}
-		if leader != nil {
-			return leader
-		}
-		time.Sleep(20 * time.Millisecond)
-	}
-	tb.Fatalf("timed out waiting for leader; states=%s", c.admissionSummary())
-	return nil
-}
-
-// waitForLeaderReady requires two leader observations in the same live term.
+// waitForLeader requires two leader observations in the same live term.
 // A single Leader admission observation is not sufficient: on slow hosts it
 // can be sampled while the election/current-term no-op is still settling,
 // allowing the next submit or read assertion to race leadership loss. This is
 // a test-harness barrier only; it deliberately does not retry the operation
 // under test.
-func (c *hashicorpRaftTestCluster) waitForLeaderReady(tb testing.TB) *hashicorpRaftTestNode {
+func (c *hashicorpRaftTestCluster) waitForLeader(tb testing.TB) *hashicorpRaftTestNode {
 	tb.Helper()
 	// Opening three durable test nodes can consume most of the old 15-second
 	// budget on a contended Windows runner. Keep failure bounded, but leave

--- a/TreeDB/internal/raftcluster/hashicorp_raft_test.go
+++ b/TreeDB/internal/raftcluster/hashicorp_raft_test.go
@@ -1130,7 +1130,7 @@ func (c *hashicorpRaftTestCluster) waitForLeader(tb testing.TB) *hashicorpRaftTe
 	var previous leaderReadinessObservation
 	var lastErr error
 	for readinessCtx.Err() == nil {
-		leader := c.waitForSingleLeader()
+		leader := c.waitForSingleLeader(tb)
 		if leader == nil {
 			previous = leaderReadinessObservation{}
 			waitForLeaderReadinessPoll(readinessCtx)
@@ -1171,18 +1171,22 @@ func sameStableLeaderTerm(previous, current leaderReadinessObservation) bool {
 	return previous.valid && current.valid && previous.nodeID == current.nodeID && previous.nodeID != "" && previous.term == current.term && current.term != 0
 }
 
-func (c *hashicorpRaftTestCluster) waitForSingleLeader() *hashicorpRaftTestNode {
+func (c *hashicorpRaftTestCluster) waitForSingleLeader(tb testing.TB) *hashicorpRaftTestNode {
+	tb.Helper()
 	var leader *hashicorpRaftTestNode
 	for _, node := range c.nodes {
 		if node.provider == nil {
 			continue
 		}
 		status, err := node.provider.ClusterAdmissionStatus(context.Background())
-		if err != nil || !status.Leader {
+		if err != nil {
+			tb.Fatalf("%s ClusterAdmissionStatus: %v", node.id, err)
+		}
+		if !status.Leader {
 			continue
 		}
 		if leader != nil {
-			return nil
+			tb.Fatalf("multiple leaders: %s and %s", leader.id, node.id)
 		}
 		leader = node
 	}

--- a/TreeDB/internal/raftcluster/hashicorp_raft_test.go
+++ b/TreeDB/internal/raftcluster/hashicorp_raft_test.go
@@ -1146,20 +1146,22 @@ func (c *hashicorpRaftTestCluster) waitForLeader(tb testing.TB) *hashicorpRaftTe
 func (c *hashicorpRaftTestCluster) waitForLeaderReady(tb testing.TB) *hashicorpRaftTestNode {
 	tb.Helper()
 	deadline := time.Now().Add(15 * time.Second)
+	readinessCtx, cancel := context.WithDeadline(context.Background(), deadline)
+	defer cancel()
 	var previous leaderReadinessObservation
 	var lastErr error
-	for time.Now().Before(deadline) {
+	for readinessCtx.Err() == nil {
 		leader := c.waitForSingleLeader()
 		if leader == nil {
 			previous = leaderReadinessObservation{}
-			time.Sleep(20 * time.Millisecond)
+			waitForLeaderReadinessPoll(readinessCtx)
 			continue
 		}
-		term, ok := HashicorpRaftTestLeaderReady(leader.provider)
-		if !ok {
-			lastErr = errors.New("leader failed live-term quorum verification")
+		term, err := HashicorpRaftTestLeaderReady(readinessCtx, leader.provider)
+		if err != nil {
+			lastErr = err
 			previous = leaderReadinessObservation{}
-			time.Sleep(20 * time.Millisecond)
+			waitForLeaderReadinessPoll(readinessCtx)
 			continue
 		}
 		current := leaderReadinessObservation{nodeID: leader.id, term: term, valid: true}
@@ -1167,10 +1169,17 @@ func (c *hashicorpRaftTestCluster) waitForLeaderReady(tb testing.TB) *hashicorpR
 			return leader
 		}
 		previous = current
-		time.Sleep(20 * time.Millisecond)
+		waitForLeaderReadinessPoll(readinessCtx)
 	}
-	tb.Fatalf("timed out waiting for leader-ready stable term; last_read_index_err=%v states=%s", lastErr, c.admissionSummary())
+	tb.Fatalf("timed out waiting for leader-ready stable term; last_readiness_err=%v states=%s", lastErr, c.admissionSummary())
 	return nil
+}
+
+func waitForLeaderReadinessPoll(ctx context.Context) {
+	select {
+	case <-time.After(20 * time.Millisecond):
+	case <-ctx.Done():
+	}
 }
 
 type leaderReadinessObservation struct {

--- a/TreeDB/internal/raftcluster/hashicorp_raft_test.go
+++ b/TreeDB/internal/raftcluster/hashicorp_raft_test.go
@@ -27,7 +27,7 @@ import (
 
 func TestHashicorpRaftProviderThreeNodeLeaderSubmitAppliesFollowers(t *testing.T) {
 	cluster := newHashicorpRaftDBCluster(t)
-	leader := cluster.waitForLeader(t)
+	leader := cluster.waitForLeaderReady(t)
 
 	entry := testClusterCreateCollectionEntry(t, 7)
 	leaderCtx, leaderCancel := context.WithTimeout(context.Background(), 5*time.Second)
@@ -1149,7 +1149,11 @@ func (c *hashicorpRaftTestCluster) waitForLeader(tb testing.TB) *hashicorpRaftTe
 // under test.
 func (c *hashicorpRaftTestCluster) waitForLeaderReady(tb testing.TB) *hashicorpRaftTestNode {
 	tb.Helper()
-	deadline := time.Now().Add(15 * time.Second)
+	// Opening three durable test nodes can consume most of the old 15-second
+	// budget on a contended Windows runner. Keep failure bounded, but leave
+	// enough time for an election before requiring the state-based quorum/term
+	// barrier below.
+	deadline := time.Now().Add(30 * time.Second)
 	readinessCtx, cancel := context.WithDeadline(context.Background(), deadline)
 	defer cancel()
 	var previous leaderReadinessObservation

--- a/TreeDB/internal/raftcluster/hashicorp_raft_test.go
+++ b/TreeDB/internal/raftcluster/hashicorp_raft_test.go
@@ -1155,9 +1155,9 @@ func (c *hashicorpRaftTestCluster) waitForLeaderReady(tb testing.TB) *hashicorpR
 			time.Sleep(20 * time.Millisecond)
 			continue
 		}
-		term, ok := HashicorpRaftTestLeaderTerm(leader.provider)
+		term, ok := HashicorpRaftTestLeaderReady(leader.provider)
 		if !ok {
-			lastErr = errors.New("leader has no current term")
+			lastErr = errors.New("leader failed live-term quorum verification")
 			previous = leaderReadinessObservation{}
 			time.Sleep(20 * time.Millisecond)
 			continue

--- a/TreeDB/internal/raftcluster/hashicorp_raft_testhook_test.go
+++ b/TreeDB/internal/raftcluster/hashicorp_raft_testhook_test.go
@@ -1,7 +1,10 @@
 package raftcluster
 
 import (
+	"context"
+	"errors"
 	"strconv"
+	"testing"
 
 	hraft "github.com/hashicorp/raft"
 )
@@ -10,13 +13,35 @@ import (
 // read needed by the external-package integration harness. Keeping this in a
 // _test.go file avoids extending the production provider API for test
 // readiness checks.
-func HashicorpRaftTestLeaderReady(provider *HashicorpRaftProvider) (uint64, bool) {
+func HashicorpRaftTestLeaderReady(ctx context.Context, provider *HashicorpRaftProvider) (uint64, error) {
 	if provider == nil || provider.raft == nil {
-		return 0, false
+		return 0, ErrHashicorpRaftUnavailable
 	}
-	if err := provider.raft.VerifyLeader().Error(); err != nil {
-		return 0, false
+	if err := waitHashicorpRaftFuture(ctx, provider.raft.VerifyLeader()); err != nil {
+		return 0, err
 	}
 	term, err := strconv.ParseUint(provider.raft.Stats()["term"], 10, 64)
-	return term, err == nil && term != 0 && provider.raft.State() == hraft.Leader
+	if err != nil || term == 0 || provider.raft.State() != hraft.Leader {
+		return 0, errors.New("leader term is no longer current")
+	}
+	return term, nil
+}
+
+type blockingHashicorpRaftFuture struct {
+	release <-chan struct{}
+}
+
+func (f blockingHashicorpRaftFuture) Error() error {
+	<-f.release
+	return nil
+}
+
+func TestWaitHashicorpRaftFutureHonorsCanceledContext(t *testing.T) {
+	release := make(chan struct{})
+	defer close(release)
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	if err := waitHashicorpRaftFuture(ctx, blockingHashicorpRaftFuture{release: release}); !errors.Is(err, context.Canceled) {
+		t.Fatalf("waitHashicorpRaftFuture error=%v want context cancellation", err)
+	}
 }

--- a/TreeDB/internal/raftcluster/hashicorp_raft_testhook_test.go
+++ b/TreeDB/internal/raftcluster/hashicorp_raft_testhook_test.go
@@ -1,14 +1,22 @@
 package raftcluster
 
-import "strconv"
+import (
+	"strconv"
 
-// HashicorpRaftTestLeaderTerm exposes only the live current term needed by the
-// external-package integration harness. Keeping this in a _test.go file avoids
-// extending the production provider API for test readiness checks.
-func HashicorpRaftTestLeaderTerm(provider *HashicorpRaftProvider) (uint64, bool) {
+	hraft "github.com/hashicorp/raft"
+)
+
+// HashicorpRaftTestLeaderReady performs the live quorum verification and term
+// read needed by the external-package integration harness. Keeping this in a
+// _test.go file avoids extending the production provider API for test
+// readiness checks.
+func HashicorpRaftTestLeaderReady(provider *HashicorpRaftProvider) (uint64, bool) {
 	if provider == nil || provider.raft == nil {
 		return 0, false
 	}
+	if err := provider.raft.VerifyLeader().Error(); err != nil {
+		return 0, false
+	}
 	term, err := strconv.ParseUint(provider.raft.Stats()["term"], 10, 64)
-	return term, err == nil && term != 0
+	return term, err == nil && term != 0 && provider.raft.State() == hraft.Leader
 }

--- a/TreeDB/internal/raftcluster/hashicorp_raft_testhook_test.go
+++ b/TreeDB/internal/raftcluster/hashicorp_raft_testhook_test.go
@@ -1,0 +1,14 @@
+package raftcluster
+
+import "strconv"
+
+// HashicorpRaftTestLeaderTerm exposes only the live current term needed by the
+// external-package integration harness. Keeping this in a _test.go file avoids
+// extending the production provider API for test readiness checks.
+func HashicorpRaftTestLeaderTerm(provider *HashicorpRaftProvider) (uint64, bool) {
+	if provider == nil || provider.raft == nil {
+		return 0, false
+	}
+	term, err := strconv.ParseUint(provider.raft.Stats()["term"], 10, 64)
+	return term, err == nil && term != 0
+}


### PR DESCRIPTION
## Summary

Closes #3665. Part of #3776.

Replaces the shared timing-only Hashicorp Raft integration-test leader helper with a bounded, harness-only readiness barrier. Every harness consumer now requires a candidate to pass Hashicorp Raft `VerifyLeader` and report the same live term in two consecutive observations before the test proceeds.

The verification future and poll wait share one context/deadline through the existing `waitHashicorpRaftFuture` helper. The hook lives in `_test.go`; no production provider API, retry policy, ambiguity result, storage behavior, or leadership-loss semantics changes.

## New current-main evidence

After PR #3789 merged, exact main `636afcada7bf98a8aa0989c055f9f8595e36d6f7` reproduced this family in TreeDB run `29453490325`, job `87481296183`: `TestHashicorpRaftProviderThreeNodeLeaderSubmitAppliesFollowers` exhausted the old 15-second timing-only wait with all three nodes lacking a known leader.

PR #3793 then reproduced the same family in run `29453548518`, job `87481480099`: after the old leader was shut down, the timing-only helper admitted a replacement that immediately lost leadership during submit in `TestHashicorpRaftProviderLeaderCrashAfterCommitRestartCatchUpConverges`.

Those two fresh failures show that the contract belongs at the shared helper boundary, not a fixed list of call sites. The bounded readiness budget is 30 seconds because opening three durable test nodes consumed most of the former budget on the contended hosted Windows run; an election must still pass live quorum verification and same-leader/same-term observations. Operations under test are never retried.

The shared barrier preserves the old helper's immediate failures for admission-status errors and simultaneous leaders; those distinct harness defects are not collapsed into a generic readiness timeout.

## Deterministic characterization

- `TestHashicorpRaftLeaderReadinessRequiresConsecutiveObservationsInOneTerm` rejects a single observation, leader change, term change, and invalid observation.
- `TestWaitHashicorpRaftFutureHonorsCanceledContext` supplies an intentionally blocked future with a pre-canceled context and proves verification cannot wait indefinitely.

## Validation (`GOWORK=off`)

- Leader-submit/read-index/snapshot, post-crash failover, and the two characterizations: `-count=20` — pass in 105.746s.
- Full `TreeDB/internal/raftcluster` package: `-count=3` — pass in 55.448s.
- Focused affected scenarios under `-race`: pass in 6.397s.
- `git diff --check`: pass.

Validated locally on exact head `59820ad6b1b6d32ab47a992417d9519012d1b73f`, refreshed from base `636afcada7bf98a8aa0989c055f9f8595e36d6f7`.

## Performance

Not performance-relevant: all changes are integration-test harness code outside production paths.

## Merge gate

Pending fresh exact-head full CI, an exact-head Codex review, zero unresolved review threads, and three independent green hosted `windows-core-2` executions. Linux/race CI must remain green.
