### PR TITLE
fix(collections): reconcile accepted text-index publication

### DIFF
--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -9913,6 +9913,12 @@ func retryInsertBatchMutation(run func() ([][]byte, error)) ([][]byte, error) {
 }
 
 func isRetriableCollectionMutationError(err error) bool {
+	// Once publication ownership transferred, running a logical mutation again
+	// can apply it twice. Callers with operation-specific reconciliation must
+	// handle this status before consulting ordinary pre-publication retry classes.
+	if backenddb.CommitPublicationAccepted(err) {
+		return false
+	}
 	return errors.Is(err, ErrConcurrentMutation) ||
 		isRetriableOrderedRootPublishConflict(err) ||
 		isRetriableCollectionCatalogReadEOF(err)

--- a/TreeDB/collections/text_catalog.go
+++ b/TreeDB/collections/text_catalog.go
@@ -28,11 +28,25 @@ func (c *Collection) CreateTextIndex(def TextIndexDefinition) (*CollectionMeta, 
 	if err := c.ensureWriteDomainOpen(); err != nil {
 		return nil, emptyStats, err
 	}
+	return c.createTextIndexWithRetry(def, c.createTextIndexOnce)
+}
+
+func (c *Collection) createTextIndexWithRetry(def TextIndexDefinition, run func(TextIndexDefinition) (*CollectionMeta, TextIndexBackfillStats, error)) (*CollectionMeta, TextIndexBackfillStats, error) {
+	var emptyStats TextIndexBackfillStats
 	var lastErr error
 	for attempt := 0; attempt < maxCollectionMutationRetries; attempt++ {
-		meta, stats, err := c.createTextIndexOnce(def)
+		meta, stats, err := run(def)
+		if err == nil {
+			return meta, stats, nil
+		}
+		if backenddb.CommitPublicationAccepted(err) {
+			if !isRetriableOrderedRootPublishConflict(err) {
+				return nil, emptyStats, err
+			}
+			return c.reconcileAcceptedTextIndexCreate(def.Name, meta, stats, err)
+		}
 		if !isRetriableTextIndexMutationError(err) {
-			return meta, stats, err
+			return nil, emptyStats, err
 		}
 		lastErr = err
 		waitBeforeCollectionMutationRetry(attempt)
@@ -111,7 +125,7 @@ func (c *Collection) createTextIndexOnce(def TextIndexDefinition) (*CollectionMe
 		return c.buildSchemaAndRootDescriptorSystemIterator(baseMeta, newMeta, plan.rootNames, plan.baseRootIDs, rootIDs)
 	})
 	if err != nil {
-		return nil, emptyStats, err
+		return newMeta.copy(), plan.stats, err
 	}
 	if len(rootIDs) != len(plan.rootNames) {
 		return nil, emptyStats, unexpectedOrderedRootCountError(newMeta.Name, len(plan.rootNames), len(rootIDs))
@@ -141,11 +155,24 @@ func (c *Collection) DropTextIndex(name string) (*CollectionMeta, error) {
 	if err := c.ensureWriteDomainOpen(); err != nil {
 		return nil, err
 	}
+	return c.dropTextIndexWithRetry(name, c.dropTextIndexOnce)
+}
+
+func (c *Collection) dropTextIndexWithRetry(name string, run func(string) (*CollectionMeta, error)) (*CollectionMeta, error) {
 	var lastErr error
 	for attempt := 0; attempt < maxCollectionMutationRetries; attempt++ {
-		meta, err := c.dropTextIndexOnce(name)
+		meta, err := run(name)
+		if err == nil {
+			return meta, nil
+		}
+		if backenddb.CommitPublicationAccepted(err) {
+			if !isRetriableOrderedRootPublishConflict(err) {
+				return nil, err
+			}
+			return c.reconcileAcceptedTextIndexDrop(name, err)
+		}
 		if !isRetriableTextIndexMutationError(err) {
-			return meta, err
+			return nil, err
 		}
 		lastErr = err
 		waitBeforeCollectionMutationRetry(attempt)
@@ -154,6 +181,9 @@ func (c *Collection) DropTextIndex(name string) (*CollectionMeta, error) {
 }
 
 func isRetriableTextIndexMutationError(err error) bool {
+	if backenddb.CommitPublicationAccepted(err) {
+		return false
+	}
 	if isRetriableCollectionMutationError(err) {
 		return true
 	}
@@ -219,7 +249,7 @@ func (c *Collection) dropTextIndexOnce(name string) (*CollectionMeta, error) {
 		return c.buildSchemaOnlySystemDeltaIterator(baseMeta, encodedMeta, clearedRootNames)
 	})
 	if err != nil {
-		return nil, err
+		return newMeta.copy(), err
 	}
 	c.meta = newMeta
 	clearedRootIDs := make([]uint64, len(clearedRootNames))
@@ -227,6 +257,66 @@ func (c *Collection) dropTextIndexOnce(name string) (*CollectionMeta, error) {
 	c.rememberCatalogAtSystemRoot(newSystemRoot, nextCatalog)
 	c.noteWriteDomainCatalog(newSystemRoot, nextCatalog)
 	return newMeta.copy(), nil
+}
+
+func (c *Collection) reconcileAcceptedTextIndexCreate(name string, desired *CollectionMeta, stats TextIndexBackfillStats, publicationErr error) (*CollectionMeta, TextIndexBackfillStats, error) {
+	var emptyStats TextIndexBackfillStats
+	if desired == nil {
+		return nil, emptyStats, publicationErr
+	}
+	desiredDef, ok := findTextIndex(desired.TextIndexes, name)
+	if !ok {
+		return nil, emptyStats, publicationErr
+	}
+	unlockSchema := c.lockCollectionSchemaWrite()
+	defer unlockSchema()
+	if err := c.db.Checkpoint(); err != nil {
+		return nil, emptyStats, errors.Join(publicationErr, fmt.Errorf("collections: settle accepted text index create: %w", err))
+	}
+	catalog, err := c.loadCurrentCatalogForAcceptedTextIndexMutation()
+	if err != nil {
+		return nil, emptyStats, errors.Join(publicationErr, err)
+	}
+	got, ok := findTextIndex(catalog.meta.TextIndexes, desiredDef.Name)
+	if !ok || !textIndexDefinitionValuesEqual(got, desiredDef) {
+		return nil, emptyStats, errors.Join(publicationErr, fmt.Errorf("collections: accepted text index create did not reconcile exact index %q", desiredDef.Name))
+	}
+	return catalog.meta.copy(), stats, nil
+}
+
+func (c *Collection) reconcileAcceptedTextIndexDrop(name string, publicationErr error) (*CollectionMeta, error) {
+	unlockSchema := c.lockCollectionSchemaWrite()
+	defer unlockSchema()
+	if err := c.db.Checkpoint(); err != nil {
+		return nil, errors.Join(publicationErr, fmt.Errorf("collections: settle accepted text index drop: %w", err))
+	}
+	catalog, err := c.loadCurrentCatalogForAcceptedTextIndexMutation()
+	if err != nil {
+		return nil, errors.Join(publicationErr, err)
+	}
+	if _, ok := findTextIndex(catalog.meta.TextIndexes, name); ok {
+		return nil, errors.Join(publicationErr, fmt.Errorf("collections: accepted text index drop left index %q present", name))
+	}
+	return catalog.meta.copy(), nil
+}
+
+func (c *Collection) loadCurrentCatalogForAcceptedTextIndexMutation() (*collectionCatalog, error) {
+	snap := c.db.AcquireSnapshot()
+	if snap == nil {
+		return nil, backenddb.ErrClosed
+	}
+	defer func() { _ = snap.Close() }()
+	catalog, err := loadCollectionCatalog(snap, c.meta.Name)
+	if err != nil {
+		return nil, err
+	}
+	if catalog == nil {
+		return nil, errCollectionNotFound
+	}
+	c.meta = catalog.meta
+	c.rememberCatalog(snap, catalog)
+	c.noteWriteDomainCatalog(snapshotSystemRoot(snap), catalog)
+	return catalog, nil
 }
 
 // TextIndexStorageStats validates and summarizes persistent text roots for a

--- a/TreeDB/collections/text_index_test.go
+++ b/TreeDB/collections/text_index_test.go
@@ -58,6 +58,7 @@ func TestRetriableTextIndexMutationErrorClassifiesOnlyExpectedConflicts(t *testi
 		{name: "ordered root conflict", err: errors.New("concurrent modification detected during ordered root group publish"), want: true},
 		{name: "schema conflict", err: fmt.Errorf(`%w detected for "volatile"`, errConcurrentSchemaModification), want: true},
 		{name: "wrapped schema conflict", err: fmt.Errorf("outer: %w", fmt.Errorf(`%w detected for "volatile"`, errConcurrentSchemaModification)), want: true},
+		{name: "accepted root conflict", err: acceptedTextIndexCommitErrorForTest{error: errors.New("durable-root candidate base changed: injected")}, want: false},
 		{name: "plain schema text", err: errors.New(`collections: concurrent schema modification detected for "volatile"`), want: false},
 		{name: "root conflict", err: errors.New(`collections: concurrent root modification detected for "volatile/primary"`), want: false},
 		{name: "unrelated", err: errors.New("boom"), want: false},
@@ -68,6 +69,130 @@ func TestRetriableTextIndexMutationErrorClassifiesOnlyExpectedConflicts(t *testi
 				t.Fatalf("isRetriableTextIndexMutationError(%v)=%t want %t", tc.err, got, tc.want)
 			}
 		})
+	}
+}
+
+type acceptedTextIndexCommitErrorForTest struct {
+	error
+}
+
+func (acceptedTextIndexCommitErrorForTest) CommitPublicationAccepted() bool {
+	return true
+}
+
+func (e acceptedTextIndexCommitErrorForTest) Unwrap() error {
+	return e.error
+}
+
+func TestTextIndexAcceptedPublicationReconcilesWithoutLogicalReplay(t *testing.T) {
+	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = d.Close() }()
+	mgr := NewCollectionManager(d)
+	if _, err := mgr.CreateCollection(&CollectionMeta{Name: "docs"}); err != nil {
+		t.Fatalf("CreateCollection: %v", err)
+	}
+	col, err := mgr.OpenCollection("docs")
+	if err != nil {
+		t.Fatalf("OpenCollection: %v", err)
+	}
+	def := TextIndexDefinition{
+		Name:    "volatile",
+		Version: TextIndexVersionV2,
+		Fields:  []TextIndexField{{Field: "body"}},
+	}
+	acceptedCause := errors.New("accepted root conflict")
+	acceptedErr := acceptedTextIndexCommitErrorForTest{error: fmt.Errorf("durable-root candidate base changed: %w", acceptedCause)}
+
+	createCalls := 0
+	created, _, err := col.createTextIndexWithRetry(def, func(got TextIndexDefinition) (*CollectionMeta, TextIndexBackfillStats, error) {
+		createCalls++
+		meta, stats, createErr := col.createTextIndexOnce(got)
+		if createErr != nil {
+			return meta, stats, createErr
+		}
+		return meta, stats, acceptedErr
+	})
+	if err != nil {
+		t.Fatalf("reconcile accepted create: %v", err)
+	}
+	if createCalls != 1 {
+		t.Fatalf("create attempts=%d want 1 logical publication", createCalls)
+	}
+	gotDef, ok := findTextIndex(created.TextIndexes, def.Name)
+	if !ok || gotDef.Version != TextIndexVersionV2 {
+		t.Fatalf("created text index=%+v found=%t", gotDef, ok)
+	}
+	if _, _, err := col.CreateTextIndex(def); err == nil || !strings.Contains(err.Error(), "duplicate index") {
+		t.Fatalf("ordinary duplicate create err=%v want duplicate index", err)
+	}
+	mismatched := created.copy()
+	for i := range mismatched.TextIndexes {
+		if mismatched.TextIndexes[i].Name == def.Name {
+			mismatched.TextIndexes[i].StorePositions = true
+		}
+	}
+	if _, _, err := col.reconcileAcceptedTextIndexCreate(def.Name, mismatched, TextIndexBackfillStats{}, acceptedErr); !errors.Is(err, acceptedCause) || !strings.Contains(err.Error(), "did not reconcile exact index") {
+		t.Fatalf("mismatched accepted create err=%v want original conflict plus exact-state diagnostic", err)
+	}
+	if _, err := col.reconcileAcceptedTextIndexDrop(def.Name, acceptedErr); !errors.Is(err, acceptedCause) || !strings.Contains(err.Error(), "left index") {
+		t.Fatalf("mismatched accepted drop err=%v want original conflict plus presence diagnostic", err)
+	}
+
+	dropCalls := 0
+	dropped, err := col.dropTextIndexWithRetry(def.Name, func(name string) (*CollectionMeta, error) {
+		dropCalls++
+		meta, dropErr := col.dropTextIndexOnce(name)
+		if dropErr != nil {
+			return meta, dropErr
+		}
+		return meta, acceptedErr
+	})
+	if err != nil {
+		t.Fatalf("reconcile accepted drop: %v", err)
+	}
+	if dropCalls != 1 {
+		t.Fatalf("drop attempts=%d want 1 logical publication", dropCalls)
+	}
+	if _, ok := findTextIndex(dropped.TextIndexes, def.Name); ok {
+		t.Fatalf("dropped metadata still contains %q", def.Name)
+	}
+	if _, err := col.DropTextIndex(def.Name); !errors.Is(err, ErrIndexNotFound) {
+		t.Fatalf("ordinary missing drop err=%v want ErrIndexNotFound", err)
+	}
+
+	terminalCause := errors.New("injected storage failure")
+	terminalErr := acceptedTextIndexCommitErrorForTest{error: terminalCause}
+	terminalCalls := 0
+	if _, _, err := col.createTextIndexWithRetry(def, func(TextIndexDefinition) (*CollectionMeta, TextIndexBackfillStats, error) {
+		terminalCalls++
+		return nil, TextIndexBackfillStats{}, terminalErr
+	}); !errors.Is(err, terminalCause) {
+		t.Fatalf("non-conflict accepted create err=%v want original storage failure", err)
+	}
+	if terminalCalls != 1 {
+		t.Fatalf("non-conflict accepted create attempts=%d want no logical replay", terminalCalls)
+	}
+	if _, ok := findTextIndex(col.meta.TextIndexes, def.Name); ok {
+		t.Fatalf("non-conflict accepted error unexpectedly recreated %q", def.Name)
+	}
+}
+
+func TestCollectionMutationRetryDoesNotReplayAcceptedPublication(t *testing.T) {
+	cause := errors.New("accepted root conflict")
+	wantErr := acceptedTextIndexCommitErrorForTest{error: fmt.Errorf("durable-root candidate base changed: %w", cause)}
+	attempts := 0
+	_, err := retryInsertBatchMutation(func() ([][]byte, error) {
+		attempts++
+		return nil, wantErr
+	})
+	if !errors.Is(err, cause) {
+		t.Fatalf("retryInsertBatchMutation err=%v want accepted conflict", err)
+	}
+	if attempts != 1 {
+		t.Fatalf("retryInsertBatchMutation attempts=%d want no logical replay", attempts)
 	}
 }
 

--- a/TreeDB/db/db.go
+++ b/TreeDB/db/db.go
@@ -745,6 +745,47 @@ func wrapFinalizeCommitError(err error, cleanupCreatedSegmentsSafe bool) error {
 	}
 }
 
+type acceptedFinalizeCommitError struct {
+	err error
+}
+
+func (e *acceptedFinalizeCommitError) Error() string {
+	if e == nil || e.err == nil {
+		return ""
+	}
+	return e.err.Error()
+}
+
+func (e *acceptedFinalizeCommitError) Unwrap() error {
+	if e == nil {
+		return nil
+	}
+	return e.err
+}
+
+func (e *acceptedFinalizeCommitError) CommitPublicationAccepted() bool {
+	return e != nil
+}
+
+func wrapAcceptedFinalizeCommitError(err error) error {
+	if err == nil {
+		return nil
+	}
+	return &acceptedFinalizeCommitError{err: err}
+}
+
+// CommitPublicationAccepted reports whether err was returned after root
+// publication ownership transferred and the candidate became visible. Such an
+// error may still describe an unsatisfied admission or durability obligation;
+// callers must not replay the logical mutation as though publication never
+// happened.
+func CommitPublicationAccepted(err error) bool {
+	var accepted interface {
+		CommitPublicationAccepted() bool
+	}
+	return errors.As(err, &accepted) && accepted.CommitPublicationAccepted()
+}
+
 func finalizeCommitErrorAllowsCreatedSegmentCleanup(err error) bool {
 	var commitErr *finalizeCommitError
 	return errors.As(err, &commitErr) && commitErr.cleanupCreatedSegmentsSafe

--- a/TreeDB/db/root_publication_activation.go
+++ b/TreeDB/db/root_publication_activation.go
@@ -702,12 +702,12 @@ func (db *DB) finalizeQueuedRootPublicationV1(
 	}
 	if err := runtime.coordinator.WaitForAdmission(context.Background(), receipt); err != nil {
 		post = db.finalizeAcceptedCommitPostWorkOnError(post)
-		return post, wrapFinalizeCommitError(publicRootPublicationErrorV1(err), false)
+		return post, wrapAcceptedFinalizeCommitError(publicRootPublicationErrorV1(err))
 	}
 	if syncWrite && !db.commandWAL {
 		if err := runtime.coordinator.WaitThrough(context.Background(), next.CommitSeq); err != nil {
 			post = db.finalizeAcceptedCommitPostWorkOnError(post)
-			return post, wrapFinalizeCommitError(publicRootPublicationErrorV1(err), false)
+			return post, wrapAcceptedFinalizeCommitError(publicRootPublicationErrorV1(err))
 		}
 	}
 	return post, nil

--- a/TreeDB/db/root_publication_activation_test.go
+++ b/TreeDB/db/root_publication_activation_test.go
@@ -6,8 +6,32 @@ import (
 	"testing"
 	"time"
 
+	"github.com/snissn/gomap/TreeDB/internal/iterator"
 	"github.com/snissn/gomap/TreeDB/internal/rootpublication"
 )
+
+func TestCommitPublicationAcceptedClassifiesOnlyPostAcceptanceErrors(t *testing.T) {
+	accepted := wrapAcceptedFinalizeCommitError(errTestWriteMetaFailpoint)
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{name: "nil", err: nil, want: false},
+		{name: "plain", err: errTestWriteMetaFailpoint, want: false},
+		{name: "pre-accept safe", err: wrapFinalizeCommitError(errTestWriteMetaFailpoint, true), want: false},
+		{name: "ambiguous not accepted", err: wrapFinalizeCommitError(ErrRecoveryRequired, false), want: false},
+		{name: "accepted", err: accepted, want: true},
+		{name: "wrapped accepted", err: errors.Join(errors.New("outer"), accepted), want: true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := CommitPublicationAccepted(tc.err); got != tc.want {
+				t.Fatalf("CommitPublicationAccepted(%v)=%t want %t", tc.err, got, tc.want)
+			}
+		})
+	}
+}
 
 func TestActivatedRootPublicationTripsFormerDirectPublisher(t *testing.T) {
 	database, err := Open(Options{Dir: t.TempDir(), Durability: DurabilityWALOffRelaxed})
@@ -316,6 +340,9 @@ func TestRootPublicationBuildGroupCommandWALAcceptedWaitFailureDoesNotPoisonOpen
 	if !errors.Is(err, errTestWriteMetaFailpoint) {
 		t.Fatalf("accepted build-group wait error=%v, want retryable meta failpoint", err)
 	}
+	if !CommitPublicationAccepted(err) {
+		t.Fatalf("accepted build-group wait error=%v was not marked post-acceptance", err)
+	}
 	if errors.Is(err, ErrRecoveryRequired) {
 		t.Fatalf("accepted build-group wait error=%v unexpectedly requires recovery", err)
 	}
@@ -333,6 +360,40 @@ func TestRootPublicationBuildGroupCommandWALAcceptedWaitFailureDoesNotPoisonOpen
 	}
 	if err := database.SetSync([]byte("after-group"), []byte("same-handle-progress")); err != nil {
 		t.Fatalf("SetSync after accepted build-group error: %v", err)
+	}
+}
+
+func TestOrderedRootSystemBuilderAcceptedWaitErrorIsClassified(t *testing.T) {
+	database, err := Open(Options{
+		Dir:                    t.TempDir(),
+		Durability:             DurabilityWALOffRelaxed,
+		DisableBackgroundPrune: true,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		database.testFailWriteMeta.Store(false)
+		_ = database.Close()
+	}()
+
+	database.testRootPublicationDependencyBytes.Store(rootpublication.HardPendingBytes + 1)
+	database.testFailWriteMeta.Store(true)
+	_, _, err = database.PublishOrderedRootDeltaGroupWithSystemBuilder(nil, func([]uint64) (iterator.UnsafeIterator, error) {
+		return mustFrozenSystemMemtable(t, "accepted/system-schema", "visible-before-durable").NewIterator(nil, nil), nil
+	})
+	database.testFailWriteMeta.Store(false)
+	if !errors.Is(err, errTestWriteMetaFailpoint) {
+		t.Fatalf("accepted ordered-root wait error=%v, want retryable meta failpoint", err)
+	}
+	if !CommitPublicationAccepted(err) {
+		t.Fatalf("accepted ordered-root wait error=%v was not marked post-acceptance", err)
+	}
+	if errors.Is(err, ErrRecoveryRequired) {
+		t.Fatalf("accepted ordered-root wait error=%v unexpectedly requires recovery", err)
+	}
+	if err := database.Checkpoint(); err != nil {
+		t.Fatalf("Checkpoint retrying accepted ordered-root publication: %v", err)
 	}
 }
 


### PR DESCRIPTION
Closes #3843.

## Summary

- Mark root-publication errors returned after coordinator ownership transfer with a package-supported accepted-publication predicate.
- Prevent generic collection mutation retries from executing an already-accepted logical mutation again.
- For the known retryable durable-root conflict class, settle the accepted candidate through `Checkpoint`, reload the current collection catalog, and return success only when create matches the exact normalized text-index definition or drop confirms absence.
- Preserve the original error for non-conflict accepted outcomes, failed settlement, catalog reload failures, or exact-state mismatches.
- Preserve ordinary duplicate-index and index-not-found behavior.

## Failure contract

Proof-B run `29544192920` at predecessor PR #3842 head `c80259612346237b8c64265d773808372c7ff83c` passed 13/14 TreeDB jobs. `windows-core-1` alone failed `TestTextV2HardeningConcurrentRewriteCreateDropSearchWrite2734` when its single-owner create/drop loop observed `collections: duplicate index "volatile"` after an accepted schema publication was retried.

Failure job: https://github.com/snissn/gomap/actions/runs/29544192920/job/87772681817

## Local validation

On rebased head `11162ba74` over current main `aea072600`:

- accepted-publication DB and collections regressions: 100 iterations
- named concurrent rewrite/create/drop/search/write hardening test: 100 iterations
- accepted root-publication DB suite under `-race`: 10 iterations
- accepted collections regressions plus named hardening test under `-race`: 20 iterations
- `GOWORK=off go vet ./TreeDB/db ./TreeDB/collections`
- `git diff origin/main...HEAD --check`

On the identical patch before the non-overlapping #3835 main rebase:

- full `./TreeDB/collections`: passed in 177s
- full `./TreeDB/collections -race`: passed in 306s
- full `./TreeDB/db`: passed in 301s

The first full collections race process hit a Go runtime SIGSEGV in `runtime.startTheWorld` from an unrelated `testing.AllocsPerRun` allocation-slope test. Host memory remained available, the exact test then passed 100/100 under race, and the single classified exact-command retry passed. No further retry was used.

Full exact-base package validation and hosted actual/proof-A/proof-B TreeDB matrices will be added before merge.
