### PR TITLE
test: bind sync checkpoint fixture to canonical profiles

### DIFF
--- a/TreeDB/sync_latency_bench_test.go
+++ b/TreeDB/sync_latency_bench_test.go
@@ -7,30 +7,26 @@ import (
 
 func TestSyncDurabilityBoundaryDoesNotCheckpoint(t *testing.T) {
 	tests := []struct {
-		name       string
-		durability DurabilityMode
-		commandWAL bool
+		name    string
+		profile Profile
 	}{
-		{name: "wal_on_sync", durability: DurabilityDurable},
-		{name: "wal_on_sync_command_wal", durability: DurabilityDurable, commandWAL: true},
-		{name: "wal_on_relaxed_sync", durability: DurabilityWALOnRelaxed},
-		{name: "wal_on_relaxed_sync_command_wal", durability: DurabilityWALOnRelaxed, commandWAL: true},
+		{name: "command_wal_durable", profile: ProfileCommandWALDurable},
+		{name: "command_wal_relaxed", profile: ProfileCommandWALRelaxed},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			d, err := Open(Options{
-				Dir:                              t.TempDir(),
-				Durability:                       tt.durability,
-				CommandWAL:                       tt.commandWAL,
-				BackgroundCheckpointInterval:     -1,
-				BackgroundCheckpointIdleDuration: -1,
-				MaxWALBytes:                      -1,
-			})
+			d, err := Open(syncBoundaryIsolatedOptions(tt.profile, t.TempDir()))
 			if err != nil {
 				t.Fatalf("open: %v", err)
 			}
 			defer func() { _ = d.Close() }()
+			if got := d.ResolvedProfile(); got != tt.profile {
+				t.Fatalf("resolved profile=%q, want %q", got, tt.profile)
+			}
+			if got := d.Stats()["treedb.cache.vlog_generation.scheduler_state"]; got != "disabled" {
+				t.Fatalf("value-log generation scheduler state=%q, want disabled", got)
+			}
 
 			val := make([]byte, 128)
 			var key [8]byte
@@ -49,50 +45,54 @@ func TestSyncDurabilityBoundaryDoesNotCheckpoint(t *testing.T) {
 	}
 }
 
+func syncBoundaryIsolatedOptions(profile Profile, dir string) Options {
+	opts := OptionsFor(profile, dir)
+	opts.BackgroundCheckpointInterval = -1
+	opts.BackgroundCheckpointIdleDuration = -1
+	opts.MaxWALBytes = -1
+	opts.BackgroundIndexVacuumInterval = -1
+	opts.DisableBackgroundPrune = true
+	opts.ValueLog.Generational.Policy = ValueLogGenerationOff
+	return opts
+}
+
 func BenchmarkSyncLatencyCached(b *testing.B) {
 	tests := []struct {
 		name                     string
-		durability               DurabilityMode
-		commandWAL               bool
+		profile                  Profile
 		batchSize                int
 		byteHint                 bool
 		nonZeroValue             bool
 		valueSize                int
 		valueLogPointerThreshold int
 	}{
-		{name: "SetSync/wal_on_sync", durability: DurabilityDurable},
-		{name: "SetSync/wal_on_sync_command_wal", durability: DurabilityDurable, commandWAL: true},
-		{name: "SetSync/wal_on_relaxed_sync", durability: DurabilityWALOnRelaxed},
-		{name: "SetSync/wal_on_relaxed_sync_command_wal", durability: DurabilityWALOnRelaxed, commandWAL: true},
-		{name: "BatchWriteSync/wal_on_sync/32/entry_hint", durability: DurabilityDurable, batchSize: 32},
-		{name: "BatchWriteSync/wal_on_sync_command_wal/32/entry_hint", durability: DurabilityDurable, commandWAL: true, batchSize: 32},
-		{name: "BatchWriteSync/wal_on_relaxed_sync/32/entry_hint", durability: DurabilityWALOnRelaxed, batchSize: 32},
-		{name: "BatchWriteSync/wal_on_relaxed_sync_command_wal/32/entry_hint", durability: DurabilityWALOnRelaxed, commandWAL: true, batchSize: 32},
-		{name: "BatchWriteSync/wal_on_relaxed_sync_command_wal/32/entry_hint_nonzero_value", durability: DurabilityWALOnRelaxed, commandWAL: true, batchSize: 32, nonZeroValue: true},
+		{name: "SetSync/command_wal_durable", profile: ProfileCommandWALDurable},
+		{name: "SetSync/command_wal_relaxed", profile: ProfileCommandWALRelaxed},
+		{name: "BatchWriteSync/command_wal_durable/32/entry_hint", profile: ProfileCommandWALDurable, batchSize: 32},
+		{name: "BatchWriteSync/command_wal_relaxed/32/entry_hint", profile: ProfileCommandWALRelaxed, batchSize: 32},
+		{name: "BatchWriteSync/command_wal_relaxed/32/entry_hint_nonzero_value", profile: ProfileCommandWALRelaxed, batchSize: 32, nonZeroValue: true},
 		// Force 128B values onto the value-log path so allocation profiles expose
 		// append-buffer behavior without changing the rest of the low-fanout batch
 		// shape.
-		{name: "BatchWriteSync/wal_on_relaxed_sync_command_wal/32/entry_hint_pointer_threshold_1", durability: DurabilityWALOnRelaxed, commandWAL: true, batchSize: 32, valueLogPointerThreshold: 1},
-		{name: "BatchWriteSync/wal_on_relaxed_sync_command_wal/32/byte_hint", durability: DurabilityWALOnRelaxed, commandWAL: true, batchSize: 32, byteHint: true},
-		{name: "BatchWriteSync/wal_on_relaxed_sync_command_wal/32/byte_hint_nonzero_value", durability: DurabilityWALOnRelaxed, commandWAL: true, batchSize: 32, byteHint: true, nonZeroValue: true},
-		{name: "BatchWriteSync/wal_on_sync_command_wal/128/entry_hint", durability: DurabilityDurable, commandWAL: true, batchSize: 128},
-		{name: "BatchWriteSync/wal_on_relaxed_sync_command_wal/128/entry_hint", durability: DurabilityWALOnRelaxed, commandWAL: true, batchSize: 128},
+		{name: "BatchWriteSync/command_wal_relaxed/32/entry_hint_pointer_threshold_1", profile: ProfileCommandWALRelaxed, batchSize: 32, valueLogPointerThreshold: 1},
+		{name: "BatchWriteSync/command_wal_relaxed/32/byte_hint", profile: ProfileCommandWALRelaxed, batchSize: 32, byteHint: true},
+		{name: "BatchWriteSync/command_wal_relaxed/32/byte_hint_nonzero_value", profile: ProfileCommandWALRelaxed, batchSize: 32, byteHint: true, nonZeroValue: true},
+		{name: "BatchWriteSync/command_wal_durable/128/entry_hint", profile: ProfileCommandWALDurable, batchSize: 128},
+		{name: "BatchWriteSync/command_wal_relaxed/128/entry_hint", profile: ProfileCommandWALRelaxed, batchSize: 128},
 	}
 
 	for _, tt := range tests {
 		b.Run(tt.name, func(b *testing.B) {
-			d, err := Open(Options{
-				Dir:        b.TempDir(),
-				Durability: tt.durability,
-				CommandWAL: tt.commandWAL,
-				ValueLog: ValueLogOptions{
-					PointerThreshold: tt.valueLogPointerThreshold,
-				},
-			})
+			opts := syncBoundaryIsolatedOptions(tt.profile, b.TempDir())
+			opts.ValueLog.PointerThreshold = tt.valueLogPointerThreshold
+			d, err := Open(opts)
 			if err != nil {
 				b.Fatalf("open: %v", err)
 			}
 			defer func() { _ = d.Close() }()
+			if got := d.ResolvedProfile(); got != tt.profile {
+				b.Fatalf("resolved profile=%q, want %q", got, tt.profile)
+			}
 
 			valueSize := tt.valueSize
 			if valueSize <= 0 {


### PR DESCRIPTION
Closes #3879

Parent: #3776
Blocks: #3790 / #3791

## Summary

`TestSyncDurabilityBoundaryDoesNotCheckpoint` could still fail on a slow Windows runner after PR #3880 because command-WAL profiles run without the internal journal, allowing the value-log generation scheduler's periodic GC path to perform its own legitimate checkpoint. Separately, canonical profile activation made the fixture's raw `Durability` / `CommandWAL` options ineffective: all four labeled variants resolved to the default command-WAL durable profile.

This follow-up binds the assertion and benchmark to the supported canonical command-WAL profiles and removes every independent background checkpoint source from the fixture.

## RED Evidence

PR #3791 exact head `dfb11340dfe09f1257238d5c57a5084c48c39ec4`:

- Actual `29643075570`: 18/18 pass on attempt 1.
- Proof A `29643130332`: 18/18 pass on attempt 1.
- Proof B `29643629941`: only Windows core-4 job `88078084347` failed.
- Failure: `TestSyncDurabilityBoundaryDoesNotCheckpoint/wal_on_sync`, `checkpoint.runs=1, want 0 before explicit Checkpoint/Close`.
- The subtest took 14.30 seconds; core-4 had 1228 starts, 1228 terminals, and no unfinished tests.
- No rerun was used.

## What Changed

- Build the fixture with `OptionsFor(ProfileCommandWALDurable, dir)` and `OptionsFor(ProfileCommandWALRelaxed, dir)`.
- Assert the resolved profile matches the requested profile.
- Disable the interval, idle, WAL-size, index-vacuum, prune, and value-log generation background sources for this semantic assertion.
- Assert the value-log generation scheduler is actually `disabled`.
- Rename the sync benchmark variants to their canonical profiles and remove duplicate/mislabeled raw-option cases.

Only `TreeDB/sync_latency_bench_test.go` changes. Production durability, WAL, checkpoint, value-log, GC, on-disk behavior, timeouts, retries, and platform coverage are unchanged.

## Local Validation

Exact head `913e6140c` on `main@445fdee99`:

- `GOWORK=off TMPDIR=/mnt/fast4tb/tmp go test ./TreeDB -run '^TestSyncDurabilityBoundaryDoesNotCheckpoint$' -count=100` — pass (`40.122s`)
- `GOWORK=off TMPDIR=/mnt/fast4tb/tmp go test -race ./TreeDB -run '^TestSyncDurabilityBoundaryDoesNotCheckpoint$' -count=20` — pass (`10.443s`)
- complete `BenchmarkSyncLatencyCached` matrix at `-benchtime=2x` — pass; all cases report `checkpoint.runs=0`
- `GOWORK=off TMPDIR=/mnt/fast4tb/tmp go vet ./TreeDB/...` — pass
- `GOWORK=off TMPDIR=/mnt/fast4tb/tmp go test ./TreeDB -count=1` — pass (`349.258s`)
- gofmt and `git diff --check` — pass

## Performance Classification

No production performance change. This fixes benchmark identity and isolation. Rows previously labeled as separate raw durability/command-WAL combinations were not distinct after canonical profile activation and should not be compared as if they were.

## Hosted Gates

- [ ] Ordinary exact-head CI
- [ ] Codex and CodeRabbit exact-head reviews
- [ ] Zero unresolved review threads
- [ ] TreeDB actual matrix
- [ ] TreeDB proof A
- [ ] TreeDB proof B
- [ ] Post-merge current-main TreeDB matrix


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved sync durability boundary coverage by testing behavior through configurable profiles.
  * Added validation that selected profiles resolve correctly and that value-log generation scheduling is disabled in isolated scenarios.
  * Updated sync latency benchmarks to use consistent profile-based configurations and dynamically adjustable thresholds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->