### PR TITLE
db: bind root publications to their build-time base

### DIFF
--- a/TreeDB/caching/db_test.go
+++ b/TreeDB/caching/db_test.go
@@ -2259,7 +2259,7 @@ func TestCachingDB_PrunesRetainedValueLog(t *testing.T) {
 	}
 	forceRetainedPruneIdle(cache)
 	cache.waitForRetainedValueLogPrune()
-	if err := backend.Commit(backend.State().RootPageID); err != nil {
+	if err := backend.ForceCommit(backend.State().RootPageID); err != nil {
 		t.Fatalf("commit durable-slot successor: %v", err)
 	}
 	cache.PruneRetainedValueLogsForMaintenance()

--- a/TreeDB/collections/api_test.go
+++ b/TreeDB/collections/api_test.go
@@ -662,7 +662,7 @@ func TestCollectionLeafGenerationPackGC_RoundTripWithTemplateV1SecondaryIndexes(
 	// a later root publication overwrites it. Checkpoint alone does not advance
 	// CommitSeq, so recommit the packed root without publishing a new cached
 	// leaf-log dependency before asserting physical reclamation.
-	if err := d.Commit(d.State().RootPageID); err != nil {
+	if err := d.ForceCommit(d.State().RootPageID); err != nil {
 		t.Fatalf("commit packed durable-slot successor: %v", err)
 	}
 

--- a/TreeDB/db/closed_db_public_methods_test.go
+++ b/TreeDB/db/closed_db_public_methods_test.go
@@ -55,7 +55,7 @@ func TestClosedDB_Close(t *testing.T) {
 
 func TestClosedDB_Commit(t *testing.T) {
 	runClosedDBMethod(t, "Commit", func(d *DB) {
-		_ = d.Commit(0)
+		_ = d.ForceCommit(0)
 	})
 }
 

--- a/TreeDB/db/command_wal_publish_bench_test.go
+++ b/TreeDB/db/command_wal_publish_bench_test.go
@@ -48,7 +48,13 @@ func BenchmarkFinalizeCommitSameRoots(b *testing.B) {
 func benchmarkFinalizeCommitWithWriteMu(db *DB, root, sysRoot uint64) error {
 	db.writeMu.Lock()
 	defer db.writeMu.Unlock()
-	post, err := db.finalizeCommitLockedWithOptions(root, sysRoot, nil, false, adaptiveMetricsZero(), nil, false, nil, nil, nil, finalizeCommitOptions{})
+	db.mu.RLock()
+	baseSeq := db.meta.CommitSeq
+	db.mu.RUnlock()
+	post, err := db.finalizeCommitLockedWithOptions(root, sysRoot, nil, false, adaptiveMetricsZero(), nil, false, nil, nil, nil, finalizeCommitOptions{
+		expectedBaseCommitSeq:    baseSeq,
+		hasExpectedBaseCommitSeq: true,
+	})
 	if err != nil {
 		return err
 	}

--- a/TreeDB/db/command_wal_recovery_test.go
+++ b/TreeDB/db/command_wal_recovery_test.go
@@ -773,7 +773,7 @@ func TestCommandWALRejectsUnloggedCommit(t *testing.T) {
 	db := openCommandWALDB(t, dir)
 	defer db.Close()
 
-	if err := db.Commit(db.State().RootPageID + 1); !errors.Is(err, ErrCommandWALUnsupported) {
+	if err := db.ForceCommit(db.State().RootPageID + 1); !errors.Is(err, ErrCommandWALUnsupported) {
 		t.Fatalf("Commit in command WAL mode error=%v, want ErrCommandWALUnsupported", err)
 	}
 	if err := db.CompactIndex(); !errors.Is(err, ErrCommandWALUnsupported) {
@@ -1562,7 +1562,7 @@ func TestCommandWALFinalizeFailurePoisonsOpenHandle(t *testing.T) {
 	_ = b.Close()
 	db.testFailFinalizeCommit.Store(false)
 
-	if err := db.Commit(db.State().RootPageID); !errors.Is(err, ErrRecoveryRequired) {
+	if err := db.ForceCommit(db.State().RootPageID); !errors.Is(err, ErrRecoveryRequired) {
 		t.Fatalf("Commit after poison error=%v, want ErrRecoveryRequired", err)
 	}
 	if _, err := db.ValueLogGC(context.Background(), ValueLogGCOptions{}); !errors.Is(err, ErrRecoveryRequired) {

--- a/TreeDB/db/compact_storage_test.go
+++ b/TreeDB/db/compact_storage_test.go
@@ -3048,7 +3048,7 @@ func TestCompactStorageLeafPackMultiPassRescansAfterForegroundCommit(t *testing.
 			if state == nil {
 				t.Fatal("missing state before foreground commit")
 			}
-			if err := d.Commit(state.RootPageID); err != nil {
+			if err := d.ForceCommit(state.RootPageID); err != nil {
 				t.Fatalf("foreground same-root commit: %v", err)
 			}
 		case "leaf-generation-pack-2":

--- a/TreeDB/db/conditional_txn_test.go
+++ b/TreeDB/db/conditional_txn_test.go
@@ -347,7 +347,7 @@ func TestConditionalTxnRejectsDirectRootPublishChangingReadKey(t *testing.T) {
 	}
 
 	newRoot := buildConditionalTxnManualRoot(t, d, "guard", "after")
-	if err := d.Commit(newRoot); err != nil {
+	if err := d.ForceCommit(newRoot); err != nil {
 		t.Fatalf("direct Commit: %v", err)
 	}
 	if err := tx.Set([]byte("target"), []byte("value")); err != nil {
@@ -382,7 +382,7 @@ func TestConditionalTxnAllowsDirectSameRootPublish(t *testing.T) {
 	if state == nil {
 		t.Fatalf("missing DB state")
 	}
-	if err := d.Commit(state.RootPageID); err != nil {
+	if err := d.ForceCommit(state.RootPageID); err != nil {
 		t.Fatalf("same-root Commit: %v", err)
 	}
 	if err := tx.Set([]byte("target"), []byte("value")); err != nil {

--- a/TreeDB/db/db.go
+++ b/TreeDB/db/db.go
@@ -549,6 +549,8 @@ type DB struct {
 	testAfterOptimisticPublishPrepareHook          func()
 	testCommandWALBeforeDurablePublishLockHook     func()
 	testCommandWALCleanupAfterScanHook             func()
+	testBeforeFinalizeCommitHook                   func()
+	testAfterFinalizeRootSerializationReleaseHook  func()
 	testDurableRootCandidatePreparedHook           func()
 	testRootPublicationDependencyBytes             atomic.Uint64
 	testScanCandidateExternalReferencesHook        func()
@@ -3131,13 +3133,9 @@ type finalizeCommitPost struct {
 	drainLeafGenerationPending        bool
 }
 
-// finalizeCommitLocked performs the durability-critical publish path.
-// Callers that already hold commit serialization may run post work after
-// releasing the serialization lock.
-func (db *DB) finalizeCommitLocked(newRootID uint64, sysRootID uint64, retired []uint64, sync bool, metrics adaptive.Metrics, touchedValueLogSegments []uint32, forceValueLogRefresh bool, vlogRefDelta *valueLogRefDelta, leafManifest *leafGenerationManifest, leafManifestRawFileIDs []uint32) (finalizeCommitPost, error) {
-	return db.finalizeCommitLockedWithOptions(newRootID, sysRootID, retired, sync, metrics, touchedValueLogSegments, forceValueLogRefresh, vlogRefDelta, leafManifest, leafManifestRawFileIDs, finalizeCommitOptions{})
-}
-
+// finalizeCommitLockedWithOptions performs the durability-critical publish
+// path. Every caller must bind its constructed roots to the exact visible
+// commit sequence from which they were derived.
 func (db *DB) finalizeCommitLockedWithOptions(newRootID uint64, sysRootID uint64, retired []uint64, sync bool, metrics adaptive.Metrics, touchedValueLogSegments []uint32, forceValueLogRefresh bool, vlogRefDelta *valueLogRefDelta, leafManifest *leafGenerationManifest, leafManifestRawFileIDs []uint32, opts finalizeCommitOptions) (finalizeCommitPost, error) {
 	post := finalizeCommitPost{
 		metrics: metrics,
@@ -3153,6 +3151,9 @@ func (db *DB) finalizeCommitLockedWithOptions(newRootID uint64, sysRootID uint64
 	}
 	if err := db.commandWALPoisonedError(); err != nil {
 		return post, err
+	}
+	if !opts.hasExpectedBaseCommitSeq {
+		return post, errors.New("missing expected base commit sequence")
 	}
 	rootRuntime := db.rootPublication
 	builder := opts.rootPublicationBuilder
@@ -3604,19 +3605,13 @@ func (db *DB) finalizeAcceptedCommitPostWorkOnError(post finalizeCommitPost) fin
 	return finalizeCommitPost{accepted: true, commitSeq: commitSeq}
 }
 
-// finalizeCommit handles durability and state updates.
-func (db *DB) finalizeCommit(newRootID uint64, sysRootID uint64, retired []uint64, sync bool, metrics adaptive.Metrics, touchedValueLogSegments []uint32, forceValueLogRefresh bool, vlogRefDelta *valueLogRefDelta, leafManifest *leafGenerationManifest, leafManifestRawFileIDs []uint32) error {
-	post, err := db.finalizeCommitLocked(newRootID, sysRootID, retired, sync, metrics, touchedValueLogSegments, forceValueLogRefresh, vlogRefDelta, leafManifest, leafManifestRawFileIDs)
-	if err != nil {
-		return err
-	}
-	db.finalizeCommitPostWork(post)
-	return nil
-}
-
 // finalizeCommitReleasingRootSerialization transfers a completed root build to
 // the durable publisher. The caller must hold every lock named by release. The
-// helper acquires publication serialization in root-lock order, releases those
+// expected base sequence must be the visible commit observed before root
+// construction began; sampling it in this helper would let a predecessor
+// activate after construction but before finalization and bless a stale root.
+//
+// The helper acquires publication serialization in root-lock order, releases those
 // locks before legacy dependency preparation, and keeps the durable publisher
 // locked through candidate preparation, exact I/O, and visible-state install.
 func (db *DB) finalizeCommitReleasingRootSerialization(
@@ -3631,21 +3626,21 @@ func (db *DB) finalizeCommitReleasingRootSerialization(
 	leafManifest *leafGenerationManifest,
 	leafManifestRawFileIDs []uint32,
 	opts finalizeCommitOptions,
+	expectedBaseCommitSeq uint64,
 	release func(),
 	onError func(error),
 ) (finalizeCommitPost, error) {
 	if release == nil {
 		return finalizeCommitPost{}, errors.New("missing root-serialization release")
 	}
+	if hook := db.testBeforeFinalizeCommitHook; hook != nil {
+		hook()
+	}
 	if opts.durableIndex == nil {
 		opts.durableIndex = db.idx.Load()
 	}
-	if !opts.hasExpectedBaseCommitSeq {
-		db.mu.RLock()
-		opts.expectedBaseCommitSeq = db.meta.CommitSeq
-		db.mu.RUnlock()
-		opts.hasExpectedBaseCommitSeq = true
-	}
+	opts.expectedBaseCommitSeq = expectedBaseCommitSeq
+	opts.hasExpectedBaseCommitSeq = true
 	rootRuntime := db.rootPublication
 	var builder *rootpublication.BuilderToken
 	if rootRuntime != nil {
@@ -3671,6 +3666,9 @@ func (db *DB) finalizeCommitReleasingRootSerialization(
 	durablePublishLocked = true
 	defer releaseDurablePublish()
 	release()
+	if hook := db.testAfterFinalizeRootSerializationReleaseHook; hook != nil {
+		hook()
+	}
 
 	guard, err := db.prepareFinalizeCommitDurability(sync)
 	if err != nil {
@@ -3731,11 +3729,13 @@ func (db *DB) Commit(newRootID uint64) error {
 	// Need sysRootID.
 	db.mu.RLock()
 	sysRoot := db.meta.SystemRootPageID
+	baseSeq := db.meta.CommitSeq
 	db.mu.RUnlock()
 
 	post, err := db.finalizeCommitReleasingRootSerialization(
 		newRootID, sysRoot, nil, true, adaptive.Metrics{}, nil, true, nil, nil, nil,
 		finalizeCommitOptions{closeTeardownPinned: true},
+		baseSeq,
 		func() {
 			db.writeMu.Unlock()
 			writeLocked = false
@@ -4436,6 +4436,7 @@ func (db *DB) CompactIndex() error {
 	reader := newValueReader(state.ValueLogSet)
 	tr := tree.New(idx.pager, reader, state.RootPageID)
 	rootID := state.RootPageID
+	baseSeq := db.meta.CommitSeq
 	db.mu.RUnlock()
 
 	// Collect pages in the old tree so they can be retired after the swap.
@@ -4473,6 +4474,7 @@ func (db *DB) CompactIndex() error {
 	post, err := db.finalizeCommitReleasingRootSerialization(
 		newRoot, sysRoot, retired, true, adaptive.Metrics{}, nil, true, nil, nil, nil,
 		finalizeCommitOptions{closeTeardownPinned: true},
+		baseSeq,
 		func() {
 			db.writeMu.Unlock()
 			writeLocked = false

--- a/TreeDB/db/db.go
+++ b/TreeDB/db/db.go
@@ -3694,12 +3694,22 @@ func (db *DB) finalizeCommitReleasingRootSerialization(
 	return post, err
 }
 
-// Commit persists the new root (Sync=true by default).
-// Note: This is usually called internally by Batch.Write or externally if manual root management.
-// If manual, retired pages are unknown? `Commit` signature assumes manual root.
-// If external user calls Commit, they might not know retired pages.
-// We'll accept nil for retired if manual.
-func (db *DB) Commit(newRootID uint64) error {
+// CommitAtState synchronously persists a manually constructed user root only
+// when the visible commit sequence and roots still match the caller's basis.
+// Callers must capture basis before constructing newRootID.
+func (db *DB) CommitAtState(newRootID uint64, basis StateToken) error {
+	return db.commitManualRoot(newRootID, basis, true)
+}
+
+// ForceCommit synchronously force-sets a manually constructed user root. It
+// intentionally does not detect publications that occurred while newRootID was
+// constructed. Prefer CommitAtState unless last-writer-wins replacement is the
+// explicit operation.
+func (db *DB) ForceCommit(newRootID uint64) error {
+	return db.commitManualRoot(newRootID, StateToken{}, false)
+}
+
+func (db *DB) commitManualRoot(newRootID uint64, basis StateToken, conditional bool) error {
 	if db.readOnly {
 		return ErrReadOnly
 	}
@@ -3708,8 +3718,6 @@ func (db *DB) Commit(newRootID uint64) error {
 	if err := db.rejectUnloggedCommandWALRootPublish(); err != nil {
 		return err
 	}
-	// Public Commit assumes the caller has built a new tree.
-	// We need to serialize with other writers.
 	db.writeMu.Lock()
 	writeLocked := true
 	defer func() {
@@ -3721,16 +3729,20 @@ func (db *DB) Commit(newRootID uint64) error {
 		return err
 	}
 
-	// Since we are committing a root provided by caller, we assume they based it on current state?
-	// If caller is external, they might have read old state.
-	// But Commit(newRoot) implies "Force Set Root".
-	// We just commit it.
-
-	// Need sysRootID.
 	db.mu.RLock()
+	userRoot := db.meta.UserRootPageID
 	sysRoot := db.meta.SystemRootPageID
 	baseSeq := db.meta.CommitSeq
 	db.mu.RUnlock()
+	if conditional && (baseSeq != basis.CommitSeq || userRoot != basis.RootPageID || sysRoot != basis.SystemRootPageID) {
+		return fmt.Errorf(
+			"%w: manual root basis commit=%d/%d user_root=%d/%d system_root=%d/%d",
+			ErrConcurrentModification,
+			basis.CommitSeq, baseSeq,
+			basis.RootPageID, userRoot,
+			basis.SystemRootPageID, sysRoot,
+		)
+	}
 
 	post, err := db.finalizeCommitReleasingRootSerialization(
 		newRootID, sysRoot, nil, true, adaptive.Metrics{}, nil, true, nil, nil, nil,
@@ -3751,9 +3763,9 @@ func (db *DB) Commit(newRootID uint64) error {
 
 // Checkpoint forces a durable boundary for previously-published backend state.
 //
-// Unlike Commit, this does not publish a new root or advance CommitSeq. It is
-// intended for callers that already made writes visible with relaxed durability
-// and now need those writes durable on disk.
+// Unlike CommitAtState or ForceCommit, this does not publish a new root or
+// advance CommitSeq. It is intended for callers that already made writes
+// visible with relaxed durability and now need those writes durable on disk.
 func (db *DB) Checkpoint() error {
 	return db.checkpoint(false)
 }

--- a/TreeDB/db/db.go
+++ b/TreeDB/db/db.go
@@ -3755,6 +3755,13 @@ func (db *DB) commitManualRoot(newRootID uint64, basis StateToken, conditional b
 		nil,
 	)
 	if err != nil {
+		if conditional && errors.Is(err, errDurableRootCandidateStale) {
+			return fmt.Errorf(
+				"%w: manual root basis advanced during publication from commit=%d",
+				ErrConcurrentModification,
+				basis.CommitSeq,
+			)
+		}
 		return err
 	}
 	db.finalizeCommitPostWork(post)

--- a/TreeDB/db/db.go
+++ b/TreeDB/db/db.go
@@ -3718,6 +3718,26 @@ func (db *DB) commitManualRoot(newRootID uint64, basis StateToken, conditional b
 	if err := db.rejectUnloggedCommandWALRootPublish(); err != nil {
 		return err
 	}
+	for {
+		post, err := db.commitManualRootAttempt(newRootID, basis, conditional)
+		if err == nil {
+			db.finalizeCommitPostWork(post)
+			return nil
+		}
+		if !errors.Is(err, errDurableRootCandidateStale) {
+			return err
+		}
+		if conditional {
+			return fmt.Errorf(
+				"%w: manual root basis advanced during publication from commit=%d",
+				ErrConcurrentModification,
+				basis.CommitSeq,
+			)
+		}
+	}
+}
+
+func (db *DB) commitManualRootAttempt(newRootID uint64, basis StateToken, conditional bool) (finalizeCommitPost, error) {
 	db.writeMu.Lock()
 	writeLocked := true
 	defer func() {
@@ -3726,7 +3746,7 @@ func (db *DB) commitManualRoot(newRootID uint64, basis StateToken, conditional b
 		}
 	}()
 	if err := db.checkWriteAdmissionLocked(); err != nil {
-		return err
+		return finalizeCommitPost{}, err
 	}
 
 	db.mu.RLock()
@@ -3735,7 +3755,7 @@ func (db *DB) commitManualRoot(newRootID uint64, basis StateToken, conditional b
 	baseSeq := db.meta.CommitSeq
 	db.mu.RUnlock()
 	if conditional && (baseSeq != basis.CommitSeq || userRoot != basis.RootPageID || sysRoot != basis.SystemRootPageID) {
-		return fmt.Errorf(
+		return finalizeCommitPost{}, fmt.Errorf(
 			"%w: manual root basis commit=%d/%d user_root=%d/%d system_root=%d/%d",
 			ErrConcurrentModification,
 			basis.CommitSeq, baseSeq,
@@ -3744,7 +3764,7 @@ func (db *DB) commitManualRoot(newRootID uint64, basis StateToken, conditional b
 		)
 	}
 
-	post, err := db.finalizeCommitReleasingRootSerialization(
+	return db.finalizeCommitReleasingRootSerialization(
 		newRootID, sysRoot, nil, true, adaptive.Metrics{}, nil, true, nil, nil, nil,
 		finalizeCommitOptions{closeTeardownPinned: true},
 		baseSeq,
@@ -3754,18 +3774,6 @@ func (db *DB) commitManualRoot(newRootID uint64, basis StateToken, conditional b
 		},
 		nil,
 	)
-	if err != nil {
-		if conditional && errors.Is(err, errDurableRootCandidateStale) {
-			return fmt.Errorf(
-				"%w: manual root basis advanced during publication from commit=%d",
-				ErrConcurrentModification,
-				basis.CommitSeq,
-			)
-		}
-		return err
-	}
-	db.finalizeCommitPostWork(post)
-	return nil
 }
 
 // Checkpoint forces a durable boundary for previously-published backend state.

--- a/TreeDB/db/durable_root_teardown_test.go
+++ b/TreeDB/db/durable_root_teardown_test.go
@@ -126,7 +126,7 @@ func TestRootPublicationPathsPinTeardownThroughPostWork(t *testing.T) {
 		{
 			name: "Commit",
 			run: func(_ *testing.T, database *DB) error {
-				return database.Commit(database.State().RootPageID)
+				return database.ForceCommit(database.State().RootPageID)
 			},
 		},
 		{

--- a/TreeDB/db/leaf_generation_manifest_test.go
+++ b/TreeDB/db/leaf_generation_manifest_test.go
@@ -812,7 +812,7 @@ func TestCommitRejectsClosingDBAfterWriteMuAcquisition(t *testing.T) {
 	db.writeMu.Lock()
 	db.closing.Store(true)
 	commitDone := make(chan error, 1)
-	go func() { commitDone <- db.Commit(rootID) }()
+	go func() { commitDone <- db.ForceCommit(rootID) }()
 	db.writeMu.Unlock()
 
 	select {

--- a/TreeDB/db/leaf_generation_pack_test.go
+++ b/TreeDB/db/leaf_generation_pack_test.go
@@ -39,7 +39,7 @@ func leafGenerationKey(prefix string, i int) []byte {
 func advanceLeafGenerationPackDurableRootHorizon(t *testing.T, db *DB, reason string) {
 	t.Helper()
 	state := db.State()
-	if err := db.Commit(state.RootPageID); err != nil {
+	if err := db.ForceCommit(state.RootPageID); err != nil {
 		t.Fatalf("advance recoverable-root horizon (%s): %v", reason, err)
 	}
 }

--- a/TreeDB/db/leaf_generation_plan_test.go
+++ b/TreeDB/db/leaf_generation_plan_test.go
@@ -798,7 +798,7 @@ func TestLeafGenerationPlan_CachesLiveStatsPerPublishedState(t *testing.T) {
 		t.Fatalf("scan count after uncached gc helper=%d, want %d", got, want)
 	}
 
-	if err := db.Commit(rootBefore); err != nil {
+	if err := db.ForceCommit(rootBefore); err != nil {
 		t.Fatalf("Commit same root: %v", err)
 	}
 	stateSameRoot := db.State()

--- a/TreeDB/db/manual_root_commit_test.go
+++ b/TreeDB/db/manual_root_commit_test.go
@@ -1,0 +1,39 @@
+package db
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestCommitAtStateRejectsAdvancedBasis(t *testing.T) {
+	database, err := Open(Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = database.Close() }()
+
+	basis, ok := database.StateToken()
+	if !ok {
+		t.Fatal("initial state token unavailable")
+	}
+	if err := database.SetSync([]byte("key"), []byte("value")); err != nil {
+		t.Fatalf("advance visible root: %v", err)
+	}
+
+	err = database.CommitAtState(basis.RootPageID, basis)
+	if !errors.Is(err, ErrConcurrentModification) {
+		t.Fatalf("stale CommitAtState error=%v want %v", err, ErrConcurrentModification)
+	}
+	value, err := database.Get([]byte("key"))
+	if err != nil || string(value) != "value" {
+		t.Fatalf("value after stale rejection=%q err=%v want value", string(value), err)
+	}
+
+	current, ok := database.StateToken()
+	if !ok {
+		t.Fatal("current state token unavailable")
+	}
+	if err := database.CommitAtState(current.RootPageID, current); err != nil {
+		t.Fatalf("CommitAtState at current basis: %v", err)
+	}
+}

--- a/TreeDB/db/manual_root_commit_test.go
+++ b/TreeDB/db/manual_root_commit_test.go
@@ -3,6 +3,9 @@ package db
 import (
 	"errors"
 	"testing"
+	"time"
+
+	"github.com/snissn/gomap/TreeDB/internal/iterator"
 )
 
 func TestCommitAtStateRejectsAdvancedBasis(t *testing.T) {
@@ -35,5 +38,91 @@ func TestCommitAtStateRejectsAdvancedBasis(t *testing.T) {
 	}
 	if err := database.CommitAtState(current.RootPageID, current); err != nil {
 		t.Fatalf("CommitAtState at current basis: %v", err)
+	}
+}
+
+func TestCommitAtStateMapsPublicationRaceToConcurrentModification(t *testing.T) {
+	database, err := Open(Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = database.Close() }()
+
+	basis, ok := database.StateToken()
+	if !ok {
+		t.Fatal("initial state token unavailable")
+	}
+
+	predecessorReleased := make(chan struct{})
+	releasePredecessor := make(chan struct{})
+	database.testAfterFinalizeRootSerializationReleaseHook = func() {
+		close(predecessorReleased)
+		<-releasePredecessor
+	}
+	defer func() { database.testAfterFinalizeRootSerializationReleaseHook = nil }()
+
+	system := mustFrozenSystemMemtable(t, "sys/manual-root-race", "preserved")
+	predecessorErr := make(chan error, 1)
+	go func() {
+		_, _, publishErr := database.PublishOrderedRootDeltaGroupWithSystemDeltaBuilder(nil, func([]uint64) (iterator.UnsafeIterator, error) {
+			return system.NewIterator(nil, nil), nil
+		})
+		predecessorErr <- publishErr
+	}()
+	select {
+	case <-predecessorReleased:
+	case <-time.After(5 * time.Second):
+		t.Fatal("predecessor did not release root serialization")
+	}
+	database.testAfterFinalizeRootSerializationReleaseHook = nil
+
+	manualReady := make(chan struct{})
+	database.testBeforeFinalizeCommitHook = func() { close(manualReady) }
+	defer func() { database.testBeforeFinalizeCommitHook = nil }()
+
+	manualErr := make(chan error, 1)
+	go func() {
+		manualErr <- database.CommitAtState(basis.RootPageID, basis)
+	}()
+	select {
+	case <-manualReady:
+	case <-time.After(5 * time.Second):
+		t.Fatal("CommitAtState did not reach finalization")
+	}
+	database.testBeforeFinalizeCommitHook = nil
+
+	close(releasePredecessor)
+	select {
+	case err = <-predecessorErr:
+	case <-time.After(5 * time.Second):
+		t.Fatal("predecessor did not finish")
+	}
+	if err != nil {
+		t.Fatalf("predecessor publication: %v", err)
+	}
+	select {
+	case err = <-manualErr:
+	case <-time.After(5 * time.Second):
+		t.Fatal("CommitAtState did not return after racing publication")
+	}
+	if !errors.Is(err, ErrConcurrentModification) {
+		t.Fatalf("CommitAtState race error=%v want %v", err, ErrConcurrentModification)
+	}
+	if errors.Is(err, errDurableRootCandidateStale) {
+		t.Fatalf("CommitAtState exposed internal stale-candidate error: %v", err)
+	}
+
+	snap := database.AcquireSnapshot()
+	if snap == nil {
+		t.Fatal("snapshot after concurrent-modification rejection is nil")
+	}
+	defer func() { _ = snap.Close() }()
+	state, ok := snap.StateToken()
+	if !ok {
+		t.Fatal("snapshot state unavailable")
+	}
+	entry, err := snap.GetEntryAtRoot(state.SystemRootPageID, []byte("sys/manual-root-race"))
+	if err != nil || string(entry.Value) != "preserved" {
+		t.Fatalf("racing publication value=%q err=%v want preserved", string(entry.Value), err)
 	}
 }

--- a/TreeDB/db/manual_root_commit_test.go
+++ b/TreeDB/db/manual_root_commit_test.go
@@ -126,3 +126,89 @@ func TestCommitAtStateMapsPublicationRaceToConcurrentModification(t *testing.T) 
 		t.Fatalf("racing publication value=%q err=%v want preserved", string(entry.Value), err)
 	}
 }
+
+func TestForceCommitRebasesAfterPublicationRace(t *testing.T) {
+	database, err := Open(Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = database.Close() }()
+
+	basis, ok := database.StateToken()
+	if !ok {
+		t.Fatal("initial state token unavailable")
+	}
+
+	predecessorReleased := make(chan struct{})
+	releasePredecessor := make(chan struct{})
+	database.testAfterFinalizeRootSerializationReleaseHook = func() {
+		close(predecessorReleased)
+		<-releasePredecessor
+	}
+	defer func() { database.testAfterFinalizeRootSerializationReleaseHook = nil }()
+
+	system := mustFrozenSystemMemtable(t, "sys/force-root-race", "preserved")
+	predecessorErr := make(chan error, 1)
+	go func() {
+		_, _, publishErr := database.PublishOrderedRootDeltaGroupWithSystemDeltaBuilder(nil, func([]uint64) (iterator.UnsafeIterator, error) {
+			return system.NewIterator(nil, nil), nil
+		})
+		predecessorErr <- publishErr
+	}()
+	select {
+	case <-predecessorReleased:
+	case <-time.After(5 * time.Second):
+		t.Fatal("predecessor did not release root serialization")
+	}
+	database.testAfterFinalizeRootSerializationReleaseHook = nil
+
+	manualReady := make(chan struct{})
+	database.testBeforeFinalizeCommitHook = func() { close(manualReady) }
+	defer func() { database.testBeforeFinalizeCommitHook = nil }()
+
+	manualErr := make(chan error, 1)
+	go func() {
+		manualErr <- database.ForceCommit(basis.RootPageID)
+	}()
+	select {
+	case <-manualReady:
+	case <-time.After(5 * time.Second):
+		t.Fatal("ForceCommit did not reach finalization")
+	}
+	database.testBeforeFinalizeCommitHook = nil
+
+	close(releasePredecessor)
+	select {
+	case err = <-predecessorErr:
+	case <-time.After(5 * time.Second):
+		t.Fatal("predecessor did not finish")
+	}
+	if err != nil {
+		t.Fatalf("predecessor publication: %v", err)
+	}
+	select {
+	case err = <-manualErr:
+	case <-time.After(5 * time.Second):
+		t.Fatal("ForceCommit did not return after racing publication")
+	}
+	if err != nil {
+		t.Fatalf("ForceCommit after racing publication: %v", err)
+	}
+
+	snap := database.AcquireSnapshot()
+	if snap == nil {
+		t.Fatal("snapshot after force publication is nil")
+	}
+	defer func() { _ = snap.Close() }()
+	state, ok := snap.StateToken()
+	if !ok {
+		t.Fatal("snapshot state unavailable")
+	}
+	if state.RootPageID != basis.RootPageID {
+		t.Fatalf("forced user root=%d want %d", state.RootPageID, basis.RootPageID)
+	}
+	entry, err := snap.GetEntryAtRoot(state.SystemRootPageID, []byte("sys/force-root-race"))
+	if err != nil || string(entry.Value) != "preserved" {
+		t.Fatalf("racing publication value=%q err=%v want preserved", string(entry.Value), err)
+	}
+}

--- a/TreeDB/db/ordered_root_publish.go
+++ b/TreeDB/db/ordered_root_publish.go
@@ -1597,6 +1597,7 @@ func (db *DB) PublishOrderedRootIterator(baseRoot uint64, iter iterator.UnsafeIt
 	post, err := db.finalizeCommitReleasingRootSerialization(
 		userRoot, systemRoot, retired, false, metrics, nil, true, vlogRefDelta, nil, nil,
 		finalizeCommitOptions{closeTeardownPinned: true},
+		baseSeq,
 		func() {
 			db.writeMu.Unlock()
 			writeLocked = false
@@ -1792,7 +1793,7 @@ func (db *DB) PublishOrderedRootDeltaGroupWithSystemBuilder(ordered []OrderedRoo
 	var post finalizeCommitPost
 	post, err = db.finalizeCommitReleasingRootSerialization(
 		userRoot, newSystemRoot, retired, false, merged, touchedValueLogSegments, true, vlogRefDelta, nil, nil,
-		finalizeCommitOptions{closeTeardownPinned: true}, releaseWrite, nil,
+		finalizeCommitOptions{closeTeardownPinned: true}, baseSeq, releaseWrite, nil,
 	)
 	phaseStats.finalizeNs += orderedRootDeltaGroupPhaseDurationNs(phaseStart)
 	phaseStats.finalizeCalls++
@@ -2237,6 +2238,7 @@ func (db *DB) publishOrderedRootDeltaGroupWithSystemDeltaBuilderWithMaintenanceP
 	db.mu.RLock()
 	userRoot := db.meta.UserRootPageID
 	baseSystemRoot := db.meta.SystemRootPageID
+	baseSeq := db.meta.CommitSeq
 	db.mu.RUnlock()
 	if preflight != nil {
 		phaseStart := time.Now()
@@ -2340,7 +2342,7 @@ func (db *DB) publishOrderedRootDeltaGroupWithSystemDeltaBuilderWithMaintenanceP
 	// tracker conservative by invalidating it after commit.
 	var vlogRefDelta *valueLogRefDelta
 	phaseStart = time.Now()
-	err = db.finalizeOrderedRootPublishWithCommandWALOptions(userRoot, newSystemRoot, retired, false, merged, touchedValueLogSegments, true, vlogRefDelta, nil, nil, commandWALIntent, opts, releaseWrite)
+	err = db.finalizeOrderedRootPublishWithCommandWALOptions(userRoot, newSystemRoot, retired, false, merged, touchedValueLogSegments, true, vlogRefDelta, nil, nil, baseSeq, commandWALIntent, opts, releaseWrite)
 	phaseStats.finalizeNs += orderedRootDeltaGroupPhaseDurationNs(phaseStart)
 	phaseStats.finalizeCalls++
 	if err != nil {
@@ -2427,6 +2429,7 @@ func (db *DB) publishOrderedRootDeltaGroupWithCommandWALContextAndSystemDeltaBui
 	db.mu.RLock()
 	userRoot := db.meta.UserRootPageID
 	baseSystemRoot := db.meta.SystemRootPageID
+	baseSeq := db.meta.CommitSeq
 	db.mu.RUnlock()
 	if preflight != nil {
 		phaseStart := time.Now()
@@ -2575,6 +2578,7 @@ func (db *DB) publishOrderedRootDeltaGroupWithCommandWALContextAndSystemDeltaBui
 	post, err := db.finalizeCommitReleasingRootSerialization(
 		userRoot, newSystemRoot, retired, syncCommandWAL, merged, touchedValueLogSegments,
 		true, vlogRefDelta, nil, nil, finalizeOpts,
+		baseSeq,
 		func() {
 			db.commitMu.Unlock()
 			commitLocked = false
@@ -3161,6 +3165,7 @@ func (db *DB) publishOrderedRootDeltaBatchGroupWithSystemDeltaBuilderSerialized(
 	db.mu.RLock()
 	userRoot := db.meta.UserRootPageID
 	baseSystemRoot := db.meta.SystemRootPageID
+	baseSeq := db.meta.CommitSeq
 	db.mu.RUnlock()
 	if preflight != nil {
 		phaseStart := time.Now()
@@ -3266,7 +3271,7 @@ func (db *DB) publishOrderedRootDeltaBatchGroupWithSystemDeltaBuilderSerialized(
 	// conservative by invalidating it after commit.
 	var vlogRefDelta *valueLogRefDelta
 	phaseStart = time.Now()
-	err = db.finalizeOrderedRootPublishWithCommandWALOptions(userRoot, newSystemRoot, retired, false, merged, touchedValueLogSegments, true, vlogRefDelta, nil, nil, commandWALIntent, opts, releaseWrite)
+	err = db.finalizeOrderedRootPublishWithCommandWALOptions(userRoot, newSystemRoot, retired, false, merged, touchedValueLogSegments, true, vlogRefDelta, nil, nil, baseSeq, commandWALIntent, opts, releaseWrite)
 	phaseStats.finalizeNs += orderedRootDeltaGroupPhaseDurationNs(phaseStart)
 	phaseStats.finalizeCalls++
 	if err != nil {
@@ -3349,6 +3354,7 @@ func (db *DB) publishOrderedRootDeltaBatchGroupWithCommandWALContextAndSystemDel
 	db.mu.RLock()
 	userRoot := db.meta.UserRootPageID
 	baseSystemRoot := db.meta.SystemRootPageID
+	baseSeq := db.meta.CommitSeq
 	db.mu.RUnlock()
 	if preflight != nil {
 		phaseStart := time.Now()
@@ -3506,6 +3512,7 @@ func (db *DB) publishOrderedRootDeltaBatchGroupWithCommandWALContextAndSystemDel
 	post, err := db.finalizeCommitReleasingRootSerialization(
 		userRoot, newSystemRoot, retired, syncCommandWAL, merged, touchedValueLogSegments,
 		true, vlogRefDelta, nil, nil, finalizeOpts,
+		baseSeq,
 		func() {
 			db.commitMu.Unlock()
 			commitLocked = false
@@ -3548,7 +3555,7 @@ type orderedRootCommandWALPublishOptions struct {
 	durableResourceRequirements rootpublication.StableLogicalObligationRequirements
 }
 
-func (db *DB) finalizeOrderedRootPublishWithCommandWALOptions(newRootID uint64, sysRootID uint64, retired []uint64, sync bool, metrics adaptive.Metrics, touchedValueLogSegments []uint32, forceValueLogRefresh bool, vlogRefDelta *valueLogRefDelta, leafManifest *leafGenerationManifest, leafManifestRawFileIDs []uint32, intent *CommandWALIntent, opts orderedRootCommandWALPublishOptions, releaseRootSerialization func()) error {
+func (db *DB) finalizeOrderedRootPublishWithCommandWALOptions(newRootID uint64, sysRootID uint64, retired []uint64, sync bool, metrics adaptive.Metrics, touchedValueLogSegments []uint32, forceValueLogRefresh bool, vlogRefDelta *valueLogRefDelta, leafManifest *leafGenerationManifest, leafManifestRawFileIDs []uint32, baseSeq uint64, intent *CommandWALIntent, opts orderedRootCommandWALPublishOptions, releaseRootSerialization func()) error {
 	defer opts.durableResources.Release()
 	if intent == nil {
 		finalizeOpts := finalizeCommitOptions{
@@ -3559,7 +3566,7 @@ func (db *DB) finalizeOrderedRootPublishWithCommandWALOptions(newRootID uint64, 
 		post, err := db.finalizeCommitReleasingRootSerialization(
 			newRootID, sysRootID, retired, sync, metrics, touchedValueLogSegments,
 			forceValueLogRefresh, vlogRefDelta, leafManifest, leafManifestRawFileIDs,
-			finalizeOpts, releaseRootSerialization, nil,
+			finalizeOpts, baseSeq, releaseRootSerialization, nil,
 		)
 		if err != nil {
 			return err
@@ -3588,7 +3595,7 @@ func (db *DB) finalizeOrderedRootPublishWithCommandWALOptions(newRootID uint64, 
 	post, err := db.finalizeCommitReleasingRootSerialization(
 		newRootID, sysRootID, retired, sync, metrics, touchedValueLogSegments,
 		forceValueLogRefresh, vlogRefDelta, leafManifest, leafManifestRawFileIDs,
-		finalizeOpts,
+		finalizeOpts, baseSeq,
 		func() {
 			db.commitMu.Unlock()
 			commitLocked = false
@@ -3759,6 +3766,7 @@ func (db *DB) publishOrderedRootGroup(systemIter iterator.UnsafeIterator, ordere
 	post, err := db.finalizeCommitReleasingRootSerialization(
 		userRoot, newSystemRoot, retired, false, merged, touchedValueLogSegments,
 		true, vlogRefDelta, nil, nil, finalizeCommitOptions{closeTeardownPinned: true},
+		baseSeq,
 		func() {
 			db.writeMu.Unlock()
 			writeLocked = false

--- a/TreeDB/db/ordered_root_publish_test.go
+++ b/TreeDB/db/ordered_root_publish_test.go
@@ -470,6 +470,7 @@ func TestFinalizeOrderedRootPublishExistingCoverageSyncRunsRawPublishBarriers(t 
 	db.mu.RLock()
 	userRoot := db.meta.UserRootPageID
 	systemRoot := db.meta.SystemRootPageID
+	baseSeq := db.meta.CommitSeq
 	db.mu.RUnlock()
 	barrierErr := errors.New("raw publish barrier ran")
 	var barrierCalled atomic.Bool
@@ -488,6 +489,7 @@ func TestFinalizeOrderedRootPublishExistingCoverageSyncRunsRawPublishBarriers(t 
 		nil,
 		nil,
 		nil,
+		baseSeq,
 		coverage,
 		orderedRootCommandWALPublishOptions{},
 		func() {},
@@ -514,6 +516,7 @@ func TestFinalizeOrderedRootPublishExistingCoverageSyncRunsRawPublishBarriers(t 
 		nil,
 		nil,
 		nil,
+		baseSeq,
 		coverage,
 		orderedRootCommandWALPublishOptions{},
 		func() {},
@@ -1917,6 +1920,99 @@ func TestPublishOrderedRootDeltaGroups_CloseUnconsumedIteratorsOnPolicyError(t *
 				t.Fatalf("second iterator closes=%d want 1", second.closes)
 			}
 		})
+	}
+}
+
+func TestOrderedRootDeltaRejectsBaseActivatedAfterRootBuild(t *testing.T) {
+	database, err := Open(Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = database.Close() }()
+
+	firstReleased := make(chan struct{})
+	releaseFirst := make(chan struct{})
+	database.testAfterFinalizeRootSerializationReleaseHook = func() {
+		close(firstReleased)
+		<-releaseFirst
+	}
+	publishDelta := func(key, value string) error {
+		_, _, err := database.PublishOrderedRootDeltaGroupWithSystemDeltaBuilder(nil, func([]uint64) (iterator.UnsafeIterator, error) {
+			delta := mustFrozenSystemMemtable(t, key, value)
+			return delta.NewIterator(nil, nil), nil
+		})
+		return err
+	}
+
+	firstErr := make(chan error, 1)
+	go func() { firstErr <- publishDelta("sys/first", "first") }()
+	select {
+	case <-firstReleased:
+	case <-time.After(5 * time.Second):
+		t.Fatal("first publication did not release root serialization")
+	}
+	database.testAfterFinalizeRootSerializationReleaseHook = nil
+
+	secondAtFinalize := make(chan struct{})
+	releaseSecond := make(chan struct{})
+	database.testBeforeFinalizeCommitHook = func() {
+		close(secondAtFinalize)
+		<-releaseSecond
+	}
+	secondErr := make(chan error, 1)
+	go func() { secondErr <- publishDelta("sys/second", "second") }()
+	select {
+	case <-secondAtFinalize:
+	case <-time.After(5 * time.Second):
+		t.Fatal("second publication did not finish its stale root build")
+	}
+
+	close(releaseFirst)
+	if err := <-firstErr; err != nil {
+		t.Fatalf("first publication: %v", err)
+	}
+	close(releaseSecond)
+	err = <-secondErr
+	database.testBeforeFinalizeCommitHook = nil
+	if !errors.Is(err, errDurableRootCandidateStale) {
+		t.Fatalf("second publication err=%v want stale candidate rejection", err)
+	}
+	if CommitPublicationAccepted(err) {
+		t.Fatalf("second publication stale rejection was marked accepted: %v", err)
+	}
+
+	snap := database.AcquireSnapshot()
+	if snap == nil {
+		t.Fatal("snapshot after stale rejection is nil")
+	}
+	state, ok := snap.StateToken()
+	if !ok {
+		_ = snap.Close()
+		t.Fatal("snapshot state unavailable")
+	}
+	entry, err := snap.GetEntryAtRoot(state.SystemRootPageID, []byte("sys/first"))
+	_ = snap.Close()
+	if err != nil || string(entry.Value) != "first" {
+		t.Fatalf("first value after stale rejection=%q err=%v want first", string(entry.Value), err)
+	}
+
+	if err := publishDelta("sys/second", "second"); err != nil {
+		t.Fatalf("retry second publication: %v", err)
+	}
+	snap = database.AcquireSnapshot()
+	if snap == nil {
+		t.Fatal("snapshot after retry is nil")
+	}
+	defer func() { _ = snap.Close() }()
+	state, ok = snap.StateToken()
+	if !ok {
+		t.Fatal("snapshot state after retry unavailable")
+	}
+	for key, want := range map[string]string{"sys/first": "first", "sys/second": "second"} {
+		entry, err := snap.GetEntryAtRoot(state.SystemRootPageID, []byte(key))
+		if err != nil || string(entry.Value) != want {
+			t.Fatalf("%s after retry=%q err=%v want %q", key, string(entry.Value), err, want)
+		}
 	}
 }
 

--- a/TreeDB/db/system_root_publish.go
+++ b/TreeDB/db/system_root_publish.go
@@ -82,6 +82,7 @@ func (db *DB) PublishSystemRootIterator(iter iterator.UnsafeIterator) (uint64, e
 	db.mu.RLock()
 	userRoot := db.meta.UserRootPageID
 	baseSystemRoot := db.meta.SystemRootPageID
+	baseSeq := db.meta.CommitSeq
 	db.mu.RUnlock()
 
 	ptrCollector, collectedIter := newPendingValueLogAppendPtrCollectingIterator(iter)
@@ -119,6 +120,7 @@ func (db *DB) PublishSystemRootIterator(iter iterator.UnsafeIterator) (uint64, e
 	post, err := db.finalizeCommitReleasingRootSerialization(
 		userRoot, newSystemRoot, retired, false, metrics, touchedValueLogSegments,
 		true, vlogRefDelta, nil, nil, finalizeCommitOptions{},
+		baseSeq,
 		func() {
 			db.writeMu.Unlock()
 			writeLocked = false

--- a/TreeDB/db/vlog_rewrite.go
+++ b/TreeDB/db/vlog_rewrite.go
@@ -2490,16 +2490,15 @@ func (db *DB) applyRewriteSwapBatchToSystemRoot(swaps []rewriteSwap, sync bool) 
 	if idx == nil {
 		return fmt.Errorf("vlog-rewrite: system root: missing index")
 	}
-	state := db.state.Load()
-	if state == nil {
-		return fmt.Errorf("vlog-rewrite: system root: missing backend state")
-	}
-
 	db.mu.RLock()
+	state := db.state.Load()
 	userRoot := db.meta.UserRootPageID
 	systemRoot := db.meta.SystemRootPageID
 	baseSeq := db.meta.CommitSeq
 	db.mu.RUnlock()
+	if state == nil {
+		return fmt.Errorf("vlog-rewrite: system root: missing backend state")
+	}
 	if systemRoot == 0 {
 		return nil
 	}
@@ -2557,16 +2556,15 @@ func (db *DB) applyRewriteSwapBatchToCollectionRoot(target *collectionRewriteRoo
 	if idx == nil {
 		return fmt.Errorf("vlog-rewrite: collection root: missing index")
 	}
-	state := db.state.Load()
-	if state == nil {
-		return fmt.Errorf("vlog-rewrite: collection root: missing backend state")
-	}
-
 	db.mu.RLock()
+	state := db.state.Load()
 	userRoot := db.meta.UserRootPageID
 	systemRoot := db.meta.SystemRootPageID
 	baseSeq := db.meta.CommitSeq
 	db.mu.RUnlock()
+	if state == nil {
+		return fmt.Errorf("vlog-rewrite: collection root: missing backend state")
+	}
 	if systemRoot == 0 {
 		return nil
 	}

--- a/TreeDB/db/vlog_rewrite.go
+++ b/TreeDB/db/vlog_rewrite.go
@@ -2518,6 +2518,7 @@ func (db *DB) applyRewriteSwapBatchToSystemRoot(swaps []rewriteSwap, sync bool) 
 	post, err := db.finalizeCommitReleasingRootSerialization(
 		userRoot, newSystemRoot, retired, sync, metrics, touched,
 		systemOpts.outerLeavesInValueLog, vlogRefDelta, nil, nil, finalizeCommitOptions{},
+		baseSeq,
 		func() {
 			db.writeMu.Unlock()
 			writeLocked = false
@@ -2613,6 +2614,7 @@ func (db *DB) applyRewriteSwapBatchToCollectionRoot(target *collectionRewriteRoo
 		post, err := db.finalizeCommitReleasingRootSerialization(
 			userRoot, systemRoot, retired, sync, metrics, touched,
 			rootOpts.outerLeavesInValueLog, vlogRefDelta, nil, nil, finalizeCommitOptions{},
+			baseSeq,
 			func() {
 				db.writeMu.Unlock()
 				writeLocked = false
@@ -2647,6 +2649,7 @@ func (db *DB) applyRewriteSwapBatchToCollectionRoot(target *collectionRewriteRoo
 	post, err := db.finalizeCommitReleasingRootSerialization(
 		userRoot, newSystemRoot, retired, sync, metrics, touched,
 		forceValueLogRefresh, vlogRefDelta, nil, nil, finalizeCommitOptions{},
+		baseSeq,
 		func() {
 			db.writeMu.Unlock()
 			writeLocked = false
@@ -2972,6 +2975,7 @@ func (db *DB) applyRewriteSwapBatchSerialized(swaps []rewriteSwap, sync bool) er
 				db.vacuum.RecordEntries(entries)
 			},
 		},
+		baseSeq,
 		func() {
 			db.writeMu.Unlock()
 			writeLocked = false

--- a/TreeDB/db/write_admission_test.go
+++ b/TreeDB/db/write_admission_test.go
@@ -75,7 +75,7 @@ func TestExclusiveWritersRejectCloseAfterQueuingForWriteMu(t *testing.T) {
 		name string
 		call func() error
 	}{
-		{name: "commit", call: func() error { return db.Commit(userRoot) }},
+		{name: "force-commit", call: func() error { return db.ForceCommit(userRoot) }},
 		{name: "checkpoint", call: db.Checkpoint},
 		{name: "compact-index", call: db.CompactIndex},
 		{name: "compact-storage-plan", call: func() error {


### PR DESCRIPTION
Fixes #3843
Parent tracker: #3776

## Summary

- bind every root-serialization-releasing publication to the commit sequence observed with its input roots before construction
- reject a candidate as stale when a predecessor activates after that candidate's root build but before finalization
- require the low-level finalizer to fail closed when no expected base commit sequence is supplied
- capture value-log rewrite state, roots, and commit sequence under one root-serialization read lock
- replace the ambiguous manual `Commit(root)` API with basis-checked `CommitAtState(root, token)` and explicitly named last-writer-wins `ForceCommit(root)`
- map both `CommitAtState` conflict windows to the public `ErrConcurrentModification` contract without exposing the internal stale-candidate sentinel
- rebase unconditional `ForceCommit` publication when a late predecessor activation invalidates its sampled base, while preserving basis-checked conditional behavior
- add deterministic interleaving regressions that prove predecessor mutations cannot be overwritten and both conditional rejection and unconditional force publication preserve the public contract

## Root cause

The publication handoff intentionally releases construction serialization before durability preparation and visible activation. That lets a successor begin building while its predecessor is still preparing.

`finalizeCommitReleasingRootSerialization` previously filled an omitted `expectedBaseCommitSeq` by sampling visible metadata only after the successor finished its root build. If the predecessor activated in that interval, the successor's stale root—built from commit N—was incorrectly labeled as based on N+1 and could install as N+2. In the text hardening workload that erased a successful create or drop, producing later duplicate/not-found errors in the single-owner lifecycle.

## Scope and semantics

The patch preserves construction/durability concurrency and existing typed stale-candidate retry behavior. It does not change text-index duplicate/not-found rules, hard-admission semantics, command-WAL behavior, persistent value-log reachability, compaction, stable-resource handling, or recovery policy.

Audited handoffs include ordered iterator/group and batch group publication, command-WAL context publication, system-root publication, manual public commit, compaction, and value-log rewrite. Existing direct finalizer paths already supplied their build-time base; the low-level finalizer now rejects any future omission.

The review refresh also closes adjacent basis and public-error gaps. Both online value-log rewrite paths now load the value-log state inside the same root-serialization read lock that captures roots and commit sequence, so an activation cannot pair old state with a new root basis. Manual root publication now requires a caller-captured `StateToken` through `CommitAtState`; `ForceCommit` preserves the pre-alpha last-writer-wins escape hatch but makes that behavior explicit. If a predecessor activates after `CommitAtState`'s early token comparison but before the durability finalizer checks the build base, the method translates that internal stale-candidate rejection to `ErrConcurrentModification` as documented. The corresponding late activation during unconditional `ForceCommit` now retries from the current system-root basis rather than leaking the internal stale-candidate error; the requested user root remains the explicit last writer.

## Local evidence

Before the fix, the deterministic regression failed because the stale second publication returned success instead of `errDurableRootCandidateStale`.

On exact commit `d42ca9ee348175ad160fd9d485cedb839f4ae948`:

- stale-manual-basis, late conditional-conflict, and late force-rebase regressions: 100/100 normal
- late conditional-conflict and force-rebase regressions: 20/20 under `-race`
- selected online value-log rewrite, manual-root, force-rebase, and stale-publication coverage: 20/20 normal and 5/5 under `-race`
- unchanged `TestTextV2HardeningConcurrentRewriteCreateDropSearchWrite2734`: 500/500 normal
- unchanged hardening test: 20/20 under `-race`
- `go vet ./TreeDB/db ./TreeDB/caching ./TreeDB/collections`: pass
- full normal: `TreeDB/db` 446.660s, `TreeDB/caching` 100.636s, `TreeDB/collections` 314.979s
- full race: `TreeDB/db` 481.635s, `TreeDB/caching` 118.351s, `TreeDB/collections` 406.989s

Hosted completion still requires the exact-head TreeDB matrix, two independent exact-SHA proof matrices, clean exact-head Codex review, zero unresolved threads, and a green post-merge default-branch matrix.
