### PR TITLE
collections: bound generic reconstruction windows

### DIFF
--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -20933,7 +20933,6 @@ func (c *Collection) ScanDocumentsFunc(maxDocuments int, fn func(DocumentRecord)
 			return c.scanDocumentsFuncWithMonotonicColumnReconstruction(snap, catalog, maxDocuments, fn, &scanStats)
 		}
 		scanStats.GenericFallback = true
-		scanStats.PhysicalPasses++ // generic visibility scan follows any preflight pass.
 		return c.scanDocumentsFuncWithColumnReconstruction(snap, catalog, it, maxDocuments, fn, &scanStats)
 	}
 	truncated := false
@@ -20976,108 +20975,123 @@ func (c *Collection) scanDocumentsFuncWithColumnReconstruction(
 	stats *CollectionDocumentScanStats,
 ) (bool, error) {
 	columnStoreConfig := catalog.meta.Options.ColumnStore.copy()
-	capacity := maxDocuments
-	if capacity > 256 {
-		capacity = 256
-	}
-	records := make([]DocumentRecord, 0, capacity)
-	for it.Valid() {
-		if it.IsDeleted() {
-			it.Next()
-			continue
-		}
-		if len(records) >= maxDocuments {
-			break
-		}
-		records = append(records, DocumentRecord{
-			ID:       bytes.Clone(it.UnsafeKey()),
-			Document: it.ValueCopy(nil),
-		})
-		it.Next()
-	}
-	if err := it.Error(); err != nil {
-		return false, err
-	}
-	truncated := false
-	for it.Valid() {
-		if !it.IsDeleted() {
-			truncated = true
-			break
-		}
-		it.Next()
-	}
-	if err := it.Error(); err != nil {
-		return false, err
-	}
-	if len(records) == 0 {
-		return truncated, nil
-	}
-	ids := make([][]byte, len(records))
-	for i := range records {
-		ids[i] = records[i].ID
-	}
-	visible, err := c.scanColumnPhysicalVisibleRowsAtSnapshotForTargets(
-		snap,
-		catalog,
-		catalog.meta.Name,
-		catalog.rootID(collectionColumnManifestRootName(catalog.meta.Name)),
-		columnStoreConfig,
-		true,
-		newColumnPhysicalVisibilityTargetIDs(ids),
-		nil,
-	)
-	if err != nil {
-		return false, err
-	}
-	if stats != nil {
-		stats.PhysicalRows += uint64(visible.Diagnostics.RowsScanned)
-		stats.PhysicalBytes += uint64(visible.Diagnostics.PhysicalBytesScanned)
-		stats.PhysicalDecodedBlocks += uint64(visible.Diagnostics.DecodedBlocks)
-	}
-	visibleRows := visible.Rows
-	visiblePos := 0
-	var typedColumnCache *typedColumnPartReconstructionCache
-	if columnStoreHasTypedColumnPartOwners(columnStoreConfig) {
-		typedColumnCache = &typedColumnPartReconstructionCache{Parts: make(map[uint64]typedColumnPartDecodedValues)}
-	}
-	retainedSemanticCache := newColumnRetainedSemanticStreamV1DecodeCacheForDocumentRecords(&columnStoreConfig, records)
 	manifestRootID := catalog.rootID(collectionColumnManifestRootName(catalog.meta.Name))
 	typedScratch := make([]columnDeclaredValue, 0, len(columnStoreTypedColumnPartFields(columnStoreConfig)))
 	mergeScratch := make([]columnDeclaredValue, 0, len(columnStoreConfig.Columns))
 	retainedTemplateResolver := columnRetainedPayloadTemplateResolver(snap, catalog)
-	for _, record := range records {
-		for visiblePos < len(visibleRows) && bytes.Compare(visibleRows[visiblePos].ID, record.ID) < 0 {
-			visiblePos++
+	// The generic fallback may serve arbitrary primary-to-physical ordering, but
+	// it must not retain the requested corpus while resolving that ordering.
+	// Reuse the certified path's ownership bound for each target/visibility and
+	// reconstruction window.
+	windowSize := min(maxDocuments, columnReconstructionMonotonicBatchSize)
+	records := make([]DocumentRecord, 0, windowSize)
+	scanned := 0
+	for it.Valid() && scanned < maxDocuments {
+		records = records[:0]
+		for it.Valid() && len(records) < windowSize && scanned+len(records) < maxDocuments {
+			if it.IsDeleted() {
+				it.Next()
+				continue
+			}
+			records = append(records, DocumentRecord{
+				ID:       bytes.Clone(it.UnsafeKey()),
+				Document: it.ValueCopy(nil),
+			})
+			it.Next()
 		}
-		if visiblePos >= len(visibleRows) || !bytes.Equal(visibleRows[visiblePos].ID, record.ID) {
-			return false, fmt.Errorf("collections: column reconstruction missing visible physical row for id %q", string(record.ID))
+		if err := it.Error(); err != nil {
+			return false, err
 		}
-		typedValues, err := c.typedColumnPartValuesForVisibleRowAtSnapshotIntoWithCache(snap, manifestRootID, columnStoreConfig, visibleRows[visiblePos], typedColumnCache, typedScratch)
+		if len(records) == 0 {
+			break
+		}
+		if stats != nil {
+			stats.PhysicalPasses++
+			stats.MaxRecordWindow = max(stats.MaxRecordWindow, uint64(len(records)))
+		}
+		ids := make([][]byte, len(records))
+		for i := range records {
+			ids[i] = records[i].ID
+		}
+		visible, err := c.scanColumnPhysicalVisibleRowsAtSnapshotForTargets(
+			snap,
+			catalog,
+			catalog.meta.Name,
+			manifestRootID,
+			columnStoreConfig,
+			true,
+			newColumnPhysicalVisibilityTargetIDs(ids),
+			nil,
+		)
 		if err != nil {
 			return false, err
 		}
-		fullValues, err := mergeColumnReconstructionValuesInto(columnStoreConfig, visibleRows[visiblePos].Values, typedValues.Values, mergeScratch)
-		if err != nil {
-			return false, err
+		if stats != nil {
+			stats.PhysicalRows += uint64(visible.Diagnostics.RowsScanned)
+			stats.PhysicalBytes += uint64(visible.Diagnostics.PhysicalBytesScanned)
+			stats.PhysicalDecodedBlocks += uint64(visible.Diagnostics.DecodedBlocks)
+			stats.MaxVisibleRowWindow = max(stats.MaxVisibleRowWindow, uint64(len(visible.Rows)))
 		}
-		retainedDocument, err := resolveColumnRetainedPayloadAtSnapshotWithCache(snap, catalog, columnStoreConfig, record.Document, retainedSemanticCache)
-		if err != nil {
-			return false, err
+		visibleRows := visible.Rows
+		visiblePos := 0
+		var typedColumnCache *typedColumnPartReconstructionCache
+		if columnStoreHasTypedColumnPartOwners(columnStoreConfig) {
+			typedColumnCache = &typedColumnPartReconstructionCache{Parts: make(map[uint64]typedColumnPartDecodedValues)}
 		}
-		_, reconstructed, err := reconstructColumnDocumentFromVisibleRowValuesProjectedIntoWithResolver(nil, columnStoreConfig, retainedDocument, visibleRows[visiblePos], fullValues, nil, nil, retainedTemplateResolver)
-		if err != nil {
-			return false, err
-		}
-		record.Document = reconstructed
-		next, err := fn(record)
-		if err != nil {
-			return false, err
-		}
-		if !next {
-			return false, nil
+		retainedSemanticCache := newColumnRetainedSemanticStreamV1DecodeCacheForDocumentRecords(&columnStoreConfig, records)
+		for _, record := range records {
+			for visiblePos < len(visibleRows) && bytes.Compare(visibleRows[visiblePos].ID, record.ID) < 0 {
+				visiblePos++
+			}
+			if visiblePos >= len(visibleRows) || !bytes.Equal(visibleRows[visiblePos].ID, record.ID) {
+				return false, fmt.Errorf("collections: column reconstruction missing visible physical row for id %q", string(record.ID))
+			}
+			typedValues, err := c.typedColumnPartValuesForVisibleRowAtSnapshotIntoWithCache(snap, manifestRootID, columnStoreConfig, visibleRows[visiblePos], typedColumnCache, typedScratch)
+			if err != nil {
+				return false, err
+			}
+			fullValues, err := mergeColumnReconstructionValuesInto(columnStoreConfig, visibleRows[visiblePos].Values, typedValues.Values, mergeScratch)
+			if err != nil {
+				return false, err
+			}
+			retainedDocument, err := resolveColumnRetainedPayloadAtSnapshotWithCache(snap, catalog, columnStoreConfig, record.Document, retainedSemanticCache)
+			if err != nil {
+				return false, err
+			}
+			_, reconstructed, err := reconstructColumnDocumentFromVisibleRowValuesProjectedIntoWithResolver(nil, columnStoreConfig, retainedDocument, visibleRows[visiblePos], fullValues, nil, nil, retainedTemplateResolver)
+			if err != nil {
+				return false, err
+			}
+			record.Document = reconstructed
+			if stats != nil {
+				stats.ReconstructedRows++
+				if retainedSemanticCache != nil {
+					stats.MaxRetainedBlocks = max(stats.MaxRetainedBlocks, uint64(len(retainedSemanticCache.blocks)))
+				}
+			}
+			next, err := fn(record)
+			if err != nil {
+				return false, err
+			}
+			if !next {
+				return false, nil
+			}
+			scanned++
 		}
 	}
-	return truncated, nil
+	if err := it.Error(); err != nil {
+		return false, err
+	}
+	if scanned < maxDocuments {
+		return false, nil
+	}
+	for it.Valid() {
+		if !it.IsDeleted() {
+			return true, nil
+		}
+		it.Next()
+	}
+	return false, it.Error()
 }
 
 func loadCollectionCatalog(snap *backenddb.Snapshot, name string) (*collectionCatalog, error) {

--- a/TreeDB/collections/column_reconstruction_monotonic_test.go
+++ b/TreeDB/collections/column_reconstruction_monotonic_test.go
@@ -463,11 +463,24 @@ func TestScanDocumentsFuncMonotonicReconstructionTypedSortKeyFallsBackP3887(t *t
 	if err != nil || truncated || len(got) != rows {
 		t.Fatalf("scan err=%v truncated=%t rows=%d want %d", err, truncated, len(got), rows)
 	}
+	wantDigest := sha256.New()
+	gotDigest := sha256.New()
 	for i, record := range got {
 		if want := string(ids[i]); string(record.ID) != want {
 			t.Fatalf("id[%d]=%q want %q", i, record.ID, want)
 		}
 		assertJSONEqualM13C(t, record.Document, docs[i])
+		wantDigest.Write(ids[i])
+		wantDigest.Write([]byte{0})
+		wantDigest.Write(docs[i])
+		wantDigest.Write([]byte{'\n'})
+		gotDigest.Write(record.ID)
+		gotDigest.Write([]byte{0})
+		gotDigest.Write(record.Document)
+		gotDigest.Write([]byte{'\n'})
+	}
+	if got, want := gotDigest.Sum(nil), wantDigest.Sum(nil); !bytes.Equal(got, want) {
+		t.Fatalf("reconstruction digest=%x want %x", got, want)
 	}
 	stats := col.LastDocumentScanStats()
 	if stats.CertifiedMonotonicPath || !stats.GenericFallback || stats.PhysicalPasses != 3 || stats.MaxRecordWindow != columnReconstructionMonotonicBatchSize || stats.MaxVisibleRowWindow != columnReconstructionMonotonicBatchSize || stats.ReconstructedRows != rows || stats.PhysicalRows == 0 || stats.PhysicalDecodedBlocks == 0 {

--- a/TreeDB/collections/column_reconstruction_monotonic_test.go
+++ b/TreeDB/collections/column_reconstruction_monotonic_test.go
@@ -432,25 +432,70 @@ func TestScanDocumentsFuncMonotonicReconstructionTypedSortKeyFallsBackP3887(t *t
 	if err != nil {
 		t.Fatal(err)
 	}
-	if _, err := col.InsertBatch([][]byte{[]byte("e0000"), []byte("e0001")}, [][]byte{[]byte(`{"time_us":2}`), []byte(`{"time_us":1}`)}); err != nil {
+	const rows = columnReconstructionMonotonicBatchSize*2 + 3
+	ids := make([][]byte, rows)
+	docs := make([][]byte, rows)
+	for i := range ids {
+		ids[i] = []byte(fmt.Sprintf("e%04d", i))
+		// The typed sort key deliberately orders physical parts differently from
+		// primary ID order, which keeps this shape on the generic fallback.
+		docs[i] = []byte(fmt.Sprintf(`{"time_us":%d,"payload":"row-%04d"}`, rows-i, i))
+	}
+	if _, err := col.InsertBatch(ids, docs); err != nil {
+		t.Fatal(err)
+	}
+	if err := d.Close(); err != nil {
+		t.Fatal(err)
+	}
+	d, err = backenddb.Open(backenddb.Options{Dir: dir, DisableBackgroundPrune: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	col, err = NewCollectionManager(d).OpenCollection("events")
+	if err != nil {
 		t.Fatal(err)
 	}
 	var got []DocumentRecord
-	truncated, err := col.ScanDocumentsFunc(2, func(record DocumentRecord) (bool, error) {
+	truncated, err := col.ScanDocumentsFunc(rows, func(record DocumentRecord) (bool, error) {
 		got = append(got, record)
 		return true, nil
 	})
-	if err != nil || truncated || len(got) != 2 {
-		t.Fatalf("scan err=%v truncated=%t rows=%d", err, truncated, len(got))
+	if err != nil || truncated || len(got) != rows {
+		t.Fatalf("scan err=%v truncated=%t rows=%d want %d", err, truncated, len(got), rows)
 	}
-	if string(got[0].ID) != "e0000" || string(got[1].ID) != "e0001" {
-		t.Fatalf("IDs=%q,%q want e0000,e0001", got[0].ID, got[1].ID)
+	for i, record := range got {
+		if want := string(ids[i]); string(record.ID) != want {
+			t.Fatalf("id[%d]=%q want %q", i, record.ID, want)
+		}
+		assertJSONEqualM13C(t, record.Document, docs[i])
 	}
-	assertJSONMapEqual1875(t, got[0].Document, map[string]any{"time_us": float64(2)})
-	assertJSONMapEqual1875(t, got[1].Document, map[string]any{"time_us": float64(1)})
 	stats := col.LastDocumentScanStats()
-	if stats.CertifiedMonotonicPath || !stats.GenericFallback || stats.PhysicalPasses != 1 {
-		t.Fatalf("scan stats=%+v want generic fallback for typed sort-key rows", stats)
+	if stats.CertifiedMonotonicPath || !stats.GenericFallback || stats.PhysicalPasses != 3 || stats.MaxRecordWindow != columnReconstructionMonotonicBatchSize || stats.MaxVisibleRowWindow != columnReconstructionMonotonicBatchSize || stats.ReconstructedRows != rows || stats.PhysicalRows == 0 || stats.PhysicalDecodedBlocks == 0 {
+		t.Fatalf("scan stats=%+v want bounded generic fallback for typed sort-key rows", stats)
+	}
+	limitedCalls := 0
+	truncated, err = col.ScanDocumentsFunc(rows-1, func(DocumentRecord) (bool, error) {
+		limitedCalls++
+		return true, nil
+	})
+	if err != nil || !truncated || limitedCalls != rows-1 {
+		t.Fatalf("limited scan err=%v truncated=%t calls=%d want nil/true/%d", err, truncated, limitedCalls, rows-1)
+	}
+	if stats := col.LastDocumentScanStats(); stats.PhysicalPasses != 3 || stats.MaxRecordWindow != columnReconstructionMonotonicBatchSize || stats.MaxVisibleRowWindow != columnReconstructionMonotonicBatchSize {
+		t.Fatalf("limited scan stats=%+v want three bounded generic windows", stats)
+	}
+	stoppedCalls := 0
+	truncated, err = col.ScanDocumentsFunc(rows, func(DocumentRecord) (bool, error) {
+		stoppedCalls++
+		return stoppedCalls < 2, nil
+	})
+	if err != nil || truncated || stoppedCalls != 2 {
+		t.Fatalf("stopped scan err=%v truncated=%t calls=%d want nil/false/2", err, truncated, stoppedCalls)
+	}
+	wantErr := errors.New("typed sort-key callback error")
+	_, err = col.ScanDocumentsFunc(rows, func(DocumentRecord) (bool, error) { return false, wantErr })
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("callback err=%v want %v", err, wantErr)
 	}
 }
 


### PR DESCRIPTION
Part of #3897

## Scope

Bounds the generic `ScanDocumentsFunc` reconstruction fallback at 256 records end-to-end. This is the fallback used by the canonical typed-sort-key shape; it remains a fallback and does not broaden #3887 certified monotonic eligibility.

Each window now owns only its target IDs, visible rows, typed reconstruction cache, and retained-payload decode cache. `CollectionDocumentScanStats` reports actual fallback physical passes, record/visible window maxima, reconstructed rows, physical rows, bytes, and decoded blocks.

## Correctness

Expanded the typed-sort-key regression into a reopened 515-row, multi-window scan. It verifies exact primary order and reconstructed JSON, generic-path diagnostics, `maxDocuments`/truncation, callback false, and callback error semantics.

## Validation

- `go test ./TreeDB/collections -count=1`
- `go test -race ./TreeDB/collections -run '^(TestScanDocumentsFuncMonotonicReconstructionTypedSortKeyFallsBackP3887|TestScanDocumentsFuncMonotonicReconstructionBoundsWindowsP3887|TestScanDocumentsFuncMonotonicReconstructionUpdateFallsBackP3887)$' -count=1`
- `go vet ./TreeDB/collections`
- `P3887_BENCH_ROWS=10000 go test ./TreeDB/collections -run '^$' -bench '^BenchmarkScanDocumentsFuncMonotonicReconstructionP3887$' -benchmem -count=5`

Certified monotonic-path benchmark remained bounded across all five samples: 256 max record/visible rows, one typed generation, two physical passes and two decoded blocks. Timing ranged 36.7–44.2 ms/op; allocation range was 39.23–39.34 MB/op (host: i5-11400F).

## Non-goals

JSONBench result/report wiring and canonical 10M resource evidence remain required before #3897 closes. No typed-sort-key certification broadening, WAL/value-log/GC work, storage pruning, or on-disk format change.

## Status

Ready for latest-head CI and Codex review; coordinator owns merge.
