### PR TITLE
test: isolate sync checkpoint boundary from background maintenance

### DIFF
--- a/TreeDB/sync_latency_bench_test.go
+++ b/TreeDB/sync_latency_bench_test.go
@@ -20,9 +20,12 @@ func TestSyncDurabilityBoundaryDoesNotCheckpoint(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			d, err := Open(Options{
-				Dir:        t.TempDir(),
-				Durability: tt.durability,
-				CommandWAL: tt.commandWAL,
+				Dir:                              t.TempDir(),
+				Durability:                       tt.durability,
+				CommandWAL:                       tt.commandWAL,
+				BackgroundCheckpointInterval:     -1,
+				BackgroundCheckpointIdleDuration: -1,
+				MaxWALBytes:                      -1,
 			})
 			if err != nil {
 				t.Fatalf("open: %v", err)


### PR DESCRIPTION
## Summary

- isolate `TestSyncDurabilityBoundaryDoesNotCheckpoint` from periodic, idle, and WAL-size auto-checkpoint triggers
- preserve all four durability/command-WAL cases and the exact zero-checkpoint assertion
- leave production checkpoint, WAL, durability, value-log, and CI timeout semantics unchanged

Closes #3879
Parent tracker: #3776

## Why

Exact current-main TreeDB run `29631883261`, Windows core-4 job `88047092176`, failed `wal_on_sync_command_wal` after 8.26s with `checkpoint.runs=1`. The fixture used the default 2-second idle auto-checkpoint trigger, so a delayed runner could observe an unrelated valid background checkpoint before the test's explicit boundary. The same subtest passed the three exact pre-merge matrices in 0.13-0.40s.

This is a test-fixture ownership correction. `SetSync` remains required not to checkpoint, and the assertion is unchanged.

## Test-first evidence

- RED: hosted current-main run `29631883261/88047092176` at `92f9dba492c8c77928ce88ffa785b688b97a0739`
- A synthetic local pre-fix red would require timing sleeps or production hooks, so the exact hosted failure is retained as the timing-dependent witness.
- GREEN: the fixture now disables all three independent auto-checkpoint sources.

## Local validation

- `GOWORK=off go test ./TreeDB -run '^TestSyncDurabilityBoundaryDoesNotCheckpoint$' -count=100` (`85.984s`)
- `GOWORK=off go test -race ./TreeDB -run '^TestSyncDurabilityBoundaryDoesNotCheckpoint$' -count=20` (`19.684s`)
- `GOWORK=off go vet ./TreeDB/...`
- `gofmt` clean
- `git diff --check origin/main...HEAD`
- clean worktree; effective diff is only `TreeDB/sync_latency_bench_test.go`

## Performance classification

Not performance-relevant: test-only options changed; production code, workloads, thresholds, and job budgets are untouched.

## Hosted and review evidence

- [x] Every ordinary exact-head PR workflow is green: 32/32 checks
- [x] TreeDB actual `29639053551`, proof A `29639068173`, and proof B `29639619138` each passed 18/18 on attempt 1; no rerun was used
- [x] All 15 Windows core artifacts have zero fail events, exact started/terminal parity, and no unfinished tests
- [x] Core-4 passed all four target cases in every matrix: `0.11-0.13s`, `0.17-0.18s`, and `0.28-0.52s`
- [x] Actual core walls: `10m32s`, `8m39s`, `11m55s`, `9m10s`, `15m03s`
- [x] Proof A core walls: `10m41s`, `10m20s`, `11m46s`, `10m23s`, `15m42s`
- [x] Proof B core walls: `10m20s`, `9m42s`, `14m41s`, `10m08s`, `16m35s`
- [x] Codex reported no major issues on exact head `85f389dd9`; CodeRabbit completed; GraphQL reports zero review threads
- [x] Immediately before merge, PR head/base are `85f389dd9a77a8dad77c4cfc3ac72a33385efc0d` / `d98c45b470d466404b8842432ea6ac2348487511`, current `main` is the same base, and GitHub reports `CLEAN`
- [x] Post-merge exact-main run `29640215992` passed 18/18 on attempt 1 at merge commit `9a16214e01b1a9c858ffeafd5079c6175ed462bc`; all five core artifacts are complete/clean
- [x] Required-check ruleset `19140463` was activated only after the exact-main gate passed
