### PR TITLE
test(caching): own retained prune quiet waiter

### DIFF
--- a/TreeDB/caching/vlog_generation_scheduler_test.go
+++ b/TreeDB/caching/vlog_generation_scheduler_test.go
@@ -2761,6 +2761,17 @@ func TestVlogGenerationMaintenance_PeriodicLeafPackDoesNotBlockOnScheduledRetain
 	}
 	db, cleanup := openLeafPackMaintenanceTestDB(t, recorder)
 	defer cleanup()
+	// The setup checkpoint may have scheduled retained-prune work. Settle that
+	// request before this test schedules and inspects its own quiet waiter.
+	forceRetainedPruneIdle(db)
+	db.waitForRetainedValueLogPrune()
+	db.retainedPruneMu.Lock()
+	inheritedWaiting := db.retainedPruneDone != nil
+	inheritedRunning := db.retainedPruneRunningDone != nil
+	db.retainedPruneMu.Unlock()
+	if inheritedWaiting || inheritedRunning {
+		t.Fatalf("inherited retained prune after setup settlement: waiting=%t running=%t", inheritedWaiting, inheritedRunning)
+	}
 
 	retainedPath := filepath.Join(t.TempDir(), "value_vlog", "value-l0-000321.log")
 	seedRetainedPrunePressure(db, retainedPath, 2<<30)
@@ -2771,19 +2782,12 @@ func TestVlogGenerationMaintenance_PeriodicLeafPackDoesNotBlockOnScheduledRetain
 	db.lastForegroundReadUnixNano.Store(now.Add(-2 * vlogForegroundReadQuietWindow).UnixNano())
 	db.scheduleRetainedValueLogPrune()
 
-	deadline := time.Now().Add(2 * schedulerTestWait(t))
-	for {
-		db.retainedPruneMu.Lock()
-		waiting := db.retainedPruneDone != nil
-		running := db.retainedPruneRunningDone != nil
-		db.retainedPruneMu.Unlock()
-		if waiting && !running {
-			break
-		}
-		if time.Now().After(deadline) {
-			t.Fatalf("retained prune did not enter scheduled quiet-wait state in time")
-		}
-		time.Sleep(10 * time.Millisecond)
+	db.retainedPruneMu.Lock()
+	waiting := db.retainedPruneDone != nil
+	running := db.retainedPruneRunningDone != nil
+	db.retainedPruneMu.Unlock()
+	if !waiting || running {
+		t.Fatalf("owned retained prune after scheduling: waiting=%t running=%t, want waiting only", waiting, running)
 	}
 
 	start := time.Now()


### PR DESCRIPTION
Closes #3841

Parent tracker: #3776

Unblocks #3839 / PR #3840

## Problem

Exact-head Root run `29540368756`, Ubuntu shard 2 job `87761133260`, failed `TestVlogGenerationMaintenance_PeriodicLeafPackDoesNotBlockOnScheduledRetainedPruneQuietWait` after polling eight seconds for a scheduled/not-active prune state.

The test's setup performs a checkpoint before the test schedules the prune it intends to inspect. A retained prune inherited from that setup can still own `retainedPruneDone`, and scheduling deliberately coalesces behind an in-flight request. The test could therefore wait for a state that its own request never owned.

## Fix

- Make the inherited setup state quiet, wait for any setup-owned retained prune to settle, and assert both retained-prune slots are empty.
- Seed the test pressure and foreground-hot timestamps, then schedule exactly the request the test owns.
- Inspect the synchronously published scheduled/not-active state directly under `retainedPruneMu`, removing the eight-second sleep/poll loop.
- Preserve the existing proof that periodic leaf-pack maintenance runs, completes within `<=500ms`, calls the backend exactly once, and clears maintenance-active state while retained prune waits for quiet.

No production scheduler, retained-prune, leaf-pack, timeout, retry, value-log, durability, or storage-format behavior changes.

## Validation

- named test normal x100: pass (`16.358s`)
- named test race x20: pass (`4.836s`)
- adjacent periodic leaf-pack and retained-prune quiet-wait tests race x10: pass (`10.108s`)
- full `TreeDB/caching` race: pass (`93.129s`)
- `GOWORK=off go vet ./TreeDB/caching`: pass
- `git diff --check`: pass

## Performance

Not product-performance-relevant: test synchronization only. The existing deterministic `<=500ms` leaf-pack nonblocking contract is unchanged.

## Merge order

After this PR passes exact-head CI/review and merges, PR #3840 will refresh onto current main and discard all pre-merge proof evidence.
