### PR TITLE
[CI] isolate allocation gate and rebalance Windows collections

### DIFF
--- a/.github/scripts/test_treedb_windows_core_headroom.py
+++ b/.github/scripts/test_treedb_windows_core_headroom.py
@@ -83,6 +83,41 @@ class TreeDBWindowsCoreHeadroomTest(unittest.TestCase):
                     rf'\"\${tests_file}\"',
                 )
 
+    def test_collections_runnables_are_split_across_core_shards(self) -> None:
+        workflow = WORKFLOW.read_text(encoding="utf-8")
+        test_job = workflow_job(workflow, "test")
+        core_case = re.search(
+            r"^            windows-core\)\n(?P<body>.*?)(?=^              ;;$)",
+            test_job,
+            re.MULTILINE | re.DOTALL,
+        )
+        self.assertIsNotNone(core_case, "missing windows-core shell case")
+        body = core_case.group("body")
+
+        self.assertIn(
+            "grep -v '^github.com/snissn/gomap/TreeDB/collections$'",
+            body,
+            "collections must not remain an indivisible package-modulo assignment",
+        )
+        self.assertIn(
+            r"go test ./collections -list '^(Test|Example|Fuzz).*' | tr -d '\r' | "
+            r"grep -E '^(Test|Example|Fuzz)' > "
+            '"$collections_all_file"',
+            body,
+            "collections enumeration must retain ordinary fuzz-seed coverage",
+        )
+        self.assertRegex(
+            body,
+            r'awk -v idx="\$package_shard_index" -v n="\$package_shard_count" .* '
+            r'"\$collections_all_file" > "\$collections_test_file"',
+        )
+        self.assertIn(
+            'run_named_test_file ./collections "TreeDB/collections test '
+            'shard=${package_shard_index}/${package_shard_count}" '
+            '"$collections_test_file" treedb-test.jsonl',
+            body,
+        )
+
     def test_caching_shards_keep_their_existing_bounded_caps(self) -> None:
         workflow = WORKFLOW.read_text(encoding="utf-8")
 

--- a/.github/workflows/treedb-tests.yml
+++ b/.github/workflows/treedb-tests.yml
@@ -329,11 +329,15 @@ jobs:
               root_test_file="$(make_tmp)"
               db_all_file="$(make_tmp)"
               db_test_file="$(make_tmp)"
-              go list ./... | grep -v '^github.com/snissn/gomap/TreeDB$' | grep -v '^github.com/snissn/gomap/TreeDB/caching$' | grep -v '^github.com/snissn/gomap/TreeDB/db$' | awk -v idx="$package_shard_index" -v n="$package_shard_count" 'BEGIN { c = 0 } { if ((c % n) == idx) print; c++ }' > "$package_file"
+              collections_all_file="$(make_tmp)"
+              collections_test_file="$(make_tmp)"
+              go list ./... | grep -v '^github.com/snissn/gomap/TreeDB$' | grep -v '^github.com/snissn/gomap/TreeDB/caching$' | grep -v '^github.com/snissn/gomap/TreeDB/collections$' | grep -v '^github.com/snissn/gomap/TreeDB/db$' | awk -v idx="$package_shard_index" -v n="$package_shard_count" 'BEGIN { c = 0 } { if ((c % n) == idx) print; c++ }' > "$package_file"
               go test . -list '^(Test|Example).*' | tr -d '\r' | grep -E '^(Test|Example)' > "$root_all_file"
               go test ./db -list 'Test.*' | tr -d '\r' | grep '^Test' > "$db_all_file"
+              go test ./collections -list '^(Test|Example|Fuzz).*' | tr -d '\r' | grep -E '^(Test|Example|Fuzz)' > "$collections_all_file"
               awk -v idx="$package_shard_index" -v n="$package_shard_count" 'BEGIN { c = 0 } { if ((c % n) == idx) print; c++ }' "$root_all_file" > "$root_test_file"
               awk -v idx="$package_shard_index" -v n="$package_shard_count" 'BEGIN { c = 0 } { if ((c % n) == idx) print; c++ }' "$db_all_file" > "$db_test_file"
+              awk -v idx="$package_shard_index" -v n="$package_shard_count" 'BEGIN { c = 0 } { if ((c % n) == idx) print; c++ }' "$collections_all_file" > "$collections_test_file"
               echo "TreeDB windows-core package shard=${package_shard_index}/${package_shard_count}"
               ran_tests=false
               if [ -s "$package_file" ]; then
@@ -346,6 +350,10 @@ jobs:
               fi
               if [ -s "$db_test_file" ]; then
                 run_named_test_file ./db "TreeDB/db test shard=${package_shard_index}/${package_shard_count}" "$db_test_file" treedb-test.jsonl
+                ran_tests=true
+              fi
+              if [ -s "$collections_test_file" ]; then
+                run_named_test_file ./collections "TreeDB/collections test shard=${package_shard_index}/${package_shard_count}" "$collections_test_file" treedb-test.jsonl
                 ran_tests=true
               fi
               if [ "$ran_tests" = false ]; then

--- a/TreeDB/collections/column_vector_graph_quantized_asset_test.go
+++ b/TreeDB/collections/column_vector_graph_quantized_asset_test.go
@@ -941,6 +941,12 @@ func TestColumnGraphScalarU8CenteredQueryScratch2258(t *testing.T) {
 	if _, err := scorer.scoreOrdinal(1, &scratch, nil); err != nil {
 		t.Fatalf("warm scoreOrdinal: %v", err)
 	}
+	if collectionsRaceEnabled {
+		t.Skip("exact allocation counts are unstable under race instrumentation")
+	}
+	if !enterIsolatedVectorAllocationGate(t, "scalar-u8-centered-query-scratch") {
+		return
+	}
 	var stats columnVectorGraphNativeSearchStats
 	allocs := testing.AllocsPerRun(1000, func() {
 		scorer, err := reader.prepareScalarU8QuantizedScorer(columnVectorGraphNativeSearchQueryModeQuantizedOnly, def.QuantizedIndexes[0].Name, query, queryInvNorm, &scratch)


### PR DESCRIPTION
Closes #3867.
Closes #3868.

Parent tracker: #3776.

## What changed

- keep the centered scalar_u8 test's setup, query-centering parity, scratch reuse, warm scorer preparation, and warm score in the ordinary parent process;
- skip only `testing.AllocsPerRun` under the race detector;
- run the unchanged 1,000-sample exact-zero allocation assertion in the existing fresh-copy test-binary harness with a dedicated selector.
- keep the three Windows core jobs and their 30-minute caps, but remove `TreeDB/collections` from whole-package modulo assignment;
- enumerate the collections package's top-level `Test*`, `Example*`, and `Fuzz*` runnable entries and split them deterministically by the existing core shard index/count;
- execute each collections selection through the existing bounded named-test wrapper, with a test-first workflow contract covering exclusion, enumeration, partitioning, and execution.

No product code, scorer behavior, durability behavior, coverage, job count, timeout, or allocation threshold changes.

## Why

Post-merge `main@d81ae897f3b749caac69685dad49cf26a1e0b183` run `29601135696`, Ubuntu job `87953248798`, failed only `TestColumnGraphScalarU8CenteredQueryScratch2258` at `allocs/run=1 want 0`. The merged code did not touch this vector path. The unchanged exact test passed locally 100/100 normally and 20/20 under race, matching the already-characterized package-global `testing.AllocsPerRun` contamination class from #3848/#3849.

The same run's attempt-1 `windows-core-1` job `87953248729` reached the exact 30-minute cap while still testing. Its timing artifact recorded 594.40s for the split TreeDB root package and 494.27s for the indivisible collections package; `windows-core-2` and `windows-core-3` passed in 13m15 and 11m16. Current main already splits root and DB tests by name, but assigns all 2,379 top-level collections runnable entries to one core job as a whole package. The count includes one `Fuzz*` target whose ordinary seed corpus must remain covered. Deterministic three-way name partitioning yields 793/793/793 selections without changing coverage.

## Local evidence

All commands passed on the exact proposed diff:

```text
GOWORK=off go test ./TreeDB/collections -run '^TestColumnGraphScalarU8CenteredQueryScratch2258$' -count=100
ok github.com/snissn/gomap/TreeDB/collections 60.057s

GOWORK=off go test -race ./TreeDB/collections -run '^TestColumnGraphScalarU8CenteredQueryScratch2258$' -count=20
ok github.com/snissn/gomap/TreeDB/collections 7.541s

GOWORK=off go test ./TreeDB/collections -run '^(TestColumnGraphScalarU8CenteredQueryScratch2258|TestColumnGraphScalarU8QuantizedScoreOrdinalsUsesScalarU8BatchKernel2260)$' -count=20
ok github.com/snissn/gomap/TreeDB/collections 20.156s

python3 .github/scripts/test_treedb_windows_core_headroom.py
Ran 5 tests: OK

GOWORK=off go test ./TreeDB/collections
ok github.com/snissn/gomap/TreeDB/collections 194.275s

GOMAXPROCS=2 GOWORK=off go test -race ./TreeDB/collections
ok github.com/snissn/gomap/TreeDB/collections 321.762s

GOWORK=off go vet ./TreeDB/collections
PASS

ruby -e 'require "yaml"; YAML.parse_file(".github/workflows/treedb-tests.yml")'
PASS
```

Live enumeration found 2,379 collections runnable entries and partitioned them 793/793/793 across the unchanged three core shards.

## Hosted evidence

- Every ordinary workflow on the actual PR branch passed at exact head `134bc60d287e506d41a00d2f5a58cb1a98a2f38d`.
- Actual TreeDB run `29607549915` passed 15/15 on attempt 2 after one classified Ubuntu job-cap rerun. The attempt-1 Ubuntu artifact had no test failure and is tracked separately by #3871; its sole rerun passed in 8m12s. No second retry was used.
- Independent exact-SHA proof A `29607624188` passed 15/15 without reruns.
- Independent exact-SHA proof B `29609113105` passed 15/15 without reruns.
- All nine Windows core jobs passed without reruns under the unchanged 30-minute cap:
  - actual: 21m06s / 15m37s / 16m49s;
  - proof A: 20m32s / 15m29s / 18m01s;
  - proof B: 20m46s / 16m02s / 13m54s.
- The slowest core sample retained 8m54s of cap margin.
- Codex reviewed exact head `134bc60d28` with no major issues; CodeRabbit reviewed the full three-file exact diff with no findings; zero current review threads exist.
- Duplicate non-TreeDB workflows created only by the two exact-SHA proof refs were canceled immediately and are excluded from evidence.

## Boundaries preserved

- exact steady-state allocation requirement remains zero;
- 1,000-run measurement remains unchanged;
- parent and race paths still execute correctness and warmup;
- no unrelated test serialization or skip;
- three Windows core jobs and their 30-minute caps remain unchanged;
- every collections top-level test/example/fuzz target remains selected exactly once across the three core shards;
- no product fallback or semantic weakening.
