### PR TITLE
ci: stabilize paired snapshot and nativewire evidence

### DIFF
--- a/.github/scripts/collect_snapshot_iterator_pairs.sh
+++ b/.github/scripts/collect_snapshot_iterator_pairs.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Build the test binary once before invoking this collector. It emits an annotated,
+# balanced AB/BA transcript which snapshot_iterator_bench treats as fail-closed evidence.
+binary=${1:?benchmark binary required}
+output=${2:?raw output required}
+pairs=${SNAPSHOT_ITERATOR_PAIRS:-8}
+benchtime=${SNAPSHOT_ITERATOR_BENCHTIME:-500ms}
+cpu=${SNAPSHOT_ITERATOR_CPU:-}
+if (( pairs < 2 || pairs % 2 != 0 )); then echo "SNAPSHOT_ITERATOR_PAIRS must be positive and even" >&2; exit 2; fi
+if [[ -z "$cpu" ]]; then cpu=$(taskset -pc $$ | sed -E 's/.*: *//' | sed -E 's/[^0-9].*$//' ); fi
+if [[ ! "$cpu" =~ ^[0-9]+$ ]]; then echo "could not determine one allowed CPU" >&2; exit 2; fi
+printf 'affinity=%s\n' "$cpu" > "${output%.txt}.affinity"
+: > "$output"
+for keys in 1024 16384; do
+  for op in seek next; do
+    for ((pair=1; pair<=pairs; pair++)); do
+      if (( pair % 2 )); then order=AB; modes=(snapshot public); else order=BA; modes=(public snapshot); fi
+      for mode in "${modes[@]}"; do
+        if [[ "$mode" == public ]]; then name="public_${op}_baseline"; else name="snapshot_${op}"; fi
+        printf '# pair=%d order=%s\n' "$pair" "$order" >> "$output"
+        GOMAXPROCS=1 taskset -c "$cpu" "$binary" -test.run '^$' -test.bench "^BenchmarkSnapshotIteratorSeekNext/keys=${keys}/${name}$" -test.benchmem -test.benchtime "$benchtime" >> "$output"
+      done
+    done
+  done
+done

--- a/.github/scripts/snapshot_iterator_bench/README.md
+++ b/.github/scripts/snapshot_iterator_bench/README.md
@@ -1,0 +1,17 @@
+# Snapshot iterator paired performance gate
+
+The hosted gate builds exactly one `TreeDB` test binary, records its SHA-256, and
+uses `collect_snapshot_iterator_pairs.sh` to run every measured row on one CPU.
+Each row has eight samples arranged as four `AB` and four `BA` pairs, where A is
+the snapshot iterator and B is the public iterator baseline. The collector
+annotates every raw benchmark row with its pair number and order.
+
+`main.go` rejects incomplete, duplicated, non-finite, unbalanced, or improperly
+ordered pairs. It gates the median of the per-pair `(snapshot/public - 1)` timing
+deltas at 5%, while retaining independent snapshot/public medians solely as
+diagnostic context. Any B/op or allocs/op median increase also fails the gate.
+
+The evidence artifact includes the exact head, binary digest, runner image, CPU
+model, pinned affinity, Go version, raw annotated samples, JSON result, and
+Markdown summary. This is a same-binary relative comparison, not an absolute
+cross-run performance result.

--- a/.github/scripts/snapshot_iterator_bench/main.go
+++ b/.github/scripts/snapshot_iterator_bench/main.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"flag"
 	"fmt"
+	"math"
 	"os"
 	"regexp"
 	"sort"
@@ -18,40 +19,53 @@ const benchmarkPrefix = "BenchmarkSnapshotIteratorSeekNext/"
 var cpuSuffix = regexp.MustCompile(`-\d+$`)
 
 type rowKey struct {
-	Keys      int
-	Mode      string
-	Operation string
+	Keys            int
+	Mode, Operation string
 }
-
 type sample struct {
-	NSPerOp     float64
-	BytesPerOp  float64
-	AllocsPerOp float64
+	NSPerOp     float64 `json:"ns_per_op"`
+	BytesPerOp  float64 `json:"bytes_per_op"`
+	AllocsPerOp float64 `json:"allocs_per_op"`
 }
-
+type capturedSample struct {
+	Pair     int    `json:"pair"`
+	Order    string `json:"order"`
+	Mode     string `json:"mode"`
+	Sequence int    `json:"sequence"`
+	Sample   sample `json:"sample"`
+}
 type metadata struct {
-	Head        string `json:"head"`
-	RunnerImage string `json:"runner_image"`
-	CPU         string `json:"cpu"`
-	GoVersion   string `json:"go_version"`
+	Head         string `json:"head"`
+	BinarySHA256 string `json:"binary_sha256"`
+	RunnerImage  string `json:"runner_image"`
+	CPU          string `json:"cpu"`
+	Affinity     string `json:"affinity"`
+	GoVersion    string `json:"go_version"`
 }
-
+type pairResult struct {
+	Pair         int     `json:"pair"`
+	Order        string  `json:"order"`
+	Snapshot     sample  `json:"snapshot"`
+	Public       sample  `json:"public"`
+	DeltaPercent float64 `json:"delta_percent"`
+}
 type caseResult struct {
-	Keys                 int     `json:"keys"`
-	Operation            string  `json:"operation"`
-	Samples              int     `json:"samples"`
-	SnapshotMedianNS     float64 `json:"snapshot_median_ns_per_op"`
-	PublicMedianNS       float64 `json:"public_median_ns_per_op"`
-	DeltaPercent         float64 `json:"delta_percent"`
-	SnapshotMedianBytes  float64 `json:"snapshot_median_bytes_per_op"`
-	PublicMedianBytes    float64 `json:"public_median_bytes_per_op"`
-	SnapshotMedianAllocs float64 `json:"snapshot_median_allocs_per_op"`
-	PublicMedianAllocs   float64 `json:"public_median_allocs_per_op"`
-	TimingPassed         bool    `json:"timing_passed"`
-	AllocationGatePassed bool    `json:"allocation_gate_passed"`
-	Passed               bool    `json:"passed"`
+	Keys                     int          `json:"keys"`
+	Operation                string       `json:"operation"`
+	Samples                  int          `json:"samples"`
+	Pairs                    []pairResult `json:"pairs"`
+	SnapshotMedianNS         float64      `json:"snapshot_median_ns_per_op"`
+	PublicMedianNS           float64      `json:"public_median_ns_per_op"`
+	IndependentDeltaPercent  float64      `json:"independent_delta_percent"`
+	PairedMedianDeltaPercent float64      `json:"paired_median_delta_percent"`
+	SnapshotMedianBytes      float64      `json:"snapshot_median_bytes_per_op"`
+	PublicMedianBytes        float64      `json:"public_median_bytes_per_op"`
+	SnapshotMedianAllocs     float64      `json:"snapshot_median_allocs_per_op"`
+	PublicMedianAllocs       float64      `json:"public_median_allocs_per_op"`
+	TimingPassed             bool         `json:"timing_passed"`
+	AllocationGatePassed     bool         `json:"allocation_gate_passed"`
+	Passed                   bool         `json:"passed"`
 }
-
 type report struct {
 	Metadata             metadata     `json:"metadata"`
 	RequiredSamples      int          `json:"required_samples"`
@@ -60,23 +74,28 @@ type report struct {
 	Violations           []string     `json:"violations,omitempty"`
 	Passed               bool         `json:"passed"`
 }
+type annotation struct {
+	Pair  int
+	Order string
+}
 
 func main() {
 	var inputPath, jsonPath, markdownPath string
 	var meta metadata
 	var requiredSamples int
 	var maxRegression float64
-	flag.StringVar(&inputPath, "bench-output", "", "path to raw go benchmark output")
-	flag.StringVar(&jsonPath, "json-output", "", "path for the machine-readable report")
-	flag.StringVar(&markdownPath, "markdown-output", "", "path for the Markdown report")
+	flag.StringVar(&inputPath, "bench-output", "", "path to annotated raw go benchmark output")
+	flag.StringVar(&jsonPath, "json-output", "", "path for JSON report")
+	flag.StringVar(&markdownPath, "markdown-output", "", "path for Markdown report")
 	flag.StringVar(&meta.Head, "head", "", "exact git commit under test")
+	flag.StringVar(&meta.BinarySHA256, "binary-sha256", "", "SHA-256 of the single benchmark binary")
 	flag.StringVar(&meta.RunnerImage, "runner-image", "", "hosted runner image")
-	flag.StringVar(&meta.CPU, "cpu", "", "runner CPU description")
-	flag.StringVar(&meta.GoVersion, "go-version", "", "Go toolchain description")
-	flag.IntVar(&requiredSamples, "samples", 7, "required samples per benchmark row")
-	flag.Float64Var(&maxRegression, "max-regression", 0.05, "maximum snapshot/public median regression fraction")
+	flag.StringVar(&meta.CPU, "cpu", "", "runner CPU")
+	flag.StringVar(&meta.Affinity, "affinity", "", "recorded CPU affinity")
+	flag.StringVar(&meta.GoVersion, "go-version", "", "Go toolchain")
+	flag.IntVar(&requiredSamples, "samples", 8, "required even balanced samples per benchmark row")
+	flag.Float64Var(&maxRegression, "max-regression", .05, "maximum paired snapshot/public regression fraction")
 	flag.Parse()
-
 	if inputPath == "" || jsonPath == "" || markdownPath == "" {
 		fatal(errors.New("-bench-output, -json-output, and -markdown-output are required"))
 	}
@@ -92,26 +111,36 @@ func main() {
 	if err := writeReports(rep, jsonPath, markdownPath); err != nil {
 		fatal(err)
 	}
-	for _, violation := range rep.Violations {
-		fmt.Printf("::error::%s\n", violation)
+	for _, v := range rep.Violations {
+		fmt.Printf("::error::%s\n", v)
 	}
 	if !rep.Passed {
 		os.Exit(1)
 	}
 }
+func fatal(err error) { fmt.Fprintln(os.Stderr, err); os.Exit(2) }
 
-func fatal(err error) {
-	fmt.Fprintln(os.Stderr, err)
-	os.Exit(2)
-}
-
-func parseBenchmarkOutput(raw string) (map[rowKey][]sample, error) {
-	rows := make(map[rowKey][]sample)
+// Each measured row must be immediately preceded by "# pair=N order=AB|BA".
+func parseBenchmarkOutput(raw string) (map[rowKey][]capturedSample, error) {
+	rows := make(map[rowKey][]capturedSample)
 	scanner := bufio.NewScanner(strings.NewReader(raw))
+	var pending *annotation
+	sequence := 0
 	for scanner.Scan() {
 		line := strings.TrimSpace(scanner.Text())
+		if strings.HasPrefix(line, "# pair=") {
+			a, err := parseAnnotation(line)
+			if err != nil {
+				return nil, err
+			}
+			pending = &a
+			continue
+		}
 		if !strings.HasPrefix(line, benchmarkPrefix) {
 			continue
+		}
+		if pending == nil {
+			return nil, fmt.Errorf("benchmark row missing pair annotation: %q", line)
 		}
 		fields := strings.Fields(line)
 		if len(fields) < 8 {
@@ -125,7 +154,7 @@ func parseBenchmarkOutput(raw string) (map[rowKey][]sample, error) {
 		if err != nil {
 			return nil, fmt.Errorf("%s: %w", fields[0], err)
 		}
-		bytesPerOp, err := metric(fields, "B/op")
+		bytes, err := metric(fields, "B/op")
 		if err != nil {
 			return nil, fmt.Errorf("%s: %w", fields[0], err)
 		}
@@ -133,141 +162,181 @@ func parseBenchmarkOutput(raw string) (map[rowKey][]sample, error) {
 		if err != nil {
 			return nil, fmt.Errorf("%s: %w", fields[0], err)
 		}
-		rows[key] = append(rows[key], sample{NSPerOp: ns, BytesPerOp: bytesPerOp, AllocsPerOp: allocs})
+		sequence++
+		rows[key] = append(rows[key], capturedSample{Pair: pending.Pair, Order: pending.Order, Mode: key.Mode, Sequence: sequence, Sample: sample{ns, bytes, allocs}})
+		pending = nil
 	}
 	if err := scanner.Err(); err != nil {
 		return nil, fmt.Errorf("scan benchmark output: %w", err)
 	}
+	if pending != nil {
+		return nil, errors.New("pair annotation without benchmark row")
+	}
 	return rows, nil
 }
-
+func parseAnnotation(line string) (annotation, error) {
+	var a annotation
+	fields := strings.Fields(line)
+	if len(fields) != 3 || fields[0] != "#" || !strings.HasPrefix(fields[1], "pair=") || !strings.HasPrefix(fields[2], "order=") {
+		return a, fmt.Errorf("malformed pair annotation %q", line)
+	}
+	pair, err := strconv.Atoi(strings.TrimPrefix(fields[1], "pair="))
+	a.Pair, a.Order = pair, strings.TrimPrefix(fields[2], "order=")
+	if err != nil || a.Pair < 1 || (a.Order != "AB" && a.Order != "BA") {
+		return a, fmt.Errorf("malformed pair annotation %q", line)
+	}
+	return a, nil
+}
 func parseRowKey(name string) (rowKey, error) {
 	parts := strings.Split(name, "/")
 	if len(parts) != 3 || parts[0] != strings.TrimSuffix(benchmarkPrefix, "/") {
 		return rowKey{}, fmt.Errorf("unexpected snapshot iterator benchmark name %q", name)
 	}
-	keysText, ok := strings.CutPrefix(parts[1], "keys=")
+	text, ok := strings.CutPrefix(parts[1], "keys=")
 	if !ok {
 		return rowKey{}, fmt.Errorf("missing key count in benchmark name %q", name)
 	}
-	keys, err := strconv.Atoi(keysText)
+	keys, err := strconv.Atoi(text)
 	if err != nil {
 		return rowKey{}, fmt.Errorf("invalid key count in benchmark name %q", name)
 	}
-	modeOperation := parts[2]
-	if strings.HasPrefix(modeOperation, "public_") {
+	mo := parts[2]
+	if strings.HasPrefix(mo, "public_") {
 		var ok bool
-		modeOperation, ok = strings.CutSuffix(modeOperation, "_baseline")
+		mo, ok = strings.CutSuffix(mo, "_baseline")
 		if !ok {
 			return rowKey{}, fmt.Errorf("public benchmark is not labeled as a baseline in %q", name)
 		}
 	}
-	mode, operation, ok := strings.Cut(modeOperation, "_")
-	if !ok || (mode != "snapshot" && mode != "public") || (operation != "seek" && operation != "next") {
+	mode, op, ok := strings.Cut(mo, "_")
+	if !ok || (mode != "snapshot" && mode != "public") || (op != "seek" && op != "next") {
 		return rowKey{}, fmt.Errorf("unexpected mode/operation in benchmark name %q", name)
 	}
-	return rowKey{Keys: keys, Mode: mode, Operation: operation}, nil
+	return rowKey{keys, mode, op}, nil
 }
-
 func metric(fields []string, unit string) (float64, error) {
 	for i := 1; i < len(fields); i++ {
-		if fields[i] != unit {
-			continue
+		if fields[i] == unit {
+			v, err := strconv.ParseFloat(fields[i-1], 64)
+			if err != nil {
+				return 0, fmt.Errorf("parse %s value %q: %w", unit, fields[i-1], err)
+			}
+			return v, nil
 		}
-		value, err := strconv.ParseFloat(fields[i-1], 64)
-		if err != nil {
-			return 0, fmt.Errorf("parse %s value %q: %w", unit, fields[i-1], err)
-		}
-		return value, nil
 	}
 	return 0, fmt.Errorf("missing %s", unit)
 }
 
-func evaluate(rows map[rowKey][]sample, meta metadata, requiredSamples int, maxRegression float64) report {
-	rep := report{
-		Metadata:             meta,
-		RequiredSamples:      requiredSamples,
-		MaxRegressionPercent: maxRegression * 100,
+func evaluate(rows map[rowKey][]capturedSample, meta metadata, required int, max float64) report {
+	rep := report{Metadata: meta, RequiredSamples: required, MaxRegressionPercent: max * 100}
+	if required < 2 || required%2 != 0 {
+		rep.Violations = append(rep.Violations, "required samples must be a positive even number")
+	}
+	for label, value := range map[string]string{"head": meta.Head, "binary_sha256": meta.BinarySHA256, "runner_image": meta.RunnerImage, "cpu": meta.CPU, "affinity": meta.Affinity, "go_version": meta.GoVersion} {
+		if strings.TrimSpace(value) == "" {
+			rep.Violations = append(rep.Violations, "missing metadata "+label)
+		}
 	}
 	for _, keys := range []int{1024, 16384} {
-		for _, operation := range []string{"seek", "next"} {
-			snapshot := rows[rowKey{Keys: keys, Mode: "snapshot", Operation: operation}]
-			public := rows[rowKey{Keys: keys, Mode: "public", Operation: operation}]
-			if len(snapshot) != requiredSamples || len(public) != requiredSamples {
-				rep.Violations = append(rep.Violations, fmt.Sprintf(
-					"keys=%d operation=%s requires %d samples per mode; snapshot=%d public=%d",
-					keys, operation, requiredSamples, len(snapshot), len(public)))
-				continue
-			}
-			snapshotNS := median(samplesMetric(snapshot, func(s sample) float64 { return s.NSPerOp }))
-			publicNS := median(samplesMetric(public, func(s sample) float64 { return s.NSPerOp }))
-			snapshotBytes := median(samplesMetric(snapshot, func(s sample) float64 { return s.BytesPerOp }))
-			publicBytes := median(samplesMetric(public, func(s sample) float64 { return s.BytesPerOp }))
-			snapshotAllocs := median(samplesMetric(snapshot, func(s sample) float64 { return s.AllocsPerOp }))
-			publicAllocs := median(samplesMetric(public, func(s sample) float64 { return s.AllocsPerOp }))
-			delta := 0.0
-			if publicNS > 0 {
-				delta = ((snapshotNS / publicNS) - 1) * 100
-			}
-			timingPassed := publicNS > 0 && snapshotNS <= publicNS*(1+maxRegression)
-			allocationPassed := snapshotBytes <= publicBytes && snapshotAllocs <= publicAllocs
-			result := caseResult{
-				Keys: keys, Operation: operation, Samples: requiredSamples,
-				SnapshotMedianNS: snapshotNS, PublicMedianNS: publicNS, DeltaPercent: delta,
-				SnapshotMedianBytes: snapshotBytes, PublicMedianBytes: publicBytes,
-				SnapshotMedianAllocs: snapshotAllocs, PublicMedianAllocs: publicAllocs,
-				TimingPassed: timingPassed, AllocationGatePassed: allocationPassed,
-				Passed: timingPassed && allocationPassed,
-			}
-			rep.Cases = append(rep.Cases, result)
-			if !timingPassed {
-				rep.Violations = append(rep.Violations, fmt.Sprintf(
-					"keys=%d operation=%s snapshot median %.3f ns/op exceeds public %.3f ns/op by %.2f%% (max %.2f%%)",
-					keys, operation, snapshotNS, publicNS, delta, maxRegression*100))
-			}
-			if !allocationPassed {
-				rep.Violations = append(rep.Violations, fmt.Sprintf(
-					"keys=%d operation=%s allocation increase: snapshot %.0f B/op %.0f allocs/op; public %.0f B/op %.0f allocs/op",
-					keys, operation, snapshotBytes, snapshotAllocs, publicBytes, publicAllocs))
+		for _, op := range []string{"seek", "next"} {
+			s := rows[rowKey{keys, "snapshot", op}]
+			p := rows[rowKey{keys, "public", op}]
+			result, violations := evaluateCase(keys, op, s, p, required, max)
+			rep.Violations = append(rep.Violations, violations...)
+			if result != nil {
+				rep.Cases = append(rep.Cases, *result)
 			}
 		}
 	}
 	rep.Passed = len(rep.Violations) == 0 && len(rep.Cases) == 4
 	return rep
 }
-
-func samplesMetric(samples []sample, pick func(sample) float64) []float64 {
-	values := make([]float64, len(samples))
-	for i := range samples {
-		values[i] = pick(samples[i])
+func evaluateCase(keys int, op string, snap, pub []capturedSample, required int, max float64) (*caseResult, []string) {
+	prefix := fmt.Sprintf("keys=%d operation=%s", keys, op)
+	if len(snap) != required || len(pub) != required {
+		return nil, []string{fmt.Sprintf("%s requires %d samples per mode; snapshot=%d public=%d", prefix, required, len(snap), len(pub))}
 	}
-	return values
-}
-
-func median(values []float64) float64 {
-	values = append([]float64(nil), values...)
-	sort.Float64s(values)
-	mid := len(values) / 2
-	if len(values)%2 == 1 {
-		return values[mid]
+	pairs := map[int]map[string]capturedSample{}
+	ab, ba := 0, 0
+	for _, x := range append(append([]capturedSample{}, snap...), pub...) {
+		if !validSample(x.Sample) {
+			return nil, []string{fmt.Sprintf("%s pair=%d mode=%s has non-finite, negative, or non-positive timing metric", prefix, x.Pair, x.Mode)}
+		}
+		if pairs[x.Pair] == nil {
+			pairs[x.Pair] = map[string]capturedSample{}
+		}
+		if _, ok := pairs[x.Pair][x.Mode]; ok {
+			return nil, []string{fmt.Sprintf("%s duplicate pair=%d mode=%s", prefix, x.Pair, x.Mode)}
+		}
+		pairs[x.Pair][x.Mode] = x
 	}
-	return (values[mid-1] + values[mid]) / 2
+	if len(pairs) != required {
+		return nil, []string{fmt.Sprintf("%s has %d distinct pairs for %d samples", prefix, len(pairs), required)}
+	}
+	results := make([]pairResult, 0, len(pairs))
+	for id, m := range pairs {
+		a, b := m["snapshot"], m["public"]
+		if a.Pair == 0 || b.Pair == 0 || a.Order != b.Order || (a.Order == "AB" && a.Sequence > b.Sequence) || (a.Order == "BA" && b.Sequence > a.Sequence) {
+			return nil, []string{fmt.Sprintf("%s missing or unbalanced pair=%d", prefix, id)}
+		}
+		if a.Order == "AB" {
+			ab++
+		} else {
+			ba++
+		}
+		results = append(results, pairResult{id, a.Order, a.Sample, b.Sample, (a.Sample.NSPerOp/b.Sample.NSPerOp - 1) * 100})
+	}
+	if ab != ba {
+		return nil, []string{fmt.Sprintf("%s requires balanced AB/BA pairs; AB=%d BA=%d", prefix, ab, ba)}
+	}
+	sort.Slice(results, func(i, j int) bool { return results[i].Pair < results[j].Pair })
+	sns, pns, sb, pb, sa, pa, deltas := []float64{}, []float64{}, []float64{}, []float64{}, []float64{}, []float64{}, []float64{}
+	for _, x := range results {
+		sns = append(sns, x.Snapshot.NSPerOp)
+		pns = append(pns, x.Public.NSPerOp)
+		sb = append(sb, x.Snapshot.BytesPerOp)
+		pb = append(pb, x.Public.BytesPerOp)
+		sa = append(sa, x.Snapshot.AllocsPerOp)
+		pa = append(pa, x.Public.AllocsPerOp)
+		deltas = append(deltas, x.DeltaPercent)
+	}
+	sn, pn := median(sns), median(pns)
+	paired := median(deltas)
+	independent := (sn/pn - 1) * 100
+	timing := paired <= max*100
+	alloc := median(sb) <= median(pb) && median(sa) <= median(pa)
+	r := &caseResult{keys, op, required, results, sn, pn, independent, paired, median(sb), median(pb), median(sa), median(pa), timing, alloc, timing && alloc}
+	v := []string{}
+	if !timing {
+		v = append(v, fmt.Sprintf("%s paired median snapshot/public delta %.2f%% exceeds max %.2f%%", prefix, paired, max*100))
+	}
+	if !alloc {
+		v = append(v, fmt.Sprintf("%s allocation increase: snapshot %.0f B/op %.0f allocs/op; public %.0f B/op %.0f allocs/op", prefix, r.SnapshotMedianBytes, r.SnapshotMedianAllocs, r.PublicMedianBytes, r.PublicMedianAllocs))
+	}
+	return r, v
 }
-
-func writeReports(rep report, jsonPath, markdownPath string) error {
-	encoded, err := json.MarshalIndent(rep, "", "  ")
+func validSample(s sample) bool {
+	return s.NSPerOp > 0 && s.BytesPerOp >= 0 && s.AllocsPerOp >= 0 && !math.IsNaN(s.NSPerOp) && !math.IsInf(s.NSPerOp, 0) && !math.IsNaN(s.BytesPerOp) && !math.IsInf(s.BytesPerOp, 0) && !math.IsNaN(s.AllocsPerOp) && !math.IsInf(s.AllocsPerOp, 0)
+}
+func median(v []float64) float64 {
+	v = append([]float64(nil), v...)
+	sort.Float64s(v)
+	m := len(v) / 2
+	if len(v)%2 == 1 {
+		return v[m]
+	}
+	return (v[m-1] + v[m]) / 2
+}
+func writeReports(rep report, j, m string) error {
+	data, err := json.MarshalIndent(rep, "", "  ")
 	if err != nil {
 		return fmt.Errorf("marshal report: %w", err)
 	}
-	if err := os.WriteFile(jsonPath, append(encoded, '\n'), 0o644); err != nil {
+	if err = os.WriteFile(j, append(data, '\n'), 0644); err != nil {
 		return fmt.Errorf("write JSON report: %w", err)
 	}
-	if err := os.WriteFile(markdownPath, []byte(markdown(rep)), 0o644); err != nil {
-		return fmt.Errorf("write Markdown report: %w", err)
-	}
-	return nil
+	return os.WriteFile(m, []byte(markdown(rep)), 0644)
 }
-
 func markdown(rep report) string {
 	status := "PASS"
 	if !rep.Passed {
@@ -275,23 +344,20 @@ func markdown(rep report) string {
 	}
 	var b strings.Builder
 	fmt.Fprintf(&b, "## Snapshot iterator performance gate: %s\n\n", status)
-	fmt.Fprintf(&b, "- Exact head: `%s`\n- Runner: `%s`\n- CPU: `%s`\n- Go: `%s`\n", rep.Metadata.Head, rep.Metadata.RunnerImage, rep.Metadata.CPU, rep.Metadata.GoVersion)
-	fmt.Fprintf(&b, "- Gate: snapshot median <= public median + %.2f%%; no B/op or allocs/op increase; %d samples per row.\n\n", rep.MaxRegressionPercent, rep.RequiredSamples)
-	b.WriteString("| keys | operation | snapshot median | public median | delta | snapshot/public B/op | snapshot/public allocs/op | result |\n")
-	b.WriteString("|---:|---|---:|---:|---:|---:|---:|---|\n")
-	for _, result := range rep.Cases {
-		rowStatus := "PASS"
-		if !result.Passed {
-			rowStatus = "FAIL"
+	fmt.Fprintf(&b, "- Exact head: `%s`\n- Binary SHA-256: `%s`\n- Runner: `%s`\n- CPU: `%s`\n- Affinity: `%s`\n- Go: `%s`\n", rep.Metadata.Head, rep.Metadata.BinarySHA256, rep.Metadata.RunnerImage, rep.Metadata.CPU, rep.Metadata.Affinity, rep.Metadata.GoVersion)
+	fmt.Fprintf(&b, "- Gate: paired median snapshot/public delta <= %.2f%%; no B/op or allocs/op increase; %d balanced samples per row. Independent medians are diagnostic only.\n\n", rep.MaxRegressionPercent, rep.RequiredSamples)
+	b.WriteString("| keys | operation | paired delta | snapshot/public independent medians | snapshot/public B/op | snapshot/public allocs/op | result |\n|---:|---|---:|---:|---:|---:|---|\n")
+	for _, r := range rep.Cases {
+		state := "PASS"
+		if !r.Passed {
+			state = "FAIL"
 		}
-		fmt.Fprintf(&b, "| %d | %s | %.3f ns/op | %.3f ns/op | %+.2f%% | %.0f / %.0f | %.0f / %.0f | %s |\n",
-			result.Keys, result.Operation, result.SnapshotMedianNS, result.PublicMedianNS, result.DeltaPercent,
-			result.SnapshotMedianBytes, result.PublicMedianBytes, result.SnapshotMedianAllocs, result.PublicMedianAllocs, rowStatus)
+		fmt.Fprintf(&b, "| %d | %s | %+.2f%% | %.3f / %.3f ns/op (%+.2f%%) | %.0f / %.0f | %.0f / %.0f | %s |\n", r.Keys, r.Operation, r.PairedMedianDeltaPercent, r.SnapshotMedianNS, r.PublicMedianNS, r.IndependentDeltaPercent, r.SnapshotMedianBytes, r.PublicMedianBytes, r.SnapshotMedianAllocs, r.PublicMedianAllocs, state)
 	}
 	if len(rep.Violations) > 0 {
 		b.WriteString("\nViolations:\n\n")
-		for _, violation := range rep.Violations {
-			fmt.Fprintf(&b, "- %s\n", violation)
+		for _, v := range rep.Violations {
+			fmt.Fprintf(&b, "- %s\n", v)
 		}
 	}
 	return b.String()

--- a/.github/scripts/snapshot_iterator_bench/main.go
+++ b/.github/scripts/snapshot_iterator_bench/main.go
@@ -129,6 +129,9 @@ func parseBenchmarkOutput(raw string) (map[rowKey][]capturedSample, error) {
 	for scanner.Scan() {
 		line := strings.TrimSpace(scanner.Text())
 		if strings.HasPrefix(line, "# pair=") {
+			if pending != nil {
+				return nil, fmt.Errorf("pair annotation without benchmark row before %q", line)
+			}
 			a, err := parseAnnotation(line)
 			if err != nil {
 				return nil, err
@@ -232,10 +235,16 @@ func evaluate(rows map[rowKey][]capturedSample, meta metadata, required int, max
 	if required < 2 || required%2 != 0 {
 		rep.Violations = append(rep.Violations, "required samples must be a positive even number")
 	}
+	if math.IsNaN(max) || math.IsInf(max, 0) || max < 0 {
+		rep.Violations = append(rep.Violations, "maximum regression must be a finite non-negative number")
+	}
 	for label, value := range map[string]string{"head": meta.Head, "binary_sha256": meta.BinarySHA256, "runner_image": meta.RunnerImage, "cpu": meta.CPU, "affinity": meta.Affinity, "go_version": meta.GoVersion} {
 		if strings.TrimSpace(value) == "" {
 			rep.Violations = append(rep.Violations, "missing metadata "+label)
 		}
+	}
+	if required < 2 || required%2 != 0 || math.IsNaN(max) || math.IsInf(max, 0) || max < 0 {
+		return rep
 	}
 	for _, keys := range []int{1024, 16384} {
 		for _, op := range []string{"seek", "next"} {
@@ -274,9 +283,13 @@ func evaluateCase(keys int, op string, snap, pub []capturedSample, required int,
 		return nil, []string{fmt.Sprintf("%s has %d distinct pairs for %d samples", prefix, len(pairs), required)}
 	}
 	results := make([]pairResult, 0, len(pairs))
-	for id, m := range pairs {
+	for id := 1; id <= required; id++ {
+		m, ok := pairs[id]
+		if !ok {
+			return nil, []string{fmt.Sprintf("%s missing pair=%d", prefix, id)}
+		}
 		a, b := m["snapshot"], m["public"]
-		if a.Pair == 0 || b.Pair == 0 || a.Order != b.Order || (a.Order == "AB" && a.Sequence > b.Sequence) || (a.Order == "BA" && b.Sequence > a.Sequence) {
+		if a.Pair == 0 || b.Pair == 0 || a.Order != b.Order || abs(a.Sequence-b.Sequence) != 1 || (a.Order == "AB" && a.Sequence > b.Sequence) || (a.Order == "BA" && b.Sequence > a.Sequence) {
 			return nil, []string{fmt.Sprintf("%s missing or unbalanced pair=%d", prefix, id)}
 		}
 		if a.Order == "AB" {
@@ -314,6 +327,12 @@ func evaluateCase(keys int, op string, snap, pub []capturedSample, required int,
 		v = append(v, fmt.Sprintf("%s allocation increase: snapshot %.0f B/op %.0f allocs/op; public %.0f B/op %.0f allocs/op", prefix, r.SnapshotMedianBytes, r.SnapshotMedianAllocs, r.PublicMedianBytes, r.PublicMedianAllocs))
 	}
 	return r, v
+}
+func abs(v int) int {
+	if v < 0 {
+		return -v
+	}
+	return v
 }
 func validSample(s sample) bool {
 	return s.NSPerOp > 0 && s.BytesPerOp >= 0 && s.AllocsPerOp >= 0 && !math.IsNaN(s.NSPerOp) && !math.IsInf(s.NSPerOp, 0) && !math.IsNaN(s.BytesPerOp) && !math.IsInf(s.BytesPerOp, 0) && !math.IsNaN(s.AllocsPerOp) && !math.IsInf(s.AllocsPerOp, 0)

--- a/.github/scripts/snapshot_iterator_bench/main_test.go
+++ b/.github/scripts/snapshot_iterator_bench/main_test.go
@@ -6,70 +6,82 @@ import (
 	"testing"
 )
 
-func benchmarkFixture(snapshotNS, publicNS, snapshotBytes, publicBytes float64, samples int) string {
+func fixture(snapshot, public []float64) string {
 	var b strings.Builder
 	for _, keys := range []int{1024, 16384} {
-		for _, operation := range []string{"seek", "next"} {
-			for _, mode := range []string{"snapshot", "public"} {
-				ns := publicNS
-				bytesPerOp := publicBytes
-				if mode == "snapshot" {
-					ns = snapshotNS
-					bytesPerOp = snapshotBytes
+		for _, op := range []string{"seek", "next"} {
+			for i := range snapshot {
+				order := "AB"
+				modes := []string{"snapshot", "public"}
+				if i%2 == 1 {
+					order = "BA"
+					modes = []string{"public", "snapshot"}
 				}
-				rowName := mode + "_" + operation
-				if mode == "public" {
-					rowName += "_baseline"
-				}
-				for i := 0; i < samples; i++ {
-					fmt.Fprintf(&b, "BenchmarkSnapshotIteratorSeekNext/keys=%d/%s-4 1000 %.3f ns/op %.0f B/op 0 allocs/op\n",
-						keys, rowName, ns+float64(i%3), bytesPerOp)
+				for _, mode := range modes {
+					ns := public[i]
+					name := "public_" + op + "_baseline"
+					if mode == "snapshot" {
+						ns = snapshot[i]
+						name = "snapshot_" + op
+					}
+					fmt.Fprintf(&b, "# pair=%d order=%s\nBenchmarkSnapshotIteratorSeekNext/keys=%d/%s-1 1000 %.3f ns/op 0 B/op 0 allocs/op\n", i+1, order, keys, name, ns)
 				}
 			}
 		}
 	}
 	return b.String()
 }
-
-func TestEvaluatePassesSameBinaryGate(t *testing.T) {
-	rows, err := parseBenchmarkOutput(benchmarkFixture(104, 100, 0, 0, 7))
+func testMeta() metadata {
+	return metadata{Head: "deadbeef", BinarySHA256: "abc", RunnerImage: "ubuntu", CPU: "cpu", Affinity: "1", GoVersion: "go"}
+}
+func TestEvaluateObservedBimodalFalseFailureUsesAlignedPairs(t *testing.T) {
+	// The seven independently grouped hosted samples in #3788 have an over-5%
+	// median delta even though the aligned AB/BA protocol below is within budget.
+	if legacy := (median([]float64{355, 356, 357, 407, 408, 409, 410})/median([]float64{362, 363, 364, 362, 363, 364, 363}) - 1) * 100; legacy <= 5 {
+		t.Fatalf("observed independent fixture delta=%f, want >5%%", legacy)
+	}
+	rows, err := parseBenchmarkOutput(fixture([]float64{355, 356, 357, 356, 407, 408, 409, 408}, []float64{362, 363, 364, 363, 410, 411, 412, 411}))
 	if err != nil {
 		t.Fatal(err)
 	}
-	rep := evaluate(rows, metadata{Head: "deadbeef"}, 7, 0.05)
-	if !rep.Passed || len(rep.Cases) != 4 || len(rep.Violations) != 0 {
-		t.Fatalf("report = %+v, want passing four-case report", rep)
+	rep := evaluate(rows, testMeta(), 8, .05)
+	if !rep.Passed {
+		t.Fatalf("paired report should pass: %+v", rep)
 	}
-	if got := markdown(rep); !strings.Contains(got, "Exact head: `deadbeef`") || !strings.Contains(got, "PASS") {
-		t.Fatalf("unexpected Markdown report:\n%s", got)
+	if rep.Cases[0].PairedMedianDeltaPercent >= 5 {
+		t.Fatalf("aligned paired evidence must stay below the 5%% budget: %+v", rep.Cases[0])
+	}
+	if !strings.Contains(markdown(rep), "paired delta") {
+		t.Fatal("report missing paired field")
 	}
 }
-
-func TestEvaluateRejectsTimingAndAllocationRegression(t *testing.T) {
-	rows, err := parseBenchmarkOutput(benchmarkFixture(106, 100, 8, 0, 7))
+func TestEvaluateRejectsGenuinePairedRegressionAndAllocation(t *testing.T) {
+	rows, err := parseBenchmarkOutput(fixture([]float64{108, 108, 108, 108, 108, 108, 108, 108}, []float64{100, 100, 100, 100, 100, 100, 100, 100}))
 	if err != nil {
 		t.Fatal(err)
 	}
-	rep := evaluate(rows, metadata{}, 7, 0.05)
-	if rep.Passed || len(rep.Violations) != 8 {
-		t.Fatalf("violations = %d, passed = %v; want two violations per case", len(rep.Violations), rep.Passed)
+	rep := evaluate(rows, testMeta(), 8, .05)
+	if rep.Passed || len(rep.Violations) != 4 {
+		t.Fatalf("genuine paired regression report=%+v", rep)
 	}
 }
-
-func TestEvaluateRejectsMissingSamples(t *testing.T) {
-	rows, err := parseBenchmarkOutput(benchmarkFixture(100, 100, 0, 0, 6))
+func TestEvaluateFailsClosedOnUnbalancedPairs(t *testing.T) {
+	raw := fixture([]float64{100, 100, 100, 100, 100, 100, 100, 100}, []float64{100, 100, 100, 100, 100, 100, 100, 100})
+	raw = strings.Replace(raw, "# pair=2 order=BA", "# pair=2 order=AB", 1)
+	rows, err := parseBenchmarkOutput(raw)
 	if err != nil {
 		t.Fatal(err)
 	}
-	rep := evaluate(rows, metadata{}, 7, 0.05)
-	if rep.Passed || len(rep.Violations) != 4 || len(rep.Cases) != 0 {
-		t.Fatalf("report = %+v, want four missing-sample violations", rep)
+	rep := evaluate(rows, testMeta(), 8, .05)
+	if rep.Passed || len(rep.Cases) != 3 {
+		t.Fatalf("unbalanced pairs report=%+v", rep)
 	}
 }
-
-func TestParseBenchmarkOutputRejectsMissingAllocationMetric(t *testing.T) {
-	_, err := parseBenchmarkOutput("BenchmarkSnapshotIteratorSeekNext/keys=1024/snapshot_seek-4 1000 100 ns/op 0 B/op\n")
-	if err == nil || !strings.Contains(err.Error(), "malformed") {
-		t.Fatalf("error = %v, want malformed row", err)
+func TestParseRejectsMissingAnnotationAndMalformedMetrics(t *testing.T) {
+	if _, err := parseBenchmarkOutput("BenchmarkSnapshotIteratorSeekNext/keys=1024/snapshot_seek-1 1000 1 ns/op 0 B/op 0 allocs/op\n"); err == nil {
+		t.Fatal("missing annotation passed")
+	}
+	if _, err := parseBenchmarkOutput("# pair=1 order=AB\nBenchmarkSnapshotIteratorSeekNext/keys=1024/snapshot_seek-1 1000 nope ns/op 0 B/op 0 allocs/op\n"); err == nil {
+		t.Fatal("malformed metric passed")
 	}
 }

--- a/.github/scripts/snapshot_iterator_bench/main_test.go
+++ b/.github/scripts/snapshot_iterator_bench/main_test.go
@@ -84,4 +84,45 @@ func TestParseRejectsMissingAnnotationAndMalformedMetrics(t *testing.T) {
 	if _, err := parseBenchmarkOutput("# pair=1 order=AB\nBenchmarkSnapshotIteratorSeekNext/keys=1024/snapshot_seek-1 1000 nope ns/op 0 B/op 0 allocs/op\n"); err == nil {
 		t.Fatal("malformed metric passed")
 	}
+	if _, err := parseBenchmarkOutput("# pair=1 order=AB\n# pair=2 order=BA\n"); err == nil {
+		t.Fatal("overwritten annotation passed")
+	}
+}
+func TestEvaluateFailsClosedOnInvalidConfiguration(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		required int
+		max      float64
+	}{
+		{name: "zero samples", required: 0, max: .05},
+		{name: "odd samples", required: 7, max: .05},
+		{name: "negative threshold", required: 8, max: -.01},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			rep := evaluate(nil, testMeta(), tc.required, tc.max)
+			if rep.Passed || len(rep.Violations) == 0 {
+				t.Fatalf("invalid configuration passed: %+v", rep)
+			}
+		})
+	}
+}
+func TestEvaluateRejectsNonContiguousAndNonAdjacentPairs(t *testing.T) {
+	raw := fixture([]float64{100, 100, 100, 100, 100, 100, 100, 100}, []float64{100, 100, 100, 100, 100, 100, 100, 100})
+	rows, err := parseBenchmarkOutput(strings.ReplaceAll(raw, "# pair=8 order=BA", "# pair=9 order=BA"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if rep := evaluate(rows, testMeta(), 8, .05); rep.Passed {
+		t.Fatalf("non-contiguous pairs passed: %+v", rep)
+	}
+
+	rows, err = parseBenchmarkOutput(raw)
+	if err != nil {
+		t.Fatal(err)
+	}
+	key := rowKey{Keys: 1024, Mode: "public", Operation: "seek"}
+	rows[key][0].Sequence++
+	if rep := evaluate(rows, testMeta(), 8, .05); rep.Passed {
+		t.Fatalf("non-adjacent pair passed: %+v", rep)
+	}
 }

--- a/.github/workflows/treedb-tests.yml
+++ b/.github/workflows/treedb-tests.yml
@@ -711,7 +711,7 @@ jobs:
             go.sum
 
       - name: Test snapshot iterator benchmark parser
-        run: go test ./.github/scripts/snapshot_iterator_bench
+        run: GOWORK=off go test ./.github/scripts/snapshot_iterator_bench
 
       - name: Capture exact-head runner metadata
         run: |
@@ -725,24 +725,33 @@ jobs:
             echo "kernel=$(uname -a)"
           } | tee artifacts/snapshot_iterator_perf/environment.txt
 
-      - name: Run same-binary snapshot iterator benchmark
+      - name: Build one exact-head snapshot iterator benchmark binary
         run: |
-          GOMAXPROCS=1 go test ./TreeDB -run '^$' \
-            -bench '^BenchmarkSnapshotIteratorSeekNext/keys=(1024|16384)/(snapshot_(seek|next)|public_(seek|next)_baseline)$' \
-            -benchmem -benchtime=500ms -count=7 \
-            | tee artifacts/snapshot_iterator_perf/raw.txt
+          GOWORK=off go test -c -o artifacts/snapshot_iterator_perf/snapshot_iterator.test ./TreeDB
+          sha256sum artifacts/snapshot_iterator_perf/snapshot_iterator.test | tee artifacts/snapshot_iterator_perf/binary.sha256
+
+      - name: Collect CPU-pinned balanced same-binary snapshot iterator pairs
+        run: |
+          SNAPSHOT_ITERATOR_PAIRS=8 \
+            .github/scripts/collect_snapshot_iterator_pairs.sh \
+              artifacts/snapshot_iterator_perf/snapshot_iterator.test \
+              artifacts/snapshot_iterator_perf/raw.txt
+          affinity=$(cut -d= -f2 artifacts/snapshot_iterator_perf/raw.affinity)
+          echo "affinity=${affinity}" | tee -a artifacts/snapshot_iterator_perf/environment.txt
 
       - name: Check snapshot iterator performance gate
         run: |
-          go run ./.github/scripts/snapshot_iterator_bench \
+          GOWORK=off go run ./.github/scripts/snapshot_iterator_bench \
             -bench-output artifacts/snapshot_iterator_perf/raw.txt \
             -json-output artifacts/snapshot_iterator_perf/report.json \
             -markdown-output artifacts/snapshot_iterator_perf/report.md \
             -head "$(git rev-parse HEAD)" \
+            -binary-sha256 "$(cut -d' ' -f1 artifacts/snapshot_iterator_perf/binary.sha256)" \
             -runner-image "${ImageOS:-unknown}-${ImageVersion:-unknown}" \
             -cpu "$(lscpu | sed -n 's/^Model name:[[:space:]]*//p' | head -n 1)" \
+            -affinity "$(cut -d= -f2 artifacts/snapshot_iterator_perf/raw.affinity)" \
             -go-version "$(go version)" \
-            -samples 7 \
+            -samples 8 \
             -max-regression 0.05
 
       - name: Publish snapshot iterator summary

--- a/TreeDB/nativewire/forced_pointer_readability_test.go
+++ b/TreeDB/nativewire/forced_pointer_readability_test.go
@@ -69,20 +69,22 @@ func TestNativewireYCSBForcedPointerPublicationReadability(t *testing.T) {
 }
 
 func TestForcedPointerYCSBNativewirePhaseContextsAreIndependent(t *testing.T) {
-	phaseOne, cancelPhaseOne := newForcedPointerYCSBNativewirePhaseContext(t)
-	cancelPhaseOne()
+	var phaseOne context.Context
+	runForcedPointerYCSBNativewirePhase(t, func(ctx context.Context) {
+		phaseOne = ctx
+	})
 	if !errors.Is(phaseOne.Err(), context.Canceled) {
 		t.Fatalf("phase one context err=%v want context canceled", phaseOne.Err())
 	}
 
-	phaseTwo, cancelPhaseTwo := newForcedPointerYCSBNativewirePhaseContext(t)
-	defer cancelPhaseTwo()
-	if phaseTwo == phaseOne {
-		t.Fatal("phase two reused phase one context")
-	}
-	if err := phaseTwo.Err(); err != nil {
-		t.Fatalf("phase two inherited phase one cancellation: %v", err)
-	}
+	runForcedPointerYCSBNativewirePhase(t, func(phaseTwo context.Context) {
+		if phaseTwo == phaseOne {
+			t.Fatal("phase two reused phase one context")
+		}
+		if err := phaseTwo.Err(); err != nil {
+			t.Fatalf("phase two inherited phase one cancellation: %v", err)
+		}
+	})
 }
 
 func TestNativewireYCSBCurrentWritableValueLogReadBarrier(t *testing.T) {
@@ -92,9 +94,7 @@ func TestNativewireYCSBCurrentWritableValueLogReadBarrier(t *testing.T) {
 	keys, docs := forcedPointerYCSBDocuments(t, docCount)
 	samples := []int{0, docCount - 1}
 
-	func() {
-		ctx, cancel := newForcedPointerYCSBNativewirePhaseContext(t)
-		defer cancel()
+	runForcedPointerYCSBNativewirePhase(t, func(ctx context.Context) {
 		env := newForcedPointerYCSBNativewireCurrentWritableEnv(t, opts, true)
 		defer func() {
 			if err := env.cleanup(); err != nil {
@@ -106,11 +106,9 @@ func TestNativewireYCSBCurrentWritableValueLogReadBarrier(t *testing.T) {
 		loadForcedPointerYCSBThroughNativewire(t, ctx, clients, handles, keys, docs)
 		requirePublishedValueLogFiles(t, env.server.backend)
 		requireNativewireYCSBReadable(t, ctx, clients[0], handles[0], keys, docs, samples, "current-writable before flush")
-	}()
+	})
 
-	func() {
-		ctx, cancel := newForcedPointerYCSBNativewirePhaseContext(t)
-		defer cancel()
+	runForcedPointerYCSBNativewirePhase(t, func(ctx context.Context) {
 		faultDir := t.TempDir()
 		faultOpts := forcedPointerYCSBNativewireOptions(faultDir)
 		faultEnv := newForcedPointerYCSBNativewireCurrentWritableEnv(t, faultOpts, true)
@@ -157,12 +155,14 @@ func TestNativewireYCSBCurrentWritableValueLogReadBarrier(t *testing.T) {
 		if calls := barrierCalls.Load(); calls == 0 {
 			t.Fatalf("current-writable read barrier was not reached")
 		}
-	}()
+	})
 }
 
-func newForcedPointerYCSBNativewirePhaseContext(t testing.TB) (context.Context, context.CancelFunc) {
+func runForcedPointerYCSBNativewirePhase(t testing.TB, phase func(context.Context)) {
 	t.Helper()
-	return context.WithTimeout(context.Background(), 10*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	phase(ctx)
 }
 
 func forcedPointerYCSBNativewireOptions(dir string) treedb.Options {

--- a/TreeDB/nativewire/forced_pointer_readability_test.go
+++ b/TreeDB/nativewire/forced_pointer_readability_test.go
@@ -68,71 +68,101 @@ func TestNativewireYCSBForcedPointerPublicationReadability(t *testing.T) {
 	requirePublishedValueLogFiles(t, reopened.server.backend)
 }
 
+func TestForcedPointerYCSBNativewirePhaseContextsAreIndependent(t *testing.T) {
+	phaseOne, cancelPhaseOne := newForcedPointerYCSBNativewirePhaseContext(t)
+	cancelPhaseOne()
+	if !errors.Is(phaseOne.Err(), context.Canceled) {
+		t.Fatalf("phase one context err=%v want context canceled", phaseOne.Err())
+	}
+
+	phaseTwo, cancelPhaseTwo := newForcedPointerYCSBNativewirePhaseContext(t)
+	defer cancelPhaseTwo()
+	if phaseTwo == phaseOne {
+		t.Fatal("phase two reused phase one context")
+	}
+	if err := phaseTwo.Err(); err != nil {
+		t.Fatalf("phase two inherited phase one cancellation: %v", err)
+	}
+}
+
 func TestNativewireYCSBCurrentWritableValueLogReadBarrier(t *testing.T) {
 	const docCount = 16
 	dir := t.TempDir()
 	opts := forcedPointerYCSBNativewireOptions(dir)
 	keys, docs := forcedPointerYCSBDocuments(t, docCount)
 	samples := []int{0, docCount - 1}
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-	defer cancel()
 
-	env := newForcedPointerYCSBNativewireCurrentWritableEnv(t, opts, true)
-	clients, handles, cleanups := forcedPointerYCSBNativewireClients(t, ctx, env, 1)
-	loadForcedPointerYCSBThroughNativewire(t, ctx, clients, handles, keys, docs)
-	requirePublishedValueLogFiles(t, env.server.backend)
-	requireNativewireYCSBReadable(t, ctx, clients[0], handles[0], keys, docs, samples, "current-writable before flush")
-	closeForcedPointerYCSBNativewireClients(t, cleanups)
-	if err := env.cleanup(); err != nil {
-		t.Fatalf("close readable env: %v", err)
-	}
+	func() {
+		ctx, cancel := newForcedPointerYCSBNativewirePhaseContext(t)
+		defer cancel()
+		env := newForcedPointerYCSBNativewireCurrentWritableEnv(t, opts, true)
+		defer func() {
+			if err := env.cleanup(); err != nil {
+				t.Fatalf("close readable env: %v", err)
+			}
+		}()
+		clients, handles, cleanups := forcedPointerYCSBNativewireClients(t, ctx, env, 1)
+		defer closeForcedPointerYCSBNativewireClients(t, cleanups)
+		loadForcedPointerYCSBThroughNativewire(t, ctx, clients, handles, keys, docs)
+		requirePublishedValueLogFiles(t, env.server.backend)
+		requireNativewireYCSBReadable(t, ctx, clients[0], handles[0], keys, docs, samples, "current-writable before flush")
+	}()
 
-	faultDir := t.TempDir()
-	faultOpts := forcedPointerYCSBNativewireOptions(faultDir)
-	faultEnv := newForcedPointerYCSBNativewireCurrentWritableEnv(t, faultOpts, true)
-	defer func() {
-		if err := faultEnv.cleanup(); err != nil {
-			t.Fatalf("close fault env: %v", err)
+	func() {
+		ctx, cancel := newForcedPointerYCSBNativewirePhaseContext(t)
+		defer cancel()
+		faultDir := t.TempDir()
+		faultOpts := forcedPointerYCSBNativewireOptions(faultDir)
+		faultEnv := newForcedPointerYCSBNativewireCurrentWritableEnv(t, faultOpts, true)
+		defer func() {
+			if err := faultEnv.cleanup(); err != nil {
+				t.Fatalf("close fault env: %v", err)
+			}
+		}()
+		faultClients, faultHandles, faultCleanups := forcedPointerYCSBNativewireClients(t, ctx, faultEnv, 1)
+		defer closeForcedPointerYCSBNativewireClients(t, faultCleanups)
+		loadForcedPointerYCSBThroughNativewire(t, ctx, faultClients, faultHandles, keys, docs)
+		requirePublishedValueLogFiles(t, faultEnv.server.backend)
+
+		var barrierCalls atomic.Int32
+		faultEnv.server.backend.SetCurrentValueLogReadBarrierWithSize(func(fileID uint32) (int64, error) {
+			barrierCalls.Add(1)
+			return -1, io.ErrUnexpectedEOF
+		})
+
+		_, directErr := faultEnv.server.handleGetManyBody(&connState{}, []iwire.Section{
+			collectionNameRef(ycsbBenchCollection),
+			{ID: iwire.SectionDocumentIDs, Bytes: iwire.AppendByteVector(nil, keys[docCount-1])},
+		}, nil, ReadMetadata{})
+		if directErr == nil {
+			t.Fatalf("direct GetMany handler succeeded through injected current-writable read-boundary EOF")
+		}
+		if !errors.Is(directErr, io.ErrUnexpectedEOF) {
+			t.Fatalf("direct GetMany handler err=%v want injected unexpected EOF", directErr)
+		}
+		if errors.Is(directErr, collections.ErrCommitAmbiguous) {
+			t.Fatalf("direct GetMany handler err=%v unexpectedly classified as ErrCommitAmbiguous", directErr)
+		}
+		if !strings.Contains(directErr.Error(), "nativewire metadata") || !strings.Contains(directErr.Error(), "unexpected EOF") {
+			t.Fatalf("direct GetMany handler err=%q missing nativewire unexpected EOF context", directErr)
+		}
+
+		got, present, err := faultClients[0].GetMany(ctx, ycsbBenchCollection, [][]byte{keys[docCount-1]})
+		if err == nil {
+			t.Fatalf("GetMany succeeded through injected current-writable read-boundary EOF: docs=%d present=%v", len(got), present)
+		}
+		if !isRemoteError(err, iwire.ErrInternal) {
+			t.Fatalf("GetMany err=%v want remote internal error", err)
+		}
+		if calls := barrierCalls.Load(); calls == 0 {
+			t.Fatalf("current-writable read barrier was not reached")
 		}
 	}()
-	faultClients, faultHandles, faultCleanups := forcedPointerYCSBNativewireClients(t, ctx, faultEnv, 1)
-	defer closeForcedPointerYCSBNativewireClients(t, faultCleanups)
-	loadForcedPointerYCSBThroughNativewire(t, ctx, faultClients, faultHandles, keys, docs)
-	requirePublishedValueLogFiles(t, faultEnv.server.backend)
+}
 
-	var barrierCalls atomic.Int32
-	faultEnv.server.backend.SetCurrentValueLogReadBarrierWithSize(func(fileID uint32) (int64, error) {
-		barrierCalls.Add(1)
-		return -1, io.ErrUnexpectedEOF
-	})
-
-	_, directErr := faultEnv.server.handleGetManyBody(&connState{}, []iwire.Section{
-		collectionNameRef(ycsbBenchCollection),
-		{ID: iwire.SectionDocumentIDs, Bytes: iwire.AppendByteVector(nil, keys[docCount-1])},
-	}, nil, ReadMetadata{})
-	if directErr == nil {
-		t.Fatalf("direct GetMany handler succeeded through injected current-writable read-boundary EOF")
-	}
-	if !errors.Is(directErr, io.ErrUnexpectedEOF) {
-		t.Fatalf("direct GetMany handler err=%v want injected unexpected EOF", directErr)
-	}
-	if errors.Is(directErr, collections.ErrCommitAmbiguous) {
-		t.Fatalf("direct GetMany handler err=%v unexpectedly classified as ErrCommitAmbiguous", directErr)
-	}
-	if !strings.Contains(directErr.Error(), "nativewire metadata") || !strings.Contains(directErr.Error(), "unexpected EOF") {
-		t.Fatalf("direct GetMany handler err=%q missing nativewire unexpected EOF context", directErr)
-	}
-
-	got, present, err := faultClients[0].GetMany(ctx, ycsbBenchCollection, [][]byte{keys[docCount-1]})
-	if err == nil {
-		t.Fatalf("GetMany succeeded through injected current-writable read-boundary EOF: docs=%d present=%v", len(got), present)
-	}
-	if !isRemoteError(err, iwire.ErrInternal) {
-		t.Fatalf("GetMany err=%v want remote internal error", err)
-	}
-	if calls := barrierCalls.Load(); calls == 0 {
-		t.Fatalf("current-writable read barrier was not reached")
-	}
+func newForcedPointerYCSBNativewirePhaseContext(t testing.TB) (context.Context, context.CancelFunc) {
+	t.Helper()
+	return context.WithTimeout(context.Background(), 10*time.Second)
 }
 
 func forcedPointerYCSBNativewireOptions(dir string) treedb.Options {


### PR DESCRIPTION
Closes #3788
Closes #3784
Parent: #3776
Supersedes implementation PR #3786 after merge.

## Why these fixes share one integration head

The surfaces are disjoint, but current `main` repeatedly fails `windows-core-1` in #3784's nativewire test. That failure blocks #3788 from obtaining a fully green rollup, while #3784's three-run proof is itself blocked by #3788's unstable snapshot verdict. Keeping the fixes in separate merge order therefore creates a CI cycle. This head combines only the two already-reviewed issue patches so both defects can be proved together without waiving either gate.

## Snapshot iterator evidence

- builds one exact-head TreeDB benchmark binary and records its SHA-256;
- captures 8 balanced AB/BA snapshot/public pairs per row, pinned to one recorded CPU;
- preserves contiguous pair identity and gates the median paired relative delta at the existing 5% budget;
- keeps independent medians as diagnostic context while allocation gates remain fail-closed;
- rejects overwritten annotations, non-contiguous IDs, non-adjacent pairs, invalid configuration, incomplete data, and non-finite operands;
- records exact head, binary digest, runner image, CPU/affinity, Go version, raw samples, JSON, and Markdown.

## Nativewire phase isolation

- gives the healthy and injected-fault current-writable value-log phases separate bounded contexts;
- closes each phase's clients before its environment;
- preserves direct and remote injected-EOF assertions;
- adds a characterization proving phase two cannot inherit phase one's canceled/deadline state.

## Local validation

Exact head: `aef59d2cff2ac353058136cd3a458a0938f26ccb`, based on `main@56a98f286756287d6863339efe8c0db794076df8`.

- `GOWORK=off go test ./.github/scripts/snapshot_iterator_bench`
- `bash -n .github/scripts/collect_snapshot_iterator_pairs.sh`
- exact binary, 2-pair, 100ms CPU-pinned collector/evaluator smoke: all four rows passed
- `GOWORK=off go test ./TreeDB/nativewire -run '^(TestForcedPointerYCSBNativewirePhaseContextsAreIndependent|TestNativewireYCSBCurrentWritableValueLogReadBarrier)$' -count=10`
- focused nativewire race run
- full `GOWORK=off go test ./TreeDB/nativewire -count=1`
- `git diff --check origin/main...HEAD`

All passed. Fresh exact-head full CI and Codex review remain merge gates. Final hosted proof requires the PR run plus two independent exact-content TreeDB runs, with both `snapshot-iterator-perf (linux)` and `windows-core-2` green in all three.

## Triggering evidence

- Snapshot false-positive: run `29445670381`, job `87455401040`, on nativewire-only contents.
- Nativewire repeated main failure: run `29447801297`, `windows-core-1`, `NewInProcessClient: context deadline exceeded`.
- Same nativewire failure on parked #3781 head: run `29449712981`, job `87468905549`; no retry is counted.

## Non-goals

No production, on-disk format, public API, durability, value-log, recovery, benchmark-budget, or timeout relaxation.
