### PR TITLE
test: scope collection close drain completion

### DIFF
--- a/TreeDB/collections/api_test.go
+++ b/TreeDB/collections/api_test.go
@@ -10602,6 +10602,11 @@ func TestCollectionCloseWaitsForInlineUpdateWithoutCombiner(t *testing.T) {
 	t.Cleanup(func() { _ = d.Close() })
 
 	mgr := NewCollectionManager(d)
+	collectionCloseHookDone := make(chan struct{})
+	d.RegisterCloseHook(func() error {
+		close(collectionCloseHookDone)
+		return nil
+	})
 	if _, err := mgr.CreateCollection(&CollectionMeta{
 		Name: "users",
 		Options: CollectionOptions{
@@ -10677,11 +10682,16 @@ func TestCollectionCloseWaitsForInlineUpdateWithoutCombiner(t *testing.T) {
 		t.Fatal("inline update did not finish after release")
 	}
 	select {
+	case <-collectionCloseHookDone:
+	case <-time.After(collectionTestTimeout(t, 5*time.Second)):
+		t.Fatal("collection close hook did not finish after inline update completed")
+	}
+	select {
 	case err := <-closeDone:
 		if err != nil {
 			t.Fatalf("close after inline update: %v", err)
 		}
-	case <-time.After(collectionTestTimeout(t, time.Second)):
+	case <-time.After(collectionTestTimeout(t, 30*time.Second)):
 		t.Fatal("close did not finish after inline update completed")
 	}
 	if updateErr != nil && !errors.Is(updateErr, backenddb.ErrClosed) {


### PR DESCRIPTION
Closes #3881.
Predecessor of #3879 / PR #3880.

## What changed

- Register a test-local ordinary close hook after the collection manager's close-before hook.
- Wait for that event to prove the collection manager has drained the inline update and flushed its state.
- Keep `DB.Close` as the production operation under test, but give the remaining whole-database teardown its own bounded safety deadline.
- Preserve the held-callback ordering check, update result contract, explicit close result, reopen, and persisted updated-value assertion.

No production code or durability, WAL, value-log, GC, stable-resource, or teardown semantics change.

## RED witness

PR #3880 proof-B run `29633556971`, Windows core-3 job `88051715340`, failed `TestCollectionCloseWaitsForInlineUpdateWithoutCombiner` because its final one-second wait covered all of `DB.Close`. The timeout fired about 1.32s after test start and cleanup completed about 0.43s later. The same exact test passed in the preceding actual/proof-A runs at 0.24s/0.05s. No failed-job rerun was used.

## Local validation

- `GOMAXPROCS=2 GOWORK=off go test ./TreeDB/collections -run '^TestCollectionCloseWaitsForInlineUpdateWithoutCombiner$' -count=100 -timeout=10m`
- `GOMAXPROCS=2 GOWORK=off go test -race ./TreeDB/collections -run '^TestCollectionCloseWaitsForInlineUpdateWithoutCombiner$' -count=20 -timeout=10m`
- Six affected/adjacent close-drain tests under race, 20 repetitions each
- `GOMAXPROCS=2 GOWORK=off go test ./TreeDB/collections -count=1 -timeout=15m` (`179.104s`)
- `GOWORK=off go vet ./TreeDB/collections`
- `gofmt`, `git diff --check`, and clean committed diff

## Hosted/review gate

Require exact-head actual plus two independent TreeDB proof matrices, exact-head Codex review, actionable CodeRabbit findings resolved, and zero unresolved threads before merge. Inspect Windows core-3 JSON artifacts for the target test, zero fail events, and no unfinished tests.
