### PR TITLE
test(collections): settle GC publication after snapshot drain

### DIFF
--- a/TreeDB/collections/column_asset_gc_test.go
+++ b/TreeDB/collections/column_asset_gc_test.go
@@ -894,6 +894,14 @@ func TestColumnAssetGCRetainsSupersededSegmentWhileOlderSnapshotPinnedM15C(t *te
 		t.Fatalf("Close pinned snapshot: %v", err)
 	}
 	pinnedClosed = true
+	// Closing the explicit snapshot releases its history pin, but the rewrite's
+	// visible root may still be crossing the asynchronous publication boundary.
+	// Settle that root before capturing destructive-maintenance authority so the
+	// test isolates fallback-slot retention instead of racing coordinator epoch
+	// advancement during RecoverableRootSet revalidation.
+	if err := d.Checkpoint(); err != nil {
+		t.Fatalf("settle rewrite publication after snapshot drain: %v", err)
+	}
 
 	drainedStats, err := col.ColumnAssetGC(context.Background(), ColumnAssetGCOptions{
 		CandidateRefs: candidates,

--- a/TreeDB/collections/stable_resource_inventory_test.go
+++ b/TreeDB/collections/stable_resource_inventory_test.go
@@ -15,6 +15,7 @@ import (
 	"testing"
 	"time"
 
+	backenddb "github.com/snissn/gomap/TreeDB/db"
 	"github.com/snissn/gomap/TreeDB/internal/authorityinventory"
 	"github.com/snissn/gomap/TreeDB/internal/rootpublication"
 )
@@ -416,6 +417,9 @@ func testColumnAssetGCRejectsCommitAdvanceWithUnchangedCandidateFrontier(t *test
 	}
 	key := []byte("published-to-other-segment")
 	document := []byte(`{"time_us":3,"kind":"like","did":"did:other"}`)
+	// This hook runs after GC captured and pinned its RecoverableRootSet but
+	// before the stable deleter's final revalidation. Advance the publication
+	// basis deterministically so the stale capability must fail closed.
 	restoreHook := setColumnAssetStableDeleteAfterPlanTestHook(func() {
 		if _, err := colB.Insert(key, document); err != nil {
 			t.Fatal(err)
@@ -428,6 +432,9 @@ func testColumnAssetGCRejectsCommitAdvanceWithUnchangedCandidateFrontier(t *test
 	})
 	if !errors.Is(err, ErrColumnAssetGCPlanStale) {
 		t.Fatalf("commit-advance GC error=%v want ErrColumnAssetGCPlanStale", err)
+	}
+	if !errors.Is(err, backenddb.ErrRecoverableRootSetStale) {
+		t.Fatalf("commit-advance GC error=%v want ErrRecoverableRootSetStale", err)
 	}
 	if stats.SegmentsEligible != 1 || stats.SegmentsDeleted != 0 {
 		t.Fatalf("commit-advance GC stats=%+v want eligible untouched", stats)


### PR DESCRIPTION
Closes #3873

Parent tracker: #3776

Blocks #3796 / PR #3798 until this PR merges and that PR refreshes onto current `main`.

## What changed

- settle rewrite/root publication with an explicit `Checkpoint` after the older snapshot closes and before the fixture captures destructive GC authority;
- strengthen the deterministic capture-to-revalidation interleaving to require both `ErrColumnAssetGCPlanStale` and its underlying `ErrRecoverableRootSetStale` classification;
- retain the existing zero-deletion, candidate-presence, cross-manager readability, fallback-slot retention, and eventual-deletion assertions.

## Why

PR #3798's exact-head TreeDB run `29614535658` failed `race-check (linux)-2` in `TestColumnAssetGCRetainsSupersededSegmentWhileOlderSnapshotPinnedM15C` with a fail-closed stale recoverable-root capability. The disjoint PR has no collections changes, and the same failure reproduced locally 12/100 under race before this patch.

Closing the explicit snapshot releases its history pin, but the rewrite's visible root can still be crossing the asynchronous publication boundary. The fixture previously began destructive GC immediately, so the coordinator could advance between reachability planning, recoverable-root capture/pinning, and final revalidation. The production path correctly rejected that stale capability and deleted nothing. This test-only handoff makes the integration fixture own the publication state it assumes.

## Validation

Pre-fix characterization:

```text
GOWORK=off GOMAXPROCS=2 go test -race ./TreeDB/collections -run '^TestColumnAssetGCRetainsSupersededSegmentWhileOlderSnapshotPinnedM15C$' -count=100
FAIL: 12/100 repetitions returned ErrRecoverableRootSetStale at post-drain GC
```

Post-fix:

```text
GOWORK=off GOMAXPROCS=2 go test ./TreeDB/collections -run '^TestColumnAssetGCRetainsSupersededSegmentWhileOlderSnapshotPinnedM15C$' -count=1000
PASS (235.174s)

GOWORK=off GOMAXPROCS=2 go test -race ./TreeDB/collections -run '^TestColumnAssetGCRetainsSupersededSegmentWhileOlderSnapshotPinnedM15C$' -count=100
PASS (25.787s)

GOWORK=off GOMAXPROCS=2 go test ./TreeDB/collections -run '^TestColumnAssetGCRejectsCommitAdvanceWithUnchangedCandidateFrontier$' -count=100
PASS (18.534s)

GOWORK=off GOMAXPROCS=2 go test -race ./TreeDB/collections -run '^TestColumnAssetGCRejectsCommitAdvanceWithUnchangedCandidateFrontier$' -count=20
PASS (4.422s)

adjacent GC/rewrite/recoverable-root set: normal x20 and race x10
PASS (21.172s / 12.632s)

GOWORK=off GOMAXPROCS=2 go test ./TreeDB/collections
PASS (179.978s)

GOWORK=off GOMAXPROCS=2 go test -race ./TreeDB/collections
PASS (294.173s)

GOWORK=off GOMAXPROCS=2 go vet ./TreeDB/collections
PASS

git diff --check
PASS
```

Exact-head hosted matrices and exact-head reviews will be recorded on the final head before merge.

## Boundaries

- test-only; no production hot-path or on-disk-format change;
- no retry or normalization of stale destructive capabilities;
- no weakening of recoverable-root fencing, stable-resource pins, snapshot/history pins, durable-root selection, or persistent value-log reachability;
- no performance threshold change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test coverage for column asset garbage collection and snapshot handling.
  * Added deterministic validation for stale garbage-collection requests and their expected recovery error.
  * Added checkpoint verification to ensure cleanup behavior is evaluated from a settled database state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->