### PR TITLE
collections: bound monotonic document reconstruction

### DIFF
--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -409,6 +409,8 @@ type Collection struct {
 	lastInsertStats            CollectionInsertStats
 	updateStatsMu              sync.RWMutex
 	lastUpdateStats            CollectionUpdateStats
+	documentScanStatsMu        sync.RWMutex
+	lastDocumentScanStats      CollectionDocumentScanStats
 	vectorIndexLoadMu          sync.Mutex
 	vectorIndexesMu            sync.RWMutex
 	vectorIndexes              map[string]*VectorIndex
@@ -442,6 +444,34 @@ type Collection struct {
 	queryReadyGenerationHits          uint64
 	queryReadyGenerationBuilds        uint64
 	queryReadyGenerationInvalidations uint64
+}
+
+// CollectionDocumentScanStats describes the most recent ScanDocumentsFunc
+// execution on this Collection handle. It is a per-scan snapshot, not a
+// cumulative process metric.
+type CollectionDocumentScanStats struct {
+	CertifiedMonotonicPath bool
+	GenericFallback        bool
+	PhysicalPasses         uint64
+	PhysicalRows           uint64
+	PhysicalBytes          uint64
+	PhysicalDecodedBlocks  uint64
+	ReconstructedRows      uint64
+	MaxRecordWindow        uint64
+	MaxVisibleRowWindow    uint64
+	// MaxTypedGenerations is the peak number of resident typed generations.
+	MaxTypedGenerations uint64
+	// MaxTypedDecodedBytes is the peak owned decoded typed value state for one
+	// bounded reconstruction window. It excludes source part bytes.
+	MaxTypedDecodedBytes uint64
+	// MaxTypedSourcePartBytes is the largest encoded typed part read while
+	// reconstructing a bounded window. It is reported separately from owned
+	// decoded state because the read cache reuses its source buffer.
+	MaxTypedSourcePartBytes uint64
+	// MaxRetainedBlocks is the peak number of decoded semantic-stream retained
+	// blocks kept by the scan-wide fixed-capacity cache.
+	MaxRetainedBlocks         uint64
+	PreflightProjectedColumns uint64
 }
 
 type CollectionRootOverlayCompactionStats struct {
@@ -1512,6 +1542,26 @@ func cloneCollectionUpdateStats(stats CollectionUpdateStats) CollectionUpdateSta
 		stats.SecondaryRuns = append([]CollectionUpdateSecondaryRunStats(nil), stats.SecondaryRuns...)
 	}
 	return stats
+}
+
+// LastDocumentScanStats returns an owned snapshot of the most recent
+// ScanDocumentsFunc execution on this Collection handle.
+func (c *Collection) LastDocumentScanStats() CollectionDocumentScanStats {
+	if c == nil {
+		return CollectionDocumentScanStats{}
+	}
+	c.documentScanStatsMu.RLock()
+	defer c.documentScanStatsMu.RUnlock()
+	return c.lastDocumentScanStats
+}
+
+func (c *Collection) setLastDocumentScanStats(stats CollectionDocumentScanStats) {
+	if c == nil {
+		return
+	}
+	c.documentScanStatsMu.Lock()
+	c.lastDocumentScanStats = stats
+	c.documentScanStatsMu.Unlock()
 }
 
 func initCollectionUpdateIndexStats(stats *CollectionUpdateStats, collectionName string, runtimes []indexRuntime, enabled bool) {
@@ -20840,6 +20890,8 @@ func (c *Collection) ScanDocumentsFunc(maxDocuments int, fn func(DocumentRecord)
 	if fn == nil {
 		return false, errors.New("collections: scan callback is nil")
 	}
+	var scanStats CollectionDocumentScanStats
+	defer func() { c.setLastDocumentScanStats(scanStats) }()
 	if err := c.flushBufferedWrites(); err != nil {
 		return false, err
 	}
@@ -20865,7 +20917,24 @@ func (c *Collection) ScanDocumentsFunc(maxDocuments int, fn func(DocumentRecord)
 	defer func() { _ = it.Close() }()
 	reconstructDocuments := columnStoreCanReconstructDocument(catalog.meta)
 	if reconstructDocuments {
-		return c.scanDocumentsFuncWithColumnReconstruction(snap, catalog, it, maxDocuments, fn)
+		certified, preflightDiag, preflightRan, err := c.preflightMonotonicColumnReconstruction(snap, catalog)
+		if err != nil {
+			return false, err
+		}
+		if preflightRan {
+			scanStats.PreflightProjectedColumns = uint64(preflightDiag.ProjectedColumns)
+			scanStats.PhysicalPasses++
+			scanStats.PhysicalRows += uint64(preflightDiag.RowsScanned)
+			scanStats.PhysicalBytes += uint64(preflightDiag.PhysicalBytesScanned)
+			scanStats.PhysicalDecodedBlocks += uint64(preflightDiag.DecodedBlocks)
+		}
+		if certified {
+			scanStats.CertifiedMonotonicPath = true
+			return c.scanDocumentsFuncWithMonotonicColumnReconstruction(snap, catalog, maxDocuments, fn, &scanStats)
+		}
+		scanStats.GenericFallback = true
+		scanStats.PhysicalPasses++ // generic visibility scan follows any preflight pass.
+		return c.scanDocumentsFuncWithColumnReconstruction(snap, catalog, it, maxDocuments, fn, &scanStats)
 	}
 	truncated := false
 	scanned := 0
@@ -20904,6 +20973,7 @@ func (c *Collection) scanDocumentsFuncWithColumnReconstruction(
 	it iterator.UnsafeIterator,
 	maxDocuments int,
 	fn func(DocumentRecord) (bool, error),
+	stats *CollectionDocumentScanStats,
 ) (bool, error) {
 	columnStoreConfig := catalog.meta.Options.ColumnStore.copy()
 	capacity := maxDocuments
@@ -20958,6 +21028,11 @@ func (c *Collection) scanDocumentsFuncWithColumnReconstruction(
 	)
 	if err != nil {
 		return false, err
+	}
+	if stats != nil {
+		stats.PhysicalRows += uint64(visible.Diagnostics.RowsScanned)
+		stats.PhysicalBytes += uint64(visible.Diagnostics.PhysicalBytesScanned)
+		stats.PhysicalDecodedBlocks += uint64(visible.Diagnostics.DecodedBlocks)
 	}
 	visibleRows := visible.Rows
 	visiblePos := 0

--- a/TreeDB/collections/column_reconstruction_monotonic.go
+++ b/TreeDB/collections/column_reconstruction_monotonic.go
@@ -20,6 +20,16 @@ var errColumnReconstructionMonotonicStop = errors.New("collections: stop monoton
 // scanColumnValuesRows so incompatible layouts retain the generic, full-part
 // reconstruction behavior.
 func columnStoreSupportsMonotonicSelectedTypedReconstruction(cfg ColumnStoreConfig) bool {
+	for _, key := range cfg.SortKey {
+		for _, column := range cfg.Columns {
+			if column.Name == key.Column && columnStoreColumnIsTypedColumnPart(column) {
+				// Typed-column parts are stored in their sort-key order, while
+				// visible RowIndex remains in primary/physical order. The certified
+				// path has no locator remapping, so retain generic reconstruction.
+				return false
+			}
+		}
+	}
 	for _, field := range columnStoreTypedColumnPartFields(cfg) {
 		if field.Nullable {
 			return false

--- a/TreeDB/collections/column_reconstruction_monotonic.go
+++ b/TreeDB/collections/column_reconstruction_monotonic.go
@@ -1,0 +1,352 @@
+package collections
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+
+	backenddb "github.com/snissn/gomap/TreeDB/db"
+)
+
+// columnReconstructionMonotonicBatchSize bounds all reconstruction-owned
+// records and visible rows on the certified insert-only fast path.
+const columnReconstructionMonotonicBatchSize = 256
+
+var errColumnReconstructionMonotonicStop = errors.New("collections: stop monotonic reconstruction scan")
+
+// preflightMonotonicColumnReconstruction certifies that the physical row assets
+// and primary root describe the same ordered, insert-only snapshot. Any normal
+// mutation or ordering mismatch declines the fast path; structural mismatch
+// fails closed.
+func (c *Collection) preflightMonotonicColumnReconstruction(snap *backenddb.Snapshot, catalog *collectionCatalog) (bool, columnPhysicalScanDiagnostics, bool, error) {
+	cfg := catalog.meta.Options.ColumnStore.copy()
+	rootID := catalog.rootID(collectionColumnManifestRootName(catalog.meta.Name))
+	view, err := c.prepareColumnPhysicalScanSnapshotViewAtSnapshot(snap, catalog, catalog.meta.Name, rootID, cfg, true)
+	if err != nil {
+		return false, view.Diagnostics, false, err
+	}
+	if view.MutationParts != 0 {
+		return false, view.Diagnostics, false, nil
+	}
+	primary, err := collectionIteratorAtCatalogRoot(snap, catalog, collectionPrimaryRootName(catalog.meta.Name), nil, nil, false)
+	if err != nil {
+		return false, view.Diagnostics, false, err
+	}
+	if primary == nil {
+		return false, view.Diagnostics, false, nil
+	}
+	defer func() { _ = primary.Close() }()
+
+	classifier := monotonicColumnReconstructionPreflight{eligible: true}
+	diag, err := c.scanColumnPhysicalRowsInSnapshotView(view, columnPhysicalScanRequest{ProjectedColumns: []string{}, Visitor: func(row columnPhysicalScanRowView) error {
+		if primary.Valid() {
+			classifier.observe(row, primary.UnsafeKey(), true)
+			primary.Next()
+			if err := primary.Error(); err != nil {
+				return err
+			}
+			return nil
+		}
+		classifier.observe(row, nil, false)
+		return nil
+	}})
+	if err != nil {
+		return false, diag, true, err
+	}
+	if err := primary.Error(); err != nil {
+		return false, diag, true, err
+	}
+	certified, err := classifier.finish(primary.Valid())
+	if err != nil {
+		return false, diag, true, err
+	}
+	return certified, diag, true, nil
+}
+
+// monotonicColumnReconstructionPreflight is deliberately independent of the
+// storage scanner so malformed ordered-ID streams can be tested directly.
+type monotonicColumnReconstructionPreflight struct {
+	previous                           []byte
+	previousGeneration, previousPartID uint64
+	havePreviousPart                   bool
+	eligible, primaryMismatch, orphan  bool
+	duplicate                          bool
+}
+
+func (s *monotonicColumnReconstructionPreflight) observe(row columnPhysicalScanRowView, primaryID []byte, primaryValid bool) {
+	if row.Deleted || row.Operation != ColumnPublishOperationInsert {
+		s.eligible = false
+		return
+	}
+	if s.previous != nil {
+		order := bytes.Compare(s.previous, row.ID)
+		if order == 0 {
+			s.duplicate = true
+		}
+		if order > 0 {
+			s.eligible = false
+		}
+	}
+	if s.havePreviousPart && (row.Generation < s.previousGeneration || (row.Generation == s.previousGeneration && row.PartID < s.previousPartID)) {
+		s.eligible = false
+	}
+	s.previousGeneration, s.previousPartID, s.havePreviousPart = row.Generation, row.PartID, true
+	if !primaryValid {
+		s.orphan = true
+		return
+	}
+	if !bytes.Equal(primaryID, row.ID) {
+		s.primaryMismatch = true
+	}
+	s.previous = append(s.previous[:0], row.ID...)
+}
+
+func (s *monotonicColumnReconstructionPreflight) finish(primaryValid bool) (bool, error) {
+	if s.duplicate {
+		return false, errors.New("collections: monotonic reconstruction duplicate physical id")
+	}
+	if !s.eligible {
+		return false, nil
+	}
+	if s.orphan || s.primaryMismatch {
+		return false, errors.New("collections: monotonic reconstruction primary/physical id mismatch")
+	}
+	if primaryValid {
+		return false, errors.New("collections: monotonic reconstruction primary row missing physical match")
+	}
+	return true, nil
+}
+
+func (c *Collection) scanDocumentsFuncWithMonotonicColumnReconstruction(snap *backenddb.Snapshot, catalog *collectionCatalog, maxDocuments int, fn func(DocumentRecord) (bool, error), stats *CollectionDocumentScanStats) (bool, error) {
+	cfg := catalog.meta.Options.ColumnStore.copy()
+	rootID := catalog.rootID(collectionColumnManifestRootName(catalog.meta.Name))
+	view, err := c.prepareColumnPhysicalScanSnapshotViewAtSnapshot(snap, catalog, catalog.meta.Name, rootID, cfg, true)
+	if err != nil {
+		return false, err
+	}
+	primary, err := collectionIteratorAtCatalogRoot(snap, catalog, collectionPrimaryRootName(catalog.meta.Name), nil, nil, false)
+	if err != nil || primary == nil {
+		return false, err
+	}
+	defer func() { _ = primary.Close() }()
+
+	var typedCache *typedColumnPartReconstructionCache
+	if columnStoreHasTypedColumnPartOwners(cfg) {
+		readCache, err := newColumnPhysicalAssetReadCacheWithIntegrity(c.db.ColumnAssetRootDir(), cfg.AssetManager.Namespace, ColumnAssetReadIntegrityVerify)
+		if err != nil {
+			return false, err
+		}
+		typedCache = &typedColumnPartReconstructionCache{ReadCache: &readCache}
+		defer func() { _ = typedCache.ReadCache.close() }()
+	}
+	// Retained semantic blocks may span reconstruction windows. Keep the cache
+	// for the whole certified scan so a block is decoded once, while its fixed
+	// capacity keeps the retained state bounded independently of row count.
+	var retainedCache *columnRetainedSemanticStreamV1DecodeCache
+	if columnStoreRetainedPayloadUsesSemanticStreamV1(&cfg) {
+		retainedCache = newColumnRetainedSemanticStreamV1DecodeCache()
+	}
+
+	records := make([]DocumentRecord, 0, min(maxDocuments, columnReconstructionMonotonicBatchSize))
+	visibleRows := make([]columnPhysicalVisibleRow, 0, cap(records))
+	scanned := 0
+	visitedPhysicalRows := 0
+	stopped := false
+	var callbackErr error
+	flush := func() error {
+		if len(records) == 0 {
+			return nil
+		}
+		if stats != nil {
+			stats.MaxRecordWindow = max(stats.MaxRecordWindow, uint64(len(records)))
+			stats.MaxVisibleRowWindow = max(stats.MaxVisibleRowWindow, uint64(len(visibleRows)))
+		}
+		manifestRootID := catalog.rootID(collectionColumnManifestRootName(catalog.meta.Name))
+		mergeScratch := make([]columnDeclaredValue, 0, len(cfg.Columns))
+		resolver := columnRetainedPayloadTemplateResolver(snap, catalog)
+		typedWindow, err := c.typedColumnPartValuesForMonotonicWindow(snap, manifestRootID, cfg, visibleRows, typedCache)
+		if err != nil {
+			return err
+		}
+		if stats != nil && typedCache != nil {
+			stats.MaxTypedGenerations = max(stats.MaxTypedGenerations, typedCache.WindowGenerations)
+			stats.MaxTypedDecodedBytes = max(stats.MaxTypedDecodedBytes, typedCache.WindowDecodedBytes)
+			stats.MaxTypedSourcePartBytes = max(stats.MaxTypedSourcePartBytes, typedCache.WindowSourcePartBytes)
+		}
+		for i := range records {
+			fullValues, err := mergeColumnReconstructionValuesInto(cfg, visibleRows[i].Values, typedWindow[i].Values, mergeScratch)
+			if err != nil {
+				return err
+			}
+			retained, err := resolveColumnRetainedPayloadAtSnapshotWithCache(snap, catalog, cfg, records[i].Document, retainedCache)
+			if err != nil {
+				return err
+			}
+			_, reconstructed, err := reconstructColumnDocumentFromVisibleRowValuesProjectedIntoWithResolver(nil, cfg, retained, visibleRows[i], fullValues, nil, nil, resolver)
+			if err != nil {
+				return err
+			}
+			records[i].Document = reconstructed
+			if stats != nil {
+				stats.ReconstructedRows++
+				if retainedCache != nil {
+					stats.MaxRetainedBlocks = max(stats.MaxRetainedBlocks, uint64(len(retainedCache.blocks)))
+				}
+			}
+			next, err := fn(records[i])
+			if err != nil {
+				return err
+			}
+			if !next {
+				stopped = true
+				return nil
+			}
+		}
+		records = records[:0]
+		visibleRows = visibleRows[:0]
+		return nil
+	}
+	diag, scanErr := c.scanColumnPhysicalRowsInSnapshotView(view, columnPhysicalScanRequest{Visitor: func(row columnPhysicalScanRowView) error {
+		visitedPhysicalRows++
+		if scanned >= maxDocuments {
+			return errColumnReconstructionMonotonicStop
+		}
+		if !primary.Valid() || !bytes.Equal(primary.UnsafeKey(), row.ID) {
+			return fmt.Errorf("collections: certified monotonic reconstruction primary mismatch for id %q", row.ID)
+		}
+		records = append(records, DocumentRecord{ID: bytes.Clone(primary.UnsafeKey()), Document: primary.ValueCopy(nil)})
+		var visible columnPhysicalVisibleRow
+		assignColumnPhysicalVisibleRow(&visible, row)
+		visibleRows = append(visibleRows, visible)
+		primary.Next()
+		if err := primary.Error(); err != nil {
+			return err
+		}
+		scanned++
+		if len(records) == columnReconstructionMonotonicBatchSize {
+			if err := flush(); err != nil {
+				callbackErr = err
+				return errColumnReconstructionMonotonicStop
+			}
+			if stopped {
+				return errColumnReconstructionMonotonicStop
+			}
+		}
+		return nil
+	}})
+	if stats != nil {
+		stats.PhysicalPasses++
+		// The generic scanner does not return a partial summary when the visitor
+		// stops mid-asset, so use the exact visitor count for this pass.
+		stats.PhysicalRows += uint64(visitedPhysicalRows)
+		stats.PhysicalBytes += uint64(diag.PhysicalBytesScanned)
+		stats.PhysicalDecodedBlocks += uint64(diag.DecodedBlocks)
+	}
+	if callbackErr != nil {
+		return false, callbackErr
+	}
+	if scanErr != nil && !errors.Is(scanErr, errColumnReconstructionMonotonicStop) {
+		return false, scanErr
+	}
+	if stopped {
+		return false, nil
+	}
+	if err := flush(); err != nil {
+		return false, err
+	}
+	if stopped {
+		return false, nil
+	}
+	if err := primary.Error(); err != nil {
+		return false, err
+	}
+	if scanned < maxDocuments {
+		return false, nil
+	}
+	// The preflight has already proved exact one-to-one equality, so a remaining
+	// primary record is the only possible truncation signal at this snapshot.
+	return primary.Valid(), nil
+}
+
+// typedColumnPartValuesForMonotonicWindow decodes only row indexes referenced
+// by this bounded reconstruction window. The caller's certified ordering makes
+// generations monotonic; output positions preserve primary callback order.
+func (c *Collection) typedColumnPartValuesForMonotonicWindow(snap *backenddb.Snapshot, rootID uint64, cfg ColumnStoreConfig, rows []columnPhysicalVisibleRow, cache *typedColumnPartReconstructionCache) ([]typedColumnPartVisibleValues, error) {
+	out := make([]typedColumnPartVisibleValues, len(rows))
+	if !columnStoreHasTypedColumnPartOwners(cfg) {
+		return out, nil
+	}
+	fields := columnStoreTypedColumnPartFields(cfg)
+	if len(fields) == 0 {
+		return out, nil
+	}
+	if cache == nil {
+		cache = &typedColumnPartReconstructionCache{}
+	}
+	cache.WindowDecodedBytes = 0
+	cache.WindowGenerations = 0
+	cache.WindowSourcePartBytes = 0
+	cache.Fields = fields
+	if cache.ReadCache == nil {
+		rc, err := newColumnPhysicalAssetReadCacheWithIntegrity(c.db.ColumnAssetRootDir(), cfg.AssetManager.Namespace, ColumnAssetReadIntegrityVerify)
+		if err != nil {
+			return nil, err
+		}
+		cache.ReadCache = &rc
+		defer func() { _ = cache.ReadCache.close() }()
+	}
+	for start := 0; start < len(rows); {
+		generation := rows[start].Generation
+		end := start + 1
+		for end < len(rows) && rows[end].Generation == generation {
+			end++
+		}
+		indexes := make([]int, end-start)
+		for i := start; i < end; i++ {
+			indexes[i-start] = rows[i].RowIndex
+		}
+		part := cache.SelectivePart
+		if part == nil || cache.SelectivePartGeneration != generation {
+			ref, found, err := c.typedColumnPartRefForGenerationWithCache(snap, rootID, cfg, generation, cache)
+			if err != nil {
+				return nil, err
+			}
+			if !found {
+				return nil, fmt.Errorf("collections: typed-column reconstruction missing typed_column_part asset for generation=%d", generation)
+			}
+			raw, err := cache.ReadCache.read(ref.Ref, nil)
+			if err != nil {
+				return nil, err
+			}
+			cache.WindowSourcePartBytes = max(cache.WindowSourcePartBytes, uint64(len(raw)))
+			cache.PartLoads++
+			part, err = typedColumnAdapterPartFromBytesForReconstruction(typedColumnAdapterOptions{Fields: fields, SchemaVersion: uint32(cfg.SchemaHash)}, raw)
+			if err != nil {
+				return nil, err
+			}
+			cache.SelectivePart = part
+			cache.SelectivePartGeneration = generation
+		}
+		decoded, _, err := part.scanDecodedValuesSelectedRows(nil, indexes)
+		if err != nil {
+			return nil, err
+		}
+		cache.TypedPartDecodes++
+		// Only this adapter part remains resident; replacing it releases the
+		// previous generation before its source scratch is reused.
+		cache.WindowGenerations = 1
+		cache.WindowDecodedBytes += typedColumnPartDecodedValuesResidentBytes(decoded)
+		for i := start; i < end; i++ {
+			values := make([]columnDeclaredValue, len(fields))
+			for field := range fields {
+				if field >= len(decoded.Values) || i-start >= len(decoded.Values[field]) {
+					return nil, fmt.Errorf("collections: typed-column selected row decode field=%d row=%d unavailable", field, i-start)
+				}
+				values[field] = decoded.Values[field][i-start]
+			}
+			out[i] = typedColumnPartVisibleValues{Values: values}
+		}
+		start = end
+	}
+	return out, nil
+}

--- a/TreeDB/collections/column_reconstruction_monotonic.go
+++ b/TreeDB/collections/column_reconstruction_monotonic.go
@@ -14,12 +14,41 @@ const columnReconstructionMonotonicBatchSize = 256
 
 var errColumnReconstructionMonotonicStop = errors.New("collections: stop monotonic reconstruction scan")
 
+// columnStoreSupportsMonotonicSelectedTypedReconstruction is a metadata-only
+// gate for the certified path. That path asks each typed-column part to decode
+// selected rows; keep it opt-in to exactly the shapes supported by
+// scanColumnValuesRows so incompatible layouts retain the generic, full-part
+// reconstruction behavior.
+func columnStoreSupportsMonotonicSelectedTypedReconstruction(cfg ColumnStoreConfig) bool {
+	for _, field := range columnStoreTypedColumnPartFields(cfg) {
+		if field.Nullable {
+			return false
+		}
+		if columnStoreValueTypeIsPrimitiveScalar(field.ValueType) ||
+			columnStoreValueTypeIsDenseNumericVector(field.ValueType) ||
+			field.ValueType == ColumnStoreValueByteVector ||
+			columnStoreValueTypeIsPackedUintVector(field.ValueType) {
+			continue
+		}
+		switch field.ValueType {
+		case ColumnStoreValueString, ColumnStoreValueInt64, ColumnStoreValueBool:
+			continue
+		default:
+			return false
+		}
+	}
+	return true
+}
+
 // preflightMonotonicColumnReconstruction certifies that the physical row assets
 // and primary root describe the same ordered, insert-only snapshot. Any normal
 // mutation or ordering mismatch declines the fast path; structural mismatch
 // fails closed.
 func (c *Collection) preflightMonotonicColumnReconstruction(snap *backenddb.Snapshot, catalog *collectionCatalog) (bool, columnPhysicalScanDiagnostics, bool, error) {
 	cfg := catalog.meta.Options.ColumnStore.copy()
+	if !columnStoreSupportsMonotonicSelectedTypedReconstruction(cfg) {
+		return false, columnPhysicalScanDiagnostics{}, false, nil
+	}
 	rootID := catalog.rootID(collectionColumnManifestRootName(catalog.meta.Name))
 	view, err := c.prepareColumnPhysicalScanSnapshotViewAtSnapshot(snap, catalog, catalog.meta.Name, rootID, cfg, true)
 	if err != nil {

--- a/TreeDB/collections/column_reconstruction_monotonic_test.go
+++ b/TreeDB/collections/column_reconstruction_monotonic_test.go
@@ -408,6 +408,50 @@ func TestScanDocumentsFuncMonotonicReconstructionSelectiveTypedColumnP3887(t *te
 	}
 }
 
+func TestScanDocumentsFuncMonotonicReconstructionUnsupportedSelectedTypedFallsBackP3887(t *testing.T) {
+	dir := t.TempDir()
+	if err := backenddb.SaveFormatConfig(dir, backenddb.FormatConfig{RequiredFeatures: []string{backenddb.RequiredFeatureCommandWALV1}}); err != nil {
+		t.Fatal(err)
+	}
+	d, err := backenddb.Open(backenddb.Options{Dir: dir, DisableBackgroundPrune: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = d.Close() }()
+	cfg := &ColumnStoreConfig{Enabled: true, Columns: []ColumnStoreColumn{
+		{Name: "maybe_kind", Path: "maybe_kind", ValueType: ColumnStoreValueString, Dictionary: true, Nullable: true, Owner: TypedStorageOwnerColumnPart},
+		{Name: "tags", Path: "tags", ValueType: ColumnStoreValueUint32List, Owner: TypedStorageOwnerColumnPart},
+	}}
+	mgr := NewCollectionManager(d)
+	if _, err := mgr.CreateCollection(&CollectionMeta{Name: "events", Options: CollectionOptions{ColumnStore: cfg}}); err != nil {
+		t.Fatal(err)
+	}
+	col, err := mgr.OpenCollection("events")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := col.InsertBatch([][]byte{[]byte("a"), []byte("b")}, [][]byte{
+		[]byte(`{"maybe_kind":"present","tags":[1,2],"retained":"first"}`),
+		[]byte(`{"tags":[3],"retained":"second"}`),
+	}); err != nil {
+		t.Fatal(err)
+	}
+	var got []DocumentRecord
+	truncated, err := col.ScanDocumentsFunc(2, func(record DocumentRecord) (bool, error) {
+		got = append(got, record)
+		return true, nil
+	})
+	if err != nil || truncated || len(got) != 2 {
+		t.Fatalf("scan err=%v truncated=%t rows=%d", err, truncated, len(got))
+	}
+	assertJSONMapEqual1875(t, got[0].Document, map[string]any{"maybe_kind": "present", "tags": []any{float64(1), float64(2)}, "retained": "first"})
+	assertJSONMapEqual1875(t, got[1].Document, map[string]any{"tags": []any{float64(3)}, "retained": "second"})
+	stats := col.LastDocumentScanStats()
+	if stats.CertifiedMonotonicPath || !stats.GenericFallback || stats.PhysicalPasses != 1 {
+		t.Fatalf("scan stats=%+v want generic fallback before selected-row typed decoding", stats)
+	}
+}
+
 func TestScanDocumentsFuncMonotonicReconstructionBoundsRetainedSemanticCacheP3887(t *testing.T) {
 	dir := t.TempDir()
 	if err := backenddb.SaveFormatConfig(dir, backenddb.FormatConfig{RequiredFeatures: []string{backenddb.RequiredFeatureCommandWALV1}}); err != nil {

--- a/TreeDB/collections/column_reconstruction_monotonic_test.go
+++ b/TreeDB/collections/column_reconstruction_monotonic_test.go
@@ -1,0 +1,438 @@
+package collections
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"errors"
+	"fmt"
+	"os"
+	"strconv"
+	"testing"
+
+	backenddb "github.com/snissn/gomap/TreeDB/db"
+)
+
+func BenchmarkScanDocumentsFuncMonotonicReconstructionP3887(b *testing.B) {
+	rows := 100000
+	if raw := os.Getenv("P3887_BENCH_ROWS"); raw != "" {
+		var err error
+		rows, err = strconv.Atoi(raw)
+		if err != nil || rows <= 0 {
+			b.Fatalf("P3887_BENCH_ROWS=%q", raw)
+		}
+	}
+	// The fixture's DB directory is explicitly under /mnt/fast4tb for benchmark runs.
+	dir, err := os.MkdirTemp("/mnt/fast4tb", "gomap3887_bench_*")
+	if err != nil {
+		b.Fatal(err)
+	}
+	b.Cleanup(func() { _ = os.RemoveAll(dir) })
+	if err := backenddb.SaveFormatConfig(dir, backenddb.FormatConfig{RequiredFeatures: []string{backenddb.RequiredFeatureCommandWALV1}}); err != nil {
+		b.Fatal(err)
+	}
+	d, err := backenddb.Open(backenddb.Options{Dir: dir, DisableBackgroundPrune: true})
+	if err != nil {
+		b.Fatal(err)
+	}
+	b.Cleanup(func() { _ = d.Close() })
+	mgr := NewCollectionManager(d)
+	// time_us is intentionally a typed-column-part-owned field so this measures
+	// selective typed reconstruction, not only compatibility row assets.
+	cfg := &ColumnStoreConfig{Enabled: true, Columns: []ColumnStoreColumn{{Name: "time_us", Path: "time_us", ValueType: ColumnStoreValueInt64, Owner: TypedStorageOwnerColumnPart}, {Name: "kind", Path: "kind", ValueType: ColumnStoreValueString, Dictionary: true}, {Name: "operation", Path: "operation", ValueType: ColumnStoreValueString, Dictionary: true}, {Name: "collection", Path: "collection", ValueType: ColumnStoreValueString, Dictionary: true}, {Name: "did", Path: "did", ValueType: ColumnStoreValueString, Dictionary: true}}}
+	if _, err := mgr.CreateCollection(&CollectionMeta{Name: "events", Options: CollectionOptions{ColumnStore: cfg}}); err != nil {
+		b.Fatal(err)
+	}
+	col, err := mgr.OpenCollection("events")
+	if err != nil {
+		b.Fatal(err)
+	}
+	ids, docs := make([][]byte, rows), make([][]byte, rows)
+	for i := range ids {
+		ids[i] = []byte(fmt.Sprintf("e%09d", i))
+		docs[i] = []byte(fmt.Sprintf(`{"time_us":%d,"kind":"commit","operation":"create","collection":"app.bsky.feed.post","did":"did:%09d"}`, i, i))
+	}
+	const insertBatchRows = 100000
+	for start := 0; start < rows; start += insertBatchRows {
+		end := min(start+insertBatchRows, rows)
+		if _, err := col.InsertBatch(ids[start:end], docs[start:end]); err != nil {
+			b.Fatal(err)
+		}
+	}
+	if err := d.Close(); err != nil {
+		b.Fatal(err)
+	}
+	d, err = backenddb.Open(backenddb.Options{Dir: dir, DisableBackgroundPrune: true})
+	if err != nil {
+		b.Fatal(err)
+	}
+	col, err = NewCollectionManager(d).OpenCollection("events")
+	if err != nil {
+		b.Fatal(err)
+	}
+	b.ReportAllocs()
+	b.ReportMetric(float64(rows), "rows/op")
+	b.ResetTimer()
+	var scanStats CollectionDocumentScanStats
+	for i := 0; i < b.N; i++ {
+		count := 0
+		truncated, err := col.ScanDocumentsFunc(rows, func(DocumentRecord) (bool, error) { count++; return true, nil })
+		if err != nil || truncated || count != rows {
+			b.Fatalf("scan err=%v truncated=%t rows=%d", err, truncated, count)
+		}
+		scanStats = col.LastDocumentScanStats()
+		if !scanStats.CertifiedMonotonicPath || scanStats.GenericFallback || scanStats.PhysicalPasses != 2 || scanStats.PhysicalRows != uint64(rows*2) || scanStats.PhysicalDecodedBlocks != 2*uint64((rows+insertBatchRows-1)/insertBatchRows) || scanStats.MaxRecordWindow > uint64(columnReconstructionMonotonicBatchSize) || scanStats.MaxVisibleRowWindow > uint64(columnReconstructionMonotonicBatchSize) || scanStats.MaxTypedGenerations > 1 || scanStats.MaxRetainedBlocks > uint64(defaultColumnRetainedSemanticStreamV1DecodeCacheBlocks) {
+			b.Fatalf("scan stats=%+v", scanStats)
+		}
+	}
+	b.ReportMetric(float64(scanStats.MaxRecordWindow), "max_records/window")
+	b.ReportMetric(float64(scanStats.MaxVisibleRowWindow), "max_visible_rows/window")
+	b.ReportMetric(float64(scanStats.MaxTypedGenerations), "max_typed_generations/resident")
+	b.ReportMetric(float64(scanStats.MaxTypedDecodedBytes), "max_typed_decoded_bytes/window")
+	b.ReportMetric(float64(scanStats.MaxTypedSourcePartBytes), "max_typed_source_bytes/window")
+	b.ReportMetric(float64(scanStats.MaxRetainedBlocks), "max_retained_blocks/scan")
+	b.ReportMetric(float64(scanStats.PhysicalPasses), "physical_passes/op")
+	b.ReportMetric(float64(scanStats.PhysicalDecodedBlocks), "physical_decoded_blocks/op")
+}
+
+func TestScanDocumentsFuncMonotonicReconstructionReopenCanonicalParityP3887(t *testing.T) {
+	rows := 529
+	events := make([]columnPhysicalJSONBenchParityEventP0, rows)
+	for i := range events {
+		events[i] = columnPhysicalJSONBenchParityEventP0{ID: fmt.Sprintf("e%04d", i), TimeUS: int64(i), Kind: "commit", Operation: "create", Collection: "app.bsky.feed.post", Did: fmt.Sprintf("did:%04d", i)}
+	}
+	col, closeFn := openColumnPhysicalJSONBenchParityFixtureP0(t, events)
+	defer closeFn()
+	want := sha256.New()
+	for _, event := range events {
+		fmt.Fprintf(want, "%s\x00{\"time_us\":%d,\"kind\":%q,\"operation\":%q,\"collection\":%q,\"did\":%q}\n", event.ID, event.TimeUS, event.Kind, event.Operation, event.Collection, event.Did)
+	}
+	got := sha256.New()
+	count := 0
+	truncated, err := col.ScanDocumentsFunc(rows, func(record DocumentRecord) (bool, error) {
+		count++
+		got.Write(record.ID)
+		got.Write([]byte{0})
+		got.Write(record.Document)
+		got.Write([]byte{'\n'})
+		return true, nil
+	})
+	if err != nil || truncated || count != rows {
+		t.Fatalf("scan err=%v truncated=%t rows=%d want nil/false/%d", err, truncated, count, rows)
+	}
+	if !bytes.Equal(got.Sum(nil), want.Sum(nil)) {
+		t.Fatalf("canonical reconstructed sha256=%x want %x", got.Sum(nil), want.Sum(nil))
+	}
+}
+
+func TestScanDocumentsFuncMonotonicReconstructionCallbackAndTruncationP3887(t *testing.T) {
+	events := make([]columnPhysicalJSONBenchParityEventP0, 4)
+	for i := range events {
+		events[i] = columnPhysicalJSONBenchParityEventP0{ID: fmt.Sprintf("e%04d", i), TimeUS: int64(i), Kind: "commit", Operation: "create", Collection: "app.bsky.feed.post", Did: fmt.Sprintf("did:%04d", i)}
+	}
+	col, closeFn := openColumnPhysicalJSONBenchParityFixtureP0(t, events)
+	defer closeFn()
+	for _, tc := range []struct {
+		name          string
+		limit         int
+		stopAt        int
+		wantTruncated bool
+	}{
+		{name: "below", limit: 3, wantTruncated: true}, {name: "equal", limit: 4, wantTruncated: false}, {name: "above", limit: 5, wantTruncated: false}, {name: "early_false", limit: 4, stopAt: 2, wantTruncated: false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			calls := 0
+			truncated, err := col.ScanDocumentsFunc(tc.limit, func(DocumentRecord) (bool, error) { calls++; return tc.stopAt == 0 || calls < tc.stopAt, nil })
+			if err != nil || truncated != tc.wantTruncated {
+				t.Fatalf("err=%v truncated=%t want nil/%t", err, truncated, tc.wantTruncated)
+			}
+			if tc.stopAt != 0 && calls != tc.stopAt {
+				t.Fatalf("calls=%d want %d", calls, tc.stopAt)
+			}
+		})
+	}
+	wantErr := errors.New("callback error")
+	_, err := col.ScanDocumentsFunc(4, func(DocumentRecord) (bool, error) { return false, wantErr })
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("callback err=%v want %v", err, wantErr)
+	}
+	if stats := col.LastDocumentScanStats(); stats.ReconstructedRows != 1 {
+		t.Fatalf("callback-error reconstructed rows=%d want 1", stats.ReconstructedRows)
+	}
+}
+
+func TestMonotonicColumnReconstructionPreflightClassifierP3887(t *testing.T) {
+	row := func(id string) columnPhysicalScanRowView {
+		return columnPhysicalScanRowView{ID: []byte(id), Generation: 1, PartID: 1, Operation: ColumnPublishOperationInsert}
+	}
+	for _, tc := range []struct {
+		name     string
+		physical []columnPhysicalScanRowView
+		primary  [][]byte
+		wantCert bool
+		wantErr  string
+	}{
+		{name: "ordered", physical: []columnPhysicalScanRowView{row("a"), row("b")}, primary: [][]byte{[]byte("a"), []byte("b")}, wantCert: true},
+		{name: "shuffled_fallback", physical: []columnPhysicalScanRowView{row("b"), row("a")}, primary: [][]byte{[]byte("a"), []byte("b")}},
+		{name: "duplicate_fail_closed", physical: []columnPhysicalScanRowView{row("a"), row("a")}, primary: [][]byte{[]byte("a"), []byte("a")}, wantErr: "duplicate"},
+		{name: "orphan_fail_closed", physical: []columnPhysicalScanRowView{row("a"), row("b")}, primary: [][]byte{[]byte("a")}, wantErr: "mismatch"},
+		{name: "missing_fail_closed", physical: []columnPhysicalScanRowView{row("a")}, primary: [][]byte{[]byte("a"), []byte("b")}, wantErr: "missing"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			state := monotonicColumnReconstructionPreflight{eligible: true}
+			for i, physical := range tc.physical {
+				if i < len(tc.primary) {
+					state.observe(physical, tc.primary[i], true)
+				} else {
+					state.observe(physical, nil, false)
+				}
+			}
+			certified, err := state.finish(len(tc.primary) > len(tc.physical))
+			if tc.wantErr != "" {
+				if err == nil || !bytes.Contains([]byte(err.Error()), []byte(tc.wantErr)) {
+					t.Fatalf("err=%v want %q", err, tc.wantErr)
+				}
+				return
+			}
+			if err != nil || certified != tc.wantCert {
+				t.Fatalf("certified=%t err=%v want %t/nil", certified, err, tc.wantCert)
+			}
+		})
+	}
+}
+
+func TestScanDocumentsFuncMonotonicReconstructionWindowBoundariesP3887(t *testing.T) {
+	rows := columnReconstructionMonotonicBatchSize*2 + 17
+	events := make([]columnPhysicalJSONBenchParityEventP0, rows)
+	for i := range events {
+		events[i] = columnPhysicalJSONBenchParityEventP0{ID: fmt.Sprintf("e%04d", i), TimeUS: int64(i), Kind: "commit", Operation: "create", Collection: "app.bsky.feed.post", Did: fmt.Sprintf("did:%04d", i)}
+	}
+	col, closeFn := openColumnPhysicalJSONBenchParityFixtureP0(t, events)
+	defer closeFn()
+	for _, limit := range []int{columnReconstructionMonotonicBatchSize - 1, columnReconstructionMonotonicBatchSize, columnReconstructionMonotonicBatchSize + 1} {
+		calls := 0
+		truncated, err := col.ScanDocumentsFunc(limit, func(DocumentRecord) (bool, error) { calls++; return true, nil })
+		if err != nil || !truncated || calls != limit {
+			t.Fatalf("limit=%d err=%v truncated=%t calls=%d", limit, err, truncated, calls)
+		}
+		if stats := col.LastDocumentScanStats(); stats.PhysicalRows != uint64(rows+limit+1) {
+			t.Fatalf("limit=%d physical rows=%d want %d", limit, stats.PhysicalRows, rows+limit+1)
+		}
+	}
+	partialCalls := 0
+	truncated, err := col.ScanDocumentsFunc(17, func(DocumentRecord) (bool, error) {
+		partialCalls++
+		return partialCalls < 3, nil
+	})
+	if err != nil || truncated || partialCalls != 3 {
+		t.Fatalf("partial callback err=%v truncated=%t calls=%d", err, truncated, partialCalls)
+	}
+	for _, stopAt := range []int{1, columnReconstructionMonotonicBatchSize, rows} {
+		calls := 0
+		truncated, err := col.ScanDocumentsFunc(rows, func(DocumentRecord) (bool, error) { calls++; return calls < stopAt, nil })
+		if err != nil || truncated || calls != stopAt {
+			t.Fatalf("stopAt=%d err=%v truncated=%t calls=%d", stopAt, err, truncated, calls)
+		}
+		calls = 0
+		wantErr := fmt.Errorf("stop-%d", stopAt)
+		_, err = col.ScanDocumentsFunc(rows, func(DocumentRecord) (bool, error) {
+			calls++
+			if calls == stopAt {
+				return false, wantErr
+			}
+			return true, nil
+		})
+		if !errors.Is(err, wantErr) || calls != stopAt {
+			t.Fatalf("error stopAt=%d err=%v calls=%d", stopAt, err, calls)
+		}
+	}
+}
+
+func TestScanDocumentsFuncMonotonicReconstructionUpdateFallsBackP3887(t *testing.T) {
+	events := []columnPhysicalJSONBenchParityEventP0{{ID: "e0000", TimeUS: 1, Kind: "commit", Operation: "create", Collection: "app.bsky.feed.post", Did: "did:old"}}
+	col, closeFn := openColumnPhysicalJSONBenchParityFixtureP0(t, events)
+	defer closeFn()
+	if _, err := col.Replace([]byte("e0000"), []byte(`{"time_us":2,"kind":"commit","operation":"create","collection":"app.bsky.feed.post","did":"did:new"}`)); err != nil {
+		t.Fatalf("Update: %v", err)
+	}
+	var got []byte
+	_, err := col.ScanDocumentsFunc(1, func(record DocumentRecord) (bool, error) {
+		got = append([]byte(nil), record.Document...)
+		return true, nil
+	})
+	if err != nil {
+		t.Fatalf("ScanDocumentsFunc: %v", err)
+	}
+	if stats := col.LastDocumentScanStats(); stats.CertifiedMonotonicPath || !stats.GenericFallback || stats.PhysicalPasses != 1 {
+		t.Fatalf("scan stats=%+v want generic fallback", stats)
+	}
+	if want := `"did":"did:new"`; !bytes.Contains(got, []byte(want)) {
+		t.Fatalf("reconstructed document=%s want %s", got, want)
+	}
+}
+
+func TestScanDocumentsFuncMonotonicReconstructionShuffledGenerationsFallBackP3887(t *testing.T) {
+	dir := t.TempDir()
+	if err := backenddb.SaveFormatConfig(dir, backenddb.FormatConfig{RequiredFeatures: []string{backenddb.RequiredFeatureCommandWALV1}}); err != nil {
+		t.Fatal(err)
+	}
+	d, err := backenddb.Open(backenddb.Options{Dir: dir, DisableBackgroundPrune: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = d.Close() }()
+	mgr := NewCollectionManager(d)
+	cfg := &ColumnStoreConfig{Enabled: true, Columns: []ColumnStoreColumn{{Name: "time_us", Path: "time_us", ValueType: ColumnStoreValueInt64}}}
+	if _, err := mgr.CreateCollection(&CollectionMeta{Name: "events", Options: CollectionOptions{ColumnStore: cfg}}); err != nil {
+		t.Fatal(err)
+	}
+	col, err := mgr.OpenCollection("events")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := col.InsertBatch([][]byte{[]byte("e0002")}, [][]byte{[]byte(`{"time_us":2}`)}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := col.InsertBatch([][]byte{[]byte("e0001")}, [][]byte{[]byte(`{"time_us":1}`)}); err != nil {
+		t.Fatal(err)
+	}
+	callbacks := 0
+	var ids []string
+	truncated, err := col.ScanDocumentsFunc(2, func(record DocumentRecord) (bool, error) {
+		callbacks++
+		ids = append(ids, string(record.ID))
+		return true, nil
+	})
+	if err != nil || truncated || fmt.Sprint(ids) != "[e0001 e0002]" {
+		t.Fatalf("scan err=%v truncated=%t ids=%v", err, truncated, ids)
+	}
+	if stats := col.LastDocumentScanStats(); stats.CertifiedMonotonicPath || !stats.GenericFallback || callbacks != 2 {
+		t.Fatalf("scan stats=%+v callbacks=%d want generic fallback", stats, callbacks)
+	}
+}
+
+func TestScanDocumentsFuncMonotonicReconstructionBoundsWindowsP3887(t *testing.T) {
+	rows := columnReconstructionMonotonicBatchSize*2 + 17
+	events := make([]columnPhysicalJSONBenchParityEventP0, rows)
+	for i := range events {
+		events[i] = columnPhysicalJSONBenchParityEventP0{ID: fmt.Sprintf("e%04d", i), TimeUS: int64(i), Kind: "commit", Operation: "create", Collection: "app.bsky.feed.post", Did: fmt.Sprintf("did:%04d", i)}
+	}
+	col, closeFn := openColumnPhysicalJSONBenchParityFixtureP0(t, events)
+	defer closeFn()
+	var ids []string
+	truncated, err := col.ScanDocumentsFunc(rows, func(record DocumentRecord) (bool, error) { ids = append(ids, string(record.ID)); return true, nil })
+	if err != nil || truncated || len(ids) != rows {
+		t.Fatalf("scan err=%v truncated=%t rows=%d want nil/false/%d", err, truncated, len(ids), rows)
+	}
+	for i, id := range ids {
+		if id != events[i].ID {
+			t.Fatalf("callback order id[%d]=%q want %q", i, id, events[i].ID)
+		}
+	}
+	if stats := col.LastDocumentScanStats(); !stats.CertifiedMonotonicPath || stats.GenericFallback || stats.PhysicalPasses != 2 || stats.PhysicalRows != uint64(rows*2) || stats.PhysicalDecodedBlocks != 2 || stats.PreflightProjectedColumns != 0 || stats.MaxRecordWindow != 256 || stats.MaxVisibleRowWindow != 256 || stats.ReconstructedRows != uint64(rows) {
+		t.Fatalf("scan stats=%+v want certified bounded reconstruction", stats)
+	}
+}
+
+func TestScanDocumentsFuncMonotonicReconstructionSelectiveTypedColumnP3887(t *testing.T) {
+	const rows = columnReconstructionMonotonicBatchSize + 3
+	dir := t.TempDir()
+	if err := backenddb.SaveFormatConfig(dir, backenddb.FormatConfig{RequiredFeatures: []string{backenddb.RequiredFeatureCommandWALV1}}); err != nil {
+		t.Fatal(err)
+	}
+	d, err := backenddb.Open(backenddb.Options{Dir: dir, DisableBackgroundPrune: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = d.Close() }()
+	cfg := &ColumnStoreConfig{Enabled: true, Columns: []ColumnStoreColumn{
+		{Name: "time_us", Path: "time_us", ValueType: ColumnStoreValueInt64, Owner: TypedStorageOwnerColumnPart},
+		{Name: "kind", Path: "kind", ValueType: ColumnStoreValueString, Dictionary: true, Owner: TypedStorageOwnerColumnPart},
+	}}
+	mgr := NewCollectionManager(d)
+	if _, err := mgr.CreateCollection(&CollectionMeta{Name: "events", Options: CollectionOptions{ColumnStore: cfg}}); err != nil {
+		t.Fatal(err)
+	}
+	col, err := mgr.OpenCollection("events")
+	if err != nil {
+		t.Fatal(err)
+	}
+	ids, docs := make([][]byte, rows), make([][]byte, rows)
+	for i := range ids {
+		ids[i] = []byte(fmt.Sprintf("e%04d", i))
+		kind := "generation-one"
+		if i >= 200 {
+			kind = "generation-two"
+		}
+		docs[i] = []byte(fmt.Sprintf(`{"time_us":%d,"kind":%q}`, i, kind))
+	}
+	// Cross the 256-row reconstruction window with two generations: resident
+	// typed state must stay at one part even when a window sees both.
+	if _, err := col.InsertBatch(ids[:200], docs[:200]); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := col.InsertBatch(ids[200:], docs[200:]); err != nil {
+		t.Fatal(err)
+	}
+	if err := d.Close(); err != nil {
+		t.Fatal(err)
+	}
+	d, err = backenddb.Open(backenddb.Options{Dir: dir, DisableBackgroundPrune: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	col, err = NewCollectionManager(d).OpenCollection("events")
+	if err != nil {
+		t.Fatal(err)
+	}
+	var got []string
+	truncated, err := col.ScanDocumentsFunc(rows, func(record DocumentRecord) (bool, error) {
+		got = append(got, string(record.Document))
+		return true, nil
+	})
+	if err != nil || truncated || len(got) != rows {
+		t.Fatalf("scan err=%v truncated=%t rows=%d", err, truncated, len(got))
+	}
+	for i, document := range got {
+		kind := "generation-one"
+		if i >= 200 {
+			kind = "generation-two"
+		}
+		want := fmt.Sprintf(`{"time_us":%d,"kind":%q}`, i, kind)
+		if document != want {
+			t.Fatalf("document[%d]=%s want %s", i, document, want)
+		}
+	}
+	stats := col.LastDocumentScanStats()
+	if !stats.CertifiedMonotonicPath || stats.MaxTypedGenerations != 1 || stats.MaxTypedDecodedBytes == 0 || stats.MaxTypedSourcePartBytes == 0 {
+		t.Fatalf("scan stats=%+v want bounded selective typed reconstruction", stats)
+	}
+}
+
+func TestScanDocumentsFuncMonotonicReconstructionBoundsRetainedSemanticCacheP3887(t *testing.T) {
+	dir := t.TempDir()
+	if err := backenddb.SaveFormatConfig(dir, backenddb.FormatConfig{RequiredFeatures: []string{backenddb.RequiredFeatureCommandWALV1}}); err != nil {
+		t.Fatal(err)
+	}
+	d, err := backenddb.Open(backenddb.Options{Dir: dir, DisableBackgroundPrune: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = d.Close() }()
+	col := createColumnRetainedSemanticStreamCollection(t, d, "events")
+	ids, docs := retainedSemanticStreamDocuments(columnReconstructionMonotonicBatchSize + 3)
+	if _, err := col.InsertBatch(ids, docs); err != nil {
+		t.Fatal(err)
+	}
+	count := 0
+	truncated, err := col.ScanDocumentsFunc(len(ids), func(record DocumentRecord) (bool, error) {
+		count++
+		return true, nil
+	})
+	if err != nil || truncated || count != len(ids) {
+		t.Fatalf("scan err=%v truncated=%t rows=%d", err, truncated, count)
+	}
+	stats := col.LastDocumentScanStats()
+	if stats.MaxRetainedBlocks == 0 || stats.MaxRetainedBlocks > uint64(defaultColumnRetainedSemanticStreamV1DecodeCacheBlocks) {
+		t.Fatalf("scan stats=%+v want retained cache within %d blocks", stats, defaultColumnRetainedSemanticStreamV1DecodeCacheBlocks)
+	}
+}

--- a/TreeDB/collections/column_reconstruction_monotonic_test.go
+++ b/TreeDB/collections/column_reconstruction_monotonic_test.go
@@ -21,8 +21,10 @@ func BenchmarkScanDocumentsFuncMonotonicReconstructionP3887(b *testing.B) {
 			b.Fatalf("P3887_BENCH_ROWS=%q", raw)
 		}
 	}
-	// The fixture's DB directory is explicitly under /mnt/fast4tb for benchmark runs.
-	dir, err := os.MkdirTemp("/mnt/fast4tb", "gomap3887_bench_*")
+	// P3887_BENCH_DIR can select fast storage; an empty base uses the portable
+	// default temporary directory.
+	base := os.Getenv("P3887_BENCH_DIR")
+	dir, err := os.MkdirTemp(base, "gomap3887_bench_*")
 	if err != nil {
 		b.Fatal(err)
 	}
@@ -328,7 +330,7 @@ func TestScanDocumentsFuncMonotonicReconstructionBoundsWindowsP3887(t *testing.T
 			t.Fatalf("callback order id[%d]=%q want %q", i, id, events[i].ID)
 		}
 	}
-	if stats := col.LastDocumentScanStats(); !stats.CertifiedMonotonicPath || stats.GenericFallback || stats.PhysicalPasses != 2 || stats.PhysicalRows != uint64(rows*2) || stats.PhysicalDecodedBlocks != 2 || stats.PreflightProjectedColumns != 0 || stats.MaxRecordWindow != 256 || stats.MaxVisibleRowWindow != 256 || stats.ReconstructedRows != uint64(rows) {
+	if stats := col.LastDocumentScanStats(); !stats.CertifiedMonotonicPath || stats.GenericFallback || stats.PhysicalPasses != 2 || stats.PhysicalRows != uint64(rows*2) || stats.PhysicalDecodedBlocks != 2 || stats.PreflightProjectedColumns != 0 || stats.MaxRecordWindow != columnReconstructionMonotonicBatchSize || stats.MaxVisibleRowWindow != columnReconstructionMonotonicBatchSize || stats.ReconstructedRows != uint64(rows) {
 		t.Fatalf("scan stats=%+v want certified bounded reconstruction", stats)
 	}
 }

--- a/TreeDB/collections/column_reconstruction_monotonic_test.go
+++ b/TreeDB/collections/column_reconstruction_monotonic_test.go
@@ -410,6 +410,50 @@ func TestScanDocumentsFuncMonotonicReconstructionSelectiveTypedColumnP3887(t *te
 	}
 }
 
+func TestScanDocumentsFuncMonotonicReconstructionTypedSortKeyFallsBackP3887(t *testing.T) {
+	dir := t.TempDir()
+	if err := backenddb.SaveFormatConfig(dir, backenddb.FormatConfig{RequiredFeatures: []string{backenddb.RequiredFeatureCommandWALV1}}); err != nil {
+		t.Fatal(err)
+	}
+	d, err := backenddb.Open(backenddb.Options{Dir: dir, DisableBackgroundPrune: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = d.Close() }()
+	cfg := &ColumnStoreConfig{Enabled: true,
+		Columns: []ColumnStoreColumn{{Name: "time_us", Path: "time_us", ValueType: ColumnStoreValueInt64, Owner: TypedStorageOwnerColumnPart}},
+		SortKey: []ColumnSortKey{{Column: "time_us"}},
+	}
+	mgr := NewCollectionManager(d)
+	if _, err := mgr.CreateCollection(&CollectionMeta{Name: "events", Options: CollectionOptions{ColumnStore: cfg}}); err != nil {
+		t.Fatal(err)
+	}
+	col, err := mgr.OpenCollection("events")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := col.InsertBatch([][]byte{[]byte("e0000"), []byte("e0001")}, [][]byte{[]byte(`{"time_us":2}`), []byte(`{"time_us":1}`)}); err != nil {
+		t.Fatal(err)
+	}
+	var got []DocumentRecord
+	truncated, err := col.ScanDocumentsFunc(2, func(record DocumentRecord) (bool, error) {
+		got = append(got, record)
+		return true, nil
+	})
+	if err != nil || truncated || len(got) != 2 {
+		t.Fatalf("scan err=%v truncated=%t rows=%d", err, truncated, len(got))
+	}
+	if string(got[0].ID) != "e0000" || string(got[1].ID) != "e0001" {
+		t.Fatalf("IDs=%q,%q want e0000,e0001", got[0].ID, got[1].ID)
+	}
+	assertJSONMapEqual1875(t, got[0].Document, map[string]any{"time_us": float64(2)})
+	assertJSONMapEqual1875(t, got[1].Document, map[string]any{"time_us": float64(1)})
+	stats := col.LastDocumentScanStats()
+	if stats.CertifiedMonotonicPath || !stats.GenericFallback || stats.PhysicalPasses != 1 {
+		t.Fatalf("scan stats=%+v want generic fallback for typed sort-key rows", stats)
+	}
+}
+
 func TestScanDocumentsFuncMonotonicReconstructionUnsupportedSelectedTypedFallsBackP3887(t *testing.T) {
 	dir := t.TempDir()
 	if err := backenddb.SaveFormatConfig(dir, backenddb.FormatConfig{RequiredFeatures: []string{backenddb.RequiredFeatureCommandWALV1}}); err != nil {

--- a/TreeDB/collections/typed_column_publication.go
+++ b/TreeDB/collections/typed_column_publication.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"time"
+	"unsafe"
 
 	backenddb "github.com/snissn/gomap/TreeDB/db"
 )
@@ -432,6 +433,30 @@ type typedColumnPartReconstructionCache struct {
 	CacheMisses      uint64
 	PartLoads        uint64
 	TypedPartDecodes uint64
+
+	// Window* describe only the current bounded selective reconstruction
+	// window. They deliberately do not accumulate across a scan.
+	WindowDecodedBytes    uint64
+	WindowGenerations     uint64
+	WindowSourcePartBytes uint64
+
+	// SelectivePart is a source-backed adapter retained only while the
+	// certified physical stream remains on one generation. Its image aliases
+	// ReadCache's reusable source scratch. Decoded values must own any data that
+	// outlives a read because a later generation reuses that scratch.
+	SelectivePart           *typedColumnAdapterPart
+	SelectivePartGeneration uint64
+}
+
+func typedColumnPartDecodedValuesResidentBytes(values typedColumnPartDecodedValues) uint64 {
+	bytes := uint64(len(values.PrimaryIDs))*uint64(unsafe.Sizeof(int64(0))) + uint64(len(values.RowByPrimaryID))*uint64(unsafe.Sizeof(int(0)))
+	for _, row := range values.Values {
+		bytes += uint64(cap(row)) * uint64(unsafe.Sizeof(columnDeclaredValue{}))
+		for _, value := range row {
+			bytes += uint64(cap(value.Float32Vector))*4 + uint64(cap(value.DenseNumericVector)) + uint64(cap(value.Uint32List))*4 + uint64(cap(value.AdjacencyList))*4 + uint64(cap(value.Bytes)) + uint64(cap(value.StringBytes)) + uint64(len(value.String))
+		}
+	}
+	return bytes
 }
 
 func (c *Collection) typedColumnPartValuesForVisibleRowAtSnapshot(snap *backenddb.Snapshot, manifestRootID uint64, cfg ColumnStoreConfig, physicalRow columnPhysicalVisibleRow) (typedColumnPartVisibleValues, error) {

--- a/TreeDB/collections/typed_storage_naming_test.go
+++ b/TreeDB/collections/typed_storage_naming_test.go
@@ -390,6 +390,8 @@ var typedStorageLegacyNameAllowlist = []typedStorageLegacyNameAllowlistEntry{
 	{path: "TreeDB/collections/column_query_plan.go", classification: typedStorageLegacyCompatibility, matchingLines: 43, occurrences: 43},
 	{path: "TreeDB/collections/column_query_plan_test.go", classification: typedStorageLegacyCompatibility, matchingLines: 56, occurrences: 68},
 	{path: "TreeDB/collections/column_reconstruction.go", classification: typedStorageLegacyCompatibility, matchingLines: 57, occurrences: 72},
+	{path: "TreeDB/collections/column_reconstruction_monotonic.go", classification: typedStorageLegacyCompatibility, matchingLines: 6, occurrences: 8},
+	{path: "TreeDB/collections/column_reconstruction_monotonic_test.go", classification: typedStorageLegacyCompatibility, matchingLines: 12, occurrences: 22},
 	{path: "TreeDB/collections/column_reconstruction_test.go", classification: typedStorageLegacyCompatibility, matchingLines: 27, occurrences: 31},
 	{path: "TreeDB/collections/column_retained_payload_audit.go", classification: typedStorageLegacyCompatibility, matchingLines: 8, occurrences: 8},
 	{path: "TreeDB/collections/column_retained_payload_audit_test.go", classification: typedStorageLegacyCompatibility, matchingLines: 29, occurrences: 30},

--- a/TreeDB/collections/typed_storage_naming_test.go
+++ b/TreeDB/collections/typed_storage_naming_test.go
@@ -391,7 +391,7 @@ var typedStorageLegacyNameAllowlist = []typedStorageLegacyNameAllowlistEntry{
 	{path: "TreeDB/collections/column_query_plan_test.go", classification: typedStorageLegacyCompatibility, matchingLines: 56, occurrences: 68},
 	{path: "TreeDB/collections/column_reconstruction.go", classification: typedStorageLegacyCompatibility, matchingLines: 57, occurrences: 72},
 	{path: "TreeDB/collections/column_reconstruction_monotonic.go", classification: typedStorageLegacyCompatibility, matchingLines: 6, occurrences: 8},
-	{path: "TreeDB/collections/column_reconstruction_monotonic_test.go", classification: typedStorageLegacyCompatibility, matchingLines: 12, occurrences: 22},
+	{path: "TreeDB/collections/column_reconstruction_monotonic_test.go", classification: typedStorageLegacyCompatibility, matchingLines: 15, occurrences: 26},
 	{path: "TreeDB/collections/column_reconstruction_test.go", classification: typedStorageLegacyCompatibility, matchingLines: 27, occurrences: 31},
 	{path: "TreeDB/collections/column_retained_payload_audit.go", classification: typedStorageLegacyCompatibility, matchingLines: 8, occurrences: 8},
 	{path: "TreeDB/collections/column_retained_payload_audit_test.go", classification: typedStorageLegacyCompatibility, matchingLines: 29, occurrences: 30},

--- a/TreeDB/collections/vector_index_rebuild.go
+++ b/TreeDB/collections/vector_index_rebuild.go
@@ -394,7 +394,7 @@ func (c *Collection) columnVectorGraphRowsFromCatalogSnapshot(snap *backenddb.Sn
 		return true, nil
 	}
 	if columnStoreCanReconstructDocument(catalog.meta) {
-		_, err = c.scanDocumentsFuncWithColumnReconstruction(snap, catalog, it, maxCollectionInt, visit)
+		_, err = c.scanDocumentsFuncWithColumnReconstruction(snap, catalog, it, maxCollectionInt, visit, nil)
 		return rows, err
 	}
 	for it.Valid() {


### PR DESCRIPTION
Closes #3887

## Summary
- Certifies an insert-only, monotonic physical stream before callbacks, then reconstructs in 256-row windows with generic fallback for mutations/order decline and fail-closed structural mismatch handling.
- Gates certification on metadata-known selected-row typed decode support: nullable and unsupported typed-column-part shapes, plus typed-column-part sort-key layouts use the established generic full-part reconstruction path before physical preflight or callbacks.
- Adds selective typed-column decoding with one resident generation/source part, plus a scan-wide fixed-capacity retained semantic cache.
- Exposes per-scan bounded-state and physical-work diagnostics.

## Validation
- `GOWORK=off go test ./TreeDB/collections -run P3887 -count=1`
- `GOWORK=off go test ./TreeDB/collections -run SortKey -count=1`
- `GOWORK=off go test -race ./TreeDB/collections -run P3887 -count=1`
- `GOWORK=off go vet ./TreeDB/collections`
- `GOWORK=off go test ./TreeDB/collections -run ^TestTypedStorageLegacyNameAllowlistIsComplete$ -count=1`
- `GOWORK=off go test ./TreeDB/collections -count=1`
- `P3887_BENCH_ROWS=100000 GOWORK=off go test ./TreeDB/collections -run ^$ -bench ^BenchmarkScanDocumentsFuncMonotonicReconstructionP3887$ -benchtime=1x -count=1`

## Benchmark evidence
Matched typed 1M fixture (DB/artifacts under `/mnt/fast4tb`):
- baseline: 4.298s/op, 4.410GB/op, 47.03M allocs/op, peak RSS 3.05GB
- candidate: 3.275s/op, 3.919GB/op, 45.05M allocs/op, peak RSS 1.07GB

Latest 100k candidate check: 362.7ms/op, 411.0MB/op, 4.52M allocs/op; certified with 256 record/visible-row windows, 1 resident typed generation, 2 retained blocks, and 2 physical passes/decoded blocks.

Fresh latest-head Codex review requested at head `38806a36d`; CI and review are pending.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an optimized document reconstruction path for eligible monotonic column data.
  - Added scan statistics reporting, including physical scan, reconstruction, memory, and fallback metrics.
  - Added automatic fallback for updates, unsupported layouts, and inconsistent data ordering.

- **Performance**
  - Reduced unnecessary decoding and memory usage through bounded scans and selective typed-column loading.

- **Tests**
  - Added coverage for correctness, truncation, callbacks, fallback behavior, window boundaries, reopen consistency, and performance benchmarks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->





