### PR TITLE
test(nativewire): isolate current-writable read-barrier phase contexts

### DIFF
--- a/TreeDB/nativewire/forced_pointer_readability_test.go
+++ b/TreeDB/nativewire/forced_pointer_readability_test.go
@@ -69,20 +69,22 @@ func TestNativewireYCSBForcedPointerPublicationReadability(t *testing.T) {
 }
 
 func TestForcedPointerYCSBNativewirePhaseContextsAreIndependent(t *testing.T) {
-	phaseOne, cancelPhaseOne := newForcedPointerYCSBNativewirePhaseContext(t)
-	cancelPhaseOne()
+	var phaseOne context.Context
+	runForcedPointerYCSBNativewirePhase(t, func(ctx context.Context) {
+		phaseOne = ctx
+	})
 	if !errors.Is(phaseOne.Err(), context.Canceled) {
 		t.Fatalf("phase one context err=%v want context canceled", phaseOne.Err())
 	}
 
-	phaseTwo, cancelPhaseTwo := newForcedPointerYCSBNativewirePhaseContext(t)
-	defer cancelPhaseTwo()
-	if phaseTwo == phaseOne {
-		t.Fatal("phase two reused phase one context")
-	}
-	if err := phaseTwo.Err(); err != nil {
-		t.Fatalf("phase two inherited phase one cancellation: %v", err)
-	}
+	runForcedPointerYCSBNativewirePhase(t, func(phaseTwo context.Context) {
+		if phaseTwo == phaseOne {
+			t.Fatal("phase two reused phase one context")
+		}
+		if err := phaseTwo.Err(); err != nil {
+			t.Fatalf("phase two inherited phase one cancellation: %v", err)
+		}
+	})
 }
 
 func TestNativewireYCSBCurrentWritableValueLogReadBarrier(t *testing.T) {
@@ -92,9 +94,7 @@ func TestNativewireYCSBCurrentWritableValueLogReadBarrier(t *testing.T) {
 	keys, docs := forcedPointerYCSBDocuments(t, docCount)
 	samples := []int{0, docCount - 1}
 
-	func() {
-		ctx, cancel := newForcedPointerYCSBNativewirePhaseContext(t)
-		defer cancel()
+	runForcedPointerYCSBNativewirePhase(t, func(ctx context.Context) {
 		env := newForcedPointerYCSBNativewireCurrentWritableEnv(t, opts, true)
 		defer func() {
 			if err := env.cleanup(); err != nil {
@@ -106,11 +106,9 @@ func TestNativewireYCSBCurrentWritableValueLogReadBarrier(t *testing.T) {
 		loadForcedPointerYCSBThroughNativewire(t, ctx, clients, handles, keys, docs)
 		requirePublishedValueLogFiles(t, env.server.backend)
 		requireNativewireYCSBReadable(t, ctx, clients[0], handles[0], keys, docs, samples, "current-writable before flush")
-	}()
+	})
 
-	func() {
-		ctx, cancel := newForcedPointerYCSBNativewirePhaseContext(t)
-		defer cancel()
+	runForcedPointerYCSBNativewirePhase(t, func(ctx context.Context) {
 		faultDir := t.TempDir()
 		faultOpts := forcedPointerYCSBNativewireOptions(faultDir)
 		faultEnv := newForcedPointerYCSBNativewireCurrentWritableEnv(t, faultOpts, true)
@@ -157,12 +155,14 @@ func TestNativewireYCSBCurrentWritableValueLogReadBarrier(t *testing.T) {
 		if calls := barrierCalls.Load(); calls == 0 {
 			t.Fatalf("current-writable read barrier was not reached")
 		}
-	}()
+	})
 }
 
-func newForcedPointerYCSBNativewirePhaseContext(t testing.TB) (context.Context, context.CancelFunc) {
+func runForcedPointerYCSBNativewirePhase(t testing.TB, phase func(context.Context)) {
 	t.Helper()
-	return context.WithTimeout(context.Background(), 10*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	phase(ctx)
 }
 
 func forcedPointerYCSBNativewireOptions(dir string) treedb.Options {

--- a/TreeDB/nativewire/forced_pointer_readability_test.go
+++ b/TreeDB/nativewire/forced_pointer_readability_test.go
@@ -68,71 +68,101 @@ func TestNativewireYCSBForcedPointerPublicationReadability(t *testing.T) {
 	requirePublishedValueLogFiles(t, reopened.server.backend)
 }
 
+func TestForcedPointerYCSBNativewirePhaseContextsAreIndependent(t *testing.T) {
+	phaseOne, cancelPhaseOne := newForcedPointerYCSBNativewirePhaseContext(t)
+	cancelPhaseOne()
+	if !errors.Is(phaseOne.Err(), context.Canceled) {
+		t.Fatalf("phase one context err=%v want context canceled", phaseOne.Err())
+	}
+
+	phaseTwo, cancelPhaseTwo := newForcedPointerYCSBNativewirePhaseContext(t)
+	defer cancelPhaseTwo()
+	if phaseTwo == phaseOne {
+		t.Fatal("phase two reused phase one context")
+	}
+	if err := phaseTwo.Err(); err != nil {
+		t.Fatalf("phase two inherited phase one cancellation: %v", err)
+	}
+}
+
 func TestNativewireYCSBCurrentWritableValueLogReadBarrier(t *testing.T) {
 	const docCount = 16
 	dir := t.TempDir()
 	opts := forcedPointerYCSBNativewireOptions(dir)
 	keys, docs := forcedPointerYCSBDocuments(t, docCount)
 	samples := []int{0, docCount - 1}
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-	defer cancel()
 
-	env := newForcedPointerYCSBNativewireCurrentWritableEnv(t, opts, true)
-	clients, handles, cleanups := forcedPointerYCSBNativewireClients(t, ctx, env, 1)
-	loadForcedPointerYCSBThroughNativewire(t, ctx, clients, handles, keys, docs)
-	requirePublishedValueLogFiles(t, env.server.backend)
-	requireNativewireYCSBReadable(t, ctx, clients[0], handles[0], keys, docs, samples, "current-writable before flush")
-	closeForcedPointerYCSBNativewireClients(t, cleanups)
-	if err := env.cleanup(); err != nil {
-		t.Fatalf("close readable env: %v", err)
-	}
+	func() {
+		ctx, cancel := newForcedPointerYCSBNativewirePhaseContext(t)
+		defer cancel()
+		env := newForcedPointerYCSBNativewireCurrentWritableEnv(t, opts, true)
+		defer func() {
+			if err := env.cleanup(); err != nil {
+				t.Fatalf("close readable env: %v", err)
+			}
+		}()
+		clients, handles, cleanups := forcedPointerYCSBNativewireClients(t, ctx, env, 1)
+		defer closeForcedPointerYCSBNativewireClients(t, cleanups)
+		loadForcedPointerYCSBThroughNativewire(t, ctx, clients, handles, keys, docs)
+		requirePublishedValueLogFiles(t, env.server.backend)
+		requireNativewireYCSBReadable(t, ctx, clients[0], handles[0], keys, docs, samples, "current-writable before flush")
+	}()
 
-	faultDir := t.TempDir()
-	faultOpts := forcedPointerYCSBNativewireOptions(faultDir)
-	faultEnv := newForcedPointerYCSBNativewireCurrentWritableEnv(t, faultOpts, true)
-	defer func() {
-		if err := faultEnv.cleanup(); err != nil {
-			t.Fatalf("close fault env: %v", err)
+	func() {
+		ctx, cancel := newForcedPointerYCSBNativewirePhaseContext(t)
+		defer cancel()
+		faultDir := t.TempDir()
+		faultOpts := forcedPointerYCSBNativewireOptions(faultDir)
+		faultEnv := newForcedPointerYCSBNativewireCurrentWritableEnv(t, faultOpts, true)
+		defer func() {
+			if err := faultEnv.cleanup(); err != nil {
+				t.Fatalf("close fault env: %v", err)
+			}
+		}()
+		faultClients, faultHandles, faultCleanups := forcedPointerYCSBNativewireClients(t, ctx, faultEnv, 1)
+		defer closeForcedPointerYCSBNativewireClients(t, faultCleanups)
+		loadForcedPointerYCSBThroughNativewire(t, ctx, faultClients, faultHandles, keys, docs)
+		requirePublishedValueLogFiles(t, faultEnv.server.backend)
+
+		var barrierCalls atomic.Int32
+		faultEnv.server.backend.SetCurrentValueLogReadBarrierWithSize(func(fileID uint32) (int64, error) {
+			barrierCalls.Add(1)
+			return -1, io.ErrUnexpectedEOF
+		})
+
+		_, directErr := faultEnv.server.handleGetManyBody(&connState{}, []iwire.Section{
+			collectionNameRef(ycsbBenchCollection),
+			{ID: iwire.SectionDocumentIDs, Bytes: iwire.AppendByteVector(nil, keys[docCount-1])},
+		}, nil, ReadMetadata{})
+		if directErr == nil {
+			t.Fatalf("direct GetMany handler succeeded through injected current-writable read-boundary EOF")
+		}
+		if !errors.Is(directErr, io.ErrUnexpectedEOF) {
+			t.Fatalf("direct GetMany handler err=%v want injected unexpected EOF", directErr)
+		}
+		if errors.Is(directErr, collections.ErrCommitAmbiguous) {
+			t.Fatalf("direct GetMany handler err=%v unexpectedly classified as ErrCommitAmbiguous", directErr)
+		}
+		if !strings.Contains(directErr.Error(), "nativewire metadata") || !strings.Contains(directErr.Error(), "unexpected EOF") {
+			t.Fatalf("direct GetMany handler err=%q missing nativewire unexpected EOF context", directErr)
+		}
+
+		got, present, err := faultClients[0].GetMany(ctx, ycsbBenchCollection, [][]byte{keys[docCount-1]})
+		if err == nil {
+			t.Fatalf("GetMany succeeded through injected current-writable read-boundary EOF: docs=%d present=%v", len(got), present)
+		}
+		if !isRemoteError(err, iwire.ErrInternal) {
+			t.Fatalf("GetMany err=%v want remote internal error", err)
+		}
+		if calls := barrierCalls.Load(); calls == 0 {
+			t.Fatalf("current-writable read barrier was not reached")
 		}
 	}()
-	faultClients, faultHandles, faultCleanups := forcedPointerYCSBNativewireClients(t, ctx, faultEnv, 1)
-	defer closeForcedPointerYCSBNativewireClients(t, faultCleanups)
-	loadForcedPointerYCSBThroughNativewire(t, ctx, faultClients, faultHandles, keys, docs)
-	requirePublishedValueLogFiles(t, faultEnv.server.backend)
+}
 
-	var barrierCalls atomic.Int32
-	faultEnv.server.backend.SetCurrentValueLogReadBarrierWithSize(func(fileID uint32) (int64, error) {
-		barrierCalls.Add(1)
-		return -1, io.ErrUnexpectedEOF
-	})
-
-	_, directErr := faultEnv.server.handleGetManyBody(&connState{}, []iwire.Section{
-		collectionNameRef(ycsbBenchCollection),
-		{ID: iwire.SectionDocumentIDs, Bytes: iwire.AppendByteVector(nil, keys[docCount-1])},
-	}, nil, ReadMetadata{})
-	if directErr == nil {
-		t.Fatalf("direct GetMany handler succeeded through injected current-writable read-boundary EOF")
-	}
-	if !errors.Is(directErr, io.ErrUnexpectedEOF) {
-		t.Fatalf("direct GetMany handler err=%v want injected unexpected EOF", directErr)
-	}
-	if errors.Is(directErr, collections.ErrCommitAmbiguous) {
-		t.Fatalf("direct GetMany handler err=%v unexpectedly classified as ErrCommitAmbiguous", directErr)
-	}
-	if !strings.Contains(directErr.Error(), "nativewire metadata") || !strings.Contains(directErr.Error(), "unexpected EOF") {
-		t.Fatalf("direct GetMany handler err=%q missing nativewire unexpected EOF context", directErr)
-	}
-
-	got, present, err := faultClients[0].GetMany(ctx, ycsbBenchCollection, [][]byte{keys[docCount-1]})
-	if err == nil {
-		t.Fatalf("GetMany succeeded through injected current-writable read-boundary EOF: docs=%d present=%v", len(got), present)
-	}
-	if !isRemoteError(err, iwire.ErrInternal) {
-		t.Fatalf("GetMany err=%v want remote internal error", err)
-	}
-	if calls := barrierCalls.Load(); calls == 0 {
-		t.Fatalf("current-writable read barrier was not reached")
-	}
+func newForcedPointerYCSBNativewirePhaseContext(t testing.TB) (context.Context, context.CancelFunc) {
+	t.Helper()
+	return context.WithTimeout(context.Background(), 10*time.Second)
 }
 
 func forcedPointerYCSBNativewireOptions(dir string) treedb.Options {


### PR DESCRIPTION
Fixes #3784
Related: #3776

The Windows workflow-only failure on [TreeDB run 29441268032](https://github.com/snissn/gomap/actions/runs/29441268032) reused a single 10-second context across independent healthy and fault-injection environments.

This test-only change gives each lifecycle its own bounded 10-second context, preserves the read-barrier assertions, and cleans up clients before their environment. It also characterizes that canceling phase one cannot cancel phase two.

Validation:
- focused target and characterization: `GOWORK=off go test ./TreeDB/nativewire ... -count=10`
- focused race: `GOWORK=off go test -race ./TreeDB/nativewire ... -count=1`
- full package: `GOWORK=off go test ./TreeDB/nativewire -count=1`

Merge gate:
- latest-head hosted CI
- exact-head Codex review with all findings resolved
- three independent hosted `windows-core-2` executions containing the named test