### PR TITLE
test: stabilize inherited CI timing contracts

### DIFF
--- a/TreeDB/caching/vlog_generation_scheduler_test.go
+++ b/TreeDB/caching/vlog_generation_scheduler_test.go
@@ -158,6 +158,23 @@ func forceRewriteStageConfirmDue(t *testing.T, db *DB) {
 	db.clearVlogGenerationRewriteStageConfirmation()
 }
 
+func holdVlogGenerationDeferredMaintenanceRunnerForTest(t *testing.T, db *DB) {
+	t.Helper()
+	if db == nil {
+		return
+	}
+	if db.vlogGenerationDeferredMaintenancePending.Load() {
+		t.Fatalf("deferred maintenance unexpectedly pending before test ownership barrier")
+	}
+	if !db.vlogGenerationDeferredMaintenanceRunning.CompareAndSwap(false, true) {
+		t.Fatalf("deferred maintenance runner unexpectedly active before test ownership barrier")
+	}
+	t.Cleanup(func() {
+		db.vlogGenerationDeferredMaintenancePending.Store(false)
+		db.vlogGenerationDeferredMaintenanceRunning.Store(false)
+	})
+}
+
 func disableVlogGenerationLoop(t *testing.T) {
 	t.Helper()
 	t.Setenv(envDisableVlogGenerationLoop, "1")
@@ -7340,6 +7357,7 @@ func TestVlogGenerationMaintenance_CheckpointPendingYieldsToDueStageConfirm(t *t
 
 	db.vlogGenerationCheckpointKickPending.Store(true)
 	t.Cleanup(func() { db.vlogGenerationCheckpointKickPending.Store(false) })
+	holdVlogGenerationDeferredMaintenanceRunnerForTest(t, db)
 
 	db.maybeRunVlogGenerationMaintenanceWithOptions(true, vlogGenerationMaintenanceOptions{
 		bypassQuiet:           true,
@@ -7357,6 +7375,9 @@ func TestVlogGenerationMaintenance_CheckpointPendingYieldsToDueStageConfirm(t *t
 	}
 	if !db.vlogGenerationCheckpointKickPending.Load() {
 		t.Fatalf("checkpoint-pending retry should remain queued while due stage confirmation is pending")
+	}
+	if !db.vlogGenerationDeferredMaintenancePending.Load() {
+		t.Fatalf("due stage confirmation should remain queued behind the test-owned deferred runner")
 	}
 }
 
@@ -7399,6 +7420,7 @@ func TestVlogGenerationMaintenance_CheckpointPendingYieldsToDueAgeBlockedRetry(t
 
 	db.vlogGenerationCheckpointKickPending.Store(true)
 	t.Cleanup(func() { db.vlogGenerationCheckpointKickPending.Store(false) })
+	holdVlogGenerationDeferredMaintenanceRunnerForTest(t, db)
 
 	_, planCallsBefore := recorder.recordedPlan()
 	_, rewriteCallsBefore := recorder.recordedRewrite()
@@ -7427,6 +7449,9 @@ func TestVlogGenerationMaintenance_CheckpointPendingYieldsToDueAgeBlockedRetry(t
 	}
 	if !db.vlogGenerationCheckpointKickPending.Load() {
 		t.Fatalf("checkpoint-pending retry should remain queued while due age-blocked retry is pending")
+	}
+	if !db.vlogGenerationDeferredMaintenancePending.Load() {
+		t.Fatalf("due age-blocked retry should remain queued behind the test-owned deferred runner")
 	}
 }
 

--- a/TreeDB/db/command_wal_stats_test.go
+++ b/TreeDB/db/command_wal_stats_test.go
@@ -559,11 +559,16 @@ func TestCommandWALCleanupStatsCountConsumedBytes(t *testing.T) {
 			t.Fatalf("%s=%d, want %d (stats=%#v)", key, got, want, stats)
 		}
 	}
-	// The proof count is the observed-work signal. On platforms with coarse
-	// monotonic clock resolution, this short phase can legitimately measure 0ns.
-	_ = commandWALTestStatUint64(t, stats, "treedb.command_wal.cleanup.proof.ns_total")
+	// The exact counts and byte totals are the observed-work signals. On
+	// platforms with coarse monotonic clock resolution, both short phases can
+	// legitimately measure 0ns; still require their stats to exist and parse.
 	for _, key := range []string{
+		"treedb.command_wal.cleanup.proof.ns_total",
 		"treedb.command_wal.cleanup.ns_total",
+	} {
+		_ = commandWALTestStatUint64(t, stats, key)
+	}
+	for _, key := range []string{
 		"treedb.command_wal.cleanup.covered_bytes_total",
 		"treedb.command_wal.cleanup.retained_bytes_total",
 		"treedb.command_wal.cleanup.removed_bytes_total",


### PR DESCRIPTION
## Objective

Stabilize two inherited CI contracts exposed while proving PR #3828: the value-log due-stage-confirm test's observation interval and command-WAL cleanup timing on coarse Windows clocks.

Closes #3829.
Closes #3830.

## Context

- PR #3828 proof B failed `TestVlogGenerationMaintenance_CheckpointPendingYieldsToDueStageConfirm` after a legitimate deferred stage-confirm runner incremented the shared plan recorder before the test sampled it.
- Exact main at `99b636099f7fd698a30ae63e6a3b5fa85d027441` failed `TestCommandWALCleanupStatsCountConsumedBytes` with `cleanup.ns_total=0` even though every exact cleanup count and byte total proved the work occurred.

## Non-goals

- No production scheduler behavior changes.
- No command-WAL cleanup, durability, coverage, or accounting changes.
- No sleeps, retries, counter resets, threshold waivers, format changes, or public API changes.

## Design

- Let the two scheduler tests temporarily own the deferred-runner latch. This prevents the legitimate asynchronous retry from entering the recorder's strict zero-plan interval while preserving the assertions that no plan/rewrite occurred and that both pending intents remain queued.
- Require both command-WAL cleanup duration stats to exist and parse, but allow either to be zero at sub-clock resolution. Exact count, segment, byte, and sync totals remain the observed-work proof.

## Scope

- Includes: `TreeDB/caching/vlog_generation_scheduler_test.go`, `TreeDB/db/command_wal_stats_test.go`.
- Excludes: all production caching, value-log, command-WAL, durability, and storage code.

## Correctness

Tests run on exact head `7baacd544`:

```text
GOWORK=off go test ./TreeDB/caching -run '^TestVlogGenerationMaintenance_CheckpointPendingYieldsToDue(StageConfirm|AgeBlockedRetry)$' -count=1000
PASS (153.868s)

GOWORK=off go test ./TreeDB/db -run '^(TestCommandWALCleanupStatsCountConsumedBytes|TestCommandWALStatsScanRefreshesWithoutAppliedLSNChange|TestCommandWALStatsDisabledDoesNotScanWAL)$' -count=1000
PASS (73.247s)

GOWORK=off go test ./TreeDB/caching -run '^(TestVlogGenerationMaintenance_CheckpointPendingYieldsToDue(StageConfirm|AgeBlockedRetry)|TestVlogGenerationMaintenance_SchedulesDueStageConfirmationOnExit|TestSchedulePendingVlogGenerationCheckpointKick_PrioritizesDueDeferredWake)$' -count=100
PASS (28.479s)

GOWORK=off go test -race ./TreeDB/caching -run '^(TestVlogGenerationMaintenance_CheckpointPendingYieldsToDue(StageConfirm|AgeBlockedRetry)|TestVlogGenerationMaintenance_SchedulesDueStageConfirmationOnExit)$' -count=20
PASS (6.528s)

GOWORK=off go test -race ./TreeDB/db -run '^(TestCommandWALCleanupStatsCountConsumedBytes|TestCommandWALStatsScanRefreshesWithoutAppliedLSNChange|TestCommandWALStatsDisabledDoesNotScanWAL)$' -count=20
PASS (1.879s)

GOWORK=off go vet ./TreeDB/caching ./TreeDB/db
PASS

GOWORK=off go test ./TreeDB/caching ./TreeDB/db -count=1
PASS (caching 100.981s; db 334.352s)
```

## Performance

Test-contract-only change; no production path or benchmark result changes.

## Rollout / Toggle Plan

No runtime rollout or toggle. Revert the test-only commit if the contracts need to be redesigned.

## Follow-ups

- Refresh and restart every exact-head gate for #3828 after this PR merges.
- Continue the #3776 dependency graph in topological order.

### AI Review Loop

- Codex latest-head review: pending mature-head request.
- CodeRabbit latest-head review: pending.
- Review comments/threads: pending.
- Re-request after final meaningful push: required.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Improved maintenance scheduling test reliability by ensuring deferred maintenance work is evaluated under controlled execution conditions.
  - Updated cleanup statistics coverage to verify that timing counters are present and parseable, including when very short operations report zero nanoseconds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->