### PR TITLE
test(treedb): isolate allocation-only CI gates

### DIFF
--- a/TreeDB/collections/column_physical_query_test.go
+++ b/TreeDB/collections/column_physical_query_test.go
@@ -2916,6 +2916,9 @@ func TestColumnPhysicalQueryStringKeyFallbackAllocationsM13B(t *testing.T) {
 	if _, err := exec.stringKey(stringValue); err != nil {
 		t.Fatalf("warm string stringKey: %v", err)
 	}
+	if collectionsRaceEnabled {
+		t.Skip("exact allocation counts are not stable under race instrumentation")
+	}
 
 	if allocs := testing.AllocsPerRun(100, func() {
 		got, err := exec.stringKey(bytesValue)
@@ -2943,6 +2946,15 @@ func TestColumnPhysicalQueryAdapterAllocationSlopeM13B(t *testing.T) {
 	large, closeLarge := openColumnPhysicalQueryFixtureM13B(t, largeEvents)
 	defer closeLarge()
 	req := ColumnPhysicalQueryRequest{Kind: ColumnPhysicalQueryGroupCount, GroupColumn: "kind"}
+	if _, err := small.RunColumnPhysicalQuery(req); err != nil {
+		t.Fatalf("warm small RunColumnPhysicalQuery: %v", err)
+	}
+	if _, err := large.RunColumnPhysicalQuery(req); err != nil {
+		t.Fatalf("warm large RunColumnPhysicalQuery: %v", err)
+	}
+	if collectionsRaceEnabled {
+		t.Skip("exact allocation counts are not stable under race instrumentation")
+	}
 
 	smallAllocs := testing.AllocsPerRun(5, func() {
 		if _, err := small.RunColumnPhysicalQuery(req); err != nil {
@@ -2994,6 +3006,9 @@ func TestColumnPhysicalQueryRunnerParityAndAllocationM1634(t *testing.T) {
 		if result.Diagnostics.SegmentFileCacheMisses != 0 {
 			t.Fatalf("runner diagnostics=%+v want no per-run segment cache misses after prepared dictionary-code setup", result.Diagnostics)
 		}
+	}
+	if collectionsRaceEnabled {
+		t.Skip("exact allocation counts are not stable under race instrumentation")
 	}
 
 	allocs := testing.AllocsPerRun(20, func() {
@@ -3047,6 +3062,9 @@ func TestColumnPhysicalQueryRunnerDistinctSidecarParityAndAllocationM1634(t *tes
 		if result.Diagnostics.SegmentFileCacheMisses != 0 {
 			t.Fatalf("runner diagnostics=%+v want no per-run segment cache misses after prepared dictionary-code setup", result.Diagnostics)
 		}
+	}
+	if collectionsRaceEnabled {
+		t.Skip("exact allocation counts are not stable under race instrumentation")
 	}
 
 	allocs := testing.AllocsPerRun(20, func() {
@@ -3105,6 +3123,9 @@ func TestColumnPhysicalQueryRunnerInt64ValueSidecarParityAndAllocationM1634(t *t
 			t.Fatalf("runner diagnostics=%+v want no per-run segment cache misses after prepared int64 sidecar setup", result.Diagnostics)
 		}
 		wantGroups = len(result.Groups)
+	}
+	if collectionsRaceEnabled {
+		t.Skip("exact allocation counts are not stable under race instrumentation")
 	}
 
 	allocs := testing.AllocsPerRun(20, func() {
@@ -3183,6 +3204,9 @@ func TestColumnPhysicalQueryRunnerDictInt64SidecarParityAndAllocationM1634(t *te
 					t.Fatalf("runner diagnostics=%+v want no per-run segment cache misses after prepared sidecar setup", result.Diagnostics)
 				}
 				wantGroups = len(result.Groups)
+			}
+			if collectionsRaceEnabled {
+				t.Skip("exact allocation counts are not stable under race instrumentation")
 			}
 			allocs := testing.AllocsPerRun(20, func() {
 				result, err := runner.Run()
@@ -4048,6 +4072,9 @@ func TestColumnPhysicalQuerySerialSidecarAllocationBudgetM1634(t *testing.T) {
 			if result.Diagnostics.RowMaterializations != 0 {
 				t.Fatalf("preview diagnostics=%+v want sidecar path", result.Diagnostics)
 			}
+			if collectionsRaceEnabled {
+				t.Skip("exact allocation counts are not stable under race instrumentation")
+			}
 			allocs := testing.AllocsPerRun(20, func() {
 				result, err := collection.RunColumnPhysicalQuery(tc.req)
 				if err != nil {
@@ -4064,12 +4091,6 @@ func TestColumnPhysicalQuerySerialSidecarAllocationBudgetM1634(t *testing.T) {
 				// Windows CI carries extra runtime/path allocation noise in this
 				// routed one-shot path; keep the stricter budget on Unix hosts
 				// where the #1634 performance evidence is collected.
-				maxAllocs += 32
-			}
-			if collectionsRaceEnabled {
-				// The race detector instruments this routed allocation-budget
-				// path and shifts AllocsPerRun upward. Keep the normal budget
-				// strict for the performance evidence builds.
 				maxAllocs += 32
 			}
 			if allocs > maxAllocs {
@@ -4253,6 +4274,9 @@ func TestColumnPhysicalQueryRunnerAggregateMetadataParityAndAllocationM1634(t *t
 				if result.Diagnostics.PhysicalBytesScanned <= 0 || result.Diagnostics.PhysicalBytesScanned != baseline.Diagnostics.PhysicalBytesScanned {
 					t.Fatalf("runner physical bytes=%d want metadata bytes=%d", result.Diagnostics.PhysicalBytesScanned, baseline.Diagnostics.PhysicalBytesScanned)
 				}
+			}
+			if collectionsRaceEnabled {
+				t.Skip("exact allocation counts are not stable under race instrumentation")
 			}
 			allocs := testing.AllocsPerRun(20, func() {
 				result, err := runner.Run()

--- a/TreeDB/collections/column_vector_graph_search_test.go
+++ b/TreeDB/collections/column_vector_graph_search_test.go
@@ -1037,6 +1037,9 @@ func TestColumnVectorGraphNativeSearchWarmScratchZeroAllocsV3(t *testing.T) {
 	if collectionsRaceEnabled {
 		t.Skip("AllocsPerRun is not stable under -race")
 	}
+	if !enterIsolatedVectorAllocationGate(t, "native-search-warm-scratch") {
+		return
+	}
 	var hotErr error
 	allocs := testing.AllocsPerRun(1000, func() {
 		if hotErr != nil {

--- a/TreeDB/collections/vector_allocation_isolation_test.go
+++ b/TreeDB/collections/vector_allocation_isolation_test.go
@@ -1,0 +1,57 @@
+package collections
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"regexp"
+	"strings"
+	"testing"
+	"time"
+)
+
+const collectionsVectorAllocationGateEnv = "TREEDB_COLLECTIONS_VECTOR_ALLOCATION_GATE"
+
+// enterIsolatedVectorAllocationGate runs the current test once in a fresh copy
+// of the test binary. testing.AllocsPerRun reads process-global malloc counters,
+// so an exact hot-path contract must not share its measurement process with
+// unrelated collection background work from the full package suite.
+//
+// The parent has already exercised setup, warmup, and correctness assertions.
+// It returns false after the isolated child passes. The selected child returns
+// true and performs the exact allocation measurement below the call site.
+func enterIsolatedVectorAllocationGate(t *testing.T, gate string) bool {
+	t.Helper()
+
+	selected := os.Getenv(collectionsVectorAllocationGateEnv)
+	if selected != "" {
+		if selected != gate {
+			t.Fatalf("isolated vector allocation gate selector=%q want %q", selected, gate)
+		}
+		return true
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, os.Args[0],
+		"-test.run=^"+regexp.QuoteMeta(t.Name())+"$",
+		"-test.count=1",
+		"-test.timeout=90s",
+	)
+	prefix := collectionsVectorAllocationGateEnv + "="
+	cmd.Env = make([]string, 0, len(os.Environ())+1)
+	for _, entry := range os.Environ() {
+		if !strings.HasPrefix(entry, prefix) {
+			cmd.Env = append(cmd.Env, entry)
+		}
+	}
+	cmd.Env = append(cmd.Env, prefix+gate)
+	output, err := cmd.CombinedOutput()
+	if ctx.Err() != nil {
+		t.Fatalf("isolated vector allocation gate %q timed out: %v\n%s", gate, ctx.Err(), output)
+	}
+	if err != nil {
+		t.Fatalf("isolated vector allocation gate %q: %v\n%s", gate, err, output)
+	}
+	return false
+}

--- a/TreeDB/collections/vector_index_search_test.go
+++ b/TreeDB/collections/vector_index_search_test.go
@@ -3946,6 +3946,12 @@ func TestVectorIndexSearcherSearchWithBufferResultEquivalenceAndZeroAllocs2124(t
 	if _, err := bufferedSearcher.SearchWithBuffer(opts, &buffer); err != nil {
 		t.Fatalf("warm SearchWithBuffer for allocation check: %v", err)
 	}
+	if collectionsRaceEnabled {
+		t.Skip("AllocsPerRun is not stable under -race")
+	}
+	if !enterIsolatedVectorAllocationGate(t, "search-with-buffer") {
+		return
+	}
 	var sink int
 	allocs := testing.AllocsPerRun(1000, func() {
 		got, err := bufferedSearcher.SearchWithBuffer(opts, &buffer)


### PR DESCRIPTION
Closes #3848.
Closes #3849.

Parent tracker: #3776.

## Summary

- run the two observed warm vector exact-allocation contracts in isolated copies of the same test binary, preserving their exact zero-allocation assertions
- keep physical-query setup, warm queries, parity, result, and diagnostic checks active under race instrumentation while skipping only exact allocation sampling
- retain all ten physical-query normal-mode allocation counts, slopes, and budgets unchanged
- fail closed if an isolated vector child receives the wrong gate selector or exceeds its bounded timeout

## Failure Classification

PR #3847's Ubuntu job reported one allocation in both vector gates while an exact-SHA proof job and repeated local Go 1.26.0/1.26.5 runs passed. Fallback CPU dispatch reproduced one gate once in 100 iterations. `testing.AllocsPerRun` samples process-global allocation counters, so unrelated package background work can contaminate an exact-zero gate.

During the fix, the full collections race suite then crashed in `runtime.startTheWorld` from `testing.AllocsPerRun` inside a physical-query allocation test. Exact allocation measurement is not a valid race-instrumented contract; the functional path remains covered before the measurement-only skip.

No normal allocation threshold, production behavior, durability rule, timeout, or Windows budget is relaxed.

## Local Evidence

- affected vector/physical-query tests, normal: `-count=20` pass
- affected vector/physical-query tests, race: `-count=10` pass
- affected vector/physical-query tests, Go 1.26.5 normal: `-count=10` pass
- vector gates with fallback CPU dispatch: `-count=100` pass
- vector gates with Go 1.26.5: `-count=100` pass
- full `GOWORK=off go test ./TreeDB/collections -count=1 -timeout=25m`: pass in 179.860s
- full `GOWORK=off go test -race ./TreeDB/collections -count=1 -timeout=25m`: pass in 299.602s; pre-fix crashed after 115.086s
- wrong isolated gate selector: fails closed with the expected selector mismatch
- `GOWORK=off go vet ./TreeDB/collections`: pass
- `git diff --check`: pass

## Hosted Gates

- [ ] latest-head ordinary PR checks
- [ ] exact-head TreeDB PR matrix and independent proof matrices
- [ ] latest-head Codex review clean
- [ ] zero unresolved review threads
- [ ] current-base verification before merge


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved reliability of allocation and performance checks across column and vector query tests.
  * Allocation-sensitive assertions now safely skip when running with the race detector.
  * Added isolated test execution and warmup handling for more stable zero-allocation measurements.
  * Preserved functional and result-equivalence coverage while reducing false failures from unstable allocation counts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->