### PR TITLE
ci(treedb): rebalance Linux race shards

### DIFF
--- a/.github/ci/treedb_db_weighted_shard0_tests.txt
+++ b/.github/ci/treedb_db_weighted_shard0_tests.txt
@@ -1,3 +1,4 @@
-# Pinned to shard 0 because this TreeDB/db test dominated the previous
-# line-count shard on Windows and race runs.
+# Pinned to shard 0 because these TreeDB/db tests dominated prior
+# line-count shards on Windows or race runs.
 TestValidateFragmentationReport_EndToEnd
+TestVacuumIndexOnline_RebuildsPackedInternalTreeForLeafRefs

--- a/.github/workflows/treedb-tests.yml
+++ b/.github/workflows/treedb-tests.yml
@@ -469,7 +469,7 @@ jobs:
           - shard: 2
             shard_index: 1
             shard_count: 2
-    timeout-minutes: 20
+    timeout-minutes: 25
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
Closes #3792
Parent tracker: #3776

## Summary

- pin the current ~5-minute TreeDB/db online-vacuum race test to weighted shard 1
- keep the full DB race test set complete and disjoint across both shards
- increase the bounded Linux race-job cap from 20 to 25 minutes so the projected slower shard retains at least 20% hosted-runner margin
- preserve every existing race test and all production/durability behavior unchanged

## Diagnosis

PR #3789 exact run `29450673477/87472062901` crossed the old 20-minute cap. `TestVacuumRaceMissingKey` appeared as the last running test, but it had started only about six seconds before cancellation and then passed normally in two independent exact-head matrices.

The actual imbalance was stale weighting:

| Evidence | race shard 1 | race shard 2 |
| --- | ---: | ---: |
| exact comparison | ~13m10s-13m25s | 19m19s-19m37s |
| dominant DB test | existing pin ~1s | `TestVacuumIndexOnline_RebuildsPackedInternalTreeForLeafRefs` 279-309s |

Moving that dominant test projects the shards to roughly 18 minutes and 15 minutes. A 25-minute bounded cap gives the slower projected shard more than 20% margin without changing normal gate latency.

## Validation

- generated 1,255 DB tests and proved the two shard sets are a complete, disjoint union
- proved `TestVacuumIndexOnline_RebuildsPackedInternalTreeForLeafRefs` appears only in weighted shard 1
- `GOWORK=off GOMEMLIMIT=4GiB GOMAXPROCS=2 go test -race -count=1 -timeout=10m ./TreeDB/db -run '^TestVacuumIndexOnline_RebuildsPackedInternalTreeForLeafRefs$'` — pass, 262.148s
- `GOWORK=off GOMEMLIMIT=4GiB GOMAXPROCS=2 go test -race -count=3 -timeout=10m ./TreeDB/db -run '^TestVacuumRaceMissingKey$'` — pass, 290.105s total
- workflow YAML parse — pass
- `git diff --check origin/main...HEAD` — pass

After #3665 merged, exact head `d87ee196ac9e862dc053bc27e619907aaa677552` refreshed onto `main@2e9e6f4ad9bd3d0d57a23b347bc82896c1cdf487` without conflict. The complete/disjoint 1,255-test selection proof repeated successfully; the dominant moved test passed under race in 264.994s; `TestVacuumRaceMissingKey` passed under race in 106.529s; YAML and diff checks remained clean.

## Hosted exact-head evidence before predecessor refresh

The zero-based weighting file maps to the user-facing `race-check (linux)-1` job; the unlisted complement is `race-check (linux)-2`.

| TreeDB run | race job 1 | race job 2 | rollup |
| --- | ---: | ---: | --- |
| PR `29453548518` | 17m38s pass | 14m24s pass | 13/14; only #3665 Raft readiness failed |
| proof `29453594624` | 17m30s pass | 14m20s pass | 14/14 green |
| proof `29453596595` | 17m57s pass | 14m24s pass | 14/14 green |

All six race jobs pass under the 25-minute cap. The formerly overloaded second job fell from 19m19s-19m37s to 14m20s-14m24s, while the slower first job retained at least 7 minutes of cap margin.

The old PR-branch `windows-core-2` failure was `TestHashicorpRaftProviderLeaderCrashAfterCommitRestartCatchUpConverges` losing replacement leadership during submit, owned by predecessor #3665 / PR #3782. It was not retried or counted as #3792 evidence. #3665 is now merged, and fresh exact-head runs `29459472659`, `29459494004`, and `29459493967` are the only final merge evidence.

## Final exact-head evidence

All three independent TreeDB workflows are green on exact head `d87ee196ac9e862dc053bc27e619907aaa677552` and exact base `main@2e9e6f4ad9bd3d0d57a23b347bc82896c1cdf487`:

| TreeDB run | race job 1 | race job 2 | rollup |
| --- | ---: | ---: | --- |
| PR `29459472659` | 17m56s pass | 14m33s pass | 14/14 green |
| proof `29459493967` | 18m10s pass | 14m06s pass | 14/14 green |
| proof `29459494004` | 11m25s pass | 14m18s pass | 14/14 green after one classified failed-job rerun |

The first attempt of proof `29459494004` failed only in `TestCachingDB_ExclusiveWriteWithFlushMuHeldReleasesFlushMuWhileWaiting` (`maintenance waits=0, want 1`), with no race-detector report. The test observes `flushMu` release before proving the writer has registered its checkpoint wait; that narrow test-only scheduler window is isolated and owned by #3796. Its single allowed failed-job rerun passed. No product code, race assertion, or test selection was changed for that classification.

All actual PR-branch workflows are green. Duplicate non-TreeDB workflows attached to the two proof refs were canceled and account for GitHub's aggregate `UNSTABLE` label; they are not PR-branch or TreeDB merge evidence.

## Merge gates

- [x] exact-head Codex review clean on current head: https://github.com/snissn/gomap/pull/3793#issuecomment-4986388133
- [x] zero unresolved review threads on current head
- [x] all actual latest-head PR-branch workflows green
- [x] three independent exact-head TreeDB workflows green with both race-shard durations recorded
