### PR TITLE
ci(treedb): aggregate incompressible perf evidence

### DIFF
--- a/.github/scripts/check_vlog_auto_incompressible.go
+++ b/.github/scripts/check_vlog_auto_incompressible.go
@@ -15,6 +15,17 @@ var (
 	reValueLog   = regexp.MustCompile(`maindb/(?:value_vlog|wal):[^\n]*\bvalue=([0-9]+(?:\.[0-9]+)?\s*[A-Za-z]+)`)
 )
 
+type repeatedStringFlag []string
+
+func (f *repeatedStringFlag) String() string {
+	return strings.Join(*f, ",")
+}
+
+func (f *repeatedStringFlag) Set(value string) error {
+	*f = append(*f, value)
+	return nil
+}
+
 type runMetrics struct {
 	OpsPerSec float64
 	WALValue  float64
@@ -22,60 +33,88 @@ type runMetrics struct {
 
 func main() {
 	var (
-		offLogPath        string
-		autoLogPath       string
+		offLogPaths       repeatedStringFlag
+		autoLogPaths      repeatedStringFlag
 		minThroughputFrac float64
 		maxSizeFrac       float64
+		minSamples        int
 	)
-	flag.StringVar(&offLogPath, "off-log", "", "path to unified_bench output for treedb_vlog_off")
-	flag.StringVar(&autoLogPath, "auto-log", "", "path to unified_bench output for treedb_vlog_auto")
+	flag.Var(&offLogPaths, "off-log", "path to unified_bench output for treedb_vlog_off; repeat once per paired sample")
+	flag.Var(&autoLogPaths, "auto-log", "path to unified_bench output for treedb_vlog_auto; repeat once per paired sample")
 	flag.Float64Var(&minThroughputFrac, "min-throughput-frac", 1.01, "strict #1529 parity-plus auto/off batch-write throughput fraction; values at or below this fail")
 	flag.Float64Var(&maxSizeFrac, "max-size-frac", 1.02, "maximum allowed auto/off value-log bytes fraction")
+	flag.IntVar(&minSamples, "min-samples", 2, "minimum number of complete paired samples required")
 	flag.Parse()
 
-	if offLogPath == "" || autoLogPath == "" {
-		fmt.Fprintln(os.Stderr, "missing -off-log or -auto-log")
+	if len(offLogPaths) != len(autoLogPaths) {
+		fmt.Fprintf(os.Stderr, "paired sample count mismatch: off=%d auto=%d\n", len(offLogPaths), len(autoLogPaths))
 		os.Exit(2)
 	}
-
-	off, err := parseMetrics(offLogPath)
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "parse off log: %v\n", err)
+	if minSamples < 2 {
+		fmt.Fprintf(os.Stderr, "invalid -min-samples %d: must be at least 2\n", minSamples)
 		os.Exit(2)
 	}
-	auto, err := parseMetrics(autoLogPath)
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "parse auto log: %v\n", err)
+	if minThroughputFrac <= 0 || math.IsNaN(minThroughputFrac) || math.IsInf(minThroughputFrac, 0) {
+		fmt.Fprintf(os.Stderr, "invalid -min-throughput-frac %.4f: must be finite and positive\n", minThroughputFrac)
 		os.Exit(2)
 	}
-	if off.OpsPerSec <= 0 || off.WALValue <= 0 {
-		fmt.Fprintf(os.Stderr, "invalid off metrics: ops=%.3f wal_value=%.0f\n", off.OpsPerSec, off.WALValue)
+	if maxSizeFrac <= 0 || math.IsNaN(maxSizeFrac) || math.IsInf(maxSizeFrac, 0) {
+		fmt.Fprintf(os.Stderr, "invalid -max-size-frac %.4f: must be finite and positive\n", maxSizeFrac)
 		os.Exit(2)
 	}
-	if auto.OpsPerSec <= 0 || auto.WALValue <= 0 {
-		fmt.Fprintf(os.Stderr, "invalid auto metrics: ops=%.3f wal_value=%.0f\n", auto.OpsPerSec, auto.WALValue)
+	if len(offLogPaths) < minSamples {
+		fmt.Fprintf(os.Stderr, "insufficient paired samples: got=%d want>=%d\n", len(offLogPaths), minSamples)
 		os.Exit(2)
 	}
-
-	throughputFrac := auto.OpsPerSec / off.OpsPerSec
-	sizeFrac := auto.WALValue / off.WALValue
-
-	fmt.Printf("incompressible gate: off_ops=%.0f auto_ops=%.0f throughput_frac=%.4f (min=%.4f)\n", off.OpsPerSec, auto.OpsPerSec, throughputFrac, minThroughputFrac)
-	fmt.Printf("incompressible gate: off_value_log=%.0f auto_value_log=%.0f size_frac=%.4f (max=%.4f)\n", off.WALValue, auto.WALValue, sizeFrac, maxSizeFrac)
 
 	fail := false
-	if throughputFrac <= minThroughputFrac {
-		fmt.Fprintf(os.Stderr, "FAIL throughput gate: auto/off=%.4f <= %.4f\n", throughputFrac, minThroughputFrac)
-		fail = true
+	throughputLogSum := 0.0
+	maxObservedSizeFrac := 0.0
+	for idx := range offLogPaths {
+		off, err := parseMetrics(offLogPaths[idx])
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "parse off log sample %d: %v\n", idx+1, err)
+			os.Exit(2)
+		}
+		auto, err := parseMetrics(autoLogPaths[idx])
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "parse auto log sample %d: %v\n", idx+1, err)
+			os.Exit(2)
+		}
+		if off.OpsPerSec <= 0 || off.WALValue <= 0 {
+			fmt.Fprintf(os.Stderr, "invalid off metrics sample %d: ops=%.3f wal_value=%.0f\n", idx+1, off.OpsPerSec, off.WALValue)
+			os.Exit(2)
+		}
+		if auto.OpsPerSec <= 0 || auto.WALValue <= 0 {
+			fmt.Fprintf(os.Stderr, "invalid auto metrics sample %d: ops=%.3f wal_value=%.0f\n", idx+1, auto.OpsPerSec, auto.WALValue)
+			os.Exit(2)
+		}
+
+		throughputFrac := auto.OpsPerSec / off.OpsPerSec
+		sizeFrac := auto.WALValue / off.WALValue
+		throughputLogSum += math.Log(throughputFrac)
+		if sizeFrac > maxObservedSizeFrac {
+			maxObservedSizeFrac = sizeFrac
+		}
+
+		fmt.Printf("incompressible gate sample %d: off_ops=%.0f auto_ops=%.0f throughput_frac=%.4f\n", idx+1, off.OpsPerSec, auto.OpsPerSec, throughputFrac)
+		fmt.Printf("incompressible gate sample %d: off_value_log=%.0f auto_value_log=%.0f size_frac=%.4f\n", idx+1, off.WALValue, auto.WALValue, sizeFrac)
+		if sizeFrac > maxSizeFrac {
+			fmt.Fprintf(os.Stderr, "FAIL size gate sample %d: auto/off=%.4f > %.4f\n", idx+1, sizeFrac, maxSizeFrac)
+			fail = true
+		}
 	}
-	if sizeFrac > maxSizeFrac {
-		fmt.Fprintf(os.Stderr, "FAIL size gate: auto/off=%.4f > %.4f\n", sizeFrac, maxSizeFrac)
+
+	aggregateThroughputFrac := math.Exp(throughputLogSum / float64(len(offLogPaths)))
+	fmt.Printf("incompressible gate aggregate: samples=%d throughput_geomean=%.4f (min=%.4f) max_size_frac=%.4f (max=%.4f)\n", len(offLogPaths), aggregateThroughputFrac, minThroughputFrac, maxObservedSizeFrac, maxSizeFrac)
+	if aggregateThroughputFrac <= minThroughputFrac {
+		fmt.Fprintf(os.Stderr, "FAIL aggregate throughput gate: auto/off geomean=%.4f <= %.4f\n", aggregateThroughputFrac, minThroughputFrac)
 		fail = true
 	}
 	if fail {
 		os.Exit(1)
 	}
-	fmt.Println("PASS incompressible auto-vs-off gate")
+	fmt.Println("PASS incompressible auto-vs-off aggregate gate")
 }
 
 func parseMetrics(path string) (runMetrics, error) {

--- a/.github/scripts/test_vlog_auto_incompressible.py
+++ b/.github/scripts/test_vlog_auto_incompressible.py
@@ -55,6 +55,8 @@ class VLogAutoIncompressibleCheckerTest(unittest.TestCase):
         size_ratios: list[float] | None = None,
         *,
         omit_last_auto: bool = False,
+        off_ops_per_sec: float = 1_000_000,
+        corrupt_last_auto: bool = False,
     ) -> subprocess.CompletedProcess[str]:
         if size_ratios is None:
             size_ratios = [0.996] * len(throughput_ratios)
@@ -68,15 +70,18 @@ class VLogAutoIncompressibleCheckerTest(unittest.TestCase):
                 off_log = Path(temp_dir) / f"off-{index}.txt"
                 auto_log = Path(temp_dir) / f"auto-{index}.txt"
                 off_log.write_text(
-                    "Batch Write / fixture = 1,000,000\n"
+                    f"Batch Write / fixture = {off_ops_per_sec:.3f}\n"
                     "maindb/value_vlog: fixture value=100 MB\n",
                     encoding="utf-8",
                 )
-                auto_log.write_text(
-                    f"Batch Write / fixture = {throughput_ratio * 1_000_000:.3f}\n"
-                    f"maindb/value_vlog: fixture value={size_ratio * 100:.3f} MB\n",
-                    encoding="utf-8",
-                )
+                if corrupt_last_auto and index == len(throughput_ratios):
+                    auto_log.write_text("missing benchmark rows\n", encoding="utf-8")
+                else:
+                    auto_log.write_text(
+                        f"Batch Write / fixture = {throughput_ratio * off_ops_per_sec:.3f}\n"
+                        f"maindb/value_vlog: fixture value={size_ratio * 100:.3f} MB\n",
+                        encoding="utf-8",
+                    )
                 args.extend(["-off-log", str(off_log)])
                 if not (omit_last_auto and index == len(throughput_ratios)):
                     args.extend(["-auto-log", str(auto_log)])
@@ -125,6 +130,18 @@ class VLogAutoIncompressibleCheckerTest(unittest.TestCase):
         self.assertEqual(result.returncode, 2, result.stdout + result.stderr)
         self.assertIn("paired sample count mismatch", result.stderr)
 
+    def test_non_positive_metrics_fail_closed(self) -> None:
+        result = self.run_checker([1.02, 1.03], off_ops_per_sec=0)
+
+        self.assertEqual(result.returncode, 2, result.stdout + result.stderr)
+        self.assertIn("invalid off metrics sample 1", result.stderr)
+
+    def test_missing_benchmark_rows_fail_closed(self) -> None:
+        result = self.run_checker([1.02, 1.03], corrupt_last_auto=True)
+
+        self.assertEqual(result.returncode, 2, result.stdout + result.stderr)
+        self.assertIn("parse auto log sample 2", result.stderr)
+
 
 class VLogAutoIncompressibleWorkflowContractTest(unittest.TestCase):
     def test_workflow_uses_full_balanced_sample_set_without_early_success(self) -> None:
@@ -153,6 +170,10 @@ class VLogAutoIncompressibleWorkflowContractTest(unittest.TestCase):
         self.assertIn("geometric mean of every balanced pair must exceed 1.01x", script)
         self.assertIn("Upload value-log performance evidence", script)
         self.assertIn("if: always()", script)
+        self.assertIn('2>&1 | tee "${summary_log}"', script)
+        self.assertIn('checker_status=${PIPESTATUS[0]}', script)
+        self.assertIn('>> "${GITHUB_STEP_SUMMARY}"', script)
+        self.assertIn("vlog_auto_incompressible_summary.txt", script)
         self.assertIn("vlog_auto_incompressible_off_sample*.txt", script)
         self.assertIn("vlog_auto_incompressible_auto_sample*.txt", script)
 

--- a/.github/scripts/test_vlog_auto_incompressible.py
+++ b/.github/scripts/test_vlog_auto_incompressible.py
@@ -144,6 +144,14 @@ class VLogAutoIncompressibleCheckerTest(unittest.TestCase):
 
 
 class VLogAutoIncompressibleWorkflowContractTest(unittest.TestCase):
+    def test_perf_job_runs_aggregate_checker_self_tests(self) -> None:
+        workflow = normalized(WORKFLOW.read_text(encoding="utf-8"))
+
+        self.assertIn(
+            "name: Aggregate perf gate self-tests env: PYTHONDONTWRITEBYTECODE: \"1\" run: python3 .github/scripts/test_vlog_auto_incompressible.py",
+            workflow,
+        )
+
     def test_workflow_uses_full_balanced_sample_set_without_early_success(self) -> None:
         script = normalized(perf_job_script())
 

--- a/.github/scripts/test_vlog_auto_incompressible.py
+++ b/.github/scripts/test_vlog_auto_incompressible.py
@@ -1,0 +1,161 @@
+#!/usr/bin/env python3
+"""Tests for the paired incompressible value-log performance gate."""
+
+from pathlib import Path
+import math
+import re
+import subprocess
+import tempfile
+import unittest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+CHECKER = REPO_ROOT / ".github" / "scripts" / "check_vlog_auto_incompressible.go"
+WORKFLOW = REPO_ROOT / ".github" / "workflows" / "treedb-tests.yml"
+
+
+def normalized(text: str) -> str:
+    return re.sub(r"\s+", " ", text)
+
+
+def perf_job_script() -> str:
+    workflow = WORKFLOW.read_text(encoding="utf-8")
+    match = re.search(
+        r"      - name: Incompressible auto-vs-off gate\n"
+        r"        run: \|\n(?P<body>.*?)"
+        r"(?=^  snapshot-iterator-perf:)",
+        workflow,
+        re.MULTILINE | re.DOTALL,
+    )
+    if match is None:
+        raise AssertionError("missing incompressible auto-vs-off workflow step")
+    return match.group("body")
+
+
+class VLogAutoIncompressibleCheckerTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls._build_dir = tempfile.TemporaryDirectory()
+        cls.checker_bin = Path(cls._build_dir.name) / "check-vlog-auto-incompressible"
+        subprocess.run(
+            ["go", "build", "-o", str(cls.checker_bin), str(CHECKER)],
+            cwd=REPO_ROOT,
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+
+    @classmethod
+    def tearDownClass(cls) -> None:
+        cls._build_dir.cleanup()
+
+    def run_checker(
+        self,
+        throughput_ratios: list[float],
+        size_ratios: list[float] | None = None,
+        *,
+        omit_last_auto: bool = False,
+    ) -> subprocess.CompletedProcess[str]:
+        if size_ratios is None:
+            size_ratios = [0.996] * len(throughput_ratios)
+        self.assertEqual(len(throughput_ratios), len(size_ratios))
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            args = [str(self.checker_bin)]
+            for index, (throughput_ratio, size_ratio) in enumerate(
+                zip(throughput_ratios, size_ratios, strict=True), start=1
+            ):
+                off_log = Path(temp_dir) / f"off-{index}.txt"
+                auto_log = Path(temp_dir) / f"auto-{index}.txt"
+                off_log.write_text(
+                    "Batch Write / fixture = 1,000,000\n"
+                    "maindb/value_vlog: fixture value=100 MB\n",
+                    encoding="utf-8",
+                )
+                auto_log.write_text(
+                    f"Batch Write / fixture = {throughput_ratio * 1_000_000:.3f}\n"
+                    f"maindb/value_vlog: fixture value={size_ratio * 100:.3f} MB\n",
+                    encoding="utf-8",
+                )
+                args.extend(["-off-log", str(off_log)])
+                if not (omit_last_auto and index == len(throughput_ratios)):
+                    args.extend(["-auto-log", str(auto_log)])
+            args.extend(
+                [
+                    "-min-samples",
+                    str(len(throughput_ratios)),
+                    "-min-throughput-frac",
+                    "1.01",
+                    "-max-size-frac",
+                    "1.02",
+                ]
+            )
+            return subprocess.run(args, capture_output=True, text=True, check=False)
+
+    def test_one_lucky_sample_cannot_override_mostly_failing_pairs(self) -> None:
+        ratios = [0.9955, 0.9988, 0.9896, 0.9593, 0.9807, 0.9763, 0.9890, 0.99, 1.0, 1.0186]
+        result = self.run_checker(ratios)
+
+        self.assertEqual(result.returncode, 1, result.stdout + result.stderr)
+        expected = math.prod(ratios) ** (1 / len(ratios))
+        self.assertIn(f"throughput_geomean={expected:.4f}", result.stdout)
+        self.assertIn("FAIL aggregate throughput gate", result.stderr)
+
+    def test_complete_paired_aggregate_above_strict_boundary_passes(self) -> None:
+        result = self.run_checker([1.02, 1.03, 1.04, 1.05])
+
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+        self.assertIn("PASS incompressible auto-vs-off aggregate gate", result.stdout)
+
+    def test_aggregate_equal_to_boundary_fails(self) -> None:
+        result = self.run_checker([1.01, 1.01])
+
+        self.assertEqual(result.returncode, 1, result.stdout + result.stderr)
+        self.assertIn("<= 1.0100", result.stderr)
+
+    def test_any_sample_over_size_bound_fails(self) -> None:
+        result = self.run_checker([1.02, 1.03], [0.996, 1.021])
+
+        self.assertEqual(result.returncode, 1, result.stdout + result.stderr)
+        self.assertIn("FAIL size gate sample 2", result.stderr)
+
+    def test_mismatched_pair_counts_fail_closed(self) -> None:
+        result = self.run_checker([1.02, 1.03], omit_last_auto=True)
+
+        self.assertEqual(result.returncode, 2, result.stdout + result.stderr)
+        self.assertIn("paired sample count mismatch", result.stderr)
+
+
+class VLogAutoIncompressibleWorkflowContractTest(unittest.TestCase):
+    def test_workflow_uses_full_balanced_sample_set_without_early_success(self) -> None:
+        script = normalized(perf_job_script())
+
+        self.assertIn("sample_count=6", script)
+        self.assertIn("if ((sample_count % 2 != 0)); then", script)
+        self.assertIn("sample_count must be even to balance off/auto row order", script)
+        self.assertNotIn("max_attempts", script)
+        self.assertNotIn("exit 0", script)
+        self.assertIn(
+            'if ((sample % 2 == 1)); then echo "sample ${sample} order=off-auto" run_vlog_row treedb_vlog_off "${off_log}" run_vlog_row treedb_vlog_auto "${auto_log}" else echo "sample ${sample} order=auto-off" run_vlog_row treedb_vlog_auto "${auto_log}" run_vlog_row treedb_vlog_off "${off_log}"',
+            script,
+        )
+
+    def test_workflow_aggregates_every_pair_at_strict_existing_bounds(self) -> None:
+        script = normalized(perf_job_script())
+
+        self.assertIn(
+            'checker_args+=( -off-log "${off_logs[$sample]}" -auto-log "${auto_logs[$sample]}" )',
+            script,
+        )
+        self.assertIn('-min-samples "${sample_count}"', script)
+        self.assertIn("-min-throughput-frac 1.01", script)
+        self.assertIn("-max-size-frac 1.02", script)
+        self.assertIn("geometric mean of every balanced pair must exceed 1.01x", script)
+        self.assertIn("Upload value-log performance evidence", script)
+        self.assertIn("if: always()", script)
+        self.assertIn("vlog_auto_incompressible_off_sample*.txt", script)
+        self.assertIn("vlog_auto_incompressible_auto_sample*.txt", script)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/workflows/treedb-tests.yml
+++ b/.github/workflows/treedb-tests.yml
@@ -610,6 +610,11 @@ jobs:
           cache-dependency-path: |
             go.sum
 
+      - name: Aggregate perf gate self-tests
+        env:
+          PYTHONDONTWRITEBYTECODE: "1"
+        run: python3 .github/scripts/test_vlog_auto_incompressible.py
+
       - name: ValueLog dict compressibility bench
         run: |
           go test ./TreeDB/internal/valuelog -run '^$' \

--- a/.github/workflows/treedb-tests.yml
+++ b/.github/workflows/treedb-tests.yml
@@ -625,25 +625,28 @@ jobs:
 
       - name: Incompressible auto-vs-off gate
         run: |
-          max_attempts=5
-          for attempt in $(seq 1 "$max_attempts"); do
-            off_log="vlog_auto_incompressible_off_attempt${attempt}.txt"
-            auto_log="vlog_auto_incompressible_auto_attempt${attempt}.txt"
-            echo "incompressible gate attempt ${attempt}/${max_attempts}"
+          sample_count=6
+          if ((sample_count % 2 != 0)); then
+            echo "sample_count must be even to balance off/auto row order"
+            exit 2
+          fi
 
-            # This gate measures the explicit bench_unsafe compression ceiling,
-            # not the command_wal_durable default used by production callers.
-            # Keep it independent of the unconfigured flush-admission default
-            # under test in #2788. Force admission off for both rows so the
-            # strict auto/off comparison stays on the old serial/default-off
-            # flush boundary and measures value-log auto behavior rather than
-            # span-native admission changes.
+          # This gate measures the explicit bench_unsafe compression ceiling,
+          # not the command_wal_durable default used by production callers.
+          # Keep it independent of the unconfigured flush-admission default
+          # under test in #2788. Force admission off for both rows so the
+          # strict auto/off comparison stays on the old serial/default-off
+          # flush boundary and measures value-log auto behavior rather than
+          # span-native admission changes.
+          run_vlog_row() {
+            local db="$1"
+            local output="$2"
             if ! go run ./cmd/unified_bench \
               -profile fast \
               -keys 1000000 \
               -valsize 512 \
               -batchsize 1024 \
-              -dbs treedb_vlog_off \
+              -dbs "${db}" \
               -test batch_write \
               -val-pattern random \
               -format markdown \
@@ -654,52 +657,57 @@ jobs:
               -treedb-value-log-threshold=1 \
               -treedb-vlog-dict-train-bytes=-1 \
               -treedb-flush-admission-policy=off \
-              > "${off_log}" 2>&1; then
-              echo "treedb_vlog_off benchmark failed on attempt ${attempt}"
-              tail -n 80 "${off_log}" || true
-              continue
+              > "${output}" 2>&1; then
+              echo "${db} benchmark failed"
+              tail -n 80 "${output}" || true
+              return 1
             fi
+          }
 
-            if ! go run ./cmd/unified_bench \
-              -profile fast \
-              -keys 1000000 \
-              -valsize 512 \
-              -batchsize 1024 \
-              -dbs treedb_vlog_auto \
-              -test batch_write \
-              -val-pattern random \
-              -format markdown \
-              -progress=false \
-              -keep=false \
-              -seed 1 \
-              -treedb-force-value-pointers=true \
-              -treedb-value-log-threshold=1 \
-              -treedb-vlog-dict-train-bytes=-1 \
-              -treedb-flush-admission-policy=off \
-              > "${auto_log}" 2>&1; then
-              echo "treedb_vlog_auto benchmark failed on attempt ${attempt}"
-              tail -n 80 "${auto_log}" || true
-              continue
+          off_logs=()
+          auto_logs=()
+          for sample in $(seq 1 "${sample_count}"); do
+            off_log="vlog_auto_incompressible_off_sample${sample}.txt"
+            auto_log="vlog_auto_incompressible_auto_sample${sample}.txt"
+            off_logs+=("${off_log}")
+            auto_logs+=("${auto_log}")
+            echo "incompressible gate sample ${sample}/${sample_count}"
+
+            if ((sample % 2 == 1)); then
+              echo "sample ${sample} order=off-auto"
+              run_vlog_row treedb_vlog_off "${off_log}"
+              run_vlog_row treedb_vlog_auto "${auto_log}"
+            else
+              echo "sample ${sample} order=auto-off"
+              run_vlog_row treedb_vlog_auto "${auto_log}"
+              run_vlog_row treedb_vlog_off "${off_log}"
             fi
-
-            # #1529 intentionally makes this a strict parity-plus gate. A
-            # result at or below 1.01x is failing evidence, even for the
-            # incompressible auto-vs-off case.
-            if go run .github/scripts/check_vlog_auto_incompressible.go \
-              -off-log "${off_log}" \
-              -auto-log "${auto_log}" \
-              -min-throughput-frac 1.01 \
-              -max-size-frac 1.02; then
-              exit 0
-            fi
-
-            echo "incompressible gate threshold check failed on attempt ${attempt}"
-            tail -n 80 "${off_log}" || true
-            tail -n 80 "${auto_log}" || true
           done
 
-          echo "incompressible auto-vs-off gate failed after ${max_attempts} attempts"
-          exit 1
+          checker_args=()
+          for sample in $(seq 0 $((sample_count - 1))); do
+            checker_args+=( -off-log "${off_logs[$sample]}" -auto-log "${auto_logs[$sample]}" )
+          done
+
+          # #1529 intentionally makes this a strict parity-plus gate. The
+          # geometric mean of every balanced pair must exceed 1.01x; one lucky
+          # sample cannot override a mostly failing sample set.
+          go run .github/scripts/check_vlog_auto_incompressible.go \
+            "${checker_args[@]}" \
+            -min-samples "${sample_count}" \
+            -min-throughput-frac 1.01 \
+            -max-size-frac 1.02
+
+      - name: Upload value-log performance evidence
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: vlog-perf-smoke-${{ github.run_id }}-${{ github.run_attempt }}
+          path: |
+            vlog_dict_bench.txt
+            vlog_auto_incompressible_off_sample*.txt
+            vlog_auto_incompressible_auto_sample*.txt
+          if-no-files-found: warn
 
   snapshot-iterator-perf:
     name: snapshot-iterator-perf (linux)

--- a/.github/workflows/treedb-tests.yml
+++ b/.github/workflows/treedb-tests.yml
@@ -692,11 +692,24 @@ jobs:
           # #1529 intentionally makes this a strict parity-plus gate. The
           # geometric mean of every balanced pair must exceed 1.01x; one lucky
           # sample cannot override a mostly failing sample set.
+          summary_log="vlog_auto_incompressible_summary.txt"
+          set +e
           go run .github/scripts/check_vlog_auto_incompressible.go \
             "${checker_args[@]}" \
             -min-samples "${sample_count}" \
             -min-throughput-frac 1.01 \
-            -max-size-frac 1.02
+            -max-size-frac 1.02 \
+            2>&1 | tee "${summary_log}"
+          checker_status=${PIPESTATUS[0]}
+          set -e
+
+          {
+            echo "## Incompressible value-log aggregate"
+            echo '```text'
+            cat "${summary_log}"
+            echo '```'
+          } >> "${GITHUB_STEP_SUMMARY}"
+          exit "${checker_status}"
 
       - name: Upload value-log performance evidence
         if: always()
@@ -705,6 +718,7 @@ jobs:
           name: vlog-perf-smoke-${{ github.run_id }}-${{ github.run_attempt }}
           path: |
             vlog_dict_bench.txt
+            vlog_auto_incompressible_summary.txt
             vlog_auto_incompressible_off_sample*.txt
             vlog_auto_incompressible_auto_sample*.txt
           if-no-files-found: warn

--- a/TreeDB/docs/command_wal_acceptance_test.go
+++ b/TreeDB/docs/command_wal_acceptance_test.go
@@ -109,6 +109,8 @@ func TestPR9AcceptancePerformanceGateIsStrictParityPlus(t *testing.T) {
 		"sub-parity results such as `0.80x`",
 		"every command-WAL acceptance artifact",
 		"incompressible value-log auto/off lanes",
+		"geometric mean of every fixed, order-balanced auto/off pair",
+		"one favorable sample cannot override a mostly failing sample set",
 	)
 	userCommandWAL := collapseWhitespace(readRepoText(t, "TreeDB/docs/spec/user-command-wal.md"))
 	assertContainsAll(t, userCommandWAL, "PR9 user command WAL acceptance",
@@ -116,24 +118,29 @@ func TestPR9AcceptancePerformanceGateIsStrictParityPlus(t *testing.T) {
 		"incompressible value-log auto/off throughput gates",
 		"strictly greater than `1.01x`",
 		"sub-parity evidence such as `0.80x`",
+		"geometric mean of every fixed, order-balanced auto/off pair",
+		"one favorable sample cannot override a mostly failing sample set",
 	)
 	checker := readRepoText(t, ".github/scripts/check_vlog_auto_incompressible.go")
 	assertContainsAll(t, checker, "PR9 incompressible checker",
 		`flag.Float64Var(&minThroughputFrac, "min-throughput-frac", 1.01`,
-		"throughputFrac <= minThroughputFrac",
+		"aggregateThroughputFrac <= minThroughputFrac",
 	)
 	workflow := collapseWhitespace(readRepoText(t, ".github/workflows/treedb-tests.yml"))
 	assertContainsAll(t, workflow, "PR9 perf smoke workflow",
+		"sample_count=6",
+		"run_vlog_row treedb_vlog_off",
+		"run_vlog_row treedb_vlog_auto",
 		"-min-throughput-frac 1.01",
-		"result at or below 1.01x is failing evidence",
+		"geometric mean of every balanced pair must exceed 1.01x",
 	)
 	gateStart := strings.Index(workflow, "name: Incompressible auto-vs-off gate")
 	gateEnd := strings.Index(workflow, "snapshot-iterator-perf:")
 	if gateStart < 0 || gateEnd <= gateStart {
 		t.Fatal("PR9 incompressible workflow gate boundaries not found")
 	}
-	if got := strings.Count(workflow[gateStart:gateEnd], "-profile fast"); got != 2 {
-		t.Fatalf("PR9 incompressible workflow explicit bench_unsafe selections=%d, want 2", got)
+	if got := strings.Count(workflow[gateStart:gateEnd], "-profile fast"); got != 1 {
+		t.Fatalf("PR9 incompressible workflow shared bench_unsafe selection count=%d, want 1", got)
 	}
 }
 

--- a/TreeDB/docs/spec/user-command-wal.md
+++ b/TreeDB/docs/spec/user-command-wal.md
@@ -1197,6 +1197,9 @@ Acceptance:
   throughput strictly greater than `1.01x` of the relevant baseline. Any
   required lane at or below `1.01x`, including sub-parity evidence such as
   `0.80x`, is a failing gate rather than accepted evidence.
+- the incompressible value-log lane applies that threshold to the geometric
+  mean of every fixed, order-balanced auto/off pair, so one favorable sample
+  cannot override a mostly failing sample set;
 - all required command-WAL acceptance performance gates use the same strict
   parity-plus policy: passing evidence must include `>` semantics, explicit
   `1.01x` minimum ratio thresholds, and comparative throughput ratios above the

--- a/TreeDB/docs/spec/verification.md
+++ b/TreeDB/docs/spec/verification.md
@@ -1335,6 +1335,9 @@ value-log auto/off lanes must each report candidate throughput strictly greater
 than `1.01x` of the relevant baseline. Any required lane at or below `1.01x` is
 a failing gate, including sub-parity results such as `0.80x`; those results may
 be recorded only as failing evidence, not accepted evidence.
+The incompressible value-log lane applies that threshold to the geometric mean
+of every fixed, order-balanced auto/off pair; one favorable sample cannot
+override a mostly failing sample set.
 
 The same strict parity-plus rule applies to every command-WAL acceptance artifact
 with a required performance gate: a passing status must have `>` throughput-gate


### PR DESCRIPTION
Closes #3837

Parent: #3776

## Problem

The previous incompressible value-log performance gate ran up to five same-order attempts and exited successfully on the first sample above `auto/off > 1.01`. On the same exact SHA, one job passed on a lone `1.0186` sample after two failures while its twin failed all five samples. That made runner luck, rather than the full evidence set, determine the verdict.

## Change

- collect six complete off/auto pairs;
- alternate `off-auto` and `auto-off` row order across pairs;
- evaluate the geometric mean of all six throughput ratios once;
- retain the strict `auto/off > 1.01` throughput boundary;
- retain the per-sample `auto/off <= 1.02` value-log size boundary;
- fail closed on incomplete, malformed, non-positive, or insufficient evidence;
- publish the aggregate verdict to the job summary and upload it with every raw row log and the existing dictionary benchmark log on success or failure;
- add checker and workflow-contract tests that prevent early lucky-sample success from returning.

This changes CI evidence collection only. It does not alter the persistent value log, compression behavior, durability profiles, admission, WAL, or storage formats.

## Local validation

Exact workflow parameters, six order-balanced pairs:

| Pair | auto/off throughput | auto/off value-log size |
| --- | ---: | ---: |
| 1 | 0.9951 | 0.9960 |
| 2 | 1.0543 | 0.9960 |
| 3 | 1.0822 | 0.9960 |
| 4 | 1.0628 | 0.9960 |
| 5 | 0.9955 | 0.9960 |
| 6 | 1.0941 | 0.9960 |

Aggregate throughput geometric mean: `1.0466` (strict minimum `> 1.0100`). Maximum size ratio: `0.9960` (maximum `1.0200`). No product-performance child is needed from this local evidence.

Commands:

```sh
PYTHONDONTWRITEBYTECODE=1 GOWORK=off python3 -m unittest discover -s .github/scripts -p 'test_*.py'
GOWORK=off go test ./TreeDB/docs -count=1
GOWORK=off go vet ./TreeDB/docs
GOWORK=off go vet .github/scripts/check_vlog_auto_incompressible.go
git diff --check
```

Results: 48 CI-script tests and the full docs suite passed; both vet commands and diff checks passed. The docs acceptance contract asserts all six order-balanced pairs, the aggregate throughput variable, the shared benchmark profile, and the geometric-mean rule.

Base: `f6e8d53f38a92aa286c876ec070ecbc757b99688`
Head: `5a336422d41ddf51ec3e4eef6a9410c3d286bba7`

Hosted exact-head TreeDB matrices and exact-head Codex review are required before merge.
