### PR TITLE
[DUR-06] Fail closed at public admission after publication poison

### DIFF
--- a/TreeDB/caching/conditional_txn.go
+++ b/TreeDB/caching/conditional_txn.go
@@ -98,7 +98,9 @@ func (db *DB) initConditionalTxn(tx *ConditionalTxn, withSnapshot bool) error {
 	if db == nil || db.backend == nil {
 		return backenddb.ErrClosed
 	}
-	db.beginExclusiveWrite()
+	if err := db.beginExclusiveWrite(); err != nil {
+		return err
+	}
 	defer db.writeMu.Unlock()
 	if db.closing.Load() {
 		return backenddb.ErrClosed
@@ -428,7 +430,9 @@ func (tx *ConditionalTxn) commit(sync bool) (err error) {
 		}
 	}()
 
-	tx.db.beginExclusiveWrite()
+	if err := tx.db.beginExclusiveWrite(); err != nil {
+		return err
+	}
 	writeMuHeld := true
 	unlockWriteMu := func() {
 		if writeMuHeld {

--- a/TreeDB/caching/db.go
+++ b/TreeDB/caching/db.go
@@ -8095,6 +8095,17 @@ type backendStorageDirProvider interface {
 	Dir() string
 }
 
+type backendPublicationReadinessChecker interface {
+	CheckCommandWALPublishReady() error
+}
+
+func backendPublicationReady(backend BackendDB) error {
+	if checker, ok := backend.(backendPublicationReadinessChecker); ok {
+		return checker.CheckCommandWALPublishReady()
+	}
+	return nil
+}
+
 // ValueLogIdentityPinRegistry lets nested wrappers share the same physical
 // deletion gate as the backend and cache value-log managers.
 func (db *DB) ValueLogIdentityPinRegistry() *rootpublication.IdentityPinRegistry {
@@ -23203,6 +23214,18 @@ func (db *DB) beginDirectWrite() error {
 			return backenddb.ErrClosed
 		}
 		if db.writeAdmissionWaitReason() == writeWaitReasonNone {
+			// A writer may have passed its public-wrapper preflight before waiting
+			// behind a checkpoint that subsequently poisoned root publication.
+			// Recheck at the actual cached admission boundary while writeMu keeps
+			// the checkpoint cutover from moving underneath this decision.
+			if err := backendPublicationReady(db.backend); err != nil {
+				db.writeMu.RUnlock()
+				if preWaitReason != writeWaitReasonNone {
+					db.observeWriteWaitReason(preWaitReason, time.Since(start))
+					db.observeWriteWaitForCheckpoint(time.Since(start))
+				}
+				return err
+			}
 			if preWaitReason != writeWaitReasonNone {
 				db.observeWriteWaitReason(preWaitReason, time.Since(start))
 				db.observeWriteWaitForCheckpoint(time.Since(start))
@@ -23235,6 +23258,14 @@ func (db *DB) beginDirectWriteWithFlushMuHeld() error {
 			return backenddb.ErrClosed
 		}
 		if db.writeAdmissionWaitReason() == writeWaitReasonNone {
+			if err := backendPublicationReady(db.backend); err != nil {
+				db.writeMu.RUnlock()
+				if preWaitReason != writeWaitReasonNone {
+					db.observeWriteWaitReason(preWaitReason, time.Since(start))
+					db.observeWriteWaitForCheckpoint(time.Since(start))
+				}
+				return err
+			}
 			if preWaitReason != writeWaitReasonNone {
 				db.observeWriteWaitReason(preWaitReason, time.Since(start))
 				db.observeWriteWaitForCheckpoint(time.Since(start))
@@ -23252,7 +23283,7 @@ func (db *DB) beginDirectWriteWithFlushMuHeld() error {
 	}
 }
 
-func (db *DB) beginExclusiveWrite() {
+func (db *DB) beginExclusiveWrite() error {
 	for {
 		preWaitReason := db.writeAdmissionWaitReason()
 		var start time.Time
@@ -23261,12 +23292,20 @@ func (db *DB) beginExclusiveWrite() {
 		}
 		db.writeMu.Lock()
 		if db.writeAdmissionWaitReason() == writeWaitReasonNone {
+			if err := backendPublicationReady(db.backend); err != nil {
+				db.writeMu.Unlock()
+				if preWaitReason != writeWaitReasonNone {
+					db.observeWriteWaitReason(preWaitReason, time.Since(start))
+					db.observeWriteWaitForCheckpoint(time.Since(start))
+				}
+				return err
+			}
 			if preWaitReason != writeWaitReasonNone {
 				db.observeWriteWaitReason(preWaitReason, time.Since(start))
 				db.observeWriteWaitForCheckpoint(time.Since(start))
 			}
 			db.observePostFrontierWriteAdmission()
-			return
+			return nil
 		}
 		if preWaitReason == writeWaitReasonNone {
 			start = time.Now()
@@ -23276,7 +23315,7 @@ func (db *DB) beginExclusiveWrite() {
 	}
 }
 
-func (db *DB) beginExclusiveWriteWithFlushMuHeld() {
+func (db *DB) beginExclusiveWriteWithFlushMuHeld() error {
 	for {
 		preWaitReason := db.writeAdmissionWaitReason()
 		var start time.Time
@@ -23285,12 +23324,20 @@ func (db *DB) beginExclusiveWriteWithFlushMuHeld() {
 		}
 		db.writeMu.Lock()
 		if db.writeAdmissionWaitReason() == writeWaitReasonNone {
+			if err := backendPublicationReady(db.backend); err != nil {
+				db.writeMu.Unlock()
+				if preWaitReason != writeWaitReasonNone {
+					db.observeWriteWaitReason(preWaitReason, time.Since(start))
+					db.observeWriteWaitForCheckpoint(time.Since(start))
+				}
+				return err
+			}
 			if preWaitReason != writeWaitReasonNone {
 				db.observeWriteWaitReason(preWaitReason, time.Since(start))
 				db.observeWriteWaitForCheckpoint(time.Since(start))
 			}
 			db.observePostFrontierWriteAdmission()
-			return
+			return nil
 		}
 		if preWaitReason == writeWaitReasonNone {
 			start = time.Now()
@@ -25687,7 +25734,9 @@ func (db *DB) publishCommandWALRangeSpanLayer(start, end []byte, appendCommand f
 	db.waitForRangeSpanCheckpointDrain()
 	db.flushMu.Lock()
 	defer db.flushMu.Unlock()
-	db.beginExclusiveWriteWithFlushMuHeld()
+	if err := db.beginExclusiveWriteWithFlushMuHeld(); err != nil {
+		return err
+	}
 	defer db.writeMu.Unlock()
 
 	db.mu.Lock()
@@ -25763,7 +25812,9 @@ func (db *DB) deleteRange(start, end []byte, appendCommand func() error) (err er
 	// Append journal records one-by-one to preserve batch atomicity and to avoid
 	// post-journal apply divergence on partial batch failure.
 	if !db.disableJournal {
-		db.beginExclusiveWrite()
+		if err := db.beginExclusiveWrite(); err != nil {
+			return err
+		}
 		defer db.writeMu.Unlock()
 
 		it, err := db.Iterator(start, end)
@@ -26055,7 +26106,9 @@ func (db *DB) deleteRange(start, end []byte, appendCommand func() error) (err er
 		// rotating the memtable (which can allocate large arenas).
 		db.flushMu.Lock()
 		defer db.flushMu.Unlock()
-		db.beginExclusiveWriteWithFlushMuHeld()
+		if err := db.beginExclusiveWriteWithFlushMuHeld(); err != nil {
+			return err
+		}
 		defer db.writeMu.Unlock()
 
 		db.mu.Lock()
@@ -35628,7 +35681,9 @@ func (b *Batch) writeRangeBatch(sync bool) error {
 	// a concurrent cached write can slip between the scan and the materialized
 	// point-delete batch, producing a non-serializable mix of range-deleted old
 	// keys and surviving newly inserted keys.
-	b.db.beginExclusiveWrite()
+	if err := b.db.beginExclusiveWrite(); err != nil {
+		return err
+	}
 	writeMuHeld := true
 	unlockWriteMu := func() {
 		if writeMuHeld {
@@ -35728,7 +35783,9 @@ func (b *Batch) writeRangeSpanBatch(sync bool, ranges []batch.DeleteRange) (err 
 	b.db.waitForRangeSpanCheckpointDrain()
 	b.db.flushMu.Lock()
 	defer b.db.flushMu.Unlock()
-	b.db.beginExclusiveWriteWithFlushMuHeld()
+	if err := b.db.beginExclusiveWriteWithFlushMuHeld(); err != nil {
+		return err
+	}
 	defer b.db.writeMu.Unlock()
 
 	b.db.mu.Lock()

--- a/TreeDB/public.go
+++ b/TreeDB/public.go
@@ -558,6 +558,17 @@ func (db *DB) beginPublicOperation() error {
 		db.lifecycleMu.RUnlock()
 		return ErrClosed
 	}
+	// Cached mutations can otherwise be admitted without entering the backend,
+	// even after an outcome-ambiguous root publication has poisoned it. Consult
+	// the backend poison gate while the lifecycle read lock keeps both layers
+	// stable; every caller of beginPublicOperation is a write, transaction,
+	// batch, or durability boundary.
+	if db.backend != nil {
+		if err := db.backend.CheckCommandWALPublishReady(); err != nil {
+			db.lifecycleMu.RUnlock()
+			return err
+		}
+	}
 	return nil
 }
 

--- a/TreeDB/public_poison_admission_test.go
+++ b/TreeDB/public_poison_admission_test.go
@@ -1,0 +1,51 @@
+package treedb_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	treedb "github.com/snissn/gomap/TreeDB"
+	"github.com/snissn/gomap/TreeDB/internal/durabilitycut"
+)
+
+func TestPublicCachedHandleRejectsMutationAfterPostMetaFailure(t *testing.T) {
+	opts := treedb.OptionsFor(treedb.ProfileNoWALFast, t.TempDir())
+	opts.DisableSideStores = true
+	opts.DisableBackgroundPrune = true
+	opts.BackgroundCheckpointInterval = -1
+	database, err := treedb.Open(opts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = database.Close() }()
+	if err := database.SetSync([]byte("stable/old"), []byte("old-value")); err != nil {
+		t.Fatal(err)
+	}
+	if err := database.Set([]byte("dirty/new"), []byte("new-value")); err != nil {
+		t.Fatal(err)
+	}
+
+	cutErr := errors.New("public admission: stop after meta dirty")
+	restore := durabilitycut.Install(func(event durabilitycut.Event) error {
+		if event.Point == durabilitycut.AfterMetaWrite {
+			return cutErr
+		}
+		return nil
+	})
+	err = database.Checkpoint()
+	restore()
+	if !errors.Is(err, cutErr) || !errors.Is(err, treedb.ErrRecoveryRequired) {
+		t.Fatalf("post-meta checkpoint error=%v, want injected cut and ErrRecoveryRequired", err)
+	}
+	if err := database.Set([]byte("after/poison"), []byte("must-reopen")); !errors.Is(err, treedb.ErrRecoveryRequired) {
+		t.Fatalf("public Set after post-meta failure error=%v, want ErrRecoveryRequired", err)
+	}
+	if batch := database.NewBatch(); batch != nil {
+		_ = batch.Close()
+		t.Fatal("public NewBatch after post-meta failure returned a writable batch")
+	}
+	if _, err := database.CompactStorage(context.Background(), treedb.CompactStorageOptions{}); !errors.Is(err, treedb.ErrRecoveryRequired) {
+		t.Fatalf("public CompactStorage after post-meta failure error=%v, want ErrRecoveryRequired", err)
+	}
+}

--- a/TreeDB/public_poison_admission_test.go
+++ b/TreeDB/public_poison_admission_test.go
@@ -3,11 +3,75 @@ package treedb_test
 import (
 	"context"
 	"errors"
+	"sync"
 	"testing"
+	"time"
 
 	treedb "github.com/snissn/gomap/TreeDB"
 	"github.com/snissn/gomap/TreeDB/internal/durabilitycut"
 )
+
+func TestPublicCachedWriterWaitingBehindPostMetaFailureRejectsAfterPoison(t *testing.T) {
+	opts := treedb.OptionsFor(treedb.ProfileNoWALFast, t.TempDir())
+	opts.DisableSideStores = true
+	opts.DisableBackgroundPrune = true
+	opts.BackgroundCheckpointInterval = -1
+	database, err := treedb.Open(opts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = database.Close() }()
+	if err := database.SetSync([]byte("stable/old"), []byte("old-value")); err != nil {
+		t.Fatal(err)
+	}
+	if err := database.Set([]byte("dirty/new"), []byte("new-value")); err != nil {
+		t.Fatal(err)
+	}
+
+	cutErr := errors.New("public admission race: stop after meta dirty")
+	cutReached := make(chan struct{})
+	releaseCut := make(chan struct{})
+	var cutOnce sync.Once
+	restore := durabilitycut.Install(func(event durabilitycut.Event) error {
+		if event.Point != durabilitycut.AfterMetaWrite {
+			return nil
+		}
+		cutOnce.Do(func() {
+			close(cutReached)
+			<-releaseCut
+		})
+		return cutErr
+	})
+	defer restore()
+
+	checkpointErr := make(chan error, 1)
+	go func() { checkpointErr <- database.Checkpoint() }()
+	select {
+	case <-cutReached:
+	case <-time.After(2 * time.Second):
+		close(releaseCut)
+		t.Fatal("checkpoint did not reach post-meta cut")
+	}
+
+	writeErr := make(chan error, 1)
+	go func() { writeErr <- database.Set([]byte("after/preflight"), []byte("must-reopen")) }()
+	deadline := time.Now().Add(2 * time.Second)
+	for database.Stats()["treedb.cache.write.wait_for_checkpoint.active"] != "1" {
+		if time.Now().After(deadline) {
+			close(releaseCut)
+			t.Fatal("writer did not wait behind checkpoint after public preflight")
+		}
+		time.Sleep(time.Millisecond)
+	}
+	close(releaseCut)
+
+	if err := <-checkpointErr; !errors.Is(err, cutErr) || !errors.Is(err, treedb.ErrRecoveryRequired) {
+		t.Fatalf("post-meta checkpoint error=%v, want injected cut and ErrRecoveryRequired", err)
+	}
+	if err := <-writeErr; !errors.Is(err, treedb.ErrRecoveryRequired) {
+		t.Fatalf("writer admitted after waiting behind poison error=%v, want ErrRecoveryRequired", err)
+	}
+}
 
 func TestPublicCachedHandleRejectsMutationAfterPostMetaFailure(t *testing.T) {
 	opts := treedb.OptionsFor(treedb.ProfileNoWALFast, t.TempDir())

--- a/TreeDB/public_poison_admission_test.go
+++ b/TreeDB/public_poison_admission_test.go
@@ -49,3 +49,40 @@ func TestPublicCachedHandleRejectsMutationAfterPostMetaFailure(t *testing.T) {
 		t.Fatalf("public CompactStorage after post-meta failure error=%v, want ErrRecoveryRequired", err)
 	}
 }
+
+func TestPublicCachedHandleRetainsAdmissionAfterPreMetaFailure(t *testing.T) {
+	opts := treedb.OptionsFor(treedb.ProfileNoWALFast, t.TempDir())
+	opts.DisableSideStores = true
+	opts.DisableBackgroundPrune = true
+	opts.BackgroundCheckpointInterval = -1
+	database, err := treedb.Open(opts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = database.Close() }()
+	if err := database.SetSync([]byte("stable/old"), []byte("old-value")); err != nil {
+		t.Fatal(err)
+	}
+	if err := database.Set([]byte("dirty/new"), []byte("new-value")); err != nil {
+		t.Fatal(err)
+	}
+
+	cutErr := errors.New("public admission: stop before meta write")
+	restore := durabilitycut.Install(func(event durabilitycut.Event) error {
+		if event.Point == durabilitycut.BeforeMetaWrite {
+			return cutErr
+		}
+		return nil
+	})
+	err = database.Checkpoint()
+	restore()
+	if !errors.Is(err, cutErr) || errors.Is(err, treedb.ErrRecoveryRequired) {
+		t.Fatalf("pre-meta checkpoint error=%v, want injected cut without ErrRecoveryRequired", err)
+	}
+	if err := database.Set([]byte("after/retryable"), []byte("accepted")); err != nil {
+		t.Fatalf("public Set after pre-meta failure: %v", err)
+	}
+	if err := database.Checkpoint(); err != nil {
+		t.Fatalf("retry checkpoint after pre-meta failure: %v", err)
+	}
+}


### PR DESCRIPTION
Closes #3680.

## Summary

Terminal certification for #3684 exposed a narrow activation gap: an outcome-ambiguous post-meta publication correctly poisoned the backend, but the cached public layer could still admit a new mutation without consulting that poison state. Mature-head review then found the concurrent form of the same gap: a writer could pass the public preflight, wait behind the failing checkpoint, and enter the cache after publication became poisoned.

- Add a backend publication-readiness preflight to `beginPublicOperation` while the lifecycle read lock keeps the public and backend handles stable.
- Recheck readiness at the actual cached writer-admission boundary after checkpoint waits, covering direct, exclusive, and flush-mutex-held writers.
- Reject public `Set`, batch creation and publication, transactions, durability boundaries, and maintenance once post-meta ambiguity requires reopen.
- Preserve the retry contract for pre-meta failures: later writes and a retry checkpoint remain valid.
- Keep the correction on current main after #3851's deletion-namespace durability fix.

No on-disk format or public API changes.

## Failure-class evidence

- Post-meta cut: `Checkpoint` returns the injected error joined with `ErrRecoveryRequired`; subsequent `Set` returns `ErrRecoveryRequired`, `NewBatch` returns no writable batch, and `CompactStorage` returns `ErrRecoveryRequired`.
- Concurrent post-meta cut: a writer passes the public preflight, is observed waiting behind the checkpoint, and then returns `ErrRecoveryRequired` rather than entering the cache after the checkpoint poisons publication.
- Pre-meta cut: `Checkpoint` returns the injected error without `ErrRecoveryRequired`; subsequent `Set` and retry `Checkpoint` succeed.

## Validation

Exact head: `976422048fad57e132b58cccb605dd1eff312bcc`
Exact base: `b63240d6944e8a8d4de341746e228a2e4186ee97`

- `go test ./TreeDB -run '^TestPublicCached(WriterWaitingBehindPostMetaFailureRejectsAfterPoison|HandleRejectsMutationAfterPostMetaFailure|HandleRetainsAdmissionAfterPreMetaFailure)$' -count=10`
- `go test ./TreeDB/caching -run 'Test(BeginDirectWrite|BeginExclusiveWrite|CachingDB_ExclusiveWrite)' -count=10`
- `go test -race ./TreeDB -run '^TestPublicCached(WriterWaitingBehindPostMetaFailureRejectsAfterPoison|HandleRejectsMutationAfterPostMetaFailure|HandleRetainsAdmissionAfterPreMetaFailure)$' -count=5`
- `go test ./TreeDB/db -run '^Test(CheckStorageMaintenanceReadyPoisonedCommandWALFailsClosed|CompactStorageManagerSegmentDeletionSyncsNamespaceBeforeSuccess|CompactStorageManagerSegmentDeletionSyncFailureRequiresRecovery|CompactStorageManagerSuccessfulUnlinkCloseErrorSyncsBeforeReturn|CompactStoragePinnedZombieReleaseSyncsDeletionNamespaceBeforeSuccess|CompactStoragePinnedZombieReleaseSyncFailurePoisonsHandle)$' -count=10`
- `go test ./TreeDB ./TreeDB/db ./TreeDB/caching`
- `go vet ./TreeDB/...`
- `git diff --check`

All pass. Full-suite times were TreeDB 295.783s, backend 230.649s, and cache 75.977s.

## Performance evidence

Paired six-sample runs used separately compiled exact-base and exact-head test binaries on Apple M3 with `-benchtime=1s`, interleaving base and head samples.

`BenchmarkWriteParallelCached` shows no statistically significant change at G=1, G=2, G=4, or G=8. The isolated `BenchmarkBeginPublicOperationWithDefer` preflight rises from 3.898 ns/op to 5.385 ns/op (+1.487 ns absolute, +38.13%) and remains 0 B/op, 0 allocs/op.

This bounds the additional fail-closed checks while showing they are not observable in the full cached-write benchmark.
