### PR TITLE
CI: keep vector allocation gate out of race instrumentation

### DIFF
--- a/TreeDB/collections/column_vector_graph_search_test.go
+++ b/TreeDB/collections/column_vector_graph_search_test.go
@@ -1011,9 +1011,6 @@ func TestColumnVectorGraphNativeSearchContinuesAcrossDisconnectedComponentsV3(t 
 }
 
 func TestColumnVectorGraphNativeSearchWarmScratchZeroAllocsV3(t *testing.T) {
-	if collectionsRaceEnabled {
-		t.Skip("AllocsPerRun is not stable under -race")
-	}
 	const (
 		rows = 32
 		dims = 16
@@ -1036,6 +1033,9 @@ func TestColumnVectorGraphNativeSearchWarmScratchZeroAllocsV3(t *testing.T) {
 	var scratch columnVectorGraphNativeSearchScratch
 	if _, _, err := reader.SearchCosine(query, columnVectorGraphNativeSearchOptions{TopK: 10, EfSearch: 16}, &scratch); err != nil {
 		t.Fatalf("warm SearchCosine: %v", err)
+	}
+	if collectionsRaceEnabled {
+		t.Skip("AllocsPerRun is not stable under -race")
 	}
 	var hotErr error
 	allocs := testing.AllocsPerRun(1000, func() {

--- a/TreeDB/collections/column_vector_graph_search_test.go
+++ b/TreeDB/collections/column_vector_graph_search_test.go
@@ -1011,6 +1011,9 @@ func TestColumnVectorGraphNativeSearchContinuesAcrossDisconnectedComponentsV3(t 
 }
 
 func TestColumnVectorGraphNativeSearchWarmScratchZeroAllocsV3(t *testing.T) {
+	if collectionsRaceEnabled {
+		t.Skip("AllocsPerRun is not stable under -race")
+	}
 	const (
 		rows = 32
 		dims = 16


### PR DESCRIPTION
Closes #3806

## Outcome

Keeps the warm vector-search zero-allocation measurement out of race instrumentation using the package's existing `collectionsRaceEnabled` convention. Race runs still execute setup and the warm `SearchCosine` path before skipping only `testing.AllocsPerRun`. The normal test still requires exactly zero allocations; production code and allocation budgets are unchanged.

## Characterization

- Exact-main run `29481478973/87566009582` and #3798 run `29485357929/87578438029` both failed with `hot SearchCosine allocs=1 want zero` under `-race`.
- The pre-fix named local race command reproduced the same one-allocation result immediately.
- Other repository allocation gates already document that `testing.AllocsPerRun` is unstable under race instrumentation.

## Validation

- named race invocation: setup and warm search execute, then the allocation measurement skips with the explicit instrumentation reason;
- named non-race zero-allocation test: `-count=100` passed in 19.450s;
- adjacent parallel-reader race test: `-count=20` passed in 8.461s;
- exact-head TreeDB PR matrix `29487355852`: 14/14 green;
- independent exact-head TreeDB proofs `29487404263` and `29487404404`: 14/14 green each;
- all ordinary PR workflows green; `git diff --check` passed;
- exact-head Codex review clean; CodeRabbit feedback addressed and its only thread resolved.

Exact head: `968e03b83550dbd611d72f34124cfc606438443c`
Exact base: `000fccbf2d2241d1a58f85e9d3c617ba1138a03c`
