### PR TITLE
test(treedb): settle fragmentation parity fixture

### DIFF
--- a/TreeDB/db/fragmentation_trigger_test.go
+++ b/TreeDB/db/fragmentation_trigger_test.go
@@ -37,6 +37,15 @@ func TestIndexVacuumTriggerReportMatchesFragmentationSpan(t *testing.T) {
 func compareTriggerToFullFragmentationReport(t *testing.T, d *DB, label string) {
 	t.Helper()
 
+	if err := d.Checkpoint(); err != nil {
+		t.Fatalf("%s checkpoint: %v", label, err)
+	}
+	settled := d.State()
+	if settled == nil {
+		t.Fatalf("%s missing settled state", label)
+	}
+	settledCommitSeq := settled.CommitSeq
+
 	full, err := d.FragmentationReport()
 	if err != nil {
 		t.Fatalf("%s FragmentationReport: %v", label, err)
@@ -80,6 +89,9 @@ func compareTriggerToFullFragmentationReport(t *testing.T, d *DB, label string) 
 	state := d.State()
 	if state == nil {
 		t.Fatalf("%s missing state", label)
+	}
+	if state.CommitSeq != settledCommitSeq {
+		t.Fatalf("%s state CommitSeq=%d want settled %d", label, state.CommitSeq, settledCommitSeq)
 	}
 	if trigger.CommitSeq != state.CommitSeq {
 		t.Fatalf("%s CommitSeq=%d want %d", label, trigger.CommitSeq, state.CommitSeq)


### PR DESCRIPTION
Closes #3854.

Parent tracker: #3776.

## Summary

- checkpoint the asynchronous fragmentation fixture before each full/trigger parity pair
- capture the settled commit sequence and require the later DB state to remain on it
- preserve every exact report-field equality and cheap-trigger probe-count assertion

## Failure Classification

PR #3850 proof-B run `29551699411`, Ubuntu job `87795418917`, failed `TestIndexVacuumTriggerReportMatchesFragmentationSpan` with trigger total pages 75,239 versus full-report total pages 72,987.

The fixture performs thousands of asynchronous mutations, then calls two public report methods that independently acquire snapshots. Deferred publication advanced the pager between those calls. The PR and proof-A exact-SHA twins passed, confirming a timing-dependent test boundary rather than a report calculation defect.

This patch establishes a synchronous measurement boundary. It does not change production reports, background vacuum policy, storage behavior, timeouts, or equality expectations.

## Local Evidence

- Go 1.26.5 named parity test: `-count=10` pass in 157.100s
- Go 1.26.5 named parity test under race: `-count=3` pass in 64.206s
- adjacent fragmentation validation/wait tests: `-count=10` pass
- full Go 1.26.5 `./TreeDB/db`: pass in 311.826s
- `GOWORK=off GOTOOLCHAIN=go1.26.5 go vet ./TreeDB/db`: pass
- `git diff --check`: pass

## Hosted Gates

- [ ] latest-head ordinary PR checks
- [ ] exact-head TreeDB PR matrix and independent proof matrices
- [ ] latest-head Codex review clean
- [ ] zero unresolved review threads
- [ ] current-base verification before merge
