### PR TITLE
ci: attribute MVCC raw gate failures per binary

### DIFF
--- a/.github/scripts/check_mvcc_raw_path_gate.py
+++ b/.github/scripts/check_mvcc_raw_path_gate.py
@@ -206,30 +206,41 @@ def evaluate(
 def annotate_binary_equivalence(
     results: list[dict[str, object]],
     binary_digests: dict[str, dict[str, str]],
-) -> tuple[bool, list[dict[str, object]]]:
+) -> list[dict[str, object]]:
     annotated: list[dict[str, object]] = []
-    all_equivalent = True
     for result in results:
         benchmark = result["benchmark"]
         assert isinstance(benchmark, str)
+        measurement_pass = result["measurement_pass"]
+        assert isinstance(measurement_pass, bool)
         package = BINARY_PACKAGE_BY_BENCHMARK[benchmark]
         package_digests = binary_digests[package]
         equivalent = package_digests["baseline"] == package_digests["candidate"]
-        all_equivalent = all_equivalent and equivalent
         annotated.append(
             {
                 **result,
                 "binary_package": package,
                 "binary_equivalent": equivalent,
+                "attribution": (
+                    "NON_ATTRIBUTABLE" if equivalent else "CANDIDATE"
+                ),
+                "acceptance_pass": measurement_pass or equivalent,
+                "acceptance_verdict": (
+                    "PASS"
+                    if measurement_pass
+                    else "EQUIVALENT"
+                    if equivalent
+                    else "FAIL"
+                ),
             }
         )
-    return all_equivalent, annotated
+    return annotated
 
 
-def acceptance_verdict(measurement_pass: bool, all_equivalent: bool) -> str:
-    if measurement_pass:
+def acceptance_verdict(results: list[dict[str, object]]) -> str:
+    if all(row["measurement_pass"] for row in results):
         return "PASS"
-    return "EQUIVALENT" if all_equivalent else "FAIL"
+    return "EQUIVALENT" if all(row["acceptance_pass"] for row in results) else "FAIL"
 
 
 def render_markdown(
@@ -262,9 +273,10 @@ def render_markdown(
     if verdict == "EQUIVALENT":
         lines.extend(
             [
-                "- equivalence acceptance: every row-producing base/head benchmark binary "
-                "is byte-identical, so the measured delta is retained but is not "
-                "attributable to the candidate revision",
+                "- equivalence acceptance: failed rows whose owning base/head benchmark "
+                "binary is byte-identical remain measured and reported, but are not "
+                "attributable to the candidate revision; rows with changed binaries "
+                "remain threshold-enforced",
             ]
         )
     lines.extend(
@@ -284,8 +296,8 @@ def render_markdown(
     lines.extend(
         [
             "",
-            "| Benchmark | Binary | Base ns/op | Head ns/op | Median delta | Paired delta | Base B/op | Head B/op | B tolerance | Base allocs/op | Head allocs/op | Measured |",
-            "| --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | --- |",
+            "| Benchmark | Binary | Base ns/op | Head ns/op | Median delta | Paired delta | Base B/op | Head B/op | B tolerance | Base allocs/op | Head allocs/op | Measured | Attribution | Acceptance |",
+            "| --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | --- | --- | --- |",
         ]
     )
     for row in results:
@@ -296,7 +308,7 @@ def render_markdown(
         lines.append(
             "| {benchmark} | {binary} | {base_ns:.3f} | {head_ns:.3f} | {delta:+.2f}% | {paired_delta:+.2f}% | "
             "{base_bytes:.3f} | {head_bytes:.3f} | {bytes_tolerance:.3f} | {base_allocs:.3f} | "
-            "{head_allocs:.3f} | {status} |".format(
+            "{head_allocs:.3f} | {status} | {attribution} | {acceptance} |".format(
                 benchmark=row["benchmark"],
                 binary=(
                     f"{row['binary_package']} EQUIVALENT"
@@ -313,6 +325,8 @@ def render_markdown(
                 base_allocs=base["allocs_per_op"],
                 head_allocs=head["allocs_per_op"],
                 status="PASS" if row["measurement_pass"] else "FAIL",
+                attribution=row["attribution"],
+                acceptance=row["acceptance_verdict"],
             )
         )
     lines.append("")
@@ -519,15 +533,22 @@ def main() -> int:
         args.max_bytes_regression_percent,
         args.max_bytes_regression_absolute,
     )
-    all_equivalent, results = annotate_binary_equivalence(results, binary_digests)
-    verdict = acceptance_verdict(measurement_pass, all_equivalent)
+    results = annotate_binary_equivalence(results, binary_digests)
+    verdict = acceptance_verdict(results)
     accepted = verdict in {"PASS", "EQUIVALENT"}
     payload = {
         "accepted": accepted,
         "no_attributable_regression": accepted,
         "verdict": verdict,
         "measurement_pass": measurement_pass,
-        "all_row_binaries_equivalent": all_equivalent,
+        "attributable_measurement_pass": all(
+            row["measurement_pass"]
+            for row in results
+            if not row["binary_equivalent"]
+        ),
+        "all_row_binaries_equivalent": all(
+            row["binary_equivalent"] for row in results
+        ),
         "binary_digests": binary_digests,
         "baseline_sha": args.baseline_sha,
         "candidate_sha": args.candidate_sha,

--- a/.github/scripts/test_mvcc_raw_path_equivalence.py
+++ b/.github/scripts/test_mvcc_raw_path_equivalence.py
@@ -29,11 +29,47 @@ class RawPathEquivalenceTests(unittest.TestCase):
     def tearDown(self) -> None:
         self.tmp.cleanup()
 
-    def results(self, passed: bool) -> list[dict[str, object]]:
-        return [
-            {"benchmark": benchmark, "measurement_pass": passed}
+    def results_with_byte_regressions(
+        self, failed_benchmarks: set[str]
+    ) -> list[dict[str, object]]:
+        baseline = {
+            benchmark: [CHECKER.Sample(100.0, 10000.0, 2.0) for _ in range(8)]
             for benchmark in CHECKER.BENCHMARKS
-        ]
+        }
+        candidate = {
+            benchmark: [
+                CHECKER.Sample(
+                    100.0,
+                    10065.0 if benchmark in failed_benchmarks else 10000.0,
+                    2.0,
+                )
+                for _ in range(8)
+            ]
+            for benchmark in CHECKER.BENCHMARKS
+        }
+        measurement_pass, rows = CHECKER.evaluate(
+            baseline, candidate, 5.0, 1.0, 64.0
+        )
+        self.assertEqual(measurement_pass, not failed_benchmarks)
+        return rows
+
+    @staticmethod
+    def log_with_byte_regressions(failed_benchmarks: set[str]) -> str:
+        lines: list[str] = []
+        for _ in range(8):
+            for benchmark in CHECKER.BENCHMARKS:
+                bytes_per_op = 10065.0 if benchmark in failed_benchmarks else 10000.0
+                lines.append(
+                    f"{benchmark}-1 1000 100.000 ns/op "
+                    f"{bytes_per_op:.3f} B/op 2.000 allocs/op"
+                )
+        return "\n".join(lines) + "\n"
+
+    @staticmethod
+    def row_for(
+        rows: list[dict[str, object]], benchmark: str
+    ) -> dict[str, object]:
+        return next(row for row in rows if row["benchmark"] == benchmark)
 
     @staticmethod
     def samples(timings: list[float]) -> list[CHECKER.Sample]:
@@ -126,56 +162,68 @@ class RawPathEquivalenceTests(unittest.TestCase):
             paths[package] = {"baseline": baseline, "candidate": candidate}
         return paths
 
-    def test_identical_package_digests_accept_equivalent_despite_failed_measurement(self) -> None:
-        parsed = CHECKER.compute_binary_digests(
-            self.binary_paths(set(CHECKER.BINARY_PACKAGES))
-        )
-        all_equivalent, rows = CHECKER.annotate_binary_equivalence(
-            self.results(False), parsed
-        )
-        self.assertTrue(all_equivalent)
-        self.assertTrue(all(row["binary_equivalent"] for row in rows))
-        self.assertFalse(all(row["measurement_pass"] for row in rows))
-        self.assertEqual(
-            CHECKER.acceptance_verdict(False, all_equivalent), "EQUIVALENT"
-        )
-
-    def test_verdict_truth_table(self) -> None:
-        cases = (
-            (True, True, "PASS"),
-            (True, False, "PASS"),
-            (False, True, "EQUIVALENT"),
-            (False, False, "FAIL"),
-        )
-        for measurement_pass, all_equivalent, expected in cases:
-            with self.subTest(
-                measurement_pass=measurement_pass,
-                all_equivalent=all_equivalent,
-            ):
-                self.assertEqual(
-                    CHECKER.acceptance_verdict(measurement_pass, all_equivalent),
-                    expected,
-                )
-
-    def test_different_package_digests_use_measured_pass(self) -> None:
-        parsed = CHECKER.compute_binary_digests(self.binary_paths(set()))
-        all_equivalent, _ = CHECKER.annotate_binary_equivalence(
-            self.results(True), parsed
-        )
-        self.assertFalse(all_equivalent)
-        self.assertEqual(CHECKER.acceptance_verdict(True, all_equivalent), "PASS")
-
-    def test_mixed_digests_cannot_mask_failed_measurement(self) -> None:
+    def test_equivalent_binary_row_accepts_failed_measurement_despite_changed_other_binary(self) -> None:
         parsed = CHECKER.compute_binary_digests(
             self.binary_paths({"db", "treedb"})
         )
-        all_equivalent, rows = CHECKER.annotate_binary_equivalence(
-            self.results(False), parsed
+        rows = CHECKER.annotate_binary_equivalence(
+            self.results_with_byte_regressions(
+                {"BenchmarkConditionalTxnBaselineBatchWrite"}
+            ),
+            parsed,
         )
-        self.assertFalse(all_equivalent)
-        self.assertTrue(rows[0]["binary_equivalent"])
-        self.assertFalse(rows[3]["binary_equivalent"])
-        self.assertEqual(CHECKER.acceptance_verdict(False, all_equivalent), "FAIL")
+        batch_write = self.row_for(
+            rows, "BenchmarkConditionalTxnBaselineBatchWrite"
+        )
+        self.assertTrue(batch_write["binary_equivalent"])
+        self.assertFalse(batch_write["measurement_pass"])
+        self.assertFalse(batch_write["bytes_pass"])
+        self.assertEqual(batch_write["bytes_delta"], 65.0)
+        self.assertEqual(batch_write["attribution"], "NON_ATTRIBUTABLE")
+        self.assertEqual(batch_write["acceptance_verdict"], "EQUIVALENT")
+        self.assertEqual(CHECKER.acceptance_verdict(rows), "EQUIVALENT")
+
+    def test_changed_binary_failed_row_remains_attributable(self) -> None:
+        parsed = CHECKER.compute_binary_digests(
+            self.binary_paths({"caching", "treedb"})
+        )
+        rows = CHECKER.annotate_binary_equivalence(
+            self.results_with_byte_regressions(
+                {"BenchmarkConditionalTxnBaselineBatchWrite"}
+            ),
+            parsed,
+        )
+        batch_write = self.row_for(
+            rows, "BenchmarkConditionalTxnBaselineBatchWrite"
+        )
+        self.assertFalse(batch_write["binary_equivalent"])
+        self.assertFalse(batch_write["measurement_pass"])
+        self.assertEqual(batch_write["attribution"], "CANDIDATE")
+        self.assertEqual(batch_write["acceptance_verdict"], "FAIL")
+        self.assertEqual(CHECKER.acceptance_verdict(rows), "FAIL")
+
+    def test_mixed_rows_cannot_hide_failed_changed_binary_row(self) -> None:
+        parsed = CHECKER.compute_binary_digests(
+            self.binary_paths({"db", "treedb"})
+        )
+        rows = CHECKER.annotate_binary_equivalence(
+            self.results_with_byte_regressions(
+                {
+                    "BenchmarkConditionalTxnBaselineBatchWrite",
+                    "BenchmarkRepeatedIterator",
+                }
+            ),
+            parsed,
+        )
+        self.assertTrue(
+            self.row_for(rows, "BenchmarkConditionalTxnBaselineBatchWrite")[
+                "binary_equivalent"
+            ]
+        )
+        self.assertFalse(
+            self.row_for(rows, "BenchmarkRepeatedIterator")["binary_equivalent"]
+        )
+        self.assertEqual(CHECKER.acceptance_verdict(rows), "FAIL")
 
     def test_malformed_or_missing_binary_evidence_fails_closed(self) -> None:
         valid = self.binary_paths(set(CHECKER.BINARY_PACKAGES))
@@ -246,7 +294,10 @@ class RawPathEquivalenceTests(unittest.TestCase):
         self.assertTrue(payload["accepted"])
         self.assertTrue(payload["no_attributable_regression"])
         self.assertFalse(payload["measurement_pass"])
+        self.assertTrue(payload["attributable_measurement_pass"])
         self.assertFalse(payload["results"][0]["measurement_pass"])
+        self.assertEqual(payload["results"][0]["attribution"], "NON_ATTRIBUTABLE")
+        self.assertEqual(payload["results"][0]["acceptance_verdict"], "EQUIVALENT")
         self.assertAlmostEqual(payload["results"][0]["paired_ns_delta_percent"], 20.0)
         self.assertNotIn("pass", payload)
         markdown = markdown_output.read_text(encoding="utf-8")
@@ -254,6 +305,68 @@ class RawPathEquivalenceTests(unittest.TestCase):
         self.assertIn("- measured threshold observation: **FAIL**", markdown)
         self.assertIn("timing acceptance: median paired candidate/base", markdown)
         self.assertIn("| Median delta | Paired delta |", markdown)
+        self.assertIn("| Measured | Attribution | Acceptance |", markdown)
+
+    def test_cli_accepts_only_equivalent_failed_row_in_mixed_digest_evidence(self) -> None:
+        baseline_log = self.root / "baseline.txt"
+        candidate_log = self.root / "candidate.txt"
+        baseline_log.write_text(self.log_with_byte_regressions(set()), encoding="utf-8")
+        candidate_log.write_text(
+            self.log_with_byte_regressions(
+                {"BenchmarkConditionalTxnBaselineBatchWrite"}
+            ),
+            encoding="utf-8",
+        )
+        paths = self.binary_paths({"db", "treedb"})
+        json_output = self.root / "summary.json"
+        markdown_output = self.root / "summary.md"
+        command = [
+            sys.executable,
+            str(CHECKER_PATH),
+            "--baseline",
+            str(baseline_log),
+            "--candidate",
+            str(candidate_log),
+            "--baseline-sha",
+            "a" * 40,
+            "--candidate-sha",
+            "b" * 40,
+            "--json-output",
+            str(json_output),
+            "--markdown-output",
+            str(markdown_output),
+        ]
+        for package in CHECKER.BINARY_PACKAGES:
+            for revision in ("baseline", "candidate"):
+                command.extend(
+                    [
+                        f"--{revision}-{package}-binary",
+                        str(paths[package][revision]),
+                    ]
+                )
+        completed = subprocess.run(command, text=True, capture_output=True, check=False)
+        self.assertEqual(completed.returncode, 0, completed.stderr)
+        payload = json.loads(json_output.read_text(encoding="utf-8"))
+        self.assertEqual(payload["verdict"], "EQUIVALENT")
+        self.assertTrue(payload["accepted"])
+        self.assertFalse(payload["measurement_pass"])
+        self.assertTrue(payload["attributable_measurement_pass"])
+        db_row = self.row_for(
+            payload["results"], "BenchmarkConditionalTxnBaselineBatchWrite"
+        )
+        caching_row = self.row_for(payload["results"], "BenchmarkRepeatedIterator")
+        self.assertTrue(db_row["binary_equivalent"])
+        self.assertFalse(db_row["measurement_pass"])
+        self.assertEqual(db_row["attribution"], "NON_ATTRIBUTABLE")
+        self.assertEqual(db_row["acceptance_verdict"], "EQUIVALENT")
+        self.assertFalse(caching_row["binary_equivalent"])
+        self.assertTrue(caching_row["measurement_pass"])
+        self.assertEqual(caching_row["attribution"], "CANDIDATE")
+        self.assertEqual(caching_row["acceptance_verdict"], "PASS")
+        markdown = markdown_output.read_text(encoding="utf-8")
+        self.assertIn("- measured threshold observation: **FAIL**", markdown)
+        self.assertIn("NON_ATTRIBUTABLE | EQUIVALENT", markdown)
+        self.assertIn("CANDIDATE | PASS", markdown)
 
 
 if __name__ == "__main__":

--- a/.github/scripts/test_mvcc_raw_path_equivalence.py
+++ b/.github/scripts/test_mvcc_raw_path_equivalence.py
@@ -21,6 +21,13 @@ sys.modules[SPEC.name] = CHECKER
 SPEC.loader.exec_module(CHECKER)
 
 
+SYNTHETIC_RUNS = 8
+SYNTHETIC_NS_PER_OP = 100.0
+SYNTHETIC_BASE_BYTES_PER_OP = 10000.0
+SYNTHETIC_FAILED_BYTES_PER_OP = 10065.0
+SYNTHETIC_ALLOCS_PER_OP = 2.0
+
+
 class RawPathEquivalenceTests(unittest.TestCase):
     def setUp(self) -> None:
         self.tmp = tempfile.TemporaryDirectory()
@@ -33,17 +40,28 @@ class RawPathEquivalenceTests(unittest.TestCase):
         self, failed_benchmarks: set[str]
     ) -> list[dict[str, object]]:
         baseline = {
-            benchmark: [CHECKER.Sample(100.0, 10000.0, 2.0) for _ in range(8)]
+            benchmark: [
+                CHECKER.Sample(
+                    SYNTHETIC_NS_PER_OP,
+                    SYNTHETIC_BASE_BYTES_PER_OP,
+                    SYNTHETIC_ALLOCS_PER_OP,
+                )
+                for _ in range(SYNTHETIC_RUNS)
+            ]
             for benchmark in CHECKER.BENCHMARKS
         }
         candidate = {
             benchmark: [
                 CHECKER.Sample(
-                    100.0,
-                    10065.0 if benchmark in failed_benchmarks else 10000.0,
-                    2.0,
+                    SYNTHETIC_NS_PER_OP,
+                    (
+                        SYNTHETIC_FAILED_BYTES_PER_OP
+                        if benchmark in failed_benchmarks
+                        else SYNTHETIC_BASE_BYTES_PER_OP
+                    ),
+                    SYNTHETIC_ALLOCS_PER_OP,
                 )
-                for _ in range(8)
+                for _ in range(SYNTHETIC_RUNS)
             ]
             for benchmark in CHECKER.BENCHMARKS
         }
@@ -56,12 +74,17 @@ class RawPathEquivalenceTests(unittest.TestCase):
     @staticmethod
     def log_with_byte_regressions(failed_benchmarks: set[str]) -> str:
         lines: list[str] = []
-        for _ in range(8):
+        for _ in range(SYNTHETIC_RUNS):
             for benchmark in CHECKER.BENCHMARKS:
-                bytes_per_op = 10065.0 if benchmark in failed_benchmarks else 10000.0
+                bytes_per_op = (
+                    SYNTHETIC_FAILED_BYTES_PER_OP
+                    if benchmark in failed_benchmarks
+                    else SYNTHETIC_BASE_BYTES_PER_OP
+                )
                 lines.append(
-                    f"{benchmark}-1 1000 100.000 ns/op "
-                    f"{bytes_per_op:.3f} B/op 2.000 allocs/op"
+                    f"{benchmark}-1 1000 {SYNTHETIC_NS_PER_OP:.3f} ns/op "
+                    f"{bytes_per_op:.3f} B/op "
+                    f"{SYNTHETIC_ALLOCS_PER_OP:.3f} allocs/op"
                 )
         return "\n".join(lines) + "\n"
 

--- a/TreeDB/docs/spec/dgraph-mvcc-readiness-3673.md
+++ b/TreeDB/docs/spec/dgraph-mvcc-readiness-3673.md
@@ -133,16 +133,19 @@ The point-read and batch-write rows use separate invocations so one row cannot
 delay the base/head pair for the other. Eight samples provide exactly four AB
 and four BA pairs; odd sample counts are rejected. The gate rejects a median
 paired candidate/base timing regression over 5%, any allocation increase, or a material `B/op`
-increase. A distinct `EQUIVALENT` acceptance is available only when the checker
-hashes all six actual test-binary paths and every row-producing base/head pair
-matches (`db`, `caching`, and `treedb`). `EQUIVALENT` preserves the measured
-PASS/FAIL base/head medians and paired timing deltas but states that no observed difference can be
-attributed to the candidate code; mixed, missing, or malformed binary evidence
-fails closed and cannot produce equivalence acceptance.
-The verdict truth table is `PASS` for a passing measurement, `EQUIVALENT` only
-for a failed measurement with all row binaries matching, and `FAIL` otherwise.
-Machine-readable `no_attributable_regression` is true exactly when the verdict
-is accepted (`PASS` or `EQUIVALENT`).
+increase. The checker hashes all six actual test-binary paths and attributes
+each row to its owning `db`, `caching`, or `treedb` base/head binary pair.
+Raw PASS/FAIL medians and paired timing deltas remain reported for every row.
+A failed row with a byte-identical owning binary is reported as
+non-attributable (`EQUIVALENT` at row level); a row whose owning binary changed
+remains threshold-enforced. Mixed binary evidence may produce aggregate
+`EQUIVALENT` only when every changed-owning-binary row passes. Missing,
+malformed, duplicated, or mismatched binary evidence fails closed and cannot
+produce equivalence acceptance.
+The aggregate verdict is `PASS` when all measurements pass, `EQUIVALENT` when
+only equivalent-owning-binary rows fail, and `FAIL` when any changed-owning
+binary row fails. Machine-readable `no_attributable_regression` is true exactly
+when the verdict is accepted (`PASS` or `EQUIVALENT`).
 
 `scripts/mvcc_adapter_overhead_gate.sh` separately compares public MVCC commit,
 get, and all-version iteration rows with their direct TreeDB/physical controls.

--- a/TreeDB/docs/spec/verification.md
+++ b/TreeDB/docs/spec/verification.md
@@ -538,7 +538,8 @@ Coverage:
 
 The raw regression gate uses unchanged existing point/batch benchmarks from the
 same base and head. Because `TreeDB/mvcc` is opt-in and not called by raw APIs,
-any repeatable raw-path regression or allocation increase blocks closeout.
+any repeatable raw-path regression or allocation increase attributable to a
+changed row-owning binary blocks closeout.
 
 ## 10.4 Retained-Version Iteration and Safe Pruning
 
@@ -631,10 +632,15 @@ Coverage:
 - Existing MVCC tests retain direct fault-injection and abrupt-child-exit
   coverage that a generic in-process adapter factory cannot express.
 - `scripts/mvcc_raw_path_gate.sh` is the <=5% raw-path base/head gate. Its
-  machine-readable verdict distinguishes measured `PASS`/`FAIL` from overall
-  `EQUIVALENT` acceptance. Equivalence requires checker-computed matching
-  SHA-256 digests from all six actual row-producing benchmark binaries; mixed,
-  missing, or malformed binary evidence cannot override a failed measurement.
+  machine-readable report distinguishes raw measured `PASS`/`FAIL` from
+  per-row attribution and aggregate acceptance. The checker attributes every
+  row to the SHA-256 relation of its owning `db`, `caching`, or `treedb`
+  benchmark binary. A failed row with byte-identical base/head owner remains
+  reported but is non-attributable; a failed changed-owner row remains
+  threshold-enforced. Mixed evidence can receive aggregate `EQUIVALENT` only
+  if every changed-owner row passes. Missing, malformed, duplicated, or
+  mismatched binary evidence fails closed and cannot override a failed
+  measurement.
   Raw and adapter gates require balanced even AB/BA sample counts and default
   to eight samples per revision. The raw-gate timing verdict uses the median
   per-pair candidate/base relative delta; base/head timing medians remain


### PR DESCRIPTION
Closes #3800
Parent tracker: #3776
Blocks #3796 / PR #3798.

## Summary

- attribute each MVCC raw-path benchmark row to its owning base/candidate test-binary digest
- retain raw timing, B/op, and allocs/op measurement status while accepting a failed row as equivalent only when its own executable is byte-identical
- continue to fail every threshold miss owned by a changed binary, including mixed equivalent/changed evidence
- expose raw measurement, attribution, and acceptance separately in JSON and Markdown
- update both MVCC verification spec entry points to define the same row-owning-binary contract and fail-closed boundaries

No performance threshold, sample count, benchmark, production path, or retry policy changes.

## Exact recurrence

PR #3798 exact head `d39e039569219296b3250a894137b19b17c9d52a` differs from base `3bf55fc6ef0f15aa2d9d2db748c55c16dce979a8` only in the caching test binary. The DB test binary was byte-identical in every matrix:

`689977923a833dbbc6433d80ea630e3fd95f84a9ea3ee7984902a1e0c6fad5de`

Two matrices nevertheless failed the DB-owned `BenchmarkConditionalTxnBaselineBatchWrite` row solely on independently observed B/op medians:

- `29467340891/87523166171`: paired timing -0.94%; allocs/op 1257/1257; B/op +342; FAIL.
- `29467344960/87523178507`: paired timing -0.63%; allocs/op 1257/1257; B/op +223.5; FAIL.
- independent exact-head `29467344929/87523178502`: same binary; B/op -113; PASS.

The current checker only accepts binary equivalence if every row-producing package is identical. A legitimate caching-test change therefore makes unrelated, byte-identical DB control-row variance blocking. Because the failing DB executable is identical, that variance cannot be attributed to the candidate revision.

No failed job was retried; #3798 was parked and its matrices were canceled as superseded.

## Test-first contract

The deterministic mixed-digest characterization initially reproduced the old `FAIL`: DB and TreeDB binaries identical, caching binary changed, DB row +65 B/op (one byte over the unchanged 64-byte limit), all changed-binary rows passing.

After the fix:

- that DB row remains `measurement_pass=false` / raw `FAIL`, but is `NON_ATTRIBUTABLE` with row acceptance `EQUIVALENT`;
- the aggregate is accepted as `EQUIVALENT` because every changed-binary row passes;
- the same failed DB row with a changed DB binary remains attributable and returns `FAIL`;
- a failed equivalent DB row cannot mask a failed changed caching row;
- missing/malformed/symlinked binary evidence still fails closed; and
- the all-equivalent failed-observation CLI contract remains covered.

## Validation

Validated on exact head `590662686c2d24cac500d907f60f2c1fe7d450ce`, based exactly on `main@3bf55fc6ef0f15aa2d9d2db748c55c16dce979a8`.

- `python3 .github/scripts/test_mvcc_raw_path_equivalence.py`: 10 tests pass.
- `python3 .github/scripts/test_mvcc_benchmark_pairing.py`: 6 tests pass.
- `python3 .github/scripts/test_mvcc_candidate_checkout_guard.py`: 6 tests pass.
- `python3 .github/scripts/check_mvcc_raw_path_gate.py --self-test`: pass.
- `py_compile`, `git diff --check`, exact-base, and clean-worktree checks: pass.
- `TreeDB/docs/spec/verification.md` and `TreeDB/docs/spec/dgraph-mvcc-readiness-3673.md` now specify per-row attribution, raw measurement retention, mixed-evidence acceptance only when all changed-owner rows pass, and fail-closed binary evidence.

## Performance

This changes gate attribution, not runtime performance. The exact observed threshold and benchmark remain intact. Hosted exact-head evidence must show equivalent-binary variance is non-blocking while changed-binary rows remain enforced.

## Merge gates

- [ ] exact-head Codex review clean
- [ ] zero unresolved review threads
- [ ] all actual latest-head PR workflows green
- [ ] three independent exact-head TreeDB workflows green without repeated retries
