### PR TITLE
perf: fuse parallel q4/q5 grouped reductions

### DIFF
--- a/TreeDB/collections/column_physical_query.go
+++ b/TreeDB/collections/column_physical_query.go
@@ -226,33 +226,36 @@ type ColumnPhysicalQueryDiagnostics struct {
 	TypedColumnPrepareQ2GroupGlobalCodeRemapNanos         int64
 	TypedColumnPrepareQ2DistinctGlobalCodeRemapNanos      int64
 
-	ColumnAssetReadIntegrity     string
-	StorageSource                ColumnPhysicalQueryStorageSource
-	FallbackReason               ColumnPhysicalQueryFallbackReason
-	ScanNanos                    int64
-	VisibilityNanos              int64
-	ReduceNanos                  int64
-	ResultShapeNanos             int64
-	ReconstructionNanos          int64
-	QueryReadyEncodedExecutions  int
-	QueryReadyPreparedParts      int
-	QueryReadyBaseParts          int
-	QueryReadyDeltaParts         int
-	QueryReadyRowsCandidate      int
-	QueryReadyRowsVisible        int
-	QueryReadyRowsSuperseded     int
-	QueryReadyCodeTranslations   int
-	QueryReadyDictionaryDomains  int
-	QueryReadyScratchBytes       int64
-	QueryReadyPreparationNanos   int64
-	QueryReadyBaseScanNanos      int64
-	QueryReadyDeltaMergeNanos    int64
-	QueryReadyPredicateNanos     int64
-	QueryReadyReductionNanos     int64
-	QueryReadyGroupingNanos      int64
-	QueryReadyOrderingTopKNanos  int64
-	QueryReadyLegacyFallbacks    int
-	QueryReadyPrecomputedAnswers int
+	ColumnAssetReadIntegrity                    string
+	StorageSource                               ColumnPhysicalQueryStorageSource
+	FallbackReason                              ColumnPhysicalQueryFallbackReason
+	ScanNanos                                   int64
+	VisibilityNanos                             int64
+	ReduceNanos                                 int64
+	ResultShapeNanos                            int64
+	ReconstructionNanos                         int64
+	QueryReadyEncodedExecutions                 int
+	QueryReadyPreparedParts                     int
+	QueryReadyBaseParts                         int
+	QueryReadyDeltaParts                        int
+	QueryReadyRowsCandidate                     int
+	QueryReadyRowsVisible                       int
+	QueryReadyRowsSuperseded                    int
+	QueryReadyCodeTranslations                  int
+	QueryReadyDictionaryDomains                 int
+	QueryReadyScratchBytes                      int64
+	QueryReadyPreparationNanos                  int64
+	QueryReadyBaseScanNanos                     int64
+	QueryReadyDeltaMergeNanos                   int64
+	QueryReadyPredicateNanos                    int64
+	QueryReadyReductionNanos                    int64
+	QueryReadyFusedPredicateReductionExecutions int
+	QueryReadyFusedPredicateReductionWorkers    int
+	QueryReadyFusedPredicateReductionNanos      int64
+	QueryReadyGroupingNanos                     int64
+	QueryReadyOrderingTopKNanos                 int64
+	QueryReadyLegacyFallbacks                   int
+	QueryReadyPrecomputedAnswers                int
 }
 
 // ColumnPhysicalQueryResult is the reduced result and diagnostics from an
@@ -1563,6 +1566,9 @@ func mergeColumnPhysicalQueryDiagnostics(left, right ColumnPhysicalQueryDiagnost
 	left.QueryReadyDeltaMergeNanos += right.QueryReadyDeltaMergeNanos
 	left.QueryReadyPredicateNanos += right.QueryReadyPredicateNanos
 	left.QueryReadyReductionNanos += right.QueryReadyReductionNanos
+	left.QueryReadyFusedPredicateReductionExecutions += right.QueryReadyFusedPredicateReductionExecutions
+	left.QueryReadyFusedPredicateReductionWorkers = max(left.QueryReadyFusedPredicateReductionWorkers, right.QueryReadyFusedPredicateReductionWorkers)
+	left.QueryReadyFusedPredicateReductionNanos += right.QueryReadyFusedPredicateReductionNanos
 	left.QueryReadyGroupingNanos += right.QueryReadyGroupingNanos
 	left.QueryReadyOrderingTopKNanos += right.QueryReadyOrderingTopKNanos
 	left.QueryReadyLegacyFallbacks += right.QueryReadyLegacyFallbacks

--- a/TreeDB/collections/query_ready_execution.go
+++ b/TreeDB/collections/query_ready_execution.go
@@ -274,6 +274,9 @@ func applyQueryReadyExecutionDiagnostics(diag *ColumnPhysicalQueryDiagnostics, r
 	diag.QueryReadyCodeTranslations, diag.QueryReadyDictionaryDomains, diag.QueryReadyScratchBytes = stats.CodeTranslations, stats.DictionaryDomains, stats.ScratchBytes
 	diag.QueryReadyPreparationNanos, diag.QueryReadyBaseScanNanos, diag.QueryReadyDeltaMergeNanos = stats.PreparationNanos, stats.BaseScanNanos, stats.DeltaMergeNanos
 	diag.QueryReadyPredicateNanos, diag.QueryReadyReductionNanos = stats.PredicateNanos, stats.ReductionNanos
+	diag.QueryReadyFusedPredicateReductionExecutions = stats.FusedPredicateReductionExecutions
+	diag.QueryReadyFusedPredicateReductionWorkers = stats.FusedPredicateReductionWorkers
+	diag.QueryReadyFusedPredicateReductionNanos = stats.FusedPredicateReductionNanos
 	diag.QueryReadyGroupingNanos, diag.QueryReadyOrderingTopKNanos = stats.GroupingNanos, stats.OrderingTopKNanos
 	diag.QueryReadyLegacyFallbacks, diag.QueryReadyPrecomputedAnswers = stats.LegacyScanFallbacks, stats.PrecomputedAnswers
 	diag.DocumentMaterializations, diag.FallbackReads = stats.DocumentMaterializations, stats.Fallbacks

--- a/TreeDB/internal/typedcolumn/query_ready_execution.go
+++ b/TreeDB/internal/typedcolumn/query_ready_execution.go
@@ -4,8 +4,11 @@ import (
 	"errors"
 	"fmt"
 	"math"
+	"runtime"
 	"slices"
 	"sort"
+	"sync"
+	"sync/atomic"
 	"time"
 )
 
@@ -64,38 +67,41 @@ type QueryReadyOperatorGroup struct {
 // Fallback/materialization counters are deliberately explicit zero-valued
 // guardrails for callers and benchmark reports.
 type QueryReadyExecutionStats struct {
-	EncodedBaseDeltaExecutions int
-	PreparedParts              int
-	BaseParts                  int
-	DeltaParts                 int
-	RowsCandidate              int
-	RowsVisible                int
-	RowsSuperseded             int
-	RowsDeleted                int
-	RowsScanned                int
-	BaseRowsScanned            int
-	DeltaRowsScanned           int
-	RowsMatched                int
-	GroupsConsidered           int
-	GroupsReturned             int
-	Predicates                 int
-	DictionaryDomains          int
-	CodeTranslations           int
-	DecodedBlocks              int
-	DecodedBytes               int64
-	ScratchBytes               int64
-	PreparationNanos           int64
-	BaseScanNanos              int64
-	DeltaMergeNanos            int64
-	PredicateNanos             int64
-	ReductionNanos             int64
-	GroupingNanos              int64
-	OrderingTopKNanos          int64
-	MaterializationNanos       int64
-	DocumentMaterializations   int
-	LegacyScanFallbacks        int
-	PrecomputedAnswers         int
-	Fallbacks                  int
+	EncodedBaseDeltaExecutions        int
+	PreparedParts                     int
+	BaseParts                         int
+	DeltaParts                        int
+	RowsCandidate                     int
+	RowsVisible                       int
+	RowsSuperseded                    int
+	RowsDeleted                       int
+	RowsScanned                       int
+	BaseRowsScanned                   int
+	DeltaRowsScanned                  int
+	RowsMatched                       int
+	GroupsConsidered                  int
+	GroupsReturned                    int
+	Predicates                        int
+	DictionaryDomains                 int
+	CodeTranslations                  int
+	DecodedBlocks                     int
+	DecodedBytes                      int64
+	ScratchBytes                      int64
+	PreparationNanos                  int64
+	BaseScanNanos                     int64
+	DeltaMergeNanos                   int64
+	PredicateNanos                    int64
+	ReductionNanos                    int64
+	FusedPredicateReductionExecutions int
+	FusedPredicateReductionWorkers    int
+	FusedPredicateReductionNanos      int64
+	GroupingNanos                     int64
+	OrderingTopKNanos                 int64
+	MaterializationNanos              int64
+	DocumentMaterializations          int
+	LegacyScanFallbacks               int
+	PrecomputedAnswers                int
+	Fallbacks                         int
 }
 
 type QueryReadyOperatorResult struct {
@@ -166,6 +172,12 @@ type QueryReadyOperator struct {
 	seen              []bool
 	matchedRows       []int
 	resultGroups      []QueryReadyOperatorGroup
+	fusedMin          []atomic.Int64
+	fusedMax          []atomic.Int64
+	fusedSeen         []atomic.Bool
+	fusedWorkerErrors []error
+	fusedWorkerRows   []int
+	fusedWorkerCodes  []int
 }
 
 const queryReadyMaxGroupDistinctCells = 64 << 20
@@ -333,6 +345,19 @@ func PrepareQueryReadyOperator(reader *QueryReadyBaseDeltaReader, request QueryR
 	}
 	if runner.usesBoundedTopKShape() && request.TopK < resultCapacity {
 		resultCapacity = request.TopK
+	}
+	if len(request.Predicates) == 3 && (request.Kind == QueryReadyOperatorGroupMinInt64 || request.Kind == QueryReadyOperatorGroupMaxInt64 || request.Kind == QueryReadyOperatorGroupInt64Span) {
+		workers := min(runtime.GOMAXPROCS(0), len(runner.parts), 8)
+		if workers > 1 {
+			runner.fusedMin = make([]atomic.Int64, groups)
+			runner.fusedSeen = make([]atomic.Bool, groups)
+			if request.Kind == QueryReadyOperatorGroupMaxInt64 || request.Kind == QueryReadyOperatorGroupInt64Span {
+				runner.fusedMax = make([]atomic.Int64, groups)
+			}
+			runner.fusedWorkerErrors = make([]error, workers)
+			runner.fusedWorkerRows = make([]int, workers)
+			runner.fusedWorkerCodes = make([]int, workers)
+		}
 	}
 	runner.resultGroups = make([]QueryReadyOperatorGroup, 0, resultCapacity)
 	runner.prepareNanos = time.Since(started).Nanoseconds()
@@ -693,6 +718,17 @@ func (r *QueryReadyOperator) Run() (QueryReadyOperatorResult, error) {
 			stats.DeltaRowsScanned += rows
 			stats.DeltaMergeNanos += time.Since(phaseStart).Nanoseconds()
 		}
+		fusedStarted := time.Now()
+		if matched, handled, err := r.reduceFusedDecodedGroupedInt64(partIndex, part, rows, &stats); handled {
+			stats.FusedPredicateReductionExecutions = 1
+			stats.FusedPredicateReductionWorkers = 1
+			stats.FusedPredicateReductionNanos += time.Since(fusedStarted).Nanoseconds()
+			stats.RowsMatched += matched
+			if err != nil {
+				return QueryReadyOperatorResult{Stats: stats}, err
+			}
+			continue
+		}
 		r.matchedRows = r.matchedRows[:0]
 		predicateStart := time.Now()
 		for row := 0; row < rows; row++ {
@@ -730,6 +766,33 @@ func (r *QueryReadyOperator) Run() (QueryReadyOperatorResult, error) {
 	return QueryReadyOperatorResult{Groups: r.resultGroups, Stats: stats}, nil
 }
 
+func (r *QueryReadyOperator) reduceFusedDecodedGroupedInt64(partIndex int, part *queryReadyExecutionPart, rows int, stats *QueryReadyExecutionStats) (int, bool, error) {
+	switch r.request.Kind {
+	case QueryReadyOperatorGroupMinInt64, QueryReadyOperatorGroupMaxInt64, QueryReadyOperatorGroupInt64Span:
+	default:
+		return 0, false, nil
+	}
+	if len(r.predicates) == 0 {
+		return 0, false, nil
+	}
+	matchedRows := 0
+	var unusedExpressionSum int64
+	for row := 0; row < rows; row++ {
+		matched, err := r.rowMatches(partIndex, part, row, stats)
+		if err != nil {
+			return matchedRows, true, err
+		}
+		if !matched {
+			continue
+		}
+		if err := r.reduceRow(partIndex, part, row, &unusedExpressionSum, stats); err != nil {
+			return matchedRows, true, err
+		}
+		matchedRows++
+	}
+	return matchedRows, true, nil
+}
+
 func (r *QueryReadyOperator) canRunDirect() bool {
 	if r == nil || len(r.parts) == 0 {
 		return false
@@ -750,6 +813,9 @@ func (r *QueryReadyOperator) canRunDirect() bool {
 }
 
 func (r *QueryReadyOperator) runDirect(stats QueryReadyExecutionStats) (QueryReadyOperatorResult, error) {
+	if result, handled := r.runDirectFusedParallel(stats); handled {
+		return result.result, result.err
+	}
 	var expressionSum int64
 	for partIndex := range r.parts {
 		part := &r.parts[partIndex]
@@ -801,6 +867,183 @@ func (r *QueryReadyOperator) runDirect(stats QueryReadyExecutionStats) (QueryRea
 	stats.GroupsReturned = len(r.resultGroups)
 	stats.ScratchBytes = r.scratchBytes()
 	return QueryReadyOperatorResult{Groups: r.resultGroups, Stats: stats}, nil
+}
+
+type queryReadyFusedParallelResult struct {
+	result QueryReadyOperatorResult
+	err    error
+}
+
+func (r *QueryReadyOperator) runDirectFusedParallel(stats QueryReadyExecutionStats) (queryReadyFusedParallelResult, bool) {
+	switch r.request.Kind {
+	case QueryReadyOperatorGroupMinInt64, QueryReadyOperatorGroupMaxInt64, QueryReadyOperatorGroupInt64Span:
+	default:
+		return queryReadyFusedParallelResult{}, false
+	}
+	workers := len(r.fusedWorkerRows)
+	if workers < 2 || len(r.fusedMin) != len(r.groupDomain.values) || len(r.fusedSeen) != len(r.groupDomain.values) {
+		return queryReadyFusedParallelResult{}, false
+	}
+	if (r.request.Kind == QueryReadyOperatorGroupMaxInt64 || r.request.Kind == QueryReadyOperatorGroupInt64Span) && len(r.fusedMax) != len(r.groupDomain.values) {
+		return queryReadyFusedParallelResult{}, false
+	}
+	for partIndex := range r.parts {
+		part := &r.parts[partIndex]
+		rows := part.part.Descriptor.RowCount
+		if len(part.predicates) != 3 || len(r.predicates) != 3 || partIndex >= len(r.groupDomain.byPart) {
+			return queryReadyFusedParallelResult{}, false
+		}
+		for predicateIndex := range part.predicates {
+			predicate := &part.predicates[predicateIndex]
+			if predicate.allowed8 == nil || len(predicate.column.values) < rows {
+				return queryReadyFusedParallelResult{}, false
+			}
+		}
+		groupColumn := part.direct[r.groupProjected]
+		valueColumn := part.direct[r.valueProjected]
+		if groupColumn.kind != QueryReadyExecutionColumnCode || valueColumn.kind != QueryReadyExecutionColumnInt64 ||
+			groupColumn.rows < rows || valueColumn.rows < rows {
+			return queryReadyFusedParallelResult{}, false
+		}
+	}
+
+	for group := range r.fusedSeen {
+		r.fusedSeen[group].Store(false)
+		r.fusedMin[group].Store(math.MaxInt64)
+		if len(r.fusedMax) != 0 {
+			r.fusedMax[group].Store(math.MinInt64)
+		}
+	}
+	clear(r.fusedWorkerErrors)
+	clear(r.fusedWorkerRows)
+	clear(r.fusedWorkerCodes)
+	started := time.Now()
+	var wait sync.WaitGroup
+	wait.Add(workers - 1)
+	runWorker := func(worker int) {
+		if worker != 0 {
+			defer wait.Done()
+		}
+		matched, translated := 0, 0
+		for partIndex := worker; partIndex < len(r.parts); partIndex += workers {
+			part := &r.parts[partIndex]
+			rows := part.part.Descriptor.RowCount
+			p0, p1, p2 := &part.predicates[0], &part.predicates[1], &part.predicates[2]
+			groupColumn := part.direct[r.groupProjected]
+			valueColumn := part.direct[r.valueProjected]
+			groupTranslation := r.groupDomain.byPart[partIndex]
+			for row := range p0.column.values[:rows] {
+				if !p0.matches8(row) || !p1.matches8(row) || !p2.matches8(row) {
+					continue
+				}
+				group := r.groupDomain.emptyGlobal
+				if !groupColumn.absentAtUnchecked(row) {
+					local := groupColumn.codeAtUnchecked(row)
+					if int(local) >= len(groupTranslation) || groupTranslation[local] < 0 {
+						r.fusedWorkerErrors[worker] = fmt.Errorf("typedcolumn: query-ready fused direct group code=%d outside domain", local)
+						return
+					}
+					group = groupTranslation[local]
+					translated++
+				} else if group < 0 {
+					r.fusedWorkerErrors[worker] = errors.New("typedcolumn: query-ready fused direct nullable group has no empty domain")
+					return
+				}
+				value := valueColumn.int64AtUnchecked(row)
+				r.fusedSeen[group].Store(true)
+				switch r.request.Kind {
+				case QueryReadyOperatorGroupMinInt64:
+					atomicMinInt64(&r.fusedMin[group], value)
+				case QueryReadyOperatorGroupMaxInt64:
+					atomicMaxInt64(&r.fusedMax[group], value)
+				case QueryReadyOperatorGroupInt64Span:
+					atomicMinInt64(&r.fusedMin[group], value)
+					atomicMaxInt64(&r.fusedMax[group], value)
+				}
+				matched++
+			}
+		}
+		r.fusedWorkerRows[worker], r.fusedWorkerCodes[worker] = matched, translated
+	}
+	for worker := 1; worker < workers; worker++ {
+		go runWorker(worker)
+	}
+	runWorker(0)
+	wait.Wait()
+	elapsed := time.Since(started).Nanoseconds()
+	for worker := range r.fusedWorkerErrors {
+		if err := r.fusedWorkerErrors[worker]; err != nil {
+			stats.FusedPredicateReductionExecutions = 1
+			stats.FusedPredicateReductionWorkers = workers
+			stats.FusedPredicateReductionNanos = elapsed
+			return queryReadyFusedParallelResult{result: QueryReadyOperatorResult{Stats: stats}, err: err}, true
+		}
+		stats.RowsMatched += r.fusedWorkerRows[worker]
+		stats.CodeTranslations += r.fusedWorkerCodes[worker]
+	}
+	for partIndex := range r.parts {
+		part := &r.parts[partIndex]
+		rows := part.part.Descriptor.RowCount
+		stats.RowsScanned += rows
+		if part.role == PartRoleBase {
+			stats.BaseRowsScanned += rows
+		} else {
+			stats.DeltaRowsScanned += rows
+		}
+		for _, column := range part.direct {
+			stats.DecodedBytes += int64(len(column.values) + len(column.absent))
+		}
+	}
+	for group := range r.fusedSeen {
+		if !r.fusedSeen[group].Load() {
+			continue
+		}
+		r.seen[group] = true
+		switch r.request.Kind {
+		case QueryReadyOperatorGroupMinInt64:
+			r.int64Values[group] = r.fusedMin[group].Load()
+		case QueryReadyOperatorGroupMaxInt64:
+			r.int64Values[group] = r.fusedMax[group].Load()
+		case QueryReadyOperatorGroupInt64Span:
+			r.int64Values[group], r.int64Max[group] = r.fusedMin[group].Load(), r.fusedMax[group].Load()
+		}
+	}
+	stats.FusedPredicateReductionExecutions = 1
+	stats.FusedPredicateReductionWorkers = workers
+	stats.FusedPredicateReductionNanos = elapsed
+	if stats.DeltaRowsScanned == 0 {
+		stats.BaseScanNanos = elapsed
+	} else if stats.BaseRowsScanned == 0 {
+		stats.DeltaMergeNanos = elapsed
+	}
+	shapeStart := time.Now()
+	if err := r.shapeGroups(0, &stats); err != nil {
+		stats.GroupingNanos = time.Since(shapeStart).Nanoseconds()
+		return queryReadyFusedParallelResult{result: QueryReadyOperatorResult{Stats: stats}, err: err}, true
+	}
+	stats.GroupingNanos = time.Since(shapeStart).Nanoseconds()
+	orderStart := time.Now()
+	r.orderAndLimit()
+	stats.OrderingTopKNanos = time.Since(orderStart).Nanoseconds()
+	stats.GroupsReturned = len(r.resultGroups)
+	stats.ScratchBytes = r.scratchBytes()
+	return queryReadyFusedParallelResult{result: QueryReadyOperatorResult{Groups: r.resultGroups, Stats: stats}}, true
+}
+
+func atomicMinInt64(cell *atomic.Int64, value int64) {
+	for current := cell.Load(); value < current; current = cell.Load() {
+		if cell.CompareAndSwap(current, value) {
+			return
+		}
+	}
+}
+
+func atomicMaxInt64(cell *atomic.Int64, value int64) {
+	for current := cell.Load(); value > current; current = cell.Load() {
+		if cell.CompareAndSwap(current, value) {
+			return
+		}
+	}
 }
 
 func (r *QueryReadyOperator) selectDirectRows(partIndex int, part *queryReadyExecutionPart, rows int) error {
@@ -1293,6 +1536,8 @@ func (r *QueryReadyOperator) compareOrderedGroup(left, right QueryReadyOperatorG
 
 func (r *QueryReadyOperator) scratchBytes() int64 {
 	bytes := int64(cap(r.counts)+cap(r.hourCounts)+cap(r.matchedRows))*8 + int64(cap(r.seen)) + int64(cap(r.int64Values)+cap(r.int64Max)+cap(r.distinctBits))*8
+	bytes += int64(cap(r.fusedMin)+cap(r.fusedMax))*8 + int64(cap(r.fusedSeen))*4
+	bytes += int64(cap(r.fusedWorkerErrors))*16 + int64(cap(r.fusedWorkerRows)+cap(r.fusedWorkerCodes))*8
 	for _, domain := range r.domains {
 		for _, translation := range domain.byPart {
 			bytes += int64(cap(translation)) * 8

--- a/TreeDB/internal/typedcolumn/query_ready_execution.go
+++ b/TreeDB/internal/typedcolumn/query_ready_execution.go
@@ -720,9 +720,15 @@ func (r *QueryReadyOperator) Run() (QueryReadyOperatorResult, error) {
 		}
 		fusedStarted := time.Now()
 		if matched, handled, err := r.reduceFusedDecodedGroupedInt64(partIndex, part, rows, &stats); handled {
+			fusedElapsed := time.Since(fusedStarted).Nanoseconds()
 			stats.FusedPredicateReductionExecutions = 1
 			stats.FusedPredicateReductionWorkers = 1
-			stats.FusedPredicateReductionNanos += time.Since(fusedStarted).Nanoseconds()
+			stats.FusedPredicateReductionNanos += fusedElapsed
+			if part.role == PartRoleBase {
+				stats.BaseScanNanos += fusedElapsed
+			} else {
+				stats.DeltaMergeNanos += fusedElapsed
+			}
 			stats.RowsMatched += matched
 			if err != nil {
 				return QueryReadyOperatorResult{Stats: stats}, err

--- a/TreeDB/internal/typedcolumn/query_ready_execution.go
+++ b/TreeDB/internal/typedcolumn/query_ready_execution.go
@@ -1015,6 +1015,11 @@ func (r *QueryReadyOperator) runDirectFusedParallel(stats QueryReadyExecutionSta
 		stats.BaseScanNanos = elapsed
 	} else if stats.BaseRowsScanned == 0 {
 		stats.DeltaMergeNanos = elapsed
+	} else {
+		// The fused worker pool scans base and append-only delta parts in one
+		// interval. Attribute that indivisible interval to the public scan
+		// total instead of dropping it when both roles are present.
+		stats.BaseScanNanos = elapsed
 	}
 	shapeStart := time.Now()
 	if err := r.shapeGroups(0, &stats); err != nil {

--- a/TreeDB/internal/typedcolumn/query_ready_execution_test.go
+++ b/TreeDB/internal/typedcolumn/query_ready_execution_test.go
@@ -174,8 +174,11 @@ func TestQueryReadyBaseDeltaJSONBenchQ1ToQ5Parity(t *testing.T) {
 				if gotFused := got.Stats.FusedPredicateReductionExecutions == 1; gotFused != wantFused {
 					t.Fatalf("%s fused predicate/reduction=%v want %v stats=%+v", prepared.name, gotFused, wantFused, got.Stats)
 				}
-				if wantFused && got.Stats.FusedPredicateReductionNanos <= 0 {
-					t.Fatalf("%s fused predicate/reduction nanos=%d want positive stats=%+v", prepared.name, got.Stats.FusedPredicateReductionNanos, got.Stats)
+				// Sub-millisecond fixtures can legitimately measure as zero on
+				// Windows' coarser monotonic clock. Route and work counters are
+				// the deterministic proof that fused execution ran.
+				if wantFused && (got.Stats.FusedPredicateReductionWorkers != 1 || got.Stats.DecodedBlocks == 0) {
+					t.Fatalf("%s fused predicate/reduction work counters missing stats=%+v", prepared.name, got.Stats)
 				}
 			}
 		})

--- a/TreeDB/internal/typedcolumn/query_ready_execution_test.go
+++ b/TreeDB/internal/typedcolumn/query_ready_execution_test.go
@@ -927,10 +927,39 @@ func TestQueryReadyEncodedFusedParallelGroupedInt64Parity(t *testing.T) {
 			wantFused := runtime.GOMAXPROCS(0) > 1
 			if (got.Stats.FusedPredicateReductionExecutions == 1) != wantFused || (wantFused && got.Stats.FusedPredicateReductionWorkers <= 1) ||
 				got.Stats.RowsScanned != want.Stats.RowsScanned || got.Stats.RowsMatched != want.Stats.RowsMatched ||
-				got.Stats.DecodedBytes != want.Stats.DecodedBytes || got.Stats.DocumentMaterializations != 0 || got.Stats.LegacyScanFallbacks != 0 || got.Stats.PrecomputedAnswers != 0 {
+				got.Stats.DecodedBytes != want.Stats.DecodedBytes ||
+				got.Stats.EncodedBaseDeltaExecutions != want.Stats.EncodedBaseDeltaExecutions ||
+				got.Stats.ScratchBytes <= 0 ||
+				got.Stats.DocumentMaterializations != 0 || got.Stats.LegacyScanFallbacks != 0 || got.Stats.PrecomputedAnswers != 0 {
 				t.Fatalf("kind=%s attempt=%d stats=%+v want parity with %+v", request.Kind, attempt, got.Stats, want.Stats)
 			}
 		}
+	}
+}
+
+func TestQueryReadyEncodedFusedParallelMixedBaseDeltaTiming(t *testing.T) {
+	reader := queryReadyJSONBenchBenchmarkReaderParts(t, 32_768, 1, 4_096)
+	operator, err := PrepareQueryReadyOperator(reader, QueryReadyOperatorRequest{
+		Kind: QueryReadyOperatorGroupInt64Span, GroupColumn: "did", ValueColumn: "time_us",
+		TopK: 10, Order: QueryReadyOrderInt64Desc, SkipEmptyGroupKey: true,
+		Predicates: queryReadyPostPredicates(),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	result, err := operator.Run()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if runtime.GOMAXPROCS(0) <= 1 {
+		return
+	}
+	stats := result.Stats
+	if stats.FusedPredicateReductionExecutions != 1 || stats.BaseRowsScanned == 0 || stats.DeltaRowsScanned == 0 {
+		t.Fatalf("mixed fused route stats=%+v", stats)
+	}
+	if got := stats.BaseScanNanos + stats.DeltaMergeNanos; got != stats.FusedPredicateReductionNanos {
+		t.Fatalf("public scan timing=%d want fused interval %d", got, stats.FusedPredicateReductionNanos)
 	}
 }
 

--- a/TreeDB/internal/typedcolumn/query_ready_execution_test.go
+++ b/TreeDB/internal/typedcolumn/query_ready_execution_test.go
@@ -8,6 +8,7 @@ import (
 	"math/rand"
 	"os"
 	"path/filepath"
+	"runtime"
 	"slices"
 	"strings"
 	"testing"
@@ -168,6 +169,13 @@ func TestQueryReadyBaseDeltaJSONBenchQ1ToQ5Parity(t *testing.T) {
 				}
 				if got.Stats.EncodedBaseDeltaExecutions != 1 || got.Stats.DocumentMaterializations != 0 || got.Stats.LegacyScanFallbacks != 0 || got.Stats.RowsVisible != 6 {
 					t.Fatalf("%s stats=%+v", prepared.name, got.Stats)
+				}
+				wantFused := tc.name == "q4" || tc.name == "q4b" || tc.name == "q5"
+				if gotFused := got.Stats.FusedPredicateReductionExecutions == 1; gotFused != wantFused {
+					t.Fatalf("%s fused predicate/reduction=%v want %v stats=%+v", prepared.name, gotFused, wantFused, got.Stats)
+				}
+				if wantFused && got.Stats.FusedPredicateReductionNanos <= 0 {
+					t.Fatalf("%s fused predicate/reduction nanos=%d want positive stats=%+v", prepared.name, got.Stats.FusedPredicateReductionNanos, got.Stats)
 				}
 			}
 		})
@@ -884,6 +892,45 @@ func TestQueryReadyExecutionImageRejectsNonCanonicalRangesAndPadding(t *testing.
 
 var queryReadyBenchmarkResult QueryReadyOperatorResult
 
+func TestQueryReadyEncodedFusedParallelGroupedInt64Parity(t *testing.T) {
+	serialReader := queryReadyJSONBenchBenchmarkReaderParts(t, 32_768, 0, 32_768)
+	parallelReader := queryReadyJSONBenchBenchmarkReaderParts(t, 32_768, 0, 4_096)
+	requests := []QueryReadyOperatorRequest{
+		{Kind: QueryReadyOperatorGroupMinInt64, GroupColumn: "did", ValueColumn: "time_us", TopK: 10, Order: QueryReadyOrderInt64Asc, SkipEmptyGroupKey: true, Predicates: queryReadyPostPredicates()},
+		{Kind: QueryReadyOperatorGroupMaxInt64, GroupColumn: "did", ValueColumn: "time_us", TopK: 10, Order: QueryReadyOrderInt64Desc, SkipEmptyGroupKey: true, Predicates: queryReadyPostPredicates()},
+		{Kind: QueryReadyOperatorGroupInt64Span, GroupColumn: "did", ValueColumn: "time_us", TopK: 10, Order: QueryReadyOrderInt64Desc, SkipEmptyGroupKey: true, Predicates: queryReadyPostPredicates()},
+	}
+	for _, request := range requests {
+		serial, err := PrepareQueryReadyOperator(serialReader, request)
+		if err != nil {
+			t.Fatal(err)
+		}
+		want, err := serial.Run()
+		if err != nil {
+			t.Fatal(err)
+		}
+		parallel, err := PrepareQueryReadyOperator(parallelReader, request)
+		if err != nil {
+			t.Fatal(err)
+		}
+		for attempt := 0; attempt < 2; attempt++ {
+			got, err := parallel.Run()
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !slices.Equal(got.Groups, want.Groups) {
+				t.Fatalf("kind=%s attempt=%d groups=%+v want %+v", request.Kind, attempt, got.Groups, want.Groups)
+			}
+			wantFused := runtime.GOMAXPROCS(0) > 1
+			if (got.Stats.FusedPredicateReductionExecutions == 1) != wantFused || (wantFused && got.Stats.FusedPredicateReductionWorkers <= 1) ||
+				got.Stats.RowsScanned != want.Stats.RowsScanned || got.Stats.RowsMatched != want.Stats.RowsMatched ||
+				got.Stats.DecodedBytes != want.Stats.DecodedBytes || got.Stats.DocumentMaterializations != 0 || got.Stats.LegacyScanFallbacks != 0 || got.Stats.PrecomputedAnswers != 0 {
+				t.Fatalf("kind=%s attempt=%d stats=%+v want parity with %+v", request.Kind, attempt, got.Stats, want.Stats)
+			}
+		}
+	}
+}
+
 func BenchmarkQueryReadyEncodedJSONBenchOperators(b *testing.B) {
 	reader := queryReadyJSONBenchBenchmarkReader(b, 100_000, 20_000)
 	requests := map[string]QueryReadyOperatorRequest{
@@ -913,6 +960,43 @@ func BenchmarkQueryReadyEncodedJSONBenchOperators(b *testing.B) {
 					b.Fatal(err)
 				}
 			}
+			b.ReportMetric(float64(warm.Stats.ScratchBytes), "scratch_B")
+		})
+	}
+}
+
+func BenchmarkQueryReadyEncodedFusedGroupedInt64(b *testing.B) {
+	if runtime.GOMAXPROCS(0) < 2 {
+		b.Skip("parallel fused benchmark requires at least two runnable workers")
+	}
+	reader := queryReadyJSONBenchBenchmarkReaderParts(b, 1_000_000, 0, 16_000)
+	requests := map[string]QueryReadyOperatorRequest{
+		"q4": {Kind: QueryReadyOperatorGroupMinInt64, GroupColumn: "did", ValueColumn: "time_us", TopK: 10, Order: QueryReadyOrderInt64Asc, SkipEmptyGroupKey: true, Predicates: queryReadyPostPredicates()},
+		"q5": {Kind: QueryReadyOperatorGroupInt64Span, GroupColumn: "did", ValueColumn: "time_us", TopK: 10, Order: QueryReadyOrderInt64Desc, SkipEmptyGroupKey: true, Predicates: queryReadyPostPredicates()},
+	}
+	for _, name := range []string{"q4", "q5"} {
+		b.Run(name, func(b *testing.B) {
+			runner, err := PrepareQueryReadyOperator(reader, requests[name])
+			if err != nil {
+				b.Fatal(err)
+			}
+			warm, err := runner.Run()
+			if err != nil {
+				b.Fatal(err)
+			}
+			if warm.Stats.FusedPredicateReductionExecutions != 1 {
+				b.Fatalf("fused predicate/reduction executions=%d want 1", warm.Stats.FusedPredicateReductionExecutions)
+			}
+			b.ReportAllocs()
+			b.SetBytes(int64(warm.Stats.RowsScanned))
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				queryReadyBenchmarkResult, err = runner.Run()
+				if err != nil {
+					b.Fatal(err)
+				}
+			}
+			b.ReportMetric(float64(warm.Stats.DecodedBytes), "decoded_B/op")
 			b.ReportMetric(float64(warm.Stats.ScratchBytes), "scratch_B")
 		})
 	}
@@ -953,6 +1037,10 @@ func BenchmarkQueryReadyEncodedDeltaDepthCurve(b *testing.B) {
 }
 
 func queryReadyJSONBenchBenchmarkReader(b testing.TB, baseRows, deltaRows int) *QueryReadyBaseDeltaReader {
+	return queryReadyJSONBenchBenchmarkReaderParts(b, baseRows, deltaRows, baseRows)
+}
+
+func queryReadyJSONBenchBenchmarkReaderParts(b testing.TB, baseRows, deltaRows, basePartRows int) *QueryReadyBaseDeltaReader {
 	b.Helper()
 	buildRows := func(firstID int64, rows int) ([]int64, []string, []string, []string, []string, []int64) {
 		ids := make([]int64, rows)
@@ -978,14 +1066,35 @@ func queryReadyJSONBenchBenchmarkReader(b testing.TB, baseRows, deltaRows int) *
 		return ids, event, did, kind, operation, times
 	}
 	ids, event, did, kind, operation, times := buildRows(1, baseRows)
-	baseImage := queryReadyJSONBenchImageWithGranules(b, 9201, ids, event, did, kind, operation, times, 8_192)
-	baseBuilt, err := BuildQueryReadyBaseGeneration(queryReadyBaseTestIdentity(1), []QueryReadyBasePartInput{{SourceGeneration: 1, Image: baseImage}})
+	if basePartRows <= 0 {
+		b.Fatal("base part rows must be positive")
+	}
+	baseParts := make([]QueryReadyBasePartInput, 0, (baseRows+basePartRows-1)/basePartRows)
+	for first, partID := 0, uint64(9201); first < baseRows; first, partID = first+basePartRows, partID+1 {
+		limit := min(first+basePartRows, baseRows)
+		baseParts = append(baseParts, QueryReadyBasePartInput{
+			SourceGeneration: 1,
+			Image: queryReadyJSONBenchImageWithGranules(b, partID,
+				ids[first:limit], event[first:limit], did[first:limit], kind[first:limit], operation[first:limit], times[first:limit], 8_192),
+		})
+	}
+	baseBuilt, err := BuildQueryReadyBaseGeneration(queryReadyBaseTestIdentity(1), baseParts)
 	if err != nil {
 		b.Fatal(err)
 	}
 	base, err := OpenQueryReadyBaseGeneration(baseBuilt.Bytes, queryReadyBaseTestIdentity(1))
 	if err != nil {
 		b.Fatal(err)
+	}
+	if deltaRows == 0 {
+		reader, err := NewQueryReadyBaseDeltaReader(base, nil, QueryReadyBaseDeltaOptions{
+			SnapshotGeneration: 1,
+			Bound:              QueryReadyDeltaBoundPolicy{MaxVisibleGenerations: 1, MaxAccumulatedDeltaParts: 1, MaxRows: int64(baseRows), MaxBytes: 1 << 30},
+		})
+		if err != nil {
+			b.Fatal(err)
+		}
+		return reader
 	}
 	updates := deltaRows / 2
 	ids, event, did, kind, operation, times = buildRows(1, updates)

--- a/TreeDB/internal/typedcolumn/query_ready_execution_test.go
+++ b/TreeDB/internal/typedcolumn/query_ready_execution_test.go
@@ -180,6 +180,10 @@ func TestQueryReadyBaseDeltaJSONBenchQ1ToQ5Parity(t *testing.T) {
 				if wantFused && (got.Stats.FusedPredicateReductionWorkers != 1 || got.Stats.DecodedBlocks == 0) {
 					t.Fatalf("%s fused predicate/reduction work counters missing stats=%+v", prepared.name, got.Stats)
 				}
+				if wantFused && got.Stats.FusedPredicateReductionNanos > 0 &&
+					got.Stats.BaseScanNanos+got.Stats.DeltaMergeNanos < got.Stats.FusedPredicateReductionNanos {
+					t.Fatalf("%s public scan timing omits decoded fused interval stats=%+v", prepared.name, got.Stats)
+				}
 			}
 		})
 	}


### PR DESCRIPTION
Closes #3899
Part of #3889
Part of #3067

## Outcome

Fuse the three-predicate q4/q5 selection and grouped int64 reduction over
query-ready encoded parts, and execute independent parts with a bounded worker
set.

The production direct path:

- uses `min(GOMAXPROCS, prepared parts, 8)` workers;
- fuses predicate evaluation, dictionary translation, and min/max/span updates;
- preserves encoded base-plus-delta execution, visibility, grouping, TopK,
  empty/absent handling, and fallback guardrails;
- preallocates worker and atomic group state during preparation;
- exports explicit fused execution, worker, and timing diagnostics.

The serial decoded path uses the same fused semantic operation so direct and
fallback parity tests exercise one contract.

## Test-first correctness

The new parity test compares serial and multi-part parallel q4/q4b/q5 results
over repeated runs, including the existing base-plus-delta and consolidated
fixtures, empty group keys, exact row/match/decoded-byte counters, and zero
materialization/fallback/precomputed-answer guardrails. `GOMAXPROCS=1` proves
the serial fallback remains exact. Race coverage runs the parallel path three
times.

Commands:

```text
GOWORK=off go test ./TreeDB/internal/typedcolumn -run 'TestQueryReadyEncodedFused|TestQueryReadyBaseDeltaJSONBenchQ1ToQ5Parity' -count=1
GOMAXPROCS=1 GOWORK=off go test ./TreeDB/internal/typedcolumn -run '^TestQueryReadyEncodedFusedParallelGroupedInt64Parity$' -count=1
GOWORK=off go test -race ./TreeDB/internal/typedcolumn -run '^TestQueryReadyEncodedFusedParallelGroupedInt64Parity$' -count=3
GOWORK=off go test ./TreeDB/internal/typedcolumn ./TreeDB/collections
GOWORK=off go vet ./TreeDB/internal/typedcolumn ./TreeDB/collections
```

## Matched performance evidence

Host: Intel i5-11400F, 6 cores / 12 threads. Identical 1M, 16k-row-part
fixtures, five samples at `3x`:

| Query | Baseline median | Candidate median | Change | Baseline scratch | Candidate scratch | Candidate allocation |
|---|---:|---:|---:|---:|---:|---:|
| q4 | 2.606 ms | 0.798 ms | -69.4% | 1,183,181 B | 1,208,025 B | 10-12 allocs, 856-1,976 B/op |
| q5 | 4.383 ms | 0.805 ms | -81.6% | 1,199,573 B | 1,240,809 B | 9-12 allocs, 216-1,656 B/op |

Both paths report 13,000,000 decoded bytes/op. The candidate adds bounded
worker/goroutine allocation and about 25 KiB q4 / 41 KiB q5 scratch in exchange
for the measured throughput gain.

On independent copies of the closed canonical 10M TreeDB database, nine
baseline/candidate query samples report:

| Query | Baseline median | Candidate median | Change | ClickHouse reference | Candidate / ClickHouse |
|---|---:|---:|---:|---:|---:|
| q4 | 122.266 ms | 75.071 ms | -38.6% | 78 ms | 0.962x |
| q5 | 122.550 ms | 79.031 ms | -35.5% | 69 ms | 1.145x |

Candidate diagnostics are exact on every sample: one fused execution, eight
workers, 9,999,994 rows scanned, 895,614 rows matched, three groups, and zero
separate predicate/reduction timing because the fused phase owns that work.

Artifacts:

- `/mnt/fast4tb/gomap_3067_execution_20260718/3899_baseline_bench.txt`
- `/mnt/fast4tb/gomap_3067_execution_20260718/3899_candidate_bench.txt`
- `/mnt/fast4tb/gomap_3067_execution_20260718/3899_baseline_10m_probe.jsonl`
- `/mnt/fast4tb/gomap_3067_execution_20260718/3899_candidate_10m_probe.jsonl`

The copied databases were rebound after copying; the source canonical artifact
was not modified.

## Boundaries

- No q1/q2/q3/qexpr algorithm change.
- No precomputed answer or metadata summary.
- No load, reconstruction, WAL, value-log, storage, or format change.
- Canonical integrated evidence remains owned by #3900.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Improved execution speed for grouped integer queries using multiple predicates.
  * Added optimized parallel processing for grouped minimum, maximum, and span calculations.
  * Enhanced handling of direct and scanned query execution paths.

* **Diagnostics**
  * Added execution, worker, and timing metrics for fused predicate reduction operations.

* **Quality**
  * Expanded correctness coverage and benchmarks to verify consistent results between serial and parallel execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->