### PR TITLE
test(ci): restore command-WAL and Ubuntu smoke headroom

### DIFF
--- a/.github/scripts/test_treedb_windows_core_headroom.py
+++ b/.github/scripts/test_treedb_windows_core_headroom.py
@@ -132,6 +132,34 @@ class TreeDBWindowsCoreHeadroomTest(unittest.TestCase):
                 self.assertEqual(matrix_timeout(workflow, job_name), 25)
 
 
+class TreeDBLinuxAllPackagesHeadroomTest(unittest.TestCase):
+    def test_ubuntu_keeps_complete_serial_coverage_inside_a_bounded_cap(self) -> None:
+        workflow = WORKFLOW.read_text(encoding="utf-8")
+        matrix_match = re.search(
+            r"- name: ubuntu-latest\s+"
+            r"os: ubuntu-latest\s+"
+            r"timeout: (?P<timeout>\d+)\s+"
+            r"shard_kind: (?P<shard_kind>\S+)\s+"
+            r"run_vet: (?P<run_vet>\S+)",
+            workflow,
+        )
+        self.assertIsNotNone(matrix_match, "missing Ubuntu all-package matrix entry")
+
+        # The failed hosted run consumed about 14m13s in vet plus the four
+        # dominant packages before the fixed 15-minute cap canceled it. Keep
+        # a bounded cap with meaningful runner-variability and artifact margin.
+        self.assertEqual(int(matrix_match.group("timeout")), 25)
+        self.assertEqual(matrix_match.group("shard_kind"), "all")
+        self.assertEqual(matrix_match.group("run_vet"), "true")
+
+        test_job = workflow_job(workflow, "test")
+        self.assertIn("GOMAXPROCS: 2", test_job)
+        self.assertIn(
+            "go test -json -timeout 30m -p 1 ./... | tee treedb-test.jsonl",
+            test_job,
+        )
+
+
 class TreeDBLinuxRaceHeadroomTest(unittest.TestCase):
     def test_db_package_timeout_is_bounded_inside_the_job_cap(self) -> None:
         workflow = WORKFLOW.read_text(encoding="utf-8")

--- a/.github/workflows/treedb-tests.yml
+++ b/.github/workflows/treedb-tests.yml
@@ -178,7 +178,7 @@ jobs:
         include:
           - name: ubuntu-latest
             os: ubuntu-latest
-            timeout: 15
+            timeout: 25
             shard_kind: all
             run_vet: true
           - name: macos-latest

--- a/TreeDB/mongo_gateway/standalone_test.go
+++ b/TreeDB/mongo_gateway/standalone_test.go
@@ -661,22 +661,23 @@ func TestStandaloneServerCommandWALBSONInsertReadUpdateVisibility(t *testing.T) 
 				t.Fatalf("mongo connect: %v", err)
 			}
 
-			opTimeout := 15 * time.Second
-			if profile == treedb.ProfileCommandWALDurable {
-				opTimeout = 60 * time.Second
-			}
-			opCtx, opCancel := context.WithTimeout(context.Background(), opTimeout)
-			defer opCancel()
-			if err := client.Ping(opCtx, nil); err != nil {
+			const requestTimeout = 10 * time.Second
+			scenarioStarted := time.Now()
+			pingStarted := time.Now()
+			pingCtx, pingCancel := context.WithTimeout(context.Background(), requestTimeout)
+			err = client.Ping(pingCtx, nil)
+			pingElapsed := time.Since(pingStarted)
+			pingCancel()
+			if err != nil {
 				_ = client.Disconnect(context.Background())
 				cancel()
 				_ = ln.Close()
 				_ = standalone.Close()
-				t.Fatalf("driver ping: %v", err)
+				t.Fatalf("driver ping after %s (request limit %s): %v", pingElapsed, requestTimeout, err)
 			}
 
 			coll := client.Database("ycsb").Collection("usertable")
-			const docs = 2048
+			const docs = 512
 			const workers = 16
 			ycsbValues := func(i int) bson.D {
 				values := make(bson.D, 0, 11)
@@ -699,36 +700,45 @@ func TestStandaloneServerCommandWALBSONInsertReadUpdateVisibility(t *testing.T) 
 			}
 
 			type insertError struct {
-				index int
-				err   error
+				index   int
+				elapsed time.Duration
+				err     error
 			}
 			errCh := make(chan insertError, 1)
+			insertTimingCh := make(chan time.Duration, docs)
 			workCh := make(chan int)
+			insertCtx, insertCancel := context.WithCancel(context.Background())
 			var insertWG sync.WaitGroup
-			sendInsertErr := func(i int, err error) {
+			sendInsertErr := func(i int, elapsed time.Duration, err error) {
 				if err == nil {
 					return
 				}
 				select {
-				case errCh <- insertError{index: i, err: err}:
+				case errCh <- insertError{index: i, elapsed: elapsed, err: err}:
 				default:
 				}
-				opCancel()
+				insertCancel()
 			}
+			insertStarted := time.Now()
 			for worker := 0; worker < workers; worker++ {
 				insertWG.Add(1)
 				go func() {
 					defer insertWG.Done()
 					for {
 						select {
-						case <-opCtx.Done():
+						case <-insertCtx.Done():
 							return
 						case i, ok := <-workCh:
 							if !ok {
 								return
 							}
-							_, err := coll.InsertOne(opCtx, ycsbValues(i))
-							sendInsertErr(i, err)
+							requestStarted := time.Now()
+							requestCtx, requestCancel := context.WithTimeout(insertCtx, requestTimeout)
+							_, err := coll.InsertOne(requestCtx, ycsbValues(i))
+							requestElapsed := time.Since(requestStarted)
+							requestCancel()
+							insertTimingCh <- requestElapsed
+							sendInsertErr(i, requestElapsed, err)
 						}
 					}
 				}()
@@ -737,7 +747,7 @@ func TestStandaloneServerCommandWALBSONInsertReadUpdateVisibility(t *testing.T) 
 				defer close(workCh)
 				for i := 0; i < docs; i++ {
 					select {
-					case <-opCtx.Done():
+					case <-insertCtx.Done():
 						return
 					case workCh <- i:
 					}
@@ -746,15 +756,18 @@ func TestStandaloneServerCommandWALBSONInsertReadUpdateVisibility(t *testing.T) 
 			insertDone := make(chan struct{})
 			go func() {
 				insertWG.Wait()
+				close(insertTimingCh)
 				close(insertDone)
 			}()
 			select {
 			case insertErr := <-errCh:
+				insertCancel()
+				<-insertDone
 				_ = client.Disconnect(context.Background())
 				cancel()
 				_ = ln.Close()
 				_ = standalone.Close()
-				t.Fatalf("insert %d: %v", insertErr.index, insertErr.err)
+				t.Fatalf("insert %d after %s (request limit %s): %v", insertErr.index, insertErr.elapsed, requestTimeout, insertErr.err)
 			case <-insertDone:
 				select {
 				case insertErr := <-errCh:
@@ -762,38 +775,62 @@ func TestStandaloneServerCommandWALBSONInsertReadUpdateVisibility(t *testing.T) 
 					cancel()
 					_ = ln.Close()
 					_ = standalone.Close()
-					t.Fatalf("insert %d: %v", insertErr.index, insertErr.err)
+					t.Fatalf("insert %d after %s (request limit %s): %v", insertErr.index, insertErr.elapsed, requestTimeout, insertErr.err)
 				default:
 				}
-				if err := opCtx.Err(); err != nil {
-					_ = client.Disconnect(context.Background())
-					cancel()
-					_ = ln.Close()
-					_ = standalone.Close()
-					t.Fatalf("insert workers stopped: %v", err)
+			}
+			insertCancel()
+			insertElapsed := time.Since(insertStarted)
+			var insertMax time.Duration
+			for elapsed := range insertTimingCh {
+				if elapsed > insertMax {
+					insertMax = elapsed
 				}
 			}
 
+			var initialReadElapsed time.Duration
+			var initialReadMax time.Duration
+			var updateElapsed time.Duration
+			var updateMax time.Duration
+			var finalReadElapsed time.Duration
+			var finalReadMax time.Duration
 			for i := 0; i < docs; i++ {
 				id := "user" + strconv.Itoa(i)
 				var got map[string][]byte
-				if err := coll.FindOne(opCtx, bson.D{{Key: "_id", Value: id}}, options.FindOne().SetProjection(projection)).Decode(&got); err != nil {
-					_ = client.Disconnect(context.Background())
-					cancel()
-					_ = ln.Close()
-					_ = standalone.Close()
-					t.Fatalf("find after insert %s: %v", id, err)
+				requestStarted := time.Now()
+				requestCtx, requestCancel := context.WithTimeout(context.Background(), requestTimeout)
+				err := coll.FindOne(requestCtx, bson.D{{Key: "_id", Value: id}}, options.FindOne().SetProjection(projection)).Decode(&got)
+				requestElapsed := time.Since(requestStarted)
+				requestCancel()
+				initialReadElapsed += requestElapsed
+				if requestElapsed > initialReadMax {
+					initialReadMax = requestElapsed
 				}
-				result, err := coll.UpdateOne(opCtx,
-					bson.D{{Key: "_id", Value: id}},
-					bson.D{{Key: "$set", Value: ycsbUpdate(i)}},
-				)
 				if err != nil {
 					_ = client.Disconnect(context.Background())
 					cancel()
 					_ = ln.Close()
 					_ = standalone.Close()
-					t.Fatalf("update %s: %v", id, err)
+					t.Fatalf("find after insert %s after %s (request limit %s): %v", id, requestElapsed, requestTimeout, err)
+				}
+				requestStarted = time.Now()
+				requestCtx, requestCancel = context.WithTimeout(context.Background(), requestTimeout)
+				result, err := coll.UpdateOne(requestCtx,
+					bson.D{{Key: "_id", Value: id}},
+					bson.D{{Key: "$set", Value: ycsbUpdate(i)}},
+				)
+				requestElapsed = time.Since(requestStarted)
+				requestCancel()
+				updateElapsed += requestElapsed
+				if requestElapsed > updateMax {
+					updateMax = requestElapsed
+				}
+				if err != nil {
+					_ = client.Disconnect(context.Background())
+					cancel()
+					_ = ln.Close()
+					_ = standalone.Close()
+					t.Fatalf("update %s after %s (request limit %s): %v", id, requestElapsed, requestTimeout, err)
 				}
 				if result.MatchedCount != 1 || result.ModifiedCount != 1 {
 					_ = client.Disconnect(context.Background())
@@ -803,12 +840,21 @@ func TestStandaloneServerCommandWALBSONInsertReadUpdateVisibility(t *testing.T) 
 					t.Fatalf("update %s matched=%d modified=%d, want 1/1", id, result.MatchedCount, result.ModifiedCount)
 				}
 				got = nil
-				if err := coll.FindOne(opCtx, bson.D{{Key: "_id", Value: id}}, options.FindOne().SetProjection(projection)).Decode(&got); err != nil {
+				requestStarted = time.Now()
+				requestCtx, requestCancel = context.WithTimeout(context.Background(), requestTimeout)
+				err = coll.FindOne(requestCtx, bson.D{{Key: "_id", Value: id}}, options.FindOne().SetProjection(projection)).Decode(&got)
+				requestElapsed = time.Since(requestStarted)
+				requestCancel()
+				finalReadElapsed += requestElapsed
+				if requestElapsed > finalReadMax {
+					finalReadMax = requestElapsed
+				}
+				if err != nil {
 					_ = client.Disconnect(context.Background())
 					cancel()
 					_ = ln.Close()
 					_ = standalone.Close()
-					t.Fatalf("find after update %s: %v", id, err)
+					t.Fatalf("find after update %s after %s (request limit %s): %v", id, requestElapsed, requestTimeout, err)
 				}
 				if string(got["field0"]) != "updated"+strconv.Itoa(i)+"-0" {
 					_ = client.Disconnect(context.Background())
@@ -818,6 +864,8 @@ func TestStandaloneServerCommandWALBSONInsertReadUpdateVisibility(t *testing.T) 
 					t.Fatalf("find after update %s field0=%q want updated", id, got["field0"])
 				}
 			}
+			t.Logf("command-WAL BSON visibility profile=%s docs=%d workers=%d request_limit=%s ping=%s insert_wall=%s insert_max=%s initial_read_total=%s initial_read_max=%s update_total=%s update_max=%s final_read_total=%s final_read_max=%s scenario_wall=%s",
+				profile, docs, workers, requestTimeout, pingElapsed, insertElapsed, insertMax, initialReadElapsed, initialReadMax, updateElapsed, updateMax, finalReadElapsed, finalReadMax, time.Since(scenarioStarted))
 
 			if err := client.Disconnect(context.Background()); err != nil {
 				cancel()


### PR DESCRIPTION
Closes #3864
Closes #3871

Parent tracker: #3776

## Summary

- turn the standalone command-WAL BSON visibility test from an accidental 2,048-sync shared-deadline performance gate into a bounded 512-document semantic smoke
- preserve both relaxed and durable profiles, 16-worker inserts, BSON projection, insert visibility, exact update counts, immediate read-after-update visibility, and clean shutdown
- give every ping/insert/read/update request its own 10-second deadline; cancel concurrent inserts on the first failure and report bounded phase totals plus per-operation maxima
- raise only the Ubuntu all-package outer job cap from 15 to 25 minutes while retaining vet, `GOMAXPROCS=2`, `go test -json -timeout 30m -p 1 ./...`, and the JSON evidence artifact
- pin that complete Ubuntu command shape and bounded cap in the existing workflow contract test

## Characterization and test-first evidence

The hosted #3864 failure expired the one shared 60-second context at durable update `user1997`; it did not show that the request itself had run for 60 seconds. Exact pre-change local runs took 0.55-0.61 seconds relaxed and 12.44-14.58 seconds durable for all 2,048 documents. After the bounded smoke change, a representative durable run reported:

```text
docs=512 workers=16 request_limit=10s
insert_wall=543ms insert_max=164ms
initial_read_total=49ms initial_read_max=187us
update_total=3.54s update_max=9.51ms
final_read_total=75ms final_read_max=244us
scenario_wall=4.21s
```

That separates cumulative durable sync cost from an individually stuck operation while still executing 512 concurrent inserts and 1,536 serial visibility operations per profile.

For #3871, the new workflow contract was first run red and failed only on `15 != 25`; it already confirmed the full serial `./...` command, vet, JSON output, and `GOMAXPROCS=2`. The failed hosted job consumed about 14m13s in vet plus the four dominant packages before the 15-minute cap canceled it. Its sole same-SHA retry passed in 8m12s, and exact post-#3870 main Ubuntu also passed at the old cap, classifying this as runner variability with effectively no bounded headroom rather than missing coverage or a test failure.

## Local validation

- workflow contract: 6/6
- workflow YAML parse
- focused command-WAL visibility: normal x5
- focused command-WAL visibility: race x3
- full `TreeDB/mongo_gateway`: normal
- full `TreeDB/mongo_gateway`: race
- `go vet ./TreeDB/mongo_gateway`
- `git diff --check`

All Go commands used `GOWORK=off`; repeated and race gates used the CI-equivalent `GOMAXPROCS=2` pin.

## Boundaries

- no product command-WAL, sync, recovery, visibility, value-log, or stable-resource behavior changes
- no retries or sleeps
- no TreeDB test coverage reduction in the Ubuntu all-package job
- Windows coverage remains mandatory; exact-head candidate and two independent proof matrices are required before merge


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Improved database integration test reliability by applying consistent per-request time limits and stopping work promptly after failures.
  - Added detailed timing and performance diagnostics for database operations.
  - Reduced test data volume to support more predictable execution.

- **Chores**
  - Increased the Ubuntu test job timeout to accommodate complete test coverage.
  - Added automated checks to ensure test execution remains bounded and uses controlled concurrency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->