### PR TITLE
[DUR-08] Fence destructive maintenance on recoverable roots

### DIFF
--- a/TreeDB/caching/db.go
+++ b/TreeDB/caching/db.go
@@ -6959,6 +6959,9 @@ func (db *DB) pruneRetainedValueLogsWithObservedContextOptions(ctx context.Conte
 					_ = db.valueLogReader.EvictSegment(id)
 				}
 				if err := marker.MarkValueLogZombie(id); err != nil {
+					if errors.Is(err, backenddb.ErrValueLogZombieDeferred) {
+						continue
+					}
 					if errors.Is(err, valuelog.ErrFileNotFound) && db.cleanupOrphanedRetainedValueLogExpected(path, expectedIdentity) {
 						removed = true
 						out.RemovedSegments++
@@ -7102,6 +7105,9 @@ func (db *DB) pruneRetainedValueLogsWithObservedContextOptions(ctx context.Conte
 				_ = db.valueLogReader.EvictSegment(id)
 			}
 			if err := marker.MarkValueLogZombie(id); err != nil {
+				if errors.Is(err, backenddb.ErrValueLogZombieDeferred) {
+					continue
+				}
 				if errors.Is(err, valuelog.ErrFileNotFound) && db.cleanupOrphanedRetainedValueLogExpected(path, expectedIdentity) {
 					removed = true
 					out.RemovedSegments++

--- a/TreeDB/caching/db_test.go
+++ b/TreeDB/caching/db_test.go
@@ -2247,9 +2247,10 @@ func TestCachingDB_PrunesRetainedValueLog(t *testing.T) {
 		t.Fatalf("expected retained closed bytes after rotate, got %d", retainedBefore)
 	}
 
-	// Delete the key and checkpoint. Retained segments with only unreachable
-	// payloads should be pruned. The active segment stays open for writing, but
-	// it is not counted as a retained closed segment.
+	// Delete the key and checkpoint. The prior durable slot can still select the
+	// value-bearing root, so let the first prune retain that segment before
+	// recommitting the current root to advance the recovery horizon. The active
+	// segment stays open for writing, but it is not counted as retained closed.
 	if err := cache.Delete(key); err != nil {
 		t.Fatalf("Delete: %v", err)
 	}
@@ -2258,6 +2259,10 @@ func TestCachingDB_PrunesRetainedValueLog(t *testing.T) {
 	}
 	forceRetainedPruneIdle(cache)
 	cache.waitForRetainedValueLogPrune()
+	if err := backend.Commit(backend.State().RootPageID); err != nil {
+		t.Fatalf("commit durable-slot successor: %v", err)
+	}
+	cache.PruneRetainedValueLogsForMaintenance()
 	stats = cache.Stats()
 	segments, err = strconv.Atoi(stats["treedb.cache.vlog_retained_segments"])
 	if err != nil {

--- a/TreeDB/caching/vlog_retained_manager_drift_test.go
+++ b/TreeDB/caching/vlog_retained_manager_drift_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"time"
 
+	backenddb "github.com/snissn/gomap/TreeDB/db"
 	"github.com/snissn/gomap/TreeDB/internal/valuelog"
 )
 
@@ -87,5 +88,74 @@ func TestCheckpoint_DeletesRetainedValueLogWhenBackendManagerForgotSegment(t *te
 	}
 	if db.valueLogRetained(retainedPath) {
 		t.Fatalf("expected retained path to be forgotten")
+	}
+}
+
+func TestCheckpoint_RetainsValueLogWhenBackendDefersZombieMark(t *testing.T) {
+	dir := t.TempDir()
+	backend := NewMockBackend()
+	db, err := Open(dir, backend, Options{
+		FlushThreshold:           256 << 20,
+		DisableWAL:               true,
+		RelaxedSync:              true,
+		AllowUnsafe:              true,
+		MemtableShards:           1,
+		JournalLanes:             1,
+		ValueLogCompression:      1,
+		ValueLogPointerThreshold: 1,
+		ValueLogMaxSegmentBytes:  4 << 10,
+		ValueLogGenerationPolicy: 0,
+	})
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer func() {
+		if err := db.Close(); err != nil {
+			t.Fatalf("Close: %v", err)
+		}
+	}()
+
+	if err := db.Set([]byte("k1"), bytes.Repeat([]byte("a"), 2<<10)); err != nil {
+		t.Fatalf("Set k1: %v", err)
+	}
+	lane := &db.lanes[0]
+	lane.vlogMu.Lock()
+	retainedPath := lane.vlogPath
+	lane.vlogMu.Unlock()
+	if retainedPath == "" {
+		t.Fatal("expected current value-log path")
+	}
+	if err := db.rotateValueLogLocked(lane); err != nil {
+		t.Fatalf("rotateValueLogLocked: %v", err)
+	}
+	seedRetainedPrunePressure(db, retainedPath, 2<<30)
+
+	laneID, seq, valueLogFile, ok := parseLogSeq(filepath.Base(retainedPath))
+	if !ok || !valueLogFile || laneID < 0 {
+		t.Fatalf("parseLogSeq(%q) failed", retainedPath)
+	}
+	deferredID, err := valuelog.EncodeFileID(uint32(laneID), uint32(seq))
+	if err != nil {
+		t.Fatalf("EncodeFileID: %v", err)
+	}
+	backend.markValueLogZombieID = deferredID
+	backend.markValueLogZombieErr = backenddb.ErrValueLogZombieDeferred
+
+	if err := db.Delete([]byte("k1")); err != nil {
+		t.Fatalf("Delete k1: %v", err)
+	}
+	if err := db.Checkpoint(); err != nil {
+		t.Fatalf("Checkpoint: %v", err)
+	}
+	db.lastForegroundWriteUnixNano.Store(time.Now().Add(-2 * retainedPruneQuietWindow).UnixNano())
+	db.waitForRetainedValueLogPrune()
+	if err := db.backgroundError(); err != nil {
+		t.Fatalf("deferred zombie mark reported as background error: %v", err)
+	}
+	if _, err := os.Stat(retainedPath); err != nil {
+		t.Fatalf("deferred retained path removed: %v", err)
+	}
+	if !db.valueLogRetained(retainedPath) {
+		t.Fatal("deferred retained path was forgotten")
 	}
 }

--- a/TreeDB/collections/api_test.go
+++ b/TreeDB/collections/api_test.go
@@ -661,6 +661,16 @@ func TestCollectionLeafGenerationPackGC_RoundTripWithTemplateV1SecondaryIndexes(
 		t.Fatalf("SourceBytesLive=%d, want real collection live bytes copied (stats=%+v)", got, packStats)
 	}
 	requireCollectionMaintenanceTemplateReads(t, col)
+	// The pre-pack durable slot remains independently recovery-selectable until
+	// one later checkpoint overwrites it. Publish an inline successor so the
+	// packed source generation is no longer reachable from either durable slot
+	// before asserting physical reclamation.
+	if err := d.Set([]byte("raw/leaf-pack-gc-slot-advance"), []byte("advance")); err != nil {
+		t.Fatalf("publish durable-slot successor: %v", err)
+	}
+	if err := d.Checkpoint(); err != nil {
+		t.Fatalf("checkpoint durable-slot successor: %v", err)
+	}
 
 	gcCtx, gcCancel := collectionMaintenanceTestContext(t)
 	gcStats, err := d.LeafGenerationGC(gcCtx, backenddb.LeafGenerationGCOptions{})

--- a/TreeDB/collections/api_test.go
+++ b/TreeDB/collections/api_test.go
@@ -662,14 +662,11 @@ func TestCollectionLeafGenerationPackGC_RoundTripWithTemplateV1SecondaryIndexes(
 	}
 	requireCollectionMaintenanceTemplateReads(t, col)
 	// The pre-pack durable slot remains independently recovery-selectable until
-	// one later checkpoint overwrites it. Publish an inline successor so the
-	// packed source generation is no longer reachable from either durable slot
-	// before asserting physical reclamation.
-	if err := d.Set([]byte("raw/leaf-pack-gc-slot-advance"), []byte("advance")); err != nil {
-		t.Fatalf("publish durable-slot successor: %v", err)
-	}
+	// one later checkpoint overwrites it. Re-checkpoint the packed root without
+	// publishing a new cached leaf-log dependency before asserting physical
+	// reclamation.
 	if err := d.Checkpoint(); err != nil {
-		t.Fatalf("checkpoint durable-slot successor: %v", err)
+		t.Fatalf("checkpoint packed durable-slot successor: %v", err)
 	}
 
 	gcCtx, gcCancel := collectionMaintenanceTestContext(t)

--- a/TreeDB/collections/api_test.go
+++ b/TreeDB/collections/api_test.go
@@ -662,11 +662,11 @@ func TestCollectionLeafGenerationPackGC_RoundTripWithTemplateV1SecondaryIndexes(
 	}
 	requireCollectionMaintenanceTemplateReads(t, col)
 	// The pre-pack durable slot remains independently recovery-selectable until
-	// one later checkpoint overwrites it. Re-checkpoint the packed root without
-	// publishing a new cached leaf-log dependency before asserting physical
-	// reclamation.
-	if err := d.Checkpoint(); err != nil {
-		t.Fatalf("checkpoint packed durable-slot successor: %v", err)
+	// a later root publication overwrites it. Checkpoint alone does not advance
+	// CommitSeq, so recommit the packed root without publishing a new cached
+	// leaf-log dependency before asserting physical reclamation.
+	if err := d.Commit(d.State().RootPageID); err != nil {
+		t.Fatalf("commit packed durable-slot successor: %v", err)
 	}
 
 	gcCtx, gcCancel := collectionMaintenanceTestContext(t)

--- a/TreeDB/collections/column_asset_gc.go
+++ b/TreeDB/collections/column_asset_gc.go
@@ -8,7 +8,9 @@ import (
 	"path/filepath"
 	"sync"
 
+	backenddb "github.com/snissn/gomap/TreeDB/db"
 	"github.com/snissn/gomap/TreeDB/internal/rootpublication"
+	"github.com/snissn/gomap/TreeDB/internal/typedcolumn"
 )
 
 // ColumnAssetGCOptions controls safe M15B column asset segment reclamation.
@@ -420,6 +422,14 @@ func (c *Collection) columnAssetGC(ctx context.Context, opts ColumnAssetGCOption
 	if len(eligible) == 0 {
 		return stats, nil
 	}
+	recoverableRoots, err := c.db.CaptureRecoverableRootSet(ctx)
+	if err != nil {
+		return stats, err
+	}
+	defer recoverableRoots.Release()
+	if err := c.pinRecoverableColumnAssetSegments(ctx, recoverableRoots, opts.CandidateRefs); err != nil {
+		return stats, err
+	}
 	if hook := columnAssetStableDeleteAfterPlanHook(); hook != nil {
 		hook()
 	}
@@ -434,6 +444,9 @@ func (c *Collection) columnAssetGC(ctx context.Context, opts ColumnAssetGCOption
 			return stats, deleter.finish(err)
 		}
 		deleted, err := deleter.delete(planned, func() error {
+			if err := recoverableRoots.Revalidate(); err != nil {
+				return errors.Join(ErrColumnAssetGCPlanStale, err)
+			}
 			currentCommitSeq, currentSystemRoot := dbCommitSeqAndSystemRoot(c.db)
 			if currentCommitSeq != plan.PlanCommitSeq || currentSystemRoot != plan.SystemRoot {
 				return fmt.Errorf("%w: committed root changed for collection=%q planned_commit_seq=%d current_commit_seq=%d planned_system_root=%d current_system_root=%d",
@@ -467,6 +480,172 @@ func (c *Collection) columnAssetGC(ctx context.Context, opts ColumnAssetGCOption
 		return stats, err
 	}
 	return stats, nil
+}
+
+func (c *Collection) pinRecoverableColumnAssetSegments(ctx context.Context, roots *backenddb.RecoverableRootSet, candidateRefs []ColumnAssetRef) error {
+	if c == nil || c.db == nil || roots == nil {
+		return backenddb.ErrRecoverableRootSetStale
+	}
+	seenPaths := make(map[string]struct{})
+	var visibleRecoveryLSN uint64
+	var visibleRecoveryGeneration uint64
+	var visibleRecoveryCollection string
+	var visibleRecoveryConfig *ColumnStoreConfig
+	pinRefs := func(refs []ColumnAssetRef) error {
+		for _, ref := range refs {
+			path, err := columnAssetSegmentPath(c.db.ColumnAssetRootDir(), ref)
+			if err != nil {
+				return err
+			}
+			path = filepath.Clean(path)
+			if _, ok := seenPaths[path]; ok {
+				continue
+			}
+			file, err := os.Open(path)
+			if err != nil {
+				return fmt.Errorf("collections: open recoverable column asset %q: %w", path, err)
+			}
+			pinErr := roots.PinStableFile(file)
+			closeErr := file.Close()
+			if pinErr != nil {
+				return fmt.Errorf("collections: pin recoverable column asset %q: %w", path, pinErr)
+			}
+			if closeErr != nil {
+				return closeErr
+			}
+			seenPaths[path] = struct{}{}
+		}
+		return nil
+	}
+	for _, root := range roots.Roots() {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		snapshot := roots.AcquireSnapshotForRoot(root)
+		if snapshot == nil {
+			return backenddb.ErrRecoverableRootSetStale
+		}
+		catalog, err := c.catalogForSnapshot(snapshot)
+		if err != nil {
+			_ = snapshot.Close()
+			if errors.Is(err, errCollectionNotFound) {
+				continue
+			}
+			return fmt.Errorf("collections: capture recoverable column catalog at commit_seq=%d: %w", root.CommitSeq, err)
+		}
+		if catalog == nil {
+			_ = snapshot.Close()
+			continue
+		}
+		cfgPtr := catalog.meta.Options.ColumnStore
+		if cfgPtr == nil || !cfgPtr.Enabled {
+			_ = snapshot.Close()
+			continue
+		}
+		cfg := *cfgPtr
+		if cfg.ActiveManifest == nil {
+			if cfg.RecoveryAuthoritativeManifest != nil {
+				_ = snapshot.Close()
+				return fmt.Errorf("collections: recoverable column catalog at commit_seq=%d has recovery manifest without active manifest", root.CommitSeq)
+			}
+			_ = snapshot.Close()
+			continue
+		}
+		rootName := catalog.columnManifestRootName
+		if rootName == "" && cfg.ManifestRoot != nil {
+			rootName = cfg.ManifestRoot.Name
+		}
+		if rootName == "" {
+			rootName = collectionColumnManifestRootName(catalog.meta.Name)
+		}
+		view, viewErr := c.prepareColumnPhysicalScanSnapshotViewAtSnapshotWithSidecars(
+			snapshot,
+			catalog,
+			catalog.meta.Name,
+			catalog.rootID(rootName),
+			cfg,
+			true,
+			columnManifestScanAllSidecars(),
+		)
+		closeErr := snapshot.Close()
+		if viewErr != nil {
+			return fmt.Errorf("collections: capture recoverable column assets at commit_seq=%d: %w", root.CommitSeq, viewErr)
+		}
+		if closeErr != nil {
+			return closeErr
+		}
+		if root.Visible {
+			if view.FullConfig.RecoveryAuthoritativeAppliedCommandLSN > visibleRecoveryLSN {
+				visibleRecoveryLSN = view.FullConfig.RecoveryAuthoritativeAppliedCommandLSN
+				visibleRecoveryCollection = catalog.meta.Name
+				cfg := view.FullConfig
+				visibleRecoveryConfig = &cfg
+			}
+			if identity := view.FullConfig.RecoveryAuthoritativeManifest; identity != nil && identity.Generation > visibleRecoveryGeneration {
+				visibleRecoveryGeneration = identity.Generation
+			}
+		}
+		if err := pinRefs(columnPhysicalScanSnapshotViewAssetRefs(view)); err != nil {
+			return err
+		}
+	}
+	if roots.RequiresReplayBefore(visibleRecoveryLSN) && visibleRecoveryGeneration != 0 && visibleRecoveryConfig != nil {
+		// A durable fallback behind the visible command-WAL frontier can replay
+		// authoritative generations that the current manifest has since
+		// superseded. Only format-valid authoritative typed-row/typed-column
+		// candidates at or below the visible generation are replay inputs; derived
+		// accelerators and arbitrary unpublished candidate bytes are not roots.
+		replayRefs := make([]ColumnAssetRef, 0, len(candidateRefs))
+		for _, ref := range candidateRefs {
+			if ref.Generation == 0 || ref.Generation > visibleRecoveryGeneration {
+				continue
+			}
+			replayable, err := recoverableColumnAssetReplayCandidate(
+				c.db.ColumnAssetRootDir(), ref, visibleRecoveryCollection, *visibleRecoveryConfig, visibleRecoveryLSN,
+			)
+			if err != nil {
+				return err
+			}
+			if replayable {
+				replayRefs = append(replayRefs, ref)
+			}
+		}
+		if err := pinRefs(replayRefs); err != nil {
+			return err
+		}
+	}
+	return roots.Revalidate()
+}
+
+func recoverableColumnAssetReplayCandidate(rootDir string, ref ColumnAssetRef, collection string, cfg ColumnStoreConfig, visibleRecoveryLSN uint64) (bool, error) {
+	if visibleRecoveryLSN == 0 {
+		return false, nil
+	}
+	raw, err := readColumnPhysicalAssetFromManager(rootDir, ref)
+	if err != nil {
+		// Exact namespace/identity validation immediately before deletion owns
+		// filesystem races. Bytes that cannot validate as this ref are not a
+		// replayable published asset and therefore do not gain a replay pin.
+		return false, nil
+	}
+	switch ref.Kind {
+	case ColumnAssetKindTCS1PartImage:
+		header, _, _, err := parseColumnPhysicalAssetScanHeader(raw, ref, collection, &cfg, "")
+		if err != nil {
+			return false, nil
+		}
+		return header.AppliedCommandLSN != 0 && header.AppliedCommandLSN <= visibleRecoveryLSN, nil
+	case ColumnAssetKindTCS1TypedColumnPart:
+		image, err := typedcolumn.ParseColumnPartImage(raw)
+		if err != nil {
+			return false, nil
+		}
+		return image.PartID == ref.PartID, nil
+	default:
+		// Aggregate metadata, dictionary/int64 sidecars, HNSW packs, and
+		// query-ready assets are rebuildable derived accelerators.
+		return false, nil
+	}
 }
 
 func columnAssetGCExistingSegmentCount(plan ColumnAssetReachabilityPlan) int {

--- a/TreeDB/collections/column_asset_gc.go
+++ b/TreeDB/collections/column_asset_gc.go
@@ -482,15 +482,53 @@ func (c *Collection) columnAssetGC(ctx context.Context, opts ColumnAssetGCOption
 	return stats, nil
 }
 
+type recoverableColumnAssetReplayBasis struct {
+	appliedCommandLSN  uint64
+	manifestGeneration uint64
+	collection         string
+	config             ColumnStoreConfig
+}
+
+type recoverableColumnAssetReplayClassifier func(ColumnAssetRef, recoverableColumnAssetReplayBasis) (bool, error)
+
+func recoverableColumnAssetReplayRefs(
+	candidateRefs []ColumnAssetRef,
+	bases []recoverableColumnAssetReplayBasis,
+	requiresReplayBefore func(uint64) bool,
+	classify recoverableColumnAssetReplayClassifier,
+) ([]ColumnAssetRef, error) {
+	if len(candidateRefs) == 0 || len(bases) == 0 || requiresReplayBefore == nil || classify == nil {
+		return nil, nil
+	}
+	replayRefs := make([]ColumnAssetRef, 0, len(candidateRefs))
+	for _, ref := range candidateRefs {
+		if ref.Generation == 0 {
+			continue
+		}
+		for _, basis := range bases {
+			if basis.appliedCommandLSN == 0 || basis.manifestGeneration == 0 ||
+				ref.Generation > basis.manifestGeneration || !requiresReplayBefore(basis.appliedCommandLSN) {
+				continue
+			}
+			replayable, err := classify(ref, basis)
+			if err != nil {
+				return nil, err
+			}
+			if replayable {
+				replayRefs = append(replayRefs, ref)
+				break
+			}
+		}
+	}
+	return replayRefs, nil
+}
+
 func (c *Collection) pinRecoverableColumnAssetSegments(ctx context.Context, roots *backenddb.RecoverableRootSet, candidateRefs []ColumnAssetRef) error {
 	if c == nil || c.db == nil || roots == nil {
 		return backenddb.ErrRecoverableRootSetStale
 	}
 	seenPaths := make(map[string]struct{})
-	var visibleRecoveryLSN uint64
-	var visibleRecoveryGeneration uint64
-	var visibleRecoveryCollection string
-	var visibleRecoveryConfig *ColumnStoreConfig
+	visibleReplayBases := make([]recoverableColumnAssetReplayBasis, 0, 2)
 	pinRefs := func(refs []ColumnAssetRef) error {
 		for _, ref := range refs {
 			path, err := columnAssetSegmentPath(c.db.ColumnAssetRootDir(), ref)
@@ -575,44 +613,39 @@ func (c *Collection) pinRecoverableColumnAssetSegments(ctx context.Context, root
 			return closeErr
 		}
 		if root.Visible {
-			if view.FullConfig.RecoveryAuthoritativeAppliedCommandLSN > visibleRecoveryLSN {
-				visibleRecoveryLSN = view.FullConfig.RecoveryAuthoritativeAppliedCommandLSN
-				visibleRecoveryCollection = catalog.meta.Name
-				cfg := view.FullConfig
-				visibleRecoveryConfig = &cfg
-			}
-			if identity := view.FullConfig.RecoveryAuthoritativeManifest; identity != nil && identity.Generation > visibleRecoveryGeneration {
-				visibleRecoveryGeneration = identity.Generation
+			if identity := view.FullConfig.RecoveryAuthoritativeManifest; identity != nil &&
+				identity.Generation != 0 && view.FullConfig.RecoveryAuthoritativeAppliedCommandLSN != 0 {
+				visibleReplayBases = append(visibleReplayBases, recoverableColumnAssetReplayBasis{
+					appliedCommandLSN:  view.FullConfig.RecoveryAuthoritativeAppliedCommandLSN,
+					manifestGeneration: identity.Generation,
+					collection:         catalog.meta.Name,
+					config:             view.FullConfig,
+				})
 			}
 		}
 		if err := pinRefs(columnPhysicalScanSnapshotViewAssetRefs(view)); err != nil {
 			return err
 		}
 	}
-	if roots.RequiresReplayBefore(visibleRecoveryLSN) && visibleRecoveryGeneration != 0 && visibleRecoveryConfig != nil {
-		// A durable fallback behind the visible command-WAL frontier can replay
-		// authoritative generations that the current manifest has since
-		// superseded. Only format-valid authoritative typed-row/typed-column
-		// candidates at or below the visible generation are replay inputs; derived
-		// accelerators and arbitrary unpublished candidate bytes are not roots.
-		replayRefs := make([]ColumnAssetRef, 0, len(candidateRefs))
-		for _, ref := range candidateRefs {
-			if ref.Generation == 0 || ref.Generation > visibleRecoveryGeneration {
-				continue
-			}
-			replayable, err := recoverableColumnAssetReplayCandidate(
-				c.db.ColumnAssetRootDir(), ref, visibleRecoveryCollection, *visibleRecoveryConfig, visibleRecoveryLSN,
+	// A durable fallback behind any visible command-WAL frontier can replay
+	// authoritative generations that the corresponding visible manifest has
+	// since superseded. Preserve each root's LSN, generation, collection, and
+	// configuration as one basis so candidate parsing never mixes authorities.
+	replayRefs, err := recoverableColumnAssetReplayRefs(
+		candidateRefs,
+		visibleReplayBases,
+		roots.RequiresReplayBefore,
+		func(ref ColumnAssetRef, basis recoverableColumnAssetReplayBasis) (bool, error) {
+			return recoverableColumnAssetReplayCandidate(
+				c.db.ColumnAssetRootDir(), ref, basis.collection, basis.config, basis.appliedCommandLSN,
 			)
-			if err != nil {
-				return err
-			}
-			if replayable {
-				replayRefs = append(replayRefs, ref)
-			}
-		}
-		if err := pinRefs(replayRefs); err != nil {
-			return err
-		}
+		},
+	)
+	if err != nil {
+		return err
+	}
+	if err := pinRefs(replayRefs); err != nil {
+		return err
 	}
 	return roots.Revalidate()
 }
@@ -623,10 +656,10 @@ func recoverableColumnAssetReplayCandidate(rootDir string, ref ColumnAssetRef, c
 	}
 	raw, err := readColumnPhysicalAssetFromManager(rootDir, ref)
 	if err != nil {
-		// Exact namespace/identity validation immediately before deletion owns
-		// filesystem races. Bytes that cannot validate as this ref are not a
-		// replayable published asset and therefore do not gain a replay pin.
-		return false, nil
+		// An unreadable candidate is ambiguous until exact namespace/identity
+		// validation immediately before deletion. Fail closed so a transient I/O
+		// error cannot silently drop a required replay input.
+		return false, fmt.Errorf("collections: read recoverable column asset kind=%q namespace=%q file_id=%d: %w", ref.Kind, ref.Namespace, ref.FileID, err)
 	}
 	switch ref.Kind {
 	case ColumnAssetKindTCS1PartImage:

--- a/TreeDB/collections/column_asset_gc_test.go
+++ b/TreeDB/collections/column_asset_gc_test.go
@@ -745,7 +745,6 @@ func TestColumnAssetGCAutomaticMappedResourcePinBlocksDelete1788(t *testing.T) {
 }
 
 func TestColumnAssetGCRetainsSupersededSegmentWhileOlderSnapshotPinnedM15C(t *testing.T) {
-	t.Skip("deferred to #3681: destructive column-asset GC requires RecoverableRootSet convergence")
 	requireColumnAssetExactDestructiveGCTest(t)
 	dir := prepareColumnAssetReachabilityCommandWALDirM15A(t)
 	d := openCollectionCommandWALDB(t, dir)

--- a/TreeDB/collections/column_asset_gc_test.go
+++ b/TreeDB/collections/column_asset_gc_test.go
@@ -27,6 +27,61 @@ func requireStandaloneColumnProductionAuthorityTest(tb testing.TB) {
 	}
 }
 
+func TestRecoverableColumnAssetReplayRefsPreservePairedVisibleBasis(t *testing.T) {
+	candidate := ColumnAssetRef{Generation: 8, FileID: 7}
+	bases := []recoverableColumnAssetReplayBasis{
+		{
+			appliedCommandLSN:  30,
+			manifestGeneration: 5,
+			collection:         "newer-lsn",
+			config:             ColumnStoreConfig{AssetManager: &ColumnAssetManagerConfig{Namespace: "newer-lsn"}},
+		},
+		{
+			appliedCommandLSN:  20,
+			manifestGeneration: 9,
+			collection:         "older-lsn-higher-generation",
+			config:             ColumnStoreConfig{AssetManager: &ColumnAssetManagerConfig{Namespace: "paired-basis"}},
+		},
+	}
+	refs, err := recoverableColumnAssetReplayRefs(
+		[]ColumnAssetRef{candidate},
+		bases,
+		func(uint64) bool { return true },
+		func(ref ColumnAssetRef, basis recoverableColumnAssetReplayBasis) (bool, error) {
+			if ref != candidate {
+				t.Fatalf("classifier ref=%+v want %+v", ref, candidate)
+			}
+			if basis.appliedCommandLSN != 20 || basis.manifestGeneration != 9 ||
+				basis.collection != "older-lsn-higher-generation" || basis.config.AssetManager == nil ||
+				basis.config.AssetManager.Namespace != "paired-basis" {
+				t.Fatalf("classifier received mixed replay basis: %+v", basis)
+			}
+			return true, nil
+		},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(refs) != 1 || refs[0] != candidate {
+		t.Fatalf("replay refs=%+v want paired-basis candidate %+v", refs, candidate)
+	}
+}
+
+func TestRecoverableColumnAssetReplayCandidateFailsClosedOnUnreadableAsset(t *testing.T) {
+	ref := ColumnAssetRef{
+		Kind:       ColumnAssetKindTCS1PartImage,
+		Namespace:  "missing-replay-candidate",
+		Generation: 1,
+		PartID:     1,
+		FileID:     1,
+		Length:     1,
+	}
+	replayable, err := recoverableColumnAssetReplayCandidate(t.TempDir(), ref, "events", ColumnStoreConfig{}, 1)
+	if err == nil {
+		t.Fatalf("unreadable replay candidate returned replayable=%t without error", replayable)
+	}
+}
+
 func TestColumnAssetGCDryRunReportsReclaimableButDoesNotDeleteM15B(t *testing.T) {
 	dir := prepareColumnAssetReachabilityCommandWALDirM15A(t)
 	d := openCollectionCommandWALDB(t, dir)

--- a/TreeDB/collections/column_asset_rewrite_test.go
+++ b/TreeDB/collections/column_asset_rewrite_test.go
@@ -529,7 +529,6 @@ func TestColumnAssetRewriteCopyStableAuthorityExactSyncCounts(t *testing.T) {
 }
 
 func TestColumnAssetRewriteRemapsManifestRefsOutOfMixedSegmentM15C(t *testing.T) {
-	t.Skip("deferred to #3681: destructive column-asset rewrite cleanup requires RecoverableRootSet convergence")
 	requireColumnAssetExactDestructiveGCTest(t)
 	dir := prepareColumnAssetReachabilityCommandWALDirM15A(t)
 	d := openCollectionCommandWALDB(t, dir)
@@ -631,7 +630,6 @@ func TestColumnAssetRewriteRemapsManifestRefsOutOfMixedSegmentM15C(t *testing.T)
 	if diag.RowsScanned != 2 || diag.AssetRefs != len(afterPhysicalRefs) {
 		t.Fatalf("diag=%+v want 2 rows and %d remapped physical refs", diag, len(afterPhysicalRefs))
 	}
-
 	gcStats, err := reopened.ColumnAssetGC(context.Background(), ColumnAssetGCOptions{
 		CandidateRefs: append(append([]ColumnAssetRef(nil), stats.SupersededRefs...), candidate),
 	})
@@ -830,7 +828,6 @@ func TestColumnAssetRewriteAutomaticMappedResourcePinSkipsSegment1788(t *testing
 }
 
 func TestColumnAssetRewriteLifecycleSmokeWithMutationsM15C(t *testing.T) {
-	t.Skip("deferred to #3681: destructive column-asset rewrite cleanup requires RecoverableRootSet convergence")
 	requireColumnAssetExactDestructiveGCTest(t)
 	dir := prepareColumnAssetReachabilityCommandWALDirM15A(t)
 	d := openCollectionCommandWALDB(t, dir)
@@ -1245,6 +1242,9 @@ func staleColumnAssetRewriteManifestRootM15C(d *backenddb.DB) error {
 
 func advanceColumnAssetDurableFallbackM15C(t *testing.T, d *backenddb.DB) {
 	t.Helper()
+	if err := d.Checkpoint(); err != nil {
+		t.Fatalf("settle current durable root before fallback advance: %v", err)
+	}
 	payload, err := commitlog.EncodeRawKVBatchPayload([]commitlog.RawKVOperation{{
 		Op:    commitlog.RawKVOpSet,
 		Key:   []byte("column/rewrite/durable-fallback-advance"),
@@ -1266,6 +1266,9 @@ func advanceColumnAssetDurableFallbackM15C(t *testing.T, d *backenddb.DB) {
 		return emptySystemDelta.NewIterator(nil, nil), nil
 	}); err != nil {
 		t.Fatalf("publish fallback advance: %v", err)
+	}
+	if err := d.Checkpoint(); err != nil {
+		t.Fatalf("wait durable fallback advance: %v", err)
 	}
 }
 

--- a/TreeDB/collections/column_retained_vlog_placement_test.go
+++ b/TreeDB/collections/column_retained_vlog_placement_test.go
@@ -54,7 +54,6 @@ func TestColumnRetainedPayloadValueLogPlacementReopen(t *testing.T) {
 }
 
 func TestColumnRetainedPayloadValueLogPlacementGCRewrite(t *testing.T) {
-	t.Skip("deferred to #3681: destructive value-log GC requires RecoverableRootSet convergence")
 	dir := t.TempDir()
 	enableColumnRetainedPlacementCommandWAL(t, dir)
 
@@ -98,11 +97,19 @@ func TestColumnRetainedPayloadValueLogPlacementGCRewrite(t *testing.T) {
 		_ = d.Close()
 		t.Fatalf("Delete doc-a: %v", err)
 	}
+	if err := d.Checkpoint(); err != nil {
+		_ = d.Close()
+		t.Fatalf("settle deletion before durable slot rollover: %v", err)
+	}
 	// Advance the alternate durable slot so neither selectable closure retains
 	// doc-a's value-log segment before destructive GC.
 	if _, err := col.InsertBatch([][]byte{[]byte("doc-d")}, [][]byte{retainedPlacementDocument("slot-rollover", 4)}); err != nil {
 		_ = d.Close()
 		t.Fatalf("InsertBatch doc-d slot rollover: %v", err)
+	}
+	if err := d.Checkpoint(); err != nil {
+		_ = d.Close()
+		t.Fatalf("wait durable doc-d slot rollover: %v", err)
 	}
 
 	gcStats, err := d.ValueLogGC(context.Background(), backenddb.ValueLogGCOptions{})

--- a/TreeDB/collections/stable_resource_inventory_test.go
+++ b/TreeDB/collections/stable_resource_inventory_test.go
@@ -27,6 +27,12 @@ func testStableColumnConstructionPinBlocksCrossManagerGC(t *testing.T) {
 	if _, err := col.Insert([]byte("seed"), []byte(`{"time_us":1,"kind":"like","did":"d1"}`)); err != nil {
 		t.Fatal(err)
 	}
+	// Stabilize the seed publication before taking the registry baseline. The
+	// construction-pin assertion is about the candidate append below, not pins
+	// transferred asynchronously while the seed root becomes durable.
+	if err := d.Checkpoint(); err != nil {
+		t.Fatal(err)
+	}
 	candidatePayload := []byte("construction-authority-candidate")
 	candidate := writeColumnAssetGCCandidateSegmentM15B(t, d.ColumnAssetRootDir(), col, 117, candidatePayload)
 

--- a/TreeDB/collections/typed_column_publication_test.go
+++ b/TreeDB/collections/typed_column_publication_test.go
@@ -1612,7 +1612,6 @@ func TestTypedColumnMultipartPartSetRefsRetainedDuringGC1787(t *testing.T) {
 }
 
 func TestTypedColumnMultipartPartSetRefsRewriteAndGCSafe1787(t *testing.T) {
-	t.Skip("deferred to #3681: destructive typed-column asset cleanup requires RecoverableRootSet convergence")
 	requireColumnAssetExactDestructiveGCTest(t)
 	d, col, _ := setupSingleTypedColumnPart1755(t)
 	dir := d.Dir()
@@ -1669,6 +1668,9 @@ func TestTypedColumnMultipartPartSetRefsRewriteAndGCSafe1787(t *testing.T) {
 	// longer retains the pre-rewrite column-asset closure.
 	if _, err := NewCollectionManager(reopened).CreateCollection(&CollectionMeta{Name: "slot_rollover"}); err != nil {
 		t.Fatalf("CreateCollection slot rollover after multipart rewrite: %v", err)
+	}
+	if err := reopened.Checkpoint(); err != nil {
+		t.Fatalf("wait durable slot rollover after multipart rewrite: %v", err)
 	}
 	gcStats, err := reopenedCol.ColumnAssetGC(context.Background(), ColumnAssetGCOptions{
 		CandidateRefs: append(append([]ColumnAssetRef(nil), rewrite.SupersededRefs...), candidate),
@@ -1835,7 +1837,6 @@ func TestTypedColumnSnapshotReadsOldRefsAfterDelete(t *testing.T) {
 }
 
 func TestTypedColumnPublicationColumnAssetRewriteRoundTrip(t *testing.T) {
-	t.Skip("deferred to #3681: destructive typed-column asset cleanup requires RecoverableRootSet convergence")
 	runTypedColumnColumnAssetRewriteRoundTripMixedRefs1778(t)
 }
 
@@ -1844,7 +1845,6 @@ func TestTypedColumnColumnAssetRewriteRoundTripMixedRefs(t *testing.T) {
 }
 
 func runTypedColumnColumnAssetRewriteRoundTripMixedRefs1778(t *testing.T) {
-	t.Skip("deferred to #3681: destructive typed-column asset cleanup requires RecoverableRootSet convergence")
 	requireColumnAssetExactDestructiveGCTest(t)
 	d, col, _ := setupSingleTypedColumnPart1755(t)
 	dir := d.Dir()
@@ -1911,6 +1911,9 @@ func runTypedColumnColumnAssetRewriteRoundTripMixedRefs1778(t *testing.T) {
 	// longer retains the pre-rewrite column-asset closure.
 	if _, err := NewCollectionManager(reopened).CreateCollection(&CollectionMeta{Name: "slot_rollover"}); err != nil {
 		t.Fatalf("CreateCollection slot rollover after rewrite: %v", err)
+	}
+	if err := reopened.Checkpoint(); err != nil {
+		t.Fatalf("wait durable slot rollover after rewrite: %v", err)
 	}
 	gcStats, err := reopenedCol.ColumnAssetGC(context.Background(), ColumnAssetGCOptions{
 		CandidateRefs: append(append([]ColumnAssetRef(nil), rewrite.SupersededRefs...), candidate),

--- a/TreeDB/collections/typed_storage_naming_test.go
+++ b/TreeDB/collections/typed_storage_naming_test.go
@@ -339,6 +339,7 @@ var typedStorageLegacyNameAllowlist = []typedStorageLegacyNameAllowlistEntry{
 	{path: "TreeDB/collections/column_aggregate_metadata_predicate_1951_test.go", classification: typedStorageLegacyCompatibility, matchingLines: 77, occurrences: 78},
 	{path: "TreeDB/collections/column_aggregate_metadata_typed_column_test.go", classification: typedStorageLegacyCompatibility, matchingLines: 19, occurrences: 21},
 	{path: "TreeDB/collections/column_asset_gc_test.go", classification: typedStorageLegacyCompatibility, matchingLines: 36, occurrences: 38},
+	{path: "TreeDB/collections/column_asset_gc.go", classification: typedStorageLegacyCompatibility, matchingLines: 3, occurrences: 3},
 	{path: "TreeDB/collections/column_asset_lifecycle.go", classification: typedStorageLegacyCompatibility, matchingLines: 1, occurrences: 1},
 	{path: "TreeDB/collections/column_asset_manager.go", classification: typedStorageLegacyCompatibility, matchingLines: 31, occurrences: 52},
 	{path: "TreeDB/collections/column_asset_mappedresource_test.go", classification: typedStorageLegacyCompatibility, matchingLines: 12, occurrences: 12},

--- a/TreeDB/collections/typed_storage_naming_test.go
+++ b/TreeDB/collections/typed_storage_naming_test.go
@@ -338,7 +338,7 @@ var typedStorageLegacyNameAllowlist = []typedStorageLegacyNameAllowlistEntry{
 	{path: "TreeDB/collections/column_aggregate_metadata_predicate.go", classification: typedStorageLegacyDerived, matchingLines: 6, occurrences: 6},
 	{path: "TreeDB/collections/column_aggregate_metadata_predicate_1951_test.go", classification: typedStorageLegacyCompatibility, matchingLines: 77, occurrences: 78},
 	{path: "TreeDB/collections/column_aggregate_metadata_typed_column_test.go", classification: typedStorageLegacyCompatibility, matchingLines: 19, occurrences: 21},
-	{path: "TreeDB/collections/column_asset_gc_test.go", classification: typedStorageLegacyCompatibility, matchingLines: 36, occurrences: 38},
+	{path: "TreeDB/collections/column_asset_gc_test.go", classification: typedStorageLegacyCompatibility, matchingLines: 39, occurrences: 41},
 	{path: "TreeDB/collections/column_asset_gc.go", classification: typedStorageLegacyCompatibility, matchingLines: 3, occurrences: 3},
 	{path: "TreeDB/collections/column_asset_lifecycle.go", classification: typedStorageLegacyCompatibility, matchingLines: 1, occurrences: 1},
 	{path: "TreeDB/collections/column_asset_manager.go", classification: typedStorageLegacyCompatibility, matchingLines: 31, occurrences: 52},

--- a/TreeDB/compact_storage_cached_internal_test.go
+++ b/TreeDB/compact_storage_cached_internal_test.go
@@ -545,17 +545,25 @@ func TestCompactStorageClearsPublicRewriteSourceGCBehindActiveWriters(t *testing
 		t.Fatalf("rewrite copied no value records: %+v", rewrite)
 	}
 	// The rewrite publishes replacement pointers, but the immediately previous
-	// durable slot may still retain the source segments. Publish one inline-only
-	// successor so both durable slots have crossed the rewrite before requiring
-	// CompactStorage to report zero physical GC debt.
-	if err := db.Set([]byte("raw/rewrite-gc-slot-advance"), []byte("advance")); err != nil {
-		t.Fatalf("publish durable-slot successor: %v", err)
-	}
-	if err := db.Checkpoint(); err != nil {
-		t.Fatalf("checkpoint durable-slot successor: %v", err)
-	}
+	// durable slot may still retain the source segments. Reopen before publishing
+	// an inline-only successor so the cached writer also starts from the rewritten
+	// leaf-log generation. Both durable slots have then crossed the rewrite before
+	// CompactStorage is required to report zero physical GC debt.
 	if err := db.Close(); err != nil {
 		t.Fatalf("close after rewrite: %v", err)
+	}
+	slotAdvancer, err := Open(opts)
+	if err != nil {
+		t.Fatalf("open durable-slot advancer: %v", err)
+	}
+	if err := slotAdvancer.Set([]byte("raw/rewrite-gc-slot-advance"), []byte("advance")); err != nil {
+		t.Fatalf("publish durable-slot successor: %v", err)
+	}
+	if err := slotAdvancer.Checkpoint(); err != nil {
+		t.Fatalf("checkpoint durable-slot successor: %v", err)
+	}
+	if err := slotAdvancer.Close(); err != nil {
+		t.Fatalf("close durable-slot advancer: %v", err)
 	}
 
 	compactor, err := Open(opts)

--- a/TreeDB/compact_storage_cached_internal_test.go
+++ b/TreeDB/compact_storage_cached_internal_test.go
@@ -544,6 +544,16 @@ func TestCompactStorageClearsPublicRewriteSourceGCBehindActiveWriters(t *testing
 	if rewrite.ValueRecordsCopied == 0 {
 		t.Fatalf("rewrite copied no value records: %+v", rewrite)
 	}
+	// The rewrite publishes replacement pointers, but the immediately previous
+	// durable slot may still retain the source segments. Publish one inline-only
+	// successor so both durable slots have crossed the rewrite before requiring
+	// CompactStorage to report zero physical GC debt.
+	if err := db.Set([]byte("raw/rewrite-gc-slot-advance"), []byte("advance")); err != nil {
+		t.Fatalf("publish durable-slot successor: %v", err)
+	}
+	if err := db.Checkpoint(); err != nil {
+		t.Fatalf("checkpoint durable-slot successor: %v", err)
+	}
 	if err := db.Close(); err != nil {
 		t.Fatalf("close after rewrite: %v", err)
 	}

--- a/TreeDB/db/batch_delete_range_test.go
+++ b/TreeDB/db/batch_delete_range_test.go
@@ -202,15 +202,15 @@ func TestBatchDeleteRangeValueLogPointerRefsAndGC(t *testing.T) {
 		t.Fatalf("Get(k3)=(%d bytes,%v), want keep", len(got), err)
 	}
 
-	// The prior durable slot still names the seed generation, so its dependency
-	// manifest must keep the deleted pointer segments pinned until normal slot
-	// alternation replaces that generation.
+	// The prior durable slot still names the seed generation, so recoverable-root
+	// projection must classify the deleted pointer segments as referenced until
+	// normal slot alternation replaces that generation.
 	pinned, err := d.ValueLogGC(context.Background(), ValueLogGCOptions{DryRun: true})
 	if err != nil {
 		t.Fatalf("ValueLogGC dry run: %v", err)
 	}
-	if pinned.SegmentsPending < 2 {
-		t.Fatalf("ValueLogGC pending %d segments while older durable slot is recoverable, want at least 2: %+v", pinned.SegmentsPending, pinned)
+	if pinned.SegmentsReferenced < 2 || pinned.SegmentsEligible != 0 || pinned.SegmentsPending != 0 {
+		t.Fatalf("ValueLogGC stats while older durable slot is recoverable=%+v, want at least 2 referenced and no eligible/pending segments", pinned)
 	}
 	if err := d.SetSync([]byte("slot-advance"), []byte("inline")); err != nil {
 		t.Fatalf("advance durable slot: %v", err)

--- a/TreeDB/db/compact_storage.go
+++ b/TreeDB/db/compact_storage.go
@@ -1609,6 +1609,21 @@ func compactStorageCleanupValueLogProtectedPaths(opts CompactStorageOptions) []s
 }
 
 func (db *DB) pruneZeroByteValueLogFiles(protectedPaths []string) (int, error) {
+	recoverableRoots, err := db.captureRecoverableRootSetWithMaintenanceLockHeld(context.Background())
+	if err != nil {
+		return 0, err
+	}
+	defer recoverableRoots.Release()
+	db.publishPrepareMu.Lock()
+	defer db.publishPrepareMu.Unlock()
+	if err := recoverableRoots.Revalidate(); err != nil {
+		return 0, err
+	}
+	// No root publication can advance while publishPrepareMu is held. Consume
+	// the capability so exact topology pins do not themselves prevent removal
+	// of a zero-byte file proven outside every recoverable root.
+	recoverableRoots.Release()
+
 	layout := resolveStorageLayout(db.dir)
 	entries, err := os.ReadDir(layout.valueVLogDir)
 	if err != nil {

--- a/TreeDB/db/compact_storage_test.go
+++ b/TreeDB/db/compact_storage_test.go
@@ -633,8 +633,16 @@ func TestCompactStorageFullRewriteRewritesHighStaleValueLogSegment(t *testing.T)
 	if stats.RemainingDebt.ValueLogRewriteSegments != 0 || stats.RemainingDebt.ValueLogRewriteBytes != 0 {
 		t.Fatalf("remaining policy rewrite debt=%+v want none", stats.RemainingDebt)
 	}
-	if !stats.FullyCompacted || !stats.PolicyFullyCompacted || stats.ByteMinimized {
-		t.Fatalf("stats flags fully=%t policy=%t byte=%t debt=%+v", stats.FullyCompacted, stats.PolicyFullyCompacted, stats.ByteMinimized, stats.RemainingDebt)
+	if stats.RemainingDebt.ValueLogGCSegments == 0 || stats.FullyCompacted || stats.PolicyFullyCompacted || stats.ByteMinimized {
+		t.Fatalf("rewrite must retain older-root GC debt: flags fully=%t policy=%t byte=%t debt=%+v", stats.FullyCompacted, stats.PolicyFullyCompacted, stats.ByteMinimized, stats.RemainingDebt)
+	}
+	advancePastRetainedDurableSlotForTest(t, db)
+	converged, err := db.CompactStorage(context.Background(), opts)
+	if err != nil {
+		t.Fatalf("CompactStorage after durable horizon advance: %v", err)
+	}
+	if !converged.FullyCompacted || !converged.PolicyFullyCompacted || converged.ByteMinimized {
+		t.Fatalf("converged flags fully=%t policy=%t byte=%t debt=%+v", converged.FullyCompacted, converged.PolicyFullyCompacted, converged.ByteMinimized, converged.RemainingDebt)
 	}
 }
 
@@ -667,8 +675,16 @@ func TestCompactStorageFullRewriteDoesNotExemptSmallHighStaleValueLogSegment(t *
 	if got := stats.ValueLogRewrite.ValueBytesCopied; got <= 0 {
 		t.Fatalf("applied rewrite copied bytes=%d want >0, stats=%+v", got, stats.ValueLogRewrite)
 	}
-	if !stats.FullyCompacted || !stats.PolicyFullyCompacted || stats.ByteMinimized {
-		t.Fatalf("stats flags fully=%t policy=%t byte=%t debt=%+v", stats.FullyCompacted, stats.PolicyFullyCompacted, stats.ByteMinimized, stats.RemainingDebt)
+	if stats.RemainingDebt.ValueLogGCSegments == 0 || stats.FullyCompacted || stats.PolicyFullyCompacted || stats.ByteMinimized {
+		t.Fatalf("rewrite must retain older-root GC debt: flags fully=%t policy=%t byte=%t debt=%+v", stats.FullyCompacted, stats.PolicyFullyCompacted, stats.ByteMinimized, stats.RemainingDebt)
+	}
+	advancePastRetainedDurableSlotForTest(t, db)
+	converged, err := db.CompactStorage(context.Background(), opts)
+	if err != nil {
+		t.Fatalf("CompactStorage after durable horizon advance: %v", err)
+	}
+	if !converged.FullyCompacted || !converged.PolicyFullyCompacted || converged.ByteMinimized {
+		t.Fatalf("converged flags fully=%t policy=%t byte=%t debt=%+v", converged.FullyCompacted, converged.PolicyFullyCompacted, converged.ByteMinimized, converged.RemainingDebt)
 	}
 }
 
@@ -709,8 +725,16 @@ func TestCompactStorageExhaustiveRewriteSelectsAnyStaleValueLogSegment(t *testin
 	if got := stats.ValueLogRewrite.ValueRecordsCopied; got != 9 {
 		t.Fatalf("exhaustive rewrite copied records=%d want 9, stats=%+v", got, stats.ValueLogRewrite)
 	}
-	if !stats.FullyCompacted || !stats.PolicyFullyCompacted || !stats.ByteMinimized {
-		t.Fatalf("exhaustive stats flags fully=%t policy=%t byte=%t debt=%+v", stats.FullyCompacted, stats.PolicyFullyCompacted, stats.ByteMinimized, stats.RemainingDebt)
+	if stats.RemainingDebt.ValueLogGCSegments == 0 || stats.FullyCompacted || stats.PolicyFullyCompacted || stats.ByteMinimized {
+		t.Fatalf("exhaustive rewrite must retain older-root GC debt: flags fully=%t policy=%t byte=%t debt=%+v", stats.FullyCompacted, stats.PolicyFullyCompacted, stats.ByteMinimized, stats.RemainingDebt)
+	}
+	advancePastRetainedDurableSlotForTest(t, db)
+	converged, err := db.CompactStorage(context.Background(), CompactStorageOptions{Mode: CompactStorageExhaustive})
+	if err != nil {
+		t.Fatalf("CompactStorage exhaustive after durable horizon advance: %v", err)
+	}
+	if !converged.FullyCompacted || !converged.PolicyFullyCompacted || !converged.ByteMinimized {
+		t.Fatalf("exhaustive converged flags fully=%t policy=%t byte=%t debt=%+v", converged.FullyCompacted, converged.PolicyFullyCompacted, converged.ByteMinimized, converged.RemainingDebt)
 	}
 }
 

--- a/TreeDB/db/db.go
+++ b/TreeDB/db/db.go
@@ -118,6 +118,9 @@ type DB struct {
 	// Test hook used to advance protected-root providers at deterministic
 	// capture boundaries.
 	compactStorageAuditProtectedBasisHook func(stage string, attempt int)
+	// Test hook used to invalidate a value-log GC recoverable-root capability
+	// immediately before its destructive revalidation.
+	testValueLogGCBeforeRevalidateHook func()
 
 	// idx is the current index generation (pager + MVCC lifecycle state).
 	idx atomic.Pointer[indexGen]
@@ -4163,6 +4166,12 @@ func (db *DB) MarkValueLogZombie(id uint32) error {
 		observedSourceMissingIsError:     true,
 	}, true)
 	if err != nil {
+		if errors.Is(err, ErrRecoverableRootSetStale) {
+			return errors.Join(
+				fmt.Errorf("%w: file_id=%d", ErrValueLogZombieDeferred, id),
+				err,
+			)
+		}
 		return err
 	}
 	if stats.ObservedSourceSegmentsEligible != 1 {

--- a/TreeDB/db/db.go
+++ b/TreeDB/db/db.go
@@ -4160,6 +4160,7 @@ func (db *DB) MarkValueLogZombie(id uint32) error {
 		ObservedSourceFileIDs:            []uint32{id},
 		ObservedSourceAssumeUnreferenced: true,
 		ObservedSourceReclaimActive:      true,
+		observedSourceMissingIsError:     true,
 	}, true)
 	return err
 }

--- a/TreeDB/db/db.go
+++ b/TreeDB/db/db.go
@@ -4156,13 +4156,26 @@ func (db *DB) MarkValueLogZombie(id uint32) error {
 	if db == nil || db.valueLogManager == nil {
 		return fmt.Errorf("value log manager unavailable")
 	}
-	_, err := db.valueLogGC(context.Background(), ValueLogGCOptions{
+	stats, err := db.valueLogGC(context.Background(), ValueLogGCOptions{
 		ObservedSourceFileIDs:            []uint32{id},
 		ObservedSourceAssumeUnreferenced: true,
 		ObservedSourceReclaimActive:      true,
 		observedSourceMissingIsError:     true,
 	}, true)
-	return err
+	if err != nil {
+		return err
+	}
+	if stats.ObservedSourceSegmentsEligible != 1 {
+		return fmt.Errorf(
+			"%w: file_id=%d referenced=%d active=%d protected=%d",
+			ErrValueLogZombieDeferred,
+			id,
+			stats.ObservedSourceSegmentsReferenced,
+			stats.ObservedSourceSegmentsActive,
+			stats.ObservedSourceSegmentsProtected,
+		)
+	}
+	return nil
 }
 
 // CompactIndex rewrites the entire B-Tree sequentially to the end of the file.

--- a/TreeDB/db/db.go
+++ b/TreeDB/db/db.go
@@ -4156,7 +4156,12 @@ func (db *DB) MarkValueLogZombie(id uint32) error {
 	if db == nil || db.valueLogManager == nil {
 		return fmt.Errorf("value log manager unavailable")
 	}
-	return db.valueLogManager.MarkZombie(id)
+	_, err := db.valueLogGC(context.Background(), ValueLogGCOptions{
+		ObservedSourceFileIDs:            []uint32{id},
+		ObservedSourceAssumeUnreferenced: true,
+		ObservedSourceReclaimActive:      true,
+	}, true)
+	return err
 }
 
 // CompactIndex rewrites the entire B-Tree sequentially to the end of the file.

--- a/TreeDB/db/durable_root_runtime.go
+++ b/TreeDB/db/durable_root_runtime.go
@@ -380,7 +380,7 @@ func (db *DB) scanCandidateExternalReferencesV1(snapshot *Snapshot) (map[uint32]
 	if err := registerValuePointers(primaryRootIDs); err != nil {
 		return nil, err
 	}
-	roots, _, err := maintenanceReachabilityRoots(context.Background(), snapshot, nil, nil, false)
+	roots, _, err := maintenanceReachabilityRoots(context.Background(), snapshot, nil, nil, false, false)
 	if err != nil {
 		return nil, err
 	}

--- a/TreeDB/db/leaf_generation_gc.go
+++ b/TreeDB/db/leaf_generation_gc.go
@@ -107,6 +107,14 @@ func (db *DB) leafGenerationGCAttempt(ctx context.Context, opts LeafGenerationGC
 	if err != nil || !prepared {
 		return stats, false, err
 	}
+	var recoverableRoots *RecoverableRootSet
+	if !opts.DryRun {
+		recoverableRoots, err = db.captureRecoverableRootSetWithMaintenanceLockHeld(ctx)
+		if err != nil {
+			return stats, false, err
+		}
+		defer recoverableRoots.Release()
+	}
 
 	snap := db.AcquireSnapshot()
 	if snap == nil {
@@ -131,6 +139,14 @@ func (db *DB) leafGenerationGCAttempt(ctx context.Context, opts LeafGenerationGC
 		_ = snap.Close()
 		return stats, false, err
 	}
+	var recoverableLive map[uint64]struct{}
+	if recoverableRoots != nil {
+		recoverableLive, err = db.collectRecoverableLeafGenerationIDs(ctx, recoverableRoots, snap.state.LeafGenerations)
+		if err != nil {
+			_ = snap.Close()
+			return stats, false, err
+		}
+	}
 	if err := snap.Close(); err != nil {
 		return stats, false, err
 	}
@@ -140,7 +156,7 @@ func (db *DB) leafGenerationGCAttempt(ctx context.Context, opts LeafGenerationGC
 	if opts.DryRun {
 		return db.leafGenerationGCDryRunFromScan(basis, liveGenerations)
 	}
-	stats, err = db.leafGenerationGCApplyScan(basis, liveGenerations)
+	stats, err = db.leafGenerationGCApplyScan(basis, liveGenerations, recoverableLive, recoverableRoots)
 	return stats, false, err
 }
 
@@ -269,11 +285,11 @@ func (db *DB) leafGenerationGCDryRunFromScan(basis leafGenerationGCScanBasis, li
 	runLeafGenerationGCExclusivePhaseHook(false)
 	db.writeMu.Unlock()
 
-	decision := db.buildLeafGenerationGCDecision(manifest, filePaths, currentLeafLogRawFileIDs, liveGenerations, basis.commitSeq, true)
+	decision := db.buildLeafGenerationGCDecision(manifest, filePaths, currentLeafLogRawFileIDs, liveGenerations, nil, basis.commitSeq, true)
 	return decision.stats, false, nil
 }
 
-func (db *DB) leafGenerationGCApplyScan(basis leafGenerationGCScanBasis, liveGenerations map[uint64]struct{}) (LeafGenerationGCStats, error) {
+func (db *DB) leafGenerationGCApplyScan(basis leafGenerationGCScanBasis, liveGenerations, recoverableGenerations map[uint64]struct{}, recoverableRoots *RecoverableRootSet) (LeafGenerationGCStats, error) {
 	var stats LeafGenerationGCStats
 
 	db.writeMu.Lock()
@@ -295,8 +311,12 @@ func (db *DB) leafGenerationGCApplyScan(basis leafGenerationGCScanBasis, liveGen
 		return stats, err
 	}
 	filePaths := db.leafGenerationFilePaths(manifest)
-	decision := db.buildLeafGenerationGCDecision(manifest, filePaths, currentLeafLogRawFileIDs, liveGenerations, basis.commitSeq, false)
+	decision := db.buildLeafGenerationGCDecision(manifest, filePaths, currentLeafLogRawFileIDs, liveGenerations, recoverableGenerations, basis.commitSeq, false)
 	stats = decision.stats
+	if err := recoverableRoots.Revalidate(); err != nil {
+		return stats, err
+	}
+	recoverableRoots.Release()
 
 	if len(decision.zombieFileIDs) > 0 {
 		for fileID := range decision.zombieFileIDs {
@@ -343,7 +363,37 @@ func (db *DB) leafGenerationGCApplyScan(basis leafGenerationGCScanBasis, liveGen
 	return stats, nil
 }
 
-func (db *DB) buildLeafGenerationGCDecision(manifest *leafGenerationManifest, filePaths map[uint32]string, currentLeafLogRawFileIDs map[uint32]struct{}, liveGenerations map[uint64]struct{}, currentCommitSeq uint64, dryRun bool) leafGenerationGCDecision {
+func (db *DB) collectRecoverableLeafGenerationIDs(ctx context.Context, roots *RecoverableRootSet, current *leafGenerationView) (map[uint64]struct{}, error) {
+	captured := roots.Roots()
+	if len(captured) == 0 {
+		return nil, ErrRecoverableRootSetStale
+	}
+	snap := roots.AcquireSnapshotForRoot(captured[0])
+	if snap == nil {
+		return nil, ErrRecoverableRootSetStale
+	}
+	protectedRootIDs := make([]uint64, 0, len(captured))
+	protectedSystemRootIDs := make([]uint64, 0, len(captured))
+	for _, root := range captured {
+		protectedRootIDs = append(protectedRootIDs, root.UserRootPageID)
+		protectedSystemRootIDs = append(protectedSystemRootIDs, root.SystemRootPageID)
+	}
+	scan, err := db.maintenanceReachabilityScan(ctx, snap, maintenanceReachabilityScanOptions{
+		Collectors:             maintenanceReachabilityLeafFileIDs,
+		ProtectedRootIDs:       protectedRootIDs,
+		ProtectedSystemRootIDs: protectedSystemRootIDs,
+	})
+	closeErr := snap.Close()
+	if err != nil {
+		return nil, err
+	}
+	if closeErr != nil {
+		return nil, closeErr
+	}
+	return roots.leafGenerationIDsForFiles(scan.leafFileIDs, current)
+}
+
+func (db *DB) buildLeafGenerationGCDecision(manifest *leafGenerationManifest, filePaths map[uint32]string, currentLeafLogRawFileIDs map[uint32]struct{}, liveGenerations, recoverableGenerations map[uint64]struct{}, currentCommitSeq uint64, dryRun bool) leafGenerationGCDecision {
 	decision := leafGenerationGCDecision{zombieFileIDs: make(map[uint32]struct{})}
 	activeFileRefs := leafGenerationActiveFileRefCounts(manifest)
 	for i := range manifest.Generations {
@@ -402,6 +452,20 @@ func (db *DB) buildLeafGenerationGCDecision(manifest *leafGenerationManifest, fi
 			decision.stats.GenerationsLive++
 			if gen.State != leafGenerationStateSealed {
 				gen.State = leafGenerationStateSealed
+				decision.intermediateChanged = true
+			}
+			continue
+		}
+		// A generation referenced only by an independently recoverable root is
+		// retained debt, not part of the currently visible tree. Keep it retiring
+		// so a later pass can reclaim it after every durable fallback advances.
+		if _, ok := recoverableGenerations[gen.GenerationID]; ok {
+			decision.stats.GenerationsRetiring++
+			if gen.State != leafGenerationStateRetiring {
+				gen.State = leafGenerationStateRetiring
+				if currentCommitSeq > gen.RetiredCommitSeq {
+					gen.RetiredCommitSeq = currentCommitSeq
+				}
 				decision.intermediateChanged = true
 			}
 			continue

--- a/TreeDB/db/leaf_generation_gc.go
+++ b/TreeDB/db/leaf_generation_gc.go
@@ -108,13 +108,15 @@ func (db *DB) leafGenerationGCAttempt(ctx context.Context, opts LeafGenerationGC
 		return stats, false, err
 	}
 	var recoverableRoots *RecoverableRootSet
-	if !opts.DryRun {
+	if opts.DryRun {
+		recoverableRoots, err = db.captureRecoverableRootSetForInspectionWithMaintenanceLockHeld(ctx)
+	} else {
 		recoverableRoots, err = db.captureRecoverableRootSetWithMaintenanceLockHeld(ctx)
-		if err != nil {
-			return stats, false, err
-		}
-		defer recoverableRoots.Release()
 	}
+	if err != nil {
+		return stats, false, err
+	}
+	defer recoverableRoots.Release()
 
 	snap := db.AcquireSnapshot()
 	if snap == nil {
@@ -144,6 +146,9 @@ func (db *DB) leafGenerationGCAttempt(ctx context.Context, opts LeafGenerationGC
 		recoverableLive, err = db.collectRecoverableLeafGenerationIDs(ctx, recoverableRoots, snap.state.LeafGenerations)
 		if err != nil {
 			_ = snap.Close()
+			if opts.DryRun && errors.Is(err, ErrRecoverableRootSetStale) {
+				return stats, true, nil
+			}
 			return stats, false, err
 		}
 	}
@@ -154,7 +159,7 @@ func (db *DB) leafGenerationGCAttempt(ctx context.Context, opts LeafGenerationGC
 	releaseTeardown()
 
 	if opts.DryRun {
-		return db.leafGenerationGCDryRunFromScan(basis, liveGenerations)
+		return db.leafGenerationGCDryRunFromScan(basis, liveGenerations, recoverableLive, recoverableRoots)
 	}
 	stats, err = db.leafGenerationGCApplyScan(basis, liveGenerations, recoverableLive, recoverableRoots)
 	return stats, false, err
@@ -259,7 +264,7 @@ func (db *DB) leafGenerationGCValidatedManifestClone(basis leafGenerationGCScanB
 	return manifest, true
 }
 
-func (db *DB) leafGenerationGCDryRunFromScan(basis leafGenerationGCScanBasis, liveGenerations map[uint64]struct{}) (LeafGenerationGCStats, bool, error) {
+func (db *DB) leafGenerationGCDryRunFromScan(basis leafGenerationGCScanBasis, liveGenerations, recoverableGenerations map[uint64]struct{}, recoverableRoots *RecoverableRootSet) (LeafGenerationGCStats, bool, error) {
 	var stats LeafGenerationGCStats
 
 	db.writeMu.Lock()
@@ -282,10 +287,19 @@ func (db *DB) leafGenerationGCDryRunFromScan(basis leafGenerationGCScanBasis, li
 		return stats, false, err
 	}
 	filePaths := db.leafGenerationFilePaths(manifest)
+	if err := recoverableRoots.Revalidate(); err != nil {
+		runLeafGenerationGCExclusivePhaseHook(false)
+		db.writeMu.Unlock()
+		if errors.Is(err, ErrRecoverableRootSetStale) {
+			return stats, true, nil
+		}
+		return stats, false, err
+	}
+	recoverableRoots.Release()
 	runLeafGenerationGCExclusivePhaseHook(false)
 	db.writeMu.Unlock()
 
-	decision := db.buildLeafGenerationGCDecision(manifest, filePaths, currentLeafLogRawFileIDs, liveGenerations, nil, basis.commitSeq, true)
+	decision := db.buildLeafGenerationGCDecision(manifest, filePaths, currentLeafLogRawFileIDs, liveGenerations, recoverableGenerations, basis.commitSeq, true)
 	return decision.stats, false, nil
 }
 

--- a/TreeDB/db/leaf_generation_gc_test.go
+++ b/TreeDB/db/leaf_generation_gc_test.go
@@ -354,6 +354,20 @@ func requireLeafGenerationGCResult(t *testing.T, done <-chan leafGenerationGCTes
 	return LeafGenerationGCStats{}
 }
 
+func requireLeafGenerationGCResultAllowRecoverableStale(t *testing.T, done <-chan leafGenerationGCTestResult) LeafGenerationGCStats {
+	t.Helper()
+	select {
+	case result := <-done:
+		if result.err != nil && !errors.Is(result.err, ErrRecoverableRootSetStale) {
+			t.Fatalf("LeafGenerationGC: %v", result.err)
+		}
+		return result.stats
+	case <-time.After(5 * time.Second):
+		t.Fatal("LeafGenerationGC did not finish after releasing live scan")
+	}
+	return LeafGenerationGCStats{}
+}
+
 func TestLeafGenerationView_SkipsRetiringAndDeletedGenerations(t *testing.T) {
 	manifest := &leafGenerationManifest{
 		Version:             leafGenerationManifestVersion,
@@ -402,7 +416,7 @@ func TestLeafGenerationGC_LiveScanDoesNotBlockForegroundWrite(t *testing.T) {
 	releaseScan, done := startLeafGenerationGCPausedAtLiveScan(t, db, LeafGenerationGCOptions{})
 	requireLeafGenerationForegroundSetCompletes(t, db, "scan-concurrent")
 	releaseScan()
-	_ = requireLeafGenerationGCResult(t, done)
+	_ = requireLeafGenerationGCResultAllowRecoverableStale(t, done)
 
 	got, err := db.Get([]byte("scan-concurrent"))
 	if err != nil {
@@ -437,7 +451,7 @@ func TestLeafGenerationGC_QueuedCheckpointDoesNotGateLaterWrite(t *testing.T) {
 	requireLeafGenerationOperationCompletes(t, "Checkpoint while live scan paused", checkpointDone)
 	requireLeafGenerationOperationCompletes(t, "SetSync queued after Checkpoint", setDone)
 	releaseScan()
-	_ = requireLeafGenerationGCResult(t, gcDone)
+	_ = requireLeafGenerationGCResultAllowRecoverableStale(t, gcDone)
 
 	got, err := db.Get([]byte("checkpoint-scan-concurrent"))
 	if err != nil {
@@ -511,7 +525,7 @@ func TestLeafGenerationGC_RevalidationFailureSkipsStalePublish(t *testing.T) {
 		t.Fatalf("concurrent write did not advance CommitSeq: before=%+v after=%+v", before, afterWrite)
 	}
 	releaseScan()
-	stats := requireLeafGenerationGCResult(t, done)
+	stats := requireLeafGenerationGCResultAllowRecoverableStale(t, done)
 	if stats.GenerationsDeleted != 0 || stats.FilesDeleted != 0 {
 		t.Fatalf("stale scan applied deletion: stats=%+v", stats)
 	}
@@ -1381,6 +1395,10 @@ func TestLeafGenerationGC_RetiresPinnedGenerationUntilSnapshotCloses(t *testing.
 		closeNoErr(t, snap)
 		t.Fatalf("pin count after republish=%d, want %d", got, want)
 	}
+	// Rotate both durable slots past the old generation so this assertion
+	// isolates the user snapshot pin rather than the independently recoverable
+	// fallback meta root now included by RecoverableRootSet.
+	advancePastRetainedDurableSlotForTest(t, db)
 
 	stats1, err := db.LeafGenerationGC(context.Background(), LeafGenerationGCOptions{})
 	if err != nil {
@@ -1421,7 +1439,6 @@ func TestLeafGenerationGC_RetiresPinnedGenerationUntilSnapshotCloses(t *testing.
 		t.Fatalf("pin count after close=%d, want 0", got)
 	}
 
-	advancePastRetainedDurableSlotForTest(t, db)
 	stats2, err := db.LeafGenerationGC(context.Background(), LeafGenerationGCOptions{})
 	if err != nil {
 		t.Fatalf("LeafGenerationGC after close: %v", err)

--- a/TreeDB/db/leaf_generation_gc_test.go
+++ b/TreeDB/db/leaf_generation_gc_test.go
@@ -778,6 +778,38 @@ func TestLeafGenerationGC_DeletesFullyDeadGeneration(t *testing.T) {
 	}
 }
 
+func TestLeafGenerationGC_DryRunRetainsOlderRecoverableRootGeneration(t *testing.T) {
+	db, leafLog := openLeafGenerationGCTestDB(t)
+
+	writeLeafGenerationKeys(t, db, "recoverable", 64, 'a')
+	path1, fileID1 := currentLeafSegmentOrFatal(t, leafLog)
+	rawFileID1 := page.ValueLogSegmentID(fileID1)
+	if err := leafLog.rotateLeaf(); err != nil {
+		t.Fatalf("rotateLeaf: %v", err)
+	}
+	writeLeafGenerationKeys(t, db, "recoverable", 64, 'b')
+
+	manifest := loadLeafGenerationManifestOrFatal(t, db.dir)
+	gen1 := findLeafGenerationByFileID(t, manifest, rawFileID1)
+	if got, want := gen1.State, leafGenerationStateSealed; got != want {
+		t.Fatalf("older generation state=%q, want %q", got, want)
+	}
+
+	stats, err := db.LeafGenerationGC(context.Background(), LeafGenerationGCOptions{DryRun: true})
+	if err != nil {
+		t.Fatalf("LeafGenerationGC dry-run: %v", err)
+	}
+	if got, want := stats.GenerationsRetiring, 1; got != want {
+		t.Fatalf("GenerationsRetiring=%d, want %d for older recoverable root (stats=%+v)", got, want, stats)
+	}
+	if stats.GenerationsEligible != 0 || stats.BytesEligible != 0 {
+		t.Fatalf("dry-run reported older recoverable generation eligible: %+v", stats)
+	}
+	if _, err := os.Stat(path1); err != nil {
+		t.Fatalf("dry-run disturbed older recoverable generation: %v", err)
+	}
+}
+
 func TestLeafPageLogLanes_CheckpointReopenPublishesEveryCurrentLane(t *testing.T) {
 	db, leafLog, opts := openLeafLogLaneGCTestDB(t, 0)
 	closed := false

--- a/TreeDB/db/maintenance_reachability.go
+++ b/TreeDB/db/maintenance_reachability.go
@@ -15,6 +15,7 @@ const (
 	maintenanceReachabilityValueLogRefCounts maintenanceReachabilityCollectors = 1 << iota
 	maintenanceReachabilityValueLogLiveBytes
 	maintenanceReachabilityLeafGenerationTotals
+	maintenanceReachabilityLeafFileIDs
 )
 
 func (c maintenanceReachabilityCollectors) has(want maintenanceReachabilityCollectors) bool {
@@ -22,10 +23,11 @@ func (c maintenanceReachabilityCollectors) has(want maintenanceReachabilityColle
 }
 
 type maintenanceReachabilityScanOptions struct {
-	Collectors              maintenanceReachabilityCollectors
-	ProtectedRootIDs        []uint64
-	ProtectedSystemRootIDs  []uint64
-	DisableLeafSubtreeCache bool
+	Collectors               maintenanceReachabilityCollectors
+	ProtectedRootIDs         []uint64
+	ProtectedSystemRootIDs   []uint64
+	ProjectProtectedValueLog bool
+	DisableLeafSubtreeCache  bool
 }
 
 type maintenanceReachabilityResult struct {
@@ -33,6 +35,7 @@ type maintenanceReachabilityResult struct {
 	valueLogReferencedSegments map[uint32]struct{}
 	valueLogLiveBytesBySegment map[uint32]int64
 	leafGenerationLive         leafGenerationLiveScanStats
+	leafFileIDs                map[uint32]struct{}
 	counters                   CompactStorageAuditStats
 
 	// Internal evidence for collector-selection tests. These count actual
@@ -41,7 +44,7 @@ type maintenanceReachabilityResult struct {
 	leafFrameProjections uint64
 }
 
-func maintenanceReachabilityRoots(ctx context.Context, snap *Snapshot, protectedRootIDs, protectedSystemRootIDs []uint64, projectValueLog bool) ([]maintenanceRoot, int, error) {
+func maintenanceReachabilityRoots(ctx context.Context, snap *Snapshot, protectedRootIDs, protectedSystemRootIDs []uint64, projectValueLog, projectProtectedValueLog bool) ([]maintenanceRoot, int, error) {
 	roots, err := maintenanceRootsForSnapshotWithContext(ctx, snap)
 	if err != nil {
 		return nil, 0, err
@@ -80,6 +83,13 @@ func maintenanceReachabilityRoots(ctx context.Context, snap *Snapshot, protected
 			addProtected(root)
 		}
 	}
+	if projectValueLog && projectProtectedValueLog {
+		// Protected roots are independently recovery-selectable, so value-log
+		// projection must include them just like the snapshot's current roots.
+		// Returning the pre-protection count would walk these roots only for leaf
+		// generations and silently omit their ValuePtr references.
+		return roots, len(roots), nil
+	}
 	return roots, valueLogRootCount, nil
 }
 
@@ -93,7 +103,9 @@ func (db *DB) maintenanceReachabilityScan(ctx context.Context, snap *Snapshot, o
 	}
 	collectRefs := opts.Collectors.has(maintenanceReachabilityValueLogRefCounts)
 	collectLive := opts.Collectors.has(maintenanceReachabilityValueLogLiveBytes)
-	collectLeaf := opts.Collectors.has(maintenanceReachabilityLeafGenerationTotals)
+	collectLeafTotals := opts.Collectors.has(maintenanceReachabilityLeafGenerationTotals)
+	collectLeafFiles := opts.Collectors.has(maintenanceReachabilityLeafFileIDs)
+	collectLeaf := collectLeafTotals || collectLeafFiles
 	collectValueLog := collectRefs || collectLive
 	if collectRefs {
 		result.valueLogRefCounts = make(map[uint32]uint64)
@@ -102,8 +114,11 @@ func (db *DB) maintenanceReachabilityScan(ctx context.Context, snap *Snapshot, o
 	if collectLive {
 		result.valueLogLiveBytesBySegment = make(map[uint32]int64)
 	}
-	if collectLeaf {
+	if collectLeafTotals {
 		result.leafGenerationLive.Generations = make(map[uint64]leafGenerationLiveTotals)
+	}
+	if collectLeafFiles {
+		result.leafFileIDs = make(map[uint32]struct{})
 	}
 	if opts.Collectors == 0 {
 		return result, nil
@@ -111,13 +126,16 @@ func (db *DB) maintenanceReachabilityScan(ctx context.Context, snap *Snapshot, o
 
 	var leafScan *leafGenerationScanContext
 	var err error
-	if collectLeaf {
+	if collectLeafTotals {
 		leafScan, err = db.newLeafGenerationScanContext(snap)
 		if err != nil {
 			return result, err
 		}
 	}
-	roots, valueLogRootCount, err := maintenanceReachabilityRoots(ctx, snap, opts.ProtectedRootIDs, opts.ProtectedSystemRootIDs, collectValueLog)
+	roots, valueLogRootCount, err := maintenanceReachabilityRoots(
+		ctx, snap, opts.ProtectedRootIDs, opts.ProtectedSystemRootIDs,
+		collectValueLog, opts.ProjectProtectedValueLog,
+	)
 	if err != nil {
 		return result, err
 	}
@@ -147,7 +165,7 @@ func (db *DB) maintenanceReachabilityScan(ctx context.Context, snap *Snapshot, o
 		}
 	}
 	verifyAlways := snap.idx.pager.VerifyOnRead()
-	leafCacheOnly := collectLeaf && !collectValueLog && !opts.DisableLeafSubtreeCache && !verifyAlways
+	leafCacheOnly := collectLeafTotals && !collectLeafFiles && !collectValueLog && !opts.DisableLeafSubtreeCache && !verifyAlways
 	var memo map[uint64]memoEntry
 	var leafMemo map[uint64]leafGenerationSubtreeStats
 	if collectValueLog {
@@ -356,6 +374,9 @@ func (db *DB) maintenanceReachabilityScan(ctx context.Context, snap *Snapshot, o
 			}
 			children := childStacks[depth][:0]
 			err := n.WalkInternalChildren(&children, func(ptr page.LeafLogPtr) error {
+				if collectLeafFiles && ptr.FileID != 0 {
+					result.leafFileIDs[ptr.FileID] = struct{}{}
+				}
 				if leafScan != nil {
 					result.leafFrameProjections++
 					var visitErr error
@@ -389,7 +410,7 @@ func (db *DB) maintenanceReachabilityScan(ctx context.Context, snap *Snapshot, o
 		} else {
 			leafMemo[pageID] = entry.leafTotals
 		}
-		if collectLeaf && !opts.DisableLeafSubtreeCache && !verifyAlways {
+		if collectLeafTotals && !opts.DisableLeafSubtreeCache && !verifyAlways {
 			db.storeLeafGenerationSubtreeStats(pageID, entry.leafTotals)
 		}
 		return entry.leafTotals, nil
@@ -442,7 +463,7 @@ func (db *DB) maintenanceReachabilityScan(ctx context.Context, snap *Snapshot, o
 		if err != nil {
 			return result, err
 		}
-		if collectLeaf {
+		if collectLeafTotals {
 			result.leafGenerationLive.Generations = mergeLeafGenerationTotals(result.leafGenerationLive.Generations, stats)
 		}
 		if valueLogProjection && !directValueLogProjection {

--- a/TreeDB/db/recoverable_root_set.go
+++ b/TreeDB/db/recoverable_root_set.go
@@ -94,14 +94,30 @@ func (db *DB) CaptureRecoverableRootSet(ctx context.Context) (*RecoverableRootSe
 const recoverableRootSetCaptureAttempts = 8
 
 func (db *DB) captureRecoverableRootSetWithMaintenanceLockHeld(ctx context.Context) (*RecoverableRootSet, error) {
+	return db.captureRecoverableRootSetWithMaintenanceLockHeldMode(ctx, true)
+}
+
+// captureRecoverableRootSetForInspectionWithMaintenanceLockHeld captures the
+// same recovery closure for read-only audit paths. Unlike the destructive
+// capability path, it remains available on read-only or recovery-required
+// handles because callers may only inspect the captured roots and resources.
+func (db *DB) captureRecoverableRootSetForInspectionWithMaintenanceLockHeld(ctx context.Context) (*RecoverableRootSet, error) {
+	return db.captureRecoverableRootSetWithMaintenanceLockHeldMode(ctx, false)
+}
+
+func (db *DB) captureRecoverableRootSetWithMaintenanceLockHeldMode(ctx context.Context, requireMaintenanceReady bool) (*RecoverableRootSet, error) {
 	if ctx == nil {
 		ctx = context.Background()
 	}
 	if err := ctx.Err(); err != nil {
 		return nil, err
 	}
-	if err := db.CheckStorageMaintenanceReady(); err != nil {
-		return nil, err
+	if requireMaintenanceReady {
+		if err := db.CheckStorageMaintenanceReady(); err != nil {
+			return nil, err
+		}
+	} else if db == nil || db.closing.Load() {
+		return nil, ErrClosed
 	}
 	stable := db.acquireStableSnapshotWithMaintenanceLockHeld()
 	if stable == nil || stable.idx == nil || stable.idx.registry == nil {

--- a/TreeDB/db/recoverable_root_set.go
+++ b/TreeDB/db/recoverable_root_set.go
@@ -179,8 +179,8 @@ func (db *DB) tryCaptureRecoverableRootSet(stable *Snapshot) (*RecoverableRootSe
 		}
 	}()
 
-	db.rootReuseMu.RLock()
 	db.durablePublishMu.Lock()
+	db.rootReuseMu.RLock()
 	durable := recoverableDurableBasis{
 		slot: db.durableRoot.slot, slotCommit: db.durableRoot.slotCommit,
 		slotRecord: db.durableRoot.slotRecord, pending: db.durableRoot.pending,

--- a/TreeDB/db/recoverable_root_set.go
+++ b/TreeDB/db/recoverable_root_set.go
@@ -1,0 +1,571 @@
+package db
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"math"
+	"os"
+	"sync"
+	"sync/atomic"
+
+	"github.com/snissn/gomap/TreeDB/internal/rootpublication"
+	"github.com/snissn/gomap/TreeDB/page"
+)
+
+// ErrRecoverableRootSetStale reports that a recovery-selectable root changed
+// after a maintenance plan captured its authority. Callers must rebuild the
+// plan; destructive work must not retry from the stale capability.
+var ErrRecoverableRootSetStale = errors.New("treedb: recoverable root set changed")
+
+// RecoverableRoot is an immutable scalar root that was visible, durable, or
+// queued when a RecoverableRootSet was captured.
+type RecoverableRoot struct {
+	CommitSeq         uint64
+	UserRootPageID    uint64
+	SystemRootPageID  uint64
+	AppliedCommandLSN uint64
+	MaxEntryRevision  uint64
+	Durable           bool
+	Visible           bool
+}
+
+type recoverableDurableBasis struct {
+	slot       uint64
+	slotCommit [2]uint64
+	slotRecord [2]rootpublication.DurableRootRecordV1
+	pending    *durableRootPublishCandidateV1
+	ambiguous  []*durableRootPublishCandidateV1
+}
+
+func (basis recoverableDurableBasis) equal(other recoverableDurableBasis) bool {
+	if basis.slot != other.slot || basis.slotCommit != other.slotCommit || basis.slotRecord != other.slotRecord || basis.pending != other.pending || len(basis.ambiguous) != len(other.ambiguous) {
+		return false
+	}
+	for i := range basis.ambiguous {
+		if basis.ambiguous[i] != other.ambiguous[i] {
+			return false
+		}
+	}
+	return true
+}
+
+type recoverableIdentityPin struct {
+	identity rootpublication.StableIdentity
+	pin      *rootpublication.IdentityPin
+}
+
+// RecoverableRootSet is an opaque, DB-minted maintenance capability. Its
+// fields are deliberately private: callers can inspect copied roots, acquire
+// root-bound snapshots, add exact physical pins discovered while traversing a
+// root, revalidate, and release, but cannot manufacture authority.
+type RecoverableRootSet struct {
+	db *DB
+
+	roots               []RecoverableRoot
+	visible             StateToken
+	durable             recoverableDurableBasis
+	coordinator         *rootpublication.Coordinator
+	coordinatorEpoch    uint64
+	idx                 *indexGen
+	stableSnapshot      *Snapshot
+	oldestRegistryID    int64
+	systemRootEpoch     uint64
+	resources           []*rootpublication.StableResourceSet
+	identityPinRegistry *rootpublication.IdentityPinRegistry
+
+	mu           sync.Mutex
+	identityPins map[rootpublication.StableIdentity]recoverableIdentityPin
+	released     atomic.Bool
+}
+
+// CaptureRecoverableRootSet captures the exact bounded recovery closure while
+// serializing with storage maintenance admission.
+func (db *DB) CaptureRecoverableRootSet(ctx context.Context) (*RecoverableRootSet, error) {
+	if db == nil {
+		return nil, ErrClosed
+	}
+	db.maintenanceMu.Lock()
+	defer db.maintenanceMu.Unlock()
+	return db.captureRecoverableRootSetWithMaintenanceLockHeld(ctx)
+}
+
+const recoverableRootSetCaptureAttempts = 8
+
+func (db *DB) captureRecoverableRootSetWithMaintenanceLockHeld(ctx context.Context) (*RecoverableRootSet, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	if err := db.CheckStorageMaintenanceReady(); err != nil {
+		return nil, err
+	}
+	stable := db.acquireStableSnapshotWithMaintenanceLockHeld()
+	if stable == nil || stable.idx == nil || stable.idx.registry == nil {
+		if stable != nil {
+			_ = stable.Close()
+		}
+		return nil, errors.New("treedb: capture recoverable root set stable index")
+	}
+
+	for attempt := 0; attempt < recoverableRootSetCaptureAttempts; attempt++ {
+		if err := ctx.Err(); err != nil {
+			_ = stable.Close()
+			return nil, err
+		}
+		capability, retry, err := db.tryCaptureRecoverableRootSet(stable)
+		if err != nil {
+			_ = stable.Close()
+			return nil, err
+		}
+		if !retry {
+			return capability, nil
+		}
+	}
+	_ = stable.Close()
+	return nil, fmt.Errorf("%w: capture did not converge", ErrRecoverableRootSetStale)
+}
+
+func (db *DB) tryCaptureRecoverableRootSet(stable *Snapshot) (*RecoverableRootSet, bool, error) {
+	var coordinator *rootpublication.Coordinator
+	if db.rootPublication != nil {
+		coordinator = db.rootPublication.coordinator
+	}
+	var coordinatorView rootpublication.ReachabilitySnapshot
+	var err error
+	if coordinator != nil {
+		coordinatorView, err = coordinator.CaptureReachability()
+		if err != nil {
+			return nil, false, publicRootPublicationErrorV1(err)
+		}
+	}
+	releaseCoordinator := true
+	defer func() {
+		if releaseCoordinator {
+			coordinatorView.Release()
+		}
+	}()
+
+	var visibleResources *rootpublication.StableResourceSet
+	if db.rootPublication != nil {
+		visibleResources, err = db.rootPublication.cloneVisibleResources()
+		if err != nil {
+			return nil, false, err
+		}
+	}
+	releaseVisible := true
+	defer func() {
+		if releaseVisible {
+			visibleResources.Release()
+		}
+	}()
+
+	db.rootReuseMu.RLock()
+	db.durablePublishMu.Lock()
+	durable := recoverableDurableBasis{
+		slot: db.durableRoot.slot, slotCommit: db.durableRoot.slotCommit,
+		slotRecord: db.durableRoot.slotRecord, pending: db.durableRoot.pending,
+		ambiguous: append([]*durableRootPublishCandidateV1(nil), db.durableRoot.ambiguous...),
+	}
+	sources := make([]*rootpublication.StableResourceSet, 0, 5+len(db.durableRoot.ambiguous))
+	sources = append(sources, db.durableRoot.slotResources[:]...)
+	if pending := db.durableRoot.pending; pending != nil {
+		sources = append(sources, pending.resources)
+	}
+	for _, ambiguous := range db.durableRoot.ambiguous {
+		if ambiguous != nil {
+			sources = append(sources, ambiguous.resources)
+		}
+	}
+	durableResources, cloneErr := cloneRecoverableResourceUnion(sources...)
+	db.durablePublishMu.Unlock()
+	if cloneErr != nil {
+		db.rootReuseMu.RUnlock()
+		return nil, false, cloneErr
+	}
+
+	state, ok := db.StateToken()
+	if !ok || stable.idx != db.idx.Load() {
+		db.rootReuseMu.RUnlock()
+		durableResources.Release()
+		return nil, true, nil
+	}
+	roots := recoverableRootsForBasis(state, durable, coordinatorView)
+	oldest := state.CommitSeq
+	for _, root := range roots {
+		if root.CommitSeq != 0 && (oldest == 0 || root.CommitSeq < oldest) {
+			oldest = root.CommitSeq
+		}
+	}
+	oldestRegistryID, _ := stable.idx.registry.RegisterWithHint(oldest, -1)
+	systemRootEpoch := db.systemRootPublishEpoch.Load()
+	db.rootReuseMu.RUnlock()
+
+	cleanupRetry := func() {
+		if oldestRegistryID != 0 {
+			stable.idx.registry.Unregister(oldestRegistryID)
+		}
+		durableResources.Release()
+	}
+	if coordinator != nil {
+		if err := coordinator.RevalidateReachability(coordinatorView.Epoch); err != nil {
+			cleanupRetry()
+			if errors.Is(err, rootpublication.ErrInvalidCandidate) {
+				return nil, true, nil
+			}
+			return nil, false, publicRootPublicationErrorV1(err)
+		}
+		if coordinatorView.Visible.CommitSeq() != state.CommitSeq || coordinatorView.Visible.UserRootPageID() != state.RootPageID || coordinatorView.Visible.SystemRootPageID() != state.SystemRootPageID || coordinatorView.Visible.AppliedCommandLSN() != state.AppliedCommandLSN || coordinatorView.Visible.MaxEntryRevision() != uint64(state.MaxEntryRevision) || coordinatorView.Durable.CommitSeq() != durable.slotRecord[durable.slot].CommitSeq {
+			cleanupRetry()
+			return nil, true, nil
+		}
+	}
+	current, ok := db.StateToken()
+	if !ok || current != state || db.idx.Load() != stable.idx || db.systemRootPublishEpoch.Load() != systemRootEpoch {
+		cleanupRetry()
+		return nil, true, nil
+	}
+	db.durablePublishMu.Lock()
+	currentDurable := recoverableDurableBasis{
+		slot: db.durableRoot.slot, slotCommit: db.durableRoot.slotCommit,
+		slotRecord: db.durableRoot.slotRecord, pending: db.durableRoot.pending,
+		ambiguous: append([]*durableRootPublishCandidateV1(nil), db.durableRoot.ambiguous...),
+	}
+	db.durablePublishMu.Unlock()
+	if !durable.equal(currentDurable) {
+		cleanupRetry()
+		return nil, true, nil
+	}
+
+	resources := make([]*rootpublication.StableResourceSet, 0, 3)
+	if durableResources != nil {
+		resources = append(resources, durableResources)
+	}
+	if coordinatorView.Resources != nil {
+		resources = append(resources, coordinatorView.Resources)
+		coordinatorView.Resources = nil
+	}
+	if visibleResources != nil {
+		resources = append(resources, visibleResources)
+		visibleResources = nil
+	}
+	releaseCoordinator = false
+	releaseVisible = false
+	return &RecoverableRootSet{
+		db: db, roots: roots, visible: state, durable: durable,
+		coordinator: coordinator, coordinatorEpoch: coordinatorView.Epoch,
+		idx: stable.idx, stableSnapshot: stable, oldestRegistryID: oldestRegistryID,
+		systemRootEpoch: systemRootEpoch, resources: resources,
+		identityPinRegistry: db.StableResourceIdentityPinRegistry(),
+		identityPins:        make(map[rootpublication.StableIdentity]recoverableIdentityPin),
+	}, false, nil
+}
+
+func cloneRecoverableResourceUnion(sources ...*rootpublication.StableResourceSet) (*rootpublication.StableResourceSet, error) {
+	filtered := sources[:0]
+	for _, source := range sources {
+		if source != nil {
+			filtered = append(filtered, source)
+		}
+	}
+	if len(filtered) == 0 {
+		return nil, nil
+	}
+	view, err := rootpublication.UnionStableResourceSets(filtered...)
+	if err != nil {
+		return nil, err
+	}
+	return rootpublication.CloneStableResourceSetExcludingKinds(view)
+}
+
+func recoverableRootsForBasis(state StateToken, durable recoverableDurableBasis, coordinator rootpublication.ReachabilitySnapshot) []RecoverableRoot {
+	roots := make([]RecoverableRoot, 0, 6+len(coordinator.Pending)+len(durable.ambiguous))
+	add := func(root RecoverableRoot) {
+		if root.CommitSeq == 0 || root.UserRootPageID == 0 || root.SystemRootPageID == 0 {
+			return
+		}
+		for i := range roots {
+			if roots[i].CommitSeq == root.CommitSeq &&
+				roots[i].UserRootPageID == root.UserRootPageID &&
+				roots[i].SystemRootPageID == root.SystemRootPageID &&
+				roots[i].AppliedCommandLSN == root.AppliedCommandLSN &&
+				roots[i].MaxEntryRevision == root.MaxEntryRevision {
+				roots[i].Durable = roots[i].Durable || root.Durable
+				roots[i].Visible = roots[i].Visible || root.Visible
+				return
+			}
+		}
+		roots = append(roots, root)
+	}
+	for _, record := range durable.slotRecord {
+		add(RecoverableRoot{
+			CommitSeq: record.CommitSeq, UserRootPageID: record.UserRootPageID, SystemRootPageID: record.SystemRootPageID,
+			AppliedCommandLSN: record.AppliedCommandLSN, MaxEntryRevision: record.MaxEntryRevision, Durable: true,
+		})
+	}
+	if durable.pending != nil {
+		next := durable.pending.next
+		add(recoverableRootFromMeta(next, false, true))
+	}
+	for _, ambiguous := range durable.ambiguous {
+		if ambiguous != nil {
+			add(recoverableRootFromMeta(ambiguous.next, false, true))
+		}
+	}
+	add(RecoverableRoot{
+		CommitSeq: state.CommitSeq, UserRootPageID: state.RootPageID, SystemRootPageID: state.SystemRootPageID,
+		AppliedCommandLSN: state.AppliedCommandLSN, MaxEntryRevision: uint64(state.MaxEntryRevision), Visible: true,
+	})
+	add(recoverableRootFromFrontier(coordinator.Visible, false, true))
+	add(recoverableRootFromFrontier(coordinator.Durable, true, false))
+	for _, pending := range coordinator.Pending {
+		add(recoverableRootFromFrontier(pending, false, true))
+	}
+	return roots
+}
+
+func recoverableRootFromMeta(meta page.MetaPageBody, durable, visible bool) RecoverableRoot {
+	return RecoverableRoot{
+		CommitSeq: meta.CommitSeq, UserRootPageID: meta.UserRootPageID, SystemRootPageID: meta.SystemRootPageID,
+		AppliedCommandLSN: meta.AppliedCommandLSN, MaxEntryRevision: meta.MaxEntryRevision,
+		Durable: durable, Visible: visible,
+	}
+}
+
+func recoverableRootFromFrontier(frontier rootpublication.Frontier, durable, visible bool) RecoverableRoot {
+	return RecoverableRoot{
+		CommitSeq: frontier.CommitSeq(), UserRootPageID: frontier.UserRootPageID(), SystemRootPageID: frontier.SystemRootPageID(),
+		AppliedCommandLSN: frontier.AppliedCommandLSN(), MaxEntryRevision: frontier.MaxEntryRevision(),
+		Durable: durable, Visible: visible,
+	}
+}
+
+// Roots returns a copy of the captured recovery-selectable scalar roots.
+func (set *RecoverableRootSet) Roots() []RecoverableRoot {
+	if set == nil || set.released.Load() {
+		return nil
+	}
+	return append([]RecoverableRoot(nil), set.roots...)
+}
+
+// RequiresReplayBefore reports whether at least one captured recovery root
+// would have to replay through appliedLSN. Maintenance uses this bounded
+// scalar proof to retain resources superseded by a command until every
+// independently recoverable durable generation has crossed that command.
+func (set *RecoverableRootSet) RequiresReplayBefore(appliedLSN uint64) bool {
+	if set == nil || set.released.Load() || appliedLSN == 0 {
+		return false
+	}
+	for _, root := range set.roots {
+		if root.AppliedCommandLSN < appliedLSN {
+			return true
+		}
+	}
+	return false
+}
+
+func (set *RecoverableRootSet) leafGenerationIDsForFiles(fileIDs map[uint32]struct{}, current *leafGenerationView) (map[uint64]struct{}, error) {
+	live := make(map[uint64]struct{})
+	unresolved := make(map[uint32]struct{}, len(fileIDs))
+	for fileID := range fileIDs {
+		if fileID != 0 {
+			unresolved[fileID] = struct{}{}
+		}
+	}
+	consumeManifest := func(manifest *leafGenerationManifest) {
+		if manifest == nil {
+			return
+		}
+		for _, generation := range manifest.Generations {
+			for _, fileID := range generation.FileIDs {
+				if _, ok := fileIDs[fileID]; !ok {
+					continue
+				}
+				live[generation.GenerationID] = struct{}{}
+				delete(unresolved, fileID)
+			}
+		}
+	}
+	if current != nil {
+		consumeManifest(current.sourceManifest)
+	}
+	seen := make(map[rootpublication.StableIdentity]struct{})
+	for _, resources := range set.resources {
+		for _, token := range resources.Tokens() {
+			if token == nil || token.Kind() != rootpublication.ResourceOuterLeafManifest {
+				continue
+			}
+			identity := token.Identity()
+			if _, ok := seen[identity]; ok {
+				continue
+			}
+			seen[identity] = struct{}{}
+			frontier := token.Frontier()
+			if frontier.Bytes == 0 || frontier.Bytes > math.MaxInt64 {
+				return nil, fmt.Errorf("%w: recoverable outer-leaf manifest has invalid frontier", rootpublication.ErrFrontierBeyondResource)
+			}
+			var data []byte
+			if err := token.WithPinnedFile(func(file *os.File) error {
+				var readErr error
+				data, readErr = io.ReadAll(io.NewSectionReader(file, 0, int64(frontier.Bytes)))
+				return readErr
+			}); err != nil {
+				return nil, err
+			}
+			manifest, err := decodeLeafGenerationManifest(data, token.ResourceID())
+			if err != nil {
+				return nil, err
+			}
+			// A recycled file ID can legitimately map to different generations in
+			// independently recoverable manifests. Preserve every matching
+			// generation rather than collapsing by the scalar file ID.
+			consumeManifest(manifest)
+		}
+	}
+	if len(unresolved) != 0 {
+		return nil, fmt.Errorf("treedb: recoverable leaf files have no retained generation manifest: %v", unresolved)
+	}
+	return live, nil
+}
+
+// AcquireSnapshotForRoot returns a snapshot rebound to one captured root. The
+// capability's oldest-sequence registry pin prevents page reuse while this
+// bounded traversal is in progress.
+func (set *RecoverableRootSet) AcquireSnapshotForRoot(root RecoverableRoot) *Snapshot {
+	if set == nil || set.released.Load() || set.db == nil || !set.containsRoot(root) {
+		return nil
+	}
+	if err := set.Revalidate(); err != nil {
+		return nil
+	}
+	snapshot := set.db.AcquireSnapshot()
+	if snapshot == nil {
+		return nil
+	}
+	if snapshot.idx != set.idx {
+		_ = snapshot.Close()
+		return nil
+	}
+	state := cloneDBState(snapshot.state)
+	if state == nil {
+		_ = snapshot.Close()
+		return nil
+	}
+	state.CommitSeq = root.CommitSeq
+	state.RootPageID = root.UserRootPageID
+	state.SystemRootPageID = root.SystemRootPageID
+	state.AppliedCommandLSN = root.AppliedCommandLSN
+	state.MaxEntryRevision = page.EntryRevision(root.MaxEntryRevision)
+	snapshot.state = state
+	snapshot.tree.Reset(snapshot.idx.pager, &snapshot.reader, state.RootPageID)
+	snapshot.treePager = snapshot.idx.pager
+	snapshot.treeRoot = state.RootPageID
+	return snapshot
+}
+
+func (set *RecoverableRootSet) containsRoot(root RecoverableRoot) bool {
+	for _, candidate := range set.roots {
+		if candidate.CommitSeq == root.CommitSeq &&
+			candidate.UserRootPageID == root.UserRootPageID &&
+			candidate.SystemRootPageID == root.SystemRootPageID &&
+			candidate.AppliedCommandLSN == root.AppliedCommandLSN &&
+			candidate.MaxEntryRevision == root.MaxEntryRevision {
+			return true
+		}
+	}
+	return false
+}
+
+// PinStableFile adds an exact physical deletion pin discovered while walking a
+// captured root. Duplicate aliases of the same inode coalesce within the
+// capability.
+func (set *RecoverableRootSet) PinStableFile(file *os.File) error {
+	if set == nil || set.released.Load() || set.identityPinRegistry == nil {
+		return ErrRecoverableRootSetStale
+	}
+	identity, err := rootpublication.StableIdentityFromFile(file)
+	if err != nil {
+		return err
+	}
+	identity.Generation = 0
+	set.mu.Lock()
+	defer set.mu.Unlock()
+	if set.released.Load() {
+		return ErrRecoverableRootSetStale
+	}
+	if _, ok := set.identityPins[identity]; ok {
+		return nil
+	}
+	if err := set.identityPinRegistry.Observe(identity); err != nil {
+		return err
+	}
+	pin, err := set.identityPinRegistry.Pin(identity)
+	if err != nil {
+		_ = set.identityPinRegistry.Unobserve(identity)
+		return err
+	}
+	set.identityPins[identity] = recoverableIdentityPin{identity: identity, pin: pin}
+	return nil
+}
+
+// Revalidate proves that the captured visible/durable root basis and exact
+// coordinator debt are still current immediately before destructive mutation.
+func (set *RecoverableRootSet) Revalidate() error {
+	if set == nil || set.released.Load() || set.db == nil {
+		return ErrRecoverableRootSetStale
+	}
+	if set.coordinator != nil {
+		if err := set.coordinator.RevalidateReachability(set.coordinatorEpoch); err != nil {
+			return errors.Join(ErrRecoverableRootSetStale, publicRootPublicationErrorV1(err))
+		}
+	}
+	state, ok := set.db.StateToken()
+	if !ok || state != set.visible || set.db.idx.Load() != set.idx || set.db.systemRootPublishEpoch.Load() != set.systemRootEpoch {
+		return ErrRecoverableRootSetStale
+	}
+	set.db.durablePublishMu.Lock()
+	current := recoverableDurableBasis{
+		slot: set.db.durableRoot.slot, slotCommit: set.db.durableRoot.slotCommit,
+		slotRecord: set.db.durableRoot.slotRecord, pending: set.db.durableRoot.pending,
+		ambiguous: append([]*durableRootPublishCandidateV1(nil), set.db.durableRoot.ambiguous...),
+	}
+	set.db.durablePublishMu.Unlock()
+	if !set.durable.equal(current) {
+		return ErrRecoverableRootSetStale
+	}
+	return nil
+}
+
+// Release drops every stable resource, exact identity, sequence, and index pin
+// owned by the capability. It is safe to call repeatedly.
+func (set *RecoverableRootSet) Release() {
+	if set == nil || !set.released.CompareAndSwap(false, true) {
+		return
+	}
+	set.mu.Lock()
+	pins := make([]recoverableIdentityPin, 0, len(set.identityPins))
+	for _, pin := range set.identityPins {
+		pins = append(pins, pin)
+	}
+	set.identityPins = nil
+	set.mu.Unlock()
+	for _, owned := range pins {
+		owned.pin.Release()
+		_ = set.identityPinRegistry.Unobserve(owned.identity)
+	}
+	for _, resources := range set.resources {
+		resources.Release()
+	}
+	set.resources = nil
+	if set.oldestRegistryID != 0 && set.idx != nil && set.idx.registry != nil {
+		set.idx.registry.Unregister(set.oldestRegistryID)
+		set.oldestRegistryID = 0
+	}
+	if set.stableSnapshot != nil {
+		_ = set.stableSnapshot.Close()
+		set.stableSnapshot = nil
+	}
+}

--- a/TreeDB/db/recoverable_root_set_bench_test.go
+++ b/TreeDB/db/recoverable_root_set_bench_test.go
@@ -1,0 +1,55 @@
+package db
+
+import (
+	"context"
+	"fmt"
+	"testing"
+)
+
+// BenchmarkRecoverableRootSetCaptureRevalidate is the committed #3681 fixture
+// for protected-set construction. Varying the logical key count while keeping
+// publication debt fixed makes accidental tree-size-dependent capture work
+// visible in both latency and allocations.
+func BenchmarkRecoverableRootSetCaptureRevalidate(b *testing.B) {
+	for _, keys := range []int{0, 16 * 1024} {
+		b.Run(fmt.Sprintf("keys=%d", keys), func(b *testing.B) {
+			database, err := Open(Options{Dir: b.TempDir(), DisableBackgroundPrune: true})
+			if err != nil {
+				b.Fatalf("Open: %v", err)
+			}
+			b.Cleanup(func() { _ = database.Close() })
+			if keys != 0 {
+				batch := database.NewBatchWithSize(keys)
+				for i := 0; i < keys; i++ {
+					key := []byte(fmt.Sprintf("recoverable-root-set-%08d", i))
+					if err := batch.Set(key, []byte("fixture-value")); err != nil {
+						_ = batch.Close()
+						b.Fatalf("Set fixture key %d: %v", i, err)
+					}
+				}
+				if err := batch.WriteSync(); err != nil {
+					_ = batch.Close()
+					b.Fatalf("WriteSync fixture: %v", err)
+				}
+				if err := batch.Close(); err != nil {
+					b.Fatalf("Close fixture batch: %v", err)
+				}
+			}
+
+			b.ReportAllocs()
+			b.ReportMetric(float64(keys), "fixture-keys")
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				set, err := database.CaptureRecoverableRootSet(context.Background())
+				if err != nil {
+					b.Fatalf("CaptureRecoverableRootSet: %v", err)
+				}
+				if err := set.Revalidate(); err != nil {
+					set.Release()
+					b.Fatalf("Revalidate: %v", err)
+				}
+				set.Release()
+			}
+		})
+	}
+}

--- a/TreeDB/db/recoverable_root_set_test.go
+++ b/TreeDB/db/recoverable_root_set_test.go
@@ -1,0 +1,185 @@
+package db
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/snissn/gomap/TreeDB/internal/rootpublication"
+)
+
+func TestRecoverableRootSetIncludesBothDurableSlotsAndRevalidates(t *testing.T) {
+	database, err := Open(Options{Dir: t.TempDir(), DisableBackgroundPrune: true})
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer func() { _ = database.Close() }()
+
+	if err := database.SetSync([]byte("one"), []byte("1")); err != nil {
+		t.Fatalf("SetSync one: %v", err)
+	}
+	if err := database.SetSync([]byte("two"), []byte("2")); err != nil {
+		t.Fatalf("SetSync two: %v", err)
+	}
+
+	set, err := database.CaptureRecoverableRootSet(context.Background())
+	if err != nil {
+		t.Fatalf("CaptureRecoverableRootSet: %v", err)
+	}
+	defer set.Release()
+	if err := set.Revalidate(); err != nil {
+		t.Fatalf("Revalidate unchanged set: %v", err)
+	}
+
+	roots := set.Roots()
+	for slot, record := range database.durableRoot.slotRecord {
+		if record.CommitSeq == 0 {
+			t.Fatalf("durable slot %d is empty after two synchronous writes", slot)
+		}
+		found := false
+		for _, root := range roots {
+			if root.CommitSeq == record.CommitSeq && root.UserRootPageID == record.UserRootPageID && root.SystemRootPageID == record.SystemRootPageID && root.Durable {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Fatalf("durable slot %d record %+v missing from roots %+v", slot, record, roots)
+		}
+	}
+	for _, root := range roots {
+		snapshot := set.AcquireSnapshotForRoot(root)
+		if snapshot == nil {
+			t.Fatalf("AcquireSnapshotForRoot(%+v) returned nil", root)
+		}
+		state, ok := snapshot.StateToken()
+		if !ok || state.CommitSeq != root.CommitSeq || state.RootPageID != root.UserRootPageID || state.SystemRootPageID != root.SystemRootPageID {
+			_ = snapshot.Close()
+			t.Fatalf("root snapshot state=%+v ok=%v want %+v", state, ok, root)
+		}
+		if err := snapshot.Close(); err != nil {
+			t.Fatalf("Close root snapshot: %v", err)
+		}
+	}
+}
+
+func TestRecoverableRootSetKeepsDistinctReplayFrontiersForSamePages(t *testing.T) {
+	durable := recoverableDurableBasis{slotRecord: [2]rootpublication.DurableRootRecordV1{
+		{CommitSeq: 7, UserRootPageID: 11, SystemRootPageID: 13, AppliedCommandLSN: 3, MaxEntryRevision: 17},
+	}}
+	roots := recoverableRootsForBasis(StateToken{
+		CommitSeq: 7, RootPageID: 11, SystemRootPageID: 13, AppliedCommandLSN: 5, MaxEntryRevision: 19,
+	}, durable, rootpublication.ReachabilitySnapshot{})
+	if len(roots) != 2 {
+		t.Fatalf("roots=%+v want distinct durable and visible replay frontiers", roots)
+	}
+	set := &RecoverableRootSet{roots: roots}
+	for _, root := range roots {
+		if !set.containsRoot(root) {
+			t.Fatalf("captured root rejected: %+v", root)
+		}
+	}
+	mutated := roots[0]
+	mutated.AppliedCommandLSN++
+	if set.containsRoot(mutated) {
+		t.Fatalf("uncaptured replay frontier accepted: %+v", mutated)
+	}
+}
+
+func TestRecoverableRootSetRejectsWriteAfterCapture(t *testing.T) {
+	database, err := Open(Options{Dir: t.TempDir(), DisableBackgroundPrune: true})
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer func() { _ = database.Close() }()
+
+	set, err := database.CaptureRecoverableRootSet(context.Background())
+	if err != nil {
+		t.Fatalf("CaptureRecoverableRootSet: %v", err)
+	}
+	defer set.Release()
+	if err := database.Set([]byte("after"), []byte("capture")); err != nil {
+		t.Fatalf("Set: %v", err)
+	}
+	if err := set.Revalidate(); !errors.Is(err, ErrRecoverableRootSetStale) {
+		t.Fatalf("Revalidate after write=%v want ErrRecoverableRootSetStale", err)
+	}
+}
+
+func TestRecoverableRootSetRejectsDurableAdvanceAfterCapture(t *testing.T) {
+	database, err := Open(Options{
+		Dir:                       t.TempDir(),
+		DisableBackgroundPrune:    true,
+		rootPublicationFixedDelay: 100 * time.Millisecond,
+	})
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer func() { _ = database.Close() }()
+
+	if err := database.Set([]byte("visible"), []byte("not-yet-durable")); err != nil {
+		t.Fatalf("Set: %v", err)
+	}
+	set, err := database.CaptureRecoverableRootSet(context.Background())
+	if err != nil {
+		t.Fatalf("CaptureRecoverableRootSet: %v", err)
+	}
+	defer set.Release()
+	if err := set.Revalidate(); err != nil {
+		t.Fatalf("Revalidate before durable advance: %v", err)
+	}
+	if err := database.Checkpoint(); err != nil {
+		t.Fatalf("Checkpoint: %v", err)
+	}
+	if err := set.Revalidate(); !errors.Is(err, ErrRecoverableRootSetStale) {
+		t.Fatalf("Revalidate after durable advance=%v want ErrRecoverableRootSetStale", err)
+	}
+}
+
+func TestRecoverableRootSetExactFilePinBlocksDeleteUntilRelease(t *testing.T) {
+	database, err := Open(Options{Dir: t.TempDir(), DisableBackgroundPrune: true})
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer func() { _ = database.Close() }()
+
+	set, err := database.CaptureRecoverableRootSet(context.Background())
+	if err != nil {
+		t.Fatalf("CaptureRecoverableRootSet: %v", err)
+	}
+	path := filepath.Join(t.TempDir(), "segment")
+	if err := os.WriteFile(path, []byte("stable"), 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	file, err := os.Open(path)
+	if err != nil {
+		t.Fatalf("Open file: %v", err)
+	}
+	identity, err := rootpublication.StableIdentityFromFile(file)
+	if err != nil {
+		_ = file.Close()
+		t.Fatalf("StableIdentityFromFile: %v", err)
+	}
+	identity.Generation = 0
+	if err := set.PinStableFile(file); err != nil {
+		_ = file.Close()
+		t.Fatalf("PinStableFile: %v", err)
+	}
+	if err := file.Close(); err != nil {
+		t.Fatalf("Close file: %v", err)
+	}
+
+	registry := database.StableResourceIdentityPinRegistry()
+	if _, err := registry.BeginDeleteAt(identity, "recoverable-root-set/test-segment"); !errors.Is(err, rootpublication.ErrResourcePinned) {
+		t.Fatalf("BeginDeleteAt while pinned=%v want ErrResourcePinned", err)
+	}
+	set.Release()
+	lease, err := registry.BeginDeleteAt(identity, "recoverable-root-set/test-segment")
+	if err != nil {
+		t.Fatalf("BeginDeleteAt after release: %v", err)
+	}
+	lease.Abort()
+}

--- a/TreeDB/db/vlog_gc.go
+++ b/TreeDB/db/vlog_gc.go
@@ -2,6 +2,7 @@ package db
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"sync"
@@ -15,6 +16,12 @@ import (
 // before reachability is re-evaluated; keeping a small recent window prevents
 // deleting freshly rotated segments that may still back in-memory pointers.
 const valueLogKeepRecentSegmentsPerLane = 2
+
+// ErrValueLogZombieDeferred reports that MarkValueLogZombie retained the
+// requested segment because it is still reachable or otherwise protected.
+// Callers should keep their cleanup record and retry after recovery roots or
+// other lifecycle pins advance.
+var ErrValueLogZombieDeferred = errors.New("treedb: value-log zombie marking deferred")
 
 // valueLogGCPostRefreshCurrentSetNoRefresh is a narrow test seam for the
 // second no-refresh read after the fallback Refresh call.
@@ -285,6 +292,11 @@ func (db *DB) valueLogGC(ctx context.Context, opts ValueLogGCOptions, lockMainte
 		}
 		return stats, nil
 	}
+	defer func() {
+		if set != nil {
+			_ = vm.Release(set)
+		}
+	}()
 	valueSet := &valuelog.Set{Files: files}
 	keptIDs := currentValueLogIDs(valueSet)
 	protectedAll := mergeUniqueNonEmptyPaths(opts.ProtectedPaths, opts.ProtectedInUsePaths, opts.ProtectedRetainedPaths)
@@ -545,6 +557,7 @@ func (db *DB) valueLogGC(ctx context.Context, opts ValueLogGCOptions, lockMainte
 	if opts.DryRun {
 		if set != nil {
 			_ = vm.Release(set)
+			set = nil
 		}
 		return stats, nil
 	}

--- a/TreeDB/db/vlog_gc.go
+++ b/TreeDB/db/vlog_gc.go
@@ -73,6 +73,10 @@ type ValueLogGCOptions struct {
 	// otherwise-active segment. Callers must first prove the source is
 	// unreferenced and fence cached writers past the source.
 	ObservedSourceReclaimActive bool
+	// observedSourceMissingIsError preserves MarkValueLogZombie's historical
+	// missing-manager signal without changing rewrite cleanup's documented
+	// best-effort treatment of already-retired observed IDs.
+	observedSourceMissingIsError bool
 }
 
 // ValueLogGCStats summarizes value-log GC work.
@@ -216,13 +220,11 @@ func (db *DB) valueLogGC(ctx context.Context, opts ValueLogGCOptions, lockMainte
 		if err != nil {
 			return stats, err
 		}
-		if !observedOnly {
-			if referenced == nil {
-				referenced = make(map[uint32]struct{}, len(recoverableReferenced))
-			}
-			for fileID := range recoverableReferenced {
-				referenced[fileID] = struct{}{}
-			}
+		if referenced == nil {
+			referenced = make(map[uint32]struct{}, len(recoverableReferenced))
+		}
+		for fileID := range recoverableReferenced {
+			referenced[fileID] = struct{}{}
 		}
 
 		db.publishPrepareMu.Lock()
@@ -340,13 +342,14 @@ func (db *DB) valueLogGC(ctx context.Context, opts ValueLogGCOptions, lockMainte
 			}
 			f, ok := files[id]
 			if !ok {
-				// MarkValueLogZombie historically delegated directly to the
-				// manager, whose missing-ID result is part of the caching backend
-				// contract: callers use ErrFileNotFound to remove an orphaned
-				// retained path that the manager no longer tracks. Observed-only
-				// GC must preserve that signal rather than reporting a successful
-				// no-op and letting the orphan escape lifecycle ownership.
-				return stats, fmt.Errorf("%w: file_id=%d", valuelog.ErrFileNotFound, id)
+				if opts.observedSourceMissingIsError {
+					// MarkValueLogZombie historically delegated directly to the
+					// manager, whose missing-ID result is part of the caching backend
+					// contract: callers use ErrFileNotFound to remove an orphaned
+					// retained path that the manager no longer tracks.
+					return stats, fmt.Errorf("%w: file_id=%d", valuelog.ErrFileNotFound, id)
+				}
+				continue
 			}
 			size := fileSize(f)
 			stats.ObservedSourceSegments++
@@ -543,10 +546,10 @@ func (db *DB) valueLogGC(ctx context.Context, opts ValueLogGCOptions, lockMainte
 		// Consume the exact recovery authority only after classification is
 		// complete. publishPrepareMu remains held, so no new visible root can make
 		// one of these segments reachable between the final validation and zombie
-		// mutation. Keep the capability pinned through manager-topology publication:
-		// rewritten sources referenced only by an older recoverable root leave the
-		// current ValueLogSet immediately, while their exact physical identities
-		// remain unlink-protected until that recovery authority is retired.
+		// mutation. Segments selected by an older recoverable root were excluded
+		// during classification; eligible rewritten sources leave the current
+		// ValueLogSet here, while snapshot/resource pins retain their exact physical
+		// identities until every remaining reader releases them.
 		if err := recoverableRoots.Revalidate(); err != nil {
 			return stats, err
 		}

--- a/TreeDB/db/vlog_gc.go
+++ b/TreeDB/db/vlog_gc.go
@@ -174,6 +174,7 @@ func (db *DB) valueLogGC(ctx context.Context, opts ValueLogGCOptions, lockMainte
 	observedOnly := len(opts.ObservedSourceFileIDs) > 0 && opts.ObservedSourceAssumeUnreferenced
 	var referenced map[uint32]struct{}
 	var scannedSeq uint64
+	var recoverableRoots *RecoverableRootSet
 	if !observedOnly {
 		// A full scan is O(N), so it must never run while publishPrepareMu is
 		// exclusively held. Safety invariant: GC never zombifies a segment from a
@@ -195,6 +196,7 @@ func (db *DB) valueLogGC(ctx context.Context, opts ValueLogGCOptions, lockMainte
 
 			db.publishPrepareMu.Lock()
 			if db.currentCommitSeq() == scannedSeq {
+				db.publishPrepareMu.Unlock()
 				break
 			}
 			db.publishPrepareMu.Unlock()
@@ -202,11 +204,32 @@ func (db *DB) valueLogGC(ctx context.Context, opts ValueLogGCOptions, lockMainte
 				return stats, nil
 			}
 		}
-	} else if !opts.DryRun {
-		db.publishPrepareMu.Lock()
 	}
 	if !opts.DryRun {
+		var err error
+		recoverableRoots, err = db.captureRecoverableRootSetWithMaintenanceLockHeld(ctx)
+		if err != nil {
+			return stats, err
+		}
+		defer recoverableRoots.Release()
+		recoverableReferenced, err := db.referencedValueLogSegmentsForRecoverableRootSet(ctx, recoverableRoots)
+		if err != nil {
+			return stats, err
+		}
+		if !observedOnly {
+			if referenced == nil {
+				referenced = make(map[uint32]struct{}, len(recoverableReferenced))
+			}
+			for fileID := range recoverableReferenced {
+				referenced[fileID] = struct{}{}
+			}
+		}
+
+		db.publishPrepareMu.Lock()
 		defer db.publishPrepareMu.Unlock()
+		if !observedOnly && db.currentCommitSeq() != scannedSeq {
+			return stats, ErrRecoverableRootSetStale
+		}
 	}
 
 	// Commit-sequence equality fences published roots, not prepared output. The
@@ -325,6 +348,14 @@ func (db *DB) valueLogGC(ctx context.Context, opts ValueLogGCOptions, lockMainte
 			stats.SegmentsTotal++
 			stats.BytesTotal += size
 
+			if _, ok := referenced[id]; ok {
+				stats.SegmentsReferenced++
+				stats.BytesReferenced += size
+				stats.ObservedSourceSegmentsReferenced++
+				stats.ObservedSourceBytesReferenced += size
+				continue
+			}
+
 			if _, ok := pendingAppendIDs[id]; ok {
 				stats.SegmentsProtected++
 				stats.BytesProtected += size
@@ -392,14 +423,6 @@ func (db *DB) valueLogGC(ctx context.Context, opts ValueLogGCOptions, lockMainte
 				stats.ObservedSourceSegmentsPending++
 				stats.ObservedSourceBytesPending += size
 				continue
-			}
-			// MarkZombie only retires the file from future manager sets. Physical
-			// unlink separately acquires an exact-identity delete lease, so either
-			// durable meta slot, a visible candidate, or a snapshot retaining this
-			// identity keeps the path present for recovery. #3681 will unify logical
-			// eligibility and this physical gate under RecoverableRootSet.
-			if err := vm.MarkZombie(id); err != nil {
-				return stats, err
 			}
 			candidates[id] = candidate{path: f.Path, size: size, observed: true}
 		}
@@ -500,13 +523,6 @@ func (db *DB) valueLogGC(ctx context.Context, opts ValueLogGCOptions, lockMainte
 				}
 				continue
 			}
-			// Recovery-selectable durable slots retain exact identity tokens. The
-			// manager therefore cannot unlink this zombie until every older root and
-			// explicit pin releases the matching identity, even when this scan saw a
-			// newer visible root that no longer references the segment.
-			if err := vm.MarkZombie(id); err != nil {
-				return stats, err
-			}
 			candidates[id] = candidate{path: f.Path, size: size, observed: observed}
 		}
 	}
@@ -517,13 +533,41 @@ func (db *DB) valueLogGC(ctx context.Context, opts ValueLogGCOptions, lockMainte
 		}
 		return stats, nil
 	}
+	if len(candidates) > 0 {
+		// Consume the exact recovery authority only after classification is
+		// complete. publishPrepareMu remains held, so no new visible root can make
+		// one of these segments reachable between the final validation and zombie
+		// mutation. Keep the capability pinned through manager-topology publication:
+		// rewritten sources referenced only by an older recoverable root leave the
+		// current ValueLogSet immediately, while their exact physical identities
+		// remain unlink-protected until that recovery authority is retired.
+		if err := recoverableRoots.Revalidate(); err != nil {
+			return stats, err
+		}
+		for id := range candidates {
+			if err := vm.MarkZombie(id); err != nil {
+				return stats, err
+			}
+		}
+		if err := db.publishValueLogSetNoRefresh(); err != nil {
+			return stats, err
+		}
+		// The new current topology no longer selects these files. Persistent
+		// durable-root resource tokens and snapshot ValueLogSets now own any
+		// required physical retention, so the capability's cloned pins can drop
+		// before releasing this operation's local manager set.
+		recoverableRoots.Release()
+	}
 
 	if set != nil {
 		_ = vm.Release(set)
+		set = nil
 	}
 
-	if err := db.publishValueLogSetNoRefresh(); err != nil {
-		return stats, err
+	if len(candidates) == 0 {
+		if err := db.publishValueLogSetNoRefresh(); err != nil {
+			return stats, err
+		}
 	}
 
 	for _, info := range candidates {

--- a/TreeDB/db/vlog_gc.go
+++ b/TreeDB/db/vlog_gc.go
@@ -569,6 +569,9 @@ func (db *DB) valueLogGC(ctx context.Context, opts ValueLogGCOptions, lockMainte
 		// during classification; eligible rewritten sources leave the current
 		// ValueLogSet here, while snapshot/resource pins retain their exact physical
 		// identities until every remaining reader releases them.
+		if hook := db.testValueLogGCBeforeRevalidateHook; hook != nil {
+			hook()
+		}
 		if err := recoverableRoots.Revalidate(); err != nil {
 			return stats, err
 		}

--- a/TreeDB/db/vlog_gc.go
+++ b/TreeDB/db/vlog_gc.go
@@ -340,7 +340,13 @@ func (db *DB) valueLogGC(ctx context.Context, opts ValueLogGCOptions, lockMainte
 			}
 			f, ok := files[id]
 			if !ok {
-				continue
+				// MarkValueLogZombie historically delegated directly to the
+				// manager, whose missing-ID result is part of the caching backend
+				// contract: callers use ErrFileNotFound to remove an orphaned
+				// retained path that the manager no longer tracks. Observed-only
+				// GC must preserve that signal rather than reporting a successful
+				// no-op and letting the orphan escape lifecycle ownership.
+				return stats, fmt.Errorf("%w: file_id=%d", valuelog.ErrFileNotFound, id)
 			}
 			size := fileSize(f)
 			stats.ObservedSourceSegments++

--- a/TreeDB/db/vlog_gc.go
+++ b/TreeDB/db/vlog_gc.go
@@ -209,9 +209,13 @@ func (db *DB) valueLogGC(ctx context.Context, opts ValueLogGCOptions, lockMainte
 			}
 		}
 	}
-	if !opts.DryRun {
+	{
 		var err error
-		recoverableRoots, err = db.captureRecoverableRootSetWithMaintenanceLockHeld(ctx)
+		if opts.DryRun {
+			recoverableRoots, err = db.captureRecoverableRootSetForInspectionWithMaintenanceLockHeld(ctx)
+		} else {
+			recoverableRoots, err = db.captureRecoverableRootSetWithMaintenanceLockHeld(ctx)
+		}
 		if err != nil {
 			return stats, err
 		}
@@ -227,10 +231,12 @@ func (db *DB) valueLogGC(ctx context.Context, opts ValueLogGCOptions, lockMainte
 			referenced[fileID] = struct{}{}
 		}
 
-		db.publishPrepareMu.Lock()
-		defer db.publishPrepareMu.Unlock()
-		if !observedOnly && db.currentCommitSeq() != scannedSeq {
-			return stats, ErrRecoverableRootSetStale
+		if !opts.DryRun {
+			db.publishPrepareMu.Lock()
+			defer db.publishPrepareMu.Unlock()
+			if !observedOnly && db.currentCommitSeq() != scannedSeq {
+				return stats, ErrRecoverableRootSetStale
+			}
 		}
 	}
 

--- a/TreeDB/db/vlog_gc.go
+++ b/TreeDB/db/vlog_gc.go
@@ -183,6 +183,17 @@ func (db *DB) valueLogGC(ctx context.Context, opts ValueLogGCOptions, lockMainte
 		return stats, fmt.Errorf("value log manager unavailable")
 	}
 	observedOnly := len(opts.ObservedSourceFileIDs) > 0 && opts.ObservedSourceAssumeUnreferenced
+	missingObservedSourceError := func() error {
+		if !observedOnly || !opts.observedSourceMissingIsError {
+			return nil
+		}
+		for _, id := range opts.ObservedSourceFileIDs {
+			if id != 0 {
+				return fmt.Errorf("%w: file_id=%d", valuelog.ErrFileNotFound, id)
+			}
+		}
+		return nil
+	}
 	var referenced map[uint32]struct{}
 	var scannedSeq uint64
 	var recoverableRoots *RecoverableRootSet
@@ -277,6 +288,9 @@ func (db *DB) valueLogGC(ctx context.Context, opts ValueLogGCOptions, lockMainte
 		if set != nil {
 			_ = vm.Release(set)
 		}
+		if err := missingObservedSourceError(); err != nil {
+			return stats, err
+		}
 		if !opts.DryRun && !db.readOnly {
 			db.persistValueLogRefTrackerBestEffort()
 		}
@@ -286,6 +300,9 @@ func (db *DB) valueLogGC(ctx context.Context, opts ValueLogGCOptions, lockMainte
 	if len(files) == 0 {
 		if set != nil {
 			_ = vm.Release(set)
+		}
+		if err := missingObservedSourceError(); err != nil {
+			return stats, err
 		}
 		if !opts.DryRun && !db.readOnly {
 			db.persistValueLogRefTrackerBestEffort()

--- a/TreeDB/db/vlog_gc_incremental.go
+++ b/TreeDB/db/vlog_gc_incremental.go
@@ -655,6 +655,40 @@ func (db *DB) scanValueLogRefCounts(ctx context.Context) (map[uint32]uint64, uin
 	return result.valueLogRefCounts, commitSeq, nil
 }
 
+func (db *DB) referencedValueLogSegmentsForRecoverableRootSet(ctx context.Context, roots *RecoverableRootSet) (map[uint32]struct{}, error) {
+	if roots == nil {
+		return nil, ErrRecoverableRootSetStale
+	}
+	captured := roots.Roots()
+	if len(captured) == 0 {
+		return nil, ErrRecoverableRootSetStale
+	}
+	snap := roots.AcquireSnapshotForRoot(captured[0])
+	if snap == nil {
+		return nil, ErrRecoverableRootSetStale
+	}
+	protectedRootIDs := make([]uint64, 0, len(captured))
+	protectedSystemRootIDs := make([]uint64, 0, len(captured))
+	for _, root := range captured {
+		protectedRootIDs = append(protectedRootIDs, root.UserRootPageID)
+		protectedSystemRootIDs = append(protectedSystemRootIDs, root.SystemRootPageID)
+	}
+	result, err := db.maintenanceReachabilityScan(ctx, snap, maintenanceReachabilityScanOptions{
+		Collectors:               maintenanceReachabilityValueLogRefCounts,
+		ProtectedRootIDs:         protectedRootIDs,
+		ProtectedSystemRootIDs:   protectedSystemRootIDs,
+		ProjectProtectedValueLog: true,
+	})
+	closeErr := snap.Close()
+	if err != nil {
+		return nil, err
+	}
+	if closeErr != nil {
+		return nil, closeErr
+	}
+	return result.valueLogReferencedSegments, nil
+}
+
 func scanValueLogRefCountRootIterator(snap *Snapshot, root maintenanceRoot) iterator.UnsafeIterator {
 	opts := tree.IteratorOptions{Mode: tree.IteratorModePointerProjection}
 	if snap != nil && root.kind == maintenanceRootUser && root.rootID == snap.treeRoot {

--- a/TreeDB/db/vlog_gc_lock_bench_test.go
+++ b/TreeDB/db/vlog_gc_lock_bench_test.go
@@ -16,12 +16,16 @@ import (
 func BenchmarkValueLogGCPublishDuringPausedFullScan(b *testing.B) {
 	const scanPause = 25 * time.Millisecond
 	type gcResult struct {
-		stats ValueLogGCStats
-		err   error
+		stats   ValueLogGCStats
+		elapsed time.Duration
+		err     error
 	}
 
 	var publishElapsed time.Duration
+	var gcElapsed time.Duration
 	var segmentsDeleted int
+	var bytesScanned, bytesReclaimed int64
+	var bytesReferenced, bytesActive, bytesProtected, bytesPending int64
 	for i := 0; i < b.N; i++ {
 		b.StopTimer()
 		db, err := Open(Options{Dir: b.TempDir()})
@@ -47,8 +51,9 @@ func BenchmarkValueLogGCPublishDuringPausedFullScan(b *testing.B) {
 		})
 		gcDone := make(chan gcResult, 1)
 		go func() {
+			started := time.Now()
 			stats, err := db.ValueLogGC(context.Background(), ValueLogGCOptions{})
-			gcDone <- gcResult{stats: stats, err: err}
+			gcDone <- gcResult{stats: stats, elapsed: time.Since(started), err: err}
 		}()
 		<-scanStarted
 		key := []byte(fmt.Sprintf("publish-during-scan-%d", i))
@@ -70,13 +75,27 @@ func BenchmarkValueLogGCPublishDuringPausedFullScan(b *testing.B) {
 			_ = db.Close()
 			b.Fatalf("ValueLogGC: %v", result.err)
 		}
+		gcElapsed += result.elapsed
 		segmentsDeleted += result.stats.SegmentsDeleted
+		bytesScanned += result.stats.BytesTotal
+		bytesReclaimed += result.stats.BytesDeleted
+		bytesReferenced += result.stats.BytesReferenced
+		bytesActive += result.stats.BytesActive
+		bytesProtected += result.stats.BytesProtected
+		bytesPending += result.stats.BytesPending
 		if err := db.Close(); err != nil {
 			b.Fatalf("close: %v", err)
 		}
 	}
 
 	b.ReportMetric(float64(publishElapsed.Nanoseconds())/float64(b.N), "publish-ns/op")
+	b.ReportMetric(float64(gcElapsed.Nanoseconds())/float64(b.N), "gc-convergence-ns/op")
 	b.ReportMetric(float64(scanPause.Nanoseconds()), "scan-pause-ns/op")
 	b.ReportMetric(float64(segmentsDeleted)/float64(b.N), "segments-deleted/op")
+	b.ReportMetric(float64(bytesScanned)/float64(b.N), "bytes-scanned/op")
+	b.ReportMetric(float64(bytesReclaimed)/float64(b.N), "bytes-reclaimed/op")
+	b.ReportMetric(float64(bytesReferenced)/float64(b.N), "bytes-retained-referenced/op")
+	b.ReportMetric(float64(bytesActive)/float64(b.N), "bytes-retained-active/op")
+	b.ReportMetric(float64(bytesProtected)/float64(b.N), "bytes-retained-protected/op")
+	b.ReportMetric(float64(bytesPending)/float64(b.N), "bytes-retained-pending/op")
 }

--- a/TreeDB/db/vlog_gc_test.go
+++ b/TreeDB/db/vlog_gc_test.go
@@ -1120,6 +1120,22 @@ func TestMarkValueLogZombie_PreservesMissingSegmentSignal(t *testing.T) {
 	}
 }
 
+func TestMarkValueLogZombie_PreservesMissingSegmentSignalWhenValueLogIsEmpty(t *testing.T) {
+	db, err := Open(Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	missingID, err := valuelog.EncodeFileID(0, 1)
+	if err != nil {
+		t.Fatalf("missing fileid: %v", err)
+	}
+	if err := db.MarkValueLogZombie(missingID); !errors.Is(err, valuelog.ErrFileNotFound) {
+		t.Fatalf("MarkValueLogZombie missing error=%v, want ErrFileNotFound", err)
+	}
+}
+
 func TestValueLogGC_ProtectedPathBreakdownStats(t *testing.T) {
 	dir := t.TempDir()
 

--- a/TreeDB/db/vlog_gc_test.go
+++ b/TreeDB/db/vlog_gc_test.go
@@ -608,6 +608,9 @@ func TestValueLogGC_ObservedSourceCannotZombieOlderRecoverableRootSegment(t *tes
 	if stats.ObservedSourceSegmentsReferenced != 1 || stats.ObservedSourceSegmentsEligible != 0 || stats.ObservedSourceSegmentsDeleted != 0 {
 		t.Fatalf("observed-only GC did not retain older-root reference: %+v", stats)
 	}
+	if err := database.MarkValueLogZombie(oldPtr.FileID); !errors.Is(err, ErrValueLogZombieDeferred) {
+		t.Fatalf("MarkValueLogZombie older-root error=%v want ErrValueLogZombieDeferred", err)
+	}
 	oldPath := valueLogSegmentPath(t, dir, oldPtr.FileID)
 	if _, err := os.Stat(oldPath); err != nil {
 		t.Fatalf("observed-only GC removed older-root segment: %v", err)

--- a/TreeDB/db/vlog_gc_test.go
+++ b/TreeDB/db/vlog_gc_test.go
@@ -317,6 +317,69 @@ func TestValueLogGC_RemovesUnreferencedSegment(t *testing.T) {
 	}
 }
 
+func TestMarkValueLogZombieTreatsStaleRecoverableRootSetAsDeferred(t *testing.T) {
+	dir := t.TempDir()
+
+	database, err := Open(Options{Dir: dir, DisableBackgroundPrune: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = database.Close() }()
+
+	path := filepath.Join(ValueLogDirPath(dir), "value-l0-000001.log")
+	fileID, err := valuelog.EncodeFileID(0, 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	writer, err := valuelog.NewWriter(path, fileID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ptr, err := writer.Append(0, nil, 1, bytes.Repeat([]byte("stale-zombie|"), 128))
+	if err != nil {
+		_ = writer.Close()
+		t.Fatal(err)
+	}
+	if err := writer.Close(); err != nil {
+		t.Fatal(err)
+	}
+	registerTestValueLogProducer(t, dir, path, fileID)
+
+	batch := database.NewBatch().(*Batch)
+	if err := batch.SetPointer([]byte("stale-zombie"), ptr); err != nil {
+		t.Fatal(err)
+	}
+	if err := batch.Write(); err != nil {
+		t.Fatal(err)
+	}
+	if err := batch.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := database.Delete([]byte("stale-zombie")); err != nil {
+		t.Fatal(err)
+	}
+	advancePastRetainedDurableSlotForTest(t, database)
+
+	originalEpoch := database.systemRootPublishEpoch.Load()
+	t.Cleanup(func() {
+		database.testValueLogGCBeforeRevalidateHook = nil
+		database.systemRootPublishEpoch.Store(originalEpoch)
+	})
+	var once sync.Once
+	database.testValueLogGCBeforeRevalidateHook = func() {
+		once.Do(func() { database.systemRootPublishEpoch.Add(1) })
+	}
+	err = database.MarkValueLogZombie(fileID)
+	database.testValueLogGCBeforeRevalidateHook = nil
+	database.systemRootPublishEpoch.Store(originalEpoch)
+	if !errors.Is(err, ErrValueLogZombieDeferred) || !errors.Is(err, ErrRecoverableRootSetStale) {
+		t.Fatalf("MarkValueLogZombie error=%v, want deferred stale capability", err)
+	}
+	if _, err := os.Stat(path); err != nil {
+		t.Fatalf("stale zombie attempt removed segment: %v", err)
+	}
+}
+
 func TestValueLogGC_StableIdentityPinDefersUnreferencedSegmentDelete(t *testing.T) {
 	dir := t.TempDir()
 	database, err := Open(Options{Dir: dir, DisableBackgroundPrune: true})

--- a/TreeDB/db/vlog_gc_test.go
+++ b/TreeDB/db/vlog_gc_test.go
@@ -526,6 +526,103 @@ func TestValueLogGC_VisibleDeleteCannotUnlinkOlderDurableRootSegment(t *testing.
 	}
 }
 
+func TestValueLogGC_ObservedSourceCannotZombieOlderRecoverableRootSegment(t *testing.T) {
+	dir := t.TempDir()
+	database, err := Open(Options{
+		Dir:                       dir,
+		Durability:                DurabilityWALOffRelaxed,
+		DisableBackgroundPrune:    true,
+		rootPublicationFixedDelay: 100 * time.Millisecond,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = database.Close() })
+
+	oldValue := bytes.Repeat([]byte("observed-older-root-value|"), 32)
+	oldPtr := appendPointersInNewSegment(t, dir, 0, 1, 410_000, 1, func(int) []byte {
+		return oldValue
+	})[0]
+	appendPointersInNewSegment(t, dir, 0, 2, 420_000, 1, func(int) []byte {
+		return []byte("active-segment")
+	})
+	if err := database.RefreshValueLogSet(); err != nil {
+		t.Fatal(err)
+	}
+
+	batch := database.NewBatch().(*Batch)
+	if err := batch.SetPointer([]byte("durable"), oldPtr); err != nil {
+		t.Fatal(err)
+	}
+	if err := batch.WriteSync(); err != nil {
+		t.Fatal(err)
+	}
+	if err := batch.Close(); err != nil {
+		t.Fatal(err)
+	}
+	durableBefore := database.durableRoot.record.CommitSeq
+
+	releasePublisher := make(chan struct{})
+	releasedPublisher := false
+	release := func() {
+		if !releasedPublisher {
+			close(releasePublisher)
+			releasedPublisher = true
+		}
+	}
+	restoreCuts := durabilitycut.Install(func(event durabilitycut.Event) error {
+		if event.Root == dir && event.Point == durabilitycut.BeforePublicationSealWrite {
+			<-releasePublisher
+		}
+		return nil
+	})
+	t.Cleanup(func() {
+		release()
+		restoreCuts()
+	})
+
+	if err := database.Delete([]byte("durable")); err != nil {
+		t.Fatal(err)
+	}
+	publication := database.rootPublication.coordinator.Stats()
+	if publication.VisibleCommitSeq <= durableBefore || publication.DurableCommitSeq != durableBefore {
+		t.Fatalf("post-delete visible/durable frontier=(%d,%d), want visible > durable=%d", publication.VisibleCommitSeq, publication.DurableCommitSeq, durableBefore)
+	}
+
+	stats, err := database.ValueLogGC(context.Background(), ValueLogGCOptions{
+		ObservedSourceFileIDs:            []uint32{oldPtr.FileID},
+		ObservedSourceAssumeUnreferenced: true,
+		ObservedSourceReclaimActive:      true,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if stats.ObservedSourceSegmentsReferenced != 1 || stats.ObservedSourceSegmentsEligible != 0 || stats.ObservedSourceSegmentsDeleted != 0 {
+		t.Fatalf("observed-only GC did not retain older-root reference: %+v", stats)
+	}
+	oldPath := valueLogSegmentPath(t, dir, oldPtr.FileID)
+	if _, err := os.Stat(oldPath); err != nil {
+		t.Fatalf("observed-only GC removed older-root segment: %v", err)
+	}
+
+	recovered, err := openReadOnlyNoLock(Options{Dir: dir, ReadOnly: true})
+	if err != nil {
+		t.Fatalf("open older recoverable root: %v", err)
+	}
+	got, err := recovered.Get([]byte("durable"))
+	if err != nil {
+		_ = recovered.Close()
+		t.Fatal(err)
+	}
+	if !bytes.Equal(got, oldValue) {
+		_ = recovered.Close()
+		t.Fatalf("older recoverable value mismatch: got %d bytes want %d", len(got), len(oldValue))
+	}
+	if err := recovered.Close(); err != nil {
+		t.Fatal(err)
+	}
+}
+
 func TestValueLogGC_KeepsPendingValueLogAppenderSegments(t *testing.T) {
 	dir := t.TempDir()
 

--- a/TreeDB/db/vlog_gc_test.go
+++ b/TreeDB/db/vlog_gc_test.go
@@ -479,8 +479,8 @@ func TestValueLogGC_VisibleDeleteCannotUnlinkOlderDurableRootSegment(t *testing.
 	if publication.VisibleCommitSeq <= durableBefore || publication.DurableCommitSeq != durableBefore {
 		t.Fatalf("post-delete visible/durable frontier=(%d,%d), want visible > durable=%d", publication.VisibleCommitSeq, publication.DurableCommitSeq, durableBefore)
 	}
-	if stats.SegmentsEligible == 0 || stats.SegmentsPending == 0 {
-		t.Fatalf("GC did not logically retire the older-root segment: %+v", stats)
+	if stats.SegmentsReferenced == 0 || stats.BytesReferenced == 0 || stats.SegmentsEligible != 0 || stats.SegmentsPending != 0 {
+		t.Fatalf("GC did not classify the older-root segment as recoverably referenced: %+v", stats)
 	}
 	oldPath := filepath.Join(dir, "value_vlog", "value-l0-000001.log")
 	if _, err := os.Stat(oldPath); err != nil {
@@ -512,6 +512,17 @@ func TestValueLogGC_VisibleDeleteCannotUnlinkOlderDurableRootSegment(t *testing.
 	restoreCuts = func() {}
 	if err := database.Checkpoint(); err != nil {
 		t.Fatal(err)
+	}
+	advancePastRetainedDurableSlotForTest(t, database)
+	converged, err := database.ValueLogGC(context.Background(), ValueLogGCOptions{})
+	if err != nil {
+		t.Fatalf("ValueLogGC after durable-root advance: %v", err)
+	}
+	if converged.SegmentsDeleted == 0 || converged.BytesDeleted == 0 {
+		t.Fatalf("older-root value-log debt did not converge after both slots advanced: %+v", converged)
+	}
+	if _, err := os.Stat(oldPath); !os.IsNotExist(err) {
+		t.Fatalf("older-root segment still present after convergence GC: %v", err)
 	}
 }
 

--- a/TreeDB/db/vlog_gc_test.go
+++ b/TreeDB/db/vlog_gc_test.go
@@ -924,6 +924,31 @@ func TestValueLogGC_ObservedSourceReclaimActiveRequiresExplicitOption(t *testing
 	}
 }
 
+func TestMarkValueLogZombie_PreservesMissingSegmentSignal(t *testing.T) {
+	dir := t.TempDir()
+
+	db, err := Open(Options{Dir: dir})
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	appendPointersInNewSegment(t, dir, 0, 1, 1_000, 1, func(int) []byte {
+		return bytes.Repeat([]byte("tracked|"), 32)
+	})
+	if err := db.RefreshValueLogSet(); err != nil {
+		t.Fatalf("RefreshValueLogSet: %v", err)
+	}
+
+	missingID, err := valuelog.EncodeFileID(0, 2)
+	if err != nil {
+		t.Fatalf("missing fileid: %v", err)
+	}
+	if err := db.MarkValueLogZombie(missingID); !errors.Is(err, valuelog.ErrFileNotFound) {
+		t.Fatalf("MarkValueLogZombie missing error=%v, want ErrFileNotFound", err)
+	}
+}
+
 func TestValueLogGC_ProtectedPathBreakdownStats(t *testing.T) {
 	dir := t.TempDir()
 

--- a/TreeDB/db/vlog_gc_test.go
+++ b/TreeDB/db/vlog_gc_test.go
@@ -468,7 +468,7 @@ func TestValueLogGC_VisibleDeleteCannotUnlinkOlderDurableRootSegment(t *testing.
 		}
 	}
 
-	stats, err := database.ValueLogGC(context.Background(), ValueLogGCOptions{})
+	dryRun, err := database.ValueLogGC(context.Background(), ValueLogGCOptions{DryRun: true})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -478,6 +478,14 @@ func TestValueLogGC_VisibleDeleteCannotUnlinkOlderDurableRootSegment(t *testing.
 	publication := database.rootPublication.coordinator.Stats()
 	if publication.VisibleCommitSeq <= durableBefore || publication.DurableCommitSeq != durableBefore {
 		t.Fatalf("post-delete visible/durable frontier=(%d,%d), want visible > durable=%d", publication.VisibleCommitSeq, publication.DurableCommitSeq, durableBefore)
+	}
+	if dryRun.SegmentsReferenced == 0 || dryRun.BytesReferenced == 0 || dryRun.SegmentsEligible != 0 || dryRun.SegmentsPending != 0 {
+		t.Fatalf("dry-run GC did not classify the older-root segment as recoverably referenced: %+v", dryRun)
+	}
+
+	stats, err := database.ValueLogGC(context.Background(), ValueLogGCOptions{})
+	if err != nil {
+		t.Fatal(err)
 	}
 	if stats.SegmentsReferenced == 0 || stats.BytesReferenced == 0 || stats.SegmentsEligible != 0 || stats.SegmentsPending != 0 {
 		t.Fatalf("GC did not classify the older-root segment as recoverably referenced: %+v", stats)

--- a/TreeDB/db/vlog_rewrite.go
+++ b/TreeDB/db/vlog_rewrite.go
@@ -112,6 +112,10 @@ type ValueLogRewriteStats struct {
 	// SourceBytesReclaimed is the number of unreferenced source bytes deleted by
 	// a caller-managed reclaim path after rewrite.
 	SourceBytesReclaimed int64
+	// SourceSegmentsRetainedRecoverableRootStale reports retirement candidates
+	// retained because the recoverable-root basis changed during cleanup.
+	SourceSegmentsRetainedRecoverableRootStale int
+	SourceBytesRetainedRecoverableRootStale    int64
 
 	TemplateRecordsAttempted int
 	TemplateRecordsKept      int
@@ -2142,12 +2146,13 @@ func (db *DB) valueLogRewriteOnline(ctx context.Context, opts ValueLogRewriteOnl
 			_ = db.valueLogManager.Release(currentSet)
 		}
 	}
-	markZombieCandidate := func(id uint32, existedBefore bool) error {
+	retirementCandidates := make([]uint32, 0, len(oldValueIDs)+len(newValueIDs))
+	addRetirementCandidate := func(id uint32, existedBefore bool) {
 		if _, ok := referencedAfter[id]; ok {
-			return nil
+			return
 		}
 		if _, ok := protectedIDs[id]; ok {
-			return nil
+			return
 		}
 		// When active-segment skipping is enabled, avoid marking currently
 		// active pre-existing segments zombie. Concurrent writers may still be
@@ -2155,28 +2160,52 @@ func (db *DB) valueLogRewriteOnline(ctx context.Context, opts ValueLogRewriteOnl
 		// index.
 		if existedBefore && allowActiveSkip {
 			if _, ok := activeIDs[id]; ok {
-				return nil
+				return
 			}
 		}
-		if err := db.valueLogManager.MarkZombie(id); err != nil {
-			return err
-		}
-		return nil
+		retirementCandidates = append(retirementCandidates, id)
 	}
 	for id := range oldValueIDs {
-		if err := markZombieCandidate(id, true); err != nil {
-			return stats, err
-		}
+		addRetirementCandidate(id, true)
 	}
 	for _, id := range newValueIDs {
 		if _, existed := oldValueIDs[id]; existed {
 			continue
 		}
-		if err := markZombieCandidate(id, false); err != nil {
-			return stats, err
-		}
+		addRetirementCandidate(id, false)
 	}
-	if err := db.publishValueLogSetNoRefresh(); err != nil {
+	if len(retirementCandidates) > 0 {
+		// Source retirement is delegated to the same recoverable-root capability
+		// used by standalone GC. The rewrite's visible-root scan is only an
+		// optimization; GC rechecks every selectable durable/pending root and
+		// revalidates immediately before zombie mutation.
+		if _, err := db.valueLogGC(context.WithoutCancel(ctx), ValueLogGCOptions{
+			ProtectedPaths:                   opts.ProtectedPaths,
+			ObservedSourceFileIDs:            retirementCandidates,
+			ObservedSourceAssumeUnreferenced: true,
+			ObservedSourceReclaimActive:      true,
+		}, false); err != nil {
+			if !errors.Is(err, ErrRecoverableRootSetStale) {
+				return stats, err
+			}
+			stats.SourceSegmentsRetainedRecoverableRootStale = len(retirementCandidates)
+			currentSet := db.valueLogManager.CurrentSetNoRefresh()
+			for _, id := range retirementCandidates {
+				if currentSet != nil {
+					stats.SourceBytesRetainedRecoverableRootStale += fileSize(currentSet.Files[id])
+				}
+			}
+			if currentSet != nil {
+				_ = db.valueLogManager.Release(currentSet)
+			}
+			// Pointer swaps are already committed. Publish the non-destructive
+			// manager topology and leave every stale candidate intact for a later
+			// maintenance pass.
+			if err := db.publishValueLogSetNoRefresh(); err != nil {
+				return stats, err
+			}
+		}
+	} else if err := db.publishValueLogSetNoRefresh(); err != nil {
 		return stats, err
 	}
 	postSet := db.valueLogManager.CurrentSetNoRefresh()

--- a/TreeDB/db/vlog_rewrite_test.go
+++ b/TreeDB/db/vlog_rewrite_test.go
@@ -2122,11 +2122,12 @@ func TestValueLogRewriteOnline_ObservedSourceGCReclaimsActiveUnreferencedSource(
 	if err != nil {
 		t.Fatalf("ValueLogGC without active reclaim: %v", err)
 	}
-	if activeStats.ObservedSourceSegmentsActive != 1 || activeStats.ObservedSourceSegmentsDeleted != 0 {
-		t.Fatalf("observed active source should remain without reclaim option: %+v", activeStats)
+	if activeStats.ObservedSourceSegmentsDeleted != 0 ||
+		activeStats.ObservedSourceSegmentsReferenced+activeStats.ObservedSourceSegmentsActive != 1 {
+		t.Fatalf("observed source should remain while active or recoverable: %+v", activeStats)
 	}
 	if _, err := os.Stat(sourcePath); err != nil {
-		t.Fatalf("active source should remain without reclaim option, stat=%v", err)
+		t.Fatalf("active or recoverable source should remain without reclaim option, stat=%v", err)
 	}
 
 	advancePastRetainedDurableSlotForTest(t, db)
@@ -4652,8 +4653,31 @@ func TestValueLogRewrite_BatchedPointerSwap_SnapshotIsolation(t *testing.T) {
 	if state == nil || state.ValueLogSet == nil {
 		t.Fatalf("db state missing ValueLogSet after rewrite")
 	}
+	if _, ok := state.ValueLogSet.Files[oldID]; !ok {
+		t.Fatalf("old segment %d missing while an older durable root can still select it", oldID)
+	}
+
+	advancePastRetainedDurableSlotForTest(t, db)
+	if _, err := db.ValueLogGC(context.Background(), ValueLogGCOptions{
+		ObservedSourceFileIDs:            []uint32{oldID},
+		ObservedSourceAssumeUnreferenced: true,
+		ObservedSourceReclaimActive:      true,
+	}); err != nil {
+		t.Fatalf("ValueLogGC after durable-slot advance: %v", err)
+	}
+	state = db.State()
+	if state == nil || state.ValueLogSet == nil {
+		t.Fatalf("db state missing ValueLogSet after source retirement")
+	}
 	if _, ok := state.ValueLogSet.Files[oldID]; ok {
-		t.Fatalf("old segment %d still visible in current state after rewrite", oldID)
+		t.Fatalf("old segment %d still visible after every recoverable root released it", oldID)
+	}
+	gotSnap, err = snap.Get([]byte("k2"))
+	if err != nil {
+		t.Fatalf("snapshot get k2 after source retirement: %v", err)
+	}
+	if !bytes.Equal(gotSnap, bytes.Repeat([]byte{11}, 512)) {
+		t.Fatalf("snapshot value mismatch after source retirement")
 	}
 }
 

--- a/TreeDB/docs/spec/README.md
+++ b/TreeDB/docs/spec/README.md
@@ -114,6 +114,9 @@ Given pre-alpha status, this is a living spec that tracks implementation.
   - generated issue #3677 authority map for external resource fields, producers,
     identity/frontier evidence, namespace operations, recovery validation,
     deletion ownership, quarantines, and adjacent issue boundaries.
+- `TreeDB/docs/spec/recoverable-root-set-maintenance-3681.md`
+  - issue #3681 destructive-maintenance authority, checked call-site inventory,
+    stale-plan behavior, adjacent-issue boundaries, and convergence contract.
 - `TreeDB/docs/spec/recovery.md`
   - open-time recovery pipeline, replay ordering, truncated tail behavior, failure modes.
 - `TreeDB/docs/spec/user-command-wal.md`

--- a/TreeDB/docs/spec/recoverable-root-set-maintenance-3681.md
+++ b/TreeDB/docs/spec/recoverable-root-set-maintenance-3681.md
@@ -1,0 +1,83 @@
+# Recoverable-root maintenance authority
+
+Issue #3681 makes destructive TreeDB maintenance consume one DB-minted
+`RecoverableRootSet`. The capability is a bounded snapshot of every root and
+stable resource that can still become recovery-selectable. It includes both
+validated durable meta slots, the visible and queued publication frontiers,
+publication resource manifests, snapshot/history pins, the oldest protected
+commit sequence, and the applied command-WAL frontier of each root.
+
+A destructive plan MUST capture the capability after maintenance admission and
+MUST revalidate that same instance immediately before its first mutation. A
+stale capability deletes nothing. Callers MAY release exact resource pins after
+successful revalidation only while holding a publication fence that prevents a
+new visible root from appearing before the mutation completes.
+
+Capture performs no tree scan. Its scalar work is bounded by the two durable
+slots and publication debt; resource work is bounded by retained manifests and
+pins. Maintenance operations walk the captured roots only when they need a
+resource-specific reachability projection.
+
+## Checked destructive-call-site inventory
+
+| Storage class | Destructive owner | Capability integration | Status |
+|---|---|---|---|
+| Persistent value-log segments | `TreeDB/db/vlog_gc.go` | scans value pointers from every captured root, unions exact referenced segment IDs, then revalidates under `publishPrepareMu` before `MarkZombie`; full GC only retires segments absent from the whole union | active |
+| Value-log rewrite sources | `TreeDB/db/vlog_rewrite.go` | publishes rewritten pointers first; source retirement delegates to capability-backed value-log GC. A current-unreferenced source may leave the current manager topology while an older root's exact resource pin defers physical unlink; a stale cleanup capability records retained debt rather than failing the committed rewrite | active |
+| Exported/cached value-log zombie requests | `TreeDB/db/db.go` (`MarkValueLogZombie`) and cached retention callers | delegates to capability-backed observed-source GC instead of directly marking a manager file zombie | active |
+| Zero-byte value-log cleanup | `TreeDB/db/compact_storage.go` (`pruneZeroByteValueLogFiles`) | captures and revalidates under the publication fence, then keeps that fence through stable deletion and directory durability | active |
+| Raw and packed outer-leaf generations | `TreeDB/db/leaf_generation_gc.go` | scans raw leaf FileIDs from every captured root, resolves them through every retained leaf-generation manifest, preserves FileID reuse/ABA generations, and revalidates before zombie publication | active |
+| Leaf pack/rewrite sources | `TreeDB/db/leaf_generation_pack.go`, `TreeDB/db/compact_storage.go` | replacement output is stabilized and published first; physical retirement is exclusively owned by capability-backed leaf-generation GC | active |
+| Column, dictionary, template, typed-column, vector-graph, text, and query-ready assets | `TreeDB/collections/column_asset_gc.go` and `column_asset_rewrite.go` | scans each captured collection catalog/manifest, pins exact referenced segment identities, protects published generations replayable from an older durable WAL frontier, and revalidates before `BeginDeleteAt`. Current query-ready base/delta/consolidated assets remain rebuildable and non-authoritative, but share the same exact-identity retirement gate | active |
+| Online index vacuum/replacement | `TreeDB/db/vacuum_online.go` | production entry remains fail-closed with `ErrVacuumRecoverableRootSetRequired`; the legacy replacement path is test-only until it can publish a durable replacement and prove the old index identity unreachable | fenced |
+| Offline `CompactIndex` | `TreeDB/db/db.go` | appends and publishes new pages in the same index namespace; it does not unlink or replace the index file. Page eligibility is governed by the page rule below | no external unlink |
+| Graveyard extraction and page/freelist reuse | COW allocator and root-reuse paths from #3678 | `RecoverableRootSet` registers the oldest captured commit sequence and holds the root-reuse read fence; actual page eligibility remains the #3678 generation rule | delegated to #3678 |
+| Stable unlink/rename instrumentation | `TreeDB/db/namespace_mutation.go`, `TreeDB/internal/valuelog/stable_resource.go`, and collection stable deleters | exact identity, namespace lease, unlink observation, and directory-sync failure handling remain the PR #3706 contract; #3681 adds root authority before those operations | inherited from PR #3706 |
+| Command-WAL segment deletion | `TreeDB/db/command_wal_publish.go` and cached WAL cleanup | ordinary WAL deletion is intentionally owned by #3682. #3681 only supplies the applied/replayable frontier used by resource retirement | adjacent #3682 |
+
+The following direct filesystem operations are not deletion of published
+recovery state and therefore do not consume the capability:
+
+- rollback truncation/removal of unpublished prepared column-asset tails, after
+  proving no later writer appended to the shared segment;
+- growth/materialization truncates that extend an index generation to its
+  prepared high-water mark;
+- temporary-file and temporary-directory cleanup before publication;
+- rebuildable legacy vector-index epochs, which never select recovery state and
+  retain exact-search fallback;
+- Raft transport snapshot staging/cleanup, which is outside the local TreeDB
+  root-selection namespace.
+
+## Failure and convergence contract
+
+- Candidate enqueue, durable-meta rotation, system-root publication, index
+  replacement, or publication-resource debt changes invalidate the capability.
+- An invalid capability returns `ErrRecoverableRootSetStale`; destructive paths
+  retain their candidates and expose retryable debt/diagnostics.
+- A durable fallback behind the visible command-WAL frontier protects
+  format-valid authoritative typed-row/typed-column generations that replay can
+  recreate. Newer or malformed unpublished candidates are not replay roots.
+  Query-ready assets remain rebuildable and non-authoritative unless a later
+  contract explicitly promotes them.
+- Once both durable slots advance beyond the retired root and explicit
+  snapshots/iterators/`KeepRecent` pins drain, a fresh maintenance pass can
+  reclaim the retained resource.
+- Namespace deletion is successful only after its owning directory has been
+  made durable. An unlink followed by directory-sync failure is recovery
+  required, never reported as clean success.
+
+## Verification map
+
+- `TreeDB/db/recoverable_root_set_test.go`: both durable slots, stale candidate
+  enqueue, stale durable advance, root-bound snapshots, and exact identity pins.
+- `TreeDB/db/vlog_gc_test.go`: an older durable root remains readable after a
+  newer visible root drops its value-log pointer.
+- `TreeDB/db/leaf_generation_gc_test.go`: stale scans delete nothing, durable
+  fallback generations remain live, FileID reuse is conservative, and debt
+  converges after fallback/snapshot advance.
+- `TreeDB/collections/column_asset_gc_test.go` and
+  `column_asset_rewrite_test.go`: snapshot and replay-frontier retention,
+  replacement-before-retirement, exact stale-plan checks, and post-advance
+  convergence.
+- PR #3706 stable-resource tests remain the namespace identity, unlink, and
+  directory-durability regression suite.

--- a/TreeDB/docs/spec/recoverable-root-set-maintenance-3681.md
+++ b/TreeDB/docs/spec/recoverable-root-set-maintenance-3681.md
@@ -23,7 +23,7 @@ resource-specific reachability projection.
 | Storage class | Destructive owner | Capability integration | Status |
 |---|---|---|---|
 | Persistent value-log segments | `TreeDB/db/vlog_gc.go` | scans value pointers from every captured root, unions exact referenced segment IDs, then revalidates under `publishPrepareMu` before `MarkZombie`; full GC only retires segments absent from the whole union | active |
-| Value-log rewrite sources | `TreeDB/db/vlog_rewrite.go` | publishes rewritten pointers first; source retirement delegates to capability-backed value-log GC. A current-unreferenced source may leave the current manager topology while an older root's exact resource pin defers physical unlink; a stale cleanup capability records retained debt rather than failing the committed rewrite | active |
+| Value-log rewrite sources | `TreeDB/db/vlog_rewrite.go` | publishes rewritten pointers first; source retirement delegates to capability-backed value-log GC. A source remains in the current manager topology while any recoverable root still references it. Once absent from every recoverable root, zombie publication removes it from the current topology while snapshot/resource pins defer physical unlink; a stale cleanup capability records retained debt rather than failing the committed rewrite | active |
 | Exported/cached value-log zombie requests | `TreeDB/db/db.go` (`MarkValueLogZombie`) and cached retention callers | delegates to capability-backed observed-source GC instead of directly marking a manager file zombie | active |
 | Zero-byte value-log cleanup | `TreeDB/db/compact_storage.go` (`pruneZeroByteValueLogFiles`) | captures and revalidates under the publication fence, then keeps that fence through stable deletion and directory durability | active |
 | Raw and packed outer-leaf generations | `TreeDB/db/leaf_generation_gc.go` | scans raw leaf FileIDs from every captured root, resolves them through every retained leaf-generation manifest, preserves FileID reuse/ABA generations, and revalidates before zombie publication | active |
@@ -70,8 +70,8 @@ recovery state and therefore do not consume the capability:
 
 - `TreeDB/db/recoverable_root_set_test.go`: both durable slots, stale candidate
   enqueue, stale durable advance, root-bound snapshots, and exact identity pins.
-- `TreeDB/db/vlog_gc_test.go`: an older durable root remains readable after a
-  newer visible root drops its value-log pointer.
+- `TreeDB/db/vlog_gc_test.go`: full and observed-source GC both retain an older
+  durable root's value-log pointer after a newer visible root drops it.
 - `TreeDB/db/leaf_generation_gc_test.go`: stale scans delete nothing, durable
   fallback generations remain live, FileID reuse is conservative, and debt
   converges after fallback/snapshot advance.

--- a/TreeDB/internal/dictdb/stable_resource_capture_test.go
+++ b/TreeDB/internal/dictdb/stable_resource_capture_test.go
@@ -41,6 +41,7 @@ func TestCaptureDictionaryResourcesReturnsExactTransitiveClosureForReusedPointer
 	}
 	registry := store.backend.StableResourceIdentityPinRegistry()
 	baselinePins := registry.ActivePins()
+	baselineLinks := registry.ActiveStableNamespaceLinks()
 
 	resources, err := store.CaptureDictionaryResources(ctx, reusedID)
 	if err != nil {
@@ -53,6 +54,17 @@ func TestCaptureDictionaryResourcesReturnsExactTransitiveClosureForReusedPointer
 	if got := registry.ActivePins(); got != baselinePins+2 {
 		t.Fatalf("active index/value-log identity pins=%d want baseline %d + 2 capture pins", got, baselinePins)
 	}
+	if got := registry.ActiveStableNamespaceLinks(); got != baselineLinks+1 {
+		t.Fatalf("stable namespace links=%d want baseline %d + 1 value-log link", got, baselineLinks)
+	}
+	reusedResources, err := store.CaptureDictionaryResources(ctx, reusedID)
+	if err != nil {
+		t.Fatalf("recapture reused dictionary: %v", err)
+	}
+	if got := registry.ActiveStableNamespaceLinks(); got != baselineLinks+1 {
+		t.Fatalf("stable namespace links after recapture=%d want cached %d", got, baselineLinks+1)
+	}
+	reusedResources.Release()
 
 	wantDigest := sha256.Sum256(payload)
 	paths := make(map[string]bool, 2)
@@ -66,6 +78,9 @@ func TestCaptureDictionaryResourcesReturnsExactTransitiveClosureForReusedPointer
 		paths[token.DiagnosticPath()] = true
 		if token.DiagnosticPath() == "index.db" && token.Namespace() == nil {
 			t.Fatal("index token missing stable namespace evidence")
+		}
+		if token.DiagnosticPath() == "value_vlog/value-l0-000001.log" && token.Namespace() == nil {
+			t.Fatal("value-log token missing stable namespace evidence")
 		}
 		obligations := token.LogicalObligations()
 		if len(obligations) != 1 {
@@ -127,8 +142,14 @@ func TestCaptureDictionaryResourcesReopenedPointerUsesExactRecordFrontier(t *tes
 	}
 	defer resources.Release()
 	for _, token := range resources.Tokens() {
-		if token.DiagnosticPath() == "value_vlog/value-l0-000001.log" && token.Frontier().Bytes != wantFrontier {
+		if token.DiagnosticPath() != "value_vlog/value-l0-000001.log" {
+			continue
+		}
+		if token.Frontier().Bytes != wantFrontier {
 			t.Fatalf("value-log frontier=%d want exact record end %d", token.Frontier().Bytes, wantFrontier)
+		}
+		if token.Namespace() == nil {
+			t.Fatal("reopened value-log token missing stable namespace evidence")
 		}
 	}
 }

--- a/TreeDB/internal/rootpublication/coordinator.go
+++ b/TreeDB/internal/rootpublication/coordinator.go
@@ -104,6 +104,27 @@ type Coordinator struct {
 	resourcePinHighWater map[ResourceKind]uint64
 	durableRootLineage   DurableRootLineageID
 	durableRootSequence  uint64
+	reachabilityEpoch    uint64
+}
+
+// ReachabilitySnapshot is a bounded, independently pinned view of every root
+// and stable resource that can still become recovery-selectable. The epoch is
+// opaque to callers; it is used only for exact pre-mutation revalidation.
+type ReachabilitySnapshot struct {
+	Epoch     uint64
+	Visible   Frontier
+	Durable   Frontier
+	Pending   []Frontier
+	Resources *StableResourceSet
+}
+
+// Release drops the independently cloned resource pins owned by the snapshot.
+func (snapshot *ReachabilitySnapshot) Release() {
+	if snapshot == nil {
+		return
+	}
+	snapshot.Resources.Release()
+	snapshot.Resources = nil
 }
 
 // PublishAttempt is an opaque identity for exactly one captured callback.
@@ -147,6 +168,7 @@ func New(options Options) (*Coordinator, error) {
 		oldestRecoverable:  options.OldestRecoverableCommitSeq,
 		resourceActivePins: make(map[ResourceKind]uint64), resourcePinHighWater: make(map[ResourceKind]uint64),
 		durableRootLineage: options.DurableRootLineage, durableRootSequence: options.DurableRootSequence,
+		reachabilityEpoch: 1,
 	}
 	if c.oldestRecoverable == 0 {
 		c.oldestRecoverable = c.durable.commitSeq
@@ -260,6 +282,7 @@ func (c *Coordinator) enqueueLocked(candidate *PreparedRootCandidate, supersede 
 	}
 	c.observeResourcePinHighWaterLocked()
 	c.visible = candidate.frontier
+	c.reachabilityEpoch++
 	if wasEmpty {
 		c.firstPendingAt = c.clock.Now()
 		c.installTimerLocked()
@@ -273,6 +296,62 @@ func (c *Coordinator) enqueueLocked(candidate *PreparedRootCandidate, supersede 
 		c.requestPublishLocked(WakeHardAdmission)
 	}
 	return enqueueDecision{sequence: candidate.frontier.commitSeq, failureGeneration: c.failureGeneration, hard: hard}, nil
+}
+
+// CaptureReachability independently pins the exact pending/recovery resource
+// union while copying the scalar visible, durable, and pending root frontiers.
+// It performs no tree scan and its work is bounded by coordinator debt.
+func (c *Coordinator) CaptureReachability() (ReachabilitySnapshot, error) {
+	if c == nil {
+		return ReachabilitySnapshot{}, ErrClosed
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if err := c.terminalErrorLocked(); err != nil {
+		return ReachabilitySnapshot{}, err
+	}
+
+	sets := make([]*StableResourceSet, 0, len(c.pending)+len(c.recoverySets))
+	pending := make([]Frontier, 0, len(c.pending))
+	for _, entry := range c.pending {
+		pending = append(pending, entry.candidate.frontier)
+		if resources := entry.candidate.resourceSet(); resources != nil {
+			sets = append(sets, resources)
+		}
+	}
+	sets = append(sets, c.recoverySets...)
+	var resources *StableResourceSet
+	if len(sets) != 0 {
+		view, err := UnionStableResourceSets(sets...)
+		if err != nil {
+			return ReachabilitySnapshot{}, err
+		}
+		resources, err = CloneStableResourceSetExcludingKinds(view)
+		if err != nil {
+			return ReachabilitySnapshot{}, err
+		}
+	}
+	return ReachabilitySnapshot{
+		Epoch: c.reachabilityEpoch, Visible: c.visible, Durable: c.durable,
+		Pending: pending, Resources: resources,
+	}, nil
+}
+
+// RevalidateReachability proves that no candidate was enqueued and no durable
+// prefix was consumed since CaptureReachability returned.
+func (c *Coordinator) RevalidateReachability(epoch uint64) error {
+	if c == nil {
+		return ErrClosed
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if err := c.terminalErrorLocked(); err != nil {
+		return err
+	}
+	if epoch == 0 || epoch != c.reachabilityEpoch {
+		return ErrInvalidCandidate
+	}
+	return nil
 }
 
 func (c *Coordinator) preflightDurableRootLocked(candidate *PreparedRootCandidate) error {
@@ -733,6 +812,7 @@ func (c *Coordinator) finishPublishLocked(candidate *PreparedRootCandidate, grou
 		c.durable = candidate.frontier
 		c.durable.commitSeq = durableSeq
 		c.oldestRecoverable = oldest
+		c.reachabilityEpoch++
 		if latest := (DurableRootGroup{members: group.members}).Latest(); latest != nil {
 			c.durableRootLineage = latest.Lineage()
 			c.durableRootSequence = latest.Sequence()

--- a/TreeDB/internal/rootpublication/coordinator_test.go
+++ b/TreeDB/internal/rootpublication/coordinator_test.go
@@ -176,6 +176,117 @@ func TestNewRejectsRecoverableFrontierNewerThanDurable(t *testing.T) {
 	}
 }
 
+func TestReachabilityEpochInvalidatesOnEnqueueAndDurablePublish(t *testing.T) {
+	calls := make(chan *PreparedRootCandidate, 1)
+	release := make(chan struct{})
+	c, err := New(Options{Publisher: PublisherFunc(func(ctx context.Context, candidate *PreparedRootCandidate) PublishResult {
+		calls <- candidate
+		select {
+		case <-release:
+			return PublishResult{Outcome: PublishSucceeded}
+		case <-ctx.Done():
+			return PublishResult{Outcome: PublishRetryableFailure, Err: ctx.Err()}
+		}
+	})})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer stopClean(t, c)
+
+	initial, err := c.CaptureReachability()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer initial.Release()
+	if err := c.Enqueue(context.Background(), candidate(t, 1, 1)); err != nil {
+		t.Fatal(err)
+	}
+	if err := c.RevalidateReachability(initial.Epoch); !errors.Is(err, ErrInvalidCandidate) {
+		t.Fatalf("initial snapshot after enqueue=%v", err)
+	}
+
+	pending, err := c.CaptureReachability()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer pending.Release()
+	if pending.Visible.CommitSeq() != 1 || pending.Durable.CommitSeq() != 0 || len(pending.Pending) != 1 || pending.Pending[0].CommitSeq() != 1 {
+		t.Fatalf("pending snapshot=%+v", pending)
+	}
+	waitDone := make(chan error, 1)
+	go func() { waitDone <- c.WaitThrough(context.Background(), 1) }()
+	waitForCall(t, calls)
+	close(release)
+	if err := <-waitDone; err != nil {
+		t.Fatal(err)
+	}
+	if err := c.RevalidateReachability(pending.Epoch); !errors.Is(err, ErrInvalidCandidate) {
+		t.Fatalf("pending snapshot after durable publication=%v", err)
+	}
+
+	durable, err := c.CaptureReachability()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer durable.Release()
+	if durable.Visible.CommitSeq() != 1 || durable.Durable.CommitSeq() != 1 || len(durable.Pending) != 0 {
+		t.Fatalf("durable snapshot=%+v", durable)
+	}
+	if err := c.RevalidateReachability(durable.Epoch); err != nil {
+		t.Fatalf("unchanged durable snapshot=%v", err)
+	}
+}
+
+func TestReachabilityEpochSurvivesRetryableFailure(t *testing.T) {
+	want := errors.New("pre-meta retry")
+	c, err := New(Options{Publisher: PublisherFunc(func(context.Context, *PreparedRootCandidate) PublishResult {
+		return PublishResult{Outcome: PublishRetryableFailure, Err: want}
+	})})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer stopClean(t, c)
+	if err := c.Enqueue(context.Background(), candidate(t, 1, 1)); err != nil {
+		t.Fatal(err)
+	}
+	snapshot, err := c.CaptureReachability()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer snapshot.Release()
+	if err := c.WaitThrough(context.Background(), 1); !errors.Is(err, want) {
+		t.Fatalf("wait=%v", err)
+	}
+	if err := c.RevalidateReachability(snapshot.Epoch); err != nil {
+		t.Fatalf("retryable failure changed reachability=%v", err)
+	}
+}
+
+func TestReachabilityRevalidationFailsClosedAfterAmbiguousPublish(t *testing.T) {
+	want := errors.New("meta sync ambiguous")
+	c, err := New(Options{Publisher: PublisherFunc(func(context.Context, *PreparedRootCandidate) PublishResult {
+		return PublishResult{Outcome: PublishAmbiguous, Err: want}
+	})})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer stopClean(t, c)
+	if err := c.Enqueue(context.Background(), candidate(t, 1, 1)); err != nil {
+		t.Fatal(err)
+	}
+	snapshot, err := c.CaptureReachability()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer snapshot.Release()
+	if err := c.WaitThrough(context.Background(), 1); !errors.Is(err, ErrRecoveryRequired) || !errors.Is(err, want) {
+		t.Fatalf("wait=%v", err)
+	}
+	if err := c.RevalidateReachability(snapshot.Epoch); !errors.Is(err, ErrRecoveryRequired) || !errors.Is(err, want) {
+		t.Fatalf("ambiguous revalidation=%v", err)
+	}
+}
+
 func TestVisibleFrontierDoesNotSatisfyDurabilityWaiter(t *testing.T) {
 	calls := make(chan *PreparedRootCandidate, 1)
 	release := make(chan struct{})

--- a/TreeDB/internal/rootpublication/pin_registry.go
+++ b/TreeDB/internal/rootpublication/pin_registry.go
@@ -632,6 +632,11 @@ func (lease *IdentityDeleteLease) CommitDeleted() {
 		state := registry.stateLocked(lease.identity)
 		state.deleting = false
 		state.retired = true
+		for link := range registry.stableLinks {
+			if link.child == lease.identity {
+				delete(registry.stableLinks, link)
+			}
+		}
 		registry.deleteIdleStateLocked(lease.identity, state)
 		delete(registry.namespaces, lease.namespace)
 		registry.mu.Unlock()

--- a/TreeDB/internal/rootpublication/pin_registry_test.go
+++ b/TreeDB/internal/rootpublication/pin_registry_test.go
@@ -53,6 +53,38 @@ func TestIdentityPinRegistrySerializesPinAndDelete(t *testing.T) {
 	pin.Release()
 }
 
+func TestIdentityDeleteLeaseCommitForgetsStableNamespaceLinksForDeletedChild(t *testing.T) {
+	dir := t.TempDir()
+	parent, err := os.Open(dir)
+	if err != nil {
+		t.Fatalf("open parent: %v", err)
+	}
+	defer parent.Close()
+	childPath := filepath.Join(dir, "000001.vlog")
+	child, err := os.OpenFile(childPath, os.O_RDWR|os.O_CREATE|os.O_EXCL, 0o600)
+	if err != nil {
+		t.Fatalf("create child: %v", err)
+	}
+	defer child.Close()
+
+	registry := NewIdentityPinRegistry()
+	if err := registry.RememberStableNamespaceLink(parent, child, filepath.Base(childPath)); err != nil {
+		t.Fatalf("remember stable namespace link: %v", err)
+	}
+	identity, err := StableIdentityFromFile(child)
+	if err != nil {
+		t.Fatalf("child identity: %v", err)
+	}
+	lease, err := registry.BeginDelete(identity)
+	if err != nil {
+		t.Fatalf("begin delete: %v", err)
+	}
+	lease.CommitDeleted()
+	if got := registry.ActiveStableNamespaceLinks(); got != 0 {
+		t.Fatalf("stable namespace links after delete commit=%d want 0", got)
+	}
+}
+
 func TestIdentityPinRegistryCoalescesLogicalGenerations(t *testing.T) {
 	registry := NewIdentityPinRegistry()
 	first := testStableIdentity(1)

--- a/TreeDB/internal/rootpublication/resource_identity_windows_test.go
+++ b/TreeDB/internal/rootpublication/resource_identity_windows_test.go
@@ -198,7 +198,14 @@ func TestStableNamespaceCreationSyncsExactChildWindows(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer parent.Close()
-	resource, err := OpenStableChildFile(parent, "child", os.O_CREATE|os.O_EXCL|os.O_RDWR, 0o600)
+	created, err := OpenStableChildFile(parent, "child", os.O_CREATE|os.O_EXCL|os.O_RDWR, 0o600)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := created.Close(); err != nil {
+		t.Fatal(err)
+	}
+	resource, err := OpenStableChildFile(parent, "child", os.O_RDONLY, 0)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/TreeDB/internal/rootpublication/resource_token.go
+++ b/TreeDB/internal/rootpublication/resource_token.go
@@ -1233,7 +1233,7 @@ func newStableNamespaceToken(spec StableNamespaceSpec, adapter namespacePersiste
 	persistenceIdentity := identity
 	persistenceIdentity.Generation = 0
 	if stableNamespaceCreationPersistsThroughChild() && spec.Operation == NamespaceCreate && spec.LinkedResource != nil {
-		persistence, err = duplicateStableFile(spec.LinkedResource)
+		persistence, err = duplicateStableSyncFile(spec.LinkedResource)
 		if err != nil {
 			_ = pinned.Close()
 			return nil, fmt.Errorf("duplicate namespace creation resource: %w", err)

--- a/TreeDB/internal/typedcolumn/transplant_test.go
+++ b/TreeDB/internal/typedcolumn/transplant_test.go
@@ -631,6 +631,10 @@ func TestTypedColumnTransplantNoProductionPublication(t *testing.T) {
 		// #2118 is the scoped production physical-accounting reporter that
 		// reads validated typed-column part images for byte accounting only.
 		filepath.Clean(filepath.Join(collectionsDir, "column_store_physical_accounting.go")): {},
+		// #3681 validates candidate typed-column part images only to determine
+		// whether an older recoverable root can replay them. The GC path owns no
+		// typed-column publication or query data plane.
+		filepath.Clean(filepath.Join(collectionsDir, "column_asset_gc.go")): {},
 		// #3698 is the scoped query-independent generation-open seam. It binds
 		// validated QRBG/QRDG direct views to the existing collection physical
 		// identity and reader leases without exposing query-shaped operators or

--- a/TreeDB/internal/valuelog/stable_resource.go
+++ b/TreeDB/internal/valuelog/stable_resource.go
@@ -415,9 +415,9 @@ func validateStableExternalRIDMembership(file *File, child StableExternalRIDSegm
 }
 
 // StableExistingPhysicalResourceToken captures an exact manager-owned segment
-// for a producer outside the value-log domain. The segment's namespace was
-// durably installed before it entered the manager; the returned token adds the
-// shared physical deletion pin and the caller's producer classification.
+// for a producer outside the value-log domain. The returned token certifies or
+// reuses the segment's exact durable namespace link, then adds the shared
+// physical deletion pin and the caller's producer classification.
 func (m *Manager) StableExistingPhysicalResourceToken(
 	fileID uint32,
 	spec rootpublication.StableResourceSpec,
@@ -437,7 +437,59 @@ func (m *Manager) StableExistingPhysicalResourceToken(
 	}
 	spec.File = file.File
 	spec.PinRegistry = m.stableResourcePins
+	if spec.Namespace == nil {
+		namespace, err := m.stableExistingPhysicalNamespaceToken(file, spec.DiagnosticPath)
+		if err != nil {
+			return nil, err
+		}
+		defer namespace.Release()
+		spec.Namespace = namespace
+	}
 	return constructor(spec)
+}
+
+func (m *Manager) stableExistingPhysicalNamespaceToken(file *File, diagnosticPath string) (*rootpublication.StableNamespaceToken, error) {
+	if m == nil || file == nil || file.File == nil || m.stableResourcePins == nil {
+		return nil, fmt.Errorf("%w: stable physical namespace capture unavailable", rootpublication.ErrUnresolvedResource)
+	}
+	parent, err := captureStableValueLogParent(file.Path, file.File)
+	if err != nil {
+		return nil, err
+	}
+	defer parent.Close()
+	parentGeneration, err := rootpublication.StableNamespaceParentGeneration(parent)
+	if err != nil {
+		return nil, err
+	}
+	namespaceDiagnosticPath := filepath.Dir(diagnosticPath)
+	if namespaceDiagnosticPath == "." {
+		return nil, fmt.Errorf("%w: stable physical resource diagnostic path has no parent namespace", rootpublication.ErrUnresolvedResource)
+	}
+	namespaceSpec := rootpublication.StableNamespaceSpec{
+		Parent: parent, LinkedResource: file.File, ParentGeneration: parentGeneration,
+		Operation: rootpublication.NamespaceCreate, NewName: filepath.Base(file.Path),
+		DiagnosticPath: namespaceDiagnosticPath,
+	}
+	namespace, err := m.stableResourcePins.NewStableNamespaceTokenForKnownLink(namespaceSpec)
+	if err == nil {
+		return namespace, nil
+	}
+	if !errors.Is(err, rootpublication.ErrNamespaceUnstable) {
+		return nil, err
+	}
+	namespace, err = newValueLogStableNamespaceToken(namespaceSpec)
+	if err != nil {
+		return nil, err
+	}
+	if err := namespace.Stabilize(); err != nil {
+		namespace.Release()
+		return nil, err
+	}
+	if err := m.stableResourcePins.RememberStableNamespaceLink(parent, file.File, filepath.Base(file.Path)); err != nil {
+		namespace.Release()
+		return nil, err
+	}
+	return namespace, nil
 }
 
 func (m *Manager) observeStableFileLocked(file *File) error {

--- a/TreeDB/internal/valuelog/stable_resource_test.go
+++ b/TreeDB/internal/valuelog/stable_resource_test.go
@@ -15,6 +15,32 @@ import (
 	"github.com/snissn/gomap/TreeDB/page"
 )
 
+func TestStableExistingPhysicalResourceTokenRejectsDiagnosticPathWithoutParentNamespace(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "value-l0-000001.log")
+	if err := os.WriteFile(path, nil, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	manager, err := NewManagerWithStableResourcePinRegistry(dir, rootpublication.NewIdentityPinRegistry())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer manager.Close()
+	fileID, err := EncodeFileID(0, 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = manager.StableExistingPhysicalResourceToken(fileID, rootpublication.StableResourceSpec{
+		DiagnosticPath: "value-l0-000001.log",
+	}, func(rootpublication.StableResourceSpec) (*rootpublication.StableResourceToken, error) {
+		t.Fatal("constructor called for a resource with no parent namespace")
+		return nil, nil
+	})
+	if !errors.Is(err, rootpublication.ErrUnresolvedResource) {
+		t.Fatalf("base-only diagnostic path error=%v want ErrUnresolvedResource", err)
+	}
+}
+
 func TestOrdinaryOuterLeafCreationClassifiesFallbackDirectorySync(t *testing.T) {
 	dir := filepath.Join(t.TempDir(), "leaf_vlog")
 	if err := os.MkdirAll(dir, 0o700); err != nil {

--- a/experiments/colgranule/cmd/jsonbench_compare/remaining_test.go
+++ b/experiments/colgranule/cmd/jsonbench_compare/remaining_test.go
@@ -436,12 +436,15 @@ func validateRemainingTemplateV1MeasurementStorageReconstructsJSONBenchRows(t *t
 	if result.RewriteRecordsCopied == 0 {
 		t.Fatalf("remaining measurement copied no value-log records: %+v", result)
 	}
-	if result.RewriteReclaimFiles == 0 || result.RewriteReclaimBytes == 0 {
-		t.Fatalf("remaining measurement did not reclaim rewritten sources through cached fence path: %+v", result)
+	if result.RewriteSourceBytes == 0 {
+		t.Fatalf("remaining measurement observed no value-log source bytes: %+v", result)
 	}
-	// Rewrite reclamation is reported from the files actually deleted. An exact
-	// ingest segment may remain reachable from the independently recoverable
-	// older durable-root slot until a later publication supersedes that slot.
+	if (result.RewriteReclaimFiles == 0) != (result.RewriteReclaimBytes == 0) {
+		t.Fatalf("remaining measurement reported inconsistent rewrite reclamation: %+v", result)
+	}
+	// Rewrite reclamation is reported only for files physically deleted during
+	// this pass. An ingest segment may remain reachable from the independently
+	// recoverable older durable-root slot until later publications supersede it.
 	validateStoredRemainingCollectionReconstructsJSONBenchRows(t, source, ds, imagePart, dbDir, collections.DocumentFormatTemplateV1)
 }
 


### PR DESCRIPTION
Closes #3681

## Summary

- add the DB-minted `RecoverableRootSet` capability over both durable slots, visible/pending publication frontiers, replay/revision frontiers, snapshot/page-reuse pins, and exact stable-resource identities
- require destructive value-log, outer-leaf, compact-storage, and column-asset maintenance to capture the capability, project resource-specific reachability, and revalidate immediately before mutation
- retain online index vacuum as explicitly fail-closed until its replacement workflow can consume the same authority
- certify side-store value-log dependencies with exact durable namespace proof, including Windows read-only-handle upgrades and conservative cached-link invalidation after deletion
- document the checked destructive-callsite inventory and committed maintenance performance fixtures

## Destructive-callsite inventory

| Storage class | Owner | #3681 integration |
|---|---|---|
| persistent value-log segments | `TreeDB/db/vlog_gc.go` | full GC projects value pointers from every captured root; exact revalidation occurs under `publishPrepareMu` before zombie mutation |
| value-log rewrite sources | `TreeDB/db/vlog_rewrite.go` | replacement pointers publish first; source retirement delegates to capability-backed observed-source GC; stale cleanup records retain debt |
| exported/cached zombie requests | `DB.MarkValueLogZombie` | delegates to capability-backed GC; stale capability races map to retryable `ErrValueLogZombieDeferred`, while missing manager identities preserve `valuelog.ErrFileNotFound` so caching can retire orphaned retained records |
| zero-byte value-log cleanup | `pruneZeroByteValueLogFiles` | captures/revalidates under the publication fence and keeps the fence through deletion/directory durability |
| raw/packed outer-leaf generations | `leaf_generation_gc.go` | scans raw FileIDs from every captured root, resolves them against retained manifests including FileID reuse/ABA, then revalidates before zombie publication |
| leaf pack/rewrite sources | leaf pack/rewrite + compact storage | stabilized replacement publishes first; capability-backed leaf-generation GC owns retirement |
| dictionary/template/column/typed-column/vector/text/query-ready assets | `column_asset_gc.go` / rewrite | walks every captured catalog/manifest, pins exact referenced segments, protects authoritative replay generations, and revalidates while the exact delete lease is held |
| online index replacement | `vacuum_online.go` | production entry remains fail-closed with `ErrVacuumRecoverableRootSetRequired`; legacy replacement is test-only |
| offline index compaction | `CompactIndex` | appends/publishes pages in the existing namespace; no index-file unlink/replacement |
| graveyard/page reuse | allocator/root-reuse path | capability registers the oldest captured commit and holds the #3678 root-reuse fence; #3678 remains the page-eligibility owner |
| physical unlink/rename | stable-resource deleters | #3681 supplies root authority; PR #3706 remains the exact identity, namespace lease, unlink observation, and directory-sync contract |
| ordinary command-WAL deletion | command-WAL cleanup | intentionally deferred to #3682; #3681 exposes the replay frontier it consumes |

Direct cleanup of unpublished prepared tails, temporary files/directories, and rebuildable legacy vector epochs is excluded because it cannot select recovery state.

## PR #3706 subtraction

This PR composes with the already-merged stable-resource identity checks, delete leases, namespace mutation observation, and directory durability behavior from PR #3706. It does not recreate unlink/rename machinery. An unlink followed by directory-sync failure remains recovery-required rather than clean success.

## Stale-plan and convergence evidence

- `TestRecoverableRootSetRejectsWriteAfterCapture`: a post-capture candidate enqueue makes the capability stale.
- `TestRecoverableRootSetRejectsDurableAdvanceAfterCapture`: durable slot rotation invalidates the captured basis.
- `TestValueLogGC_VisibleDeleteCannotUnlinkOlderDurableRootSegment`: a visible-but-not-durable delete retains the older segment until both durable slots advance, then GC converges.
- `TestValueLogGC_ObservedSourceCannotZombieOlderRecoverableRootSegment`: observed-source cleanup retains a segment still referenced by the older selectable root.
- `TestMarkValueLogZombieTreatsStaleRecoverableRootSetAsDeferred`: a root change immediately before destructive revalidation retains the segment and returns both retryable deferred and stale-capability diagnostics.
- `TestMarkValueLogZombie_PreservesMissingSegmentSignalWhenValueLogIsEmpty`: an empty manager set preserves the historical not-found signal instead of turning an orphaned retained record into permanent retry debt.
- leaf-generation concurrent-write tests accept only explicit `ErrRecoverableRootSetStale` and require zero deletion from the stale plan.
- column-asset GC holds exact pins for captured manifests plus replayable authoritative generations; stale plan/system-root changes fail before unlink.
- snapshot-pin regressions require retained debt while the older root/snapshot exists and reclamation after both authority sources drain.
- `TestCollectionLeafGenerationPackGC_RoundTripWithTemplateV1SecondaryIndexes`: a raw `Commit` path that publishes a trained dictionary through dictdb's value log now carries exact namespace proof through main-manifest recovery and remains reopenable.
- dictdb stable-resource tests prove first-capture namespace stabilization, cached-link reuse, deletion invalidation, fail-closed base-only diagnostics, and Windows exact-child durability from a read-only manager handle.

The strengthened value-log regression exposed that legacy protected roots extended leaf projection but not value-log projection. `ProjectProtectedValueLog` is enabled only for `RecoverableRootSet`, preserving compact-storage tracker semantics while making older-root pointer scanning exact. Final-head hardening also separates missing observed-source segments from already-retired rewrite cleanup, stabilizes collections resource-inventory baselines at explicit checkpoints before pin sampling, and gives generic side-store value-log dependencies the serialized namespace authority required by durable recovery.

## Performance evidence

Apple M3, `-benchtime=20x`:

- protected-set capture/revalidate: `1.004 us/op`, `1818 B/op`, `6 allocs/op` at 0 keys; `1.946 us/op`, `2632 B/op`, `22 allocs/op` at 16,384 keys
- leaf-GC writer contention: `2.758 ms` write p99 during GC versus `4.740 ms` idle p99 on this sample; `54.925 ms` GC wall p99; 2 scans/op and 5 pages/scan
- leaf-GC exclusive phase: `5.911 ms` p99/max, `1441 ops/s`
- value-log GC with a deterministic 25 ms paused scan: publish `0.284 ms/op`; GC convergence `28.113 ms/op`; 105 bytes scanned, 51 reclaimed, 54 retained as active, and zero referenced/protected/pending debt on the fixture

Capture remains bounded by two durable slots plus publication/resource debt and performs no logical key-tree scan. Destructive paths do not retry-spin on stale capabilities.

## Validation

Latest material production head: `8a8ea5888809f4ba3156cf224c65212a09f3549a`.

Previous mature-reviewed production head: `0ac1d67e843bb982bb79e90af71b2d1e335a2c68`. One final mature review is requested on the latest material head; tests, documentation, mechanical edits, or base-only merges do not reset that review gate.

- `go test ./TreeDB/... -count=1 -timeout=20m`
- `go vet ./TreeDB/...`
- `GOMAXPROCS=2 go test ./TreeDB/collections -run '^TestCollectionLeafGenerationPackGC_RoundTripWithTemplateV1SecondaryIndexes$' -count=50`
- `GOMAXPROCS=2 go test ./TreeDB/caching -run '^TestCachedManualMaintenanceDirectPointersRemainReopenable_WALOn$' -count=30`
- focused race validation across `TreeDB/internal/rootpublication`, `TreeDB/internal/valuelog`, `TreeDB/internal/dictdb`, and the exact collection/caching regressions
- Windows/amd64 test-binary compilation for `TreeDB/internal/rootpublication`, `TreeDB/internal/valuelog`, and `TreeDB/internal/dictdb`
- `go test ./TreeDB/internal/rootpublication ./TreeDB/internal/valuelog ./TreeDB/internal/dictdb ./TreeDB/collections ./TreeDB/caching -count=1 -timeout=20m` after the final fail-closed diagnostic and comment-only adjustment
- `go test ./TreeDB/db -run '^$' -bench 'Benchmark(RecoverableRootSetCaptureRevalidate|LeafGenerationGCWriterContention|LeafGenerationGCExclusivePhases|ValueLogGCPublishDuringPausedFullScan)$' -benchtime=20x -count=1 -benchmem`

Exact-head CI and a finding-free mature Codex review on `8a8ea5888809f4ba3156cf224c65212a09f3549a` are required before merge.
