### PR TITLE
CI: make checkpoint drain stats scheduler independent

### DIFF
--- a/TreeDB/caching/checkpoint_productivity_stats_test.go
+++ b/TreeDB/caching/checkpoint_productivity_stats_test.go
@@ -321,20 +321,23 @@ func TestCheckpointWaitProductivityStatsActiveBackgroundDrainsFrontier(t *testin
 	} else if activeWaitLastNs == 0 {
 		t.Fatalf("active background wait last ns=%d want >0 when samples=%d", activeWaitLastNs, activeWaitSamples)
 	}
-	if got := requireStatUint64(t, stats, "treedb.cache.checkpoint.wait.frontier_units_at_request_last"); got != 2 {
-		t.Fatalf("wait frontier at request=%d want 2", got)
+	frontierAtRequest := requireStatUint64(t, stats, "treedb.cache.checkpoint.wait.frontier_units_at_request_last")
+	if frontierAtRequest != 2 {
+		t.Fatalf("wait frontier at request=%d want 2", frontierAtRequest)
 	}
-	if got := requireStatUint64(t, stats, "treedb.cache.checkpoint.wait.remaining_frontier_units_last"); got != 1 {
-		t.Fatalf("wait remaining frontier=%d want 1", got)
+	remainingFrontier := requireStatUint64(t, stats, "treedb.cache.checkpoint.wait.remaining_frontier_units_last")
+	drainedFrontier := requireStatUint64(t, stats, "treedb.cache.checkpoint.wait.drained_frontier_units_last")
+	if remainingFrontier > frontierAtRequest || drainedFrontier+remainingFrontier != frontierAtRequest {
+		t.Fatalf("wait frontier accounting: requested=%d drained=%d remaining=%d", frontierAtRequest, drainedFrontier, remainingFrontier)
 	}
-	if got := requireStatUint64(t, stats, "treedb.cache.checkpoint.wait.drained_frontier_units_last"); got != 1 {
-		t.Fatalf("wait drained frontier=%d want 1", got)
+	if drainedFrontier == 0 {
+		t.Fatalf("wait drained frontier=%d want >0", drainedFrontier)
 	}
-	if got := requireStatUint64(t, stats, "treedb.cache.checkpoint.frontier.units_last"); got != 1 {
-		t.Fatalf("checkpoint-owned frontier units=%d want 1", got)
+	if got := requireStatUint64(t, stats, "treedb.cache.checkpoint.frontier.units_last"); got != remainingFrontier {
+		t.Fatalf("checkpoint-owned frontier units=%d want remaining %d", got, remainingFrontier)
 	}
-	if got := requireStatUint64(t, stats, "treedb.cache.checkpoint.flush_all.owned_drain_units_last"); got != 1 {
-		t.Fatalf("owned drain units=%d want 1", got)
+	if got := requireStatUint64(t, stats, "treedb.cache.checkpoint.flush_all.owned_drain_units_last"); got != remainingFrontier {
+		t.Fatalf("owned drain units=%d want remaining %d", got, remainingFrontier)
 	}
 	if activeWaitLastNs != 0 {
 		if got := requireStatFloat64(t, stats, "treedb.cache.checkpoint.wait.frontier_drain_bytes_per_sec_last"); got == 0 {


### PR DESCRIPTION
Closes #3807

## Outcome

Replaces a scheduler-dependent exact one-unit/one-unit checkpoint drain split with strict conservation and ownership assertions. The test still requires two units at request, positive background progress, `drained + remaining == requested`, and checkpoint frontier/owned-drain units equal to the residual.

Production checkpoint, root-publication, value-log, and durability behavior are unchanged.

## Characterization

- Hosted failure: #3798 run `29485357929`, macOS job `87578437983`, with `wait remaining frontier=0 want 1`.
- Pre-fix local recurrence: `GOWORK=off GOMAXPROCS=2 go test -count=500 -run '^TestCheckpointWaitProductivityStatsActiveBackgroundDrainsFrontier$' ./TreeDB/caching` reproduced the same failure five times.
- The blocked background worker owns one frontier unit, but after release it may legitimately drain the second unit before the checkpoint reacquires `flushMu`.

## Validation

- named scheduler-stressed test: `-count=500` passed in 36.012s;
- all four checkpoint-productivity tests: `-race -count=100` passed in 9.620s;
- `git diff --check` passed.

Exact head: `af1ca9d0c`
Exact base: `000fccbf2`

