### PR TITLE
[DUR-11] Close power-loss enumerator witness gaps

### DIFF
--- a/TreeDB/command_wal_durable_prefix_test.go
+++ b/TreeDB/command_wal_durable_prefix_test.go
@@ -285,6 +285,154 @@ func TestPublicCommandWALRelaxedPointerDebtStatsCloseOnSetSync(t *testing.T) {
 	}
 }
 
+func TestPublicCommandWALRelaxedPointerDebtEmitsExactDependencySyncCuts(t *testing.T) {
+	dir := t.TempDir()
+	opts := relaxedCommandWALDurablePrefixOptions(dir)
+	opts.ValueLog.PointerThreshold = 1
+	opts.ValueLog.ForcePointers = true
+	db, err := Open(opts)
+	if err != nil {
+		t.Fatalf("Open relaxed command WAL: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	var events []durabilitycut.Event
+	restore := durabilitycut.Install(func(event durabilitycut.Event) error {
+		events = append(events, event)
+		return nil
+	})
+	defer restore()
+
+	b := db.NewBatch()
+	if err := b.Set([]byte("relaxed-pointer"), bytes.Repeat([]byte("r"), 4096)); err != nil {
+		_ = b.Close()
+		t.Fatalf("relaxed pointer batch Set: %v", err)
+	}
+	if err := b.Write(); err != nil {
+		_ = b.Close()
+		t.Fatalf("relaxed pointer batch Write: %v", err)
+	}
+	if err := b.Close(); err != nil {
+		t.Fatalf("relaxed pointer batch Close: %v", err)
+	}
+
+	var relaxedValuePath string
+	for _, event := range events {
+		switch {
+		case event.Resource == durabilitycut.ResourceValueLog && event.Point == durabilitycut.AfterDependencyAppend && event.Path != "":
+			relaxedValuePath = event.Path
+		case event.Resource == durabilitycut.ResourceValueLog && event.Namespace == durabilitycut.NamespaceCreate && event.NewPath != "":
+			relaxedValuePath = event.NewPath
+		}
+	}
+	if relaxedValuePath == "" {
+		t.Fatalf("relaxed pointer write emitted no exact value-log append path: %#v", events)
+	}
+	beforeDurable := len(events)
+	if err := db.SetSync([]byte("durable-inline"), []byte("value")); err != nil {
+		t.Fatalf("SetSync: %v", err)
+	}
+
+	containsPath := func(event durabilitycut.Event, want string) bool {
+		if event.Path == want {
+			return true
+		}
+		for _, path := range event.Paths {
+			if path == want {
+				return true
+			}
+		}
+		return false
+	}
+	beforeSync, afterSync, durableAppend := -1, -1, -1
+	for i := beforeDurable; i < len(events); i++ {
+		event := events[i]
+		switch {
+		case event.Resource == durabilitycut.ResourceAuxiliary && event.Point == durabilitycut.BeforeDependencyFileSync && containsPath(event, relaxedValuePath):
+			beforeSync = i
+		case event.Resource == durabilitycut.ResourceAuxiliary && event.Point == durabilitycut.AfterDependencyFileSync && containsPath(event, relaxedValuePath):
+			afterSync = i
+		case event.Resource == durabilitycut.ResourceCommandWAL && event.Point == durabilitycut.AfterDependencyAppend && event.LSN == 2:
+			durableAppend = i
+		}
+	}
+	if beforeSync < 0 || afterSync <= beforeSync || durableAppend <= afterSync {
+		t.Fatalf("exact dependency sync cuts must bracket the value-log fsync before durable frame append: before=%d after=%d append=%d path=%q events=%#v",
+			beforeSync, afterSync, durableAppend, relaxedValuePath, events)
+	}
+}
+
+func TestPublicCommandWALRelaxedPointerDependencySyncCutsRetainDebtForRetry(t *testing.T) {
+	for _, point := range []durabilitycut.Point{
+		durabilitycut.BeforeDependencyFileSync,
+		durabilitycut.AfterDependencyFileSync,
+	} {
+		point := point
+		t.Run(string(point), func(t *testing.T) {
+			dir := t.TempDir()
+			opts := relaxedCommandWALDurablePrefixOptions(dir)
+			opts.ValueLog.PointerThreshold = 1
+			opts.ValueLog.ForcePointers = true
+			db, err := Open(opts)
+			if err != nil {
+				t.Fatalf("Open relaxed command WAL: %v", err)
+			}
+			defer func() { _ = db.Close() }()
+
+			b := db.NewBatch()
+			if err := b.Set([]byte("relaxed-pointer"), bytes.Repeat([]byte("r"), 4096)); err != nil {
+				_ = b.Close()
+				t.Fatalf("batch Set relaxed pointer: %v", err)
+			}
+			if err := b.Write(); err != nil {
+				_ = b.Close()
+				t.Fatalf("batch Write relaxed pointer: %v", err)
+			}
+			if err := b.Close(); err != nil {
+				t.Fatalf("batch Close relaxed pointer: %v", err)
+			}
+			cutErr := fmt.Errorf("injected pointer dependency cut at %s", point)
+			cut := false
+			restore := durabilitycut.Install(func(event durabilitycut.Event) error {
+				if !cut && event.Resource == durabilitycut.ResourceAuxiliary && event.Point == point {
+					cut = true
+					return cutErr
+				}
+				return nil
+			})
+			err = writeEmptyPublicCommandWALSync(db)
+			restore()
+			if !errors.Is(err, cutErr) || !cut {
+				t.Fatalf("empty WriteSync error=%v cut=%t, want injected %s cut", err, cut, point)
+			}
+			stats := db.Stats()
+			if got := stats["treedb.command_wal.durable_wal_lsn"]; got != "0" {
+				t.Fatalf("durable_wal_lsn after pre-append cut=%q, want 0", got)
+			}
+			if got := stats["treedb.command_wal.dependency_debt.entries"]; got != "1" {
+				t.Fatalf("pending debt entries after pre-append cut=%q, want retained 1", got)
+			}
+			if got := stats["treedb.command_wal.dependency_debt.retries_total"]; got != "1" {
+				t.Fatalf("pending debt retries after pre-append cut=%q, want 1", got)
+			}
+			if frames := scanPublicCommandWALV2(t, dir); len(frames) != 1 {
+				t.Fatalf("frames after pre-append cut=%+v, want only relaxed frame", frames)
+			}
+
+			if err := writeEmptyPublicCommandWALSync(db); err != nil {
+				t.Fatalf("retry empty WriteSync barrier: %v", err)
+			}
+			stats = db.Stats()
+			if got := stats["treedb.command_wal.durable_wal_lsn"]; got != "2" {
+				t.Fatalf("durable_wal_lsn after retry=%q, want 2", got)
+			}
+			if got := stats["treedb.command_wal.dependency_debt.entries"]; got != "0" {
+				t.Fatalf("pending debt entries after retry=%q, want 0", got)
+			}
+		})
+	}
+}
+
 func TestPublicCommandWALRelaxedRotationsStabilizeExactPrefixBeforeBarrierAppend(t *testing.T) {
 	dir := t.TempDir()
 	opts := relaxedCommandWALDurablePrefixOptions(dir)

--- a/TreeDB/db/command_wal_raw.go
+++ b/TreeDB/db/command_wal_raw.go
@@ -732,9 +732,32 @@ func (db *DB) syncCommandWALDependenciesThrough(lsn uint64, extra *rootpublicati
 	if err != nil {
 		return err
 	}
+	dependencyPaths, err := stableResourceDependencyObservationPathsV1(view, db.dir)
+	if err != nil {
+		db.commandWALDebt.noteRetryThrough(lsn)
+		return err
+	}
+	if len(dependencyPaths) != 0 {
+		if err := durabilitycut.Emit(durabilitycut.Event{
+			Point: durabilitycut.BeforeDependencyFileSync, Resource: durabilitycut.ResourceAuxiliary,
+			Root: db.dir, Paths: dependencyPaths,
+		}); err != nil {
+			db.commandWALDebt.noteRetryThrough(lsn)
+			return err
+		}
+	}
 	if err := view.SyncThrough(); err != nil {
 		db.commandWALDebt.noteRetryThrough(lsn)
 		return err
+	}
+	if len(dependencyPaths) != 0 {
+		if err := durabilitycut.Emit(durabilitycut.Event{
+			Point: durabilitycut.AfterDependencyFileSync, Resource: durabilitycut.ResourceAuxiliary,
+			Root: db.dir, Paths: dependencyPaths,
+		}); err != nil {
+			db.commandWALDebt.noteRetryThrough(lsn)
+			return err
+		}
 	}
 	if err := db.commandWALDebt.syncRotationFilesThrough(db.dir, db.commandWALDir, lsn); err != nil {
 		db.commandWALDebt.noteRetryThrough(lsn)

--- a/TreeDB/db/command_wal_raw.go
+++ b/TreeDB/db/command_wal_raw.go
@@ -732,32 +732,10 @@ func (db *DB) syncCommandWALDependenciesThrough(lsn uint64, extra *rootpublicati
 	if err != nil {
 		return err
 	}
-	dependencyPaths, err := stableResourceDependencyObservationPathsV1(view, db.dir)
-	if err != nil {
+	if _, err := syncStableResourceDependenciesV1(view, db.dir, view.SyncThrough, func() {
 		db.commandWALDebt.noteRetryThrough(lsn)
+	}); err != nil {
 		return err
-	}
-	if len(dependencyPaths) != 0 {
-		if err := durabilitycut.Emit(durabilitycut.Event{
-			Point: durabilitycut.BeforeDependencyFileSync, Resource: durabilitycut.ResourceAuxiliary,
-			Root: db.dir, Paths: dependencyPaths,
-		}); err != nil {
-			db.commandWALDebt.noteRetryThrough(lsn)
-			return err
-		}
-	}
-	if err := view.SyncThrough(); err != nil {
-		db.commandWALDebt.noteRetryThrough(lsn)
-		return err
-	}
-	if len(dependencyPaths) != 0 {
-		if err := durabilitycut.Emit(durabilitycut.Event{
-			Point: durabilitycut.AfterDependencyFileSync, Resource: durabilitycut.ResourceAuxiliary,
-			Root: db.dir, Paths: dependencyPaths,
-		}); err != nil {
-			db.commandWALDebt.noteRetryThrough(lsn)
-			return err
-		}
 	}
 	if err := db.commandWALDebt.syncRotationFilesThrough(db.dir, db.commandWALDir, lsn); err != nil {
 		db.commandWALDebt.noteRetryThrough(lsn)

--- a/TreeDB/db/durable_root_runtime.go
+++ b/TreeDB/db/durable_root_runtime.go
@@ -1119,7 +1119,7 @@ func executeDurableRootStorageTransactionV1(tx durableRootStorageTransactionV1) 
 		if err := tx.resources.FlushThrough(); err != nil {
 			return false, fmt.Errorf("flush durable-root external dependencies: %w", err)
 		}
-		dependencyPaths, err := durableRootDependencyObservationPathsV1(tx.resources, tx.dir)
+		dependencyPaths, err := stableResourceDependencyObservationPathsV1(tx.resources, tx.dir)
 		if err != nil {
 			return false, fmt.Errorf("observe durable-root external dependencies: %w", err)
 		}
@@ -1192,11 +1192,11 @@ func executeDurableRootStorageTransactionV1(tx durableRootStorageTransactionV1) 
 	return true, nil
 }
 
-// durableRootDependencyObservationPathsV1 exposes only the names attached to
-// the exact handles already retained by the candidate. It never reopens a
+// stableResourceDependencyObservationPathsV1 exposes only the names attached to
+// the exact handles already retained by the resource set. It never reopens a
 // diagnostic path. The list is collected only while the deterministic cut
 // observer is active, so the production-disabled path remains allocation-free.
-func durableRootDependencyObservationPathsV1(resources *rootpublication.StableResourceSet, root string) ([]string, error) {
+func stableResourceDependencyObservationPathsV1(resources *rootpublication.StableResourceSet, root string) ([]string, error) {
 	if resources == nil || root == "" || !durabilitycut.Enabled() {
 		return nil, nil
 	}
@@ -1207,7 +1207,7 @@ func durableRootDependencyObservationPathsV1(resources *rootpublication.StableRe
 		}
 		var path string
 		if err := token.WithPinnedFile(func(file *os.File) error {
-			path = durableRootDependencyObservationPathV1(file.Name())
+			path = stableResourceDependencyObservationPathV1(file.Name())
 			if path == "" {
 				return errors.New("stable resource handle has no observation name")
 			}
@@ -1230,11 +1230,11 @@ func durableRootDependencyObservationPathsV1(resources *rootpublication.StableRe
 	return unique, nil
 }
 
-// durableRootDependencyObservationPathV1 strips the private handle suffixes
+// stableResourceDependencyObservationPathV1 strips the private handle suffixes
 // used by stable-resource pins. A resource may be cloned through several
 // candidate closures, so normalize every trailing layer before exposing the
 // underlying path to the deterministic power-loss observer.
-func durableRootDependencyObservationPathV1(path string) string {
+func stableResourceDependencyObservationPathV1(path string) string {
 	for {
 		switch {
 		case strings.HasSuffix(path, "#stable-sync-pin"):

--- a/TreeDB/db/durable_root_runtime.go
+++ b/TreeDB/db/durable_root_runtime.go
@@ -1106,6 +1106,15 @@ type durableRootStorageTransactionV1 struct {
 	beforeMetaSync  func() error
 }
 
+type stableResourceDependencySyncPhaseV1 uint8
+
+const (
+	stableResourceDependencyObserveV1 stableResourceDependencySyncPhaseV1 = iota + 1
+	stableResourceDependencyEmitBeforeV1
+	stableResourceDependencySyncV1
+	stableResourceDependencyEmitAfterV1
+)
+
 // executeDurableRootStorageTransactionV1 is the only V1 durable-meta mutation
 // implementation. Live commits, initialization, and replacement-index
 // maintenance all pass through the same dependency -> index -> meta ordering.
@@ -1119,26 +1128,14 @@ func executeDurableRootStorageTransactionV1(tx durableRootStorageTransactionV1) 
 		if err := tx.resources.FlushThrough(); err != nil {
 			return false, fmt.Errorf("flush durable-root external dependencies: %w", err)
 		}
-		dependencyPaths, err := stableResourceDependencyObservationPathsV1(tx.resources, tx.dir)
+		phase, err := syncStableResourceDependenciesV1(tx.resources, tx.dir, tx.resources.SyncThrough, nil)
 		if err != nil {
-			return false, fmt.Errorf("observe durable-root external dependencies: %w", err)
-		}
-		if len(dependencyPaths) != 0 {
-			if err := durabilitycut.Emit(durabilitycut.Event{
-				Point: durabilitycut.BeforeDependencyFileSync, Resource: durabilitycut.ResourceAuxiliary,
-				Root: tx.dir, Paths: dependencyPaths,
-			}); err != nil {
-				return false, err
-			}
-		}
-		if err := tx.resources.SyncThrough(); err != nil {
-			return false, fmt.Errorf("sync durable-root external dependencies: %w", err)
-		}
-		if len(dependencyPaths) != 0 {
-			if err := durabilitycut.Emit(durabilitycut.Event{
-				Point: durabilitycut.AfterDependencyFileSync, Resource: durabilitycut.ResourceAuxiliary,
-				Root: tx.dir, Paths: dependencyPaths,
-			}); err != nil {
+			switch phase {
+			case stableResourceDependencyObserveV1:
+				return false, fmt.Errorf("observe durable-root external dependencies: %w", err)
+			case stableResourceDependencySyncV1:
+				return false, fmt.Errorf("sync durable-root external dependencies: %w", err)
+			default:
 				return false, err
 			}
 		}
@@ -1228,6 +1225,47 @@ func stableResourceDependencyObservationPathsV1(resources *rootpublication.Stabl
 		}
 	}
 	return unique, nil
+}
+
+// syncStableResourceDependenciesV1 keeps stable-resource cut observation and
+// the corresponding sync operation in one sequence. onError lets callers
+// retain retry debt before any error is returned.
+func syncStableResourceDependenciesV1(
+	resources *rootpublication.StableResourceSet,
+	root string,
+	sync func() error,
+	onError func(),
+) (stableResourceDependencySyncPhaseV1, error) {
+	fail := func(phase stableResourceDependencySyncPhaseV1, err error) (stableResourceDependencySyncPhaseV1, error) {
+		if onError != nil {
+			onError()
+		}
+		return phase, err
+	}
+	dependencyPaths, err := stableResourceDependencyObservationPathsV1(resources, root)
+	if err != nil {
+		return fail(stableResourceDependencyObserveV1, err)
+	}
+	if len(dependencyPaths) != 0 {
+		if err := durabilitycut.Emit(durabilitycut.Event{
+			Point: durabilitycut.BeforeDependencyFileSync, Resource: durabilitycut.ResourceAuxiliary,
+			Root: root, Paths: dependencyPaths,
+		}); err != nil {
+			return fail(stableResourceDependencyEmitBeforeV1, err)
+		}
+	}
+	if err := sync(); err != nil {
+		return fail(stableResourceDependencySyncV1, err)
+	}
+	if len(dependencyPaths) != 0 {
+		if err := durabilitycut.Emit(durabilitycut.Event{
+			Point: durabilitycut.AfterDependencyFileSync, Resource: durabilitycut.ResourceAuxiliary,
+			Root: root, Paths: dependencyPaths,
+		}); err != nil {
+			return fail(stableResourceDependencyEmitAfterV1, err)
+		}
+	}
+	return 0, nil
 }
 
 // stableResourceDependencyObservationPathV1 strips the private handle suffixes

--- a/TreeDB/db/root_publication_activation_test.go
+++ b/TreeDB/db/root_publication_activation_test.go
@@ -344,8 +344,8 @@ func TestDurableRootDependencyObservationPathV1(t *testing.T) {
 	}
 	for name, path := range tests {
 		t.Run(name, func(t *testing.T) {
-			if got := durableRootDependencyObservationPathV1(path); got != "/tmp/value.log" {
-				t.Fatalf("durableRootDependencyObservationPathV1(%q)=%q want %q", path, got, "/tmp/value.log")
+			if got := stableResourceDependencyObservationPathV1(path); got != "/tmp/value.log" {
+				t.Fatalf("stableResourceDependencyObservationPathV1(%q)=%q want %q", path, got, "/tmp/value.log")
 			}
 		})
 	}

--- a/TreeDB/power_loss_oracle_test.go
+++ b/TreeDB/power_loss_oracle_test.go
@@ -356,8 +356,8 @@ func TestPowerLossOracleEnumerateCutPoints(t *testing.T) {
 			}
 			for occurrence, snapshot := range cutSnapshots {
 				t.Logf("cut occurrence=%d phase=%s resource=%s path=%s lsn=%d", occurrence, snapshot.phase, snapshot.event.Resource, snapshot.event.Path, snapshot.event.LSN)
-				validateActualCutReopen(t, snapshot.model, opts, cut, occurrence, snapshot.phase, false, snapshot.generations, snapshot.latestSealedSequence, snapshot.expectedByAppliedLSN, snapshot.commandFrames, snapshot.durableAcknowledgement, snapshot.durableAcknowledged)
-				validateActualCutReopen(t, snapshot.model, opts, cut, occurrence, snapshot.phase, true, snapshot.generations, snapshot.latestSealedSequence, snapshot.expectedByAppliedLSN, snapshot.commandFrames, snapshot.durableAcknowledgement, snapshot.durableAcknowledged)
+				validateActualCutReopen(t, snapshot.model, opts, cut, occurrence, false, snapshot.generations, snapshot.latestSealedSequence, snapshot.expectedByAppliedLSN, snapshot.commandFrames, snapshot.durableAcknowledgement, snapshot.durableAcknowledged)
+				validateActualCutReopen(t, snapshot.model, opts, cut, occurrence, true, snapshot.generations, snapshot.latestSealedSequence, snapshot.expectedByAppliedLSN, snapshot.commandFrames, snapshot.durableAcknowledgement, snapshot.durableAcknowledged)
 			}
 		})
 	}
@@ -1372,7 +1372,7 @@ func publicCommitSequence(t *testing.T, db *treedb.DB) uint64 {
 	return sequence
 }
 
-func validateActualCutReopen(t *testing.T, model *powerlossoracle.Model, opts treedb.Options, cut powerlossoracle.CutPoint, occurrence int, phase string, readOnly bool, generations []powerlossoracle.Generation, latestSealedSequence uint64, expectedByAppliedLSN map[uint64]map[string]map[string]string, observedCommandFrames []observedPowerLossCommandFrame, durableSequence uint64, durableAcknowledged bool) {
+func validateActualCutReopen(t *testing.T, model *powerlossoracle.Model, opts treedb.Options, cut powerlossoracle.CutPoint, occurrence int, readOnly bool, generations []powerlossoracle.Generation, latestSealedSequence uint64, expectedByAppliedLSN map[uint64]map[string]map[string]string, observedCommandFrames []observedPowerLossCommandFrame, durableSequence uint64, durableAcknowledged bool) {
 	t.Helper()
 	result, reopened, closeFn, err := powerlossreopen.Stable(model, opts, readOnly)
 	if err != nil {
@@ -1391,12 +1391,9 @@ func validateActualCutReopen(t *testing.T, model *powerlossoracle.Model, opts tr
 		}
 		stableFrameLSN := contiguousStablePowerLossCommandLSN(commandFrames, selectedAppliedLSN)
 		completeCommandLSN := contiguousCompletePowerLossCommandLSN(commandFrames, selectedAppliedLSN)
-		if readOnly && selectedAppliedOK && allRecoverableGenerationsComplete(generations, latestSealedSequence) && stableFrameLSN > selectedAppliedLSN && errors.Is(result.Err, treedb.ErrRecoveryRequired) {
-			if completeCommandLSN > selectedAppliedLSN {
-				t.Logf("expected read-only recovery-required seed=%d cut=%s occurrence=%d: %v", powerLossOracleSeed, cut, occurrence, result.Err)
-			} else {
-				t.Logf("known counterexample rejected by read-only Open seed=%d cut=%s occurrence=%d: checksum-valid command through LSN %d has incomplete RID closure", powerLossOracleSeed, cut, occurrence, stableFrameLSN)
-			}
+		if readOnly && selectedAppliedOK && allRecoverableGenerationsComplete(generations, latestSealedSequence) &&
+			stableFrameLSN > selectedAppliedLSN && completeCommandLSN > selectedAppliedLSN && errors.Is(result.Err, treedb.ErrRecoveryRequired) {
+			t.Logf("expected read-only recovery-required seed=%d cut=%s occurrence=%d: %v", powerLossOracleSeed, cut, occurrence, result.Err)
 			return
 		}
 		rejected := powerlossoracle.Scenario{
@@ -1408,13 +1405,6 @@ func validateActualCutReopen(t *testing.T, model *powerlossoracle.Model, opts tr
 			ReopenRejected:       true,
 		}
 		diagnosis := rejected.Validate()
-		if !readOnly && strings.Contains(result.Err.Error(), "command wal missing value-log rid") {
-			if err := powerlossoracle.RequireViolation(diagnosis, powerlossoracle.InvariantSelectedRootInvalid); err != nil {
-				t.Fatalf("seed=%d cut=%s occurrence=%d public Open rejected (%v), expected missing-RID diagnosis: %v", powerLossOracleSeed, cut, occurrence, result.Err, err)
-			}
-			t.Logf("known counterexample seed=%d cut=%s occurrence=%d: %v", powerLossOracleSeed, cut, occurrence, diagnosis)
-			return
-		}
 		if diagnosis != nil {
 			t.Fatalf("seed=%d cut=%s occurrence=%d readOnly=%t public Open rejected (%v), diagnosis: %v", powerLossOracleSeed, cut, occurrence, readOnly, result.Err, diagnosis)
 		}
@@ -1433,9 +1423,11 @@ func validateActualCutReopen(t *testing.T, model *powerlossoracle.Model, opts tr
 		"stable/": {},
 		"actual/": {},
 	}
+	// Every fixture value is non-empty. Public Get represents an absent key as
+	// an empty slice, so only non-empty reads are members of the observed map.
 	for _, key := range expectedPowerLossFixtureKeys() {
 		value, getErr := reopened.Get([]byte(key))
-		if getErr == nil {
+		if getErr == nil && len(value) != 0 {
 			prefix := "actual/"
 			if strings.HasPrefix(key, "stable/") {
 				prefix = "stable/"
@@ -1470,14 +1462,7 @@ func validateActualCutReopen(t *testing.T, model *powerlossoracle.Model, opts tr
 		CommandFrames:             commandFrames,
 		ReopenAttempted:           true,
 	}
-	validationErr := scenario.Validate()
-	if (phase == "relaxed-batch" || phase == "durable-set-sync") && validationErr != nil {
-		if err := powerlossoracle.RequireViolation(validationErr, powerlossoracle.InvariantKeyStateMismatch); err == nil {
-			t.Logf("known counterexample seed=%d cut=%s occurrence=%d: %v", powerLossOracleSeed, cut, occurrence, validationErr)
-			return
-		}
-	}
-	if validationErr != nil {
+	if validationErr := scenario.Validate(); validationErr != nil {
 		t.Fatalf("seed=%d cut=%s occurrence=%d readOnly=%t scenario: %v", powerLossOracleSeed, cut, occurrence, readOnly, validationErr)
 	}
 }


### PR DESCRIPTION
Supports #3684. Non-closing.

## Scope

- emit exact before/after dependency-file-sync cut events around deferred command-WAL dependency stabilization, before the durable barrier frame append;
- bind those events to the stable resource handles actually synchronized rather than reopening diagnostic paths;
- retain dependency debt and the pre-barrier WAL horizon when either injected cut fails, then prove a retry closes the debt;
- remove the power-loss enumerator's known-counterexample allowances for missing value-log RIDs and key-state mismatch so those scenarios must now pass normal public reopen validation;
- keep absent public reads out of the observed fixture map.

This is an implementation/witness hardening PR. It leaves issue 3684 open and makes no aggregate power-loss certification claim.

## Base and head

- foundation merge base: `aea07260060bb68261faf2a9bbcf99a3c502f0fc`
- head: `4bd6956592a56a0f9f13e221d132ac4a3223185e`

## Validation

```sh
GOWORK=off go test ./TreeDB -run '^(TestPublicCommandWALRelaxedPointerDebtEmitsExactDependencySyncCuts|TestPublicCommandWALRelaxedPointerDependencySyncCutsRetainDebtForRetry|TestPowerLossOracleEnumerateCutPoints|TestPowerLossOracleCounterexampleRelaxedCommandFrameMissingRID|TestObservedPowerLossClosureRequiresAppendedDependencySync)$' -count=1
GOWORK=off go test ./TreeDB/db -run '^(TestDurableRootDependencyObservationPathV1|TestStableResourceDependencyObservationPathV1)$' -count=1
GOWORK=off go test -race ./TreeDB -run '^(TestPublicCommandWALRelaxedPointerDebtEmitsExactDependencySyncCuts|TestPublicCommandWALRelaxedPointerDependencySyncCutsRetainDebtForRetry|TestPowerLossOracleEnumerateCutPoints|TestObservedPowerLossClosureRequiresAppendedDependencySync)$' -count=1
GOWORK=off go vet ./TreeDB ./TreeDB/db
GOWORK=off go test ./TreeDB/... -count=1
```

All pass on the exact head above.

## Contextual performance smoke

Command:

```sh
GOWORK=off go test ./TreeDB -run '^$' -bench '^BenchmarkPublicCommandWALRelaxedDurablePrefixBarrier$' -benchtime=5x -count=1 -benchmem
```

| barrier group | ns/op | ops/sec | B/op | allocs/op | exact file syncs before append | namespace syncs before append | WAL syncs after append |
|---:|---:|---:|---:|---:|---:|---:|---:|
| 1 | 6,655,617 | 150.25 | 12,705 | 76 | 1 | 1 | 1 |
| 8 | 24,839,925 | 40.26 | 21,872 | 171 | 9 | 2 | 1 |
| 32 | 84,505,333 | 11.83 | 60,934 | 405 | 33 | 2 | 1 |

This is test-infrastructure evidence, not a product throughput claim. The semantic gate is that all exact dependency and namespace sync observations precede the durable barrier append, with the WAL fsync after append.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved durability tracking for relaxed pointer writes, ensuring dependency sync failures retain their retry state.
  * Ensured subsequent sync attempts can complete pending durable WAL advancement.
  * Improved normalization and tracking of files involved in durable storage operations.

* **Tests**
  * Added coverage for dependency sync ordering, failure recovery, retry behavior, and power-loss recovery scenarios.
  * Strengthened validation of recovered key/value state after simulated interruptions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->