### PR TITLE
test(raftcluster): require a settled leader window

### DIFF
--- a/TreeDB/internal/raftcluster/hashicorp_raft_test.go
+++ b/TreeDB/internal/raftcluster/hashicorp_raft_test.go
@@ -1099,9 +1099,13 @@ func openHashicorpRaftTestDBAndFSM(tb testing.TB, cfg Config) (*backenddb.DB, *r
 
 func hashicorpRaftFastTestConfig() *hraft.Config {
 	conf := hraft.DefaultConfig()
-	conf.HeartbeatTimeout = 500 * time.Millisecond
-	conf.ElectionTimeout = 500 * time.Millisecond
-	conf.LeaderLeaseTimeout = 250 * time.Millisecond
+	// Keep the default coordination timeouts. Shortening them made durable
+	// integration tests vulnerable to false leadership churn when a contended
+	// runner stalled Raft goroutines for only a few hundred milliseconds.
+	// CommitTimeout, SnapshotInterval, SnapshotThreshold, and TrailingLogs retain
+	// the fast test behavior while leadership coordination stays at the
+	// HashiCorp defaults; the output and telemetry overrides only keep tests
+	// quiet.
 	conf.CommitTimeout = 10 * time.Millisecond
 	conf.SnapshotInterval = time.Hour
 	conf.SnapshotThreshold = ^uint64(0)
@@ -1112,12 +1116,26 @@ func hashicorpRaftFastTestConfig() *hraft.Config {
 	return conf
 }
 
-// waitForLeader requires two leader observations in the same live term.
-// A single Leader admission observation is not sufficient: on slow hosts it
-// can be sampled while the election/current-term no-op is still settling,
-// allowing the next submit or read assertion to race leadership loss. This is
-// a test-harness barrier only; it deliberately does not retry the operation
-// under test.
+func TestHashicorpRaftFastTestConfigPreservesDefaultLeadershipHeadroom(t *testing.T) {
+	defaults := hraft.DefaultConfig()
+	got := hashicorpRaftFastTestConfig()
+	if got.HeartbeatTimeout < defaults.HeartbeatTimeout {
+		t.Fatalf("HeartbeatTimeout=%s want at least HashiCorp default %s", got.HeartbeatTimeout, defaults.HeartbeatTimeout)
+	}
+	if got.ElectionTimeout < defaults.ElectionTimeout {
+		t.Fatalf("ElectionTimeout=%s want at least HashiCorp default %s", got.ElectionTimeout, defaults.ElectionTimeout)
+	}
+	if got.LeaderLeaseTimeout < defaults.LeaderLeaseTimeout {
+		t.Fatalf("LeaderLeaseTimeout=%s want at least HashiCorp default %s", got.LeaderLeaseTimeout, defaults.LeaderLeaseTimeout)
+	}
+}
+
+// waitForLeader requires continuous live-quorum observations of one leader and
+// term across the test configuration's full coordination window. A single
+// Leader admission observation, or two observations one poll apart, can be
+// sampled while the election/current-term no-op is still settling. This is a
+// test-harness barrier only; it deliberately does not retry the operation under
+// test.
 func (c *hashicorpRaftTestCluster) waitForLeader(tb testing.TB) *hashicorpRaftTestNode {
 	tb.Helper()
 	// Opening three durable test nodes can consume most of the old 15-second
@@ -1127,6 +1145,7 @@ func (c *hashicorpRaftTestCluster) waitForLeader(tb testing.TB) *hashicorpRaftTe
 	deadline := time.Now().Add(30 * time.Second)
 	readinessCtx, cancel := context.WithDeadline(context.Background(), deadline)
 	defer cancel()
+	settlingWindow := hashicorpRaftLeaderSettlingWindow(hashicorpRaftFastTestConfig())
 	var previous leaderReadinessObservation
 	var lastErr error
 	for readinessCtx.Err() == nil {
@@ -1143,14 +1162,20 @@ func (c *hashicorpRaftTestCluster) waitForLeader(tb testing.TB) *hashicorpRaftTe
 			waitForLeaderReadinessPoll(readinessCtx)
 			continue
 		}
-		current := leaderReadinessObservation{nodeID: leader.id, term: term, valid: true}
-		if sameStableLeaderTerm(previous, current) {
+		current := leaderReadinessObservation{nodeID: leader.id, term: term, observedAt: time.Now(), valid: true}
+		if sameStableLeaderTerm(previous, current, settlingWindow) {
 			return leader
 		}
-		previous = current
+		if !sameLeaderTerm(previous, current) {
+			previous = current
+		}
 		waitForLeaderReadinessPoll(readinessCtx)
 	}
-	tb.Fatalf("timed out waiting for leader-ready stable term; last_readiness_err=%v states=%s", lastErr, c.admissionSummary())
+	stableFor := time.Duration(0)
+	if previous.valid {
+		stableFor = time.Since(previous.observedAt)
+	}
+	tb.Fatalf("timed out waiting for leader-ready stable term; last_readiness_err=%v last_stable_leader=%s last_stable_term=%d stable_for=%s required=%s states=%s", lastErr, previous.nodeID, previous.term, stableFor, settlingWindow, c.admissionSummary())
 	return nil
 }
 
@@ -1162,13 +1187,32 @@ func waitForLeaderReadinessPoll(ctx context.Context) {
 }
 
 type leaderReadinessObservation struct {
-	nodeID NodeID
-	term   uint64
-	valid  bool
+	nodeID     NodeID
+	term       uint64
+	observedAt time.Time
+	valid      bool
 }
 
-func sameStableLeaderTerm(previous, current leaderReadinessObservation) bool {
+func sameLeaderTerm(previous, current leaderReadinessObservation) bool {
 	return previous.valid && current.valid && previous.nodeID == current.nodeID && previous.nodeID != "" && previous.term == current.term && current.term != 0
+}
+
+func sameStableLeaderTerm(previous, current leaderReadinessObservation, settlingWindow time.Duration) bool {
+	return settlingWindow > 0 && sameLeaderTerm(previous, current) && current.observedAt.Sub(previous.observedAt) >= settlingWindow
+}
+
+func hashicorpRaftLeaderSettlingWindow(conf *hraft.Config) time.Duration {
+	if conf == nil {
+		return 0
+	}
+	window := conf.LeaderLeaseTimeout
+	if conf.HeartbeatTimeout > window {
+		window = conf.HeartbeatTimeout
+	}
+	if conf.ElectionTimeout > window {
+		window = conf.ElectionTimeout
+	}
+	return window
 }
 
 func (c *hashicorpRaftTestCluster) waitForSingleLeader(tb testing.TB) *hashicorpRaftTestNode {
@@ -1193,22 +1237,27 @@ func (c *hashicorpRaftTestCluster) waitForSingleLeader(tb testing.TB) *hashicorp
 	return leader
 }
 
-func TestHashicorpRaftLeaderReadinessRequiresConsecutiveObservationsInOneTerm(t *testing.T) {
-	ready := leaderReadinessObservation{nodeID: "node-a", term: 4, valid: true}
-	if sameStableLeaderTerm(leaderReadinessObservation{}, ready) {
+func TestHashicorpRaftLeaderReadinessRequiresASettledTermWindow(t *testing.T) {
+	startedAt := time.Unix(1_000, 0)
+	settlingWindow := hashicorpRaftLeaderSettlingWindow(hashicorpRaftFastTestConfig())
+	ready := leaderReadinessObservation{nodeID: "node-a", term: 4, observedAt: startedAt, valid: true}
+	if sameStableLeaderTerm(leaderReadinessObservation{}, ready, settlingWindow) {
 		t.Fatal("a single leader/proof observation must not satisfy the readiness barrier")
 	}
-	if sameStableLeaderTerm(ready, leaderReadinessObservation{nodeID: "node-a", term: 5, valid: true}) {
+	if sameStableLeaderTerm(ready, leaderReadinessObservation{nodeID: "node-a", term: 4, observedAt: startedAt.Add(20 * time.Millisecond), valid: true}, settlingWindow) {
+		t.Fatal("two observations inside the Raft timing window must not satisfy the readiness barrier")
+	}
+	if sameStableLeaderTerm(ready, leaderReadinessObservation{nodeID: "node-a", term: 5, observedAt: startedAt.Add(settlingWindow), valid: true}, settlingWindow) {
 		t.Fatal("a term transition must reset the readiness barrier")
 	}
-	if sameStableLeaderTerm(ready, leaderReadinessObservation{nodeID: "node-b", term: 4, valid: true}) {
+	if sameStableLeaderTerm(ready, leaderReadinessObservation{nodeID: "node-b", term: 4, observedAt: startedAt.Add(settlingWindow), valid: true}, settlingWindow) {
 		t.Fatal("a leader transition must reset the readiness barrier")
 	}
-	if sameStableLeaderTerm(ready, leaderReadinessObservation{nodeID: "node-a", term: 4}) {
+	if sameStableLeaderTerm(ready, leaderReadinessObservation{nodeID: "node-a", term: 4, observedAt: startedAt.Add(settlingWindow)}, settlingWindow) {
 		t.Fatal("an invalid observation must not satisfy the readiness barrier")
 	}
-	if !sameStableLeaderTerm(ready, ready) {
-		t.Fatal("two valid observations for the same leader term must satisfy the readiness barrier")
+	if !sameStableLeaderTerm(ready, leaderReadinessObservation{nodeID: "node-a", term: 4, observedAt: startedAt.Add(settlingWindow), valid: true}, settlingWindow) {
+		t.Fatal("a continuously verified leader term spanning the Raft timing window must satisfy the readiness barrier")
 	}
 }
 


### PR DESCRIPTION
## Summary

Closes #3665. Part of #3776. Blocks #3796 and PR #3798.

Hardens the shared Hashicorp Raft integration-test readiness boundary after the prior fix in PR #3782 admitted a leader after only two proofs 20 ms apart. The harness now:

- preserves Hashicorp's default heartbeat, election, and leader-lease coordination headroom;
- continuously verifies live quorum and the same leader/term across the full configured coordination window (one second with the test config);
- resets the window on any proof failure, leader change, or term change; and
- retains the existing bounded 30-second diagnostic failure.

This is test-harness code only. It never retries the operation under test and changes no production provider API, commit-ambiguity mapping, storage behavior, or assertion.

## Recurrence and root cause

PR #3798 exact head `aff16f392c58443428cc22bf2ee8820f879b7db9` reproduced the family in TreeDB run `29464672736`, job `87515209193`: `TestHashicorpRaftProviderLeaderCrashAfterCommitRestartCatchUpConverges` selected a leader, then the initial acknowledged setup submit correctly returned `raftcluster: commit ambiguous` with `leadership lost while committing log`.

The prior readiness barrier required two successful `VerifyLeader` plus same-term observations but separated them by only one 20 ms poll. The fast test config simultaneously reduced Hashicorp's default 1 s heartbeat/election and 500 ms lease timeouts to 500/500/250 ms. On a contended hosted Windows runner, the selected leader could therefore be admitted while its term was still inside the coordination window, then legitimately lose leadership during the following submit.

The production path behaved correctly by surfacing ambiguity. The defect was the harness readiness/config contract, so PR #3798 was parked without a rerun and this issue was reopened.

## Test-first characterization

- `TestHashicorpRaftLeaderReadinessRequiresASettledTermWindow` initially failed because the old helper accepted same-term proofs only 20 ms apart. It now rejects that pair and only accepts a continuously verified leader/term after the full configured settling window.
- `TestHashicorpRaftFastTestConfigPreservesDefaultLeadershipHeadroom` initially failed with `HeartbeatTimeout=500ms want at least HashiCorp default 1s`. It now protects heartbeat, election, and lease headroom from future shortening.

## Validation (`GOWORK=off`)

- Exact recurrence: `-count=25` — pass in 155.953s.
- Exact recurrence with `GOMAXPROCS=2`: `-count=10` — pass in 61.896s.
- Adjacent leader submit, read-index, and precommit-crash scenarios: `-count=10` each — pass in 80.460s.
- Full `TreeDB/internal/raftcluster` package — pass in 52.671s.
- Focused recurrence/initial-submit/characterizations under `-race`, `GOMAXPROCS=2`, `-count=3` — pass in 27.383s.
- Coordinator repeat of the recurrence and both characterizations, `GOMAXPROCS=2`, `-count=3` — pass in 17.524s.
- `gofmt`, `git diff --check`, clean worktree, and exact-base checks — pass.

Validated on exact head `ba0bca5a49ccdc32f1b8ac8557852450f1771cb1`, based on main `216cc7af71bea1eadf57a0c7bf53f17e8ce27a41`.

## Performance

No production performance impact: all changes are confined to `_test.go`. Raft integration tests deliberately wait for a stronger readiness contract and remain bounded by the existing 30-second deadline.

## Merge gate

Pending fresh exact-head full CI, an exact-head Codex review, zero unresolved review threads, and three independent green hosted TreeDB matrices. In particular, all three `windows-core-2` jobs must pass without rerunning a failed job.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved leader readiness checks to ensure a leader remains stable for the required settling period before being considered ready.
  - Added clearer timeout diagnostics when leader readiness is not achieved.

- **Tests**
  - Added coverage for preserving default leadership timing safeguards.
  - Added tests for readiness resets when leadership terms or validity change.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->