### PR TITLE
[DUR-11] Land fail-closed power-loss certification foundation

### DIFF
--- a/TreeDB/docs/spec/power-loss-certification-3684.md
+++ b/TreeDB/docs/spec/power-loss-certification-3684.md
@@ -64,11 +64,24 @@ The evidence directory must be empty. Capture writes:
   manifests;
 - a separate `recovery-input/` copy so read-write recovery cannot mutate the
   crash-image evidence;
-- `recovery_trace.json` from the normal public open path; and
+- `recovery_trace.json` from the normal public open path, bound to the SHA-256
+  of `stable_image_tree.json` and the model's stable fingerprint; and
 - `metrics.json` with image sizes, file counts, trace count, and stable-image
   fingerprint.
 
-The command runner owns the exact test-binary hash and captured command log.
+Every modeled witness registers those five JSON files and
+`command_log.json` at their canonical names directly below its declared
+`TREEDB_POWERLOSS_EVIDENCE_DIR`. The verifier strictly parses every schema,
+rehashes every file named by both image-tree manifests, rejects extra image
+files and symlinks, cross-checks metrics against the trace and image trees, and
+binds the recovery trace to the immutable stable image. For read-only recovery,
+the preserved `recovery-input/` bytes must still match the stable tree exactly.
+
+The command runner owns `command_log.json`. Its versioned JSON envelope records
+the exact repository SHA, test-binary path and SHA-256, package, test name,
+arguments, replay environment, completion status, exit code, and captured
+stdout/stderr. The verifier requires a completed zero exit and an exact match
+to the child manifest; a hashed arbitrary log file is not evidence.
 
 ## Current fail-closed status
 

--- a/TreeDB/docs/spec/power-loss-certification-3684.md
+++ b/TreeDB/docs/spec/power-loss-certification-3684.md
@@ -79,9 +79,12 @@ the preserved `recovery-input/` bytes must still match the stable tree exactly.
 
 The command runner owns `command_log.json`. Its versioned JSON envelope records
 the exact repository SHA, test-binary path and SHA-256, package, test name,
-arguments, replay environment, completion status, exit code, and captured
-stdout/stderr. The verifier requires a completed zero exit and an exact match
-to the child manifest; a hashed arbitrary log file is not evidence.
+arguments, replay environment, observed outcome, completion status, exit code,
+and captured stdout/stderr. Modeled outcomes use `accepted:<state>` or
+`rejected:<reason>`; the verifier binds that class to the public-open recovery
+result and the full outcome to the command log. It requires a completed zero
+exit and an exact match to the child manifest; a hashed arbitrary log file is
+not evidence.
 
 ## Current fail-closed status
 

--- a/TreeDB/docs/spec/power-loss-certification-3684.md
+++ b/TreeDB/docs/spec/power-loss-certification-3684.md
@@ -65,6 +65,9 @@ The evidence directory must be empty. Capture writes:
   directories) and every regular file;
 - a separate `recovery-input/` copy so read-write recovery cannot mutate the
   crash-image evidence;
+- an immutable `recovery-preopen/` snapshot of the exact stable tree supplied
+  to public open, so writable recovery remains verifiable after it mutates
+  `recovery-input/`;
 - `recovery_trace.json` from the normal public open path, bound to the SHA-256
   of `stable_image_tree.json` and the model's stable fingerprint; and
 - `metrics.json` with image sizes, file counts, trace count, and stable-image
@@ -72,12 +75,16 @@ The evidence directory must be empty. Capture writes:
 
 Every modeled witness registers those five JSON files and
 `command_log.json` at their canonical names directly below its declared
-`TREEDB_POWERLOSS_EVIDENCE_DIR`. The verifier strictly parses every schema,
+`TREEDB_POWERLOSS_EVIDENCE_DIR`; modeled witnesses may not reuse that directory
+or its evidence as independent coverage. The verifier strictly parses every
+schema,
 rehashes every file named by both image-tree manifests, compares their exact
 directory sets, rejects extra image paths and symlinks, cross-checks metrics
 against the trace and image trees, and binds the recovery trace to the immutable
-stable image. For read-only recovery, the preserved `recovery-input/` namespace
-and bytes must still match the stable tree exactly.
+stable image. The preserved `recovery-preopen/` namespace and bytes must always
+match the stable tree exactly. For read-only recovery, the unchanged
+`recovery-input/` must match it too; writable recovery may mutate only that
+working copy after public open begins.
 
 The command runner owns `command_log.json`. Its versioned JSON envelope records
 the exact repository SHA, test-binary path and SHA-256, package, test name,

--- a/TreeDB/docs/spec/power-loss-certification-3684.md
+++ b/TreeDB/docs/spec/power-loss-certification-3684.md
@@ -1,0 +1,83 @@
+# Current-main power-loss certification
+
+Issue [#3684](https://github.com/snissn/gomap/issues/3684) is the final evidence
+owner for the durability graph rooted at #1595. Certification is deliberately
+fail-closed: clean shutdown, process termination, ordinary reopen, green CI,
+and benchmark results do not satisfy modeled power-loss obligations.
+
+## Evidence tiers
+
+- `clean-process` records graceful close, process termination, or ordinary
+  reopen evidence. It is regression coverage, not a corruption-safety claim.
+- `modeled-crash` records an allowed stable/dirty image from the deterministic
+  power-loss model and reopens only a copy of stable bytes through the normal
+  public `treedb.Open` path. Only this tier owns the required corruption-safety
+  matrix.
+- `block-device` is reserved for a separately provisioned destructive runner.
+  No block-device claim is made by the repository certification suite.
+
+## Bundle contract
+
+A certification bundle contains:
+
+```text
+power_loss_certification/
+  risk_inventory.json
+  manifests/*.json
+```
+
+The versioned risk inventory freezes required values, mandatory retained
+counterexamples, negative controls, and explicit covering interactions. Child
+manifests carry exact repository and PR provenance, structured test commands,
+observed cut metadata, recovery state, expected and actual outcomes, and
+SHA-256-addressed artifacts.
+
+`TreeDB/internal/powerlosscert` rejects unknown JSON fields, stale or partial
+SHAs, duplicate IDs, undeclared inventory values, incomplete interactions,
+non-production profiles, unobserved cuts, missing modeled-crash artifact
+classes, and artifact hash mismatches. Coverage and representative selection
+count only `modeled-crash` witnesses. Mandatory counterexamples and negative
+controls are selected before deterministic greedy set cover.
+
+## Replay artifact capture
+
+Ledger-addressed tests continue to use the existing replay selectors:
+
+```text
+TREEDB_POWERLOSS_CUT_ID
+TREEDB_POWERLOSS_VARIANT_ID
+TREEDB_POWERLOSS_SEED
+```
+
+Setting both variables below enables fail-closed evidence capture for a public
+reopen:
+
+```text
+TREEDB_POWERLOSS_EVIDENCE_DIR
+TREEDB_POWERLOSS_EXPECT_CUT_POINT
+```
+
+The evidence directory must be empty. Capture writes:
+
+- `operation_trace.json` with the declared cut and actual observed event count;
+- immutable `stable-image/` and `dirty-image/` trees plus deterministic tree
+  manifests;
+- a separate `recovery-input/` copy so read-write recovery cannot mutate the
+  crash-image evidence;
+- `recovery_trace.json` from the normal public open path; and
+- `metrics.json` with image sizes, file counts, trace count, and stable-image
+  fingerprint.
+
+The command runner owns the exact test-binary hash and captured command log.
+
+## Current fail-closed status
+
+The infrastructure alone does not certify current main. Before #3684 can
+close, the frozen inventory must be committed and its validator must report
+complete modeled-public-reopen ownership at one exact `origin/main` SHA.
+Known current gaps include durable-profile modeled cuts, several public API and
+authoritative-resource interactions, maintenance/cleanup cuts, durable-prefix
+negative controls, and counterexample occurrences currently tolerated by the
+canonical enumerator without ledger identities. These gaps must be assigned
+and corrected; helper-only or clean/process tests must not be relabeled as
+modeled crash evidence.

--- a/TreeDB/docs/spec/power-loss-certification-3684.md
+++ b/TreeDB/docs/spec/power-loss-certification-3684.md
@@ -61,7 +61,8 @@ The evidence directory must be empty. Capture writes:
 
 - `operation_trace.json` with the declared cut and actual observed event count;
 - immutable `stable-image/` and `dirty-image/` trees plus deterministic tree
-  manifests;
+  manifests that bind the complete directory namespace (including empty
+  directories) and every regular file;
 - a separate `recovery-input/` copy so read-write recovery cannot mutate the
   crash-image evidence;
 - `recovery_trace.json` from the normal public open path, bound to the SHA-256
@@ -72,10 +73,11 @@ The evidence directory must be empty. Capture writes:
 Every modeled witness registers those five JSON files and
 `command_log.json` at their canonical names directly below its declared
 `TREEDB_POWERLOSS_EVIDENCE_DIR`. The verifier strictly parses every schema,
-rehashes every file named by both image-tree manifests, rejects extra image
-files and symlinks, cross-checks metrics against the trace and image trees, and
-binds the recovery trace to the immutable stable image. For read-only recovery,
-the preserved `recovery-input/` bytes must still match the stable tree exactly.
+rehashes every file named by both image-tree manifests, compares their exact
+directory sets, rejects extra image paths and symlinks, cross-checks metrics
+against the trace and image trees, and binds the recovery trace to the immutable
+stable image. For read-only recovery, the preserved `recovery-input/` namespace
+and bytes must still match the stable tree exactly.
 
 The command runner owns `command_log.json`. Its versioned JSON envelope records
 the exact repository SHA, test-binary path and SHA-256, package, test name,

--- a/TreeDB/docs/spec/power-loss-certification-3684.md
+++ b/TreeDB/docs/spec/power-loss-certification-3684.md
@@ -75,9 +75,9 @@ The evidence directory must be empty. Capture writes:
 
 Every modeled witness registers those five JSON files and
 `command_log.json` at their canonical names directly below its declared
-`TREEDB_POWERLOSS_EVIDENCE_DIR`; modeled witnesses may not reuse that directory
-or its evidence as independent coverage. The verifier strictly parses every
-schema,
+`TREEDB_POWERLOSS_EVIDENCE_DIR`; modeled witnesses may not reuse that lexical or
+resolved directory as independent coverage, and no evidence-directory component
+may be a symlink. The verifier strictly parses every schema,
 rehashes every file named by both image-tree manifests, compares their exact
 directory sets, rejects extra image paths and symlinks, cross-checks metrics
 against the trace and image trees, and binds the recovery trace to the immutable

--- a/TreeDB/internal/powerlosscert/bundle.go
+++ b/TreeDB/internal/powerlosscert/bundle.go
@@ -4,15 +4,23 @@ import (
 	"crypto/sha256"
 	"fmt"
 	"io"
+	"io/fs"
 	"net/url"
 	"os"
 	"path/filepath"
+	"reflect"
 	"sort"
 	"strconv"
 	"strings"
 )
 
-const operationTraceSchemaVersion = "treedb-power-loss-operation-trace/v1"
+const (
+	operationTraceSchemaVersion = "treedb-power-loss-operation-trace/v1"
+	imageTreeSchemaVersion      = "treedb-power-loss-image-tree/v1"
+	recoveryTraceSchemaVersion  = "treedb-power-loss-recovery-trace/v1"
+	metricsSchemaVersion        = "treedb-power-loss-metrics/v1"
+	commandLogSchemaVersion     = "treedb-power-loss-command-log/v1"
+)
 
 type operationTraceArtifact struct {
 	SchemaVersion      string   `json:"schema_version"`
@@ -22,6 +30,67 @@ type operationTraceArtifact struct {
 	DeclaredCutPoint   string   `json:"declared_cut_point"`
 	ObservedEventCount int      `json:"observed_event_count"`
 	Events             []string `json:"events"`
+}
+
+type imageTreeArtifact struct {
+	SchemaVersion string                  `json:"schema_version"`
+	Kind          string                  `json:"kind"`
+	Files         []imageTreeFileArtifact `json:"files"`
+	TotalBytes    int64                   `json:"total_bytes"`
+}
+
+type imageTreeFileArtifact struct {
+	Path   string `json:"path"`
+	Bytes  int64  `json:"bytes"`
+	SHA256 string `json:"sha256"`
+}
+
+type recoveryTraceArtifact struct {
+	SchemaVersion     string `json:"schema_version"`
+	PublicAPI         string `json:"public_api"`
+	Dir               string `json:"dir"`
+	InputTreeSHA256   string `json:"input_image_tree_sha256"`
+	StableFingerprint string `json:"stable_fingerprint"`
+	ReadOnly          bool   `json:"read_only"`
+	Rejected          bool   `json:"rejected"`
+	ErrorType         string `json:"error_type"`
+	Error             string `json:"error"`
+	CommitSeq         uint64 `json:"commit_seq"`
+	AppliedLSN        uint64 `json:"applied_lsn"`
+}
+
+type metricsArtifact struct {
+	SchemaVersion     string `json:"schema_version"`
+	StableImageBytes  int64  `json:"stable_image_bytes"`
+	DirtyImageBytes   int64  `json:"dirty_image_bytes"`
+	StableFiles       int    `json:"stable_files"`
+	DirtyFiles        int    `json:"dirty_files"`
+	TraceEvents       int    `json:"trace_events"`
+	StableFingerprint string `json:"stable_fingerprint"`
+}
+
+type commandLogArtifact struct {
+	SchemaVersion string            `json:"schema_version"`
+	RepositorySHA string            `json:"repository_sha"`
+	BinaryPath    string            `json:"binary_path"`
+	BinarySHA256  string            `json:"binary_sha256"`
+	Package       string            `json:"package"`
+	TestName      string            `json:"test_name"`
+	Args          []string          `json:"args"`
+	Env           map[string]string `json:"env"`
+	Completed     bool              `json:"completed"`
+	ExitCode      int               `json:"exit_code"`
+	Stdout        string            `json:"stdout"`
+	Stderr        string            `json:"stderr"`
+}
+
+var modeledArtifactNames = map[ArtifactKind]string{
+	ArtifactKindOperationTrace:  "operation_trace.json",
+	ArtifactKindStableImageTree: "stable_image_tree.json",
+	ArtifactKindDirtyImageTree:  "dirty_image_tree.json",
+	ArtifactKindRecoveryTrace:   "recovery_trace.json",
+	ArtifactKindMetrics:         "metrics.json",
+	ArtifactKindLog:             "command_log.json",
 }
 
 type Bundle struct {
@@ -132,7 +201,7 @@ func VerifyArtifacts(root string, manifests []ChildManifest) error {
 			if witness.EvidenceTier != EvidenceTierModeledCrash {
 				continue
 			}
-			if err := verifyOperationTrace(root, manifest.ManifestID, witness); err != nil {
+			if err := verifyModeledEvidence(root, manifest, witness); err != nil {
 				return err
 			}
 		}
@@ -140,48 +209,86 @@ func VerifyArtifacts(root string, manifests []ChildManifest) error {
 	return nil
 }
 
-func verifyOperationTrace(root, manifestID string, witness Witness) error {
-	prefix := fmt.Sprintf("powerlosscert: manifest %q witness %q operation trace", manifestID, witness.ID)
-	var traceArtifact *Artifact
-	for index := range witness.Artifacts {
-		if witness.Artifacts[index].Kind == ArtifactKindOperationTrace {
-			traceArtifact = &witness.Artifacts[index]
-			break
+func verifyModeledEvidence(root string, manifest ChildManifest, witness Witness) error {
+	prefix := fmt.Sprintf("powerlosscert: manifest %q witness %q", manifest.ManifestID, witness.ID)
+	evidenceDir := normalizedArtifactPath(witness.Command.Env["TREEDB_POWERLOSS_EVIDENCE_DIR"])
+	if evidenceDir == "." || strings.HasPrefix(evidenceDir, "../") {
+		return fmt.Errorf("%s has unsafe evidence directory %q", prefix, witness.Command.Env["TREEDB_POWERLOSS_EVIDENCE_DIR"])
+	}
+	artifacts := make(map[ArtifactKind]Artifact, len(witness.Artifacts))
+	for _, artifact := range witness.Artifacts {
+		artifacts[artifact.Kind] = artifact
+		name, modeled := modeledArtifactNames[artifact.Kind]
+		if modeled {
+			wantPath := normalizedArtifactPath(filepath.ToSlash(filepath.Join(evidenceDir, name)))
+			if normalizedArtifactPath(artifact.Path) != wantPath {
+				return fmt.Errorf("%s artifact kind %q path=%q want=%q", prefix, artifact.Kind, artifact.Path, wantPath)
+			}
 		}
 	}
-	if traceArtifact == nil {
-		return fmt.Errorf("%s is missing", prefix)
+	trace, err := verifyOperationTrace(root, manifest.ManifestID, witness, artifacts[ArtifactKindOperationTrace])
+	if err != nil {
+		return err
+	}
+	stableTree, err := verifyImageTree(root, evidenceDir, manifest.ManifestID, witness.ID, artifacts[ArtifactKindStableImageTree], "stable-image")
+	if err != nil {
+		return err
+	}
+	dirtyTree, err := verifyImageTree(root, evidenceDir, manifest.ManifestID, witness.ID, artifacts[ArtifactKindDirtyImageTree], "dirty-image")
+	if err != nil {
+		return err
+	}
+	metrics, err := verifyMetrics(root, manifest.ManifestID, witness, artifacts[ArtifactKindMetrics], trace, stableTree, dirtyTree)
+	if err != nil {
+		return err
+	}
+	recovery, err := verifyRecoveryTrace(root, evidenceDir, manifest.ManifestID, witness, artifacts[ArtifactKindRecoveryTrace], artifacts[ArtifactKindStableImageTree], metrics)
+	if err != nil {
+		return err
+	}
+	if recovery.ReadOnly {
+		if _, err := verifyImageDirectory(root, evidenceDir, manifest.ManifestID, witness.ID, "recovery-input", stableTree); err != nil {
+			return err
+		}
+	}
+	return verifyCommandLog(root, manifest, witness, artifacts[ArtifactKindLog])
+}
+
+func verifyOperationTrace(root, manifestID string, witness Witness, traceArtifact Artifact) (operationTraceArtifact, error) {
+	prefix := fmt.Sprintf("powerlosscert: manifest %q witness %q operation trace", manifestID, witness.ID)
+	if traceArtifact.Kind != ArtifactKindOperationTrace {
+		return operationTraceArtifact{}, fmt.Errorf("%s is missing", prefix)
 	}
 	data, err := os.ReadFile(filepath.Join(root, filepath.FromSlash(normalizedArtifactPath(traceArtifact.Path))))
 	if err != nil {
-		return fmt.Errorf("%s: %w", prefix, err)
+		return operationTraceArtifact{}, fmt.Errorf("%s: %w", prefix, err)
 	}
 	var trace operationTraceArtifact
 	if err := decodeStrict(data, &trace); err != nil {
-		return fmt.Errorf("%s decode: %w", prefix, err)
+		return operationTraceArtifact{}, fmt.Errorf("%s decode: %w", prefix, err)
 	}
 	if trace.SchemaVersion != operationTraceSchemaVersion {
-		return fmt.Errorf("%s schema_version=%q want=%q", prefix, trace.SchemaVersion, operationTraceSchemaVersion)
+		return operationTraceArtifact{}, fmt.Errorf("%s schema_version=%q want=%q", prefix, trace.SchemaVersion, operationTraceSchemaVersion)
 	}
 	if trace.CutID != witness.CutID {
-		return fmt.Errorf("%s cut_id=%q want=%q", prefix, trace.CutID, witness.CutID)
+		return operationTraceArtifact{}, fmt.Errorf("%s cut_id=%q want=%q", prefix, trace.CutID, witness.CutID)
 	}
 	if trace.DeclaredCutPoint != witness.CutPoint {
-		return fmt.Errorf("%s declared_cut_point=%q want=%q", prefix, trace.DeclaredCutPoint, witness.CutPoint)
+		return operationTraceArtifact{}, fmt.Errorf("%s declared_cut_point=%q want=%q", prefix, trace.DeclaredCutPoint, witness.CutPoint)
 	}
 	cutPoint, occurrence, err := parseCutAddress(trace.CutID)
 	if err != nil {
-		return fmt.Errorf("%s: %w", prefix, err)
+		return operationTraceArtifact{}, fmt.Errorf("%s: %w", prefix, err)
 	}
 	if cutPoint != witness.CutPoint || occurrence != witness.CutOccurrence {
-		return fmt.Errorf("%s cut address=(%s,%d) want=(%s,%d)", prefix, cutPoint, occurrence, witness.CutPoint, witness.CutOccurrence)
+		return operationTraceArtifact{}, fmt.Errorf("%s cut address=(%s,%d) want=(%s,%d)", prefix, cutPoint, occurrence, witness.CutPoint, witness.CutOccurrence)
 	}
 	wantSeed := strconv.FormatUint(witness.Seed, 10)
 	if trace.Seed != wantSeed {
-		return fmt.Errorf("%s seed=%q want=%q", prefix, trace.Seed, wantSeed)
+		return operationTraceArtifact{}, fmt.Errorf("%s seed=%q want=%q", prefix, trace.Seed, wantSeed)
 	}
 	if trace.VariantID == "" {
-		return fmt.Errorf("%s has empty variant_id", prefix)
+		return operationTraceArtifact{}, fmt.Errorf("%s has empty variant_id", prefix)
 	}
 	matchingEvents := 0
 	cutPrefix := "cut:" + witness.CutPoint + ":"
@@ -191,10 +298,10 @@ func verifyOperationTrace(root, manifestID string, witness Witness) error {
 		}
 	}
 	if trace.ObservedEventCount != matchingEvents || trace.ObservedEventCount != witness.ObservedEventCount {
-		return fmt.Errorf("%s observed_event_count=%d matching_events=%d witness=%d", prefix, trace.ObservedEventCount, matchingEvents, witness.ObservedEventCount)
+		return operationTraceArtifact{}, fmt.Errorf("%s observed_event_count=%d matching_events=%d witness=%d", prefix, trace.ObservedEventCount, matchingEvents, witness.ObservedEventCount)
 	}
 	if matchingEvents <= witness.CutOccurrence {
-		return fmt.Errorf("%s matching events=%d do not reach occurrence=%d", prefix, matchingEvents, witness.CutOccurrence)
+		return operationTraceArtifact{}, fmt.Errorf("%s matching events=%d do not reach occurrence=%d", prefix, matchingEvents, witness.CutOccurrence)
 	}
 	wantEnv := map[string]string{
 		"TREEDB_POWERLOSS_CUT_ID":           witness.CutID,
@@ -204,11 +311,194 @@ func verifyOperationTrace(root, manifestID string, witness Witness) error {
 	}
 	for name, want := range wantEnv {
 		if got := witness.Command.Env[name]; got != want {
-			return fmt.Errorf("%s command env %s=%q want=%q", prefix, name, got, want)
+			return operationTraceArtifact{}, fmt.Errorf("%s command env %s=%q want=%q", prefix, name, got, want)
 		}
 	}
 	if witness.Command.Env["TREEDB_POWERLOSS_EVIDENCE_DIR"] == "" {
-		return fmt.Errorf("%s command env TREEDB_POWERLOSS_EVIDENCE_DIR is empty", prefix)
+		return operationTraceArtifact{}, fmt.Errorf("%s command env TREEDB_POWERLOSS_EVIDENCE_DIR is empty", prefix)
+	}
+	return trace, nil
+}
+
+func verifyImageTree(root, evidenceDir, manifestID, witnessID string, artifact Artifact, kind string) (imageTreeArtifact, error) {
+	prefix := fmt.Sprintf("powerlosscert: manifest %q witness %q %s image tree", manifestID, witnessID, strings.TrimSuffix(kind, "-image"))
+	data, err := os.ReadFile(filepath.Join(root, filepath.FromSlash(normalizedArtifactPath(artifact.Path))))
+	if err != nil {
+		return imageTreeArtifact{}, fmt.Errorf("%s: %w", prefix, err)
+	}
+	var tree imageTreeArtifact
+	if err := decodeStrict(data, &tree); err != nil {
+		return imageTreeArtifact{}, fmt.Errorf("%s decode: %w", prefix, err)
+	}
+	if tree.SchemaVersion != imageTreeSchemaVersion {
+		return imageTreeArtifact{}, fmt.Errorf("%s schema_version=%q want=%q", prefix, tree.SchemaVersion, imageTreeSchemaVersion)
+	}
+	if tree.Kind != kind {
+		return imageTreeArtifact{}, fmt.Errorf("%s kind=%q want=%q", prefix, tree.Kind, kind)
+	}
+	if err := validateDeclaredImageTree(prefix, tree); err != nil {
+		return imageTreeArtifact{}, err
+	}
+	return verifyImageDirectory(root, evidenceDir, manifestID, witnessID, kind, tree)
+}
+
+func validateDeclaredImageTree(prefix string, tree imageTreeArtifact) error {
+	var total int64
+	prior := ""
+	for index, file := range tree.Files {
+		pathKey := normalizedArtifactPath(file.Path)
+		if file.Path == "" || filepath.IsAbs(file.Path) || pathKey == "." || strings.HasPrefix(pathKey, "../") || pathKey != file.Path {
+			return fmt.Errorf("%s file %d has unsafe or non-canonical path %q", prefix, index, file.Path)
+		}
+		if prior != "" && file.Path <= prior {
+			return fmt.Errorf("%s files are not strictly sorted at %q", prefix, file.Path)
+		}
+		if file.Bytes < 0 || !validHex(file.SHA256, 64) {
+			return fmt.Errorf("%s file %q has invalid bytes or sha256", prefix, file.Path)
+		}
+		if file.Bytes > int64(^uint64(0)>>1)-total {
+			return fmt.Errorf("%s byte total overflows", prefix)
+		}
+		total += file.Bytes
+		prior = file.Path
+	}
+	if tree.TotalBytes != total {
+		return fmt.Errorf("%s total_bytes=%d want=%d", prefix, tree.TotalBytes, total)
+	}
+	return nil
+}
+
+func verifyImageDirectory(root, evidenceDir, manifestID, witnessID, kind string, declared imageTreeArtifact) (imageTreeArtifact, error) {
+	prefix := fmt.Sprintf("powerlosscert: manifest %q witness %q %s image", manifestID, witnessID, strings.TrimSuffix(kind, "-image"))
+	dir := filepath.Join(root, filepath.FromSlash(evidenceDir), kind)
+	if !pathWithin(root, dir) {
+		return imageTreeArtifact{}, fmt.Errorf("%s has unsafe directory", prefix)
+	}
+	info, err := os.Lstat(dir)
+	if err != nil {
+		return imageTreeArtifact{}, fmt.Errorf("%s: %w", prefix, err)
+	}
+	if info.Mode()&os.ModeSymlink != 0 || !info.IsDir() {
+		return imageTreeArtifact{}, fmt.Errorf("%s directory is not a real directory", prefix)
+	}
+	actual := imageTreeArtifact{SchemaVersion: imageTreeSchemaVersion, Kind: declared.Kind}
+	err = filepath.WalkDir(dir, func(path string, entry fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if entry.IsDir() {
+			return nil
+		}
+		if entry.Type()&os.ModeSymlink != 0 || !entry.Type().IsRegular() {
+			return fmt.Errorf("%s contains non-regular path %q", prefix, path)
+		}
+		rel, err := filepath.Rel(dir, path)
+		if err != nil {
+			return err
+		}
+		entryInfo, err := entry.Info()
+		if err != nil {
+			return err
+		}
+		digest, err := fileSHA256(path)
+		if err != nil {
+			return err
+		}
+		actual.Files = append(actual.Files, imageTreeFileArtifact{Path: filepath.ToSlash(rel), Bytes: entryInfo.Size(), SHA256: digest})
+		actual.TotalBytes += entryInfo.Size()
+		return nil
+	})
+	if err != nil {
+		return imageTreeArtifact{}, err
+	}
+	sort.Slice(actual.Files, func(i, j int) bool { return actual.Files[i].Path < actual.Files[j].Path })
+	if !reflect.DeepEqual(actual.Files, declared.Files) || actual.TotalBytes != declared.TotalBytes {
+		return imageTreeArtifact{}, fmt.Errorf("%s contents do not match hashed tree manifest", prefix)
+	}
+	return actual, nil
+}
+
+func verifyMetrics(root, manifestID string, witness Witness, artifact Artifact, trace operationTraceArtifact, stable, dirty imageTreeArtifact) (metricsArtifact, error) {
+	prefix := fmt.Sprintf("powerlosscert: manifest %q witness %q metrics", manifestID, witness.ID)
+	data, err := os.ReadFile(filepath.Join(root, filepath.FromSlash(normalizedArtifactPath(artifact.Path))))
+	if err != nil {
+		return metricsArtifact{}, fmt.Errorf("%s: %w", prefix, err)
+	}
+	var metrics metricsArtifact
+	if err := decodeStrict(data, &metrics); err != nil {
+		return metricsArtifact{}, fmt.Errorf("%s decode: %w", prefix, err)
+	}
+	if metrics.SchemaVersion != metricsSchemaVersion {
+		return metricsArtifact{}, fmt.Errorf("%s schema_version=%q want=%q", prefix, metrics.SchemaVersion, metricsSchemaVersion)
+	}
+	if metrics.StableImageBytes != stable.TotalBytes || metrics.DirtyImageBytes != dirty.TotalBytes || metrics.StableFiles != len(stable.Files) || metrics.DirtyFiles != len(dirty.Files) || metrics.TraceEvents != len(trace.Events) {
+		return metricsArtifact{}, fmt.Errorf("%s does not match operation trace and captured image trees", prefix)
+	}
+	if !validHex(metrics.StableFingerprint, 64) {
+		return metricsArtifact{}, fmt.Errorf("%s has invalid stable_fingerprint", prefix)
+	}
+	return metrics, nil
+}
+
+func verifyRecoveryTrace(root, evidenceDir, manifestID string, witness Witness, artifact, stableArtifact Artifact, metrics metricsArtifact) (recoveryTraceArtifact, error) {
+	prefix := fmt.Sprintf("powerlosscert: manifest %q witness %q recovery trace", manifestID, witness.ID)
+	data, err := os.ReadFile(filepath.Join(root, filepath.FromSlash(normalizedArtifactPath(artifact.Path))))
+	if err != nil {
+		return recoveryTraceArtifact{}, fmt.Errorf("%s: %w", prefix, err)
+	}
+	var recovery recoveryTraceArtifact
+	if err := decodeStrict(data, &recovery); err != nil {
+		return recoveryTraceArtifact{}, fmt.Errorf("%s decode: %w", prefix, err)
+	}
+	if recovery.SchemaVersion != recoveryTraceSchemaVersion || recovery.PublicAPI != "treedb.Open" || recovery.Dir != "recovery-input" {
+		return recoveryTraceArtifact{}, fmt.Errorf("%s has invalid schema, public_api, or dir", prefix)
+	}
+	if recovery.InputTreeSHA256 != stableArtifact.SHA256 || recovery.StableFingerprint != metrics.StableFingerprint {
+		return recoveryTraceArtifact{}, fmt.Errorf("%s does not identify the captured stable image", prefix)
+	}
+	if recovery.Rejected {
+		if recovery.ErrorType == "" || recovery.Error == "" || witness.TypedError != recovery.ErrorType {
+			return recoveryTraceArtifact{}, fmt.Errorf("%s rejected result does not match typed_error=%q", prefix, witness.TypedError)
+		}
+	} else if recovery.ErrorType != "" || recovery.Error != "" || witness.TypedError != "none" {
+		return recoveryTraceArtifact{}, fmt.Errorf("%s accepted result has error metadata or typed_error=%q", prefix, witness.TypedError)
+	}
+	recoveryDir := filepath.Join(root, filepath.FromSlash(evidenceDir), recovery.Dir)
+	if !pathWithin(root, recoveryDir) {
+		return recoveryTraceArtifact{}, fmt.Errorf("%s has unsafe recovery directory", prefix)
+	}
+	info, err := os.Lstat(recoveryDir)
+	if err != nil {
+		return recoveryTraceArtifact{}, fmt.Errorf("%s recovery directory: %w", prefix, err)
+	}
+	if info.Mode()&os.ModeSymlink != 0 || !info.IsDir() {
+		return recoveryTraceArtifact{}, fmt.Errorf("%s recovery directory is not a real directory", prefix)
+	}
+	return recovery, nil
+}
+
+func verifyCommandLog(root string, manifest ChildManifest, witness Witness, artifact Artifact) error {
+	prefix := fmt.Sprintf("powerlosscert: manifest %q witness %q command log", manifest.ManifestID, witness.ID)
+	data, err := os.ReadFile(filepath.Join(root, filepath.FromSlash(normalizedArtifactPath(artifact.Path))))
+	if err != nil {
+		return fmt.Errorf("%s: %w", prefix, err)
+	}
+	var log commandLogArtifact
+	if err := decodeStrict(data, &log); err != nil {
+		return fmt.Errorf("%s decode: %w", prefix, err)
+	}
+	var binarySHA string
+	for _, binary := range manifest.TestBinaries {
+		if normalizedArtifactPath(binary.Path) == normalizedArtifactPath(witness.Command.BinaryPath) {
+			binarySHA = binary.SHA256
+			break
+		}
+	}
+	if log.SchemaVersion != commandLogSchemaVersion || log.RepositorySHA != manifest.RepositorySHA || normalizedArtifactPath(log.BinaryPath) != normalizedArtifactPath(witness.Command.BinaryPath) || log.BinarySHA256 != binarySHA || log.Package != witness.Command.Package || log.TestName != witness.Command.TestName || !reflect.DeepEqual(log.Args, witness.Command.Args) || !reflect.DeepEqual(log.Env, witness.Command.Env) {
+		return fmt.Errorf("%s does not match the manifest command and test binary", prefix)
+	}
+	if !log.Completed || log.ExitCode != 0 || log.Stdout == "" && log.Stderr == "" {
+		return fmt.Errorf("%s does not record a completed successful command with captured output", prefix)
 	}
 	return nil
 }

--- a/TreeDB/internal/powerlosscert/bundle.go
+++ b/TreeDB/internal/powerlosscert/bundle.go
@@ -1,0 +1,121 @@
+package powerlosscert
+
+import (
+	"crypto/sha256"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"sort"
+)
+
+type Bundle struct {
+	Root      string
+	Inventory RiskInventory
+	Manifests []ChildManifest
+}
+
+func LoadBundle(root string) (Bundle, error) {
+	root, err := filepath.Abs(root)
+	if err != nil {
+		return Bundle{}, fmt.Errorf("powerlosscert: resolve bundle root: %w", err)
+	}
+	inventoryData, err := os.ReadFile(filepath.Join(root, "risk_inventory.json"))
+	if err != nil {
+		return Bundle{}, fmt.Errorf("powerlosscert: read risk inventory: %w", err)
+	}
+	inventory, err := ParseRiskInventory(inventoryData)
+	if err != nil {
+		return Bundle{}, err
+	}
+	paths, err := filepath.Glob(filepath.Join(root, "manifests", "*.json"))
+	if err != nil {
+		return Bundle{}, fmt.Errorf("powerlosscert: enumerate child manifests: %w", err)
+	}
+	if len(paths) == 0 {
+		return Bundle{}, fmt.Errorf("powerlosscert: bundle %q contains no child manifests", root)
+	}
+	manifests := make([]ChildManifest, 0, len(paths))
+	for _, path := range paths {
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return Bundle{}, fmt.Errorf("powerlosscert: read child manifest %q: %w", path, err)
+		}
+		manifest, err := ParseChildManifest(data)
+		if err != nil {
+			return Bundle{}, fmt.Errorf("powerlosscert: child manifest %q: %w", path, err)
+		}
+		manifests = append(manifests, manifest)
+	}
+	sort.Slice(manifests, func(i, j int) bool {
+		if manifests[i].ManifestID == manifests[j].ManifestID {
+			return manifests[i].Issue < manifests[j].Issue
+		}
+		return manifests[i].ManifestID < manifests[j].ManifestID
+	})
+	return Bundle{Root: root, Inventory: inventory, Manifests: manifests}, nil
+}
+
+func VerifyArtifacts(root string, manifests []ChildManifest) error {
+	root, err := filepath.Abs(root)
+	if err != nil {
+		return fmt.Errorf("powerlosscert: resolve artifact root: %w", err)
+	}
+	seen := make(map[string]string)
+	for _, manifest := range manifests {
+		artifacts := append([]Artifact(nil), manifest.TestBinaries...)
+		for _, witness := range manifest.Witnesses {
+			artifacts = append(artifacts, witness.Artifacts...)
+		}
+		for _, artifact := range artifacts {
+			prefix := fmt.Sprintf("powerlosscert: manifest %q artifact", manifest.ManifestID)
+			if err := validateArtifact(prefix, artifact); err != nil {
+				return err
+			}
+			if prior, ok := seen[artifact.Path]; ok {
+				if prior != artifact.SHA256 {
+					return fmt.Errorf("%s %q has conflicting sha256 values %s and %s", prefix, artifact.Path, prior, artifact.SHA256)
+				}
+				continue
+			}
+			seen[artifact.Path] = artifact.SHA256
+			fullPath := filepath.Join(root, filepath.FromSlash(artifact.Path))
+			if !pathWithin(root, fullPath) {
+				return fmt.Errorf("%s has unsafe path %q", prefix, artifact.Path)
+			}
+			info, err := os.Stat(fullPath)
+			if err != nil {
+				return fmt.Errorf("%s %q: %w", prefix, artifact.Path, err)
+			}
+			if !info.Mode().IsRegular() {
+				return fmt.Errorf("%s %q is not a regular file", prefix, artifact.Path)
+			}
+			digest, err := fileSHA256(fullPath)
+			if err != nil {
+				return fmt.Errorf("%s hash %q: %w", prefix, artifact.Path, err)
+			}
+			if digest != artifact.SHA256 {
+				return fmt.Errorf("%s %q sha256=%s want=%s", prefix, artifact.Path, digest, artifact.SHA256)
+			}
+		}
+	}
+	return nil
+}
+
+func fileSHA256(path string) (string, error) {
+	file, err := os.Open(path)
+	if err != nil {
+		return "", err
+	}
+	defer file.Close()
+	hash := sha256.New()
+	if _, err := io.Copy(hash, file); err != nil {
+		return "", err
+	}
+	return fmt.Sprintf("%x", hash.Sum(nil)), nil
+}
+
+func pathWithin(root, path string) bool {
+	rel, err := filepath.Rel(root, path)
+	return err == nil && rel != ".." && !filepath.IsAbs(rel) && (rel == "." || len(rel) < 3 || rel[:3] != ".."+string(filepath.Separator))
+}

--- a/TreeDB/internal/powerlosscert/bundle.go
+++ b/TreeDB/internal/powerlosscert/bundle.go
@@ -47,17 +47,18 @@ type imageTreeFileArtifact struct {
 }
 
 type recoveryTraceArtifact struct {
-	SchemaVersion     string `json:"schema_version"`
-	PublicAPI         string `json:"public_api"`
-	Dir               string `json:"dir"`
-	InputTreeSHA256   string `json:"input_image_tree_sha256"`
-	StableFingerprint string `json:"stable_fingerprint"`
-	ReadOnly          bool   `json:"read_only"`
-	Rejected          bool   `json:"rejected"`
-	ErrorType         string `json:"error_type"`
-	Error             string `json:"error"`
-	CommitSeq         uint64 `json:"commit_seq"`
-	AppliedLSN        uint64 `json:"applied_lsn"`
+	SchemaVersion      string `json:"schema_version"`
+	PublicAPI          string `json:"public_api"`
+	Dir                string `json:"dir"`
+	PreOpenSnapshotDir string `json:"pre_open_snapshot_dir"`
+	InputTreeSHA256    string `json:"input_image_tree_sha256"`
+	StableFingerprint  string `json:"stable_fingerprint"`
+	ReadOnly           bool   `json:"read_only"`
+	Rejected           bool   `json:"rejected"`
+	ErrorType          string `json:"error_type"`
+	Error              string `json:"error"`
+	CommitSeq          uint64 `json:"commit_seq"`
+	AppliedLSN         uint64 `json:"applied_lsn"`
 }
 
 type metricsArtifact struct {
@@ -184,7 +185,13 @@ func VerifyArtifacts(root string, manifests []ChildManifest) error {
 		return fmt.Errorf("powerlosscert: resolve artifact root symlinks: %w", err)
 	}
 	seen := make(map[string]string)
+	modeledEvidenceDirs := make(map[string]string)
 	for _, manifest := range manifests {
+		for _, witness := range manifest.Witnesses {
+			if err := registerModeledEvidenceDir(manifest.ManifestID, witness, modeledEvidenceDirs); err != nil {
+				return err
+			}
+		}
 		artifacts := append([]Artifact(nil), manifest.TestBinaries...)
 		for _, witness := range manifest.Witnesses {
 			artifacts = append(artifacts, witness.Artifacts...)
@@ -278,6 +285,9 @@ func verifyModeledEvidence(root string, manifest ChildManifest, witness Witness)
 	}
 	recovery, err := verifyRecoveryTrace(root, evidenceDir, manifest.ManifestID, witness, artifacts[ArtifactKindRecoveryTrace], artifacts[ArtifactKindStableImageTree], metrics)
 	if err != nil {
+		return err
+	}
+	if _, err := verifyImageDirectory(root, evidenceDir, manifest.ManifestID, witness.ID, recovery.PreOpenSnapshotDir, stableTree); err != nil {
 		return err
 	}
 	if recovery.ReadOnly {
@@ -503,8 +513,8 @@ func verifyRecoveryTrace(root, evidenceDir, manifestID string, witness Witness, 
 	if err := decodeStrict(data, &recovery); err != nil {
 		return recoveryTraceArtifact{}, fmt.Errorf("%s decode: %w", prefix, err)
 	}
-	if recovery.SchemaVersion != recoveryTraceSchemaVersion || recovery.PublicAPI != "treedb.Open" || recovery.Dir != "recovery-input" {
-		return recoveryTraceArtifact{}, fmt.Errorf("%s has invalid schema, public_api, or dir", prefix)
+	if recovery.SchemaVersion != recoveryTraceSchemaVersion || recovery.PublicAPI != "treedb.Open" || recovery.Dir != "recovery-input" || recovery.PreOpenSnapshotDir != "recovery-preopen" {
+		return recoveryTraceArtifact{}, fmt.Errorf("%s has invalid schema, public_api, dir, or pre_open_snapshot_dir", prefix)
 	}
 	if recovery.InputTreeSHA256 != stableArtifact.SHA256 || recovery.StableFingerprint != metrics.StableFingerprint {
 		return recoveryTraceArtifact{}, fmt.Errorf("%s does not identify the captured stable image", prefix)

--- a/TreeDB/internal/powerlosscert/bundle.go
+++ b/TreeDB/internal/powerlosscert/bundle.go
@@ -91,14 +91,15 @@ func VerifyArtifacts(root string, manifests []ChildManifest) error {
 			if err := validateArtifact(prefix, artifact); err != nil {
 				return err
 			}
-			if prior, ok := seen[artifact.Path]; ok {
+			pathKey := normalizedArtifactPath(artifact.Path)
+			if prior, ok := seen[pathKey]; ok {
 				if prior != artifact.SHA256 {
 					return fmt.Errorf("%s %q has conflicting sha256 values %s and %s", prefix, artifact.Path, prior, artifact.SHA256)
 				}
 				continue
 			}
-			seen[artifact.Path] = artifact.SHA256
-			fullPath := filepath.Join(root, filepath.FromSlash(artifact.Path))
+			seen[pathKey] = artifact.SHA256
+			fullPath := filepath.Join(root, filepath.FromSlash(pathKey))
 			if !pathWithin(root, fullPath) {
 				return fmt.Errorf("%s has unsafe path %q", prefix, artifact.Path)
 			}
@@ -151,7 +152,7 @@ func verifyOperationTrace(root, manifestID string, witness Witness) error {
 	if traceArtifact == nil {
 		return fmt.Errorf("%s is missing", prefix)
 	}
-	data, err := os.ReadFile(filepath.Join(root, filepath.FromSlash(traceArtifact.Path)))
+	data, err := os.ReadFile(filepath.Join(root, filepath.FromSlash(normalizedArtifactPath(traceArtifact.Path))))
 	if err != nil {
 		return fmt.Errorf("%s: %w", prefix, err)
 	}

--- a/TreeDB/internal/powerlosscert/bundle.go
+++ b/TreeDB/internal/powerlosscert/bundle.go
@@ -35,6 +35,7 @@ type operationTraceArtifact struct {
 type imageTreeArtifact struct {
 	SchemaVersion string                  `json:"schema_version"`
 	Kind          string                  `json:"kind"`
+	Directories   []string                `json:"directories"`
 	Files         []imageTreeFileArtifact `json:"files"`
 	TotalBytes    int64                   `json:"total_bytes"`
 }
@@ -376,6 +377,17 @@ func verifyImageTree(root, evidenceDir, manifestID, witnessID string, artifact A
 }
 
 func validateDeclaredImageTree(prefix string, tree imageTreeArtifact) error {
+	priorDirectory := ""
+	for index, directory := range tree.Directories {
+		pathKey := normalizedArtifactPath(directory)
+		if directory == "" || filepath.IsAbs(directory) || pathKey == "." || strings.HasPrefix(pathKey, "../") || pathKey != directory {
+			return fmt.Errorf("%s directory %d has unsafe or non-canonical path %q", prefix, index, directory)
+		}
+		if priorDirectory != "" && directory <= priorDirectory {
+			return fmt.Errorf("%s directories are not strictly sorted at %q", prefix, directory)
+		}
+		priorDirectory = directory
+	}
 	var total int64
 	prior := ""
 	for index, file := range tree.Files {
@@ -420,6 +432,13 @@ func verifyImageDirectory(root, evidenceDir, manifestID, witnessID, kind string,
 			return walkErr
 		}
 		if entry.IsDir() {
+			if path != dir {
+				rel, err := filepath.Rel(dir, path)
+				if err != nil {
+					return err
+				}
+				actual.Directories = append(actual.Directories, filepath.ToSlash(rel))
+			}
 			return nil
 		}
 		if entry.Type()&os.ModeSymlink != 0 || !entry.Type().IsRegular() {
@@ -444,8 +463,9 @@ func verifyImageDirectory(root, evidenceDir, manifestID, witnessID, kind string,
 	if err != nil {
 		return imageTreeArtifact{}, err
 	}
+	sort.Strings(actual.Directories)
 	sort.Slice(actual.Files, func(i, j int) bool { return actual.Files[i].Path < actual.Files[j].Path })
-	if !reflect.DeepEqual(actual.Files, declared.Files) || actual.TotalBytes != declared.TotalBytes {
+	if !reflect.DeepEqual(actual.Directories, declared.Directories) || !reflect.DeepEqual(actual.Files, declared.Files) || actual.TotalBytes != declared.TotalBytes {
 		return imageTreeArtifact{}, fmt.Errorf("%s contents do not match hashed tree manifest", prefix)
 	}
 	return actual, nil

--- a/TreeDB/internal/powerlosscert/bundle.go
+++ b/TreeDB/internal/powerlosscert/bundle.go
@@ -382,8 +382,8 @@ func verifyOperationTrace(root, manifestID string, witness Witness, traceArtifac
 	if trace.ObservedEventCount != matchingEvents || trace.ObservedEventCount != witness.ObservedEventCount {
 		return operationTraceArtifact{}, fmt.Errorf("%s observed_event_count=%d matching_events=%d witness=%d", prefix, trace.ObservedEventCount, matchingEvents, witness.ObservedEventCount)
 	}
-	if matchingEvents <= witness.CutOccurrence {
-		return operationTraceArtifact{}, fmt.Errorf("%s matching events=%d do not reach occurrence=%d", prefix, matchingEvents, witness.CutOccurrence)
+	if matchingEvents != witness.CutOccurrence+1 {
+		return operationTraceArtifact{}, fmt.Errorf("%s matching events=%d does not end at declared occurrence=%d", prefix, matchingEvents, witness.CutOccurrence)
 	}
 	wantEnv := map[string]string{
 		"TREEDB_POWERLOSS_CUT_ID":           witness.CutID,

--- a/TreeDB/internal/powerlosscert/bundle.go
+++ b/TreeDB/internal/powerlosscert/bundle.go
@@ -4,10 +4,25 @@ import (
 	"crypto/sha256"
 	"fmt"
 	"io"
+	"net/url"
 	"os"
 	"path/filepath"
 	"sort"
+	"strconv"
+	"strings"
 )
+
+const operationTraceSchemaVersion = "treedb-power-loss-operation-trace/v1"
+
+type operationTraceArtifact struct {
+	SchemaVersion      string   `json:"schema_version"`
+	CutID              string   `json:"cut_id"`
+	VariantID          string   `json:"variant_id"`
+	Seed               string   `json:"seed"`
+	DeclaredCutPoint   string   `json:"declared_cut_point"`
+	ObservedEventCount int      `json:"observed_event_count"`
+	Events             []string `json:"events"`
+}
 
 type Bundle struct {
 	Root      string
@@ -61,6 +76,10 @@ func VerifyArtifacts(root string, manifests []ChildManifest) error {
 	if err != nil {
 		return fmt.Errorf("powerlosscert: resolve artifact root: %w", err)
 	}
+	realRoot, err := filepath.EvalSymlinks(root)
+	if err != nil {
+		return fmt.Errorf("powerlosscert: resolve artifact root symlinks: %w", err)
+	}
 	seen := make(map[string]string)
 	for _, manifest := range manifests {
 		artifacts := append([]Artifact(nil), manifest.TestBinaries...)
@@ -83,12 +102,22 @@ func VerifyArtifacts(root string, manifests []ChildManifest) error {
 			if !pathWithin(root, fullPath) {
 				return fmt.Errorf("%s has unsafe path %q", prefix, artifact.Path)
 			}
-			info, err := os.Stat(fullPath)
+			info, err := os.Lstat(fullPath)
 			if err != nil {
 				return fmt.Errorf("%s %q: %w", prefix, artifact.Path, err)
 			}
+			if info.Mode()&os.ModeSymlink != 0 {
+				return fmt.Errorf("%s %q is a symlink", prefix, artifact.Path)
+			}
 			if !info.Mode().IsRegular() {
 				return fmt.Errorf("%s %q is not a regular file", prefix, artifact.Path)
+			}
+			resolvedPath, err := filepath.EvalSymlinks(fullPath)
+			if err != nil {
+				return fmt.Errorf("%s resolve %q: %w", prefix, artifact.Path, err)
+			}
+			if !pathWithin(realRoot, resolvedPath) {
+				return fmt.Errorf("%s %q resolves through a symlink outside the bundle", prefix, artifact.Path)
 			}
 			digest, err := fileSHA256(fullPath)
 			if err != nil {
@@ -98,8 +127,105 @@ func VerifyArtifacts(root string, manifests []ChildManifest) error {
 				return fmt.Errorf("%s %q sha256=%s want=%s", prefix, artifact.Path, digest, artifact.SHA256)
 			}
 		}
+		for _, witness := range manifest.Witnesses {
+			if witness.EvidenceTier != EvidenceTierModeledCrash {
+				continue
+			}
+			if err := verifyOperationTrace(root, manifest.ManifestID, witness); err != nil {
+				return err
+			}
+		}
 	}
 	return nil
+}
+
+func verifyOperationTrace(root, manifestID string, witness Witness) error {
+	prefix := fmt.Sprintf("powerlosscert: manifest %q witness %q operation trace", manifestID, witness.ID)
+	var traceArtifact *Artifact
+	for index := range witness.Artifacts {
+		if witness.Artifacts[index].Kind == ArtifactKindOperationTrace {
+			traceArtifact = &witness.Artifacts[index]
+			break
+		}
+	}
+	if traceArtifact == nil {
+		return fmt.Errorf("%s is missing", prefix)
+	}
+	data, err := os.ReadFile(filepath.Join(root, filepath.FromSlash(traceArtifact.Path)))
+	if err != nil {
+		return fmt.Errorf("%s: %w", prefix, err)
+	}
+	var trace operationTraceArtifact
+	if err := decodeStrict(data, &trace); err != nil {
+		return fmt.Errorf("%s decode: %w", prefix, err)
+	}
+	if trace.SchemaVersion != operationTraceSchemaVersion {
+		return fmt.Errorf("%s schema_version=%q want=%q", prefix, trace.SchemaVersion, operationTraceSchemaVersion)
+	}
+	if trace.CutID != witness.CutID {
+		return fmt.Errorf("%s cut_id=%q want=%q", prefix, trace.CutID, witness.CutID)
+	}
+	if trace.DeclaredCutPoint != witness.CutPoint {
+		return fmt.Errorf("%s declared_cut_point=%q want=%q", prefix, trace.DeclaredCutPoint, witness.CutPoint)
+	}
+	cutPoint, occurrence, err := parseCutAddress(trace.CutID)
+	if err != nil {
+		return fmt.Errorf("%s: %w", prefix, err)
+	}
+	if cutPoint != witness.CutPoint || occurrence != witness.CutOccurrence {
+		return fmt.Errorf("%s cut address=(%s,%d) want=(%s,%d)", prefix, cutPoint, occurrence, witness.CutPoint, witness.CutOccurrence)
+	}
+	wantSeed := strconv.FormatUint(witness.Seed, 10)
+	if trace.Seed != wantSeed {
+		return fmt.Errorf("%s seed=%q want=%q", prefix, trace.Seed, wantSeed)
+	}
+	if trace.VariantID == "" {
+		return fmt.Errorf("%s has empty variant_id", prefix)
+	}
+	matchingEvents := 0
+	cutPrefix := "cut:" + witness.CutPoint + ":"
+	for _, event := range trace.Events {
+		if strings.HasPrefix(event, cutPrefix) {
+			matchingEvents++
+		}
+	}
+	if trace.ObservedEventCount != matchingEvents || trace.ObservedEventCount != witness.ObservedEventCount {
+		return fmt.Errorf("%s observed_event_count=%d matching_events=%d witness=%d", prefix, trace.ObservedEventCount, matchingEvents, witness.ObservedEventCount)
+	}
+	if matchingEvents <= witness.CutOccurrence {
+		return fmt.Errorf("%s matching events=%d do not reach occurrence=%d", prefix, matchingEvents, witness.CutOccurrence)
+	}
+	wantEnv := map[string]string{
+		"TREEDB_POWERLOSS_CUT_ID":           witness.CutID,
+		"TREEDB_POWERLOSS_VARIANT_ID":       trace.VariantID,
+		"TREEDB_POWERLOSS_SEED":             wantSeed,
+		"TREEDB_POWERLOSS_EXPECT_CUT_POINT": witness.CutPoint,
+	}
+	for name, want := range wantEnv {
+		if got := witness.Command.Env[name]; got != want {
+			return fmt.Errorf("%s command env %s=%q want=%q", prefix, name, got, want)
+		}
+	}
+	if witness.Command.Env["TREEDB_POWERLOSS_EVIDENCE_DIR"] == "" {
+		return fmt.Errorf("%s command env TREEDB_POWERLOSS_EVIDENCE_DIR is empty", prefix)
+	}
+	return nil
+}
+
+func parseCutAddress(cutID string) (string, int, error) {
+	parts := strings.Split(cutID, "/")
+	if len(parts) != 4 || parts[0] != "cut" || parts[1] == "" {
+		return "", 0, fmt.Errorf("invalid cut_id %q", cutID)
+	}
+	cutPoint, err := url.PathUnescape(parts[2])
+	if err != nil || cutPoint == "" {
+		return "", 0, fmt.Errorf("invalid cut point in cut_id %q", cutID)
+	}
+	occurrence, err := strconv.Atoi(parts[3])
+	if err != nil || occurrence < 0 {
+		return "", 0, fmt.Errorf("invalid cut occurrence in cut_id %q", cutID)
+	}
+	return cutPoint, occurrence, nil
 }
 
 func fileSHA256(path string) (string, error) {

--- a/TreeDB/internal/powerlosscert/bundle.go
+++ b/TreeDB/internal/powerlosscert/bundle.go
@@ -78,6 +78,7 @@ type commandLogArtifact struct {
 	TestName      string            `json:"test_name"`
 	Args          []string          `json:"args"`
 	Env           map[string]string `json:"env"`
+	Outcome       string            `json:"outcome"`
 	Completed     bool              `json:"completed"`
 	ExitCode      int               `json:"exit_code"`
 	Stdout        string            `json:"stdout"`
@@ -104,9 +105,13 @@ func LoadBundle(root string) (Bundle, error) {
 	if err != nil {
 		return Bundle{}, fmt.Errorf("powerlosscert: resolve bundle root: %w", err)
 	}
-	inventoryData, err := os.ReadFile(filepath.Join(root, "risk_inventory.json"))
+	realRoot, err := filepath.EvalSymlinks(root)
 	if err != nil {
-		return Bundle{}, fmt.Errorf("powerlosscert: read risk inventory: %w", err)
+		return Bundle{}, fmt.Errorf("powerlosscert: resolve bundle root symlinks: %w", err)
+	}
+	inventoryData, err := readBundleMetadata(root, realRoot, filepath.Join(root, "risk_inventory.json"), "risk inventory")
+	if err != nil {
+		return Bundle{}, err
 	}
 	inventory, err := ParseRiskInventory(inventoryData)
 	if err != nil {
@@ -121,9 +126,9 @@ func LoadBundle(root string) (Bundle, error) {
 	}
 	manifests := make([]ChildManifest, 0, len(paths))
 	for _, path := range paths {
-		data, err := os.ReadFile(path)
+		data, err := readBundleMetadata(root, realRoot, path, fmt.Sprintf("child manifest %q", path))
 		if err != nil {
-			return Bundle{}, fmt.Errorf("powerlosscert: read child manifest %q: %w", path, err)
+			return Bundle{}, err
 		}
 		manifest, err := ParseChildManifest(data)
 		if err != nil {
@@ -138,6 +143,34 @@ func LoadBundle(root string) (Bundle, error) {
 		return manifests[i].ManifestID < manifests[j].ManifestID
 	})
 	return Bundle{Root: root, Inventory: inventory, Manifests: manifests}, nil
+}
+
+func readBundleMetadata(root, realRoot, path, label string) ([]byte, error) {
+	if !pathWithin(root, path) {
+		return nil, fmt.Errorf("powerlosscert: %s has unsafe path %q", label, path)
+	}
+	info, err := os.Lstat(path)
+	if err != nil {
+		return nil, fmt.Errorf("powerlosscert: read %s: %w", label, err)
+	}
+	if info.Mode()&os.ModeSymlink != 0 {
+		return nil, fmt.Errorf("powerlosscert: %s %q is a symlink", label, path)
+	}
+	if !info.Mode().IsRegular() {
+		return nil, fmt.Errorf("powerlosscert: %s %q is not a regular file", label, path)
+	}
+	resolvedPath, err := filepath.EvalSymlinks(path)
+	if err != nil {
+		return nil, fmt.Errorf("powerlosscert: resolve %s: %w", label, err)
+	}
+	if !pathWithin(realRoot, resolvedPath) {
+		return nil, fmt.Errorf("powerlosscert: %s %q resolves through a symlink outside the bundle", label, path)
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("powerlosscert: read %s: %w", label, err)
+	}
+	return data, nil
 }
 
 func VerifyArtifacts(root string, manifests []ChildManifest) error {
@@ -457,11 +490,11 @@ func verifyRecoveryTrace(root, evidenceDir, manifestID string, witness Witness, 
 		return recoveryTraceArtifact{}, fmt.Errorf("%s does not identify the captured stable image", prefix)
 	}
 	if recovery.Rejected {
-		if recovery.ErrorType == "" || recovery.Error == "" || witness.TypedError != recovery.ErrorType {
-			return recoveryTraceArtifact{}, fmt.Errorf("%s rejected result does not match typed_error=%q", prefix, witness.TypedError)
+		if recovery.ErrorType == "" || recovery.Error == "" || witness.TypedError != recovery.ErrorType || modeledOutcomeClass(witness.ActualOutcome) != "rejected" {
+			return recoveryTraceArtifact{}, fmt.Errorf("%s rejected result does not match outcome=%q and typed_error=%q", prefix, witness.ActualOutcome, witness.TypedError)
 		}
-	} else if recovery.ErrorType != "" || recovery.Error != "" || witness.TypedError != "none" {
-		return recoveryTraceArtifact{}, fmt.Errorf("%s accepted result has error metadata or typed_error=%q", prefix, witness.TypedError)
+	} else if recovery.ErrorType != "" || recovery.Error != "" || witness.TypedError != "none" || modeledOutcomeClass(witness.ActualOutcome) != "accepted" {
+		return recoveryTraceArtifact{}, fmt.Errorf("%s accepted result does not match outcome=%q and typed_error=%q", prefix, witness.ActualOutcome, witness.TypedError)
 	}
 	recoveryDir := filepath.Join(root, filepath.FromSlash(evidenceDir), recovery.Dir)
 	if !pathWithin(root, recoveryDir) {
@@ -494,7 +527,7 @@ func verifyCommandLog(root string, manifest ChildManifest, witness Witness, arti
 			break
 		}
 	}
-	if log.SchemaVersion != commandLogSchemaVersion || log.RepositorySHA != manifest.RepositorySHA || normalizedArtifactPath(log.BinaryPath) != normalizedArtifactPath(witness.Command.BinaryPath) || log.BinarySHA256 != binarySHA || log.Package != witness.Command.Package || log.TestName != witness.Command.TestName || !reflect.DeepEqual(log.Args, witness.Command.Args) || !reflect.DeepEqual(log.Env, witness.Command.Env) {
+	if log.SchemaVersion != commandLogSchemaVersion || log.RepositorySHA != manifest.RepositorySHA || normalizedArtifactPath(log.BinaryPath) != normalizedArtifactPath(witness.Command.BinaryPath) || log.BinarySHA256 != binarySHA || log.Package != witness.Command.Package || log.TestName != witness.Command.TestName || !reflect.DeepEqual(log.Args, witness.Command.Args) || !reflect.DeepEqual(log.Env, witness.Command.Env) || log.Outcome != witness.ActualOutcome {
 		return fmt.Errorf("%s does not match the manifest command and test binary", prefix)
 	}
 	if !log.Completed || log.ExitCode != 0 || log.Stdout == "" && log.Stderr == "" {

--- a/TreeDB/internal/powerlosscert/bundle.go
+++ b/TreeDB/internal/powerlosscert/bundle.go
@@ -186,6 +186,7 @@ func VerifyArtifacts(root string, manifests []ChildManifest) error {
 	}
 	seen := make(map[string]string)
 	modeledEvidenceDirs := make(map[string]string)
+	resolvedEvidenceDirs := make(map[string]string)
 	for _, manifest := range manifests {
 		for _, witness := range manifest.Witnesses {
 			if err := registerModeledEvidenceDir(manifest.ManifestID, witness, modeledEvidenceDirs); err != nil {
@@ -242,11 +243,48 @@ func VerifyArtifacts(root string, manifests []ChildManifest) error {
 			if witness.EvidenceTier != EvidenceTierModeledCrash {
 				continue
 			}
+			if err := verifyModeledEvidenceDir(root, realRoot, manifest.ManifestID, witness, resolvedEvidenceDirs); err != nil {
+				return err
+			}
 			if err := verifyModeledEvidence(root, manifest, witness); err != nil {
 				return err
 			}
 		}
 	}
+	return nil
+}
+
+func verifyModeledEvidenceDir(root, realRoot, manifestID string, witness Witness, seen map[string]string) error {
+	if witness.EvidenceTier != EvidenceTierModeledCrash {
+		return nil
+	}
+	dir := normalizedArtifactPath(witness.Command.Env["TREEDB_POWERLOSS_EVIDENCE_DIR"])
+	fullPath := root
+	for _, component := range strings.Split(filepath.FromSlash(dir), string(filepath.Separator)) {
+		fullPath = filepath.Join(fullPath, component)
+		info, err := os.Lstat(fullPath)
+		if err != nil {
+			return fmt.Errorf("powerlosscert: manifest %q witness %q inspect evidence directory %q: %w", manifestID, witness.ID, dir, err)
+		}
+		if info.Mode()&os.ModeSymlink != 0 {
+			return fmt.Errorf("powerlosscert: manifest %q witness %q has symlinked evidence directory component %q", manifestID, witness.ID, fullPath)
+		}
+		if !info.IsDir() {
+			return fmt.Errorf("powerlosscert: manifest %q witness %q evidence directory component %q is not a directory", manifestID, witness.ID, fullPath)
+		}
+	}
+	resolved, err := filepath.EvalSymlinks(fullPath)
+	if err != nil {
+		return fmt.Errorf("powerlosscert: manifest %q witness %q resolve evidence directory %q: %w", manifestID, witness.ID, dir, err)
+	}
+	if !pathWithin(realRoot, resolved) {
+		return fmt.Errorf("powerlosscert: manifest %q witness %q evidence directory %q resolves outside the bundle", manifestID, witness.ID, dir)
+	}
+	key := filepath.Clean(resolved)
+	if owner, reused := seen[key]; reused {
+		return fmt.Errorf("powerlosscert: witness %q reuses resolved modeled evidence directory %q owned by witness %q", witness.ID, dir, owner)
+	}
+	seen[key] = witness.ID
 	return nil
 }
 

--- a/TreeDB/internal/powerlosscert/bundle_test.go
+++ b/TreeDB/internal/powerlosscert/bundle_test.go
@@ -134,6 +134,7 @@ func TestVerifyArtifactsRejectsMalformedOrUnboundModeledArtifacts(t *testing.T) 
 		want  string
 	}{
 		{name: "stable tree schema", kind: ArtifactKindStableImageTree, field: "schema_version", value: "wrong/v1", want: "stable image tree"},
+		{name: "stable tree directory escape", kind: ArtifactKindStableImageTree, field: "directories", value: []string{"../escape"}, want: "unsafe or non-canonical"},
 		{name: "dirty tree totals", kind: ArtifactKindDirtyImageTree, field: "total_bytes", value: 999, want: "dirty image tree"},
 		{name: "metrics cross reference", kind: ArtifactKindMetrics, field: "trace_events", value: 999, want: "does not match"},
 		{name: "recovery input binding", kind: ArtifactKindRecoveryTrace, field: "input_image_tree_sha256", value: strings.Repeat("0", 64), want: "does not identify"},
@@ -171,6 +172,28 @@ func TestVerifyArtifactsRejectsImageBytesThatDoNotMatchTree(t *testing.T) {
 	err := VerifyArtifacts(root, []ChildManifest{manifest})
 	if err == nil || !strings.Contains(err.Error(), "contents do not match") {
 		t.Fatalf("VerifyArtifacts image mismatch error=%v", err)
+	}
+}
+
+func TestVerifyArtifactsRejectsImageDirectoryMismatch(t *testing.T) {
+	for _, imageDir := range []string{"stable-image", "recovery-input"} {
+		t.Run(imageDir, func(t *testing.T) {
+			root := t.TempDir()
+			manifest := testChildManifest("witness-a")
+			for index := range manifest.TestBinaries {
+				manifest.TestBinaries[index] = writeArtifactFixture(t, root, manifest.TestBinaries[index].Kind, manifest.TestBinaries[index].Path, "binary")
+			}
+			writeModeledEvidenceFixture(t, root, &manifest, "after-meta-write")
+			unexpected := filepath.Join(root, "artifacts", "witness-a", imageDir, "empty-wal")
+			if err := os.MkdirAll(unexpected, 0o700); err != nil {
+				t.Fatal(err)
+			}
+
+			err := VerifyArtifacts(root, []ChildManifest{manifest})
+			if err == nil || !strings.Contains(err.Error(), "contents do not match") {
+				t.Fatalf("VerifyArtifacts image directory mismatch error=%v", err)
+			}
+		})
 	}
 }
 

--- a/TreeDB/internal/powerlosscert/bundle_test.go
+++ b/TreeDB/internal/powerlosscert/bundle_test.go
@@ -148,6 +148,10 @@ func writeArtifactFixture(t *testing.T, root string, kind ArtifactKind, path, co
 
 func testOperationTraceJSON(t *testing.T, witness Witness, cutPoint string) string {
 	t.Helper()
+	events := make([]string, witness.ObservedEventCount)
+	for index := range events {
+		events[index] = "cut:" + cutPoint + ":meta:meta.db:0"
+	}
 	trace := map[string]any{
 		"schema_version":       "treedb-power-loss-operation-trace/v1",
 		"cut_id":               witness.CutID,
@@ -155,7 +159,7 @@ func testOperationTraceJSON(t *testing.T, witness Witness, cutPoint string) stri
 		"seed":                 fmt.Sprint(witness.Seed),
 		"declared_cut_point":   cutPoint,
 		"observed_event_count": witness.ObservedEventCount,
-		"events":               []string{"cut:" + cutPoint + ":meta:meta.db:0"},
+		"events":               events,
 	}
 	data, err := json.Marshal(trace)
 	if err != nil {

--- a/TreeDB/internal/powerlosscert/bundle_test.go
+++ b/TreeDB/internal/powerlosscert/bundle_test.go
@@ -125,6 +125,24 @@ func TestVerifyArtifactsRejectsOperationTraceThatDoesNotMatchWitness(t *testing.
 	}
 }
 
+func TestVerifyArtifactsRequiresTraceToEndAtDeclaredCutOccurrence(t *testing.T) {
+	root := t.TempDir()
+	manifest := testChildManifest("witness-a")
+	witness := &manifest.Witnesses[0]
+	witness.CutID = "cut/checkpoint-generation-2/after-meta-write/000"
+	witness.CutOccurrence = 0
+	witness.Command.Env["TREEDB_POWERLOSS_CUT_ID"] = witness.CutID
+	for index := range manifest.TestBinaries {
+		manifest.TestBinaries[index] = writeArtifactFixture(t, root, manifest.TestBinaries[index].Kind, manifest.TestBinaries[index].Path, "binary")
+	}
+	writeModeledEvidenceFixture(t, root, &manifest, "after-meta-write")
+
+	err := VerifyArtifacts(root, []ChildManifest{manifest})
+	if err == nil || !strings.Contains(err.Error(), "does not end at declared occurrence") {
+		t.Fatalf("VerifyArtifacts extra matching cut event error=%v", err)
+	}
+}
+
 func TestVerifyArtifactsRejectsModeledEvidenceReuseAcrossWitnesses(t *testing.T) {
 	root := t.TempDir()
 	manifest := testChildManifest("witness-a")

--- a/TreeDB/internal/powerlosscert/bundle_test.go
+++ b/TreeDB/internal/powerlosscert/bundle_test.go
@@ -297,6 +297,28 @@ func TestVerifyArtifactsRejectsSymlinkOutsideBundle(t *testing.T) {
 	}
 }
 
+func TestVerifyArtifactsRejectsSymlinkedEvidenceDirectoryComponent(t *testing.T) {
+	root := t.TempDir()
+	manifest := testChildManifest("witness-a")
+	for index := range manifest.TestBinaries {
+		manifest.TestBinaries[index] = writeArtifactFixture(t, root, manifest.TestBinaries[index].Kind, manifest.TestBinaries[index].Path, "binary")
+	}
+	writeModeledEvidenceFixture(t, root, &manifest, "after-meta-write")
+	artifactsDir := filepath.Join(root, "artifacts")
+	realArtifactsDir := filepath.Join(root, "real-artifacts")
+	if err := os.Rename(artifactsDir, realArtifactsDir); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(realArtifactsDir, artifactsDir); err != nil {
+		t.Skipf("symlinks unavailable: %v", err)
+	}
+
+	err := VerifyArtifacts(root, []ChildManifest{manifest})
+	if err == nil || !strings.Contains(err.Error(), "symlinked evidence directory") {
+		t.Fatalf("VerifyArtifacts evidence-directory symlink error=%v", err)
+	}
+}
+
 func writeBundleFixture(t *testing.T, root, name string, manifest ChildManifest) {
 	t.Helper()
 	if name == "a.json" {

--- a/TreeDB/internal/powerlosscert/bundle_test.go
+++ b/TreeDB/internal/powerlosscert/bundle_test.go
@@ -39,7 +39,11 @@ func TestVerifyArtifactsChecksContentAndRejectsEscapes(t *testing.T) {
 	}
 	for index := range manifest.Witnesses[0].Artifacts {
 		artifact := manifest.Witnesses[0].Artifacts[index]
-		manifest.Witnesses[0].Artifacts[index] = writeArtifactFixture(t, root, artifact.Kind, artifact.Path, string(artifact.Kind))
+		contents := string(artifact.Kind)
+		if artifact.Kind == ArtifactKindOperationTrace {
+			contents = testOperationTraceJSON(t, manifest.Witnesses[0], "after-meta-write")
+		}
+		manifest.Witnesses[0].Artifacts[index] = writeArtifactFixture(t, root, artifact.Kind, artifact.Path, contents)
 	}
 	if err := VerifyArtifacts(root, []ChildManifest{manifest}); err != nil {
 		t.Fatal(err)
@@ -54,6 +58,50 @@ func TestVerifyArtifactsChecksContentAndRejectsEscapes(t *testing.T) {
 	manifest.TestBinaries[0].Path = "../escape"
 	if err := VerifyArtifacts(root, []ChildManifest{manifest}); err == nil || !strings.Contains(err.Error(), "unsafe path") {
 		t.Fatalf("VerifyArtifacts escape error=%v", err)
+	}
+}
+
+func TestVerifyArtifactsRejectsOperationTraceThatDoesNotMatchWitness(t *testing.T) {
+	root := t.TempDir()
+	manifest := testChildManifest("witness-a")
+	for index := range manifest.TestBinaries {
+		manifest.TestBinaries[index] = writeArtifactFixture(t, root, manifest.TestBinaries[index].Kind, manifest.TestBinaries[index].Path, "binary")
+	}
+	for index := range manifest.Witnesses[0].Artifacts {
+		artifact := manifest.Witnesses[0].Artifacts[index]
+		contents := string(artifact.Kind)
+		if artifact.Kind == ArtifactKindOperationTrace {
+			contents = testOperationTraceJSON(t, manifest.Witnesses[0], "after-index-sync")
+		}
+		manifest.Witnesses[0].Artifacts[index] = writeArtifactFixture(t, root, artifact.Kind, artifact.Path, contents)
+	}
+
+	err := VerifyArtifacts(root, []ChildManifest{manifest})
+	if err == nil || !strings.Contains(err.Error(), "declared_cut_point") {
+		t.Fatalf("VerifyArtifacts operation-trace mismatch error=%v", err)
+	}
+}
+
+func TestVerifyArtifactsRejectsSymlinkOutsideBundle(t *testing.T) {
+	root := t.TempDir()
+	outside := filepath.Join(t.TempDir(), "binary")
+	if err := os.WriteFile(outside, []byte("binary"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	link := filepath.Join(root, "bin", "TreeDB.test")
+	if err := os.MkdirAll(filepath.Dir(link), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(outside, link); err != nil {
+		t.Skipf("symlinks unavailable: %v", err)
+	}
+	manifest := testChildManifest("witness-a")
+	digest := sha256.Sum256([]byte("binary"))
+	manifest.TestBinaries[0].SHA256 = fmt.Sprintf("%x", digest)
+
+	err := VerifyArtifacts(root, []ChildManifest{manifest})
+	if err == nil || !strings.Contains(err.Error(), "symlink") {
+		t.Fatalf("VerifyArtifacts symlink error=%v", err)
 	}
 }
 
@@ -96,4 +144,22 @@ func writeArtifactFixture(t *testing.T, root string, kind ArtifactKind, path, co
 	}
 	digest := sha256.Sum256([]byte(contents))
 	return Artifact{Kind: kind, Path: path, SHA256: fmt.Sprintf("%x", digest)}
+}
+
+func testOperationTraceJSON(t *testing.T, witness Witness, cutPoint string) string {
+	t.Helper()
+	trace := map[string]any{
+		"schema_version":       "treedb-power-loss-operation-trace/v1",
+		"cut_id":               witness.CutID,
+		"variant_id":           witness.Command.Env["TREEDB_POWERLOSS_VARIANT_ID"],
+		"seed":                 fmt.Sprint(witness.Seed),
+		"declared_cut_point":   cutPoint,
+		"observed_event_count": witness.ObservedEventCount,
+		"events":               []string{"cut:" + cutPoint + ":meta:meta.db:0"},
+	}
+	data, err := json.Marshal(trace)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return string(data)
 }

--- a/TreeDB/internal/powerlosscert/bundle_test.go
+++ b/TreeDB/internal/powerlosscert/bundle_test.go
@@ -1,0 +1,99 @@
+package powerlosscert
+
+import (
+	"crypto/sha256"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestLoadBundleIsStrictAndDeterministic(t *testing.T) {
+	root := t.TempDir()
+	writeBundleFixture(t, root, "b.json", testChildManifest("witness-b"))
+	writeBundleFixture(t, root, "a.json", testChildManifest("witness-a"))
+
+	bundle, err := LoadBundle(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got, want := []string{bundle.Manifests[0].ManifestID, bundle.Manifests[1].ManifestID}, []string{"dur-01", "dur-02"}; fmt.Sprint(got) != fmt.Sprint(want) {
+		t.Fatalf("manifest order=%v want=%v", got, want)
+	}
+
+	if err := os.WriteFile(filepath.Join(root, "risk_inventory.json"), []byte(`{"schema_version":"treedb-power-loss-risk-inventory/v1","unknown":true}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := LoadBundle(root); err == nil || !strings.Contains(err.Error(), "unknown field") {
+		t.Fatalf("LoadBundle strict error=%v", err)
+	}
+}
+
+func TestVerifyArtifactsChecksContentAndRejectsEscapes(t *testing.T) {
+	root := t.TempDir()
+	manifest := testChildManifest("witness-a")
+	for index := range manifest.TestBinaries {
+		manifest.TestBinaries[index] = writeArtifactFixture(t, root, manifest.TestBinaries[index].Kind, manifest.TestBinaries[index].Path, "binary")
+	}
+	for index := range manifest.Witnesses[0].Artifacts {
+		artifact := manifest.Witnesses[0].Artifacts[index]
+		manifest.Witnesses[0].Artifacts[index] = writeArtifactFixture(t, root, artifact.Kind, artifact.Path, string(artifact.Kind))
+	}
+	if err := VerifyArtifacts(root, []ChildManifest{manifest}); err != nil {
+		t.Fatal(err)
+	}
+
+	manifest.Witnesses[0].Artifacts[0].SHA256 = strings.Repeat("f", 64)
+	if err := VerifyArtifacts(root, []ChildManifest{manifest}); err == nil || !strings.Contains(err.Error(), "sha256") {
+		t.Fatalf("VerifyArtifacts digest error=%v", err)
+	}
+
+	manifest = testChildManifest("witness-a")
+	manifest.Witnesses[0].Artifacts[0].Path = "../escape"
+	if err := VerifyArtifacts(root, []ChildManifest{manifest}); err == nil || !strings.Contains(err.Error(), "unsafe path") {
+		t.Fatalf("VerifyArtifacts escape error=%v", err)
+	}
+}
+
+func writeBundleFixture(t *testing.T, root, name string, manifest ChildManifest) {
+	t.Helper()
+	if name == "a.json" {
+		manifest.ManifestID = "dur-01"
+		manifest.Issue = 3674
+	} else {
+		manifest.ManifestID = "dur-02"
+		manifest.Issue = 3675
+	}
+	if err := os.MkdirAll(filepath.Join(root, "manifests"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	inventoryData, err := json.Marshal(testRiskInventory())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "risk_inventory.json"), inventoryData, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	manifestData, err := json.Marshal(manifest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "manifests", name), manifestData, 0o600); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func writeArtifactFixture(t *testing.T, root string, kind ArtifactKind, path, contents string) Artifact {
+	t.Helper()
+	fullPath := filepath.Join(root, filepath.FromSlash(path))
+	if err := os.MkdirAll(filepath.Dir(fullPath), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(fullPath, []byte(contents), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	digest := sha256.Sum256([]byte(contents))
+	return Artifact{Kind: kind, Path: path, SHA256: fmt.Sprintf("%x", digest)}
+}

--- a/TreeDB/internal/powerlosscert/bundle_test.go
+++ b/TreeDB/internal/powerlosscert/bundle_test.go
@@ -31,6 +31,63 @@ func TestLoadBundleIsStrictAndDeterministic(t *testing.T) {
 	}
 }
 
+func TestLoadBundleRejectsSymlinkedMetadataOutsideBundle(t *testing.T) {
+	for _, name := range []string{"risk inventory", "child manifest"} {
+		t.Run(name, func(t *testing.T) {
+			root := t.TempDir()
+			writeBundleFixture(t, root, "a.json", testChildManifest("witness-a"))
+			path := filepath.Join(root, "risk_inventory.json")
+			if name == "child manifest" {
+				path = filepath.Join(root, "manifests", "a.json")
+			}
+			data, err := os.ReadFile(path)
+			if err != nil {
+				t.Fatal(err)
+			}
+			outside := filepath.Join(t.TempDir(), filepath.Base(path))
+			if err := os.WriteFile(outside, data, 0o600); err != nil {
+				t.Fatal(err)
+			}
+			if err := os.Remove(path); err != nil {
+				t.Fatal(err)
+			}
+			if err := os.Symlink(outside, path); err != nil {
+				t.Skipf("symlinks unavailable: %v", err)
+			}
+
+			if _, err := LoadBundle(root); err == nil || !strings.Contains(err.Error(), "symlink") {
+				t.Fatalf("LoadBundle %s symlink error=%v", name, err)
+			}
+		})
+	}
+}
+
+func TestLoadBundleRejectsManifestParentSymlinkOutsideBundle(t *testing.T) {
+	root := t.TempDir()
+	writeBundleFixture(t, root, "a.json", testChildManifest("witness-a"))
+	manifestData, err := os.ReadFile(filepath.Join(root, "manifests", "a.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	outsideManifests := filepath.Join(t.TempDir(), "manifests")
+	if err := os.MkdirAll(outsideManifests, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(outsideManifests, "a.json"), manifestData, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.RemoveAll(filepath.Join(root, "manifests")); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(outsideManifests, filepath.Join(root, "manifests")); err != nil {
+		t.Skipf("symlinks unavailable: %v", err)
+	}
+
+	if _, err := LoadBundle(root); err == nil || !strings.Contains(err.Error(), "outside the bundle") {
+		t.Fatalf("LoadBundle parent symlink error=%v", err)
+	}
+}
+
 func TestVerifyArtifactsChecksContentAndRejectsEscapes(t *testing.T) {
 	root := t.TempDir()
 	manifest := testChildManifest("witness-a")
@@ -114,6 +171,26 @@ func TestVerifyArtifactsRejectsImageBytesThatDoNotMatchTree(t *testing.T) {
 	err := VerifyArtifacts(root, []ChildManifest{manifest})
 	if err == nil || !strings.Contains(err.Error(), "contents do not match") {
 		t.Fatalf("VerifyArtifacts image mismatch error=%v", err)
+	}
+}
+
+func TestVerifyArtifactsRejectsAcceptedOutcomeForRejectedOpen(t *testing.T) {
+	root := t.TempDir()
+	manifest := testChildManifest("witness-a")
+	for index := range manifest.TestBinaries {
+		manifest.TestBinaries[index] = writeArtifactFixture(t, root, manifest.TestBinaries[index].Kind, manifest.TestBinaries[index].Path, "binary")
+	}
+	writeModeledEvidenceFixture(t, root, &manifest, "after-meta-write")
+	manifest.Witnesses[0].TypedError = "*errors.errorString"
+	rewriteArtifactJSONFields(t, root, &manifest.Witnesses[0], ArtifactKindRecoveryTrace, map[string]any{
+		"rejected":   true,
+		"error_type": "*errors.errorString",
+		"error":      "rejected modeled image",
+	})
+
+	err := VerifyArtifacts(root, []ChildManifest{manifest})
+	if err == nil || !strings.Contains(err.Error(), "outcome") {
+		t.Fatalf("VerifyArtifacts rejected-open outcome error=%v", err)
 	}
 }
 
@@ -276,6 +353,7 @@ func writeModeledEvidenceFixture(t *testing.T, root string, manifest *ChildManif
 		TestName:      witness.Command.TestName,
 		Args:          witness.Command.Args,
 		Env:           witness.Command.Env,
+		Outcome:       witness.ActualOutcome,
 		Completed:     true,
 		ExitCode:      0,
 		Stdout:        "PASS\n",
@@ -301,6 +379,11 @@ func artifactByKind(t *testing.T, witness Witness, kind ArtifactKind) Artifact {
 
 func rewriteArtifactJSONField(t *testing.T, root string, witness *Witness, kind ArtifactKind, field string, value any) {
 	t.Helper()
+	rewriteArtifactJSONFields(t, root, witness, kind, map[string]any{field: value})
+}
+
+func rewriteArtifactJSONFields(t *testing.T, root string, witness *Witness, kind ArtifactKind, fields map[string]any) {
+	t.Helper()
 	for index, artifact := range witness.Artifacts {
 		if artifact.Kind != kind {
 			continue
@@ -314,7 +397,9 @@ func rewriteArtifactJSONField(t *testing.T, root string, witness *Witness, kind 
 		if err := json.Unmarshal(data, &document); err != nil {
 			t.Fatal(err)
 		}
-		document[field] = value
+		for field, value := range fields {
+			document[field] = value
+		}
 		witness.Artifacts[index] = writeArtifactFixture(t, root, kind, artifact.Path, mustJSON(t, document))
 		return
 	}

--- a/TreeDB/internal/powerlosscert/bundle_test.go
+++ b/TreeDB/internal/powerlosscert/bundle_test.go
@@ -125,6 +125,23 @@ func TestVerifyArtifactsRejectsOperationTraceThatDoesNotMatchWitness(t *testing.
 	}
 }
 
+func TestVerifyArtifactsRejectsModeledEvidenceReuseAcrossWitnesses(t *testing.T) {
+	root := t.TempDir()
+	manifest := testChildManifest("witness-a")
+	for index := range manifest.TestBinaries {
+		manifest.TestBinaries[index] = writeArtifactFixture(t, root, manifest.TestBinaries[index].Kind, manifest.TestBinaries[index].Path, "binary")
+	}
+	writeModeledEvidenceFixture(t, root, &manifest, "after-meta-write")
+	reused := manifest.Witnesses[0]
+	reused.ID = "witness-b"
+	manifest.Witnesses = append(manifest.Witnesses, reused)
+
+	err := VerifyArtifacts(root, []ChildManifest{manifest})
+	if err == nil || !strings.Contains(err.Error(), "reuses modeled evidence directory") {
+		t.Fatalf("VerifyArtifacts modeled evidence reuse error=%v", err)
+	}
+}
+
 func TestVerifyArtifactsRejectsMalformedOrUnboundModeledArtifacts(t *testing.T) {
 	tests := []struct {
 		name  string
@@ -214,6 +231,25 @@ func TestVerifyArtifactsRejectsAcceptedOutcomeForRejectedOpen(t *testing.T) {
 	err := VerifyArtifacts(root, []ChildManifest{manifest})
 	if err == nil || !strings.Contains(err.Error(), "outcome") {
 		t.Fatalf("VerifyArtifacts rejected-open outcome error=%v", err)
+	}
+}
+
+func TestVerifyArtifactsRejectsTamperedWritableRecoveryPreOpenSnapshot(t *testing.T) {
+	root := t.TempDir()
+	manifest := testChildManifest("witness-a")
+	for index := range manifest.TestBinaries {
+		manifest.TestBinaries[index] = writeArtifactFixture(t, root, manifest.TestBinaries[index].Kind, manifest.TestBinaries[index].Path, "binary")
+	}
+	writeModeledEvidenceFixture(t, root, &manifest, "after-meta-write")
+	rewriteArtifactJSONField(t, root, &manifest.Witnesses[0], ArtifactKindRecoveryTrace, "read_only", false)
+	snapshot := filepath.Join(root, "artifacts", "witness-a", "recovery-preopen", "index.db")
+	if err := os.WriteFile(snapshot, []byte("not the modeled input"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	err := VerifyArtifacts(root, []ChildManifest{manifest})
+	if err == nil || !strings.Contains(err.Error(), "recovery-preopen") {
+		t.Fatalf("VerifyArtifacts writable recovery pre-open binding error=%v", err)
 	}
 }
 
@@ -314,6 +350,7 @@ func writeModeledEvidenceFixture(t *testing.T, root string, manifest *ChildManif
 	}{
 		{dir: "stable-image", contents: stableContents},
 		{dir: "dirty-image", contents: dirtyContents},
+		{dir: "recovery-preopen", contents: stableContents},
 		{dir: "recovery-input", contents: stableContents},
 	} {
 		if err := os.MkdirAll(filepath.Join(evidenceDir, image.dir), 0o700); err != nil {
@@ -360,12 +397,13 @@ func writeModeledEvidenceFixture(t *testing.T, root string, manifest *ChildManif
 	}
 	stableArtifact := artifactByKind(t, *witness, ArtifactKindStableImageTree)
 	contents[ArtifactKindRecoveryTrace] = mustJSON(t, recoveryTraceArtifact{
-		SchemaVersion:     recoveryTraceSchemaVersion,
-		PublicAPI:         "treedb.Open",
-		Dir:               "recovery-input",
-		InputTreeSHA256:   stableArtifact.SHA256,
-		StableFingerprint: stableFingerprint,
-		ReadOnly:          true,
+		SchemaVersion:      recoveryTraceSchemaVersion,
+		PublicAPI:          "treedb.Open",
+		Dir:                "recovery-input",
+		PreOpenSnapshotDir: "recovery-preopen",
+		InputTreeSHA256:    stableArtifact.SHA256,
+		StableFingerprint:  stableFingerprint,
+		ReadOnly:           true,
 	})
 	contents[ArtifactKindLog] = mustJSON(t, commandLogArtifact{
 		SchemaVersion: commandLogSchemaVersion,

--- a/TreeDB/internal/powerlosscert/bundle_test.go
+++ b/TreeDB/internal/powerlosscert/bundle_test.go
@@ -51,7 +51,7 @@ func TestVerifyArtifactsChecksContentAndRejectsEscapes(t *testing.T) {
 	}
 
 	manifest = testChildManifest("witness-a")
-	manifest.Witnesses[0].Artifacts[0].Path = "../escape"
+	manifest.TestBinaries[0].Path = "../escape"
 	if err := VerifyArtifacts(root, []ChildManifest{manifest}); err == nil || !strings.Contains(err.Error(), "unsafe path") {
 		t.Fatalf("VerifyArtifacts escape error=%v", err)
 	}

--- a/TreeDB/internal/powerlosscert/bundle_test.go
+++ b/TreeDB/internal/powerlosscert/bundle_test.go
@@ -37,14 +37,7 @@ func TestVerifyArtifactsChecksContentAndRejectsEscapes(t *testing.T) {
 	for index := range manifest.TestBinaries {
 		manifest.TestBinaries[index] = writeArtifactFixture(t, root, manifest.TestBinaries[index].Kind, manifest.TestBinaries[index].Path, "binary")
 	}
-	for index := range manifest.Witnesses[0].Artifacts {
-		artifact := manifest.Witnesses[0].Artifacts[index]
-		contents := string(artifact.Kind)
-		if artifact.Kind == ArtifactKindOperationTrace {
-			contents = testOperationTraceJSON(t, manifest.Witnesses[0], "after-meta-write")
-		}
-		manifest.Witnesses[0].Artifacts[index] = writeArtifactFixture(t, root, artifact.Kind, artifact.Path, contents)
-	}
+	writeModeledEvidenceFixture(t, root, &manifest, "after-meta-write")
 	if err := VerifyArtifacts(root, []ChildManifest{manifest}); err != nil {
 		t.Fatal(err)
 	}
@@ -67,18 +60,81 @@ func TestVerifyArtifactsRejectsOperationTraceThatDoesNotMatchWitness(t *testing.
 	for index := range manifest.TestBinaries {
 		manifest.TestBinaries[index] = writeArtifactFixture(t, root, manifest.TestBinaries[index].Kind, manifest.TestBinaries[index].Path, "binary")
 	}
+	writeModeledEvidenceFixture(t, root, &manifest, "after-index-sync")
+
+	err := VerifyArtifacts(root, []ChildManifest{manifest})
+	if err == nil || !strings.Contains(err.Error(), "declared_cut_point") {
+		t.Fatalf("VerifyArtifacts operation-trace mismatch error=%v", err)
+	}
+}
+
+func TestVerifyArtifactsRejectsMalformedOrUnboundModeledArtifacts(t *testing.T) {
+	tests := []struct {
+		name  string
+		kind  ArtifactKind
+		field string
+		value any
+		want  string
+	}{
+		{name: "stable tree schema", kind: ArtifactKindStableImageTree, field: "schema_version", value: "wrong/v1", want: "stable image tree"},
+		{name: "dirty tree totals", kind: ArtifactKindDirtyImageTree, field: "total_bytes", value: 999, want: "dirty image tree"},
+		{name: "metrics cross reference", kind: ArtifactKindMetrics, field: "trace_events", value: 999, want: "does not match"},
+		{name: "recovery input binding", kind: ArtifactKindRecoveryTrace, field: "input_image_tree_sha256", value: strings.Repeat("0", 64), want: "does not identify"},
+		{name: "command completion", kind: ArtifactKindLog, field: "completed", value: false, want: "completed successful"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			root := t.TempDir()
+			manifest := testChildManifest("witness-a")
+			for index := range manifest.TestBinaries {
+				manifest.TestBinaries[index] = writeArtifactFixture(t, root, manifest.TestBinaries[index].Kind, manifest.TestBinaries[index].Path, "binary")
+			}
+			writeModeledEvidenceFixture(t, root, &manifest, "after-meta-write")
+			rewriteArtifactJSONField(t, root, &manifest.Witnesses[0], test.kind, test.field, test.value)
+
+			err := VerifyArtifacts(root, []ChildManifest{manifest})
+			if err == nil || !strings.Contains(err.Error(), test.want) {
+				t.Fatalf("VerifyArtifacts error=%v want substring %q", err, test.want)
+			}
+		})
+	}
+}
+
+func TestVerifyArtifactsRejectsImageBytesThatDoNotMatchTree(t *testing.T) {
+	root := t.TempDir()
+	manifest := testChildManifest("witness-a")
+	for index := range manifest.TestBinaries {
+		manifest.TestBinaries[index] = writeArtifactFixture(t, root, manifest.TestBinaries[index].Kind, manifest.TestBinaries[index].Path, "binary")
+	}
+	writeModeledEvidenceFixture(t, root, &manifest, "after-meta-write")
+	if err := os.WriteFile(filepath.Join(root, "artifacts", "witness-a", "stable-image", "index.db"), []byte("tampered"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	err := VerifyArtifacts(root, []ChildManifest{manifest})
+	if err == nil || !strings.Contains(err.Error(), "contents do not match") {
+		t.Fatalf("VerifyArtifacts image mismatch error=%v", err)
+	}
+}
+
+func TestVerifyArtifactsRejectsUnstructuredModeledEvidence(t *testing.T) {
+	root := t.TempDir()
+	manifest := testChildManifest("witness-a")
+	for index := range manifest.TestBinaries {
+		manifest.TestBinaries[index] = writeArtifactFixture(t, root, manifest.TestBinaries[index].Kind, manifest.TestBinaries[index].Path, "binary")
+	}
 	for index := range manifest.Witnesses[0].Artifacts {
 		artifact := manifest.Witnesses[0].Artifacts[index]
 		contents := string(artifact.Kind)
 		if artifact.Kind == ArtifactKindOperationTrace {
-			contents = testOperationTraceJSON(t, manifest.Witnesses[0], "after-index-sync")
+			contents = testOperationTraceJSON(t, manifest.Witnesses[0], "after-meta-write")
 		}
 		manifest.Witnesses[0].Artifacts[index] = writeArtifactFixture(t, root, artifact.Kind, artifact.Path, contents)
 	}
 
 	err := VerifyArtifacts(root, []ChildManifest{manifest})
-	if err == nil || !strings.Contains(err.Error(), "declared_cut_point") {
-		t.Fatalf("VerifyArtifacts operation-trace mismatch error=%v", err)
+	if err == nil || !strings.Contains(err.Error(), "stable image tree") {
+		t.Fatalf("VerifyArtifacts unstructured modeled evidence error=%v", err)
 	}
 }
 
@@ -144,6 +200,134 @@ func writeArtifactFixture(t *testing.T, root string, kind ArtifactKind, path, co
 	}
 	digest := sha256.Sum256([]byte(contents))
 	return Artifact{Kind: kind, Path: path, SHA256: fmt.Sprintf("%x", digest)}
+}
+
+func writeModeledEvidenceFixture(t *testing.T, root string, manifest *ChildManifest, cutPoint string) {
+	t.Helper()
+	witness := &manifest.Witnesses[0]
+	evidenceDir := filepath.Join(root, filepath.FromSlash(witness.Command.Env["TREEDB_POWERLOSS_EVIDENCE_DIR"]))
+	stableContents := []byte("stable")
+	dirtyContents := []byte("dirty")
+	for _, image := range []struct {
+		dir      string
+		contents []byte
+	}{
+		{dir: "stable-image", contents: stableContents},
+		{dir: "dirty-image", contents: dirtyContents},
+		{dir: "recovery-input", contents: stableContents},
+	} {
+		if err := os.MkdirAll(filepath.Join(evidenceDir, image.dir), 0o700); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(evidenceDir, image.dir, "index.db"), image.contents, 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	stableDigest := sha256.Sum256(stableContents)
+	dirtyDigest := sha256.Sum256(dirtyContents)
+	stableTree := imageTreeArtifact{
+		SchemaVersion: imageTreeSchemaVersion,
+		Kind:          "stable-image",
+		Files:         []imageTreeFileArtifact{{Path: "index.db", Bytes: int64(len(stableContents)), SHA256: fmt.Sprintf("%x", stableDigest)}},
+		TotalBytes:    int64(len(stableContents)),
+	}
+	dirtyTree := imageTreeArtifact{
+		SchemaVersion: imageTreeSchemaVersion,
+		Kind:          "dirty-image",
+		Files:         []imageTreeFileArtifact{{Path: "index.db", Bytes: int64(len(dirtyContents)), SHA256: fmt.Sprintf("%x", dirtyDigest)}},
+		TotalBytes:    int64(len(dirtyContents)),
+	}
+	stableFingerprint := strings.Repeat("a", 64)
+	contents := map[ArtifactKind]string{
+		ArtifactKindOperationTrace:  testOperationTraceJSON(t, *witness, cutPoint),
+		ArtifactKindStableImageTree: mustJSON(t, stableTree),
+		ArtifactKindDirtyImageTree:  mustJSON(t, dirtyTree),
+		ArtifactKindMetrics: mustJSON(t, metricsArtifact{
+			SchemaVersion:     metricsSchemaVersion,
+			StableImageBytes:  stableTree.TotalBytes,
+			DirtyImageBytes:   dirtyTree.TotalBytes,
+			StableFiles:       len(stableTree.Files),
+			DirtyFiles:        len(dirtyTree.Files),
+			TraceEvents:       witness.ObservedEventCount,
+			StableFingerprint: stableFingerprint,
+		}),
+	}
+	for index := range witness.Artifacts {
+		artifact := witness.Artifacts[index]
+		if content, ok := contents[artifact.Kind]; ok {
+			witness.Artifacts[index] = writeArtifactFixture(t, root, artifact.Kind, artifact.Path, content)
+		}
+	}
+	stableArtifact := artifactByKind(t, *witness, ArtifactKindStableImageTree)
+	contents[ArtifactKindRecoveryTrace] = mustJSON(t, recoveryTraceArtifact{
+		SchemaVersion:     recoveryTraceSchemaVersion,
+		PublicAPI:         "treedb.Open",
+		Dir:               "recovery-input",
+		InputTreeSHA256:   stableArtifact.SHA256,
+		StableFingerprint: stableFingerprint,
+		ReadOnly:          true,
+	})
+	contents[ArtifactKindLog] = mustJSON(t, commandLogArtifact{
+		SchemaVersion: commandLogSchemaVersion,
+		RepositorySHA: manifest.RepositorySHA,
+		BinaryPath:    witness.Command.BinaryPath,
+		BinarySHA256:  manifest.TestBinaries[0].SHA256,
+		Package:       witness.Command.Package,
+		TestName:      witness.Command.TestName,
+		Args:          witness.Command.Args,
+		Env:           witness.Command.Env,
+		Completed:     true,
+		ExitCode:      0,
+		Stdout:        "PASS\n",
+	})
+	for index := range witness.Artifacts {
+		artifact := witness.Artifacts[index]
+		if content, ok := contents[artifact.Kind]; ok && (artifact.Kind == ArtifactKindRecoveryTrace || artifact.Kind == ArtifactKindLog) {
+			witness.Artifacts[index] = writeArtifactFixture(t, root, artifact.Kind, artifact.Path, content)
+		}
+	}
+}
+
+func artifactByKind(t *testing.T, witness Witness, kind ArtifactKind) Artifact {
+	t.Helper()
+	for _, artifact := range witness.Artifacts {
+		if artifact.Kind == kind {
+			return artifact
+		}
+	}
+	t.Fatalf("missing artifact kind %q", kind)
+	return Artifact{}
+}
+
+func rewriteArtifactJSONField(t *testing.T, root string, witness *Witness, kind ArtifactKind, field string, value any) {
+	t.Helper()
+	for index, artifact := range witness.Artifacts {
+		if artifact.Kind != kind {
+			continue
+		}
+		path := filepath.Join(root, filepath.FromSlash(artifact.Path))
+		data, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatal(err)
+		}
+		var document map[string]any
+		if err := json.Unmarshal(data, &document); err != nil {
+			t.Fatal(err)
+		}
+		document[field] = value
+		witness.Artifacts[index] = writeArtifactFixture(t, root, kind, artifact.Path, mustJSON(t, document))
+		return
+	}
+	t.Fatalf("missing artifact kind %q", kind)
+}
+
+func mustJSON(t *testing.T, value any) string {
+	t.Helper()
+	data, err := json.Marshal(value)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return string(data)
 }
 
 func testOperationTraceJSON(t *testing.T, witness Witness, cutPoint string) string {

--- a/TreeDB/internal/powerlosscert/coverage.go
+++ b/TreeDB/internal/powerlosscert/coverage.go
@@ -1,0 +1,252 @@
+package powerlosscert
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+)
+
+type CoverageRow struct {
+	Dimension  string   `json:"dimension"`
+	Value      string   `json:"value"`
+	WitnessIDs []string `json:"witness_ids"`
+}
+
+type CoverageReport struct {
+	SchemaVersion string        `json:"schema_version"`
+	Complete      bool          `json:"complete"`
+	Rows          []CoverageRow `json:"rows"`
+	Gaps          []string      `json:"gaps"`
+}
+
+type SelectionPlan struct {
+	SchemaVersion string   `json:"schema_version"`
+	CaseIDs       []string `json:"case_ids"`
+	Covered       []string `json:"covered"`
+}
+
+func BuildCoverageReport(inventory RiskInventory, manifests []ChildManifest) (CoverageReport, error) {
+	if err := validateRiskInventory(inventory); err != nil {
+		return CoverageReport{}, err
+	}
+	owners := make(map[string]map[string]bool)
+	for _, witness := range sortedWitnesses(manifests) {
+		if witness.EvidenceTier != EvidenceTierModeledCrash {
+			continue
+		}
+		for _, key := range witnessCoverageKeys(inventory, witness) {
+			if owners[key] == nil {
+				owners[key] = make(map[string]bool)
+			}
+			owners[key][witness.ID] = true
+		}
+	}
+	required := inventoryCoverageKeys(inventory)
+	report := CoverageReport{SchemaVersion: CoverageReportSchemaVersion}
+	for _, key := range required {
+		dimension, value, _ := strings.Cut(key, ":")
+		ids := sortedSet(owners[key])
+		report.Rows = append(report.Rows, CoverageRow{Dimension: dimension, Value: value, WitnessIDs: ids})
+		if len(ids) == 0 {
+			report.Gaps = append(report.Gaps, key)
+		}
+	}
+	report.Complete = len(report.Gaps) == 0
+	return report, nil
+}
+
+func SelectRepresentativeCases(inventory RiskInventory, manifests []ChildManifest) (SelectionPlan, error) {
+	report, err := BuildCoverageReport(inventory, manifests)
+	if err != nil {
+		return SelectionPlan{}, err
+	}
+	if !report.Complete {
+		return SelectionPlan{}, fmt.Errorf("powerlosscert: cannot select from incomplete coverage: %s", strings.Join(report.Gaps, ", "))
+	}
+	witnesses := sortedWitnesses(manifests)
+	byID := make(map[string]Witness, len(witnesses))
+	for _, witness := range witnesses {
+		if witness.EvidenceTier == EvidenceTierModeledCrash {
+			byID[witness.ID] = witness
+		}
+	}
+	selected := make(map[string]bool)
+	covered := make(map[string]bool)
+	selectWitness := func(witness Witness) {
+		if selected[witness.ID] {
+			return
+		}
+		selected[witness.ID] = true
+		for _, key := range witnessCoverageKeys(inventory, witness) {
+			covered[key] = true
+		}
+	}
+
+	for _, counterexample := range inventory.RetainedCounterexamples {
+		witness, ok := findWitness(witnesses, func(candidate Witness) bool {
+			return candidate.EvidenceTier == EvidenceTierModeledCrash && candidate.CounterexampleID == counterexample
+		})
+		if !ok {
+			return SelectionPlan{}, fmt.Errorf("powerlosscert: retained counterexample %q has no modeled witness", counterexample)
+		}
+		selectWitness(witness)
+	}
+	for _, control := range inventory.RequiredNegativeControls {
+		witness, ok := findWitness(witnesses, func(candidate Witness) bool {
+			return candidate.EvidenceTier == EvidenceTierModeledCrash && candidate.NegativeControlID == control
+		})
+		if !ok {
+			return SelectionPlan{}, fmt.Errorf("powerlosscert: negative control %q has no modeled witness", control)
+		}
+		selectWitness(witness)
+	}
+
+	required := inventoryCoverageKeys(inventory)
+	for {
+		var uncovered []string
+		for _, key := range required {
+			if !covered[key] {
+				uncovered = append(uncovered, key)
+			}
+		}
+		if len(uncovered) == 0 {
+			break
+		}
+		uncoveredSet := make(map[string]bool, len(uncovered))
+		for _, key := range uncovered {
+			uncoveredSet[key] = true
+		}
+		bestID := ""
+		bestGain := 0
+		for id, witness := range byID {
+			if selected[id] {
+				continue
+			}
+			gain := 0
+			for _, key := range witnessCoverageKeys(inventory, witness) {
+				if uncoveredSet[key] {
+					gain++
+				}
+			}
+			if gain > bestGain || (gain == bestGain && gain > 0 && (bestID == "" || id < bestID)) {
+				bestID = id
+				bestGain = gain
+			}
+		}
+		if bestGain == 0 {
+			return SelectionPlan{}, fmt.Errorf("powerlosscert: covering selector stalled with gaps: %s", strings.Join(uncovered, ", "))
+		}
+		selectWitness(byID[bestID])
+	}
+
+	caseIDs := sortedSet(selected)
+	coveredKeys := sortedSet(covered)
+	return SelectionPlan{SchemaVersion: SelectionPlanSchemaVersion, CaseIDs: caseIDs, Covered: coveredKeys}, nil
+}
+
+func inventoryCoverageKeys(inventory RiskInventory) []string {
+	var keys []string
+	for _, dimension := range requiredDimensions {
+		for _, value := range inventory.Dimensions[dimension] {
+			keys = append(keys, dimension+":"+value)
+		}
+	}
+	for _, value := range inventory.RetainedCounterexamples {
+		keys = append(keys, DimensionCounterexample+":"+value)
+	}
+	for _, value := range inventory.RequiredNegativeControls {
+		keys = append(keys, DimensionNegativeControl+":"+value)
+	}
+	for _, interaction := range inventory.RequiredInteractions {
+		keys = append(keys, "interaction:"+interaction.ID)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+func witnessCoverageKeys(inventory RiskInventory, witness Witness) []string {
+	keys := []string{
+		DimensionProfile + ":" + witness.Profile,
+		DimensionAcknowledgement + ":" + witness.Acknowledgement,
+		DimensionWritebackVariant + ":" + witness.WritebackVariant,
+	}
+	for _, value := range witness.ResourceShapes {
+		keys = append(keys, DimensionResourceShape+":"+value)
+	}
+	for _, value := range witness.StorageBoundaries {
+		keys = append(keys, DimensionStorageBoundary+":"+value)
+	}
+	for _, value := range witness.FailureClasses {
+		keys = append(keys, DimensionFailureClass+":"+value)
+	}
+	if witness.CounterexampleID != "" {
+		keys = append(keys, DimensionCounterexample+":"+witness.CounterexampleID)
+	}
+	if witness.NegativeControlID != "" {
+		keys = append(keys, DimensionNegativeControl+":"+witness.NegativeControlID)
+	}
+	for _, interaction := range inventory.RequiredInteractions {
+		if witnessSatisfiesInteraction(witness, interaction) {
+			keys = append(keys, "interaction:"+interaction.ID)
+		}
+	}
+	sort.Strings(keys)
+	return compactStrings(keys)
+}
+
+func witnessSatisfiesInteraction(witness Witness, interaction RequiredInteraction) bool {
+	for _, member := range interaction.Members {
+		var values []string
+		switch member.Dimension {
+		case DimensionProfile:
+			values = []string{witness.Profile}
+		case DimensionAcknowledgement:
+			values = []string{witness.Acknowledgement}
+		case DimensionResourceShape:
+			values = witness.ResourceShapes
+		case DimensionStorageBoundary:
+			values = witness.StorageBoundaries
+		case DimensionWritebackVariant:
+			values = []string{witness.WritebackVariant}
+		case DimensionFailureClass:
+			values = witness.FailureClasses
+		default:
+			return false
+		}
+		if !containsString(values, member.Value) {
+			return false
+		}
+	}
+	return true
+}
+
+func findWitness(witnesses []Witness, matches func(Witness) bool) (Witness, bool) {
+	for _, witness := range witnesses {
+		if matches(witness) {
+			return witness, true
+		}
+	}
+	return Witness{}, false
+}
+
+func sortedSet(set map[string]bool) []string {
+	values := make([]string, 0, len(set))
+	for value := range set {
+		values = append(values, value)
+	}
+	sort.Strings(values)
+	return values
+}
+
+func compactStrings(values []string) []string {
+	if len(values) == 0 {
+		return nil
+	}
+	out := values[:1]
+	for _, value := range values[1:] {
+		if value != out[len(out)-1] {
+			out = append(out, value)
+		}
+	}
+	return out
+}

--- a/TreeDB/internal/powerlosscert/manifest.go
+++ b/TreeDB/internal/powerlosscert/manifest.go
@@ -440,10 +440,18 @@ func validateWitness(prefix string, witness Witness, binaries map[string]bool) e
 		return fmt.Errorf("%s has no hashed artifacts", prefix)
 	}
 	artifactKinds := make(map[ArtifactKind]bool, len(witness.Artifacts))
+	artifactPaths := make(map[string]ArtifactKind, len(witness.Artifacts))
 	for _, artifact := range witness.Artifacts {
 		if err := validateArtifact(prefix+" artifact", artifact); err != nil {
 			return err
 		}
+		if binaries[artifact.Path] {
+			return fmt.Errorf("%s reuses test-binary path %q as artifact kind %q", prefix, artifact.Path, artifact.Kind)
+		}
+		if priorKind, duplicate := artifactPaths[artifact.Path]; duplicate {
+			return fmt.Errorf("%s reuses artifact path %q for kinds %q and %q", prefix, artifact.Path, priorKind, artifact.Kind)
+		}
+		artifactPaths[artifact.Path] = artifact.Kind
 		if artifactKinds[artifact.Kind] {
 			return fmt.Errorf("%s duplicates artifact kind %q", prefix, artifact.Kind)
 		}

--- a/TreeDB/internal/powerlosscert/manifest.go
+++ b/TreeDB/internal/powerlosscert/manifest.go
@@ -1,0 +1,528 @@
+// Package powerlosscert validates and selects the committed evidence used by
+// TreeDB's current-main power-loss certification. It is test infrastructure;
+// production packages do not import it.
+package powerlosscert
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+const (
+	ChildManifestSchemaVersion  = "treedb-power-loss-child/v1"
+	RiskInventorySchemaVersion  = "treedb-power-loss-risk-inventory/v1"
+	CoverageReportSchemaVersion = "treedb-power-loss-coverage/v1"
+	SelectionPlanSchemaVersion  = "treedb-power-loss-selection/v1"
+)
+
+const (
+	EvidenceTierCleanProcess EvidenceTier = "clean-process"
+	EvidenceTierModeledCrash EvidenceTier = "modeled-crash"
+	EvidenceTierBlockDevice  EvidenceTier = "block-device"
+)
+
+const (
+	ArtifactKindTestBinary      ArtifactKind = "test-binary"
+	ArtifactKindOperationTrace  ArtifactKind = "operation-trace"
+	ArtifactKindStableImageTree ArtifactKind = "stable-image-tree"
+	ArtifactKindDirtyImageTree  ArtifactKind = "dirty-image-tree"
+	ArtifactKindRecoveryTrace   ArtifactKind = "recovery-trace"
+	ArtifactKindMetrics         ArtifactKind = "metrics"
+	ArtifactKindLog             ArtifactKind = "log"
+	ArtifactKindBenchmark       ArtifactKind = "benchmark-output"
+)
+
+const (
+	DimensionProfile          = "profile"
+	DimensionAcknowledgement  = "acknowledgement"
+	DimensionResourceShape    = "resource_shape"
+	DimensionStorageBoundary  = "storage_boundary"
+	DimensionWritebackVariant = "writeback_variant"
+	DimensionFailureClass     = "failure_class"
+	DimensionCounterexample   = "counterexample"
+	DimensionNegativeControl  = "negative_control"
+)
+
+var productionProfiles = map[string]bool{
+	"command_wal_durable": true,
+	"command_wal_relaxed": true,
+	"no_wal_fast":         true,
+}
+
+var requiredDimensions = []string{
+	DimensionProfile,
+	DimensionAcknowledgement,
+	DimensionResourceShape,
+	DimensionStorageBoundary,
+	DimensionWritebackVariant,
+	DimensionFailureClass,
+}
+
+var requiredModeledArtifactKinds = []ArtifactKind{
+	ArtifactKindOperationTrace,
+	ArtifactKindStableImageTree,
+	ArtifactKindDirtyImageTree,
+	ArtifactKindRecoveryTrace,
+	ArtifactKindMetrics,
+	ArtifactKindLog,
+}
+
+type EvidenceTier string
+type ArtifactKind string
+
+type PullRequest struct {
+	Number   int    `json:"number"`
+	HeadSHA  string `json:"head_sha"`
+	MergeSHA string `json:"merge_sha"`
+}
+
+type Environment struct {
+	GoVersion       string `json:"go_version"`
+	ToolVersion     string `json:"tool_version"`
+	OS              string `json:"os"`
+	Architecture    string `json:"architecture"`
+	FilesystemModel string `json:"filesystem_model"`
+}
+
+type Artifact struct {
+	Kind   ArtifactKind `json:"kind"`
+	Path   string       `json:"path"`
+	SHA256 string       `json:"sha256"`
+}
+
+type TestCommand struct {
+	BinaryPath string            `json:"binary_path"`
+	Package    string            `json:"package"`
+	TestName   string            `json:"test_name"`
+	Args       []string          `json:"args"`
+	Env        map[string]string `json:"env,omitempty"`
+}
+
+type WitnessState struct {
+	RootMetaGeneration  string `json:"root_meta_generation"`
+	FreelistGeneration  string `json:"freelist_generation"`
+	ExternalFrontiers   string `json:"external_resource_ids_frontiers"`
+	NamespaceGeneration string `json:"namespace_generations"`
+	WALLineage          string `json:"wal_lineage"`
+	DurableLSN          string `json:"durable_lsn"`
+	CleanupPins         string `json:"cleanup_maintenance_pins"`
+}
+
+type Witness struct {
+	ID                     string       `json:"id"`
+	EvidenceTier           EvidenceTier `json:"evidence_tier"`
+	Profile                string       `json:"profile"`
+	Acknowledgement        string       `json:"acknowledgement_shape"`
+	ResourceShapes         []string     `json:"data_resource_shapes"`
+	DependencyGraph        string       `json:"dependency_graph"`
+	StorageBoundaries      []string     `json:"storage_boundaries"`
+	WritebackVariant       string       `json:"writeback_variant"`
+	FailureClasses         []string     `json:"failure_classes"`
+	ExpectedDurableHorizon string       `json:"expected_durable_horizon"`
+	ExpectedOutcome        string       `json:"expected_outcome"`
+	ActualOutcome          string       `json:"actual_outcome"`
+	TypedError             string       `json:"typed_error"`
+	State                  WitnessState `json:"state"`
+	CounterexampleID       string       `json:"counterexample_id,omitempty"`
+	NegativeControlID      string       `json:"negative_control_id,omitempty"`
+	Seed                   uint64       `json:"seed"`
+	CutID                  string       `json:"cut_id"`
+	CutPoint               string       `json:"cut_point"`
+	CutOccurrence          int          `json:"cut_occurrence"`
+	ObservedEventCount     int          `json:"observed_event_count"`
+	Command                TestCommand  `json:"command"`
+	CutExercised           bool         `json:"cut_exercised"`
+	ClaimBoundary          string       `json:"claim_boundary"`
+	Artifacts              []Artifact   `json:"artifacts"`
+}
+
+type ChildManifest struct {
+	SchemaVersion string        `json:"schema_version"`
+	ManifestID    string        `json:"manifest_id"`
+	RepositorySHA string        `json:"repository_sha"`
+	Issue         int           `json:"issue"`
+	PullRequests  []PullRequest `json:"pull_requests"`
+	Environment   Environment   `json:"environment"`
+	TestBinaries  []Artifact    `json:"test_binaries"`
+	ClaimBoundary string        `json:"claim_boundary"`
+	Witnesses     []Witness     `json:"witnesses"`
+}
+
+type RiskInventory struct {
+	SchemaVersion            string                `json:"schema_version"`
+	Dimensions               map[string][]string   `json:"dimensions"`
+	RetainedCounterexamples  []string              `json:"retained_counterexamples"`
+	RequiredNegativeControls []string              `json:"required_negative_controls"`
+	RequiredInteractions     []RequiredInteraction `json:"required_interactions"`
+}
+
+type CoverageRequirement struct {
+	Dimension string `json:"dimension"`
+	Value     string `json:"value"`
+}
+
+type RequiredInteraction struct {
+	ID      string                `json:"id"`
+	Members []CoverageRequirement `json:"members"`
+}
+
+func ParseChildManifest(data []byte) (ChildManifest, error) {
+	var manifest ChildManifest
+	if err := decodeStrict(data, &manifest); err != nil {
+		return ChildManifest{}, fmt.Errorf("powerlosscert: decode child manifest: %w", err)
+	}
+	return manifest, nil
+}
+
+func ParseRiskInventory(data []byte) (RiskInventory, error) {
+	var inventory RiskInventory
+	if err := decodeStrict(data, &inventory); err != nil {
+		return RiskInventory{}, fmt.Errorf("powerlosscert: decode risk inventory: %w", err)
+	}
+	return inventory, nil
+}
+
+func decodeStrict(data []byte, target any) error {
+	decoder := json.NewDecoder(strings.NewReader(string(data)))
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(target); err != nil {
+		return err
+	}
+	if err := decoder.Decode(&struct{}{}); err != io.EOF {
+		if err == nil {
+			return fmt.Errorf("contains a second JSON value")
+		}
+		return fmt.Errorf("trailing JSON: %w", err)
+	}
+	return nil
+}
+
+func ValidateBundle(expectedSHA string, inventory RiskInventory, manifests []ChildManifest) error {
+	if !validHex(expectedSHA, 40) {
+		return fmt.Errorf("powerlosscert: expected repository SHA %q is not a full 40-character hex SHA", expectedSHA)
+	}
+	if err := validateRiskInventory(inventory); err != nil {
+		return err
+	}
+	if len(manifests) == 0 {
+		return fmt.Errorf("powerlosscert: no child manifests")
+	}
+	manifestIDs := make(map[string]bool, len(manifests))
+	witnessIDs := make(map[string]string)
+	for i := range manifests {
+		manifest := &manifests[i]
+		if manifest.RepositorySHA != expectedSHA {
+			return fmt.Errorf("powerlosscert: manifest %q has stale repository_sha=%s want=%s", manifest.ManifestID, manifest.RepositorySHA, expectedSHA)
+		}
+		if err := validateChildManifest(*manifest); err != nil {
+			return err
+		}
+		if manifestIDs[manifest.ManifestID] {
+			return fmt.Errorf("powerlosscert: duplicate manifest id %q", manifest.ManifestID)
+		}
+		manifestIDs[manifest.ManifestID] = true
+		for _, witness := range manifest.Witnesses {
+			if err := validateWitnessInventory(inventory, manifest.ManifestID, witness); err != nil {
+				return err
+			}
+			if owner, duplicate := witnessIDs[witness.ID]; duplicate {
+				return fmt.Errorf("powerlosscert: duplicate witness id %q in manifests %q and %q", witness.ID, owner, manifest.ManifestID)
+			}
+			witnessIDs[witness.ID] = manifest.ManifestID
+		}
+	}
+	report, err := BuildCoverageReport(inventory, manifests)
+	if err != nil {
+		return err
+	}
+	if !report.Complete {
+		return fmt.Errorf("powerlosscert: incomplete frozen risk coverage: %s", strings.Join(report.Gaps, ", "))
+	}
+	return nil
+}
+
+func validateWitnessInventory(inventory RiskInventory, manifestID string, witness Witness) error {
+	prefix := fmt.Sprintf("powerlosscert: manifest %q witness %q", manifestID, witness.ID)
+	valuesByDimension := map[string][]string{
+		DimensionProfile:          {witness.Profile},
+		DimensionAcknowledgement:  {witness.Acknowledgement},
+		DimensionResourceShape:    witness.ResourceShapes,
+		DimensionStorageBoundary:  witness.StorageBoundaries,
+		DimensionWritebackVariant: {witness.WritebackVariant},
+		DimensionFailureClass:     witness.FailureClasses,
+	}
+	for _, dimension := range requiredDimensions {
+		allowed := inventory.Dimensions[dimension]
+		for _, value := range valuesByDimension[dimension] {
+			if !containsString(allowed, value) {
+				return fmt.Errorf("%s has undeclared %s=%q", prefix, dimension, value)
+			}
+		}
+	}
+	if witness.CounterexampleID != "" && !containsString(inventory.RetainedCounterexamples, witness.CounterexampleID) {
+		return fmt.Errorf("%s has undeclared counterexample=%q", prefix, witness.CounterexampleID)
+	}
+	if witness.NegativeControlID != "" && !containsString(inventory.RequiredNegativeControls, witness.NegativeControlID) {
+		return fmt.Errorf("%s has undeclared negative_control=%q", prefix, witness.NegativeControlID)
+	}
+	return nil
+}
+
+func validateRiskInventory(inventory RiskInventory) error {
+	if inventory.SchemaVersion != RiskInventorySchemaVersion {
+		return fmt.Errorf("powerlosscert: risk inventory schema_version=%q want=%q", inventory.SchemaVersion, RiskInventorySchemaVersion)
+	}
+	if len(inventory.Dimensions) != len(requiredDimensions) {
+		return fmt.Errorf("powerlosscert: risk inventory dimensions=%d want=%d", len(inventory.Dimensions), len(requiredDimensions))
+	}
+	for _, dimension := range requiredDimensions {
+		values, ok := inventory.Dimensions[dimension]
+		if !ok || len(values) == 0 {
+			return fmt.Errorf("powerlosscert: risk inventory dimension %q is missing or empty", dimension)
+		}
+		if err := validateUniqueStrings("risk inventory "+dimension, values); err != nil {
+			return err
+		}
+	}
+	if err := validateUniqueStrings("retained counterexamples", inventory.RetainedCounterexamples); err != nil {
+		return err
+	}
+	if len(inventory.RetainedCounterexamples) == 0 {
+		return fmt.Errorf("powerlosscert: retained counterexample inventory is empty")
+	}
+	if err := validateUniqueStrings("required negative controls", inventory.RequiredNegativeControls); err != nil {
+		return err
+	}
+	if len(inventory.RequiredNegativeControls) == 0 {
+		return fmt.Errorf("powerlosscert: required negative-control inventory is empty")
+	}
+	if len(inventory.RequiredInteractions) == 0 {
+		return fmt.Errorf("powerlosscert: required interaction inventory is empty")
+	}
+	interactionIDs := make(map[string]bool, len(inventory.RequiredInteractions))
+	for _, interaction := range inventory.RequiredInteractions {
+		if interaction.ID == "" {
+			return fmt.Errorf("powerlosscert: required interaction has an empty id")
+		}
+		if interactionIDs[interaction.ID] {
+			return fmt.Errorf("powerlosscert: duplicate required interaction id %q", interaction.ID)
+		}
+		interactionIDs[interaction.ID] = true
+		if len(interaction.Members) < 2 {
+			return fmt.Errorf("powerlosscert: required interaction %q has %d members want at least 2", interaction.ID, len(interaction.Members))
+		}
+		members := make(map[string]bool, len(interaction.Members))
+		for _, member := range interaction.Members {
+			values, ok := inventory.Dimensions[member.Dimension]
+			if !ok {
+				return fmt.Errorf("powerlosscert: required interaction %q references unknown dimension %q", interaction.ID, member.Dimension)
+			}
+			if !containsString(values, member.Value) {
+				return fmt.Errorf("powerlosscert: required interaction %q references undeclared %s=%q", interaction.ID, member.Dimension, member.Value)
+			}
+			key := member.Dimension + ":" + member.Value
+			if members[key] {
+				return fmt.Errorf("powerlosscert: required interaction %q duplicates member %q", interaction.ID, key)
+			}
+			members[key] = true
+		}
+	}
+	return nil
+}
+
+func validateChildManifest(manifest ChildManifest) error {
+	prefix := fmt.Sprintf("powerlosscert: manifest %q", manifest.ManifestID)
+	if manifest.SchemaVersion != ChildManifestSchemaVersion {
+		return fmt.Errorf("%s schema_version=%q want=%q", prefix, manifest.SchemaVersion, ChildManifestSchemaVersion)
+	}
+	if manifest.ManifestID == "" || manifest.Issue <= 0 || manifest.ClaimBoundary == "" {
+		return fmt.Errorf("%s has an empty required manifest field", prefix)
+	}
+	if !validHex(manifest.RepositorySHA, 40) {
+		return fmt.Errorf("%s repository_sha is not a full SHA", prefix)
+	}
+	if len(manifest.PullRequests) == 0 {
+		return fmt.Errorf("%s has no pull-request provenance", prefix)
+	}
+	for _, pr := range manifest.PullRequests {
+		if pr.Number <= 0 || !validHex(pr.HeadSHA, 40) || !validHex(pr.MergeSHA, 40) {
+			return fmt.Errorf("%s has invalid pull-request provenance: %+v", prefix, pr)
+		}
+	}
+	if manifest.Environment.GoVersion == "" || manifest.Environment.ToolVersion == "" || manifest.Environment.OS == "" || manifest.Environment.Architecture == "" || manifest.Environment.FilesystemModel == "" {
+		return fmt.Errorf("%s has incomplete environment metadata", prefix)
+	}
+	if len(manifest.TestBinaries) == 0 {
+		return fmt.Errorf("%s has no hashed test binary", prefix)
+	}
+	binaries := make(map[string]bool, len(manifest.TestBinaries))
+	for _, artifact := range manifest.TestBinaries {
+		if artifact.Kind != ArtifactKindTestBinary {
+			return fmt.Errorf("%s test binary %q has kind %q want %q", prefix, artifact.Path, artifact.Kind, ArtifactKindTestBinary)
+		}
+		if err := validateArtifact(prefix+" test binary", artifact); err != nil {
+			return err
+		}
+		if binaries[artifact.Path] {
+			return fmt.Errorf("%s duplicates test binary path %q", prefix, artifact.Path)
+		}
+		binaries[artifact.Path] = true
+	}
+	if len(manifest.Witnesses) == 0 {
+		return fmt.Errorf("%s has no witnesses", prefix)
+	}
+	for _, witness := range manifest.Witnesses {
+		if err := validateWitness(prefix, witness, binaries); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func validateWitness(prefix string, witness Witness, binaries map[string]bool) error {
+	prefix += fmt.Sprintf(" witness %q", witness.ID)
+	if witness.ID == "" || witness.Acknowledgement == "" || witness.DependencyGraph == "" || witness.WritebackVariant == "" || witness.ExpectedDurableHorizon == "" || witness.ExpectedOutcome == "" || witness.ActualOutcome == "" || witness.TypedError == "" || witness.ClaimBoundary == "" {
+		return fmt.Errorf("%s has an empty required field", prefix)
+	}
+	switch witness.EvidenceTier {
+	case EvidenceTierCleanProcess, EvidenceTierModeledCrash, EvidenceTierBlockDevice:
+	default:
+		return fmt.Errorf("%s has unknown evidence tier %q", prefix, witness.EvidenceTier)
+	}
+	if !productionProfiles[witness.Profile] {
+		return fmt.Errorf("%s selects non-production or unknown profile %q", prefix, witness.Profile)
+	}
+	if len(witness.ResourceShapes) == 0 || len(witness.StorageBoundaries) == 0 || len(witness.FailureClasses) == 0 {
+		return fmt.Errorf("%s has an empty risk dimension", prefix)
+	}
+	if err := validateUniqueStrings(prefix+" resource shapes", witness.ResourceShapes); err != nil {
+		return err
+	}
+	if err := validateUniqueStrings(prefix+" storage boundaries", witness.StorageBoundaries); err != nil {
+		return err
+	}
+	if err := validateUniqueStrings(prefix+" failure classes", witness.FailureClasses); err != nil {
+		return err
+	}
+	if witness.ExpectedOutcome != witness.ActualOutcome {
+		return fmt.Errorf("%s actual_outcome=%q want expected_outcome=%q", prefix, witness.ActualOutcome, witness.ExpectedOutcome)
+	}
+	state := witness.State
+	if state.RootMetaGeneration == "" || state.FreelistGeneration == "" || state.ExternalFrontiers == "" || state.NamespaceGeneration == "" || state.WALLineage == "" || state.DurableLSN == "" || state.CleanupPins == "" {
+		return fmt.Errorf("%s has incomplete recovery-state metadata", prefix)
+	}
+	if witness.Seed == 0 {
+		return fmt.Errorf("%s has zero seed", prefix)
+	}
+	if witness.CutID == "" || witness.CutPoint == "" || witness.CutOccurrence <= 0 {
+		return fmt.Errorf("%s has incomplete declared cut metadata", prefix)
+	}
+	if witness.ObservedEventCount < witness.CutOccurrence {
+		return fmt.Errorf("%s observed event count=%d does not reach declared occurrence=%d", prefix, witness.ObservedEventCount, witness.CutOccurrence)
+	}
+	if witness.Command.BinaryPath == "" || witness.Command.Package == "" || witness.Command.TestName == "" || len(witness.Command.Args) == 0 {
+		return fmt.Errorf("%s has incomplete structured command", prefix)
+	}
+	if err := validateUniqueStrings(prefix+" command arguments", witness.Command.Args); err != nil {
+		return err
+	}
+	if !binaries[witness.Command.BinaryPath] {
+		return fmt.Errorf("%s references unregistered test binary %q", prefix, witness.Command.BinaryPath)
+	}
+	if !witness.CutExercised {
+		return fmt.Errorf("%s passed but did not exercise its declared cut", prefix)
+	}
+	if len(witness.Artifacts) == 0 {
+		return fmt.Errorf("%s has no hashed artifacts", prefix)
+	}
+	artifactKinds := make(map[ArtifactKind]bool, len(witness.Artifacts))
+	for _, artifact := range witness.Artifacts {
+		if err := validateArtifact(prefix+" artifact", artifact); err != nil {
+			return err
+		}
+		if artifactKinds[artifact.Kind] {
+			return fmt.Errorf("%s duplicates artifact kind %q", prefix, artifact.Kind)
+		}
+		artifactKinds[artifact.Kind] = true
+	}
+	if witness.EvidenceTier == EvidenceTierModeledCrash {
+		for _, kind := range requiredModeledArtifactKinds {
+			if !artifactKinds[kind] {
+				return fmt.Errorf("%s missing required artifact kind %q", prefix, kind)
+			}
+		}
+	}
+	return nil
+}
+
+func validateArtifact(prefix string, artifact Artifact) error {
+	if !validArtifactKind(artifact.Kind) {
+		return fmt.Errorf("%s has unknown kind %q", prefix, artifact.Kind)
+	}
+	if artifact.Path == "" || filepath.IsAbs(artifact.Path) || artifact.Path == "." || strings.HasPrefix(filepath.ToSlash(filepath.Clean(artifact.Path)), "../") {
+		return fmt.Errorf("%s has unsafe path %q", prefix, artifact.Path)
+	}
+	if !validHex(artifact.SHA256, 64) {
+		return fmt.Errorf("%s %q has invalid sha256", prefix, artifact.Path)
+	}
+	return nil
+}
+
+func validArtifactKind(kind ArtifactKind) bool {
+	switch kind {
+	case ArtifactKindTestBinary, ArtifactKindOperationTrace, ArtifactKindStableImageTree,
+		ArtifactKindDirtyImageTree, ArtifactKindRecoveryTrace, ArtifactKindMetrics,
+		ArtifactKindLog, ArtifactKindBenchmark:
+		return true
+	default:
+		return false
+	}
+}
+
+func validateUniqueStrings(label string, values []string) error {
+	seen := make(map[string]bool, len(values))
+	for _, value := range values {
+		if value == "" {
+			return fmt.Errorf("powerlosscert: %s contains an empty value", label)
+		}
+		if seen[value] {
+			return fmt.Errorf("powerlosscert: %s duplicates %q", label, value)
+		}
+		seen[value] = true
+	}
+	return nil
+}
+
+func validHex(value string, length int) bool {
+	if len(value) != length {
+		return false
+	}
+	for _, r := range value {
+		if !strings.ContainsRune("0123456789abcdef", r) {
+			return false
+		}
+	}
+	return true
+}
+
+func containsString(values []string, want string) bool {
+	for _, value := range values {
+		if value == want {
+			return true
+		}
+	}
+	return false
+}
+
+func sortedWitnesses(manifests []ChildManifest) []Witness {
+	var witnesses []Witness
+	for _, manifest := range manifests {
+		witnesses = append(witnesses, manifest.Witnesses...)
+	}
+	sort.Slice(witnesses, func(i, j int) bool { return witnesses[i].ID < witnesses[j].ID })
+	return witnesses
+}

--- a/TreeDB/internal/powerlosscert/manifest.go
+++ b/TreeDB/internal/powerlosscert/manifest.go
@@ -213,6 +213,7 @@ func ValidateBundle(expectedSHA string, inventory RiskInventory, manifests []Chi
 	}
 	manifestIDs := make(map[string]bool, len(manifests))
 	witnessIDs := make(map[string]string)
+	modeledEvidenceDirs := make(map[string]string)
 	for i := range manifests {
 		manifest := &manifests[i]
 		if manifest.RepositorySHA != expectedSHA {
@@ -233,6 +234,9 @@ func ValidateBundle(expectedSHA string, inventory RiskInventory, manifests []Chi
 				return fmt.Errorf("powerlosscert: duplicate witness id %q in manifests %q and %q", witness.ID, owner, manifest.ManifestID)
 			}
 			witnessIDs[witness.ID] = manifest.ManifestID
+			if err := registerModeledEvidenceDir(manifest.ManifestID, witness, modeledEvidenceDirs); err != nil {
+				return err
+			}
 		}
 	}
 	report, err := BuildCoverageReport(inventory, manifests)
@@ -242,6 +246,22 @@ func ValidateBundle(expectedSHA string, inventory RiskInventory, manifests []Chi
 	if !report.Complete {
 		return fmt.Errorf("powerlosscert: incomplete frozen risk coverage: %s", strings.Join(report.Gaps, ", "))
 	}
+	return nil
+}
+
+func registerModeledEvidenceDir(manifestID string, witness Witness, seen map[string]string) error {
+	if witness.EvidenceTier != EvidenceTierModeledCrash {
+		return nil
+	}
+	rawDir := witness.Command.Env["TREEDB_POWERLOSS_EVIDENCE_DIR"]
+	dir := normalizedArtifactPath(rawDir)
+	if rawDir == "" || filepath.IsAbs(rawDir) || dir == "." || strings.HasPrefix(dir, "../") || dir != rawDir {
+		return fmt.Errorf("powerlosscert: manifest %q witness %q has unsafe or non-canonical modeled evidence directory %q", manifestID, witness.ID, rawDir)
+	}
+	if owner, reused := seen[dir]; reused {
+		return fmt.Errorf("powerlosscert: witness %q reuses modeled evidence directory %q owned by witness %q", witness.ID, dir, owner)
+	}
+	seen[dir] = witness.ID
 	return nil
 }
 

--- a/TreeDB/internal/powerlosscert/manifest.go
+++ b/TreeDB/internal/powerlosscert/manifest.go
@@ -367,10 +367,11 @@ func validateChildManifest(manifest ChildManifest) error {
 		if err := validateArtifact(prefix+" test binary", artifact); err != nil {
 			return err
 		}
-		if binaries[artifact.Path] {
+		pathKey := normalizedArtifactPath(artifact.Path)
+		if binaries[pathKey] {
 			return fmt.Errorf("%s duplicates test binary path %q", prefix, artifact.Path)
 		}
-		binaries[artifact.Path] = true
+		binaries[pathKey] = true
 	}
 	if len(manifest.Witnesses) == 0 {
 		return fmt.Errorf("%s has no witnesses", prefix)
@@ -430,7 +431,7 @@ func validateWitness(prefix string, witness Witness, binaries map[string]bool) e
 	if err := validateUniqueStrings(prefix+" command arguments", witness.Command.Args); err != nil {
 		return err
 	}
-	if !binaries[witness.Command.BinaryPath] {
+	if !binaries[normalizedArtifactPath(witness.Command.BinaryPath)] {
 		return fmt.Errorf("%s references unregistered test binary %q", prefix, witness.Command.BinaryPath)
 	}
 	if !witness.CutExercised {
@@ -445,13 +446,14 @@ func validateWitness(prefix string, witness Witness, binaries map[string]bool) e
 		if err := validateArtifact(prefix+" artifact", artifact); err != nil {
 			return err
 		}
-		if binaries[artifact.Path] {
+		pathKey := normalizedArtifactPath(artifact.Path)
+		if binaries[pathKey] {
 			return fmt.Errorf("%s reuses test-binary path %q as artifact kind %q", prefix, artifact.Path, artifact.Kind)
 		}
-		if priorKind, duplicate := artifactPaths[artifact.Path]; duplicate {
+		if priorKind, duplicate := artifactPaths[pathKey]; duplicate {
 			return fmt.Errorf("%s reuses artifact path %q for kinds %q and %q", prefix, artifact.Path, priorKind, artifact.Kind)
 		}
-		artifactPaths[artifact.Path] = artifact.Kind
+		artifactPaths[pathKey] = artifact.Kind
 		if artifactKinds[artifact.Kind] {
 			return fmt.Errorf("%s duplicates artifact kind %q", prefix, artifact.Kind)
 		}
@@ -471,13 +473,18 @@ func validateArtifact(prefix string, artifact Artifact) error {
 	if !validArtifactKind(artifact.Kind) {
 		return fmt.Errorf("%s has unknown kind %q", prefix, artifact.Kind)
 	}
-	if artifact.Path == "" || filepath.IsAbs(artifact.Path) || artifact.Path == "." || strings.HasPrefix(filepath.ToSlash(filepath.Clean(artifact.Path)), "../") {
+	cleanPath := normalizedArtifactPath(artifact.Path)
+	if artifact.Path == "" || filepath.IsAbs(artifact.Path) || cleanPath == "." || strings.HasPrefix(cleanPath, "../") {
 		return fmt.Errorf("%s has unsafe path %q", prefix, artifact.Path)
 	}
 	if !validHex(artifact.SHA256, 64) {
 		return fmt.Errorf("%s %q has invalid sha256", prefix, artifact.Path)
 	}
 	return nil
+}
+
+func normalizedArtifactPath(path string) string {
+	return filepath.ToSlash(filepath.Clean(filepath.FromSlash(path)))
 }
 
 func validArtifactKind(kind ArtifactKind) bool {

--- a/TreeDB/internal/powerlosscert/manifest.go
+++ b/TreeDB/internal/powerlosscert/manifest.go
@@ -412,6 +412,9 @@ func validateWitness(prefix string, witness Witness, binaries map[string]bool) e
 	if witness.ExpectedOutcome != witness.ActualOutcome {
 		return fmt.Errorf("%s actual_outcome=%q want expected_outcome=%q", prefix, witness.ActualOutcome, witness.ExpectedOutcome)
 	}
+	if witness.EvidenceTier == EvidenceTierModeledCrash && modeledOutcomeClass(witness.ActualOutcome) == "" {
+		return fmt.Errorf("%s actual_outcome=%q must identify an accepted or rejected public-open outcome", prefix, witness.ActualOutcome)
+	}
 	state := witness.State
 	if state.RootMetaGeneration == "" || state.FreelistGeneration == "" || state.ExternalFrontiers == "" || state.NamespaceGeneration == "" || state.WALLineage == "" || state.DurableLSN == "" || state.CleanupPins == "" {
 		return fmt.Errorf("%s has incomplete recovery-state metadata", prefix)
@@ -467,6 +470,16 @@ func validateWitness(prefix string, witness Witness, binaries map[string]bool) e
 		}
 	}
 	return nil
+}
+
+func modeledOutcomeClass(outcome string) string {
+	for _, class := range []string{"accepted", "rejected"} {
+		prefix := class + ":"
+		if strings.HasPrefix(outcome, prefix) && len(outcome) > len(prefix) {
+			return class
+		}
+	}
+	return ""
 }
 
 func validateArtifact(prefix string, artifact Artifact) error {

--- a/TreeDB/internal/powerlosscert/manifest.go
+++ b/TreeDB/internal/powerlosscert/manifest.go
@@ -418,10 +418,10 @@ func validateWitness(prefix string, witness Witness, binaries map[string]bool) e
 	if witness.Seed == 0 {
 		return fmt.Errorf("%s has zero seed", prefix)
 	}
-	if witness.CutID == "" || witness.CutPoint == "" || witness.CutOccurrence <= 0 {
+	if witness.CutID == "" || witness.CutPoint == "" || witness.CutOccurrence < 0 {
 		return fmt.Errorf("%s has incomplete declared cut metadata", prefix)
 	}
-	if witness.ObservedEventCount < witness.CutOccurrence {
+	if witness.ObservedEventCount <= witness.CutOccurrence {
 		return fmt.Errorf("%s observed event count=%d does not reach declared occurrence=%d", prefix, witness.ObservedEventCount, witness.CutOccurrence)
 	}
 	if witness.Command.BinaryPath == "" || witness.Command.Package == "" || witness.Command.TestName == "" || len(witness.Command.Args) == 0 {

--- a/TreeDB/internal/powerlosscert/manifest.go
+++ b/TreeDB/internal/powerlosscert/manifest.go
@@ -439,26 +439,25 @@ func validateWitness(prefix string, witness Witness, binaries map[string]bool) e
 	if state.RootMetaGeneration == "" || state.FreelistGeneration == "" || state.ExternalFrontiers == "" || state.NamespaceGeneration == "" || state.WALLineage == "" || state.DurableLSN == "" || state.CleanupPins == "" {
 		return fmt.Errorf("%s has incomplete recovery-state metadata", prefix)
 	}
-	if witness.Seed == 0 {
-		return fmt.Errorf("%s has zero seed", prefix)
-	}
-	if witness.CutID == "" || witness.CutPoint == "" || witness.CutOccurrence < 0 {
-		return fmt.Errorf("%s has incomplete declared cut metadata", prefix)
-	}
-	if witness.ObservedEventCount <= witness.CutOccurrence {
-		return fmt.Errorf("%s observed event count=%d does not reach declared occurrence=%d", prefix, witness.ObservedEventCount, witness.CutOccurrence)
+	if witness.EvidenceTier == EvidenceTierModeledCrash {
+		if witness.Seed == 0 {
+			return fmt.Errorf("%s has zero seed", prefix)
+		}
+		if witness.CutID == "" || witness.CutPoint == "" || witness.CutOccurrence < 0 {
+			return fmt.Errorf("%s has incomplete declared cut metadata", prefix)
+		}
+		if witness.ObservedEventCount <= witness.CutOccurrence {
+			return fmt.Errorf("%s observed event count=%d does not reach declared occurrence=%d", prefix, witness.ObservedEventCount, witness.CutOccurrence)
+		}
+		if !witness.CutExercised {
+			return fmt.Errorf("%s passed but did not exercise its declared cut", prefix)
+		}
 	}
 	if witness.Command.BinaryPath == "" || witness.Command.Package == "" || witness.Command.TestName == "" || len(witness.Command.Args) == 0 {
 		return fmt.Errorf("%s has incomplete structured command", prefix)
 	}
-	if err := validateUniqueStrings(prefix+" command arguments", witness.Command.Args); err != nil {
-		return err
-	}
 	if !binaries[normalizedArtifactPath(witness.Command.BinaryPath)] {
 		return fmt.Errorf("%s references unregistered test binary %q", prefix, witness.Command.BinaryPath)
-	}
-	if !witness.CutExercised {
-		return fmt.Errorf("%s passed but did not exercise its declared cut", prefix)
 	}
 	if len(witness.Artifacts) == 0 {
 		return fmt.Errorf("%s has no hashed artifacts", prefix)
@@ -507,8 +506,8 @@ func validateArtifact(prefix string, artifact Artifact) error {
 		return fmt.Errorf("%s has unknown kind %q", prefix, artifact.Kind)
 	}
 	cleanPath := normalizedArtifactPath(artifact.Path)
-	if artifact.Path == "" || filepath.IsAbs(artifact.Path) || cleanPath == "." || strings.HasPrefix(cleanPath, "../") {
-		return fmt.Errorf("%s has unsafe path %q", prefix, artifact.Path)
+	if artifact.Path == "" || filepath.IsAbs(artifact.Path) || cleanPath == "." || strings.HasPrefix(cleanPath, "../") || cleanPath != artifact.Path {
+		return fmt.Errorf("%s has unsafe path or non-canonical path %q", prefix, artifact.Path)
 	}
 	if !validHex(artifact.SHA256, 64) {
 		return fmt.Errorf("%s %q has invalid sha256", prefix, artifact.Path)

--- a/TreeDB/internal/powerlosscert/manifest_test.go
+++ b/TreeDB/internal/powerlosscert/manifest_test.go
@@ -32,6 +32,18 @@ func TestValidateBundleRejectsStaleSHAAndDuplicateWitnessIDs(t *testing.T) {
 	}
 }
 
+func TestValidateBundleRejectsModeledEvidenceReuseAcrossWitnesses(t *testing.T) {
+	manifest := testChildManifest("witness-a")
+	reused := manifest.Witnesses[0]
+	reused.ID = "witness-b"
+	manifest.Witnesses = append(manifest.Witnesses, reused)
+
+	err := ValidateBundle(testRepositorySHA, testRiskInventory(), []ChildManifest{manifest})
+	if err == nil || !strings.Contains(err.Error(), "reuses modeled evidence directory") {
+		t.Fatalf("ValidateBundle modeled evidence reuse error=%v", err)
+	}
+}
+
 func TestValidateBundleRejectsPassingWitnessWithoutDeclaredCutOrArtifacts(t *testing.T) {
 	inventory := testRiskInventory()
 	manifest := testChildManifest("witness-a")

--- a/TreeDB/internal/powerlosscert/manifest_test.go
+++ b/TreeDB/internal/powerlosscert/manifest_test.go
@@ -157,6 +157,27 @@ func TestValidateBundleRejectsUndeclaredRiskValuesAndUnownedInteractions(t *test
 	}
 }
 
+func TestValidateBundleRejectsArtifactPathAliases(t *testing.T) {
+	t.Run("artifact kinds", func(t *testing.T) {
+		manifest := testChildManifest("witness-a")
+		manifest.Witnesses[0].Artifacts[1].Path = "artifacts/subdir/../witness-a-operation.json"
+
+		err := ValidateBundle(testRepositorySHA, testRiskInventory(), []ChildManifest{manifest})
+		if err == nil || !strings.Contains(err.Error(), "reuses artifact path") {
+			t.Fatalf("ValidateBundle artifact path alias error=%v", err)
+		}
+	})
+	t.Run("test binary", func(t *testing.T) {
+		manifest := testChildManifest("witness-a")
+		manifest.Witnesses[0].Artifacts[0].Path = "bin/subdir/../TreeDB.test"
+
+		err := ValidateBundle(testRepositorySHA, testRiskInventory(), []ChildManifest{manifest})
+		if err == nil || !strings.Contains(err.Error(), "reuses test-binary path") {
+			t.Fatalf("ValidateBundle test-binary path alias error=%v", err)
+		}
+	})
+}
+
 func testRiskInventory() RiskInventory {
 	return RiskInventory{
 		SchemaVersion: RiskInventorySchemaVersion,

--- a/TreeDB/internal/powerlosscert/manifest_test.go
+++ b/TreeDB/internal/powerlosscert/manifest_test.go
@@ -97,6 +97,35 @@ func TestValidateBundleAcceptsZeroBasedFirstCutOccurrence(t *testing.T) {
 	}
 }
 
+func TestValidateChildManifestScopesCutMetadataToModeledCrashes(t *testing.T) {
+	manifest := testChildManifest("witness-a")
+	for _, tier := range []EvidenceTier{EvidenceTierCleanProcess, EvidenceTierBlockDevice} {
+		corroborating := manifest.Witnesses[0]
+		corroborating.ID = string(tier) + "-witness"
+		corroborating.EvidenceTier = tier
+		corroborating.Seed = 0
+		corroborating.CutID = ""
+		corroborating.CutPoint = ""
+		corroborating.CutOccurrence = 0
+		corroborating.ObservedEventCount = 0
+		corroborating.CutExercised = false
+		manifest.Witnesses = append(manifest.Witnesses, corroborating)
+	}
+
+	if err := validateChildManifest(manifest); err != nil {
+		t.Fatalf("validateChildManifest clean-process witness: %v", err)
+	}
+}
+
+func TestValidateChildManifestAllowsRepeatedOrderedCommandArguments(t *testing.T) {
+	manifest := testChildManifest("witness-a")
+	manifest.Witnesses[0].Command.Args = []string{"-test.run", "first", "-test.run", "second"}
+
+	if err := validateChildManifest(manifest); err != nil {
+		t.Fatalf("validateChildManifest repeated command arguments: %v", err)
+	}
+}
+
 func TestValidateBundleRejectsUnclassifiedModeledOutcome(t *testing.T) {
 	manifest := testChildManifest("witness-a")
 	manifest.Witnesses[0].ExpectedOutcome = "old-root"
@@ -186,7 +215,7 @@ func TestValidateBundleRejectsArtifactPathAliases(t *testing.T) {
 		manifest.Witnesses[0].Artifacts[1].Path = "artifacts/witness-a/subdir/../operation_trace.json"
 
 		err := ValidateBundle(testRepositorySHA, testRiskInventory(), []ChildManifest{manifest})
-		if err == nil || !strings.Contains(err.Error(), "reuses artifact path") {
+		if err == nil || !strings.Contains(err.Error(), "non-canonical path") {
 			t.Fatalf("ValidateBundle artifact path alias error=%v", err)
 		}
 	})
@@ -195,10 +224,22 @@ func TestValidateBundleRejectsArtifactPathAliases(t *testing.T) {
 		manifest.Witnesses[0].Artifacts[0].Path = "bin/subdir/../TreeDB.test"
 
 		err := ValidateBundle(testRepositorySHA, testRiskInventory(), []ChildManifest{manifest})
-		if err == nil || !strings.Contains(err.Error(), "reuses test-binary path") {
+		if err == nil || !strings.Contains(err.Error(), "non-canonical path") {
 			t.Fatalf("ValidateBundle test-binary path alias error=%v", err)
 		}
 	})
+}
+
+func TestValidateArtifactRejectsStandaloneNonCanonicalPath(t *testing.T) {
+	artifact := Artifact{
+		Kind:   ArtifactKindMetrics,
+		Path:   "artifacts/witness-a/subdir/../metrics.json",
+		SHA256: strings.Repeat("a", 64),
+	}
+
+	if err := validateArtifact("test artifact", artifact); err == nil || !strings.Contains(err.Error(), "non-canonical") {
+		t.Fatalf("validateArtifact non-canonical path error=%v", err)
+	}
 }
 
 func testRiskInventory() RiskInventory {

--- a/TreeDB/internal/powerlosscert/manifest_test.go
+++ b/TreeDB/internal/powerlosscert/manifest_test.go
@@ -160,7 +160,7 @@ func TestValidateBundleRejectsUndeclaredRiskValuesAndUnownedInteractions(t *test
 func TestValidateBundleRejectsArtifactPathAliases(t *testing.T) {
 	t.Run("artifact kinds", func(t *testing.T) {
 		manifest := testChildManifest("witness-a")
-		manifest.Witnesses[0].Artifacts[1].Path = "artifacts/subdir/../witness-a-operation.json"
+		manifest.Witnesses[0].Artifacts[1].Path = "artifacts/witness-a/subdir/../operation_trace.json"
 
 		err := ValidateBundle(testRepositorySHA, testRiskInventory(), []ChildManifest{manifest})
 		if err == nil || !strings.Contains(err.Error(), "reuses artifact path") {
@@ -267,12 +267,12 @@ func testChildManifest(witnessID string) ChildManifest {
 			CutExercised:  true,
 			ClaimBoundary: "normal public reopen from modeled stable bytes",
 			Artifacts: []Artifact{
-				{Kind: ArtifactKindOperationTrace, Path: "artifacts/witness-a-operation.json", SHA256: strings.Repeat("e", 64)},
-				{Kind: ArtifactKindStableImageTree, Path: "artifacts/witness-a-stable.json", SHA256: strings.Repeat("e", 64)},
-				{Kind: ArtifactKindDirtyImageTree, Path: "artifacts/witness-a-dirty.json", SHA256: strings.Repeat("e", 64)},
-				{Kind: ArtifactKindRecoveryTrace, Path: "artifacts/witness-a-recovery.json", SHA256: strings.Repeat("e", 64)},
-				{Kind: ArtifactKindMetrics, Path: "artifacts/witness-a-metrics.json", SHA256: strings.Repeat("e", 64)},
-				{Kind: ArtifactKindLog, Path: "artifacts/witness-a.log", SHA256: strings.Repeat("e", 64)},
+				{Kind: ArtifactKindOperationTrace, Path: "artifacts/witness-a/operation_trace.json", SHA256: strings.Repeat("e", 64)},
+				{Kind: ArtifactKindStableImageTree, Path: "artifacts/witness-a/stable_image_tree.json", SHA256: strings.Repeat("e", 64)},
+				{Kind: ArtifactKindDirtyImageTree, Path: "artifacts/witness-a/dirty_image_tree.json", SHA256: strings.Repeat("e", 64)},
+				{Kind: ArtifactKindRecoveryTrace, Path: "artifacts/witness-a/recovery_trace.json", SHA256: strings.Repeat("e", 64)},
+				{Kind: ArtifactKindMetrics, Path: "artifacts/witness-a/metrics.json", SHA256: strings.Repeat("e", 64)},
+				{Kind: ArtifactKindLog, Path: "artifacts/witness-a/command_log.json", SHA256: strings.Repeat("e", 64)},
 			},
 		}},
 	}

--- a/TreeDB/internal/powerlosscert/manifest_test.go
+++ b/TreeDB/internal/powerlosscert/manifest_test.go
@@ -85,6 +85,17 @@ func TestValidateBundleAcceptsZeroBasedFirstCutOccurrence(t *testing.T) {
 	}
 }
 
+func TestValidateBundleRejectsUnclassifiedModeledOutcome(t *testing.T) {
+	manifest := testChildManifest("witness-a")
+	manifest.Witnesses[0].ExpectedOutcome = "old-root"
+	manifest.Witnesses[0].ActualOutcome = "old-root"
+
+	err := ValidateBundle(testRepositorySHA, testRiskInventory(), []ChildManifest{manifest})
+	if err == nil || !strings.Contains(err.Error(), "accepted or rejected public-open outcome") {
+		t.Fatalf("ValidateBundle outcome class error=%v", err)
+	}
+}
+
 func TestBuildCoverageReportRequiresModeledCrashOwnership(t *testing.T) {
 	inventory := testRiskInventory()
 	manifest := testChildManifest("witness-a")
@@ -232,8 +243,8 @@ func testChildManifest(witnessID string) ChildManifest {
 			WritebackVariant:       "target-metadata-alone",
 			FailureClasses:         []string{"fallback-older-complete-root"},
 			ExpectedDurableHorizon: "older dependency-closed durable root",
-			ExpectedOutcome:        "old-root",
-			ActualOutcome:          "old-root",
+			ExpectedOutcome:        "accepted:old-root",
+			ActualOutcome:          "accepted:old-root",
 			TypedError:             "none",
 			State: WitnessState{
 				RootMetaGeneration:  "old=1,new=2",

--- a/TreeDB/internal/powerlosscert/manifest_test.go
+++ b/TreeDB/internal/powerlosscert/manifest_test.go
@@ -57,6 +57,14 @@ func TestValidateBundleRejectsPassingWitnessWithoutDeclaredCutOrArtifacts(t *tes
 	if err := ValidateBundle(testRepositorySHA, inventory, []ChildManifest{manifest}); err == nil || !strings.Contains(err.Error(), "missing required artifact kind") {
 		t.Fatalf("ValidateBundle artifact-kind error=%v", err)
 	}
+
+	manifest = testChildManifest("witness-a")
+	for index := range manifest.Witnesses[0].Artifacts {
+		manifest.Witnesses[0].Artifacts[index].Path = "artifacts/one-file-for-every-kind.json"
+	}
+	if err := ValidateBundle(testRepositorySHA, inventory, []ChildManifest{manifest}); err == nil || !strings.Contains(err.Error(), "reuses artifact path") {
+		t.Fatalf("ValidateBundle artifact-path reuse error=%v", err)
+	}
 }
 
 func TestValidateBundleAcceptsZeroBasedFirstCutOccurrence(t *testing.T) {

--- a/TreeDB/internal/powerlosscert/manifest_test.go
+++ b/TreeDB/internal/powerlosscert/manifest_test.go
@@ -59,6 +59,24 @@ func TestValidateBundleRejectsPassingWitnessWithoutDeclaredCutOrArtifacts(t *tes
 	}
 }
 
+func TestValidateBundleAcceptsZeroBasedFirstCutOccurrence(t *testing.T) {
+	inventory := testRiskInventory()
+	manifest := testChildManifest("witness-a")
+	witness := &manifest.Witnesses[0]
+	witness.CutID = "cut/checkpoint-generation-2/after-meta-write/000"
+	witness.CutOccurrence = 0
+	witness.ObservedEventCount = 1
+	witness.Command.Env["TREEDB_POWERLOSS_CUT_ID"] = witness.CutID
+	if err := ValidateBundle(testRepositorySHA, inventory, []ChildManifest{manifest}); err != nil {
+		t.Fatalf("ValidateBundle first zero-based occurrence: %v", err)
+	}
+
+	witness.ObservedEventCount = 0
+	if err := ValidateBundle(testRepositorySHA, inventory, []ChildManifest{manifest}); err == nil || !strings.Contains(err.Error(), "observed event count") {
+		t.Fatalf("ValidateBundle unobserved first occurrence error=%v", err)
+	}
+}
+
 func TestBuildCoverageReportRequiresModeledCrashOwnership(t *testing.T) {
 	inventory := testRiskInventory()
 	manifest := testChildManifest("witness-a")
@@ -203,16 +221,18 @@ func testChildManifest(witnessID string) ChildManifest {
 			CutID:              "cut/checkpoint-generation-2/after-meta-write/001",
 			CutPoint:           "after-meta-write",
 			CutOccurrence:      1,
-			ObservedEventCount: 1,
+			ObservedEventCount: 2,
 			Command: TestCommand{
 				BinaryPath: "bin/TreeDB.test",
 				Package:    "./TreeDB",
 				TestName:   "TestPowerLossOracleCounterexampleNewMetaMissingClosure",
 				Args:       []string{"-test.run", "^TestPowerLossOracleCounterexampleNewMetaMissingClosure$", "-test.v"},
 				Env: map[string]string{
-					"TREEDB_POWERLOSS_CUT_ID":     "cut/checkpoint-generation-2/after-meta-write/001",
-					"TREEDB_POWERLOSS_VARIANT_ID": "variant-a",
-					"TREEDB_POWERLOSS_SEED":       "1",
+					"TREEDB_POWERLOSS_CUT_ID":           "cut/checkpoint-generation-2/after-meta-write/001",
+					"TREEDB_POWERLOSS_VARIANT_ID":       "variant-a",
+					"TREEDB_POWERLOSS_SEED":             "1",
+					"TREEDB_POWERLOSS_EVIDENCE_DIR":     "artifacts/witness-a",
+					"TREEDB_POWERLOSS_EXPECT_CUT_POINT": "after-meta-write",
 				},
 			},
 			CutExercised:  true,

--- a/TreeDB/internal/powerlosscert/manifest_test.go
+++ b/TreeDB/internal/powerlosscert/manifest_test.go
@@ -45,6 +45,18 @@ func TestValidateBundleRejectsPassingWitnessWithoutDeclaredCutOrArtifacts(t *tes
 	if err := ValidateBundle(testRepositorySHA, inventory, []ChildManifest{manifest}); err == nil || !strings.Contains(err.Error(), "no hashed artifacts") {
 		t.Fatalf("ValidateBundle artifact error=%v", err)
 	}
+
+	manifest = testChildManifest("witness-a")
+	manifest.Witnesses[0].ObservedEventCount = 0
+	if err := ValidateBundle(testRepositorySHA, inventory, []ChildManifest{manifest}); err == nil || !strings.Contains(err.Error(), "observed event count") {
+		t.Fatalf("ValidateBundle observed-cut error=%v", err)
+	}
+
+	manifest = testChildManifest("witness-a")
+	manifest.Witnesses[0].Artifacts = manifest.Witnesses[0].Artifacts[:1]
+	if err := ValidateBundle(testRepositorySHA, inventory, []ChildManifest{manifest}); err == nil || !strings.Contains(err.Error(), "missing required artifact kind") {
+		t.Fatalf("ValidateBundle artifact-kind error=%v", err)
+	}
 }
 
 func TestBuildCoverageReportRequiresModeledCrashOwnership(t *testing.T) {
@@ -103,6 +115,22 @@ func TestSelectRepresentativeCasesIsDeterministicAndKeepsMandatoryRows(t *testin
 	}
 }
 
+func TestValidateBundleRejectsUndeclaredRiskValuesAndUnownedInteractions(t *testing.T) {
+	inventory := testRiskInventory()
+	manifest := testChildManifest("witness-a")
+	manifest.Witnesses[0].ResourceShapes = append(manifest.Witnesses[0].ResourceShapes, "undeclared-shape")
+	if err := ValidateBundle(testRepositorySHA, inventory, []ChildManifest{manifest}); err == nil || !strings.Contains(err.Error(), "undeclared resource_shape") {
+		t.Fatalf("ValidateBundle undeclared value error=%v", err)
+	}
+
+	manifest = testChildManifest("witness-a")
+	inventory.RequiredInteractions[0].Members[1].Value = "unowned-boundary"
+	inventory.Dimensions[DimensionStorageBoundary] = append(inventory.Dimensions[DimensionStorageBoundary], "unowned-boundary")
+	if err := ValidateBundle(testRepositorySHA, inventory, []ChildManifest{manifest}); err == nil || !strings.Contains(err.Error(), "interaction:") {
+		t.Fatalf("ValidateBundle interaction gap error=%v", err)
+	}
+}
+
 func testRiskInventory() RiskInventory {
 	return RiskInventory{
 		SchemaVersion: RiskInventorySchemaVersion,
@@ -116,6 +144,13 @@ func testRiskInventory() RiskInventory {
 		},
 		RetainedCounterexamples:  []string{"counterexample-a"},
 		RequiredNegativeControls: []string{"negative-a"},
+		RequiredInteractions: []RequiredInteraction{{
+			ID: "checkpoint-target-meta",
+			Members: []CoverageRequirement{
+				{Dimension: DimensionAcknowledgement, Value: "checkpoint"},
+				{Dimension: DimensionStorageBoundary, Value: "target-meta-write-sync"},
+			},
+		}},
 	}
 }
 
@@ -137,7 +172,7 @@ func testChildManifest(witnessID string) ChildManifest {
 			Architecture:    "arm64",
 			FilesystemModel: "stable-dirty-v1",
 		},
-		TestBinaries:  []Artifact{{Path: "bin/TreeDB.test", SHA256: strings.Repeat("d", 64)}},
+		TestBinaries:  []Artifact{{Kind: ArtifactKindTestBinary, Path: "bin/TreeDB.test", SHA256: strings.Repeat("d", 64)}},
 		ClaimBoundary: "modeled stable-byte crash images only; no block-device claim",
 		Witnesses: []Witness{{
 			ID:                     witnessID,
@@ -162,17 +197,34 @@ func testChildManifest(witnessID string) ChildManifest {
 				DurableLSN:          "not-applicable",
 				CleanupPins:         "older-root-pin",
 			},
-			CounterexampleID:  "counterexample-a",
-			NegativeControlID: "negative-a",
-			Seed:              1,
+			CounterexampleID:   "counterexample-a",
+			NegativeControlID:  "negative-a",
+			Seed:               1,
+			CutID:              "cut/checkpoint-generation-2/after-meta-write/001",
+			CutPoint:           "after-meta-write",
+			CutOccurrence:      1,
+			ObservedEventCount: 1,
 			Command: TestCommand{
 				BinaryPath: "bin/TreeDB.test",
 				Package:    "./TreeDB",
 				TestName:   "TestPowerLossOracleCounterexampleNewMetaMissingClosure",
+				Args:       []string{"-test.run", "^TestPowerLossOracleCounterexampleNewMetaMissingClosure$", "-test.v"},
+				Env: map[string]string{
+					"TREEDB_POWERLOSS_CUT_ID":     "cut/checkpoint-generation-2/after-meta-write/001",
+					"TREEDB_POWERLOSS_VARIANT_ID": "variant-a",
+					"TREEDB_POWERLOSS_SEED":       "1",
+				},
 			},
 			CutExercised:  true,
 			ClaimBoundary: "normal public reopen from modeled stable bytes",
-			Artifacts:     []Artifact{{Path: "artifacts/witness-a.log", SHA256: strings.Repeat("e", 64)}},
+			Artifacts: []Artifact{
+				{Kind: ArtifactKindOperationTrace, Path: "artifacts/witness-a-operation.json", SHA256: strings.Repeat("e", 64)},
+				{Kind: ArtifactKindStableImageTree, Path: "artifacts/witness-a-stable.json", SHA256: strings.Repeat("e", 64)},
+				{Kind: ArtifactKindDirtyImageTree, Path: "artifacts/witness-a-dirty.json", SHA256: strings.Repeat("e", 64)},
+				{Kind: ArtifactKindRecoveryTrace, Path: "artifacts/witness-a-recovery.json", SHA256: strings.Repeat("e", 64)},
+				{Kind: ArtifactKindMetrics, Path: "artifacts/witness-a-metrics.json", SHA256: strings.Repeat("e", 64)},
+				{Kind: ArtifactKindLog, Path: "artifacts/witness-a.log", SHA256: strings.Repeat("e", 64)},
+			},
 		}},
 	}
 }

--- a/TreeDB/internal/powerlosscert/manifest_test.go
+++ b/TreeDB/internal/powerlosscert/manifest_test.go
@@ -1,0 +1,178 @@
+package powerlosscert
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+)
+
+const testRepositorySHA = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+
+func TestParseChildManifestRejectsUnknownFields(t *testing.T) {
+	data := []byte(`{"schema_version":"treedb-power-loss-child/v1","unexpected":true}`)
+	if _, err := ParseChildManifest(data); err == nil || !strings.Contains(err.Error(), "unknown field") {
+		t.Fatalf("ParseChildManifest error=%v, want unknown-field rejection", err)
+	}
+}
+
+func TestValidateBundleRejectsStaleSHAAndDuplicateWitnessIDs(t *testing.T) {
+	inventory := testRiskInventory()
+	manifest := testChildManifest("witness-a")
+	manifest.RepositorySHA = strings.Repeat("b", 40)
+	if err := ValidateBundle(testRepositorySHA, inventory, []ChildManifest{manifest}); err == nil || !strings.Contains(err.Error(), "stale repository_sha") {
+		t.Fatalf("ValidateBundle stale SHA error=%v", err)
+	}
+
+	manifest = testChildManifest("witness-a")
+	duplicate := testChildManifest("witness-a")
+	duplicate.ManifestID = "dur-02"
+	duplicate.Issue = 3675
+	if err := ValidateBundle(testRepositorySHA, inventory, []ChildManifest{manifest, duplicate}); err == nil || !strings.Contains(err.Error(), "duplicate witness id") {
+		t.Fatalf("ValidateBundle duplicate error=%v", err)
+	}
+}
+
+func TestValidateBundleRejectsPassingWitnessWithoutDeclaredCutOrArtifacts(t *testing.T) {
+	inventory := testRiskInventory()
+	manifest := testChildManifest("witness-a")
+	manifest.Witnesses[0].CutExercised = false
+	if err := ValidateBundle(testRepositorySHA, inventory, []ChildManifest{manifest}); err == nil || !strings.Contains(err.Error(), "did not exercise its declared cut") {
+		t.Fatalf("ValidateBundle cut error=%v", err)
+	}
+
+	manifest = testChildManifest("witness-a")
+	manifest.Witnesses[0].Artifacts = nil
+	if err := ValidateBundle(testRepositorySHA, inventory, []ChildManifest{manifest}); err == nil || !strings.Contains(err.Error(), "no hashed artifacts") {
+		t.Fatalf("ValidateBundle artifact error=%v", err)
+	}
+}
+
+func TestBuildCoverageReportRequiresModeledCrashOwnership(t *testing.T) {
+	inventory := testRiskInventory()
+	manifest := testChildManifest("witness-a")
+	report, err := BuildCoverageReport(inventory, []ChildManifest{manifest})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !report.Complete || len(report.Gaps) != 0 {
+		t.Fatalf("complete report=%+v", report)
+	}
+
+	manifest.Witnesses[0].EvidenceTier = EvidenceTierCleanProcess
+	report, err = BuildCoverageReport(inventory, []ChildManifest{manifest})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if report.Complete || len(report.Gaps) == 0 {
+		t.Fatalf("clean/process evidence incorrectly satisfied modeled-crash inventory: %+v", report)
+	}
+}
+
+func TestSelectRepresentativeCasesIsDeterministicAndKeepsMandatoryRows(t *testing.T) {
+	inventory := testRiskInventory()
+	manifest := testChildManifest("broad")
+	mandatory := manifest.Witnesses[0]
+	mandatory.ID = "mandatory-counterexample"
+	mandatory.CounterexampleID = "counterexample-a"
+	mandatory.NegativeControlID = "negative-a"
+
+	narrow := mandatory
+	narrow.ID = "narrow"
+	narrow.CounterexampleID = ""
+	narrow.NegativeControlID = ""
+	narrow.ResourceShapes = nil
+	narrow.StorageBoundaries = nil
+	narrow.FailureClasses = nil
+
+	manifest.Witnesses = []Witness{narrow, mandatory}
+	first, err := SelectRepresentativeCases(inventory, []ChildManifest{manifest})
+	if err != nil {
+		t.Fatal(err)
+	}
+	secondManifest := manifest
+	secondManifest.Witnesses = []Witness{mandatory, narrow}
+	second, err := SelectRepresentativeCases(inventory, []ChildManifest{secondManifest})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(first, second) {
+		t.Fatalf("selection depends on manifest order:\nfirst=%+v\nsecond=%+v", first, second)
+	}
+	if got, want := first.CaseIDs, []string{"mandatory-counterexample"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("selected cases=%v want=%v", got, want)
+	}
+}
+
+func testRiskInventory() RiskInventory {
+	return RiskInventory{
+		SchemaVersion: RiskInventorySchemaVersion,
+		Dimensions: map[string][]string{
+			DimensionProfile:          {"command_wal_durable"},
+			DimensionAcknowledgement:  {"checkpoint"},
+			DimensionResourceShape:    {"forced-value-log-pointer"},
+			DimensionStorageBoundary:  {"target-meta-write-sync"},
+			DimensionWritebackVariant: {"target-metadata-alone"},
+			DimensionFailureClass:     {"fallback-older-complete-root"},
+		},
+		RetainedCounterexamples:  []string{"counterexample-a"},
+		RequiredNegativeControls: []string{"negative-a"},
+	}
+}
+
+func testChildManifest(witnessID string) ChildManifest {
+	return ChildManifest{
+		SchemaVersion: ChildManifestSchemaVersion,
+		ManifestID:    "dur-01",
+		RepositorySHA: testRepositorySHA,
+		Issue:         3674,
+		PullRequests: []PullRequest{{
+			Number:   3706,
+			HeadSHA:  strings.Repeat("b", 40),
+			MergeSHA: strings.Repeat("c", 40),
+		}},
+		Environment: Environment{
+			GoVersion:       "go1.26.0",
+			ToolVersion:     "powerloss-cert/v1",
+			OS:              "darwin",
+			Architecture:    "arm64",
+			FilesystemModel: "stable-dirty-v1",
+		},
+		TestBinaries:  []Artifact{{Path: "bin/TreeDB.test", SHA256: strings.Repeat("d", 64)}},
+		ClaimBoundary: "modeled stable-byte crash images only; no block-device claim",
+		Witnesses: []Witness{{
+			ID:                     witnessID,
+			EvidenceTier:           EvidenceTierModeledCrash,
+			Profile:                "command_wal_durable",
+			Acknowledgement:        "checkpoint",
+			ResourceShapes:         []string{"forced-value-log-pointer"},
+			DependencyGraph:        "meta -> index -> freelist -> value-log",
+			StorageBoundaries:      []string{"target-meta-write-sync"},
+			WritebackVariant:       "target-metadata-alone",
+			FailureClasses:         []string{"fallback-older-complete-root"},
+			ExpectedDurableHorizon: "older dependency-closed durable root",
+			ExpectedOutcome:        "old-root",
+			ActualOutcome:          "old-root",
+			TypedError:             "none",
+			State: WitnessState{
+				RootMetaGeneration:  "old=1,new=2",
+				FreelistGeneration:  "generation-2",
+				ExternalFrontiers:   "value-log-generation-2",
+				NamespaceGeneration: "namespace-generation-2",
+				WALLineage:          "none",
+				DurableLSN:          "not-applicable",
+				CleanupPins:         "older-root-pin",
+			},
+			CounterexampleID:  "counterexample-a",
+			NegativeControlID: "negative-a",
+			Seed:              1,
+			Command: TestCommand{
+				BinaryPath: "bin/TreeDB.test",
+				Package:    "./TreeDB",
+				TestName:   "TestPowerLossOracleCounterexampleNewMetaMissingClosure",
+			},
+			CutExercised:  true,
+			ClaimBoundary: "normal public reopen from modeled stable bytes",
+			Artifacts:     []Artifact{{Path: "artifacts/witness-a.log", SHA256: strings.Repeat("e", 64)}},
+		}},
+	}
+}

--- a/TreeDB/internal/powerlossoracle/evidence.go
+++ b/TreeDB/internal/powerlossoracle/evidence.go
@@ -21,6 +21,8 @@ type EvidenceSession struct {
 	Root               string
 	CutPoint           string
 	ObservedEventCount int
+	stableTreeSHA256   string
+	stableFingerprint  string
 }
 
 type evidenceTrace struct {
@@ -113,8 +115,13 @@ func BeginEvidenceFromEnv(model *Model) (*EvidenceSession, error) {
 	}); err != nil {
 		return nil, err
 	}
-	if err := writeEvidenceJSON(filepath.Join(root, "stable_image_tree.json"), stableTree); err != nil {
+	stableTreePath := filepath.Join(root, "stable_image_tree.json")
+	if err := writeEvidenceJSON(stableTreePath, stableTree); err != nil {
 		return nil, err
+	}
+	stableTreeSHA256, err := evidenceFileSHA256(stableTreePath)
+	if err != nil {
+		return nil, fmt.Errorf("powerlossoracle: hash stable image tree: %w", err)
 	}
 	if err := writeEvidenceJSON(filepath.Join(root, "dirty_image_tree.json"), dirtyTree); err != nil {
 		return nil, err
@@ -130,7 +137,13 @@ func BeginEvidenceFromEnv(model *Model) (*EvidenceSession, error) {
 	}); err != nil {
 		return nil, err
 	}
-	return &EvidenceSession{Root: root, CutPoint: cutPoint, ObservedEventCount: observed}, nil
+	return &EvidenceSession{
+		Root:               root,
+		CutPoint:           cutPoint,
+		ObservedEventCount: observed,
+		stableTreeSHA256:   stableTreeSHA256,
+		stableFingerprint:  model.StableFingerprint(),
+	}, nil
 }
 
 func portableEvidenceTrace(trace []string) []string {
@@ -155,6 +168,24 @@ func (session *EvidenceSession) RecoveryInputDir() string {
 		return ""
 	}
 	return filepath.Join(session.Root, "recovery-input")
+}
+
+// StableImageTreeSHA256 binds recovery evidence to the immutable manifest of
+// the exact stable-byte image copied into RecoveryInputDir before public open.
+func (session *EvidenceSession) StableImageTreeSHA256() string {
+	if session == nil {
+		return ""
+	}
+	return session.stableTreeSHA256
+}
+
+// StableFingerprint identifies the modeled stable namespace, identities, and
+// bytes from which the immutable image and recovery input were materialized.
+func (session *EvidenceSession) StableFingerprint() string {
+	if session == nil {
+		return ""
+	}
+	return session.stableFingerprint
 }
 
 func (session *EvidenceSession) RecordRecovery(value any) error {

--- a/TreeDB/internal/powerlossoracle/evidence.go
+++ b/TreeDB/internal/powerlossoracle/evidence.go
@@ -87,12 +87,16 @@ func BeginEvidenceFromEnv(model *Model) (*EvidenceSession, error) {
 	}
 	stableDir := filepath.Join(root, "stable-image")
 	dirtyDir := filepath.Join(root, "dirty-image")
+	preOpenDir := filepath.Join(root, "recovery-preopen")
 	recoveryDir := filepath.Join(root, "recovery-input")
 	if err := model.MaterializeStable(stableDir); err != nil {
 		return nil, fmt.Errorf("powerlossoracle: materialize stable evidence: %w", err)
 	}
 	if err := model.MaterializeVolatile(dirtyDir); err != nil {
 		return nil, fmt.Errorf("powerlossoracle: materialize dirty evidence: %w", err)
+	}
+	if err := model.MaterializeStable(preOpenDir); err != nil {
+		return nil, fmt.Errorf("powerlossoracle: materialize pre-open recovery evidence: %w", err)
 	}
 	if err := model.MaterializeStable(recoveryDir); err != nil {
 		return nil, fmt.Errorf("powerlossoracle: materialize recovery input: %w", err)

--- a/TreeDB/internal/powerlossoracle/evidence.go
+++ b/TreeDB/internal/powerlossoracle/evidence.go
@@ -220,15 +220,15 @@ func (session *EvidenceSession) RecordRecovery(value any) error {
 }
 
 func requireEmptyEvidenceRoot(root string) error {
+	if err := EnsureNoSymlinkComponents(root); err != nil {
+		return fmt.Errorf("powerlossoracle: inspect evidence directory %q: %w", root, err)
+	}
 	info, err := os.Lstat(root)
 	if os.IsNotExist(err) {
 		return nil
 	}
 	if err != nil {
 		return fmt.Errorf("powerlossoracle: inspect evidence directory %q: %w", root, err)
-	}
-	if info.Mode()&os.ModeSymlink != 0 {
-		return errorsf("evidence directory %q is a symlink", root)
 	}
 	if !info.IsDir() {
 		return errorsf("evidence directory %q is not a directory", root)
@@ -241,6 +241,29 @@ func requireEmptyEvidenceRoot(root string) error {
 		return errorsf("evidence directory %q is not empty", root)
 	}
 	return nil
+}
+
+// EnsureNoSymlinkComponents rejects any existing symlink in path, including
+// ancestors of a final component that does not exist yet.
+func EnsureNoSymlinkComponents(path string) error {
+	absolute, err := filepath.Abs(path)
+	if err != nil {
+		return fmt.Errorf("resolve path %q: %w", path, err)
+	}
+	for current := filepath.Clean(absolute); ; {
+		info, err := os.Lstat(current)
+		if err == nil && info.Mode()&os.ModeSymlink != 0 {
+			return fmt.Errorf("path component %q is a symlink", current)
+		}
+		if err != nil && !os.IsNotExist(err) {
+			return fmt.Errorf("inspect path component %q: %w", current, err)
+		}
+		parent := filepath.Dir(current)
+		if parent == current {
+			return nil
+		}
+		current = parent
+	}
 }
 
 func parseReplayCutAddress(cutID string) (string, int, error) {

--- a/TreeDB/internal/powerlossoracle/evidence.go
+++ b/TreeDB/internal/powerlossoracle/evidence.go
@@ -68,7 +68,7 @@ func BeginEvidenceFromEnv(model *Model) (*EvidenceSession, error) {
 	if err := requireEmptyEvidenceRoot(root); err != nil {
 		return nil, err
 	}
-	trace := model.Trace()
+	trace := portableEvidenceTrace(model.Trace())
 	cutPrefix := "cut:" + cutPoint + ":"
 	observed := 0
 	for _, event := range trace {
@@ -84,11 +84,15 @@ func BeginEvidenceFromEnv(model *Model) (*EvidenceSession, error) {
 	}
 	stableDir := filepath.Join(root, "stable-image")
 	dirtyDir := filepath.Join(root, "dirty-image")
+	recoveryDir := filepath.Join(root, "recovery-input")
 	if err := model.MaterializeStable(stableDir); err != nil {
 		return nil, fmt.Errorf("powerlossoracle: materialize stable evidence: %w", err)
 	}
 	if err := model.MaterializeVolatile(dirtyDir); err != nil {
 		return nil, fmt.Errorf("powerlossoracle: materialize dirty evidence: %w", err)
+	}
+	if err := model.MaterializeStable(recoveryDir); err != nil {
+		return nil, fmt.Errorf("powerlossoracle: materialize recovery input: %w", err)
 	}
 	stableTree, err := buildEvidenceTree(stableDir, "stable-image")
 	if err != nil {
@@ -129,11 +133,28 @@ func BeginEvidenceFromEnv(model *Model) (*EvidenceSession, error) {
 	return &EvidenceSession{Root: root, CutPoint: cutPoint, ObservedEventCount: observed}, nil
 }
 
+func portableEvidenceTrace(trace []string) []string {
+	out := append([]string(nil), trace...)
+	for index, event := range out {
+		if strings.HasPrefix(event, "overlay:") {
+			out[index] = "overlay:<source-root>"
+		}
+	}
+	return out
+}
+
 func (session *EvidenceSession) StableImageDir() string {
 	if session == nil {
 		return ""
 	}
 	return filepath.Join(session.Root, "stable-image")
+}
+
+func (session *EvidenceSession) RecoveryInputDir() string {
+	if session == nil {
+		return ""
+	}
+	return filepath.Join(session.Root, "recovery-input")
 }
 
 func (session *EvidenceSession) RecordRecovery(value any) error {

--- a/TreeDB/internal/powerlossoracle/evidence.go
+++ b/TreeDB/internal/powerlossoracle/evidence.go
@@ -1,0 +1,223 @@
+package powerlossoracle
+
+import (
+	"crypto/sha256"
+	"encoding/json"
+	"fmt"
+	"io"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+const (
+	EnvEvidenceDir      = "TREEDB_POWERLOSS_EVIDENCE_DIR"
+	EnvEvidenceCutPoint = "TREEDB_POWERLOSS_EXPECT_CUT_POINT"
+)
+
+type EvidenceSession struct {
+	Root               string
+	CutPoint           string
+	ObservedEventCount int
+}
+
+type evidenceTrace struct {
+	SchemaVersion      string   `json:"schema_version"`
+	CutID              string   `json:"cut_id"`
+	VariantID          string   `json:"variant_id"`
+	Seed               string   `json:"seed"`
+	DeclaredCutPoint   string   `json:"declared_cut_point"`
+	ObservedEventCount int      `json:"observed_event_count"`
+	Events             []string `json:"events"`
+}
+
+type evidenceTree struct {
+	SchemaVersion string             `json:"schema_version"`
+	Kind          string             `json:"kind"`
+	Files         []evidenceTreeFile `json:"files"`
+	TotalBytes    int64              `json:"total_bytes"`
+}
+
+type evidenceTreeFile struct {
+	Path   string `json:"path"`
+	Bytes  int64  `json:"bytes"`
+	SHA256 string `json:"sha256"`
+}
+
+type evidenceMetrics struct {
+	SchemaVersion     string `json:"schema_version"`
+	StableImageBytes  int64  `json:"stable_image_bytes"`
+	DirtyImageBytes   int64  `json:"dirty_image_bytes"`
+	StableFiles       int    `json:"stable_files"`
+	DirtyFiles        int    `json:"dirty_files"`
+	TraceEvents       int    `json:"trace_events"`
+	StableFingerprint string `json:"stable_fingerprint"`
+}
+
+func BeginEvidenceFromEnv(model *Model) (*EvidenceSession, error) {
+	root := os.Getenv(EnvEvidenceDir)
+	cutPoint := os.Getenv(EnvEvidenceCutPoint)
+	if root == "" && cutPoint == "" {
+		return nil, nil
+	}
+	if root == "" || cutPoint == "" {
+		return nil, errorsf("evidence capture requires %s and %s", EnvEvidenceDir, EnvEvidenceCutPoint)
+	}
+	if err := requireEmptyEvidenceRoot(root); err != nil {
+		return nil, err
+	}
+	trace := model.Trace()
+	cutPrefix := "cut:" + cutPoint + ":"
+	observed := 0
+	for _, event := range trace {
+		if strings.HasPrefix(event, cutPrefix) {
+			observed++
+		}
+	}
+	if observed == 0 {
+		return nil, errorsf("declared cut point %q was not observed", cutPoint)
+	}
+	if err := os.MkdirAll(root, 0o755); err != nil {
+		return nil, err
+	}
+	stableDir := filepath.Join(root, "stable-image")
+	dirtyDir := filepath.Join(root, "dirty-image")
+	if err := model.MaterializeStable(stableDir); err != nil {
+		return nil, fmt.Errorf("powerlossoracle: materialize stable evidence: %w", err)
+	}
+	if err := model.MaterializeVolatile(dirtyDir); err != nil {
+		return nil, fmt.Errorf("powerlossoracle: materialize dirty evidence: %w", err)
+	}
+	stableTree, err := buildEvidenceTree(stableDir, "stable-image")
+	if err != nil {
+		return nil, err
+	}
+	dirtyTree, err := buildEvidenceTree(dirtyDir, "dirty-image")
+	if err != nil {
+		return nil, err
+	}
+	if err := writeEvidenceJSON(filepath.Join(root, "operation_trace.json"), evidenceTrace{
+		SchemaVersion:      "treedb-power-loss-operation-trace/v1",
+		CutID:              os.Getenv(EnvReplayCut),
+		VariantID:          os.Getenv(EnvReplayVariant),
+		Seed:               os.Getenv(EnvReplaySeed),
+		DeclaredCutPoint:   cutPoint,
+		ObservedEventCount: observed,
+		Events:             trace,
+	}); err != nil {
+		return nil, err
+	}
+	if err := writeEvidenceJSON(filepath.Join(root, "stable_image_tree.json"), stableTree); err != nil {
+		return nil, err
+	}
+	if err := writeEvidenceJSON(filepath.Join(root, "dirty_image_tree.json"), dirtyTree); err != nil {
+		return nil, err
+	}
+	if err := writeEvidenceJSON(filepath.Join(root, "metrics.json"), evidenceMetrics{
+		SchemaVersion:     "treedb-power-loss-metrics/v1",
+		StableImageBytes:  stableTree.TotalBytes,
+		DirtyImageBytes:   dirtyTree.TotalBytes,
+		StableFiles:       len(stableTree.Files),
+		DirtyFiles:        len(dirtyTree.Files),
+		TraceEvents:       len(trace),
+		StableFingerprint: model.StableFingerprint(),
+	}); err != nil {
+		return nil, err
+	}
+	return &EvidenceSession{Root: root, CutPoint: cutPoint, ObservedEventCount: observed}, nil
+}
+
+func (session *EvidenceSession) StableImageDir() string {
+	if session == nil {
+		return ""
+	}
+	return filepath.Join(session.Root, "stable-image")
+}
+
+func (session *EvidenceSession) RecordRecovery(value any) error {
+	if session == nil {
+		return nil
+	}
+	return writeEvidenceJSON(filepath.Join(session.Root, "recovery_trace.json"), value)
+}
+
+func requireEmptyEvidenceRoot(root string) error {
+	entries, err := os.ReadDir(root)
+	if os.IsNotExist(err) {
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("powerlossoracle: inspect evidence directory %q: %w", root, err)
+	}
+	if len(entries) != 0 {
+		return errorsf("evidence directory %q is not empty", root)
+	}
+	return nil
+}
+
+func buildEvidenceTree(root, kind string) (evidenceTree, error) {
+	tree := evidenceTree{SchemaVersion: "treedb-power-loss-image-tree/v1", Kind: kind}
+	err := filepath.WalkDir(root, func(path string, entry fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if entry.IsDir() {
+			return nil
+		}
+		if !entry.Type().IsRegular() {
+			return fmt.Errorf("powerlossoracle: evidence image contains non-regular path %q", path)
+		}
+		rel, err := filepath.Rel(root, path)
+		if err != nil {
+			return err
+		}
+		info, err := entry.Info()
+		if err != nil {
+			return err
+		}
+		digest, err := evidenceFileSHA256(path)
+		if err != nil {
+			return err
+		}
+		tree.Files = append(tree.Files, evidenceTreeFile{Path: filepath.ToSlash(rel), Bytes: info.Size(), SHA256: digest})
+		tree.TotalBytes += info.Size()
+		return nil
+	})
+	if err != nil {
+		return evidenceTree{}, err
+	}
+	sort.Slice(tree.Files, func(i, j int) bool { return tree.Files[i].Path < tree.Files[j].Path })
+	return tree, nil
+}
+
+func evidenceFileSHA256(path string) (string, error) {
+	file, err := os.Open(path)
+	if err != nil {
+		return "", err
+	}
+	defer file.Close()
+	hash := sha256.New()
+	if _, err := io.Copy(hash, file); err != nil {
+		return "", err
+	}
+	return fmt.Sprintf("%x", hash.Sum(nil)), nil
+}
+
+func writeEvidenceJSON(path string, value any) error {
+	data, err := json.MarshalIndent(value, "", "  ")
+	if err != nil {
+		return err
+	}
+	data = append(data, '\n')
+	file, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o600)
+	if err != nil {
+		return fmt.Errorf("powerlossoracle: create evidence %q: %w", path, err)
+	}
+	if _, err := file.Write(data); err != nil {
+		_ = file.Close()
+		return err
+	}
+	return file.Close()
+}

--- a/TreeDB/internal/powerlossoracle/evidence.go
+++ b/TreeDB/internal/powerlossoracle/evidence.go
@@ -38,6 +38,7 @@ type evidenceTrace struct {
 type evidenceTree struct {
 	SchemaVersion string             `json:"schema_version"`
 	Kind          string             `json:"kind"`
+	Directories   []string           `json:"directories"`
 	Files         []evidenceTreeFile `json:"files"`
 	TotalBytes    int64              `json:"total_bytes"`
 }
@@ -216,6 +217,13 @@ func buildEvidenceTree(root, kind string) (evidenceTree, error) {
 			return err
 		}
 		if entry.IsDir() {
+			if path != root {
+				rel, err := filepath.Rel(root, path)
+				if err != nil {
+					return err
+				}
+				tree.Directories = append(tree.Directories, filepath.ToSlash(rel))
+			}
 			return nil
 		}
 		if !entry.Type().IsRegular() {
@@ -240,6 +248,7 @@ func buildEvidenceTree(root, kind string) (evidenceTree, error) {
 	if err != nil {
 		return evidenceTree{}, err
 	}
+	sort.Strings(tree.Directories)
 	sort.Slice(tree.Files, func(i, j int) bool { return tree.Files[i].Path < tree.Files[j].Path })
 	return tree, nil
 }

--- a/TreeDB/internal/powerlossoracle/evidence.go
+++ b/TreeDB/internal/powerlossoracle/evidence.go
@@ -6,9 +6,11 @@ import (
 	"fmt"
 	"io"
 	"io/fs"
+	"net/url"
 	"os"
 	"path/filepath"
 	"sort"
+	"strconv"
 	"strings"
 )
 
@@ -82,6 +84,23 @@ func BeginEvidenceFromEnv(model *Model) (*EvidenceSession, error) {
 	if observed == 0 {
 		return nil, errorsf("declared cut point %q was not observed", cutPoint)
 	}
+	selector, err := ReplaySelectorFromEnv()
+	if err != nil {
+		return nil, err
+	}
+	if selector == (ReplaySelector{}) {
+		return nil, errorsf("evidence capture requires %s, %s, and %s", EnvReplayCut, EnvReplayVariant, EnvReplaySeed)
+	}
+	replayCutPoint, replayOccurrence, err := parseReplayCutAddress(selector.CutID)
+	if err != nil {
+		return nil, err
+	}
+	if replayCutPoint != cutPoint {
+		return nil, errorsf("replay cut point %q does not match declared cut point %q", replayCutPoint, cutPoint)
+	}
+	if observed != replayOccurrence+1 {
+		return nil, errorsf("observed cut events=%d does not end at replay occurrence=%d", observed, replayOccurrence)
+	}
 	if err := os.MkdirAll(root, 0o755); err != nil {
 		return nil, err
 	}
@@ -111,9 +130,9 @@ func BeginEvidenceFromEnv(model *Model) (*EvidenceSession, error) {
 	}
 	if err := writeEvidenceJSON(filepath.Join(root, "operation_trace.json"), evidenceTrace{
 		SchemaVersion:      "treedb-power-loss-operation-trace/v1",
-		CutID:              os.Getenv(EnvReplayCut),
-		VariantID:          os.Getenv(EnvReplayVariant),
-		Seed:               os.Getenv(EnvReplaySeed),
+		CutID:              selector.CutID,
+		VariantID:          selector.VariantID,
+		Seed:               strconv.FormatUint(selector.Seed, 10),
 		DeclaredCutPoint:   cutPoint,
 		ObservedEventCount: observed,
 		Events:             trace,
@@ -201,10 +220,20 @@ func (session *EvidenceSession) RecordRecovery(value any) error {
 }
 
 func requireEmptyEvidenceRoot(root string) error {
-	entries, err := os.ReadDir(root)
+	info, err := os.Lstat(root)
 	if os.IsNotExist(err) {
 		return nil
 	}
+	if err != nil {
+		return fmt.Errorf("powerlossoracle: inspect evidence directory %q: %w", root, err)
+	}
+	if info.Mode()&os.ModeSymlink != 0 {
+		return errorsf("evidence directory %q is a symlink", root)
+	}
+	if !info.IsDir() {
+		return errorsf("evidence directory %q is not a directory", root)
+	}
+	entries, err := os.ReadDir(root)
 	if err != nil {
 		return fmt.Errorf("powerlossoracle: inspect evidence directory %q: %w", root, err)
 	}
@@ -212,6 +241,22 @@ func requireEmptyEvidenceRoot(root string) error {
 		return errorsf("evidence directory %q is not empty", root)
 	}
 	return nil
+}
+
+func parseReplayCutAddress(cutID string) (string, int, error) {
+	parts := strings.Split(cutID, "/")
+	if len(parts) != 4 || parts[0] != "cut" || parts[1] == "" {
+		return "", 0, errorsf("invalid replay cut id %q", cutID)
+	}
+	cutPoint, err := url.PathUnescape(parts[2])
+	if err != nil || cutPoint == "" {
+		return "", 0, errorsf("invalid replay cut point in %q", cutID)
+	}
+	occurrence, err := strconv.Atoi(parts[3])
+	if err != nil || occurrence < 0 {
+		return "", 0, errorsf("invalid replay cut occurrence in %q", cutID)
+	}
+	return cutPoint, occurrence, nil
 }
 
 func buildEvidenceTree(root, kind string) (evidenceTree, error) {

--- a/TreeDB/internal/powerlossoracle/evidence_test.go
+++ b/TreeDB/internal/powerlossoracle/evidence_test.go
@@ -21,6 +21,9 @@ func TestBeginEvidenceFromEnvPersistsImagesTraceAndMetrics(t *testing.T) {
 	if err := model.Write("index.db", []byte("new")); err != nil {
 		t.Fatal(err)
 	}
+	if err := model.Overlay(source); err != nil {
+		t.Fatal(err)
+	}
 	if err := model.Observe(source, durabilitycut.Event{Point: durabilitycut.AfterMetaWrite, Resource: durabilitycut.ResourceMeta}); err != nil {
 		t.Fatal(err)
 	}
@@ -46,6 +49,13 @@ func TestBeginEvidenceFromEnvPersistsImagesTraceAndMetrics(t *testing.T) {
 		if _, err := os.Stat(filepath.Join(evidenceDir, filepath.FromSlash(path))); err != nil {
 			t.Fatalf("missing evidence %s: %v", path, err)
 		}
+	}
+	traceData, err := os.ReadFile(filepath.Join(evidenceDir, "operation_trace.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(traceData), source) {
+		t.Fatalf("operation trace leaked host-specific source path: %s", traceData)
 	}
 	if err := session.RecordRecovery(map[string]any{"opened": true}); err != nil {
 		t.Fatal(err)

--- a/TreeDB/internal/powerlossoracle/evidence_test.go
+++ b/TreeDB/internal/powerlossoracle/evidence_test.go
@@ -38,6 +38,9 @@ func TestBeginEvidenceFromEnvPersistsImagesTraceAndMetrics(t *testing.T) {
 	if session == nil || session.ObservedEventCount != 1 {
 		t.Fatalf("session=%+v", session)
 	}
+	if len(session.StableImageTreeSHA256()) != 64 || len(session.StableFingerprint()) != 64 {
+		t.Fatalf("session evidence identities tree=%q fingerprint=%q", session.StableImageTreeSHA256(), session.StableFingerprint())
+	}
 	for _, path := range []string{
 		"operation_trace.json",
 		"stable_image_tree.json",

--- a/TreeDB/internal/powerlossoracle/evidence_test.go
+++ b/TreeDB/internal/powerlossoracle/evidence_test.go
@@ -75,7 +75,7 @@ func TestBeginEvidenceFromEnvPersistsImagesTraceAndMetrics(t *testing.T) {
 	if len(stableTree.Directories) != 1 || stableTree.Directories[0] != "empty-wal" {
 		t.Fatalf("stable image directories=%v want [empty-wal]", stableTree.Directories)
 	}
-	for _, image := range []string{"stable-image", "dirty-image", "recovery-input"} {
+	for _, image := range []string{"stable-image", "dirty-image", "recovery-preopen", "recovery-input"} {
 		info, err := os.Stat(filepath.Join(evidenceDir, image, "empty-wal"))
 		if err != nil || !info.IsDir() {
 			t.Fatalf("%s empty directory info=%v error=%v", image, info, err)

--- a/TreeDB/internal/powerlossoracle/evidence_test.go
+++ b/TreeDB/internal/powerlossoracle/evidence_test.go
@@ -34,6 +34,9 @@ func TestBeginEvidenceFromEnvPersistsImagesTraceAndMetrics(t *testing.T) {
 	evidenceDir := filepath.Join(t.TempDir(), "evidence")
 	t.Setenv(EnvEvidenceDir, evidenceDir)
 	t.Setenv(EnvEvidenceCutPoint, string(durabilitycut.AfterMetaWrite))
+	t.Setenv(EnvReplayCut, "cut/checkpoint-generation-2/after-meta-write/000")
+	t.Setenv(EnvReplayVariant, "variant-a")
+	t.Setenv(EnvReplaySeed, "1")
 
 	session, err := BeginEvidenceFromEnv(model)
 	if err != nil {
@@ -102,5 +105,81 @@ func TestBeginEvidenceFromEnvRejectsUnobservedDeclaredCut(t *testing.T) {
 	t.Setenv(EnvEvidenceCutPoint, string(durabilitycut.AfterMetaWrite))
 	if _, err := BeginEvidenceFromEnv(model); err == nil || !strings.Contains(err.Error(), "was not observed") {
 		t.Fatalf("BeginEvidenceFromEnv error=%v", err)
+	}
+}
+
+func TestBeginEvidenceFromEnvRequiresReplaySelector(t *testing.T) {
+	source := t.TempDir()
+	if err := os.WriteFile(filepath.Join(source, "index.db"), []byte("old"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	model, err := Capture(source)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := model.Observe(source, durabilitycut.Event{Point: durabilitycut.AfterMetaWrite, Resource: durabilitycut.ResourceMeta}); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv(EnvEvidenceDir, filepath.Join(t.TempDir(), "evidence"))
+	t.Setenv(EnvEvidenceCutPoint, string(durabilitycut.AfterMetaWrite))
+	t.Setenv(EnvReplayCut, "")
+	t.Setenv(EnvReplayVariant, "")
+	t.Setenv(EnvReplaySeed, "")
+
+	if _, err := BeginEvidenceFromEnv(model); err == nil || !strings.Contains(err.Error(), "evidence capture requires") {
+		t.Fatalf("BeginEvidenceFromEnv missing replay selector error=%v", err)
+	}
+}
+
+func TestBeginEvidenceFromEnvRequiresTraceToEndAtReplayOccurrence(t *testing.T) {
+	source := t.TempDir()
+	if err := os.WriteFile(filepath.Join(source, "index.db"), []byte("old"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	model, err := Capture(source)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for range 2 {
+		if err := model.Observe(source, durabilitycut.Event{Point: durabilitycut.AfterMetaWrite, Resource: durabilitycut.ResourceMeta}); err != nil {
+			t.Fatal(err)
+		}
+	}
+	t.Setenv(EnvEvidenceDir, filepath.Join(t.TempDir(), "evidence"))
+	t.Setenv(EnvEvidenceCutPoint, string(durabilitycut.AfterMetaWrite))
+	t.Setenv(EnvReplayCut, "cut/checkpoint-generation-2/after-meta-write/000")
+	t.Setenv(EnvReplayVariant, "variant-a")
+	t.Setenv(EnvReplaySeed, "1")
+
+	if _, err := BeginEvidenceFromEnv(model); err == nil || !strings.Contains(err.Error(), "does not end at replay occurrence") {
+		t.Fatalf("BeginEvidenceFromEnv extra matching cut event error=%v", err)
+	}
+}
+
+func TestBeginEvidenceFromEnvRejectsSymlinkedEvidenceRoot(t *testing.T) {
+	source := t.TempDir()
+	if err := os.WriteFile(filepath.Join(source, "index.db"), []byte("old"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	model, err := Capture(source)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := model.Observe(source, durabilitycut.Event{Point: durabilitycut.AfterMetaWrite, Resource: durabilitycut.ResourceMeta}); err != nil {
+		t.Fatal(err)
+	}
+	realRoot := filepath.Join(t.TempDir(), "real-evidence")
+	if err := os.Mkdir(realRoot, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	linkRoot := filepath.Join(t.TempDir(), "evidence")
+	if err := os.Symlink(realRoot, linkRoot); err != nil {
+		t.Skipf("symlinks unavailable: %v", err)
+	}
+	t.Setenv(EnvEvidenceDir, linkRoot)
+	t.Setenv(EnvEvidenceCutPoint, string(durabilitycut.AfterMetaWrite))
+
+	if _, err := BeginEvidenceFromEnv(model); err == nil || !strings.Contains(err.Error(), "symlink") {
+		t.Fatalf("BeginEvidenceFromEnv symlinked root error=%v", err)
 	}
 }

--- a/TreeDB/internal/powerlossoracle/evidence_test.go
+++ b/TreeDB/internal/powerlossoracle/evidence_test.go
@@ -1,0 +1,72 @@
+package powerlossoracle
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/snissn/gomap/TreeDB/internal/durabilitycut"
+)
+
+func TestBeginEvidenceFromEnvPersistsImagesTraceAndMetrics(t *testing.T) {
+	source := t.TempDir()
+	if err := os.WriteFile(filepath.Join(source, "index.db"), []byte("old"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	model, err := Capture(source)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := model.Write("index.db", []byte("new")); err != nil {
+		t.Fatal(err)
+	}
+	if err := model.Observe(source, durabilitycut.Event{Point: durabilitycut.AfterMetaWrite, Resource: durabilitycut.ResourceMeta}); err != nil {
+		t.Fatal(err)
+	}
+	evidenceDir := filepath.Join(t.TempDir(), "evidence")
+	t.Setenv(EnvEvidenceDir, evidenceDir)
+	t.Setenv(EnvEvidenceCutPoint, string(durabilitycut.AfterMetaWrite))
+
+	session, err := BeginEvidenceFromEnv(model)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if session == nil || session.ObservedEventCount != 1 {
+		t.Fatalf("session=%+v", session)
+	}
+	for _, path := range []string{
+		"operation_trace.json",
+		"stable_image_tree.json",
+		"dirty_image_tree.json",
+		"metrics.json",
+		"stable-image/index.db",
+		"dirty-image/index.db",
+	} {
+		if _, err := os.Stat(filepath.Join(evidenceDir, filepath.FromSlash(path))); err != nil {
+			t.Fatalf("missing evidence %s: %v", path, err)
+		}
+	}
+	if err := session.RecordRecovery(map[string]any{"opened": true}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(filepath.Join(evidenceDir, "recovery_trace.json")); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestBeginEvidenceFromEnvRejectsUnobservedDeclaredCut(t *testing.T) {
+	source := t.TempDir()
+	if err := os.WriteFile(filepath.Join(source, "index.db"), []byte("old"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	model, err := Capture(source)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv(EnvEvidenceDir, filepath.Join(t.TempDir(), "evidence"))
+	t.Setenv(EnvEvidenceCutPoint, string(durabilitycut.AfterMetaWrite))
+	if _, err := BeginEvidenceFromEnv(model); err == nil || !strings.Contains(err.Error(), "was not observed") {
+		t.Fatalf("BeginEvidenceFromEnv error=%v", err)
+	}
+}

--- a/TreeDB/internal/powerlossoracle/evidence_test.go
+++ b/TreeDB/internal/powerlossoracle/evidence_test.go
@@ -1,6 +1,7 @@
 package powerlossoracle
 
 import (
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"strings"
@@ -12,6 +13,9 @@ import (
 func TestBeginEvidenceFromEnvPersistsImagesTraceAndMetrics(t *testing.T) {
 	source := t.TempDir()
 	if err := os.WriteFile(filepath.Join(source, "index.db"), []byte("old"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(source, "empty-wal"), 0o700); err != nil {
 		t.Fatal(err)
 	}
 	model, err := Capture(source)
@@ -59,6 +63,23 @@ func TestBeginEvidenceFromEnvPersistsImagesTraceAndMetrics(t *testing.T) {
 	}
 	if strings.Contains(string(traceData), source) {
 		t.Fatalf("operation trace leaked host-specific source path: %s", traceData)
+	}
+	stableTreeData, err := os.ReadFile(filepath.Join(evidenceDir, "stable_image_tree.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var stableTree evidenceTree
+	if err := json.Unmarshal(stableTreeData, &stableTree); err != nil {
+		t.Fatal(err)
+	}
+	if len(stableTree.Directories) != 1 || stableTree.Directories[0] != "empty-wal" {
+		t.Fatalf("stable image directories=%v want [empty-wal]", stableTree.Directories)
+	}
+	for _, image := range []string{"stable-image", "dirty-image", "recovery-input"} {
+		info, err := os.Stat(filepath.Join(evidenceDir, image, "empty-wal"))
+		if err != nil || !info.IsDir() {
+			t.Fatalf("%s empty directory info=%v error=%v", image, info, err)
+		}
 	}
 	if err := session.RecordRecovery(map[string]any{"opened": true}); err != nil {
 		t.Fatal(err)

--- a/TreeDB/internal/powerlossoracle/evidence_test.go
+++ b/TreeDB/internal/powerlossoracle/evidence_test.go
@@ -31,7 +31,7 @@ func TestBeginEvidenceFromEnvPersistsImagesTraceAndMetrics(t *testing.T) {
 	if err := model.Observe(source, durabilitycut.Event{Point: durabilitycut.AfterMetaWrite, Resource: durabilitycut.ResourceMeta}); err != nil {
 		t.Fatal(err)
 	}
-	evidenceDir := filepath.Join(t.TempDir(), "evidence")
+	evidenceDir := filepath.Join(canonicalTempDir(t), "evidence")
 	t.Setenv(EnvEvidenceDir, evidenceDir)
 	t.Setenv(EnvEvidenceCutPoint, string(durabilitycut.AfterMetaWrite))
 	t.Setenv(EnvReplayCut, "cut/checkpoint-generation-2/after-meta-write/000")
@@ -101,7 +101,7 @@ func TestBeginEvidenceFromEnvRejectsUnobservedDeclaredCut(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	t.Setenv(EnvEvidenceDir, filepath.Join(t.TempDir(), "evidence"))
+	t.Setenv(EnvEvidenceDir, filepath.Join(canonicalTempDir(t), "evidence"))
 	t.Setenv(EnvEvidenceCutPoint, string(durabilitycut.AfterMetaWrite))
 	if _, err := BeginEvidenceFromEnv(model); err == nil || !strings.Contains(err.Error(), "was not observed") {
 		t.Fatalf("BeginEvidenceFromEnv error=%v", err)
@@ -120,7 +120,7 @@ func TestBeginEvidenceFromEnvRequiresReplaySelector(t *testing.T) {
 	if err := model.Observe(source, durabilitycut.Event{Point: durabilitycut.AfterMetaWrite, Resource: durabilitycut.ResourceMeta}); err != nil {
 		t.Fatal(err)
 	}
-	t.Setenv(EnvEvidenceDir, filepath.Join(t.TempDir(), "evidence"))
+	t.Setenv(EnvEvidenceDir, filepath.Join(canonicalTempDir(t), "evidence"))
 	t.Setenv(EnvEvidenceCutPoint, string(durabilitycut.AfterMetaWrite))
 	t.Setenv(EnvReplayCut, "")
 	t.Setenv(EnvReplayVariant, "")
@@ -145,7 +145,7 @@ func TestBeginEvidenceFromEnvRequiresTraceToEndAtReplayOccurrence(t *testing.T) 
 			t.Fatal(err)
 		}
 	}
-	t.Setenv(EnvEvidenceDir, filepath.Join(t.TempDir(), "evidence"))
+	t.Setenv(EnvEvidenceDir, filepath.Join(canonicalTempDir(t), "evidence"))
 	t.Setenv(EnvEvidenceCutPoint, string(durabilitycut.AfterMetaWrite))
 	t.Setenv(EnvReplayCut, "cut/checkpoint-generation-2/after-meta-write/000")
 	t.Setenv(EnvReplayVariant, "variant-a")
@@ -182,4 +182,44 @@ func TestBeginEvidenceFromEnvRejectsSymlinkedEvidenceRoot(t *testing.T) {
 	if _, err := BeginEvidenceFromEnv(model); err == nil || !strings.Contains(err.Error(), "symlink") {
 		t.Fatalf("BeginEvidenceFromEnv symlinked root error=%v", err)
 	}
+}
+
+func TestBeginEvidenceFromEnvRejectsSymlinkedEvidenceRootAncestor(t *testing.T) {
+	source := t.TempDir()
+	if err := os.WriteFile(filepath.Join(source, "index.db"), []byte("old"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	model, err := Capture(source)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := model.Observe(source, durabilitycut.Event{Point: durabilitycut.AfterMetaWrite, Resource: durabilitycut.ResourceMeta}); err != nil {
+		t.Fatal(err)
+	}
+	realParent := filepath.Join(t.TempDir(), "real-parent")
+	if err := os.Mkdir(realParent, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	linkParent := filepath.Join(t.TempDir(), "linked-parent")
+	if err := os.Symlink(realParent, linkParent); err != nil {
+		t.Skipf("symlinks unavailable: %v", err)
+	}
+	t.Setenv(EnvEvidenceDir, filepath.Join(linkParent, "new-evidence"))
+	t.Setenv(EnvEvidenceCutPoint, string(durabilitycut.AfterMetaWrite))
+	t.Setenv(EnvReplayCut, "cut/checkpoint-generation-2/after-meta-write/000")
+	t.Setenv(EnvReplayVariant, "variant-a")
+	t.Setenv(EnvReplaySeed, "1")
+
+	if _, err := BeginEvidenceFromEnv(model); err == nil || !strings.Contains(err.Error(), "symlink") {
+		t.Fatalf("BeginEvidenceFromEnv symlinked ancestor error=%v", err)
+	}
+}
+
+func canonicalTempDir(t *testing.T) string {
+	t.Helper()
+	dir, err := filepath.EvalSymlinks(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	return dir
 }

--- a/TreeDB/internal/powerlossoracle/model.go
+++ b/TreeDB/internal/powerlossoracle/model.go
@@ -716,40 +716,55 @@ func (m *Model) Crash() {
 // MaterializeStable writes only stable bytes reachable through stable names.
 // The result never contains process-volatile bytes.
 func (m *Model) MaterializeStable(root string) error {
+	return m.materialize(root, m.stableDirs, m.stable, func(node *inode) []byte { return node.stable }, "stable")
+}
+
+// MaterializeVolatile writes the process-visible namespace and bytes at the
+// modeled cut. It is evidence of the dirty pre-crash image and must never be
+// used as the recovery input.
+func (m *Model) MaterializeVolatile(root string) error {
+	return m.materialize(root, m.volatileDirs, m.volatile, func(node *inode) []byte { return node.volatile }, "volatile")
+}
+
+func (m *Model) materialize(root string, dirs map[string]rootpublication.StableIdentity, files map[string]uint64, bytesFor func(*inode) []byte, label string) error {
 	if err := os.MkdirAll(root, 0o755); err != nil {
 		return err
 	}
-	dirs := keys(m.stableDirs)
-	sort.Slice(dirs, func(i, j int) bool {
-		di, dj := strings.Count(dirs[i], "/"), strings.Count(dirs[j], "/")
+	dirPaths := keys(dirs)
+	sort.Slice(dirPaths, func(i, j int) bool {
+		di, dj := strings.Count(dirPaths[i], "/"), strings.Count(dirPaths[j], "/")
 		if di == dj {
-			return dirs[i] < dirs[j]
+			return dirPaths[i] < dirPaths[j]
 		}
 		return di < dj
 	})
-	for _, dir := range dirs {
+	for _, dir := range dirPaths {
 		if dir == "." {
 			continue
 		}
 		parent := cleanInternal(pathpkg.Dir(dir))
-		if _, ok := m.stableDirs[parent]; !ok {
-			return fmt.Errorf("powerlossoracle: stable directory %q has unstable parent %q", dir, parent)
+		if _, ok := dirs[parent]; !ok {
+			return fmt.Errorf("powerlossoracle: %s directory %q has missing parent %q", label, dir, parent)
 		}
 		if err := os.Mkdir(filepath.Join(root, filepath.FromSlash(dir)), 0o755); err != nil && !errors.Is(err, os.ErrExist) {
 			return err
 		}
 	}
-	paths := make([]string, 0, len(m.stable))
-	for path := range m.stable {
+	paths := make([]string, 0, len(files))
+	for path := range files {
 		paths = append(paths, path)
 	}
 	sort.Strings(paths)
 	for _, path := range paths {
 		parent := cleanInternal(pathpkg.Dir(path))
-		if _, ok := m.stableDirs[parent]; !ok {
-			return fmt.Errorf("powerlossoracle: stable file %q has unstable parent %q", path, parent)
+		if _, ok := dirs[parent]; !ok {
+			return fmt.Errorf("powerlossoracle: %s file %q has missing parent %q", label, path, parent)
 		}
-		if err := os.WriteFile(filepath.Join(root, filepath.FromSlash(path)), m.inodes[m.stable[path]].stable, 0o644); err != nil {
+		node := m.inodes[files[path]]
+		if node == nil {
+			return fmt.Errorf("powerlossoracle: %s file %q references missing inode", label, path)
+		}
+		if err := os.WriteFile(filepath.Join(root, filepath.FromSlash(path)), bytesFor(node), 0o644); err != nil {
 			return err
 		}
 	}

--- a/TreeDB/internal/powerlossoracle/model_test.go
+++ b/TreeDB/internal/powerlossoracle/model_test.go
@@ -324,6 +324,36 @@ func TestStableAndVolatileBytesAreIndependent(t *testing.T) {
 	}
 }
 
+func TestMaterializeVolatileWritesProcessVisibleImage(t *testing.T) {
+	source := t.TempDir()
+	if err := os.WriteFile(filepath.Join(source, "index.db"), []byte("old"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	model, err := Capture(source)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := model.Write("index.db", []byte("new")); err != nil {
+		t.Fatal(err)
+	}
+	if err := model.Create("new/asset", []byte("dirty")); err != nil {
+		t.Fatal(err)
+	}
+	dirtyDir := t.TempDir()
+	if err := model.MaterializeVolatile(dirtyDir); err != nil {
+		t.Fatal(err)
+	}
+	for path, want := range map[string]string{"index.db": "new", "new/asset": "dirty"} {
+		got, err := os.ReadFile(filepath.Join(dirtyDir, filepath.FromSlash(path)))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if string(got) != want {
+			t.Fatalf("volatile %s=%q want=%q", path, got, want)
+		}
+	}
+}
+
 func TestNestedCreateRequiresStableAncestorChain(t *testing.T) {
 	model := newModel()
 	if err := model.Create("a/b/value", []byte("stable")); err != nil {

--- a/TreeDB/internal/powerlossreopen/reopen.go
+++ b/TreeDB/internal/powerlossreopen/reopen.go
@@ -38,23 +38,27 @@ func Stable(model *powerlossoracle.Model, opts treedb.Options, readOnly bool) (R
 			return Result{}, nil, nil, err
 		}
 		recovery := struct {
-			SchemaVersion string `json:"schema_version"`
-			PublicAPI     string `json:"public_api"`
-			Dir           string `json:"dir"`
-			ReadOnly      bool   `json:"read_only"`
-			Rejected      bool   `json:"rejected"`
-			ErrorType     string `json:"error_type"`
-			Error         string `json:"error"`
-			CommitSeq     uint64 `json:"commit_seq"`
-			AppliedLSN    uint64 `json:"applied_lsn"`
+			SchemaVersion     string `json:"schema_version"`
+			PublicAPI         string `json:"public_api"`
+			Dir               string `json:"dir"`
+			InputTreeSHA256   string `json:"input_image_tree_sha256"`
+			StableFingerprint string `json:"stable_fingerprint"`
+			ReadOnly          bool   `json:"read_only"`
+			Rejected          bool   `json:"rejected"`
+			ErrorType         string `json:"error_type"`
+			Error             string `json:"error"`
+			CommitSeq         uint64 `json:"commit_seq"`
+			AppliedLSN        uint64 `json:"applied_lsn"`
 		}{
-			SchemaVersion: "treedb-power-loss-recovery-trace/v1",
-			PublicAPI:     "treedb.Open",
-			Dir:           "recovery-input",
-			ReadOnly:      result.ReadOnly,
-			Rejected:      result.Rejected,
-			CommitSeq:     result.CommitSeq,
-			AppliedLSN:    result.AppliedLSN,
+			SchemaVersion:     "treedb-power-loss-recovery-trace/v1",
+			PublicAPI:         "treedb.Open",
+			Dir:               "recovery-input",
+			InputTreeSHA256:   evidence.StableImageTreeSHA256(),
+			StableFingerprint: evidence.StableFingerprint(),
+			ReadOnly:          result.ReadOnly,
+			Rejected:          result.Rejected,
+			CommitSeq:         result.CommitSeq,
+			AppliedLSN:        result.AppliedLSN,
 		}
 		if result.Err != nil {
 			recovery.ErrorType = fmt.Sprintf("%T", result.Err)

--- a/TreeDB/internal/powerlossreopen/reopen.go
+++ b/TreeDB/internal/powerlossreopen/reopen.go
@@ -3,8 +3,10 @@
 package powerlossreopen
 
 import (
+	"errors"
 	"fmt"
 	"os"
+	"path/filepath"
 	"strconv"
 
 	treedb "github.com/snissn/gomap/TreeDB"
@@ -30,7 +32,26 @@ func Stable(model *powerlossoracle.Model, opts treedb.Options, readOnly bool) (R
 	if err != nil {
 		return Result{}, nil, nil, err
 	}
-	cleanup := func() error { return os.RemoveAll(dir) }
+	return stableAt(dir, model, opts, readOnly, true)
+}
+
+// StableAt materializes the stable-only crash image at a caller-owned path and
+// reopens it through the normal public API. The close callback releases the DB
+// and modeled identity scope but deliberately preserves dir for evidence.
+func StableAt(dir string, model *powerlossoracle.Model, opts treedb.Options, readOnly bool) (Result, *treedb.DB, func() error, error) {
+	if err := requireEmptyDestination(dir); err != nil {
+		return Result{}, nil, nil, err
+	}
+	return stableAt(dir, model, opts, readOnly, false)
+}
+
+func stableAt(dir string, model *powerlossoracle.Model, opts treedb.Options, readOnly, removeOnClose bool) (Result, *treedb.DB, func() error, error) {
+	cleanup := func() error {
+		if removeOnClose {
+			return os.RemoveAll(dir)
+		}
+		return nil
+	}
 	if err := model.MaterializeStable(dir); err != nil {
 		_ = cleanup()
 		return Result{}, nil, nil, err
@@ -67,4 +88,25 @@ func Stable(model *powerlossoracle.Model, opts treedb.Options, readOnly bool) (R
 		return result, nil, nil, fmt.Errorf("powerlossreopen: public Open returned nil DB and nil error")
 	}
 	return result, db, closeFn, nil
+}
+
+func requireEmptyDestination(dir string) error {
+	if !filepath.IsAbs(dir) {
+		absolute, err := filepath.Abs(dir)
+		if err != nil {
+			return fmt.Errorf("powerlossreopen: resolve destination %q: %w", dir, err)
+		}
+		dir = absolute
+	}
+	entries, err := os.ReadDir(dir)
+	if errors.Is(err, os.ErrNotExist) {
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("powerlossreopen: inspect destination %q: %w", dir, err)
+	}
+	if len(entries) != 0 {
+		return fmt.Errorf("powerlossreopen: destination %q is not empty", dir)
+	}
+	return nil
 }

--- a/TreeDB/internal/powerlossreopen/reopen.go
+++ b/TreeDB/internal/powerlossreopen/reopen.go
@@ -148,15 +148,15 @@ func requireEmptyDestination(dir string) error {
 		}
 		dir = absolute
 	}
+	if err := powerlossoracle.EnsureNoSymlinkComponents(dir); err != nil {
+		return fmt.Errorf("powerlossreopen: inspect destination %q: %w", dir, err)
+	}
 	info, err := os.Lstat(dir)
 	if errors.Is(err, os.ErrNotExist) {
 		return nil
 	}
 	if err != nil {
 		return fmt.Errorf("powerlossreopen: inspect destination %q: %w", dir, err)
-	}
-	if info.Mode()&os.ModeSymlink != 0 {
-		return fmt.Errorf("powerlossreopen: destination %q is a symlink", dir)
 	}
 	if !info.IsDir() {
 		return fmt.Errorf("powerlossreopen: destination %q is not a directory", dir)

--- a/TreeDB/internal/powerlossreopen/reopen.go
+++ b/TreeDB/internal/powerlossreopen/reopen.go
@@ -38,27 +38,29 @@ func Stable(model *powerlossoracle.Model, opts treedb.Options, readOnly bool) (R
 			return Result{}, nil, nil, err
 		}
 		recovery := struct {
-			SchemaVersion     string `json:"schema_version"`
-			PublicAPI         string `json:"public_api"`
-			Dir               string `json:"dir"`
-			InputTreeSHA256   string `json:"input_image_tree_sha256"`
-			StableFingerprint string `json:"stable_fingerprint"`
-			ReadOnly          bool   `json:"read_only"`
-			Rejected          bool   `json:"rejected"`
-			ErrorType         string `json:"error_type"`
-			Error             string `json:"error"`
-			CommitSeq         uint64 `json:"commit_seq"`
-			AppliedLSN        uint64 `json:"applied_lsn"`
+			SchemaVersion      string `json:"schema_version"`
+			PublicAPI          string `json:"public_api"`
+			Dir                string `json:"dir"`
+			PreOpenSnapshotDir string `json:"pre_open_snapshot_dir"`
+			InputTreeSHA256    string `json:"input_image_tree_sha256"`
+			StableFingerprint  string `json:"stable_fingerprint"`
+			ReadOnly           bool   `json:"read_only"`
+			Rejected           bool   `json:"rejected"`
+			ErrorType          string `json:"error_type"`
+			Error              string `json:"error"`
+			CommitSeq          uint64 `json:"commit_seq"`
+			AppliedLSN         uint64 `json:"applied_lsn"`
 		}{
-			SchemaVersion:     "treedb-power-loss-recovery-trace/v1",
-			PublicAPI:         "treedb.Open",
-			Dir:               "recovery-input",
-			InputTreeSHA256:   evidence.StableImageTreeSHA256(),
-			StableFingerprint: evidence.StableFingerprint(),
-			ReadOnly:          result.ReadOnly,
-			Rejected:          result.Rejected,
-			CommitSeq:         result.CommitSeq,
-			AppliedLSN:        result.AppliedLSN,
+			SchemaVersion:      "treedb-power-loss-recovery-trace/v1",
+			PublicAPI:          "treedb.Open",
+			Dir:                "recovery-input",
+			PreOpenSnapshotDir: "recovery-preopen",
+			InputTreeSHA256:    evidence.StableImageTreeSHA256(),
+			StableFingerprint:  evidence.StableFingerprint(),
+			ReadOnly:           result.ReadOnly,
+			Rejected:           result.Rejected,
+			CommitSeq:          result.CommitSeq,
+			AppliedLSN:         result.AppliedLSN,
 		}
 		if result.Err != nil {
 			recovery.ErrorType = fmt.Sprintf("%T", result.Err)

--- a/TreeDB/internal/powerlossreopen/reopen.go
+++ b/TreeDB/internal/powerlossreopen/reopen.go
@@ -28,6 +28,44 @@ type Result struct {
 // modeled identity scope and removes the materialized image whether Open
 // accepts or rejects it.
 func Stable(model *powerlossoracle.Model, opts treedb.Options, readOnly bool) (Result, *treedb.DB, func() error, error) {
+	evidence, err := powerlossoracle.BeginEvidenceFromEnv(model)
+	if err != nil {
+		return Result{}, nil, nil, err
+	}
+	if evidence != nil {
+		result, db, closeFn, err := openAt(evidence.StableImageDir(), model, opts, readOnly, false)
+		if err != nil {
+			return Result{}, nil, nil, err
+		}
+		recovery := struct {
+			SchemaVersion string `json:"schema_version"`
+			PublicAPI     string `json:"public_api"`
+			Dir           string `json:"dir"`
+			ReadOnly      bool   `json:"read_only"`
+			Rejected      bool   `json:"rejected"`
+			ErrorType     string `json:"error_type"`
+			Error         string `json:"error"`
+			CommitSeq     uint64 `json:"commit_seq"`
+			AppliedLSN    uint64 `json:"applied_lsn"`
+		}{
+			SchemaVersion: "treedb-power-loss-recovery-trace/v1",
+			PublicAPI:     "treedb.Open",
+			Dir:           result.Dir,
+			ReadOnly:      result.ReadOnly,
+			Rejected:      result.Rejected,
+			CommitSeq:     result.CommitSeq,
+			AppliedLSN:    result.AppliedLSN,
+		}
+		if result.Err != nil {
+			recovery.ErrorType = fmt.Sprintf("%T", result.Err)
+			recovery.Error = result.Err.Error()
+		}
+		if err := evidence.RecordRecovery(recovery); err != nil {
+			_ = closeFn()
+			return Result{}, nil, nil, err
+		}
+		return result, db, closeFn, nil
+	}
 	dir, err := os.MkdirTemp("", "treedb-powerloss-stable-")
 	if err != nil {
 		return Result{}, nil, nil, err
@@ -46,15 +84,21 @@ func StableAt(dir string, model *powerlossoracle.Model, opts treedb.Options, rea
 }
 
 func stableAt(dir string, model *powerlossoracle.Model, opts treedb.Options, readOnly, removeOnClose bool) (Result, *treedb.DB, func() error, error) {
+	if err := model.MaterializeStable(dir); err != nil {
+		if removeOnClose {
+			_ = os.RemoveAll(dir)
+		}
+		return Result{}, nil, nil, err
+	}
+	return openAt(dir, model, opts, readOnly, removeOnClose)
+}
+
+func openAt(dir string, model *powerlossoracle.Model, opts treedb.Options, readOnly, removeOnClose bool) (Result, *treedb.DB, func() error, error) {
 	cleanup := func() error {
 		if removeOnClose {
 			return os.RemoveAll(dir)
 		}
 		return nil
-	}
-	if err := model.MaterializeStable(dir); err != nil {
-		_ = cleanup()
-		return Result{}, nil, nil, err
 	}
 	releaseIdentities, err := model.InstallStableIdentityOverrides(dir)
 	if err != nil {

--- a/TreeDB/internal/powerlossreopen/reopen.go
+++ b/TreeDB/internal/powerlossreopen/reopen.go
@@ -33,7 +33,7 @@ func Stable(model *powerlossoracle.Model, opts treedb.Options, readOnly bool) (R
 		return Result{}, nil, nil, err
 	}
 	if evidence != nil {
-		result, db, closeFn, err := openAt(evidence.StableImageDir(), model, opts, readOnly, false)
+		result, db, closeFn, err := openAt(evidence.RecoveryInputDir(), model, opts, readOnly, false)
 		if err != nil {
 			return Result{}, nil, nil, err
 		}
@@ -50,7 +50,7 @@ func Stable(model *powerlossoracle.Model, opts treedb.Options, readOnly bool) (R
 		}{
 			SchemaVersion: "treedb-power-loss-recovery-trace/v1",
 			PublicAPI:     "treedb.Open",
-			Dir:           result.Dir,
+			Dir:           "recovery-input",
 			ReadOnly:      result.ReadOnly,
 			Rejected:      result.Rejected,
 			CommitSeq:     result.CommitSeq,

--- a/TreeDB/internal/powerlossreopen/reopen.go
+++ b/TreeDB/internal/powerlossreopen/reopen.go
@@ -148,10 +148,20 @@ func requireEmptyDestination(dir string) error {
 		}
 		dir = absolute
 	}
-	entries, err := os.ReadDir(dir)
+	info, err := os.Lstat(dir)
 	if errors.Is(err, os.ErrNotExist) {
 		return nil
 	}
+	if err != nil {
+		return fmt.Errorf("powerlossreopen: inspect destination %q: %w", dir, err)
+	}
+	if info.Mode()&os.ModeSymlink != 0 {
+		return fmt.Errorf("powerlossreopen: destination %q is a symlink", dir)
+	}
+	if !info.IsDir() {
+		return fmt.Errorf("powerlossreopen: destination %q is not a directory", dir)
+	}
+	entries, err := os.ReadDir(dir)
 	if err != nil {
 		return fmt.Errorf("powerlossreopen: inspect destination %q: %w", dir, err)
 	}

--- a/TreeDB/internal/powerlossreopen/reopen_test.go
+++ b/TreeDB/internal/powerlossreopen/reopen_test.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	treedb "github.com/snissn/gomap/TreeDB"
@@ -19,6 +20,7 @@ func TestStableAtPreservesCallerOwnedCrashImage(t *testing.T) {
 	source := t.TempDir()
 	opts := treedb.OptionsFor(treedb.ProfileNoWALFast, source)
 	opts.DisableBackgroundPrune = true
+	opts.ValueLog.PointerThreshold = 1
 	db, err := treedb.Open(opts)
 	if err != nil {
 		t.Fatal(err)
@@ -57,6 +59,7 @@ func TestStableCapturesEvidenceWhenRequested(t *testing.T) {
 	source := t.TempDir()
 	opts := treedb.OptionsFor(treedb.ProfileNoWALFast, source)
 	opts.DisableBackgroundPrune = true
+	opts.ValueLog.PointerThreshold = 1
 	db, err := treedb.Open(opts)
 	if err != nil {
 		t.Fatal(err)
@@ -77,12 +80,19 @@ func TestStableCapturesEvidenceWhenRequested(t *testing.T) {
 	evidenceDir := filepath.Join(t.TempDir(), "evidence")
 	t.Setenv(powerlossoracle.EnvEvidenceDir, evidenceDir)
 	t.Setenv(powerlossoracle.EnvEvidenceCutPoint, string(durabilitycut.AfterMetaWrite))
+	t.Setenv(powerlossoracle.EnvReplayCut, "cut/checkpoint-generation-2/after-meta-write/000")
+	t.Setenv(powerlossoracle.EnvReplayVariant, "variant-a")
+	t.Setenv(powerlossoracle.EnvReplaySeed, "1")
 	result, reopened, closeFn, err := powerlossreopen.Stable(model, opts, false)
 	if err != nil {
 		t.Fatal(err)
 	}
 	if result.Dir != filepath.Join(evidenceDir, "recovery-input") || result.Rejected || reopened == nil {
 		t.Fatalf("Stable evidence result=%+v reopened=%v", result, reopened)
+	}
+	got, err := reopened.Get([]byte("stable"))
+	if err != nil || !bytes.Equal(got, []byte("value")) {
+		t.Fatalf("Get stable=%q err=%v", got, err)
 	}
 	if err := reopened.SetSync([]byte("recovery/mutation"), []byte("must-not-change-evidence")); err != nil {
 		t.Fatal(err)
@@ -115,5 +125,42 @@ func TestStableCapturesEvidenceWhenRequested(t *testing.T) {
 	}
 	if _, err := os.Stat(filepath.Join(evidenceDir, "recovery-preopen", "recovery", "mutation")); !os.IsNotExist(err) {
 		t.Fatalf("pre-open recovery snapshot was mutated: %v", err)
+	}
+}
+
+func TestStableAtRejectsSymlinkedDestination(t *testing.T) {
+	source := t.TempDir()
+	opts := treedb.OptionsFor(treedb.ProfileNoWALFast, source)
+	opts.DisableBackgroundPrune = true
+	opts.ValueLog.PointerThreshold = 1
+	db, err := treedb.Open(opts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := db.SetSync([]byte("stable"), []byte("value")); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatal(err)
+	}
+	model, err := powerlossoracle.Capture(source)
+	if err != nil {
+		t.Fatal(err)
+	}
+	realDestination := filepath.Join(t.TempDir(), "real-destination")
+	if err := os.Mkdir(realDestination, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	linkDestination := filepath.Join(t.TempDir(), "destination")
+	if err := os.Symlink(realDestination, linkDestination); err != nil {
+		t.Skipf("symlinks unavailable: %v", err)
+	}
+
+	result, reopened, closeFn, err := powerlossreopen.StableAt(linkDestination, model, opts, true)
+	if closeFn != nil {
+		_ = closeFn()
+	}
+	if err == nil || !strings.Contains(err.Error(), "symlink") {
+		t.Fatalf("StableAt symlinked destination result=%+v reopened=%v error=%v", result, reopened, err)
 	}
 }

--- a/TreeDB/internal/powerlossreopen/reopen_test.go
+++ b/TreeDB/internal/powerlossreopen/reopen_test.go
@@ -2,6 +2,9 @@ package powerlossreopen_test
 
 import (
 	"bytes"
+	"crypto/sha256"
+	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
@@ -87,8 +90,24 @@ func TestStableCapturesEvidenceWhenRequested(t *testing.T) {
 	if err := closeFn(); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := os.Stat(filepath.Join(evidenceDir, "recovery_trace.json")); err != nil {
+	recoveryData, err := os.ReadFile(filepath.Join(evidenceDir, "recovery_trace.json"))
+	if err != nil {
 		t.Fatalf("missing recovery evidence: %v", err)
+	}
+	stableTreeData, err := os.ReadFile(filepath.Join(evidenceDir, "stable_image_tree.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var recovery struct {
+		InputTreeSHA256   string `json:"input_image_tree_sha256"`
+		StableFingerprint string `json:"stable_fingerprint"`
+	}
+	if err := json.Unmarshal(recoveryData, &recovery); err != nil {
+		t.Fatal(err)
+	}
+	stableTreeDigest := sha256.Sum256(stableTreeData)
+	if recovery.InputTreeSHA256 != fmt.Sprintf("%x", stableTreeDigest) || len(recovery.StableFingerprint) != 64 {
+		t.Fatalf("recovery evidence binding=%+v", recovery)
 	}
 	if _, err := os.Stat(filepath.Join(evidenceDir, "stable-image")); err != nil {
 		t.Fatalf("missing immutable stable image: %v", err)

--- a/TreeDB/internal/powerlossreopen/reopen_test.go
+++ b/TreeDB/internal/powerlossreopen/reopen_test.go
@@ -99,17 +99,21 @@ func TestStableCapturesEvidenceWhenRequested(t *testing.T) {
 		t.Fatal(err)
 	}
 	var recovery struct {
-		InputTreeSHA256   string `json:"input_image_tree_sha256"`
-		StableFingerprint string `json:"stable_fingerprint"`
+		PreOpenSnapshotDir string `json:"pre_open_snapshot_dir"`
+		InputTreeSHA256    string `json:"input_image_tree_sha256"`
+		StableFingerprint  string `json:"stable_fingerprint"`
 	}
 	if err := json.Unmarshal(recoveryData, &recovery); err != nil {
 		t.Fatal(err)
 	}
 	stableTreeDigest := sha256.Sum256(stableTreeData)
-	if recovery.InputTreeSHA256 != fmt.Sprintf("%x", stableTreeDigest) || len(recovery.StableFingerprint) != 64 {
+	if recovery.PreOpenSnapshotDir != "recovery-preopen" || recovery.InputTreeSHA256 != fmt.Sprintf("%x", stableTreeDigest) || len(recovery.StableFingerprint) != 64 {
 		t.Fatalf("recovery evidence binding=%+v", recovery)
 	}
 	if _, err := os.Stat(filepath.Join(evidenceDir, "stable-image")); err != nil {
 		t.Fatalf("missing immutable stable image: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(evidenceDir, "recovery-preopen", "recovery", "mutation")); !os.IsNotExist(err) {
+		t.Fatalf("pre-open recovery snapshot was mutated: %v", err)
 	}
 }

--- a/TreeDB/internal/powerlossreopen/reopen_test.go
+++ b/TreeDB/internal/powerlossreopen/reopen_test.go
@@ -1,0 +1,50 @@
+package powerlossreopen_test
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"testing"
+
+	treedb "github.com/snissn/gomap/TreeDB"
+	"github.com/snissn/gomap/TreeDB/internal/powerlossoracle"
+	"github.com/snissn/gomap/TreeDB/internal/powerlossreopen"
+)
+
+func TestStableAtPreservesCallerOwnedCrashImage(t *testing.T) {
+	source := t.TempDir()
+	opts := treedb.OptionsFor(treedb.ProfileNoWALFast, source)
+	opts.DisableBackgroundPrune = true
+	db, err := treedb.Open(opts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := db.SetSync([]byte("stable"), []byte("value")); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatal(err)
+	}
+	model, err := powerlossoracle.Capture(source)
+	if err != nil {
+		t.Fatal(err)
+	}
+	destination := filepath.Join(t.TempDir(), "preserved")
+	result, reopened, closeFn, err := powerlossreopen.StableAt(destination, model, opts, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Dir != destination || result.Rejected || reopened == nil {
+		t.Fatalf("StableAt result=%+v reopened=%v", result, reopened)
+	}
+	got, err := reopened.Get([]byte("stable"))
+	if err != nil || !bytes.Equal(got, []byte("value")) {
+		t.Fatalf("Get stable=%q err=%v", got, err)
+	}
+	if err := closeFn(); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(destination); err != nil {
+		t.Fatalf("caller-owned image removed: %v", err)
+	}
+}

--- a/TreeDB/internal/powerlossreopen/reopen_test.go
+++ b/TreeDB/internal/powerlossreopen/reopen_test.go
@@ -74,17 +74,23 @@ func TestStableCapturesEvidenceWhenRequested(t *testing.T) {
 	evidenceDir := filepath.Join(t.TempDir(), "evidence")
 	t.Setenv(powerlossoracle.EnvEvidenceDir, evidenceDir)
 	t.Setenv(powerlossoracle.EnvEvidenceCutPoint, string(durabilitycut.AfterMetaWrite))
-	result, reopened, closeFn, err := powerlossreopen.Stable(model, opts, true)
+	result, reopened, closeFn, err := powerlossreopen.Stable(model, opts, false)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if result.Dir != filepath.Join(evidenceDir, "stable-image") || result.Rejected || reopened == nil {
+	if result.Dir != filepath.Join(evidenceDir, "recovery-input") || result.Rejected || reopened == nil {
 		t.Fatalf("Stable evidence result=%+v reopened=%v", result, reopened)
+	}
+	if err := reopened.SetSync([]byte("recovery/mutation"), []byte("must-not-change-evidence")); err != nil {
+		t.Fatal(err)
 	}
 	if err := closeFn(); err != nil {
 		t.Fatal(err)
 	}
 	if _, err := os.Stat(filepath.Join(evidenceDir, "recovery_trace.json")); err != nil {
 		t.Fatalf("missing recovery evidence: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(evidenceDir, "stable-image")); err != nil {
+		t.Fatalf("missing immutable stable image: %v", err)
 	}
 }

--- a/TreeDB/internal/powerlossreopen/reopen_test.go
+++ b/TreeDB/internal/powerlossreopen/reopen_test.go
@@ -35,7 +35,7 @@ func TestStableAtPreservesCallerOwnedCrashImage(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	destination := filepath.Join(t.TempDir(), "preserved")
+	destination := filepath.Join(canonicalTempDir(t), "preserved")
 	result, reopened, closeFn, err := powerlossreopen.StableAt(destination, model, opts, true)
 	if err != nil {
 		t.Fatal(err)
@@ -77,7 +77,7 @@ func TestStableCapturesEvidenceWhenRequested(t *testing.T) {
 	if err := model.Observe(source, durabilitycut.Event{Point: durabilitycut.AfterMetaWrite, Resource: durabilitycut.ResourceMeta}); err != nil {
 		t.Fatal(err)
 	}
-	evidenceDir := filepath.Join(t.TempDir(), "evidence")
+	evidenceDir := filepath.Join(canonicalTempDir(t), "evidence")
 	t.Setenv(powerlossoracle.EnvEvidenceDir, evidenceDir)
 	t.Setenv(powerlossoracle.EnvEvidenceCutPoint, string(durabilitycut.AfterMetaWrite))
 	t.Setenv(powerlossoracle.EnvReplayCut, "cut/checkpoint-generation-2/after-meta-write/000")
@@ -163,4 +163,51 @@ func TestStableAtRejectsSymlinkedDestination(t *testing.T) {
 	if err == nil || !strings.Contains(err.Error(), "symlink") {
 		t.Fatalf("StableAt symlinked destination result=%+v reopened=%v error=%v", result, reopened, err)
 	}
+}
+
+func TestStableAtRejectsSymlinkedDestinationAncestor(t *testing.T) {
+	source := t.TempDir()
+	opts := treedb.OptionsFor(treedb.ProfileNoWALFast, source)
+	opts.DisableBackgroundPrune = true
+	opts.ValueLog.PointerThreshold = 1
+	db, err := treedb.Open(opts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := db.SetSync([]byte("stable"), []byte("value")); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatal(err)
+	}
+	model, err := powerlossoracle.Capture(source)
+	if err != nil {
+		t.Fatal(err)
+	}
+	realParent := filepath.Join(t.TempDir(), "real-parent")
+	if err := os.Mkdir(realParent, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	linkParent := filepath.Join(t.TempDir(), "linked-parent")
+	if err := os.Symlink(realParent, linkParent); err != nil {
+		t.Skipf("symlinks unavailable: %v", err)
+	}
+	destination := filepath.Join(linkParent, "new-destination")
+
+	result, reopened, closeFn, err := powerlossreopen.StableAt(destination, model, opts, true)
+	if closeFn != nil {
+		_ = closeFn()
+	}
+	if err == nil || !strings.Contains(err.Error(), "symlink") {
+		t.Fatalf("StableAt symlinked destination ancestor result=%+v reopened=%v error=%v", result, reopened, err)
+	}
+}
+
+func canonicalTempDir(t *testing.T) string {
+	t.Helper()
+	dir, err := filepath.EvalSymlinks(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	return dir
 }

--- a/TreeDB/internal/powerlossreopen/reopen_test.go
+++ b/TreeDB/internal/powerlossreopen/reopen_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	treedb "github.com/snissn/gomap/TreeDB"
+	"github.com/snissn/gomap/TreeDB/internal/durabilitycut"
 	"github.com/snissn/gomap/TreeDB/internal/powerlossoracle"
 	"github.com/snissn/gomap/TreeDB/internal/powerlossreopen"
 )
@@ -46,5 +47,44 @@ func TestStableAtPreservesCallerOwnedCrashImage(t *testing.T) {
 	}
 	if _, err := os.Stat(destination); err != nil {
 		t.Fatalf("caller-owned image removed: %v", err)
+	}
+}
+
+func TestStableCapturesEvidenceWhenRequested(t *testing.T) {
+	source := t.TempDir()
+	opts := treedb.OptionsFor(treedb.ProfileNoWALFast, source)
+	opts.DisableBackgroundPrune = true
+	db, err := treedb.Open(opts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := db.SetSync([]byte("stable"), []byte("value")); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatal(err)
+	}
+	model, err := powerlossoracle.Capture(source)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := model.Observe(source, durabilitycut.Event{Point: durabilitycut.AfterMetaWrite, Resource: durabilitycut.ResourceMeta}); err != nil {
+		t.Fatal(err)
+	}
+	evidenceDir := filepath.Join(t.TempDir(), "evidence")
+	t.Setenv(powerlossoracle.EnvEvidenceDir, evidenceDir)
+	t.Setenv(powerlossoracle.EnvEvidenceCutPoint, string(durabilitycut.AfterMetaWrite))
+	result, reopened, closeFn, err := powerlossreopen.Stable(model, opts, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Dir != filepath.Join(evidenceDir, "stable-image") || result.Rejected || reopened == nil {
+		t.Fatalf("Stable evidence result=%+v reopened=%v", result, reopened)
+	}
+	if err := closeFn(); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(filepath.Join(evidenceDir, "recovery_trace.json")); err != nil {
+		t.Fatalf("missing recovery evidence: %v", err)
 	}
 }


### PR DESCRIPTION
## Summary

This is part 1 of #3684. It intentionally does **not** close the issue or claim that TreeDB is power-loss certified.

- add strict, versioned schemas and validation for child evidence manifests, the frozen risk inventory, coverage, and deterministic covering-set selection
- accept coverage only from modeled-crash evidence and require observed cut metadata, exact command/environment provenance, test-binary identity, verified artifact hashes, and an outcome class matching the recorded public-open result
- require every modeled witness to own a unique lexical and resolved evidence directory with no symlinked components; strictly parse operation/image/recovery/metrics/command-log schemas, bind the complete captured directory namespace (including empty directories) and every file, reject extra paths and symlinks, and cross-bind metrics and public-open recovery to the exact stable image
- reject symlinked inventory/manifests and parent-symlink escapes outside the resolved bundle root
- preserve replayable stable and dirty crash images, operation traces, recovery traces, metrics, and structured command logs for selected oracle cuts
- recover evidence through the normal public `treedb.Open` path while keeping both the captured stable image and a verified pre-open recovery snapshot immutable
- document the fail-closed evidence contract and the distinction between modeled crash, clean/process restart, and optional block-device evidence

## Why this is split

The final #3684 certification bundle must name and validate an exact merged `origin/main` SHA. Landing the validator and evidence-capture substrate first lets the certification PR target a real immutable main commit instead of making its own evidence self-referential.

## Validation

Exact local head `98428de29fb44f2114a98950542d598988d83bd5`:

- `GOWORK=off go test ./TreeDB/internal/powerlosscert ./TreeDB/internal/powerlossoracle ./TreeDB/internal/powerlossreopen -count=1`
- `GOWORK=off go test -race ./TreeDB/internal/powerlosscert ./TreeDB/internal/powerlossoracle ./TreeDB/internal/powerlossreopen -count=1`
- `GOWORK=off go vet ./TreeDB/internal/powerlosscert ./TreeDB/internal/powerlossoracle ./TreeDB/internal/powerlossreopen`
- `GOWORK=off go test ./TreeDB/docs -count=1`
- verifier regressions for exact cut-occurrence binding, evidence-tier-scoped cut metadata, repeated ordered command arguments, standalone non-canonical artifact paths, symlinked capture destinations and existing ancestors, forced value-log pointer reopen durability, unstructured hashed placeholders, malformed or unbound artifacts, accepted/rejected outcome mismatch, direct and parent symlink escapes (including evidence-directory components), path aliases, captured-image tampering, extra empty directories, modeled evidence reuse across witnesses, and tampered writable-recovery pre-open snapshots
- `git diff --check`

The preceding production-equivalent head `eb82612ff257384ac4e36124391fe34178a3669e` also passed `GOWORK=off go test ./TreeDB/... -count=1` plus focused race and vet. Changes since that full run are confined to certification evidence production/validation, tests, and this spec; exact-head CI is authoritative for the final matrix.

## Deliberately still open for #3684

- build modeled durable-profile witnesses for every required API, resource, boundary, and failure interaction
- fix or ledger the currently tolerated enumerator counterexamples and prove every retained counterexample/negative control remains selected
- freeze the exact risk inventory and child manifests, run deterministic covering-set selection, and publish the final hashed bundle and human-readable reports
- run the required performance smoke and exact-head CI/review gates

Clean shutdown or process-restart tests remain corroborating evidence only. Block-device experiments, if added, remain extra evidence and are not treated as the modeled crash proof.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added power-loss certification evidence capture and verification.
  * Added structured certification bundles with integrity checks, recovery traces, metrics, and command logs.
  * Added coverage reporting and deterministic representative-case selection.
  * Added support for stable and volatile filesystem image snapshots during recovery.

* **Documentation**
  * Added the power-loss certification specification, including evidence requirements and verification rules.

* **Tests**
  * Added comprehensive validation for evidence integrity, schema compliance, path safety, recovery behavior, and coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->


