### PR TITLE
TreeDB: retain stale rewrite leaf cleanup debt

### DIFF
--- a/TreeDB/db/vlog_rewrite.go
+++ b/TreeDB/db/vlog_rewrite.go
@@ -116,6 +116,10 @@ type ValueLogRewriteStats struct {
 	// retained because the recoverable-root basis changed during cleanup.
 	SourceSegmentsRetainedRecoverableRootStale int
 	SourceBytesRetainedRecoverableRootStale    int64
+	// LeafGenerationCleanupRetainedRecoverableRootStale reports that the
+	// post-rewrite leaf-generation cleanup retained its candidates because the
+	// recoverable-root basis changed after pointer swaps committed.
+	LeafGenerationCleanupRetainedRecoverableRootStale bool
 
 	TemplateRecordsAttempted int
 	TemplateRecordsKept      int
@@ -2216,10 +2220,11 @@ func (db *DB) valueLogRewriteOnline(ctx context.Context, opts ValueLogRewriteOnl
 		return stats, err
 	}
 	if db.indexOuterLeavesInValueLog && stats.RecordsCopied > 0 {
-		if _, err := db.leafGenerationGC(context.WithoutCancel(ctx), LeafGenerationGCOptions{
+		_, cleanupErr := db.leafGenerationGC(context.WithoutCancel(ctx), LeafGenerationGCOptions{
 			ProtectedRootIDs:       db.valueLogRewriteLeafGenerationProtectedRootIDs(opts),
 			ProtectedSystemRootIDs: db.valueLogRewriteLeafGenerationProtectedSystemRootIDs(opts),
-		}, false); err != nil {
+		}, false)
+		if err := finishValueLogRewriteLeafGenerationCleanup(&stats, cleanupErr); err != nil {
 			return stats, err
 		}
 	}
@@ -2238,6 +2243,19 @@ func (db *DB) valueLogRewriteOnline(ctx context.Context, opts ValueLogRewriteOnl
 		return stats, canceledErr
 	}
 	return stats, nil
+}
+
+func finishValueLogRewriteLeafGenerationCleanup(stats *ValueLogRewriteStats, err error) error {
+	if err == nil {
+		return nil
+	}
+	if !errors.Is(err, ErrRecoverableRootSetStale) {
+		return err
+	}
+	if stats != nil {
+		stats.LeafGenerationCleanupRetainedRecoverableRootStale = true
+	}
+	return nil
 }
 
 func (db *DB) valueLogRewriteLeafGenerationProtectedRootIDs(opts ValueLogRewriteOnlineOptions) []uint64 {

--- a/TreeDB/db/vlog_rewrite_test.go
+++ b/TreeDB/db/vlog_rewrite_test.go
@@ -1037,6 +1037,109 @@ func TestValueLogRewriteOnline_RewritesCollectionLeafRefRootPointers(t *testing.
 	}
 }
 
+func TestValueLogRewriteOnline_RetainsStaleTrailingLeafGenerationCleanup(t *testing.T) {
+	db, leafLog := openLeafGenerationGCTestDB(t)
+	dir := db.dir
+
+	ptr := appendPointersInNewSegment(t, dir, 0, 1, 521_000, 1, func(int) []byte {
+		return bytes.Repeat([]byte("collection-online-stale-leaf-gc|"), 24)
+	})[0]
+	if err := db.RefreshValueLogSet(); err != nil {
+		t.Fatalf("refresh value log set: %v", err)
+	}
+	_, rootIDs, err := db.PublishOrderedRootGroupWithSystemBuilder([]OrderedRootPublishInput{{
+		BaseRoot:      0,
+		Iter:          mustFrozenSystemPointerMemtable(t, "doc/p", ptr).NewIterator(nil, nil),
+		StoragePolicy: OrderedRootStorageValueLogLeaves,
+	}}, func(rootIDs []uint64) (iterator.UnsafeIterator, error) {
+		if len(rootIDs) != 1 {
+			return nil, fmt.Errorf("rootIDs=%d want 1", len(rootIDs))
+		}
+		return mustFrozenRawMemtable(t, maintenanceTestCollectionRootKey, encodeMaintenanceRootID(rootIDs[0])).NewIterator(nil, nil), nil
+	})
+	if err != nil {
+		t.Fatalf("publish collection leaf-ref root: %v", err)
+	}
+	oldRoot := rootIDs[0]
+	oldLeafPtrs := requireLeafLogRootChildren(t, db, oldRoot)
+	if err := leafLog.Sync(); err != nil {
+		t.Fatalf("sync leaf log: %v", err)
+	}
+
+	scanEntered := make(chan struct{})
+	releaseScan := make(chan struct{})
+	var paused atomic.Bool
+	unregister := registerLeafGenerationLiveScanHook(func() {
+		if paused.CompareAndSwap(false, true) {
+			close(scanEntered)
+			<-releaseScan
+		}
+	})
+	defer unregister()
+
+	type rewriteResult struct {
+		stats ValueLogRewriteStats
+		err   error
+	}
+	done := make(chan rewriteResult, 1)
+	go func() {
+		stats, err := db.ValueLogRewriteOnline(context.Background(), ValueLogRewriteOnlineOptions{
+			SourceFileIDs: []uint32{ptr.FileID},
+			BatchSize:     1,
+		})
+		done <- rewriteResult{stats: stats, err: err}
+	}()
+	select {
+	case <-scanEntered:
+	case <-time.After(5 * time.Second):
+		close(releaseScan)
+		t.Fatal("online rewrite did not enter trailing leaf-generation scan")
+	}
+	if err := db.Checkpoint(); err != nil {
+		close(releaseScan)
+		t.Fatalf("checkpoint while trailing leaf-generation scan paused: %v", err)
+	}
+	close(releaseScan)
+
+	var result rewriteResult
+	select {
+	case result = <-done:
+	case <-time.After(15 * time.Second):
+		t.Fatal("online rewrite did not finish after releasing leaf-generation scan")
+	}
+	if result.err != nil {
+		t.Fatalf("ValueLogRewriteOnline: %v", result.err)
+	}
+	if !result.stats.LeafGenerationCleanupRetainedRecoverableRootStale {
+		t.Fatalf("retained stale leaf-generation cleanup=false, stats=%+v", result.stats)
+	}
+	if result.stats.RecordsCopied != 1 {
+		t.Fatalf("records copied=%d want 1, stats=%+v", result.stats.RecordsCopied, result.stats)
+	}
+	for _, ptr := range oldLeafPtrs {
+		path := leafLogSegmentPath(t, dir, ptr.FileID)
+		if _, err := os.Stat(path); err != nil {
+			t.Fatalf("stale trailing cleanup removed recoverable leaf segment %s: %v", path, err)
+		}
+	}
+	want := bytes.Repeat([]byte("collection-online-stale-leaf-gc|"), 24)
+	if got := readCollectionRootValue(t, db, maintenanceTestCollectionRootKey, []byte("doc/p")); !bytes.Equal(got, want) {
+		t.Fatalf("collection value mismatch after retained stale leaf-generation cleanup")
+	}
+}
+
+func TestFinishValueLogRewriteLeafGenerationCleanup_ReturnsNonStaleError(t *testing.T) {
+	want := errors.New("leaf-generation cleanup failed")
+	stats := ValueLogRewriteStats{}
+	got := finishValueLogRewriteLeafGenerationCleanup(&stats, want)
+	if !errors.Is(got, want) {
+		t.Fatalf("cleanup error=%v want %v", got, want)
+	}
+	if stats.LeafGenerationCleanupRetainedRecoverableRootStale {
+		t.Fatalf("non-stale cleanup marked as retained debt: %+v", stats)
+	}
+}
+
 func TestValueLogRewriteOnline_CollectionRootCommitUsesCurrentStoragePolicy(t *testing.T) {
 	db, leafLog := openLeafGenerationGCTestDB(t)
 	dir := db.dir


### PR DESCRIPTION
Closes #3846

Parent tracker: #3776
Blocks #3843 / PR #3845 until this PR merges and the downstream branch refreshes.

## Summary

- preserve committed online-rewrite progress when only the trailing leaf-generation cleanup loses its recoverable-root race
- record that deferred cleanup explicitly in `ValueLogRewriteStats.LeafGenerationCleanupRetainedRecoverableRootStale`
- continue returning every non-stale leaf-generation cleanup error
- add a deterministic regression that pauses the trailing live scan, advances the durable root, and proves the stale plan removes no recoverable leaf segment while the rewritten value remains readable

## Root cause and retry boundary

PR #3811 correctly made destructive maintenance fail closed when a `RecoverableRootSet` changes. `ValueLogRewriteOnline` already treats that sentinel from value-segment retirement as retained cleanup debt because its pointer swaps are committed and the stale plan deleted nothing. The trailing leaf-generation GC ran after the same commit boundary but propagated the sentinel as if the whole rewrite had failed.

This patch does not retry that stale destructive plan. It reports successful committed rewrite progress plus explicit retained cleanup debt. Any cleanup error that is not `ErrRecoverableRootSetStale` remains terminal.

## Failure evidence

Exact #3845 head `11162ba745cc6733faf2337ea309d1d4b7a6d2d7` failed TreeDB run [29547134465](https://github.com/snissn/gomap/actions/runs/29547134465), job [87781761190](https://github.com/snissn/gomap/actions/runs/29547134465/job/87781761190):

```text
TestCachedManualMaintenanceDirectPointersRemainReopenable_WALOn
maintenance round 0: rewrite round 0: treedb: recoverable root set changed
```

No failed-job rerun was used.

## Test-first evidence

Before the implementation, the new deterministic regression failed with:

```text
ValueLogRewriteOnline: treedb: recoverable root set changed
```

After the implementation:

- deterministic DB regression and non-stale classifier: 100 repetitions
- deterministic DB regression under `-race`: 10 repetitions
- original hosted caching regression: 100 repetitions
- original hosted caching regression under `-race`: 20 repetitions
- full `TreeDB/caching`: normal and race
- full `TreeDB/db`: pass in `341.362s`
- `go vet ./TreeDB/db ./TreeDB/caching`
- `git diff --check`

Exact-current-base hosted TreeDB matrices, exact-head Codex review, and zero unresolved threads remain required before merge.

## Non-goals

- weakening recoverable-root revalidation or deletion safety
- retrying a stale destructive plan in place
- treating arbitrary maintenance errors as success
- changing value-log persistence, GC reachability, on-disk formats, or public storage policy
