### PR TITLE
test(treedb): settle stable pin baseline

### DIFF
--- a/TreeDB/collections/stable_resource_inventory_test.go
+++ b/TreeDB/collections/stable_resource_inventory_test.go
@@ -37,6 +37,9 @@ func testStableColumnConstructionPinBlocksCrossManagerGC(t *testing.T) {
 	}
 	cfg := *otherCol.Meta().Options.ColumnStore
 	registry := d.StableResourceIdentityPinRegistry()
+	if err := d.Checkpoint(); err != nil {
+		t.Fatalf("settle initial publication before pin baseline: %v", err)
+	}
 	baselinePins := registry.ActivePins()
 	opened := make(chan struct{})
 	resume := make(chan struct{})


### PR DESCRIPTION
## Summary

- settle initial durable publication before sampling the stable-resource pin baseline
- retain the exact construction `baseline+1` and final-release `baseline` assertions
- align this lifecycle test with the existing stable-publication GC test

## Hosted red evidence

Exact-main TreeDB run `29494038608` completed 13/14 jobs green. Its macOS job failed `TestStableColumnConstructionPinBlocksCrossManagerGC` with 12 pins after final release versus an earlier baseline of 8. No failed-job rerun was used.

## Validation

- focused construction pin/unlink and stable-publication GC tests x100
- the same focused set under `-race` x25
- formatting and diff checks

This is a three-line test-only lifecycle fix. It adds no sleeps or polling and changes no pinning, GC, durable-root, or persistent value-log semantics.

Closes #3816