### PR TITLE
fix: preserve CompactStorage benchmark evidence

### DIFF
--- a/TreeDB/db/compact_storage_m0_bench_test.go
+++ b/TreeDB/db/compact_storage_m0_bench_test.go
@@ -273,7 +273,9 @@ func benchmarkCompactStorageM0Fixture(b *testing.B, spec compactStorageM0Fixture
 		if recorder != nil {
 			measurementRecorder = recorder
 		}
-		measurement := newCompactStorageMeasurement(fixture, artifactName, elapsed.Nanoseconds(), stats, measurementRecorder)
+		measurement := newCompactStorageMeasurementWithPlan(
+			fixture, artifactName, elapsed.Nanoseconds(), plan.ValueLogRewritePlan, stats, measurementRecorder,
+		)
 		measurement.Allocation = compactStorageMeasurementAllocation{
 			TotalAllocBytes:   afterMem.TotalAlloc - beforeMem.TotalAlloc,
 			AllocationObjects: afterMem.Mallocs - beforeMem.Mallocs,

--- a/TreeDB/db/compact_storage_m0_measurement_test.go
+++ b/TreeDB/db/compact_storage_m0_measurement_test.go
@@ -65,6 +65,7 @@ type compactStorageMeasurementLeafPack struct {
 	PageSyncTimeNanos        int64 `json:"page_sync_time_nanos"`
 	CopiedLeafSyncTimeNanos  int64 `json:"copied_leaf_sync_time_nanos"`
 	DirectorySyncTimeNanos   int64 `json:"directory_sync_time_nanos"`
+	DirectorySyncWaitNanos   int64 `json:"directory_sync_wait_nanos"`
 	FinalizeTimeNanos        int64 `json:"finalize_time_nanos"`
 	PublicationPostWorkNanos int64 `json:"publication_post_work_nanos"`
 	ReclaimedGenerations     int   `json:"reclaimed_generations"`
@@ -161,6 +162,19 @@ type compactStorageMeasurementRecorder interface {
 }
 
 func newCompactStorageMeasurement(fixture compactStorageMeasurementFixture, artifactName string, totalWallTimeNanos int64, stats CompactStorageStats, recorder compactStorageMeasurementRecorder) compactStorageMeasurement {
+	return newCompactStorageMeasurementWithPlan(
+		fixture, artifactName, totalWallTimeNanos, stats.ValueLogRewritePlan, stats, recorder,
+	)
+}
+
+func newCompactStorageMeasurementWithPlan(
+	fixture compactStorageMeasurementFixture,
+	artifactName string,
+	totalWallTimeNanos int64,
+	valueLogRewritePlan ValueLogRewritePlan,
+	stats CompactStorageStats,
+	recorder compactStorageMeasurementRecorder,
+) compactStorageMeasurement {
 	m := compactStorageMeasurement{
 		SchemaVersion:      1,
 		ArtifactName:       artifactName,
@@ -207,7 +221,8 @@ func newCompactStorageMeasurement(fixture compactStorageMeasurementFixture, arti
 		m.LeafPack.RelocationPlanTimeNanos += run.Pack.ApplyStages.RelocationTimeNanos
 		m.LeafPack.PageSyncTimeNanos += run.Pack.ApplyStages.PageSyncTimeNanos
 		m.LeafPack.CopiedLeafSyncTimeNanos += run.Pack.ApplyStages.LeafSyncTimeNanos
-		m.LeafPack.DirectorySyncTimeNanos += run.Pack.ApplyStages.DirectorySyncWaitTimeNanos
+		m.LeafPack.DirectorySyncTimeNanos += run.Pack.ApplyStages.DirectorySyncTimeNanos
+		m.LeafPack.DirectorySyncWaitNanos += run.Pack.ApplyStages.DirectorySyncWaitTimeNanos
 		m.LeafPack.FinalizeTimeNanos += run.Pack.ApplyStages.FinalizeTimeNanos
 		m.LeafPack.PublicationPostWorkNanos += run.Pack.ApplyStages.PostWorkTimeNanos
 	}
@@ -216,10 +231,10 @@ func newCompactStorageMeasurement(fixture compactStorageMeasurementFixture, arti
 	m.LeafPack.RemainingGenerationDebt = stats.RemainingDebt.LeafPackGenerations
 	m.LeafPack.RemainingGenerationBytes = stats.RemainingDebt.LeafPackBytes
 	m.ValueLog = compactStorageMeasurementValueLog{
-		PlanSegments:          stats.ValueLogRewritePlan.SegmentsSelected,
-		PlanBytesTotal:        stats.ValueLogRewritePlan.SelectedBytesTotal,
-		PlanBytesLive:         stats.ValueLogRewritePlan.SelectedBytesLive,
-		PlanBytesStale:        stats.ValueLogRewritePlan.SelectedBytesStale,
+		PlanSegments:          valueLogRewritePlan.SegmentsSelected,
+		PlanBytesTotal:        valueLogRewritePlan.SelectedBytesTotal,
+		PlanBytesLive:         valueLogRewritePlan.SelectedBytesLive,
+		PlanBytesStale:        valueLogRewritePlan.SelectedBytesStale,
 		SourceSegments:        stats.ValueLogRewrite.SourceSegmentsRequested,
 		SourceBytes:           stats.ValueLogRewrite.SourceBytesRequested,
 		RecordsCopied:         stats.ValueLogRewrite.RecordsCopied,

--- a/TreeDB/db/compact_storage_m0_measurement_test.go
+++ b/TreeDB/db/compact_storage_m0_measurement_test.go
@@ -5,6 +5,8 @@ import (
 	"time"
 )
 
+const compactStorageMeasurementSchemaVersion = 2
+
 type compactStorageMeasurementFixture struct {
 	Name                      string `json:"name"`
 	Seed                      uint64 `json:"seed"`
@@ -176,7 +178,7 @@ func newCompactStorageMeasurementWithPlan(
 	recorder compactStorageMeasurementRecorder,
 ) compactStorageMeasurement {
 	m := compactStorageMeasurement{
-		SchemaVersion:      1,
+		SchemaVersion:      compactStorageMeasurementSchemaVersion,
 		ArtifactName:       artifactName,
 		Fixture:            fixture,
 		TotalWallTimeNanos: totalWallTimeNanos,

--- a/TreeDB/db/compact_storage_measurement_test.go
+++ b/TreeDB/db/compact_storage_measurement_test.go
@@ -120,6 +120,15 @@ func TestNewCompactStorageMeasurementPreservesPreApplyEvidence(t *testing.T) {
 		m.ValueLog.RecordsCopied != 2 || m.ValueLog.ValueBytesCopied != 200 {
 		t.Fatalf("final rewrite counters lost: %+v", m.ValueLog)
 	}
+	raw, err := json.Marshal(m)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, key := range []string{"directory_sync_time_nanos", "directory_sync_wait_nanos"} {
+		if !containsJSONKey(raw, key) {
+			t.Fatalf("missing timing key %q: %s", key, raw)
+		}
+	}
 }
 
 func TestCompactStorageMeasurementJSONSchemaIsDeterministic(t *testing.T) {

--- a/TreeDB/db/compact_storage_measurement_test.go
+++ b/TreeDB/db/compact_storage_measurement_test.go
@@ -205,7 +205,7 @@ func TestWriteCompactStorageM0ArtifactPersistsCanonicalJSON(t *testing.T) {
 	if err := json.Unmarshal(raw, &decoded); err != nil {
 		t.Fatal(err)
 	}
-	if decoded.SchemaVersion != 1 || decoded.ArtifactName != measurement.ArtifactName {
+	if decoded.SchemaVersion != compactStorageMeasurementSchemaVersion || decoded.ArtifactName != measurement.ArtifactName {
 		t.Fatalf("artifact=%+v", decoded)
 	}
 }
@@ -333,6 +333,8 @@ func TestCompactStorageM0ProfileScriptUsesPortableTempRoot(t *testing.T) {
 		"mktemp -d \"$TMP_ROOT/compact_storage_m0_XXXXXX\"",
 		"allowed=$(awk '/^Cpus_allowed_list:",
 		"CPU_SET=${CPU_SET:-$(default_cpu_set)}",
+		"ARTIFACT_SCHEMA_VERSION=2",
+		".schema_version == $want",
 	} {
 		if !strings.Contains(script, want) {
 			t.Fatalf("profile script missing %q", want)

--- a/TreeDB/db/compact_storage_measurement_test.go
+++ b/TreeDB/db/compact_storage_measurement_test.go
@@ -81,6 +81,47 @@ func TestNewCompactStorageMeasurementSeparatesTimedApplyAndWorkCounters(t *testi
 	}
 }
 
+func TestNewCompactStorageMeasurementPreservesPreApplyEvidence(t *testing.T) {
+	preApplyPlan := ValueLogRewritePlan{
+		SegmentsSelected:   1,
+		SelectedBytesTotal: 300,
+		SelectedBytesLive:  200,
+		SelectedBytesStale: 100,
+	}
+	finalStats := CompactStorageStats{
+		LeafGenerationPacks: []LeafGenerationPackRunOnceStats{{
+			Ran: true,
+			Pack: LeafGenerationPackStats{
+				ApplyStages: LeafGenerationPackApplyStageStats{
+					DirectorySyncTimeNanos:     31,
+					DirectorySyncWaitTimeNanos: 7,
+				},
+			},
+		}},
+		ValueLogRewrite: ValueLogRewriteStats{
+			SourceSegmentsRequested: 1,
+			SourceBytesRequested:    300,
+			RecordsCopied:           2,
+			ValueBytesCopied:        200,
+		},
+	}
+
+	m := newCompactStorageMeasurementWithPlan(
+		compactStorageM0Fixtures[0], "artifact", 123, preApplyPlan, finalStats, nil,
+	)
+	if m.LeafPack.DirectorySyncTimeNanos != 31 || m.LeafPack.DirectorySyncWaitNanos != 7 {
+		t.Fatalf("directory sync timing=%+v", m.LeafPack)
+	}
+	if m.ValueLog.PlanSegments != 1 || m.ValueLog.PlanBytesTotal != 300 ||
+		m.ValueLog.PlanBytesLive != 200 || m.ValueLog.PlanBytesStale != 100 {
+		t.Fatalf("pre-apply rewrite plan lost: %+v", m.ValueLog)
+	}
+	if m.ValueLog.SourceSegments != 1 || m.ValueLog.SourceBytes != 300 ||
+		m.ValueLog.RecordsCopied != 2 || m.ValueLog.ValueBytesCopied != 200 {
+		t.Fatalf("final rewrite counters lost: %+v", m.ValueLog)
+	}
+}
+
 func TestCompactStorageMeasurementJSONSchemaIsDeterministic(t *testing.T) {
 	stats := CompactStorageStats{Phases: []CompactStoragePhaseStats{{Name: "leaf-generation-pack-1", WallTimeNanos: 7}}}
 	first, err := json.Marshal(newCompactStorageMeasurement(compactStorageM0Fixtures[0], "artifact", 9, stats, nil))

--- a/TreeDB/docs/performance/compact-storage-m0.md
+++ b/TreeDB/docs/performance/compact-storage-m0.md
@@ -7,6 +7,13 @@ leaf-pack work, exact checkpoint frontiers, stable calls, index-vacuum
 disposition, maintenance allocations, and matched foreground/idle write
 latencies.
 
+Current artifacts use `schema_version: 2`. Version 2 records the complete,
+potentially overlapping directory-sync operation duration in
+`leaf_pack.directory_sync_time_nanos` and the non-overlapping publication-path
+charge in `leaf_pack.directory_sync_wait_nanos`. The capture script rejects
+mixed schema versions before aggregation; version 1 artifacts must be analyzed
+separately.
+
 Run the complete pinned collection protocol:
 
 ```sh

--- a/scripts/compact_storage_m0_profile.sh
+++ b/scripts/compact_storage_m0_profile.sh
@@ -6,6 +6,7 @@ TMP_ROOT=${TMPDIR:-/tmp}
 mkdir -p "$TMP_ROOT"
 RUN_DIR=${RUN_DIR:-$(mktemp -d "$TMP_ROOT/compact_storage_m0_XXXXXX")}
 COUNT=${COUNT:-12}
+ARTIFACT_SCHEMA_VERSION=2
 
 default_cpu_set() {
   local allowed range start end cpu
@@ -72,6 +73,7 @@ run_go_test() {
   printf 'cpu=%s\n' "$(lscpu | awk -F: '/Model name/{sub(/^[ \t]+/, "", $2); print $2; exit}')"
   printf 'memory=%s\n' "$(free -h | awk '/^Mem:/{print $2 " total, " $7 " available"}')"
   printf 'count=%s\n' "$COUNT"
+  printf 'artifact_schema_version=%s\n' "$ARTIFACT_SCHEMA_VERSION"
   printf 'canonical_command=go test ./TreeDB/db -run ^$ -bench %s -benchtime=1x -count=1 -benchmem\n' "$BENCH"
 } >"$RUN_DIR/environment.txt"
 
@@ -172,6 +174,13 @@ TREEDB_COMPACT_STORAGE_M0_STRACE_MARKERS=1 \
   -o "$RUN_DIR/syscalls/strace_raw.txt" \
   go test ./TreeDB/db -run '^$' -bench "$STRESS" -benchtime=1x -count=1 -benchmem \
   >"$RUN_DIR/syscalls/raw.txt" 2>"$RUN_DIR/syscalls/stderr.txt"
+
+while IFS= read -r -d '' artifact; do
+  if ! jq -e --argjson want "$ARTIFACT_SCHEMA_VERSION" '.schema_version == $want' "$artifact" >/dev/null; then
+    printf 'artifact schema mismatch: %s (want %s)\n' "$artifact" "$ARTIFACT_SCHEMA_VERSION" >&2
+    exit 1
+  fi
+done < <(find "$RUN_DIR" -name 'sample-*.json' -print0)
 
 awk '
   /TREEDB_M0_BEGIN/ { capture=1; next }


### PR DESCRIPTION
## Summary

- record full directory-sync operation time under `directory_sync_time_nanos`
- add `directory_sync_wait_nanos` for the non-overlapping publication-path charge
- preserve the pre-apply value-log rewrite plan while retaining final execution/GC/debt counters

This resolves both exact-head Codex findings posted after #3886 merged.

## Test-first evidence

Red commit `7b4dcf857` added a regression that failed because the pre-apply-aware constructor did not exist. Implementation commit `d504156c6` makes it pass.

- `GOWORK=off go test ./TreeDB/db -run 'CompactStorageM0|CompactStorageMeasurement' -count=1`
- `GOWORK=off GOMAXPROCS=2 go test -race ./TreeDB/db -run 'CompactStorageM0|CompactStorageMeasurement' -count=1`
- `GOWORK=off GOMAXPROCS=2 GOMEMLIMIT=8GiB TREEDB_COMPACT_STORAGE_M0_SAMPLE=1 TREEDB_COMPACT_STORAGE_M0_ARTIFACT_DIR=/mnt/fast4tb/compact-storage-3894-smoke-d504156c6 taskset -c 0,1 go test ./TreeDB/db -run '^$' -bench '^BenchmarkCompactStorageM0/full-high-debt$' -benchtime=1x -count=1 -benchmem`

The smoke artifact reports one planned and requested source segment with `3,293,184` selected/requested bytes (`1,093,632` live, `2,199,552` stale); invariant checks passed.

Fixes #3894
Refs #3737
Refs #3732
