### PR TITLE
collections: bound query-ready preparation peak

### DIFF
--- a/TreeDB/collections/query_ready_build.go
+++ b/TreeDB/collections/query_ready_build.go
@@ -39,6 +39,8 @@ type queryReadyBuildRequest struct {
 	Deltas            []*typedcolumn.QueryReadyDeltaGeneration
 	ThroughGeneration uint64
 	Bound             typedcolumn.QueryReadyDeltaBoundPolicy
+	StreamingBasePlan *typedcolumn.QueryReadyBaseStreamingPlan
+	StreamingBaseLoad func(int) (typedcolumn.QueryReadyBasePartInput, error)
 }
 
 type queryReadyBuildLimits struct {
@@ -277,7 +279,13 @@ func (c *queryReadyBuildCoordinator) prepare(ctx context.Context, request queryR
 	var partID uint64
 	switch request.Kind {
 	case queryReadyBuildBase:
-		built, err := typedcolumn.BuildQueryReadyBaseGeneration(request.Identity, request.Parts)
+		var built typedcolumn.QueryReadyBaseBuildResult
+		var err error
+		if request.StreamingBasePlan != nil {
+			built, err = request.StreamingBasePlan.Emit(request.StreamingBaseLoad)
+		} else {
+			built, err = typedcolumn.BuildQueryReadyBaseGeneration(request.Identity, request.Parts)
+		}
 		if err != nil {
 			return nil, err
 		}
@@ -374,6 +382,9 @@ func (c *queryReadyBuildCoordinator) prepare(ctx context.Context, request queryR
 }
 
 func estimateQueryReadyBuildWorkingBytes(request queryReadyBuildRequest) (int64, error) {
+	if request.Kind == queryReadyBuildBase && request.StreamingBasePlan != nil {
+		return request.StreamingBasePlan.EstimatedPeakBytes()
+	}
 	// These estimates intentionally cover allocations created after admission,
 	// not the immutable input images already owned by the caller. In addition to
 	// the encoded output they reserve space for validation/build plans, stable

--- a/TreeDB/collections/query_ready_preparation.go
+++ b/TreeDB/collections/query_ready_preparation.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"math"
 	"sort"
 	"sync"
 	"time"
@@ -254,7 +255,11 @@ func (c *Collection) PrepareQueryReadyColumnGeneration(ctx context.Context, opti
 		return refs[i].Ref.PartID < refs[j].Ref.PartID
 	})
 	stats := QueryReadyColumnPreparationStats{SourceParts: len(refs)}
-	parts := make([]typedcolumn.QueryReadyBasePartInput, 0, len(refs))
+	planner, err := typedcolumn.NewQueryReadyBaseStreamingPlanner(key.Identity, len(refs))
+	if err != nil {
+		return nil, err
+	}
+	primaryBases := make([]int64, len(refs))
 	for index, source := range refs {
 		if err := ctx.Err(); err != nil {
 			return nil, err
@@ -266,12 +271,11 @@ func (c *Collection) PrepareQueryReadyColumnGeneration(ctx context.Context, opti
 		if ref.Generation == 0 || ref.Generation > identity.ManifestGeneration || source.Rows < 0 {
 			return nil, fmt.Errorf("collections: invalid query-ready source[%d] generation=%d rows=%d", index, ref.Generation, source.Rows)
 		}
-		if ref.Length <= 0 || stats.SourceBytes > preparationBudget-ref.Length {
-			required := stats.SourceBytes
-			if ref.Length > 0 && required <= int64(^uint64(0)>>1)-ref.Length {
-				required += ref.Length
-			}
-			return nil, &QueryReadyColumnPreparationBoundError{RequiredBytes: required, MaxBytes: preparationBudget}
+		if ref.Length <= 0 {
+			return nil, fmt.Errorf("collections: invalid query-ready source[%d] length=%d", index, ref.Length)
+		}
+		if ref.Length > preparationBudget {
+			return nil, &QueryReadyColumnPreparationBoundError{RequiredBytes: ref.Length, MaxBytes: preparationBudget}
 		}
 		readStarted := time.Now()
 		raw, err := readColumnPhysicalAssetFromManager(view.ColumnAssetRootDir, ref)
@@ -288,23 +292,75 @@ func (c *Collection) PrepareQueryReadyColumnGeneration(ctx context.Context, opti
 		if image.PartID != ref.PartID || image.Rows != source.Rows {
 			return nil, fmt.Errorf("collections: query-ready source[%d] image identity part_id=%d rows=%d want part_id=%d rows=%d", index, image.PartID, image.Rows, ref.PartID, source.Rows)
 		}
+		executionUpper, err := typedcolumn.EstimateQueryReadyExecutionImageUpperBound(image)
+		if err != nil {
+			return nil, fmt.Errorf("collections: estimate query-ready source[%d] execution: %w", index, err)
+		}
+		if executionUpper < 0 || executionUpper > math.MaxInt64/2 || int64(len(raw)) > math.MaxInt64-executionUpper*2 {
+			return nil, &QueryReadyColumnPreparationBoundError{RequiredBytes: math.MaxInt64, MaxBytes: preparationBudget}
+		}
+		livePassOne := int64(len(raw)) + executionUpper*2
+		metadataBytes := int64(64 << 10)
+		index64 := int64(index)
+		if index64 > (math.MaxInt64-metadataBytes)/(1024+64)-1 {
+			return nil, &QueryReadyColumnPreparationBoundError{RequiredBytes: math.MaxInt64, MaxBytes: preparationBudget}
+		}
+		metadataBytes += (index64 + 1) * (1024 + 64)
+		if livePassOne > math.MaxInt64-metadataBytes {
+			return nil, &QueryReadyColumnPreparationBoundError{RequiredBytes: math.MaxInt64, MaxBytes: preparationBudget}
+		}
+		livePassOne += metadataBytes
+		if livePassOne > preparationBudget {
+			return nil, &QueryReadyColumnPreparationBoundError{RequiredBytes: livePassOne, MaxBytes: preparationBudget}
+		}
+		primaryBases[index] = stats.SourceRows
 		stats.SourceRows += int64(image.Rows)
 		stats.SourceBytes += int64(len(raw))
-		parts = append(parts, typedcolumn.QueryReadyBasePartInput{
+		if err := planner.Add(typedcolumn.QueryReadyBasePartInput{
 			SourceGeneration: ref.Generation,
 			Image:            image,
 			PrimaryIDMode:    typedcolumn.QueryReadyPrimaryIDDensePartLocal,
 			PrimaryIDBase:    stats.SourceRows - int64(image.Rows),
-		})
+		}); err != nil {
+			return nil, fmt.Errorf("collections: plan query-ready source[%d]: %w", index, err)
+		}
 	}
-	request := queryReadyBuildRequest{Kind: queryReadyBuildBase, Identity: key.Identity, Parts: parts}
-	buildWorkingBytes, err := estimateQueryReadyBuildWorkingBytes(request)
+	plan, err := planner.Finish()
 	if err != nil {
 		return nil, err
 	}
-	if buildWorkingBytes > preparationBudget-stats.SourceBytes {
-		return nil, &QueryReadyColumnPreparationBoundError{RequiredBytes: stats.SourceBytes + buildWorkingBytes, MaxBytes: preparationBudget}
+	buildWorkingBytes, err := plan.EstimatedPeakBytes()
+	if err != nil {
+		return nil, err
 	}
+	if buildWorkingBytes > preparationBudget {
+		return nil, &QueryReadyColumnPreparationBoundError{RequiredBytes: buildWorkingBytes, MaxBytes: preparationBudget}
+	}
+	request := queryReadyBuildRequest{Kind: queryReadyBuildBase, Identity: key.Identity, StreamingBasePlan: plan, StreamingBaseLoad: func(index int) (typedcolumn.QueryReadyBasePartInput, error) {
+		if err := ctx.Err(); err != nil {
+			return typedcolumn.QueryReadyBasePartInput{}, err
+		}
+		if index < 0 || index >= len(refs) {
+			return typedcolumn.QueryReadyBasePartInput{}, fmt.Errorf("collections: query-ready emit source index=%d outside %d refs", index, len(refs))
+		}
+		source := refs[index]
+		readStarted := time.Now()
+		raw, err := readColumnPhysicalAssetFromManager(view.ColumnAssetRootDir, source.Ref)
+		stats.SourceReadTime += time.Since(readStarted)
+		if err != nil {
+			return typedcolumn.QueryReadyBasePartInput{}, fmt.Errorf("collections: reread query-ready source[%d]: %w", index, err)
+		}
+		decodeStarted := time.Now()
+		image, err := typedcolumn.ParseColumnPartImage(raw)
+		stats.SourceDecodeTime += time.Since(decodeStarted)
+		if err != nil {
+			return typedcolumn.QueryReadyBasePartInput{}, fmt.Errorf("collections: redecode query-ready source[%d]: %w", index, err)
+		}
+		if image.PartID != source.Ref.PartID || image.Rows != source.Rows {
+			return typedcolumn.QueryReadyBasePartInput{}, fmt.Errorf("collections: query-ready reread source[%d] image identity part_id=%d rows=%d want part_id=%d rows=%d", index, image.PartID, image.Rows, source.Ref.PartID, source.Rows)
+		}
+		return typedcolumn.QueryReadyBasePartInput{SourceGeneration: source.Ref.Generation, Image: image, PrimaryIDMode: typedcolumn.QueryReadyPrimaryIDDensePartLocal, PrimaryIDBase: primaryBases[index]}, nil
+	}}
 	prepared, err := coordinator.prepare(ctx, request)
 	if err != nil {
 		return nil, err
@@ -335,7 +391,7 @@ func (c *Collection) PrepareQueryReadyColumnGeneration(ctx context.Context, opti
 	stats.BytesCopied, stats.BytesHashed, stats.BytesChecksummed = build.BytesCopied, build.BytesHashed, build.BytesChecksummed
 	stats.ExecutionBytes, stats.ExecutionColumns = build.ExecutionBytes, build.ExecutionColumns
 	stats.AssetsProduced, stats.PartsProduced = build.AssetsProduced, build.PartsProduced
-	stats.ReservedInFlightBytes, stats.EstimatedPeakInFlightBytes, stats.EncodedBufferPeakBytes = build.ReservedInFlightBytes, stats.SourceBytes+build.EstimatedPeakInFlightBytes, build.EncodedBufferPeakBytes
+	stats.ReservedInFlightBytes, stats.EstimatedPeakInFlightBytes, stats.EncodedBufferPeakBytes = build.ReservedInFlightBytes, build.EstimatedPeakInFlightBytes, build.EncodedBufferPeakBytes
 	stats.WorkerLimit, stats.QueueCapacity, stats.QueueWaitTime = build.WorkerLimit, build.QueueCapacity, build.QueueWaitTime
 	stats.BuildTime, stats.AssetPreparationTime = build.BaseBuildTime, build.AssetPreparationTime
 	stats.ManagerRegistrationTime, stats.PublicationHandoffTime = build.ManagerRegistrationTime, build.HandoffTime

--- a/TreeDB/collections/query_ready_preparation_test.go
+++ b/TreeDB/collections/query_ready_preparation_test.go
@@ -3,6 +3,7 @@ package collections
 import (
 	"context"
 	"errors"
+	"fmt"
 	"os"
 	"slices"
 	"testing"
@@ -319,6 +320,158 @@ func TestPrepareQueryReadyColumnGenerationRejectsCombinedSourceBuildBound(t *tes
 	if after := len(collection.columnAssetLifecycleRegistrySnapshot()); after != before {
 		t.Fatalf("bound rejection registered prepared assets: before=%d after=%d", before, after)
 	}
+}
+
+func TestPrepareQueryReadyColumnGenerationAdmitsBoundedMultiPartPeak(t *testing.T) {
+	events := columnPhysicalJSONBenchParityEventsP0()
+	batches := make([][]columnPhysicalJSONBenchParityEventP0, 4)
+	for batchIndex := range batches {
+		batches[batchIndex] = make([]columnPhysicalJSONBenchParityEventP0, len(events))
+		for eventIndex, event := range events {
+			event.ID = fmt.Sprintf("p%d-%s", batchIndex, event.ID)
+			batches[batchIndex][eventIndex] = event
+		}
+	}
+	_, collection, closeFn, refs := openColumnPhysicalJSONBenchTypedColumnPartBatches1947(t, batches)
+	defer closeFn()
+	if len(refs) != len(batches) {
+		t.Fatalf("typed source refs=%d want %d", len(refs), len(batches))
+	}
+	legacyParts := make([]typedcolumn.QueryReadyBasePartInput, 0, len(refs))
+	var sourceBytes, primaryBase int64
+	for index, ref := range refs {
+		raw, err := readColumnPhysicalAssetFromManager(collection.db.ColumnAssetRootDir(), ref)
+		if err != nil {
+			t.Fatalf("read source[%d]: %v", index, err)
+		}
+		image, err := typedcolumn.ParseColumnPartImage(raw)
+		if err != nil {
+			t.Fatalf("parse source[%d]: %v", index, err)
+		}
+		legacyParts = append(legacyParts, typedcolumn.QueryReadyBasePartInput{SourceGeneration: ref.Generation, Image: image, PrimaryIDMode: typedcolumn.QueryReadyPrimaryIDDensePartLocal, PrimaryIDBase: primaryBase})
+		primaryBase += int64(image.Rows)
+		sourceBytes += int64(len(raw))
+	}
+	legacyBuild, err := estimateQueryReadyBuildWorkingBytes(queryReadyBuildRequest{Kind: queryReadyBuildBase, Identity: typedcolumn.QueryReadyBaseIdentity{Generation: refs[len(refs)-1].Generation}, Parts: legacyParts})
+	if err != nil {
+		t.Fatalf("estimate legacy build: %v", err)
+	}
+	legacyPeak := sourceBytes + legacyBuild
+
+	baseline, err := collection.PrepareQueryReadyColumnGeneration(context.Background(), QueryReadyColumnPreparationOptions{MaxWorkers: 1, MaxInFlightBytes: 64 << 20})
+	if err != nil {
+		t.Fatalf("baseline preparation: %v", err)
+	}
+	baselineStats := baseline.Stats()
+	if err := baseline.Close(); err != nil {
+		t.Fatalf("close baseline preparation: %v", err)
+	}
+	if sourceBytes <= 1 || legacyPeak <= sourceBytes/2 {
+		t.Fatalf("legacy source=%d peak=%d cannot form multi-part lifetime bound", sourceBytes, legacyPeak)
+	}
+	bound := legacyPeak - sourceBytes/2
+	prepared, err := collection.PrepareQueryReadyColumnGeneration(context.Background(), QueryReadyColumnPreparationOptions{MaxWorkers: 1, MaxInFlightBytes: bound})
+	if err != nil {
+		t.Fatalf("bounded multi-part preparation should admit below legacy combined peak=%d at bound=%d (candidate estimate=%d): %v", legacyPeak, bound, baselineStats.EstimatedPeakInFlightBytes, err)
+	}
+	defer func() { _ = prepared.Close() }()
+	if stats := prepared.Stats(); stats.EstimatedPeakInFlightBytes > bound {
+		t.Fatalf("prepared stats=%+v exceed admission bound=%d", stats, bound)
+	}
+}
+
+// TestPrepareQueryReadyColumnGenerationOneMillionRowsSmoke keeps the
+// production-shaped 1M fixture opt-in: it is a release gate, not a unit-test
+// tax. Run with TREEDB_QUERY_READY_1M_SMOKE=true.
+func TestPrepareQueryReadyColumnGenerationOneMillionRowsSmoke(t *testing.T) {
+	if os.Getenv("TREEDB_QUERY_READY_1M_SMOKE") != "true" {
+		t.Skip("set TREEDB_QUERY_READY_1M_SMOKE=true to run the 1M query-ready preparation smoke")
+	}
+	if !typedcolumn.QueryReadyGenerationFileOpenSupported() {
+		t.Skip("query-ready generation file open requires read-only mmap support")
+	}
+	_, collection, closeFn, _ := openColumnPhysicalJSONBenchTypedColumnPartBatches1947(t, queryReadyOneMillionTypedColumnBatches(t))
+	defer closeFn()
+	prepared, err := collection.PrepareQueryReadyColumnGeneration(context.Background(), QueryReadyColumnPreparationOptions{
+		MaxWorkers: 1, MaxInFlightBytes: 1 << 30,
+	})
+	if err != nil {
+		t.Fatalf("prepare 1M query-ready generation: %v", err)
+	}
+	defer func() { _ = prepared.Close() }()
+	if stats := prepared.Stats(); stats.SourceRows != queryReadyOneMillionRows || stats.SourceParts != queryReadyOneMillionRows/queryReadyOneMillionBatchRows || stats.OutputBytes <= 0 || stats.EstimatedPeakInFlightBytes <= 0 {
+		t.Fatalf("1M preparation stats=%+v", stats)
+	}
+	runner, err := collection.PrepareQueryReadyColumnPhysicalQuery(prepared.Files(), ColumnPhysicalQueryRequest{Kind: ColumnPhysicalQueryGroupCount, GroupColumn: "kind"})
+	if err != nil {
+		t.Fatalf("prepare 1M query-ready q1: %v", err)
+	}
+	defer func() { _ = runner.Close() }()
+	result, err := runner.Run()
+	if err != nil {
+		t.Fatalf("run 1M query-ready q1: %v", err)
+	}
+	if len(result.Groups) != 4 || result.Diagnostics.RowsScanned != queryReadyOneMillionRows || result.Diagnostics.StorageSource != ColumnPhysicalQueryStorageSourceQueryReadyBaseDelta {
+		t.Fatalf("1M query-ready q1 result=%+v", result)
+	}
+}
+
+func BenchmarkPrepareQueryReadyColumnGeneration1M(b *testing.B) {
+	if !typedcolumn.QueryReadyGenerationFileOpenSupported() {
+		b.Skip("query-ready generation file open requires read-only mmap support")
+	}
+	_, collection, closeFn, _ := openColumnPhysicalJSONBenchTypedColumnPartBatches1947(b, queryReadyOneMillionTypedColumnBatches(b))
+	b.Cleanup(closeFn)
+	options := QueryReadyColumnPreparationOptions{MaxWorkers: 1, MaxInFlightBytes: 1 << 30}
+	preview, err := collection.PrepareQueryReadyColumnGeneration(context.Background(), options)
+	if err != nil {
+		b.Fatalf("preview 1M query-ready preparation: %v", err)
+	}
+	stats := preview.Stats()
+	if err := preview.Close(); err != nil {
+		b.Fatalf("close preview 1M query-ready preparation: %v", err)
+	}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		prepared, err := collection.PrepareQueryReadyColumnGeneration(context.Background(), options)
+		if err != nil {
+			b.Fatalf("prepare 1M query-ready generation: %v", err)
+		}
+		if err := prepared.Close(); err != nil {
+			b.Fatalf("close 1M query-ready generation: %v", err)
+		}
+	}
+	b.ReportMetric(float64(stats.SourceRows), "source_rows/op")
+	b.ReportMetric(float64(stats.SourceBytes), "source_bytes/op")
+	b.ReportMetric(float64(stats.OutputBytes), "output_bytes/op")
+	b.ReportMetric(float64(stats.EstimatedPeakInFlightBytes), "estimated_peak_bytes/op")
+}
+
+const (
+	queryReadyOneMillionRows      = 1_000_000
+	queryReadyOneMillionBatchRows = 100_000
+)
+
+func queryReadyOneMillionTypedColumnBatches(tb testing.TB) [][]columnPhysicalJSONBenchParityEventP0 {
+	tb.Helper()
+	batches := make([][]columnPhysicalJSONBenchParityEventP0, 0, queryReadyOneMillionRows/queryReadyOneMillionBatchRows)
+	for start := 0; start < queryReadyOneMillionRows; start += queryReadyOneMillionBatchRows {
+		batch := make([]columnPhysicalJSONBenchParityEventP0, queryReadyOneMillionBatchRows)
+		for offset := range batch {
+			i := start + offset
+			batch[offset] = columnPhysicalJSONBenchParityEventP0{
+				ID:         fmt.Sprintf("qr%07d", i),
+				TimeUS:     1_700_000_000_000_000 + int64(i),
+				Kind:       fmt.Sprintf("kind_%02d", i%4),
+				Operation:  "create",
+				Collection: fmt.Sprintf("collection_%02d", i%4),
+				Did:        fmt.Sprintf("did_%02d", i%12),
+			}
+		}
+		batches = append(batches, batch)
+	}
+	return batches
 }
 
 func TestPrepareQueryReadyColumnGenerationRejectsMutationAndTombstoneState(t *testing.T) {

--- a/TreeDB/collections/query_ready_preparation_test.go
+++ b/TreeDB/collections/query_ready_preparation_test.go
@@ -323,6 +323,9 @@ func TestPrepareQueryReadyColumnGenerationRejectsCombinedSourceBuildBound(t *tes
 }
 
 func TestPrepareQueryReadyColumnGenerationAdmitsBoundedMultiPartPeak(t *testing.T) {
+	if !typedcolumn.QueryReadyGenerationFileOpenSupported() {
+		t.Skip("query-ready generation file open requires read-only mmap support")
+	}
 	events := columnPhysicalJSONBenchParityEventsP0()
 	batches := make([][]columnPhysicalJSONBenchParityEventP0, 4)
 	for batchIndex := range batches {

--- a/TreeDB/internal/typedcolumn/query_ready_base.go
+++ b/TreeDB/internal/typedcolumn/query_ready_base.go
@@ -185,6 +185,240 @@ func BuildQueryReadyBaseGeneration(identity QueryReadyBaseIdentity, inputs []Que
 	return result, nil
 }
 
+// QueryReadyBaseStreamingPlanner retains only deterministic QRBG layout
+// metadata between source passes. It deliberately never retains a source image
+// or execution sidecar after Add returns.
+type QueryReadyBaseStreamingPlanner struct {
+	identity       QueryReadyBaseIdentity
+	parts          []queryReadyBaseStreamingPart
+	validationTime time.Duration
+}
+
+type queryReadyBaseStreamingPart struct {
+	ordinal           int
+	sourceGeneration  uint64
+	primaryIDMode     QueryReadyPrimaryIDMode
+	primaryIDBase     int64
+	partID            uint64
+	rows              int
+	imageBytes        int
+	imageChecksum     [sha256.Size]byte
+	executionBytes    int
+	executionUpper    int64
+	executionChecksum [sha256.Size]byte
+	executionColumns  int
+	imageOffset       int
+	executionOffset   int
+}
+
+// QueryReadyBaseStreamingPlan is a completed two-pass QRBG layout. Its
+// methods retain only fixed plan metadata; callers supply each source again to
+// Emit so source images and sidecars have bounded lifetimes.
+type QueryReadyBaseStreamingPlan struct {
+	identity       QueryReadyBaseIdentity
+	parts          []queryReadyBaseStreamingPart
+	payloadOffset  int
+	totalBytes     int
+	maxLiveBytes   int64
+	validationTime time.Duration
+}
+
+func NewQueryReadyBaseStreamingPlanner(identity QueryReadyBaseIdentity, capacity int) (*QueryReadyBaseStreamingPlanner, error) {
+	if err := validateQueryReadyBaseIdentity(identity); err != nil {
+		return nil, err
+	}
+	if capacity < 0 {
+		return nil, errors.New("typedcolumn: negative query-ready streaming planner capacity")
+	}
+	return &QueryReadyBaseStreamingPlanner{identity: identity, parts: make([]queryReadyBaseStreamingPart, 0, capacity)}, nil
+}
+
+// Add validates one source and records only its deterministic output metadata.
+func (p *QueryReadyBaseStreamingPlanner) Add(input QueryReadyBasePartInput) error {
+	if p == nil {
+		return errors.New("typedcolumn: nil query-ready streaming planner")
+	}
+	started := time.Now()
+	parsed, execution, executionColumns, err := inspectQueryReadyBasePart(p.identity, input)
+	p.validationTime += time.Since(started)
+	if err != nil {
+		return err
+	}
+	executionUpper, err := EstimateQueryReadyExecutionImageUpperBound(parsed)
+	if err != nil {
+		return err
+	}
+	part := queryReadyBaseStreamingPart{
+		ordinal:          len(p.parts),
+		sourceGeneration: input.SourceGeneration, primaryIDMode: input.PrimaryIDMode, primaryIDBase: input.PrimaryIDBase,
+		partID: parsed.PartID, rows: parsed.Rows, imageBytes: len(input.Image.Bytes), imageChecksum: sha256.Sum256(input.Image.Bytes),
+		executionBytes: len(execution), executionUpper: executionUpper, executionChecksum: sha256.Sum256(execution), executionColumns: executionColumns,
+	}
+	p.parts = append(p.parts, part)
+	return nil
+}
+
+func (p *QueryReadyBaseStreamingPlanner) Finish() (*QueryReadyBaseStreamingPlan, error) {
+	if p == nil {
+		return nil, errors.New("typedcolumn: nil query-ready streaming planner")
+	}
+	parts := append([]queryReadyBaseStreamingPart(nil), p.parts...)
+	sort.Slice(parts, func(i, j int) bool {
+		if parts[i].sourceGeneration != parts[j].sourceGeneration {
+			return parts[i].sourceGeneration < parts[j].sourceGeneration
+		}
+		return parts[i].partID < parts[j].partID
+	})
+	for i := 1; i < len(parts); i++ {
+		if parts[i-1].sourceGeneration == parts[i].sourceGeneration && parts[i-1].partID == parts[i].partID {
+			return nil, fmt.Errorf("typedcolumn: query-ready base duplicate dependency generation=%d part_id=%d", parts[i].sourceGeneration, parts[i].partID)
+		}
+	}
+	if len(parts) > math.MaxUint32 || len(parts) > (math.MaxInt-queryReadyBaseHeaderBytes)/queryReadyBasePartEntryBytes {
+		return nil, fmt.Errorf("typedcolumn: query-ready base parts=%d exceed format bounds", len(parts))
+	}
+	payloadOffset, err := queryReadyBaseAlign(queryReadyBaseHeaderBytes+len(parts)*queryReadyBasePartEntryBytes, queryReadyBasePayloadAlignment)
+	if err != nil {
+		return nil, err
+	}
+	total := payloadOffset
+	var maxLive int64
+	for i := range parts {
+		total, err = queryReadyBaseAlign(total, columnPartImageSectionAlignment)
+		if err != nil || parts[i].imageBytes > math.MaxInt-total {
+			return nil, errors.New("typedcolumn: query-ready base image exceeds host size")
+		}
+		parts[i].imageOffset = total
+		total += parts[i].imageBytes
+		total, err = queryReadyBaseAlign(total, queryReadyExecutionImagePayloadAlign)
+		if err != nil || parts[i].executionBytes > math.MaxInt-total {
+			return nil, errors.New("typedcolumn: query-ready execution image exceeds host size")
+		}
+		parts[i].executionOffset = total
+		total += parts[i].executionBytes
+		if parts[i].executionUpper < 0 || parts[i].executionUpper > math.MaxInt64/2 || int64(parts[i].imageBytes) > math.MaxInt64-parts[i].executionUpper*2 {
+			return nil, errors.New("typedcolumn: query-ready streaming live size overflow")
+		}
+		live := int64(parts[i].imageBytes) + parts[i].executionUpper*2
+		if live > maxLive {
+			maxLive = live
+		}
+	}
+	return &QueryReadyBaseStreamingPlan{identity: p.identity, parts: parts, payloadOffset: payloadOffset, totalBytes: total, maxLiveBytes: maxLive, validationTime: p.validationTime}, nil
+}
+
+func (p *QueryReadyBaseStreamingPlan) OutputBytes() int64 {
+	if p == nil {
+		return 0
+	}
+	return int64(p.totalBytes)
+}
+
+// EstimatedPeakBytes covers the final output, one live source image, its
+// execution sidecar plus conservative workspace, and fixed/dependency plan
+// metadata. It intentionally does not use cumulative source bytes.
+func (p *QueryReadyBaseStreamingPlan) EstimatedPeakBytes() (int64, error) {
+	if p == nil || p.totalBytes < 0 {
+		return 0, errors.New("typedcolumn: invalid query-ready streaming plan")
+	}
+	const fixedBuildBytes = int64(64 << 10)
+	metadata := int64(len(p.parts)) * (1024 + 64)
+	if len(p.parts) != 0 && metadata/int64(len(p.parts)) != 1088 {
+		return 0, errors.New("typedcolumn: query-ready streaming metadata size overflow")
+	}
+	if int64(p.totalBytes) > math.MaxInt64-p.maxLiveBytes || int64(p.totalBytes)+p.maxLiveBytes > math.MaxInt64-fixedBuildBytes || int64(p.totalBytes)+p.maxLiveBytes+fixedBuildBytes > math.MaxInt64-metadata {
+		return 0, errors.New("typedcolumn: query-ready streaming peak size overflow")
+	}
+	return int64(p.totalBytes) + p.maxLiveBytes + fixedBuildBytes + metadata, nil
+}
+
+// Emit rereads every source through load, validates it against pass-one
+// metadata, and writes the deterministic QRBG payload without retaining prior
+// sources. A mismatch fails closed before that source is emitted.
+func (p *QueryReadyBaseStreamingPlan) Emit(load func(int) (QueryReadyBasePartInput, error)) (QueryReadyBaseBuildResult, error) {
+	if p == nil || load == nil {
+		return QueryReadyBaseBuildResult{}, errors.New("typedcolumn: invalid query-ready streaming emit")
+	}
+	started := time.Now()
+	out := make([]byte, p.totalBytes)
+	binary.LittleEndian.PutUint32(out[0:4], queryReadyBaseMagic)
+	binary.LittleEndian.PutUint16(out[4:6], queryReadyBaseVersion)
+	binary.LittleEndian.PutUint64(out[8:16], p.identity.Generation)
+	copy(out[16:48], p.identity.SchemaHash[:])
+	binary.LittleEndian.PutUint32(out[48:52], uint32(len(p.parts)))
+	binary.LittleEndian.PutUint64(out[64:72], uint64(p.payloadOffset))
+	binary.LittleEndian.PutUint64(out[72:80], uint64(p.totalBytes))
+	dependencies := make([]QueryReadyBaseDependency, len(p.parts))
+	var rows, inputBytes, executionBytes int64
+	var executionColumns int
+	for i, expected := range p.parts {
+		input, err := load(expected.ordinal)
+		if err != nil {
+			return QueryReadyBaseBuildResult{}, err
+		}
+		parsed, execution, columns, err := inspectQueryReadyBasePart(p.identity, input)
+		if err != nil {
+			return QueryReadyBaseBuildResult{}, err
+		}
+		if input.SourceGeneration != expected.sourceGeneration || input.PrimaryIDMode != expected.primaryIDMode || input.PrimaryIDBase != expected.primaryIDBase || parsed.PartID != expected.partID || parsed.Rows != expected.rows || len(input.Image.Bytes) != expected.imageBytes || sha256.Sum256(input.Image.Bytes) != expected.imageChecksum || len(execution) != expected.executionBytes || sha256.Sum256(execution) != expected.executionChecksum || columns != expected.executionColumns {
+			return QueryReadyBaseBuildResult{}, fmt.Errorf("typedcolumn: query-ready streaming source[%d] changed between plan and emit", i)
+		}
+		entry := out[queryReadyBaseHeaderBytes+i*queryReadyBasePartEntryBytes:]
+		binary.LittleEndian.PutUint64(entry[0:8], expected.sourceGeneration)
+		binary.LittleEndian.PutUint64(entry[8:16], expected.partID)
+		binary.LittleEndian.PutUint64(entry[16:24], uint64(expected.imageOffset))
+		binary.LittleEndian.PutUint64(entry[24:32], uint64(expected.imageBytes))
+		binary.LittleEndian.PutUint64(entry[32:40], uint64(expected.rows))
+		binary.LittleEndian.PutUint64(entry[40:48], uint64(parsed.ManifestBytes))
+		copy(entry[48:80], expected.imageChecksum[:])
+		binary.LittleEndian.PutUint64(entry[80:88], uint64(expected.primaryIDBase))
+		entry[88] = byte(expected.primaryIDMode)
+		binary.LittleEndian.PutUint64(entry[96:104], uint64(expected.executionOffset))
+		binary.LittleEndian.PutUint64(entry[104:112], uint64(expected.executionBytes))
+		copy(entry[112:144], expected.executionChecksum[:])
+		copy(out[expected.imageOffset:], input.Image.Bytes)
+		copy(out[expected.executionOffset:], execution)
+		dependencies[i] = QueryReadyBaseDependency{SourceGeneration: expected.sourceGeneration, PartID: expected.partID, Rows: expected.rows, ImageBytes: expected.imageBytes, ImageChecksum: expected.imageChecksum, PrimaryIDMode: expected.primaryIDMode, PrimaryIDBase: expected.primaryIDBase}
+		rows += int64(expected.rows)
+		inputBytes += int64(expected.imageBytes)
+		executionBytes += int64(expected.executionBytes)
+		executionColumns += expected.executionColumns
+	}
+	table := out[queryReadyBaseHeaderBytes : queryReadyBaseHeaderBytes+len(p.parts)*queryReadyBasePartEntryBytes]
+	binary.LittleEndian.PutUint32(out[56:60], crc32.Checksum(table, queryReadyBaseCRCTable))
+	binary.LittleEndian.PutUint32(out[52:56], queryReadyBaseHeaderChecksum(out[:queryReadyBaseHeaderBytes]))
+	return QueryReadyBaseBuildResult{Bytes: out, Dependencies: dependencies, Stats: QueryReadyBaseBuildStats{Parts: len(p.parts), Rows: rows, InputBytes: inputBytes, OutputBytes: int64(len(out)), BytesCopied: inputBytes + executionBytes, BytesHashed: inputBytes + executionBytes, BytesChecksummed: int64(len(table) + queryReadyBaseHeaderBytes), ExecutionBytes: executionBytes, ExecutionColumns: executionColumns, ValidationTime: p.validationTime, BuildTime: time.Since(started) + p.validationTime}}, nil
+}
+
+func inspectQueryReadyBasePart(identity QueryReadyBaseIdentity, input QueryReadyBasePartInput) (ColumnPartImage, []byte, int, error) {
+	if input.SourceGeneration == 0 || input.SourceGeneration > identity.Generation {
+		return ColumnPartImage{}, nil, 0, fmt.Errorf("typedcolumn: query-ready base source generation=%d exceeds base generation=%d", input.SourceGeneration, identity.Generation)
+	}
+	parsed, err := ParseColumnPartImage(input.Image.Bytes)
+	if err != nil {
+		return ColumnPartImage{}, nil, 0, err
+	}
+	readOptions := ColumnPartImageReadOptions{}
+	if input.PrimaryIDMode == QueryReadyPrimaryIDDensePartLocal {
+		readOptions.IncludeRowLocators, readOptions.ValidateRowLocators = true, true
+	}
+	decoded, err := ColumnPartFromImageWithOptions(parsed, readOptions)
+	if err != nil {
+		return ColumnPartImage{}, nil, 0, err
+	}
+	if err := validateQueryReadyPrimaryIDInput(input, decoded); err != nil {
+		return ColumnPartImage{}, nil, 0, err
+	}
+	if _, err := CertifyColumnPartLayoutContractFromImage(parsed); err != nil {
+		return ColumnPartImage{}, nil, 0, err
+	}
+	execution, columns, err := buildQueryReadyExecutionImage(decoded)
+	if err != nil {
+		return ColumnPartImage{}, nil, 0, err
+	}
+	return parsed, execution, columns, nil
+}
+
 // prepareQueryReadyBaseGeneration validates the complete logical input set and
 // computes the exact deterministic layout without allocating the output image.
 // Envelope builders use the plan to encode QRBG directly into their final

--- a/TreeDB/internal/typedcolumn/query_ready_base_test.go
+++ b/TreeDB/internal/typedcolumn/query_ready_base_test.go
@@ -1,6 +1,7 @@
 package typedcolumn
 
 import (
+	"bytes"
 	"crypto/sha256"
 	"encoding/binary"
 	"hash/crc32"
@@ -59,6 +60,60 @@ func TestQueryReadyBaseGenerationReopenParity(t *testing.T) {
 	}
 	assertTransplantInt64s(t, "value", scan.Columns["value"], []int64{100, 200, 300, 400, 500, 600})
 	assertTransplantInt64s(t, "kind_code", scan.Columns["kind_code"], []int64{0, 0, 1, 1, 1, 2})
+}
+
+func TestQueryReadyBaseStreamingPlanRejectsChangedSecondPassSource(t *testing.T) {
+	identity := queryReadyBaseTestIdentity(42)
+	image := mustTransplantImage(t, mustTransplantPart(t, 702, transplantTestOptions([]SortKeyColumn{{Column: "id"}}), transplantTestBatch()))
+	planner, err := NewQueryReadyBaseStreamingPlanner(identity, 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	input := QueryReadyBasePartInput{SourceGeneration: 17, Image: image}
+	if err := planner.Add(input); err != nil {
+		t.Fatal(err)
+	}
+	plan, err := planner.Finish()
+	if err != nil {
+		t.Fatal(err)
+	}
+	changed := input
+	changed.Image.Bytes = slices.Clone(input.Image.Bytes)
+	changed.Image.Bytes[len(changed.Image.Bytes)-1] ^= 1
+	if _, err := plan.Emit(func(int) (QueryReadyBasePartInput, error) { return changed, nil }); err == nil {
+		t.Fatal("second-pass changed source unexpectedly emitted")
+	}
+}
+
+func TestQueryReadyBaseStreamingPlanMatchesLegacyBuildWithShuffledInputs(t *testing.T) {
+	identity := queryReadyBaseTestIdentity(43)
+	left := mustTransplantImage(t, mustTransplantPart(t, 703, transplantTestOptions([]SortKeyColumn{{Column: "id"}}), transplantTestBatch()))
+	right := mustTransplantImage(t, mustTransplantPart(t, 704, transplantTestOptions([]SortKeyColumn{{Column: "id"}}), transplantTestBatch()))
+	inputs := []QueryReadyBasePartInput{{SourceGeneration: 18, Image: right}, {SourceGeneration: 17, Image: left}}
+	legacy, err := BuildQueryReadyBaseGeneration(identity, inputs)
+	if err != nil {
+		t.Fatal(err)
+	}
+	planner, err := NewQueryReadyBaseStreamingPlanner(identity, len(inputs))
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, input := range inputs {
+		if err := planner.Add(input); err != nil {
+			t.Fatal(err)
+		}
+	}
+	plan, err := planner.Finish()
+	if err != nil {
+		t.Fatal(err)
+	}
+	streamed, err := plan.Emit(func(ordinal int) (QueryReadyBasePartInput, error) { return inputs[ordinal], nil })
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(streamed.Bytes, legacy.Bytes) {
+		t.Fatal("streaming QRBG bytes differ from legacy build")
+	}
 }
 
 func TestQueryReadyBaseGenerationRejectsCorruptionAndTruncation(t *testing.T) {


### PR DESCRIPTION
Closes #3888

Tracks the #3067 preparation-memory gate.

This replaces all-source retention during QRBG preparation with a two-pass streaming plan:

- pass 1 validates each source and retains fixed identity, checksum, layout, and sidecar metadata only;
- pass 2 rereads each source by original ordinal, verifies it against the plan, and writes directly into its predetermined QRBG offsets;
- admission is conservative: final output plus the largest source and sidecar/workspace bound, with checked arithmetic.

Safety coverage includes shuffled-input byte parity with the legacy builder, changed-second-pass source rejection, and a bounded multi-part admission regression. The opt-in 1M typed-column smoke prepares QRBG then executes query-ready Q1.

Matched 1M, one-iteration benchmark on this host (`TMPDIR=/mnt/fast4tb/tmp-gomap-3888`, `-benchmem`, `/usr/bin/time -v`):

| metric | bfa281e baseline | candidate |
| --- | ---: | ---: |
| time | 157.4 ms/op | 283.9 ms/op |
| Go allocations | 128.4 MB/op, 10,054 allocs/op | 241.0 MB/op, 15,266 allocs/op |
| declared peak | 102.2 MB | 24.4 MB |
| max RSS | 2.59 GB | 0.80 GB |

Two-pass overhead is explicit: +80.4% time and +87.7% Go allocation bytes on this fixture, in exchange for -76.2% declared peak and -69.1% observed max RSS. This PR makes no 10M performance claim.

Validation:

- `go test ./TreeDB/collections ./TreeDB/internal/typedcolumn -count=1`
- focused `-race` query-ready tests
- `go vet ./TreeDB/collections ./TreeDB/internal/typedcolumn`
- opt-in 1M smoke (`TREEDB_QUERY_READY_1M_SMOKE=true`)

No merge performed.