### PR TITLE
fix(pager): serialize concurrent truncate growth

### DIFF
--- a/TreeDB/pager/pager.go
+++ b/TreeDB/pager/pager.go
@@ -19,6 +19,10 @@ var (
 	ErrReadOnly        = errors.New("pager is read-only")
 )
 
+// testHookTruncateAfterPageCount is a package-local scheduling barrier for
+// proving that overlapping grow intents do not append stale page-count deltas.
+var testHookTruncateAfterPageCount func(uint64)
+
 type chunkList struct {
 	data [][]byte
 }
@@ -522,18 +526,25 @@ func (p *Pager) Truncate(targetPages uint64) error {
 		return ErrReadOnly
 	}
 	currentPages := p.numPages.Load()
-
+	if testHookTruncateAfterPageCount != nil {
+		testHookTruncateAfterPageCount(currentPages)
+	}
 	if targetPages < currentPages {
 		return fmt.Errorf("truncation (shrinking) is forbidden: current %d, target %d", currentPages, targetPages)
 	}
-
 	if targetPages == currentPages {
+		return nil
+	}
+	p.allocMu.Lock()
+	defer p.allocMu.Unlock()
+	currentPages = p.numPages.Load()
+	if targetPages <= currentPages {
 		return nil
 	}
 
 	// diff is guaranteed positive
 	diff := int(targetPages - currentPages)
-	_, err := p.Alloc(diff)
+	_, err := p.allocLocked(diff)
 	return err
 }
 
@@ -545,7 +556,10 @@ func (p *Pager) Alloc(count int) (uint64, error) {
 	}
 	p.allocMu.Lock()
 	defer p.allocMu.Unlock()
+	return p.allocLocked(count)
+}
 
+func (p *Pager) allocLocked(count int) (uint64, error) {
 	p.mu.Lock()
 	startID := p.numPages.Load()
 	newTotal := startID + uint64(count)

--- a/TreeDB/pager/pager_test.go
+++ b/TreeDB/pager/pager_test.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -301,6 +302,73 @@ func TestPagerTruncate(t *testing.T) {
 		t.Errorf("Expected file size %d, got %d", expectedSize, info.Size())
 	}
 
+}
+
+func TestPagerTruncateSerializesConcurrentGrowth(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "index_truncate_concurrent.db")
+	chunkSize := int64(page.PageSize * 4)
+	if gran := mmapOffsetGranularity(); gran > 0 && chunkSize%gran != 0 {
+		chunkSize = gran
+	}
+
+	p, err := Open(path, chunkSize)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer p.Close()
+	if _, err := p.Alloc(2); err != nil {
+		t.Fatalf("initial Alloc: %v", err)
+	}
+
+	observed := make(chan uint64, 1)
+	release := make(chan struct{})
+	defer func() {
+		select {
+		case <-release:
+		default:
+			close(release)
+		}
+	}()
+	var snapshots atomic.Int32
+	previousHook := testHookTruncateAfterPageCount
+	testHookTruncateAfterPageCount = func(current uint64) {
+		if snapshots.Add(1) != 1 {
+			return
+		}
+		observed <- current
+		<-release
+	}
+	t.Cleanup(func() { testHookTruncateAfterPageCount = previousHook })
+
+	truncateErr := make(chan error, 1)
+	go func() { truncateErr <- p.Truncate(5) }()
+	select {
+	case current := <-observed:
+		if current != 2 {
+			t.Fatalf("truncate observed pages=%d want 2", current)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("truncate did not reach page-count snapshot")
+	}
+
+	// Both calls observed 2 pages. The old implementation serialized only the
+	// later allocations, so their stale +3 and +4 deltas produced 9 pages.
+	if err := p.Truncate(6); err != nil {
+		t.Fatalf("concurrent Truncate: %v", err)
+	}
+	close(release)
+	select {
+	case err := <-truncateErr:
+		if err != nil {
+			t.Fatalf("Truncate: %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("truncate did not finish")
+	}
+	if got := p.PageCount(); got != 6 {
+		t.Fatalf("page count=%d want later target 6", got)
+	}
 }
 
 func TestPagerAsyncPreGrow_DefaultChunkEnabled(t *testing.T) {


### PR DESCRIPTION
## Summary

- serialize `Pager.Truncate` page-count re-read and growth under `allocMu`
- avoid appending stale deltas when overlapping grow intents observe the same tail
- add a deterministic interleaving regression for concurrent truncate targets

## Root cause

`Truncate` previously read `numPages` and computed its delta before entering the allocation critical section. Overlapping grow calls could each compute from the same old tail and then append both deltas serially. This explains the hosted physical-tail 1299 versus live high-water 1250 failure without requiring a Go data race.

The fix retains invocation-time shrink rejection. If another grow reaches or overtakes the target while this call waits, the target is already satisfied and no pages are appended.

## Validation

- `GOWORK=off go test -race ./TreeDB/pager -run TestPagerTruncate -count=100`
- full `TreeDB/pager` race suite
- relevant freelist physical-tail/build-ahead race tests x100
- original collection failure-shape test x25 and race x5
- focused root-publication, durable-root, and leaf-pack DB tests normal x5 and race x1
- `git diff --check`

No root-publication, freelist, validator, GC, or persistent value-log semantics are weakened.

Closes #3808