### PR TITLE
ci(treedb): bound Linux DB race package timeout

### DIFF
--- a/.github/scripts/test_treedb_windows_core_headroom.py
+++ b/.github/scripts/test_treedb_windows_core_headroom.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Contract checks for bounded TreeDB Windows core-shard headroom."""
+"""Contract checks for bounded TreeDB CI timeout headroom."""
 
 from pathlib import Path
 import re
@@ -20,6 +20,17 @@ def matrix_timeout(workflow: str, job_name: str) -> int:
     if match is None:
         raise AssertionError(f"missing Windows matrix entry for {job_name}")
     return int(match.group("timeout"))
+
+
+def workflow_job(workflow: str, job_name: str) -> str:
+    match = re.search(
+        rf"^  {re.escape(job_name)}:\n(?P<body>.*?)(?=^  [a-zA-Z0-9_-]+:\n|\Z)",
+        workflow,
+        re.MULTILINE | re.DOTALL,
+    )
+    if match is None:
+        raise AssertionError(f"missing workflow job {job_name}")
+    return match.group("body")
 
 
 class TreeDBWindowsCoreHeadroomTest(unittest.TestCase):
@@ -45,6 +56,36 @@ class TreeDBWindowsCoreHeadroomTest(unittest.TestCase):
         ):
             with self.subTest(job_name=job_name):
                 self.assertEqual(matrix_timeout(workflow, job_name), 25)
+
+
+class TreeDBLinuxRaceHeadroomTest(unittest.TestCase):
+    def test_db_package_timeout_is_bounded_inside_the_job_cap(self) -> None:
+        workflow = WORKFLOW.read_text(encoding="utf-8")
+        race_job = workflow_job(workflow, "race")
+
+        outer_match = re.search(r"^    timeout-minutes: (?P<timeout>\d+)$", race_job, re.MULTILINE)
+        self.assertIsNotNone(outer_match, "race job must keep a bounded outer timeout")
+        outer_minutes = int(outer_match.group("timeout"))
+
+        command_match = re.search(
+            r"^(?P<command>\s*GOMEMLIMIT=.*go test -json -race -p 1 "
+            r"-timeout (?P<timeout>\d+)m ./db -run \"\$db_regex\".*)$",
+            race_job,
+            re.MULTILINE,
+        )
+        self.assertIsNotNone(
+            command_match,
+            "TreeDB/db race invocation must keep coverage and an explicit package timeout",
+        )
+        inner_minutes = int(command_match.group("timeout"))
+
+        # The failed hosted run spent about 11m15s before TreeDB/db and then
+        # exhausted Go's 10-minute default. Twelve minutes restores 20%
+        # package headroom while preserving time for fail-closed artifacts
+        # under the existing 25-minute job cap.
+        self.assertEqual(outer_minutes, 25)
+        self.assertEqual(inner_minutes, 12)
+        self.assertLess(inner_minutes, outer_minutes)
 
 
 if __name__ == "__main__":

--- a/.github/workflows/treedb-tests.yml
+++ b/.github/workflows/treedb-tests.yml
@@ -564,7 +564,7 @@ jobs:
           if [ -s "$db_test_file" ]; then
             db_regex="^($(paste -sd'|' "$db_test_file"))$"
             echo "TreeDB/db race test shard=${shard_index}/${shard_count} regex=${db_regex}"
-            GOMEMLIMIT=4GiB GOMAXPROCS=2 go test -json -race -p 1 ./db -run "$db_regex" | tee -a treedb-race.jsonl
+            GOMEMLIMIT=4GiB GOMAXPROCS=2 go test -json -race -p 1 -timeout 12m ./db -run "$db_regex" | tee -a treedb-race.jsonl
             ran_tests=true
           fi
           if [ "$ran_tests" = false ]; then


### PR DESCRIPTION
Closes #3792.

## What changed

- give the generated `TreeDB/db` Linux race invocation an explicit 12-minute package timeout
- keep the race job's existing 25-minute outer cap
- keep `-race`, `-p 1`, the generated shard regex, and complete test selection unchanged
- extend the existing timeout-headroom contract test to pin the 25m/12m budget and command shape

## Why

The latest recurrence was not a race report or product assertion. Job `87538025182` reached Go's implicit per-package `10m0s` timeout at 600.094s; the named test visible at termination had run for only about six seconds. The identical hosted selection passed on the one allowed rerun in 323.643s.

The generated distribution is complete and disjoint: 1,255 `TreeDB/db` tests total, with two weighted pins in shard 0 and the remaining 1,253 tests in the affected shard 1. The exact affected shard passed locally under the proposed command in 612.509s (660s wall including build/list setup), independently demonstrating that the old implicit 10-minute package cap was too short while the 12-minute inner budget remains bounded under the unchanged 25-minute job cap.

## Validation

- TDD contract: failed before the workflow edit because the explicit package timeout was missing; passes after the edit
- exact affected shard: 1,253/1,253 selected tests passed with `GOWORK=off GOMEMLIMIT=4GiB GOMAXPROCS=2 go test -race -p 1 -timeout 12m ./db -run <shard1-regex> -count=1`
- timeout-headroom contract: 3/3 tests pass
- workflow YAML parses
- Python AST/compile check passes
- `git diff --check` passes

No production code, test assertion, race coverage, shard membership, or outer fail-closed cap is changed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated TreeDB race-test validation to enforce bounded execution times.
  * Added checks ensuring the test command’s timeout remains safely within the overall CI job limit.
  * Configured the race-test step with an explicit 12-minute timeout to improve predictability and prevent excessively long runs.

* **Chores**
  * Refined automated workflow validation for clearer, more reliable timeout safeguards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->