### PR TITLE
test(caching): assert first rewrite queue preference

### DIFF
--- a/TreeDB/caching/vlog_generation_scheduler_test.go
+++ b/TreeDB/caching/vlog_generation_scheduler_test.go
@@ -4710,12 +4710,15 @@ func TestVlogGenerationRewriteQueue_PrefersGreaterStaleImprovementAmongExpiredRe
 	forceVlogMaintenanceIdle(db)
 	runRewriteQueueMaintenanceForTest(db)
 
-	opts, calls := recorder.recordedRewrite()
-	if calls != 1 {
-		t.Fatalf("rewrite calls=%d want=1", calls)
+	// A useful first rewrite may immediately schedule the remaining debt.
+	// Assert the first selection instead of racing that intentional follow-up.
+	rewrites := recorder.recordedRewrites()
+	if len(rewrites) == 0 {
+		t.Fatal("rewrite calls=0 want>=1")
 	}
+	opts := rewrites[0]
 	if got, want := opts.SourceFileIDs, []uint32{22}; len(got) != len(want) || got[0] != want[0] {
-		t.Fatalf("rewrite SourceFileIDs=%v want=%v", got, want)
+		t.Fatalf("first rewrite SourceFileIDs=%v want=%v", got, want)
 	}
 }
 


### PR DESCRIPTION
## Summary

- assert the first synchronized rewrite-history entry in the expired-retry preference test
- preserve the intentional production follow-up drain for remaining eligible debt
- remove the scheduler-dependent exact-total call-count assertion

Fixes #3802
Parent: #3776

## Root cause

The direct scheduler pass correctly chooses segment `22` first and leaves segment `11` eligible. Because the recorded rewrite is useful, the maintenance defer intentionally starts a follow-up drain. The old test read the concurrent recorder after the direct call returned and asserted the eventual call count was exactly one, so it observed either one or two calls depending on whether the follow-up goroutine had run.

The behavior under test is the first selection. The recorder already retains synchronized history, so this change fails closed when no call was recorded and asserts `SourceFileIDs == [22]` on history entry zero.

## Boundaries

- test-only; no production scheduler, retry, value-log, durable-root, reachability, GC, format, or API change
- no sleep, retry, timing threshold, or weakened source-ID ordering assertion

## Validation

Red characterization:

- forcing the intentional follow-up to complete before the old assertion failed deterministically with `rewrite calls=2 want=1`

Green evidence:

- named test x500 at `GOMAXPROCS=2`: pass
- named test under `-race` x100: pass
- four adjacent queue-ordering tests x100: pass
- full `TreeDB/caching` under `-race`: pass in 98.388s
- after refresh onto `main@a0006433d`, named test x200: pass in 17.204s
- exact-head full `TreeDB/caching`: pass in 79.775s
- `git diff --check`: pass

## Hosted failure being fixed

- run/job `29469260599 / 87528964692`
- `TestVlogGenerationRewriteQueue_PrefersGreaterStaleImprovementAmongExpiredRetries`
- `vlog_generation_scheduler_test.go:4715: rewrite calls=2 want=1`
