### PR TITLE
[DUR-08] Sync compacted value-log deletion namespace

### DIFF
--- a/TreeDB/db/compact_storage.go
+++ b/TreeDB/db/compact_storage.go
@@ -1709,14 +1709,14 @@ func (db *DB) pruneZeroByteValueLogFiles(protectedPaths []string) (int, error) {
 		}
 		deleted++
 	}
-	if deleted > 0 && db.valueLogManager != nil {
-		if err := db.valueLogManager.Refresh(); err != nil {
-			return deleted, err
-		}
-	}
 	if deleted > 0 {
 		if err := syncDeletionNamespaceDirectory(layout.valueVLogDir, durabilitycut.ResourceValueLog); err != nil {
 			return deleted, fmt.Errorf("compact storage: sync value-log deletion namespace: %w", err)
+		}
+		if db.valueLogManager != nil {
+			if err := db.valueLogManager.Refresh(); err != nil {
+				return deleted, err
+			}
 		}
 	}
 	return deleted, nil

--- a/TreeDB/db/compact_storage.go
+++ b/TreeDB/db/compact_storage.go
@@ -1681,11 +1681,29 @@ func (db *DB) pruneZeroByteValueLogFiles(protectedPaths []string) (int, error) {
 					if err := db.publishValueLogSetNoRefresh(); err != nil {
 						return deleted, err
 					}
-					if removed, err := db.valueLogManager.RemoveSegmentIfUnpinned(fileID); err != nil {
-						return deleted, errors.Join(err, ErrRecoveryRequired)
-					} else if removed {
+					var removed bool
+					var removeErr error
+					if hook := db.testCompactStorageRemoveValueLogSegmentHook; hook != nil {
+						removed, removeErr = hook(fileID)
+					} else {
+						removed, removeErr = db.valueLogManager.RemoveSegmentIfUnpinned(fileID)
+					}
+					if removed {
 						deleted++
 						deletionNamespaceDirty = true
+					}
+					if removeErr != nil {
+						var syncErr error
+						if deletionNamespaceDirty {
+							syncErr = db.syncDeletionNamespaceDirectoryOrPoison(
+								layout.valueVLogDir,
+								durabilitycut.ResourceValueLog,
+								"compact storage: sync value-log deletion namespace",
+							)
+						}
+						return deleted, errors.Join(removeErr, ErrRecoveryRequired, syncErr)
+					}
+					if removed {
 						continue
 					}
 					if _, err := os.Stat(path); err != nil {
@@ -1713,8 +1731,12 @@ func (db *DB) pruneZeroByteValueLogFiles(protectedPaths []string) (int, error) {
 		deletionNamespaceDirty = true
 	}
 	if deletionNamespaceDirty {
-		if err := syncDeletionNamespaceDirectory(layout.valueVLogDir, durabilitycut.ResourceValueLog); err != nil {
-			return deleted, fmt.Errorf("compact storage: sync value-log deletion namespace: %w", err)
+		if err := db.syncDeletionNamespaceDirectoryOrPoison(
+			layout.valueVLogDir,
+			durabilitycut.ResourceValueLog,
+			"compact storage: sync value-log deletion namespace",
+		); err != nil {
+			return deleted, err
 		}
 	}
 	if deleted > 0 {

--- a/TreeDB/db/compact_storage.go
+++ b/TreeDB/db/compact_storage.go
@@ -1637,6 +1637,7 @@ func (db *DB) pruneZeroByteValueLogFiles(protectedPaths []string) (int, error) {
 	protected := compactStorageProtectedPathSet(protectedPaths)
 	protectedFileIDs := compactStorageProtectedFileIDSet(protectedPaths, currentIDs)
 	deleted := 0
+	deletionNamespaceDirty := false
 	for _, entry := range entries {
 		if entry.IsDir() {
 			continue
@@ -1684,6 +1685,7 @@ func (db *DB) pruneZeroByteValueLogFiles(protectedPaths []string) (int, error) {
 						return deleted, errors.Join(err, ErrRecoveryRequired)
 					} else if removed {
 						deleted++
+						deletionNamespaceDirty = true
 						continue
 					}
 					if _, err := os.Stat(path); err != nil {
@@ -1708,11 +1710,14 @@ func (db *DB) pruneZeroByteValueLogFiles(protectedPaths []string) (int, error) {
 			continue
 		}
 		deleted++
+		deletionNamespaceDirty = true
 	}
-	if deleted > 0 {
+	if deletionNamespaceDirty {
 		if err := syncDeletionNamespaceDirectory(layout.valueVLogDir, durabilitycut.ResourceValueLog); err != nil {
 			return deleted, fmt.Errorf("compact storage: sync value-log deletion namespace: %w", err)
 		}
+	}
+	if deleted > 0 {
 		if db.valueLogManager != nil {
 			if err := db.valueLogManager.Refresh(); err != nil {
 				return deleted, err

--- a/TreeDB/db/compact_storage.go
+++ b/TreeDB/db/compact_storage.go
@@ -1714,6 +1714,11 @@ func (db *DB) pruneZeroByteValueLogFiles(protectedPaths []string) (int, error) {
 			return deleted, err
 		}
 	}
+	if deleted > 0 {
+		if err := syncDeletionNamespaceDirectory(layout.valueVLogDir, durabilitycut.ResourceValueLog); err != nil {
+			return deleted, fmt.Errorf("compact storage: sync value-log deletion namespace: %w", err)
+		}
+	}
 	return deleted, nil
 }
 

--- a/TreeDB/db/compact_storage_test.go
+++ b/TreeDB/db/compact_storage_test.go
@@ -513,6 +513,132 @@ func TestCompactStorageKeepsPinnedZombieZeroByteValueLogFiles(t *testing.T) {
 	}
 }
 
+func TestCompactStoragePinnedZombieReleaseSyncsDeletionNamespaceBeforeSuccess(t *testing.T) {
+	dir := t.TempDir()
+	opts := Options{Dir: dir}
+	d, err := Open(opts)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	if err := d.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+
+	valueLogDir := ValueLogDirPath(dir)
+	const emptyName = "value-l42-000001.log"
+	emptyPath := filepath.Join(valueLogDir, emptyName)
+	if err := os.WriteFile(emptyPath, nil, 0o644); err != nil {
+		t.Fatalf("write empty value log: %v", err)
+	}
+	fileID, ok := compactStorageValueLogFileID(emptyName)
+	if !ok {
+		t.Fatalf("parse %s failed", emptyName)
+	}
+
+	reopened, err := Open(opts)
+	if err != nil {
+		t.Fatalf("reopen: %v", err)
+	}
+	defer func() { _ = reopened.Close() }()
+	if err := reopened.RefreshValueLogSet(); err != nil {
+		t.Fatalf("explicit maintenance refresh: %v", err)
+	}
+	if reopened.valueLogManager == nil || !reopened.valueLogManager.HasSegment(fileID) {
+		t.Fatalf("expected empty segment %d to be manager-registered", fileID)
+	}
+	pinned := reopened.AcquireSnapshot()
+	if pinned == nil {
+		t.Fatal("expected pinned snapshot")
+	}
+	if _, err := reopened.CompactStorage(context.Background(), CompactStorageOptions{}); err != nil {
+		_ = pinned.Close()
+		t.Fatalf("CompactStorage: %v", err)
+	}
+	if _, err := os.Stat(emptyPath); err != nil {
+		_ = pinned.Close()
+		t.Fatalf("pinned zombie removed before release: %v", err)
+	}
+
+	var points []durabilitycut.Point
+	restore := durabilitycut.Install(func(event durabilitycut.Event) error {
+		if event.Resource == durabilitycut.ResourceValueLog && filepath.Clean(event.Path) == filepath.Clean(valueLogDir) {
+			if event.Point == durabilitycut.BeforeDeletionDirectorySync || event.Point == durabilitycut.AfterDeletionDirectorySync {
+				points = append(points, event.Point)
+			}
+		}
+		return nil
+	})
+	closeErr := pinned.Close()
+	restore()
+	if closeErr != nil {
+		t.Fatalf("close pinned snapshot: %v", closeErr)
+	}
+	want := []durabilitycut.Point{durabilitycut.BeforeDeletionDirectorySync, durabilitycut.AfterDeletionDirectorySync}
+	if !reflect.DeepEqual(points, want) {
+		t.Fatalf("deferred deletion namespace sync points=%v want=%v", points, want)
+	}
+	if _, err := os.Stat(emptyPath); !os.IsNotExist(err) {
+		t.Fatalf("expected pinned zombie file to delete after release, stat err=%v", err)
+	}
+}
+
+func TestCompactStoragePinnedZombieReleaseSyncFailurePoisonsHandle(t *testing.T) {
+	dir := t.TempDir()
+	opts := Options{Dir: dir}
+	d, err := Open(opts)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	if err := d.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+
+	valueLogDir := ValueLogDirPath(dir)
+	const emptyName = "value-l42-000001.log"
+	emptyPath := filepath.Join(valueLogDir, emptyName)
+	if err := os.WriteFile(emptyPath, nil, 0o644); err != nil {
+		t.Fatalf("write empty value log: %v", err)
+	}
+
+	reopened, err := Open(opts)
+	if err != nil {
+		t.Fatalf("reopen: %v", err)
+	}
+	defer func() { _ = reopened.Close() }()
+	if err := reopened.RefreshValueLogSet(); err != nil {
+		t.Fatalf("explicit maintenance refresh: %v", err)
+	}
+	pinned := reopened.AcquireSnapshot()
+	if pinned == nil {
+		t.Fatal("expected pinned snapshot")
+	}
+	if _, err := reopened.CompactStorage(context.Background(), CompactStorageOptions{}); err != nil {
+		_ = pinned.Close()
+		t.Fatalf("CompactStorage: %v", err)
+	}
+
+	cutErr := errors.New("injected deferred deletion directory sync cut")
+	restore := durabilitycut.Install(func(event durabilitycut.Event) error {
+		if event.Resource == durabilitycut.ResourceValueLog &&
+			event.Point == durabilitycut.BeforeDeletionDirectorySync &&
+			filepath.Clean(event.Path) == filepath.Clean(valueLogDir) {
+			return cutErr
+		}
+		return nil
+	})
+	closeErr := pinned.Close()
+	restore()
+	if !errors.Is(closeErr, cutErr) || !errors.Is(closeErr, ErrRecoveryRequired) {
+		t.Fatalf("close pinned snapshot error=%v, want injected cut and ErrRecoveryRequired", closeErr)
+	}
+	if _, err := os.Stat(emptyPath); !os.IsNotExist(err) {
+		t.Fatalf("post-unlink sync-cut path stat=%v, want removed", err)
+	}
+	if err := reopened.SetSync([]byte("after-deferred-delete-cut"), []byte("blocked")); !errors.Is(err, ErrRecoveryRequired) {
+		t.Fatalf("SetSync after deferred deletion sync cut=%v, want ErrRecoveryRequired", err)
+	}
+}
+
 func TestCompactStoragePlanMatchesAppliedRewriteScopeForLiveOnlySegments(t *testing.T) {
 	dir := t.TempDir()
 	d, err := Open(Options{Dir: dir})

--- a/TreeDB/db/compact_storage_test.go
+++ b/TreeDB/db/compact_storage_test.go
@@ -437,6 +437,87 @@ func TestCompactStorageManagerSegmentDeletionSyncFailureRequiresRecovery(t *test
 	if _, statErr := os.Stat(emptyPath); !os.IsNotExist(statErr) {
 		t.Fatalf("post-unlink sync-cut path stat=%v, want removed", statErr)
 	}
+	if !reopened.publicationPoisoned.Load() {
+		t.Fatal("deletion namespace sync cut did not poison publication")
+	}
+	if err := reopened.SetSync([]byte("post-cut"), []byte("blocked")); !errors.Is(err, ErrRecoveryRequired) {
+		t.Fatalf("SetSync after deletion namespace sync cut error=%v, want ErrRecoveryRequired", err)
+	}
+}
+
+func TestCompactStorageManagerSuccessfulUnlinkCloseErrorSyncsBeforeReturn(t *testing.T) {
+	dir := t.TempDir()
+	opts := Options{Dir: dir}
+	d, err := Open(opts)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	if err := d.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+
+	valueLogDir := ValueLogDirPath(dir)
+	if err := os.MkdirAll(valueLogDir, 0o755); err != nil {
+		t.Fatalf("mkdir value_vlog: %v", err)
+	}
+	const emptyName = "value-l42-000001.log"
+	emptyPath := filepath.Join(valueLogDir, emptyName)
+	if err := os.WriteFile(emptyPath, nil, 0o644); err != nil {
+		t.Fatalf("write empty value log: %v", err)
+	}
+	fileID, ok := compactStorageValueLogFileID(emptyName)
+	if !ok {
+		t.Fatalf("parse %s failed", emptyName)
+	}
+
+	reopened, err := Open(opts)
+	if err != nil {
+		t.Fatalf("reopen: %v", err)
+	}
+	defer func() { _ = reopened.Close() }()
+	if err := reopened.RefreshValueLogSet(); err != nil {
+		t.Fatalf("explicit maintenance refresh: %v", err)
+	}
+	if reopened.valueLogManager == nil || !reopened.valueLogManager.HasSegment(fileID) {
+		t.Fatalf("expected empty segment %d to be manager-registered", fileID)
+	}
+
+	closeErr := errors.New("injected close after successful unlink")
+	reopened.testCompactStorageRemoveValueLogSegmentHook = func(gotFileID uint32) (bool, error) {
+		if gotFileID != fileID {
+			t.Fatalf("remove file ID=%d want=%d", gotFileID, fileID)
+		}
+		removed, err := removePersistentFile(valueLogDir, emptyPath, durabilitycut.ResourceValueLog)
+		if err != nil {
+			t.Fatalf("remove persistent file: %v", err)
+		}
+		return removed, closeErr
+	}
+
+	var points []durabilitycut.Point
+	restore := durabilitycut.Install(func(event durabilitycut.Event) error {
+		if event.Resource == durabilitycut.ResourceValueLog && filepath.Clean(event.Path) == filepath.Clean(valueLogDir) {
+			if event.Point == durabilitycut.BeforeDeletionDirectorySync || event.Point == durabilitycut.AfterDeletionDirectorySync {
+				points = append(points, event.Point)
+			}
+		}
+		return nil
+	})
+	stats, compactErr := reopened.CompactStorage(context.Background(), CompactStorageOptions{})
+	restore()
+	if stats.ZeroByteValueLogFilesDeleted != 1 {
+		t.Fatalf("CompactStorage deleted=%d want=1", stats.ZeroByteValueLogFilesDeleted)
+	}
+	if !errors.Is(compactErr, closeErr) || !errors.Is(compactErr, ErrRecoveryRequired) {
+		t.Fatalf("CompactStorage error=%v, want close error and ErrRecoveryRequired", compactErr)
+	}
+	want := []durabilitycut.Point{durabilitycut.BeforeDeletionDirectorySync, durabilitycut.AfterDeletionDirectorySync}
+	if !reflect.DeepEqual(points, want) {
+		t.Fatalf("deletion namespace sync points=%v want=%v", points, want)
+	}
+	if _, statErr := os.Stat(emptyPath); !os.IsNotExist(statErr) {
+		t.Fatalf("post-unlink close-error path stat=%v, want removed", statErr)
+	}
 }
 
 func TestCompactStorageKeepsPinnedZombieZeroByteValueLogFiles(t *testing.T) {

--- a/TreeDB/db/compact_storage_test.go
+++ b/TreeDB/db/compact_storage_test.go
@@ -483,33 +483,34 @@ func TestCompactStorageManagerSuccessfulUnlinkCloseErrorSyncsBeforeReturn(t *tes
 	}
 
 	closeErr := errors.New("injected close after successful unlink")
+	removeReturned := false
 	reopened.testCompactStorageRemoveValueLogSegmentHook = func(gotFileID uint32) (bool, error) {
 		if gotFileID != fileID {
 			t.Fatalf("remove file ID=%d want=%d", gotFileID, fileID)
 		}
-		removed, err := removePersistentFile(valueLogDir, emptyPath, durabilitycut.ResourceValueLog)
-		if err != nil {
-			t.Fatalf("remove persistent file: %v", err)
+		if err := os.Remove(emptyPath); err != nil && !os.IsNotExist(err) {
+			t.Fatalf("remove value-log file: %v", err)
 		}
-		return removed, closeErr
+		removeReturned = true
+		return true, closeErr
 	}
 
 	var points []durabilitycut.Point
 	restore := durabilitycut.Install(func(event durabilitycut.Event) error {
-		if event.Resource == durabilitycut.ResourceValueLog && filepath.Clean(event.Path) == filepath.Clean(valueLogDir) {
+		if removeReturned && event.Resource == durabilitycut.ResourceValueLog && filepath.Clean(event.Path) == filepath.Clean(valueLogDir) {
 			if event.Point == durabilitycut.BeforeDeletionDirectorySync || event.Point == durabilitycut.AfterDeletionDirectorySync {
 				points = append(points, event.Point)
 			}
 		}
 		return nil
 	})
-	stats, compactErr := reopened.CompactStorage(context.Background(), CompactStorageOptions{})
+	deleted, compactErr := reopened.pruneZeroByteValueLogFiles(nil)
 	restore()
-	if stats.ZeroByteValueLogFilesDeleted != 1 {
-		t.Fatalf("CompactStorage deleted=%d want=1", stats.ZeroByteValueLogFilesDeleted)
-	}
 	if !errors.Is(compactErr, closeErr) || !errors.Is(compactErr, ErrRecoveryRequired) {
-		t.Fatalf("CompactStorage error=%v, want close error and ErrRecoveryRequired", compactErr)
+		t.Fatalf("pruneZeroByteValueLogFiles error=%v, want close error and ErrRecoveryRequired", compactErr)
+	}
+	if deleted != 1 {
+		t.Fatalf("pruneZeroByteValueLogFiles deleted=%d want=1; error=%v", deleted, compactErr)
 	}
 	want := []durabilitycut.Point{durabilitycut.BeforeDeletionDirectorySync, durabilitycut.AfterDeletionDirectorySync}
 	if !reflect.DeepEqual(points, want) {

--- a/TreeDB/db/compact_storage_test.go
+++ b/TreeDB/db/compact_storage_test.go
@@ -383,6 +383,62 @@ func TestCompactStorageManagerSegmentDeletionSyncsNamespaceBeforeSuccess(t *test
 	}
 }
 
+func TestCompactStorageManagerSegmentDeletionSyncFailureRequiresRecovery(t *testing.T) {
+	dir := t.TempDir()
+	opts := Options{Dir: dir}
+	d, err := Open(opts)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	if err := d.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+
+	valueLogDir := ValueLogDirPath(dir)
+	if err := os.MkdirAll(valueLogDir, 0o755); err != nil {
+		t.Fatalf("mkdir value_vlog: %v", err)
+	}
+	const emptyName = "value-l42-000001.log"
+	emptyPath := filepath.Join(valueLogDir, emptyName)
+	if err := os.WriteFile(emptyPath, nil, 0o644); err != nil {
+		t.Fatalf("write empty value log: %v", err)
+	}
+	fileID, ok := compactStorageValueLogFileID(emptyName)
+	if !ok {
+		t.Fatalf("parse %s failed", emptyName)
+	}
+
+	reopened, err := Open(opts)
+	if err != nil {
+		t.Fatalf("reopen: %v", err)
+	}
+	defer func() { _ = reopened.Close() }()
+	if err := reopened.RefreshValueLogSet(); err != nil {
+		t.Fatalf("explicit maintenance refresh: %v", err)
+	}
+	if reopened.valueLogManager == nil || !reopened.valueLogManager.HasSegment(fileID) {
+		t.Fatalf("expected empty segment %d to be manager-registered", fileID)
+	}
+
+	cutErr := errors.New("injected deletion directory sync cut")
+	restore := durabilitycut.Install(func(event durabilitycut.Event) error {
+		if event.Resource == durabilitycut.ResourceValueLog &&
+			event.Point == durabilitycut.BeforeDeletionDirectorySync &&
+			filepath.Clean(event.Path) == filepath.Clean(valueLogDir) {
+			return cutErr
+		}
+		return nil
+	})
+	_, compactErr := reopened.CompactStorage(context.Background(), CompactStorageOptions{})
+	restore()
+	if !errors.Is(compactErr, cutErr) || !errors.Is(compactErr, ErrRecoveryRequired) {
+		t.Fatalf("CompactStorage error=%v, want injected cut and ErrRecoveryRequired", compactErr)
+	}
+	if _, statErr := os.Stat(emptyPath); !os.IsNotExist(statErr) {
+		t.Fatalf("post-unlink sync-cut path stat=%v, want removed", statErr)
+	}
+}
+
 func TestCompactStorageKeepsPinnedZombieZeroByteValueLogFiles(t *testing.T) {
 	dir := t.TempDir()
 	opts := Options{Dir: dir}

--- a/TreeDB/db/compact_storage_test.go
+++ b/TreeDB/db/compact_storage_test.go
@@ -323,6 +323,66 @@ func TestCompactStorageManagerSegmentPostUnlinkCutRequiresRecovery(t *testing.T)
 	}
 }
 
+func TestCompactStorageManagerSegmentDeletionSyncsNamespaceBeforeSuccess(t *testing.T) {
+	dir := t.TempDir()
+	opts := Options{Dir: dir}
+	d, err := Open(opts)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	if err := d.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+
+	valueLogDir := ValueLogDirPath(dir)
+	if err := os.MkdirAll(valueLogDir, 0o755); err != nil {
+		t.Fatalf("mkdir value_vlog: %v", err)
+	}
+	const emptyName = "value-l42-000001.log"
+	emptyPath := filepath.Join(valueLogDir, emptyName)
+	if err := os.WriteFile(emptyPath, nil, 0o644); err != nil {
+		t.Fatalf("write empty value log: %v", err)
+	}
+	fileID, ok := compactStorageValueLogFileID(emptyName)
+	if !ok {
+		t.Fatalf("parse %s failed", emptyName)
+	}
+
+	reopened, err := Open(opts)
+	if err != nil {
+		t.Fatalf("reopen: %v", err)
+	}
+	defer func() { _ = reopened.Close() }()
+	if err := reopened.RefreshValueLogSet(); err != nil {
+		t.Fatalf("explicit maintenance refresh: %v", err)
+	}
+	if reopened.valueLogManager == nil || !reopened.valueLogManager.HasSegment(fileID) {
+		t.Fatalf("expected empty segment %d to be manager-registered", fileID)
+	}
+
+	var points []durabilitycut.Point
+	restore := durabilitycut.Install(func(event durabilitycut.Event) error {
+		if event.Resource == durabilitycut.ResourceValueLog && filepath.Clean(event.Path) == filepath.Clean(valueLogDir) {
+			if event.Point == durabilitycut.BeforeDeletionDirectorySync || event.Point == durabilitycut.AfterDeletionDirectorySync {
+				points = append(points, event.Point)
+			}
+		}
+		return nil
+	})
+	_, compactErr := reopened.CompactStorage(context.Background(), CompactStorageOptions{})
+	restore()
+	if compactErr != nil {
+		t.Fatalf("CompactStorage: %v", compactErr)
+	}
+	want := []durabilitycut.Point{durabilitycut.BeforeDeletionDirectorySync, durabilitycut.AfterDeletionDirectorySync}
+	if !reflect.DeepEqual(points, want) {
+		t.Fatalf("deletion namespace sync points=%v want=%v", points, want)
+	}
+	if _, statErr := os.Stat(emptyPath); !os.IsNotExist(statErr) {
+		t.Fatalf("empty value-log file still exists or stat failed: %v", statErr)
+	}
+}
+
 func TestCompactStorageKeepsPinnedZombieZeroByteValueLogFiles(t *testing.T) {
 	dir := t.TempDir()
 	opts := Options{Dir: dir}

--- a/TreeDB/db/db.go
+++ b/TreeDB/db/db.go
@@ -557,6 +557,7 @@ type DB struct {
 	testOrderedRootBatchAfterClosePreflightHook    func()
 	testStorageMaintenanceBeforeLockHook           func(string)
 	testStorageMaintenanceAfterLockHook            func(string) error
+	testCompactStorageRemoveValueLogSegmentHook    func(uint32) (bool, error)
 	testCommandWALRecoveryFailAfterLSN             atomic.Uint64
 	testCommandWALRecoveryFailBeforeDependencySync atomic.Bool
 	commandWALReplayLSN                            atomic.Uint64

--- a/TreeDB/db/db.go
+++ b/TreeDB/db/db.go
@@ -2161,6 +2161,14 @@ func openWithLock(opts Options, lock *lockfile.Lock) (*DB, error) {
 		ghostManager: &indexGhostManager{},
 		notifyError:  opts.NotifyError,
 	}
+	vm.SetDeferredDeletionSync(func(dir string, resource durabilitycut.Resource) error {
+		err := syncDeletionNamespaceDirectory(dir, resource)
+		if err != nil {
+			db.publicationPoisoned.Store(true)
+			db.reportError(fmt.Errorf("treedb: sync deferred value-log deletion namespace: %w", err))
+		}
+		return err
+	})
 	db.initializeLeafGenerationManifestStore(layout.leafVLogDir, valueLogIdentityPins)
 	db.ghostManager.start()
 	db.idx.Store(gen)

--- a/TreeDB/db/db.go
+++ b/TreeDB/db/db.go
@@ -2163,12 +2163,11 @@ func openWithLock(opts Options, lock *lockfile.Lock) (*DB, error) {
 		notifyError:  opts.NotifyError,
 	}
 	vm.SetDeferredDeletionSync(func(dir string, resource durabilitycut.Resource) error {
-		err := syncDeletionNamespaceDirectory(dir, resource)
-		if err != nil {
-			db.publicationPoisoned.Store(true)
-			db.reportError(fmt.Errorf("treedb: sync deferred value-log deletion namespace: %w", err))
-		}
-		return err
+		return db.syncDeletionNamespaceDirectoryOrPoison(
+			dir,
+			resource,
+			"treedb: sync deferred value-log deletion namespace",
+		)
 	})
 	db.initializeLeafGenerationManifestStore(layout.leafVLogDir, valueLogIdentityPins)
 	db.ghostManager.start()

--- a/TreeDB/db/namespace_mutation.go
+++ b/TreeDB/db/namespace_mutation.go
@@ -2,6 +2,7 @@ package db
 
 import (
 	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 
@@ -117,4 +118,17 @@ func syncDeletionNamespaceDirectory(dir string, resource durabilitycut.Resource)
 		durabilitycut.BeforeDeletionDirectorySync,
 		durabilitycut.AfterDeletionDirectorySync,
 	)
+}
+
+func (db *DB) syncDeletionNamespaceDirectoryOrPoison(dir string, resource durabilitycut.Resource, operation string) error {
+	err := syncDeletionNamespaceDirectory(dir, resource)
+	if err == nil {
+		return nil
+	}
+	err = fmt.Errorf("%s: %w", operation, err)
+	if db != nil {
+		db.publicationPoisoned.Store(true)
+		db.reportError(err)
+	}
+	return err
 }

--- a/TreeDB/internal/valuelog/manager.go
+++ b/TreeDB/internal/valuelog/manager.go
@@ -1276,6 +1276,7 @@ type Manager struct {
 	stableResourcePins          *rootpublication.IdentityPinRegistry
 	recoveredStableDeleteDirs   map[string]bool
 	stableDeleteRecoveryEnabled bool
+	deferredDeletionSync        func(dir string, resource durabilitycut.Resource) error
 }
 
 func NewManager(dir string) (*Manager, error) {
@@ -1340,6 +1341,32 @@ func (m *Manager) SetDisableReadChecksum(disable bool) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	m.disableReadChecksum = disable
+}
+
+// SetDeferredDeletionSync installs the durability boundary used when a zombie
+// segment can only be unlinked after its final snapshot or identity pin is
+// released. Immediate maintenance removals remain owned by their caller so a
+// caller can batch one directory sync across multiple unlinks.
+func (m *Manager) SetDeferredDeletionSync(sync func(dir string, resource durabilitycut.Resource) error) {
+	if m == nil {
+		return
+	}
+	m.mu.Lock()
+	m.deferredDeletionSync = sync
+	m.mu.Unlock()
+}
+
+func (m *Manager) syncDeferredDeletion(path string) error {
+	if m == nil {
+		return nil
+	}
+	m.mu.RLock()
+	sync := m.deferredDeletionSync
+	m.mu.RUnlock()
+	if sync == nil {
+		return nil
+	}
+	return sync(filepath.Dir(path), segmentNamespaceResource(path))
 }
 
 // SetCurrentWritableMmapEnabled enables persistent read-only mmap views for
@@ -2109,15 +2136,17 @@ func (m *Manager) retryZombieDelete(f *File) {
 
 		deleted, removeErr := closeAndRemoveStableSegmentFileResult(f, lease != nil)
 		if deleted {
+			syncErr := m.syncDeferredDeletion(f.Path)
 			commitStableDeleteLease(lease)
 			m.mu.Lock()
+			var unobserveErr error
 			if cur, exists := m.files[f.ID]; exists && cur == f && f.RefCount.Load() == 0 && f.IsZombie.Load() {
 				delete(m.files, f.ID)
-				_ = m.unobserveStableFileLocked(f)
+				unobserveErr = m.unobserveStableFileLocked(f)
 			}
 			m.mu.Unlock()
-			if removeErr != nil {
-				log.Printf("valuelog: removed retired zombie %s after close error: %v", f.Path, removeErr)
+			if finishErr := errors.Join(removeErr, syncErr, unobserveErr); finishErr != nil {
+				log.Printf("valuelog: removed retired zombie %s with finalization error: %v", f.Path, finishErr)
 			}
 			return
 		} else if !isWindowsSharingViolationError(removeErr) {

--- a/TreeDB/internal/valuelog/stable_resource.go
+++ b/TreeDB/internal/valuelog/stable_resource.go
@@ -908,14 +908,16 @@ func (m *Manager) deleteZombieFile(file *File) error {
 		}
 		return unlinkErr
 	}
+	syncErr := m.syncDeferredDeletion(file.Path)
 	commitStableDeleteLease(lease)
 	m.mu.Lock()
+	var unobserveErr error
 	if current, exists := m.files[file.ID]; exists && current == file && file.RefCount.Load() == 0 && file.IsZombie.Load() {
 		delete(m.files, file.ID)
-		_ = m.unobserveStableFileLocked(file)
+		unobserveErr = m.unobserveStableFileLocked(file)
 	}
 	m.mu.Unlock()
-	return unlinkErr
+	return errors.Join(unlinkErr, syncErr, unobserveErr)
 }
 
 func captureStableValueLogParent(path string, resource *os.File) (*os.File, error) {


### PR DESCRIPTION
Closes #3681.

Discovered while freezing #3684 final maintenance-unlink risk inventory. `CompactStorage` could unlink a safely authorized zero-byte value-log segment and return success without syncing the containing `value_vlog` directory. Reviewed follow-ups found the same omission when a pinned zombie was deleted only after its final snapshot or identity pin released, plus two fail-closed edge cases on the immediate path.

This PR:

- adds RED witnesses proving current `main` emits no deletion-directory sync for immediate or deferred successful maintenance deletion;
- syncs the exact value-log directory after authorized deletion and before topology refresh;
- routes deferred zombie deletion through the same durability boundary, including the asynchronous identity-pin retry path;
- preserves a successful unlink result even when the segment handle also returns a close error, and settles the directory-sync debt before returning that error;
- poisons the backend and reports `ErrRecoveryRequired` if either immediate or deferred post-unlink directory sync fails;
- preserves existing deletion authority and batches immediate maintenance syncs without duplicating a deferred sync.

Validation on final head `8beff271b`:

- `go test ./TreeDB/db -count=1` (125.996s)
- `go test ./TreeDB/db -run 'TestCompactStorage(ManagerSegment|PinnedZombie|KeepsPinnedZombie)' -count=10`
- `go test -race ./TreeDB/db -run 'TestCompactStorageManager(SegmentDeletionSyncFailureRequiresRecovery|SuccessfulUnlinkCloseErrorSyncsBeforeReturn)$' -count=5`
- `go test ./TreeDB/internal/valuelog -count=1`
- `go vet ./TreeDB/db ./TreeDB/internal/valuelog`
- `git diff --check`

The exact maintenance crash-image replay remains owned by #3684 after this prerequisite correction merges.
