### PR TITLE
ci: restore Windows core shard headroom

### DIFF
--- a/.github/scripts/test_treedb_windows_core_headroom.py
+++ b/.github/scripts/test_treedb_windows_core_headroom.py
@@ -33,6 +33,19 @@ class TreeDBWindowsCoreHeadroomTest(unittest.TestCase):
         self.assertEqual(matrix_timeout(workflow, "windows-core-2"), 30)
         self.assertIn("timeout-minutes: ${{ matrix.timeout }}", workflow)
 
+    def test_caching_shards_keep_their_existing_bounded_caps(self) -> None:
+        workflow = WORKFLOW.read_text(encoding="utf-8")
+
+        for job_name in (
+            "windows-caching-heavy-1",
+            "windows-caching-heavy-2",
+            "windows-caching-rest-1",
+            "windows-caching-rest-2",
+            "windows-caching-rest-3",
+        ):
+            with self.subTest(job_name=job_name):
+                self.assertEqual(matrix_timeout(workflow, job_name), 25)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/.github/scripts/test_treedb_windows_core_headroom.py
+++ b/.github/scripts/test_treedb_windows_core_headroom.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python3
+"""Contract checks for bounded TreeDB Windows core-shard headroom."""
+
+from pathlib import Path
+import re
+import unittest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+WORKFLOW = REPO_ROOT / ".github" / "workflows" / "treedb-tests.yml"
+
+
+def matrix_timeout(workflow: str, job_name: str) -> int:
+    match = re.search(
+        rf"- name: {re.escape(job_name)}\s+"
+        r"os: windows-latest\s+"
+        r"timeout: (?P<timeout>\d+)",
+        workflow,
+    )
+    if match is None:
+        raise AssertionError(f"missing Windows matrix entry for {job_name}")
+    return int(match.group("timeout"))
+
+
+class TreeDBWindowsCoreHeadroomTest(unittest.TestCase):
+    def test_core_shards_have_equal_bounded_thirty_minute_caps(self) -> None:
+        workflow = WORKFLOW.read_text(encoding="utf-8")
+
+        # Hosted evidence reached 24m48s after every selected test passed. A
+        # 30-minute cap preserves the bounded job while restoring about 20%
+        # wall-clock headroom on the slow observation.
+        self.assertEqual(matrix_timeout(workflow, "windows-core-1"), 30)
+        self.assertEqual(matrix_timeout(workflow, "windows-core-2"), 30)
+        self.assertIn("timeout-minutes: ${{ matrix.timeout }}", workflow)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/workflows/treedb-tests.yml
+++ b/.github/workflows/treedb-tests.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-24.04
     timeout-minutes: 15
     env:
-      MVCC_GATE_PATH_RE: '^((TreeDB/)|scripts/mvcc_(raw_path_gate|adapter_overhead_gate|closeout_matrix|candidate_checkout_guard)\.sh$|\.github/scripts/(check_mvcc_(raw_path|adapter_overhead)_gate|summarize_mvcc_closeout|test_(mvcc_(raw_path_equivalence|benchmark_pairing|candidate_checkout_guard)|summarize_mvcc_closeout))\.py$|\.github/workflows/treedb-tests\.yml$)'
+      MVCC_GATE_PATH_RE: '^((TreeDB/)|scripts/mvcc_(raw_path_gate|adapter_overhead_gate|closeout_matrix|candidate_checkout_guard)\.sh$|\.github/scripts/(check_mvcc_(raw_path|adapter_overhead)_gate|summarize_mvcc_closeout|test_(mvcc_(raw_path_equivalence|benchmark_pairing|candidate_checkout_guard)|summarize_mvcc_closeout)|test_treedb_windows_core_headroom)\.py$|\.github/workflows/treedb-tests\.yml$)'
     steps:
       - name: Resolve open PR and relevant paths
         id: scope
@@ -95,6 +95,7 @@ jobs:
           python3 .github/scripts/test_mvcc_benchmark_pairing.py
           python3 .github/scripts/test_summarize_mvcc_closeout.py
           python3 .github/scripts/test_mvcc_candidate_checkout_guard.py
+          python3 .github/scripts/test_treedb_windows_core_headroom.py
           for path in \
             TreeDB/snapshot_seek_iterator_bench_test.go \
             TreeDB/command_wal_public_test.go \
@@ -111,7 +112,8 @@ jobs:
             scripts/mvcc_candidate_checkout_guard.sh \
             .github/scripts/summarize_mvcc_closeout.py \
             .github/scripts/test_summarize_mvcc_closeout.py \
-            .github/scripts/test_mvcc_candidate_checkout_guard.py; do
+            .github/scripts/test_mvcc_candidate_checkout_guard.py \
+            .github/scripts/test_treedb_windows_core_headroom.py; do
             if ! grep -Eq "$MVCC_GATE_PATH_RE" <<< "$path"; then
               echo "MVCC gate path scope unexpectedly excludes: $path" >&2
               exit 1

--- a/.github/workflows/treedb-tests.yml
+++ b/.github/workflows/treedb-tests.yml
@@ -185,14 +185,14 @@ jobs:
             run_vet: true
           - name: windows-core-1
             os: windows-latest
-            timeout: 25
+            timeout: 30
             shard_kind: windows-core
             package_shard_index: 0
             package_shard_count: 2
             run_vet: true
           - name: windows-core-2
             os: windows-latest
-            timeout: 25
+            timeout: 30
             shard_kind: windows-core
             package_shard_index: 1
             package_shard_count: 2


### PR DESCRIPTION
Closes #3795
Parent tracker: #3776

## Summary

- raise only the two bounded TreeDB Windows core-shard job caps from 25 to 30 minutes
- preserve the 25-minute caps for Windows caching shards and the Linux race shards
- add a focused workflow contract test that pins equal 30-minute core caps
- leave all test selection, assertions, product code, and durability behavior unchanged

## Diagnosis

Exact-head proof run `29455967029` reached the 25-minute `windows-core-2` job cap after its Go JSON stream had completed every selected test. The timing summary reported no tests left running and successful `raftcluster`, root, and DB packages. Its single classified rerun passed in 22m18s.

The slow observation completed test execution at about 24m48s, leaving effectively no cleanup/upload margin under a 25-minute wall-clock cap. A 30-minute cap keeps the job bounded while restoring about 20% headroom. Subsequent exact-head matrices continued to put these shards in the 18-20 minute range, confirming that this is core-shard capacity variance rather than a product-test failure.

## Test-first evidence

- the new contract test failed first against both 25-minute core entries
- after the workflow change, `python3 .github/scripts/test_treedb_windows_core_headroom.py` passes both the 30-minute core-cap contract and the unchanged 25-minute caching-cap contract
- the contract is invoked by the existing one-per-workflow gate self-check, and its own path is included in that gate's change scope
- local Windows core selection proof remains complete and disjoint: 79 packages split 40/39, 378 root tests split 2/376, and 1,255 DB tests split 2/1,253, with zero missing, extra, or overlapping entries in every partition
- the full existing gate self-check suite passes after the wiring change
- workflow YAML parse passes
- `git diff --check origin/main...HEAD` passes

The branch is refreshed without conflict onto exact base `main@c20e51cec67b141528c572acdff79cbcf1deb17d` and includes the merged Linux race-shard headroom change from #3792 / PR #3793.

## Final exact-head evidence

All three independent TreeDB workflows are 14/14 green on exact head `26d2a2ef36e5945ceb2536e489d255f596f4d06f` and exact base `main@c20e51cec67b141528c572acdff79cbcf1deb17d`, without retries:

| TreeDB run | windows-core-1 | windows-core-2 | rollup |
| --- | ---: | ---: | --- |
| PR `29462657201` | 17m14s pass | 22m30s pass | 14/14 green |
| proof `29462658988` | 21m06s pass | 21m22s pass | 14/14 green |
| proof `29462658992` | 18m13s pass | 25m04s pass | 14/14 green |

The 25m04s success directly crossed the old 25-minute job cap while retaining 4m56s under the new bounded cap. All six Windows core jobs completed successfully; no test was skipped or retried. Every actual PR-branch workflow is green.

Codex initially identified that the Python contract was local-only. The exact head wires it into `Gate self-checks`, adds its path to the gate scope, and pins the unchanged caching caps; the thread was answered and resolved. Codex then reported no major issues on the exact head: https://github.com/snissn/gomap/pull/3797#issuecomment-4986866955

## Merge gates

- [x] exact-head Codex review clean
- [x] zero unresolved review threads
- [x] all actual latest-head PR workflows green
- [x] three independent exact-head TreeDB workflows green with both Windows core-shard durations recorded
