### PR TITLE
test: harden flaky CI contracts on red main

### DIFF
--- a/TreeDB/caching/checkpoint_productivity_stats_test.go
+++ b/TreeDB/caching/checkpoint_productivity_stats_test.go
@@ -321,20 +321,23 @@ func TestCheckpointWaitProductivityStatsActiveBackgroundDrainsFrontier(t *testin
 	} else if activeWaitLastNs == 0 {
 		t.Fatalf("active background wait last ns=%d want >0 when samples=%d", activeWaitLastNs, activeWaitSamples)
 	}
-	if got := requireStatUint64(t, stats, "treedb.cache.checkpoint.wait.frontier_units_at_request_last"); got != 2 {
-		t.Fatalf("wait frontier at request=%d want 2", got)
+	frontierAtRequest := requireStatUint64(t, stats, "treedb.cache.checkpoint.wait.frontier_units_at_request_last")
+	if frontierAtRequest != 2 {
+		t.Fatalf("wait frontier at request=%d want 2", frontierAtRequest)
 	}
-	if got := requireStatUint64(t, stats, "treedb.cache.checkpoint.wait.remaining_frontier_units_last"); got != 1 {
-		t.Fatalf("wait remaining frontier=%d want 1", got)
+	remainingFrontier := requireStatUint64(t, stats, "treedb.cache.checkpoint.wait.remaining_frontier_units_last")
+	drainedFrontier := requireStatUint64(t, stats, "treedb.cache.checkpoint.wait.drained_frontier_units_last")
+	if remainingFrontier > frontierAtRequest || drainedFrontier+remainingFrontier != frontierAtRequest {
+		t.Fatalf("wait frontier accounting: requested=%d drained=%d remaining=%d", frontierAtRequest, drainedFrontier, remainingFrontier)
 	}
-	if got := requireStatUint64(t, stats, "treedb.cache.checkpoint.wait.drained_frontier_units_last"); got != 1 {
-		t.Fatalf("wait drained frontier=%d want 1", got)
+	if drainedFrontier == 0 {
+		t.Fatalf("wait drained frontier=%d want >0", drainedFrontier)
 	}
-	if got := requireStatUint64(t, stats, "treedb.cache.checkpoint.frontier.units_last"); got != 1 {
-		t.Fatalf("checkpoint-owned frontier units=%d want 1", got)
+	if got := requireStatUint64(t, stats, "treedb.cache.checkpoint.frontier.units_last"); got != remainingFrontier {
+		t.Fatalf("checkpoint-owned frontier units=%d want remaining %d", got, remainingFrontier)
 	}
-	if got := requireStatUint64(t, stats, "treedb.cache.checkpoint.flush_all.owned_drain_units_last"); got != 1 {
-		t.Fatalf("owned drain units=%d want 1", got)
+	if got := requireStatUint64(t, stats, "treedb.cache.checkpoint.flush_all.owned_drain_units_last"); got != remainingFrontier {
+		t.Fatalf("owned drain units=%d want remaining %d", got, remainingFrontier)
 	}
 	if activeWaitLastNs != 0 {
 		if got := requireStatFloat64(t, stats, "treedb.cache.checkpoint.wait.frontier_drain_bytes_per_sec_last"); got == 0 {

--- a/TreeDB/caching/vlog_generation_leafref_reopen_test.go
+++ b/TreeDB/caching/vlog_generation_leafref_reopen_test.go
@@ -36,10 +36,22 @@ func ageValueLogFilesForTest(t *testing.T, dir string, age time.Duration) {
 	}
 	old := time.Now().Add(-age)
 	for _, path := range paths {
-		if err := os.Chtimes(path, old, old); err != nil {
+		if err := os.Chtimes(path, old, old); err != nil && !os.IsNotExist(err) {
 			t.Fatalf("chtimes %s: %v", path, err)
 		}
 	}
+}
+
+func TestAgeValueLogFilesForTestToleratesDisappearedMatch(t *testing.T) {
+	leafDir := filepath.Join(t.TempDir(), "leaf_vlog")
+	if err := os.MkdirAll(leafDir, 0o755); err != nil {
+		t.Fatalf("mkdir leaf vlog: %v", err)
+	}
+	path := filepath.Join(leafDir, "value-l255-000001.log")
+	if err := os.Symlink(filepath.Join(leafDir, "already-removed.log"), path); err != nil {
+		t.Skipf("symlink unavailable: %v", err)
+	}
+	ageValueLogFilesForTest(t, filepath.Dir(leafDir), time.Hour)
 }
 
 func valueLogPathForFileID(root string, fileID uint32) string {

--- a/TreeDB/collections/column_vector_graph_search_source_test.go
+++ b/TreeDB/collections/column_vector_graph_search_source_test.go
@@ -452,6 +452,9 @@ func TestColumnVectorGraphSearchSourceAllocationFreeAfterWarmup1968(t *testing.T
 	if _, err := plan.scoreSource.scoreOrdinalsScalar(plan, nil, query, queryInvNorm, ordinals, scores, scratch, &warmStats); err != nil {
 		t.Fatalf("warm score tile: %v", err)
 	}
+	if collectionsRaceEnabled {
+		t.Skip("exact allocation counts are unstable under race instrumentation")
+	}
 	var runErr error
 	allocs := testing.AllocsPerRun(1000, func() {
 		var stats columnVectorGraphNativeSearchStats


### PR DESCRIPTION
## Summary

This is the combined integration head for three disjoint red-main test contracts that form a CI dependency cycle when proved separately:

- checkpoint productivity asserts scheduler-independent drain conservation rather than an exact 1/1 split (#3807)
- scalar vector score setup/warm correctness remains under `-race`, while only `AllocsPerRun` is skipped (#3812)
- value-log test aging accepts only a legitimate ENOENT between enumeration and `Chtimes`, with a deterministic regression (#3814)

The narrow PRs #3810 and #3813 remain open until this combined head passes and merges; they will then be closed as superseded.

## Failure classification

- #3807: exact-main/PR #3798 Windows observed a fully drained frontier (`remaining=0`) where the old test required exactly one residual unit. The total requested frontier and drain/residual ownership remain exact.
- #3812: PR #3810 exact-head job [`29489557724/87592079654`](https://github.com/snissn/gomap/actions/runs/29489557724/job/87592079654) reported one allocation under race instrumentation in the scalar score-source `AllocsPerRun` gate.
- #3814: PR #3813 exact-head job [`29490540249/87595311854`](https://github.com/snissn/gomap/actions/runs/29490540249/job/87595311854) saw a leaf-log segment reclaimed between `filepath.Glob` and `os.Chtimes`.
- PR #3813 proof job [`29490572749/87595415731`](https://github.com/snissn/gomap/actions/runs/29490572749/job/87595415731) independently reproduced #3807 because its isolated branch was based on red main. Conversely, #3810 reproduced #3812. A combined exact tree is therefore required to obtain honest green hosted evidence before either change merges.

## Validation

On combined exact head `c2575b23f40ac5d2caf4efa709452b6360c5292c`:

- checkpoint active-background test x500; all checkpoint productivity tests under `-race` x100
- scalar vector allocation gate x100; adjacent scalar score-source tests under `-race` x5
- full `TreeDB/collections` package under `-race` passed in 316.915s on the same vector patch
- value-log disappeared-match plus named maintenance/reopen fixture x20; both under `-race` x10
- `git diff --check origin/main...HEAD`

All passed. Earlier node-specific focused evidence is retained in #3807, #3812, and #3814.

## Risk

Test harness only across three files. Production code, allocation budgets outside race instrumentation, durability, GC, resource-pin behavior, and requested checkpoint frontier accounting are unchanged.

Closes #3807
Closes #3812
Closes #3814
