### PR TITLE
[CI] Add Raft test scheduling headroom

### DIFF
--- a/TreeDB/internal/raftcluster/hashicorp_raft_test.go
+++ b/TreeDB/internal/raftcluster/hashicorp_raft_test.go
@@ -749,7 +749,10 @@ func TestHashicorpRaftProviderLeaderCrashBeforeCommitDoesNotReportSuccessOrMutat
 	var attempt submitAttempt
 	select {
 	case attempt = <-submitDone:
-	case <-time.After(5 * time.Second):
+	// The submit remains bounded by its five-second context. Give its result
+	// delivery enough slack that the test's own timeout cannot race that bound
+	// now that the partitioned leader intentionally retains its lease longer.
+	case <-time.After(8 * time.Second):
 		t.Fatalf("timed out waiting for partitioned pre-commit submit to fail; states=%s", cluster.admissionSummary())
 	}
 	if attempt.err == nil {
@@ -927,6 +930,8 @@ type hashicorpRaftTestNode struct {
 	barrierLogStore *barrierCountingLogStore
 }
 
+const hashicorpRaftTestCoordinationTimeout = 5 * time.Second
+
 func newHashicorpRaftDBCluster(tb testing.TB) *hashicorpRaftTestCluster {
 	tb.Helper()
 	cluster := newHashicorpRaftCluster(tb, func(tb testing.TB, cfg Config) (*backenddb.DB, CommittedCommandApplierV1, CommandEntryPreflightV1) {
@@ -1002,7 +1007,7 @@ func newHashicorpRaftCluster(tb testing.TB, nodeStores func(testing.TB, Config) 
 	}
 	transports := make(map[NodeID]*hraft.InmemTransport, len(peers))
 	for _, peer := range peers {
-		_, transport := hraft.NewInmemTransport(hraft.ServerAddress(peer.Address))
+		_, transport := hraft.NewInmemTransportWithTimeout(hraft.ServerAddress(peer.Address), hashicorpRaftTestCoordinationTimeout)
 		transports[peer.ID] = transport
 	}
 	for _, from := range peers {
@@ -1059,6 +1064,24 @@ func newHashicorpRaftCluster(tb testing.TB, nodeStores func(testing.TB, Config) 
 		}
 		cluster.nodes[peer.ID] = node
 	}
+	// The larger follower timeout would otherwise add a randomized 5-10 second
+	// delay to every initial election. TimeoutNow starts the normal HashiCorp
+	// election path immediately; waitForLeader still proves live quorum and a
+	// stable term before returning a leader to the test.
+	electionTarget := peers[0]
+	electionSource := peers[1]
+	if err := transports[electionSource.ID].TimeoutNow(
+		hraft.ServerID(electionTarget.ID),
+		hraft.ServerAddress(electionTarget.Address),
+		&hraft.TimeoutNowRequest{RPCHeader: hraft.RPCHeader{
+			ProtocolVersion: hraft.ProtocolVersionMax,
+			ID:              []byte(electionSource.ID),
+			Addr:            []byte(electionSource.Address),
+		}},
+		&hraft.TimeoutNowResponse{},
+	); err != nil {
+		tb.Fatalf("start initial HashiCorp Raft test election: %v", err)
+	}
 	tb.Cleanup(func() {
 		for _, node := range cluster.nodes {
 			_ = node.closeLocal()
@@ -1099,13 +1122,21 @@ func openHashicorpRaftTestDBAndFSM(tb testing.TB, cfg Config) (*backenddb.DB, *r
 
 func hashicorpRaftFastTestConfig() *hraft.Config {
 	conf := hraft.DefaultConfig()
-	// Keep the default coordination timeouts. Shortening them made durable
-	// integration tests vulnerable to false leadership churn when a contended
-	// runner stalled Raft goroutines for only a few hundred milliseconds.
-	// CommitTimeout, SnapshotInterval, SnapshotThreshold, and TrailingLogs retain
-	// the fast test behavior while leadership coordination stays at the
-	// HashiCorp defaults; the output and telemetry overrides only keep tests
-	// quiet.
+	// Give these in-memory integration clusters enough coordination headroom to
+	// survive multi-second scheduling stalls on the contended Windows shard.
+	// HashiCorp Raft uses HeartbeatTimeout to start follower elections and
+	// LeaderLeaseTimeout to make a leader step down when it cannot contact a
+	// quorum, so retaining the defaults still allowed legitimate leadership
+	// churn immediately after the state-based readiness barrier.
+	conf.HeartbeatTimeout = hashicorpRaftTestCoordinationTimeout
+	conf.ElectionTimeout = hashicorpRaftTestCoordinationTimeout
+	conf.LeaderLeaseTimeout = hashicorpRaftTestCoordinationTimeout
+	// The readiness barrier below deliberately retains the default one-second
+	// observation window. These larger coordination timeouts protect a later
+	// scheduler stall without turning every readiness proof into a five-second
+	// wait. CommitTimeout, SnapshotInterval, SnapshotThreshold, and TrailingLogs
+	// retain the fast test behavior; the output and telemetry overrides only
+	// keep tests quiet.
 	conf.CommitTimeout = 10 * time.Millisecond
 	conf.SnapshotInterval = time.Hour
 	conf.SnapshotThreshold = ^uint64(0)
@@ -1116,26 +1147,37 @@ func hashicorpRaftFastTestConfig() *hraft.Config {
 	return conf
 }
 
-func TestHashicorpRaftFastTestConfigPreservesDefaultLeadershipHeadroom(t *testing.T) {
+func TestHashicorpRaftFastTestConfigAddsSchedulingHeadroom(t *testing.T) {
 	defaults := hraft.DefaultConfig()
 	got := hashicorpRaftFastTestConfig()
-	if got.HeartbeatTimeout < defaults.HeartbeatTimeout {
-		t.Fatalf("HeartbeatTimeout=%s want at least HashiCorp default %s", got.HeartbeatTimeout, defaults.HeartbeatTimeout)
+	const minCoordinationTimeout = 5 * time.Second
+	if got.HeartbeatTimeout < minCoordinationTimeout {
+		t.Fatalf("HeartbeatTimeout=%s want at least CI scheduling headroom %s (HashiCorp default %s)", got.HeartbeatTimeout, minCoordinationTimeout, defaults.HeartbeatTimeout)
 	}
-	if got.ElectionTimeout < defaults.ElectionTimeout {
-		t.Fatalf("ElectionTimeout=%s want at least HashiCorp default %s", got.ElectionTimeout, defaults.ElectionTimeout)
+	if got.ElectionTimeout < minCoordinationTimeout {
+		t.Fatalf("ElectionTimeout=%s want at least CI scheduling headroom %s (HashiCorp default %s)", got.ElectionTimeout, minCoordinationTimeout, defaults.ElectionTimeout)
 	}
-	if got.LeaderLeaseTimeout < defaults.LeaderLeaseTimeout {
-		t.Fatalf("LeaderLeaseTimeout=%s want at least HashiCorp default %s", got.LeaderLeaseTimeout, defaults.LeaderLeaseTimeout)
+	if got.LeaderLeaseTimeout < minCoordinationTimeout {
+		t.Fatalf("LeaderLeaseTimeout=%s want at least CI scheduling headroom %s (HashiCorp default %s)", got.LeaderLeaseTimeout, minCoordinationTimeout, defaults.LeaderLeaseTimeout)
+	}
+	validated := *got
+	validated.LocalID = "test-node"
+	if err := hraft.ValidateConfig(&validated); err != nil {
+		t.Fatalf("ValidateConfig: %v", err)
+	}
+	wantSettlingWindow := hashicorpRaftLeaderSettlingWindow(defaults)
+	if gotSettlingWindow := hashicorpRaftTestLeaderSettlingWindow(); gotSettlingWindow != wantSettlingWindow {
+		t.Fatalf("readiness settling window=%s want HashiCorp default coordination window %s", gotSettlingWindow, wantSettlingWindow)
 	}
 }
 
 // waitForLeader requires continuous live-quorum observations of one leader and
-// term across the test configuration's full coordination window. A single
-// Leader admission observation, or two observations one poll apart, can be
-// sampled while the election/current-term no-op is still settling. This is a
-// test-harness barrier only; it deliberately does not retry the operation under
-// test.
+// term across HashiCorp Raft's default coordination window. A single Leader
+// admission observation, or two observations one poll apart, can be sampled
+// while the election/current-term no-op is still settling. The test cluster's
+// larger timeouts protect later scheduling stalls rather than extending this
+// readiness dwell. This is a test-harness barrier only; it deliberately does
+// not retry the operation under test.
 func (c *hashicorpRaftTestCluster) waitForLeader(tb testing.TB) *hashicorpRaftTestNode {
 	tb.Helper()
 	// Opening three durable test nodes can consume most of the old 15-second
@@ -1145,7 +1187,10 @@ func (c *hashicorpRaftTestCluster) waitForLeader(tb testing.TB) *hashicorpRaftTe
 	deadline := time.Now().Add(30 * time.Second)
 	readinessCtx, cancel := context.WithDeadline(context.Background(), deadline)
 	defer cancel()
-	settlingWindow := hashicorpRaftLeaderSettlingWindow(hashicorpRaftFastTestConfig())
+	// The live-quorum proof only needs to show that a term remained settled
+	// across HashiCorp's normal coordination window. The test cluster's larger
+	// timeouts are later scheduling headroom, not additional readiness evidence.
+	settlingWindow := hashicorpRaftTestLeaderSettlingWindow()
 	var previous leaderReadinessObservation
 	var lastErr error
 	for readinessCtx.Err() == nil {
@@ -1215,6 +1260,10 @@ func hashicorpRaftLeaderSettlingWindow(conf *hraft.Config) time.Duration {
 	return window
 }
 
+func hashicorpRaftTestLeaderSettlingWindow() time.Duration {
+	return hashicorpRaftLeaderSettlingWindow(hraft.DefaultConfig())
+}
+
 func (c *hashicorpRaftTestCluster) waitForSingleLeader(tb testing.TB) *hashicorpRaftTestNode {
 	tb.Helper()
 	var leader *hashicorpRaftTestNode
@@ -1239,7 +1288,7 @@ func (c *hashicorpRaftTestCluster) waitForSingleLeader(tb testing.TB) *hashicorp
 
 func TestHashicorpRaftLeaderReadinessRequiresASettledTermWindow(t *testing.T) {
 	startedAt := time.Unix(1_000, 0)
-	settlingWindow := hashicorpRaftLeaderSettlingWindow(hashicorpRaftFastTestConfig())
+	settlingWindow := hashicorpRaftTestLeaderSettlingWindow()
 	ready := leaderReadinessObservation{nodeID: "node-a", term: 4, observedAt: startedAt, valid: true}
 	if sameStableLeaderTerm(leaderReadinessObservation{}, ready, settlingWindow) {
 		t.Fatal("a single leader/proof observation must not satisfy the readiness barrier")


### PR DESCRIPTION
## Summary

- give the in-memory Hashicorp Raft integration cluster a bounded 5-second heartbeat, election, leader-lease, and RPC-processing budget for contended CI scheduling
- trigger the initial election through Hashicorp's real `TimeoutNow` path, while retaining the existing live-quorum and same-leader/term readiness proof across the default one-second window
- keep the pre-commit partition operation bounded at five seconds while preventing its result observer from racing that bound

## Failure classification

Exact post-merge `main` (`a0006433da46519d2ce7d1e8c29ee29cf7f1b8aa`) failed `windows-core-2` in `TestHashicorpRaftProviderReadIndexReturnsProductionProofForLeader` with `raftcluster: commit ambiguous` / `leadership lost while committing log`. The adjacent three-node submit test passed, and the triggering merge changed no Go or Raft code. The prior one-second readiness proof attested to stable leadership before submit, but the default 500ms leader lease and in-memory transport timeout still permitted later CI scheduling contention to cause legitimate leadership loss.

## Boundaries

- test harness/configuration only; no production Raft path changes
- no submit retry and no acceptance of ambiguous outcomes
- persistent value-log, GC, and durable-root semantics are untouched
- not performance-relevant to production; runtime evidence below guards against making the test suite pathological

## TDD and local evidence

- red: `TestHashicorpRaftFastTestConfigAddsSchedulingHeadroom` failed on the base configuration (`HeartbeatTimeout=1s`, required `5s`)
- affected plus adjacent submit tests, `GOWORK=off GOMAXPROCS=2`, `-count=25`: PASS in 69.171s (50 cluster starts)
- leadership/fault adjacency, `-count=3`: PASS in 54.617s
- full `TreeDB/internal/raftcluster`: PASS in 38.888s
- full `TreeDB/internal/raftcluster -race`: PASS in 39.796s
- runtime comparison: full package base 54.577s vs candidate 38.888s; affected pair `-count=3` base 15.134s vs candidate 8.433s
- `git diff --check`: PASS

## Merge gates

- [ ] exact-head Codex review is clean
- [ ] all review threads are resolved
- [ ] three independent exact-head TreeDB matrices are green, including `windows-core-2`

Fixes #3665


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved Raft integration test reliability by adding explicit coordination timeouts and scheduling headroom.
  * Updated leader-election readiness checks to better accommodate startup and settling time.
  * Reduced timing-related test races during leader crash and partition scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->