### PR TITLE
test(collections): settle rewrite before leaf GC

### DIFF
--- a/TreeDB/collections/text_v2_rewrite_test.go
+++ b/TreeDB/collections/text_v2_rewrite_test.go
@@ -357,6 +357,13 @@ func TestTextV2RewriteStorageMaintenanceAndValueLogGC2630(t *testing.T) {
 		_ = snap.Close()
 		t.Fatalf("old snapshot micro ok=%v len=%d err=%v want pinned old payload", ok, len(raw), err)
 	}
+	// Settle the activated rewrite publication before destructive maintenance
+	// captures its recoverable-root capability. The open snapshot still pins the
+	// old text-v2 root and is the retention boundary this test exercises.
+	if err := d.Checkpoint(); err != nil {
+		_ = snap.Close()
+		t.Fatalf("Checkpoint rewritten text-v2 index with snapshot pinned: %v", err)
+	}
 	pinnedLeafGC, err := d.LeafGenerationGC(context.Background(), backenddb.LeafGenerationGCOptions{})
 	if err != nil {
 		_ = snap.Close()


### PR DESCRIPTION
Closes #3839

Parent tracker: #3776

Unblocks #3837 / PR #3838

## Problem

Exact proof-A TreeDB run `29538791621`, race shard 1 job `87756273905`, failed `TestTextV2RewriteStorageMaintenanceAndValueLogGC2630` because destructive leaf-generation GC captured its recoverable-root capability while the preceding text-v2 rewrite publication was still changing the recovery closure:

```text
LeafGenerationGC while text-v2 snapshot pinned: treedb: recoverable root set changed
```

The exact-SHA actual shard and focused local race x20 passed, confirming a low-frequency interleaving. This is the same test-contract class fixed for the iterator lane in #3826: DUR-08 requires destructive maintenance to fail closed on a stale capability rather than retry-spin.

## Fix

- Checkpoint the activated text-v2 rewrite publication before the test's one-shot destructive leaf GC.
- Keep the old snapshot open across that checkpoint and GC, so it remains the exact retention boundary under test.
- Preserve the existing no-deletion assertion while pinned, then release/checkpoint/value-log-GC/compact and retain all search, reopen, manifest, and reclamation assertions.

No production publication, maintenance, GC, retry, value-log, persistent-storage, or format behavior changes.

## Validation

- named test normal x100: pass (`26.374s`)
- named test race x20: pass (`10.088s`)
- all `TestTextV2Rewrite*` tests race x10: pass (`11.269s`)
- full `TreeDB/collections` race: pass (`298.041s`)
- `GOWORK=off go vet ./TreeDB/collections`: pass
- `git diff --check`: pass

## Performance

Not performance-relevant: one test-only synchronization boundary.

## Merge order

After this PR passes exact-head CI/review and merges, PR #3838 will refresh onto current main and discard all pre-merge proof evidence.
