### PR TITLE
test(collections): skip scalar alloc count under race

### DIFF
--- a/TreeDB/collections/column_vector_graph_search_source_test.go
+++ b/TreeDB/collections/column_vector_graph_search_source_test.go
@@ -452,6 +452,9 @@ func TestColumnVectorGraphSearchSourceAllocationFreeAfterWarmup1968(t *testing.T
 	if _, err := plan.scoreSource.scoreOrdinalsScalar(plan, nil, query, queryInvNorm, ordinals, scores, scratch, &warmStats); err != nil {
 		t.Fatalf("warm score tile: %v", err)
 	}
+	if collectionsRaceEnabled {
+		t.Skip("exact allocation counts are unstable under race instrumentation")
+	}
 	var runErr error
 	allocs := testing.AllocsPerRun(1000, func() {
 		var stats columnVectorGraphNativeSearchStats


### PR DESCRIPTION
## Summary

- keep the scalar vector score-source warm correctness call active under `-race`
- skip only the exact `testing.AllocsPerRun` measurement when race instrumentation is enabled
- preserve the normal-suite zero-allocation budget unchanged

## Failure classification

PR #3810 exact-head TreeDB job [`29489557724/87592079654`](https://github.com/snissn/gomap/actions/runs/29489557724/job/87592079654) reported `allocs/run=1 want 0 after warmup` in `TestColumnVectorGraphSearchSourceAllocationFreeAfterWarmup1968` under `race-check (linux)-1`. PR #3810 does not touch the vector path. This is the same instrumentation-sensitive contract class already established by #3806, but in a separate score-source test.

## Validation

- `GOWORK=off go test ./TreeDB/collections -run '^TestColumnVectorGraphSearchSourceAllocationFreeAfterWarmup1968$' -count=100`
- `GOWORK=off go test -race ./TreeDB/collections -run '^TestColumnVectorGraphSearchSourceAllocationFreeAfterWarmup1968$' -count=20`
- `GOWORK=off go test -race ./TreeDB/collections -run '^TestColumnVectorGraphSearchSource' -count=5`
- `git diff --check`

All passed. The hosted failure is the characterization artifact; an isolated local pre-fix `-race -count=20` did not recur, reinforcing that exact race-instrumented allocation counts are scheduler/environment-sensitive rather than a usable allocation budget.

## Risk

Test wiring only. The warm score call still runs under `-race`; production code and the non-race zero-allocation assertion are unchanged.

Closes #3812



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated allocation checks to remain reliable when race detection is enabled.
  * Preserved validation of allocation-free behavior during standard test runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->