### PR TITLE
fix(ci): honor paired MVCC raw-gate timing samples

### DIFF
--- a/.github/scripts/check_mvcc_raw_path_gate.py
+++ b/.github/scripts/check_mvcc_raw_path_gate.py
@@ -143,9 +143,9 @@ def median_paired_ns_delta_percent(
             raise ValueError(
                 f"paired sample {index}: baseline ns/op must be positive, got {base.ns_per_op}"
             )
-        if not math.isfinite(head.ns_per_op) or head.ns_per_op < 0.0:
+        if not math.isfinite(head.ns_per_op) or head.ns_per_op <= 0.0:
             raise ValueError(
-                f"paired sample {index}: candidate ns/op must be non-negative, got {head.ns_per_op}"
+                f"paired sample {index}: candidate ns/op must be positive, got {head.ns_per_op}"
             )
         deltas.append(((head.ns_per_op / base.ns_per_op) - 1.0) * 100.0)
     return statistics.median(deltas)

--- a/.github/scripts/check_mvcc_raw_path_gate.py
+++ b/.github/scripts/check_mvcc_raw_path_gate.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import argparse
 import hashlib
 import json
+import math
 import os
 import re
 import stat
@@ -131,6 +132,25 @@ def median_sample(samples: list[Sample]) -> Sample:
     )
 
 
+def median_paired_ns_delta_percent(
+    baseline: list[Sample], candidate: list[Sample]
+) -> float:
+    if len(baseline) != len(candidate):
+        raise ValueError("baseline and candidate timing sample counts must match")
+    deltas: list[float] = []
+    for index, (base, head) in enumerate(zip(baseline, candidate), 1):
+        if not math.isfinite(base.ns_per_op) or base.ns_per_op <= 0.0:
+            raise ValueError(
+                f"paired sample {index}: baseline ns/op must be positive, got {base.ns_per_op}"
+            )
+        if not math.isfinite(head.ns_per_op) or head.ns_per_op < 0.0:
+            raise ValueError(
+                f"paired sample {index}: candidate ns/op must be non-negative, got {head.ns_per_op}"
+            )
+        deltas.append(((head.ns_per_op / base.ns_per_op) - 1.0) * 100.0)
+    return statistics.median(deltas)
+
+
 def evaluate(
     baseline: dict[str, list[Sample]],
     candidate: dict[str, list[Sample]],
@@ -143,8 +163,11 @@ def evaluate(
     for name in BENCHMARKS:
         base = median_sample(baseline[name])
         head = median_sample(candidate[name])
+        paired_ns_delta_percent = median_paired_ns_delta_percent(
+            baseline[name], candidate[name]
+        )
         ns_delta_percent = ((head.ns_per_op / base.ns_per_op) - 1.0) * 100.0
-        timing_pass = ns_delta_percent <= max_regression_percent
+        timing_pass = paired_ns_delta_percent <= max_regression_percent
         bytes_delta = head.bytes_per_op - base.bytes_per_op
         bytes_tolerance = min(
             base.bytes_per_op * max_bytes_regression_percent / 100.0,
@@ -168,6 +191,7 @@ def evaluate(
                     "allocs_per_op": head.allocs_per_op,
                 },
                 "ns_delta_percent": ns_delta_percent,
+                "paired_ns_delta_percent": paired_ns_delta_percent,
                 "bytes_delta": bytes_delta,
                 "bytes_tolerance": bytes_tolerance,
                 "timing_pass": timing_pass,
@@ -228,7 +252,8 @@ def render_markdown(
         f"- baseline: `{baseline_sha}`",
         f"- candidate: `{candidate_sha}`",
         f"- samples: {expected_samples} per revision, benchmark-group-paired alternating AB/BA order",
-        f"- timing threshold: candidate median <= baseline median + {max_regression_percent:g}%",
+        "- timing acceptance: median paired candidate/base relative delta <= "
+        f"{max_regression_percent:g}% (base/head medians remain reported for context)",
         "- allocs/op threshold: candidate median must not increase",
         "- B/op jitter threshold: candidate median may increase by at most the smaller of "
         f"{max_bytes_regression_percent:g}% or {max_bytes_regression_absolute:g} B; "
@@ -259,8 +284,8 @@ def render_markdown(
     lines.extend(
         [
             "",
-            "| Benchmark | Binary | Base ns/op | Head ns/op | Delta | Base B/op | Head B/op | B tolerance | Base allocs/op | Head allocs/op | Measured |",
-            "| --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | --- |",
+            "| Benchmark | Binary | Base ns/op | Head ns/op | Median delta | Paired delta | Base B/op | Head B/op | B tolerance | Base allocs/op | Head allocs/op | Measured |",
+            "| --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | --- |",
         ]
     )
     for row in results:
@@ -269,7 +294,7 @@ def render_markdown(
         assert isinstance(base, dict)
         assert isinstance(head, dict)
         lines.append(
-            "| {benchmark} | {binary} | {base_ns:.3f} | {head_ns:.3f} | {delta:+.2f}% | "
+            "| {benchmark} | {binary} | {base_ns:.3f} | {head_ns:.3f} | {delta:+.2f}% | {paired_delta:+.2f}% | "
             "{base_bytes:.3f} | {head_bytes:.3f} | {bytes_tolerance:.3f} | {base_allocs:.3f} | "
             "{head_allocs:.3f} | {status} |".format(
                 benchmark=row["benchmark"],
@@ -281,6 +306,7 @@ def render_markdown(
                 base_ns=base["ns_per_op"],
                 head_ns=head["ns_per_op"],
                 delta=row["ns_delta_percent"],
+                paired_delta=row["paired_ns_delta_percent"],
                 base_bytes=base["bytes_per_op"],
                 head_bytes=head["bytes_per_op"],
                 bytes_tolerance=row["bytes_tolerance"],
@@ -374,6 +400,24 @@ def self_test() -> None:
         passed, _ = evaluate(baseline, candidate, 5.0, 1.0, 64.0)
         if passed:
             raise AssertionError("B/op increase above the 64 B boundary should fail")
+
+        observed_baseline = [
+            1302945, 1176097, 1679767, 1962560, 1050465, 4438267, 1170681, 660182,
+        ]
+        observed_candidate = [
+            2491471, 839760, 1502818, 743114, 1287476, 4460418, 915485, 1558013,
+        ]
+        baseline = {
+            name: [Sample(ns_per_op, 128.0, 2.0) for ns_per_op in observed_baseline]
+            for name in BENCHMARKS
+        }
+        candidate = {
+            name: [Sample(ns_per_op, 128.0, 2.0) for ns_per_op in observed_candidate]
+            for name in BENCHMARKS
+        }
+        passed, results = evaluate(baseline, candidate, 5.0, 1.0, 64.0)
+        if not passed or results[0]["paired_ns_delta_percent"] >= 0.0:
+            raise AssertionError("paired samples should accept the observed false failure")
 
         candidate_path.write_text(synthetic_log(runs=7), encoding="utf-8")
         try:

--- a/.github/scripts/test_mvcc_raw_path_equivalence.py
+++ b/.github/scripts/test_mvcc_raw_path_equivalence.py
@@ -35,6 +35,69 @@ class RawPathEquivalenceTests(unittest.TestCase):
             for benchmark in CHECKER.BENCHMARKS
         ]
 
+    @staticmethod
+    def samples(timings: list[float]) -> list[CHECKER.Sample]:
+        return [CHECKER.Sample(timing, 128.0, 2.0) for timing in timings]
+
+    def benchmark_sets(
+        self, baseline_timings: list[float], candidate_timings: list[float]
+    ) -> tuple[dict[str, list[CHECKER.Sample]], dict[str, list[CHECKER.Sample]]]:
+        return (
+            {benchmark: self.samples(baseline_timings) for benchmark in CHECKER.BENCHMARKS},
+            {benchmark: self.samples(candidate_timings) for benchmark in CHECKER.BENCHMARKS},
+        )
+
+    def test_paired_timing_accepts_observed_independent_median_false_failure(self) -> None:
+        baseline, candidate = self.benchmark_sets(
+            [
+                1302945,
+                1176097,
+                1679767,
+                1962560,
+                1050465,
+                4438267,
+                1170681,
+                660182,
+            ],
+            [
+                2491471,
+                839760,
+                1502818,
+                743114,
+                1287476,
+                4460418,
+                915485,
+                1558013,
+            ],
+        )
+        passed, results = CHECKER.evaluate(baseline, candidate, 5.0, 1.0, 64.0)
+        self.assertTrue(passed)
+        self.assertGreater(results[0]["ns_delta_percent"], 5.0)
+        self.assertLess(results[0]["paired_ns_delta_percent"], 0.0)
+        self.assertTrue(results[0]["timing_pass"])
+
+    def test_paired_timing_rejects_real_regression(self) -> None:
+        baseline, candidate = self.benchmark_sets(
+            [100.0] * 8,
+            [106.0] * 8,
+        )
+        passed, results = CHECKER.evaluate(baseline, candidate, 5.0, 1.0, 64.0)
+        self.assertFalse(passed)
+        self.assertAlmostEqual(results[0]["paired_ns_delta_percent"], 6.0)
+        self.assertFalse(results[0]["timing_pass"])
+
+    def test_paired_timing_rejects_non_positive_baseline(self) -> None:
+        baseline, candidate = self.benchmark_sets(
+            [100.0, 100.0, 100.0, 0.0, 100.0, 100.0, 100.0, 100.0],
+            [100.0] * 8,
+        )
+        with self.assertRaisesRegex(ValueError, "baseline ns/op must be positive"):
+            CHECKER.evaluate(baseline, candidate, 5.0, 1.0, 64.0)
+
+        baseline, candidate = self.benchmark_sets([0.0] * 8, [100.0] * 8)
+        with self.assertRaisesRegex(ValueError, "baseline ns/op must be positive"):
+            CHECKER.evaluate(baseline, candidate, 5.0, 1.0, 64.0)
+
     def binary_paths(
         self, equivalent_packages: set[str]
     ) -> dict[str, dict[str, Path]]:
@@ -172,10 +235,13 @@ class RawPathEquivalenceTests(unittest.TestCase):
         self.assertTrue(payload["no_attributable_regression"])
         self.assertFalse(payload["measurement_pass"])
         self.assertFalse(payload["results"][0]["measurement_pass"])
+        self.assertAlmostEqual(payload["results"][0]["paired_ns_delta_percent"], 20.0)
         self.assertNotIn("pass", payload)
         markdown = markdown_output.read_text(encoding="utf-8")
         self.assertIn("- verdict: **EQUIVALENT**", markdown)
         self.assertIn("- measured threshold observation: **FAIL**", markdown)
+        self.assertIn("timing acceptance: median paired candidate/base", markdown)
+        self.assertIn("| Median delta | Paired delta |", markdown)
 
 
 if __name__ == "__main__":

--- a/.github/scripts/test_mvcc_raw_path_equivalence.py
+++ b/.github/scripts/test_mvcc_raw_path_equivalence.py
@@ -98,6 +98,18 @@ class RawPathEquivalenceTests(unittest.TestCase):
         with self.assertRaisesRegex(ValueError, "baseline ns/op must be positive"):
             CHECKER.evaluate(baseline, candidate, 5.0, 1.0, 64.0)
 
+    def test_paired_timing_rejects_non_positive_candidate(self) -> None:
+        baseline, candidate = self.benchmark_sets(
+            [100.0] * 8,
+            [100.0, 100.0, 100.0, 0.0, 100.0, 100.0, 100.0, 100.0],
+        )
+        with self.assertRaisesRegex(ValueError, "candidate ns/op must be positive"):
+            CHECKER.evaluate(baseline, candidate, 5.0, 1.0, 64.0)
+
+        baseline, candidate = self.benchmark_sets([100.0] * 8, [0.0] * 8)
+        with self.assertRaisesRegex(ValueError, "candidate ns/op must be positive"):
+            CHECKER.evaluate(baseline, candidate, 5.0, 1.0, 64.0)
+
     def binary_paths(
         self, equivalent_packages: set[str]
     ) -> dict[str, dict[str, Path]]:

--- a/TreeDB/docs/spec/dgraph-mvcc-readiness-3673.md
+++ b/TreeDB/docs/spec/dgraph-mvcc-readiness-3673.md
@@ -132,11 +132,11 @@ reads, batch writes, snapshot seek, iterator reuse, and durable synced writes.
 The point-read and batch-write rows use separate invocations so one row cannot
 delay the base/head pair for the other. Eight samples provide exactly four AB
 and four BA pairs; odd sample counts are rejected. The gate rejects a median
-timing regression over 5%, any allocation increase, or a material `B/op`
+paired candidate/base timing regression over 5%, any allocation increase, or a material `B/op`
 increase. A distinct `EQUIVALENT` acceptance is available only when the checker
 hashes all six actual test-binary paths and every row-producing base/head pair
 matches (`db`, `caching`, and `treedb`). `EQUIVALENT` preserves the measured
-PASS/FAIL medians and deltas but states that no observed difference can be
+PASS/FAIL base/head medians and paired timing deltas but states that no observed difference can be
 attributed to the candidate code; mixed, missing, or malformed binary evidence
 fails closed and cannot produce equivalence acceptance.
 The verdict truth table is `PASS` for a passing measurement, `EQUIVALENT` only

--- a/TreeDB/docs/spec/verification.md
+++ b/TreeDB/docs/spec/verification.md
@@ -619,7 +619,9 @@ Coverage:
   SHA-256 digests from all six actual row-producing benchmark binaries; mixed,
   missing, or malformed binary evidence cannot override a failed measurement.
   Raw and adapter gates require balanced even AB/BA sample counts and default
-  to eight samples per revision.
+  to eight samples per revision. The raw-gate timing verdict uses the median
+  per-pair candidate/base relative delta; base/head timing medians remain
+  reported as context.
   `scripts/mvcc_closeout_matrix.sh` runs the pinned CommitAt, GetAt,
   all-version, and pruning depth/durability matrix and captures CPU, peak RSS,
   normalized storage footprint, `B/op`, and `allocs/op`.


### PR DESCRIPTION
Closes #3783
Parent: #3776

## Summary

- gate timing on the median per-pair candidate/base relative delta already collected by the alternating AB/BA harness
- retain independently computed base/head medians as diagnostic context and emit both statistics in JSON and Markdown
- reject zero/non-finite timing operands and preserve allocation, B/op, binary-equivalence, and fail-closed evidence checks

## Triggering evidence and replay

PR #3781 workflow run [29442510951](https://github.com/snissn/gomap/actions/runs/29442510951), exact head `f7ac1bddfbd0b2b40b0c9198c0ddbba80760f5f6`, failed only `BenchmarkPublicCommandWALDurableTinyBatchWriteSync/placement=inline/shape=dirty_batch/ops=1`. Its preserved samples yield independent base/head medians `1239521` / `1395147 ns/op` (`+12.56%`) but a median paired candidate/base delta of `-5.02%`. Replaying the downloaded `baseline.txt` and `candidate.txt` through this checker returns measured `PASS`; the downloaded artifact did not retain the original six executables, so the replay uses distinct local stand-ins and validates the measurement verdict, not historical binary SHA evidence.

## Tests

- `python3 .github/scripts/test_mvcc_raw_path_equivalence.py`
- `python3 .github/scripts/check_mvcc_raw_path_gate.py --self-test`
- `python3 .github/scripts/test_mvcc_benchmark_pairing.py`
- `python3 .github/scripts/test_mvcc_candidate_checkout_guard.py`
- `python3 .github/scripts/test_summarize_mvcc_closeout.py`
- `python3 -m py_compile .github/scripts/check_mvcc_raw_path_gate.py .github/scripts/test_mvcc_raw_path_equivalence.py`
- `git diff --check`

No runtime TreeDB code changed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved raw-path timing regression checks by comparing paired baseline and candidate samples.
  * Prevented invalid or non-positive timing data from producing misleading results.
  * Reduced false failures for equivalent performance measurements while continuing to detect genuine regressions.

* **Documentation**
  * Clarified timing verdict calculations and acceptance criteria.
  * Updated reports to include paired timing deltas and expanded benchmark results details.

* **Tests**
  * Added coverage for equivalent timings, real regressions, invalid samples, and report output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->