### PR TITLE
collections: add snapshot-safe primary row locators

### DIFF
--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -20933,7 +20933,6 @@ func (c *Collection) ScanDocumentsFunc(maxDocuments int, fn func(DocumentRecord)
 			return c.scanDocumentsFuncWithMonotonicColumnReconstruction(snap, catalog, maxDocuments, fn, &scanStats)
 		}
 		scanStats.GenericFallback = true
-		scanStats.PhysicalPasses++ // generic visibility scan follows any preflight pass.
 		return c.scanDocumentsFuncWithColumnReconstruction(snap, catalog, it, maxDocuments, fn, &scanStats)
 	}
 	truncated := false
@@ -20975,109 +20974,72 @@ func (c *Collection) scanDocumentsFuncWithColumnReconstruction(
 	fn func(DocumentRecord) (bool, error),
 	stats *CollectionDocumentScanStats,
 ) (bool, error) {
-	columnStoreConfig := catalog.meta.Options.ColumnStore.copy()
 	capacity := maxDocuments
 	if capacity > 256 {
 		capacity = 256
 	}
-	records := make([]DocumentRecord, 0, capacity)
+	view := newCollectionReadViewAtSnapshot(c, snap, catalog, false, "")
+	defer func() { _ = view.Close() }()
+	seen := 0
 	for it.Valid() {
-		if it.IsDeleted() {
+		ids := make([][]byte, 0, capacity)
+		for it.Valid() && len(ids) < capacity && seen+len(ids) < maxDocuments {
+			if !it.IsDeleted() {
+				ids = append(ids, bytes.Clone(it.UnsafeKey()))
+			}
 			it.Next()
-			continue
 		}
-		if len(records) >= maxDocuments {
+		if err := it.Error(); err != nil {
+			return false, err
+		}
+		if len(ids) == 0 {
 			break
 		}
-		records = append(records, DocumentRecord{
-			ID:       bytes.Clone(it.UnsafeKey()),
-			Document: it.ValueCopy(nil),
-		})
-		it.Next()
+		if stats != nil {
+			stats.PhysicalPasses++
+			if uint64(len(ids)) > stats.MaxRecordWindow {
+				stats.MaxRecordWindow = uint64(len(ids))
+			}
+		}
+		refs, err := view.LookupDocumentRowRefsByID(ids, DocumentFetchOptions{})
+		if err != nil {
+			return false, err
+		}
+		rowRefs := make([]DocumentRowRef, len(refs.Results))
+		for i, result := range refs.Results {
+			if !result.Found {
+				return false, fmt.Errorf("collections: column reconstruction missing primary row locator for id %q", string(ids[i]))
+			}
+			rowRefs[i] = result.RowRef
+		}
+		fetched, err := view.FetchDocumentsByRowRef(rowRefs, DocumentFetchOptions{})
+		if err != nil {
+			return false, err
+		}
+		for _, result := range fetched.Results {
+			if !result.Found {
+				return false, fmt.Errorf("collections: column reconstruction missing point row")
+			}
+			seen++
+			next, err := fn(DocumentRecord{ID: bytes.Clone(result.ID), Document: result.Document})
+			if err != nil {
+				return false, err
+			}
+			if !next {
+				return false, nil
+			}
+		}
 	}
 	if err := it.Error(); err != nil {
 		return false, err
 	}
-	truncated := false
 	for it.Valid() {
 		if !it.IsDeleted() {
-			truncated = true
-			break
+			return true, nil
 		}
 		it.Next()
 	}
-	if err := it.Error(); err != nil {
-		return false, err
-	}
-	if len(records) == 0 {
-		return truncated, nil
-	}
-	ids := make([][]byte, len(records))
-	for i := range records {
-		ids[i] = records[i].ID
-	}
-	visible, err := c.scanColumnPhysicalVisibleRowsAtSnapshotForTargets(
-		snap,
-		catalog,
-		catalog.meta.Name,
-		catalog.rootID(collectionColumnManifestRootName(catalog.meta.Name)),
-		columnStoreConfig,
-		true,
-		newColumnPhysicalVisibilityTargetIDs(ids),
-		nil,
-	)
-	if err != nil {
-		return false, err
-	}
-	if stats != nil {
-		stats.PhysicalRows += uint64(visible.Diagnostics.RowsScanned)
-		stats.PhysicalBytes += uint64(visible.Diagnostics.PhysicalBytesScanned)
-		stats.PhysicalDecodedBlocks += uint64(visible.Diagnostics.DecodedBlocks)
-	}
-	visibleRows := visible.Rows
-	visiblePos := 0
-	var typedColumnCache *typedColumnPartReconstructionCache
-	if columnStoreHasTypedColumnPartOwners(columnStoreConfig) {
-		typedColumnCache = &typedColumnPartReconstructionCache{Parts: make(map[uint64]typedColumnPartDecodedValues)}
-	}
-	retainedSemanticCache := newColumnRetainedSemanticStreamV1DecodeCacheForDocumentRecords(&columnStoreConfig, records)
-	manifestRootID := catalog.rootID(collectionColumnManifestRootName(catalog.meta.Name))
-	typedScratch := make([]columnDeclaredValue, 0, len(columnStoreTypedColumnPartFields(columnStoreConfig)))
-	mergeScratch := make([]columnDeclaredValue, 0, len(columnStoreConfig.Columns))
-	retainedTemplateResolver := columnRetainedPayloadTemplateResolver(snap, catalog)
-	for _, record := range records {
-		for visiblePos < len(visibleRows) && bytes.Compare(visibleRows[visiblePos].ID, record.ID) < 0 {
-			visiblePos++
-		}
-		if visiblePos >= len(visibleRows) || !bytes.Equal(visibleRows[visiblePos].ID, record.ID) {
-			return false, fmt.Errorf("collections: column reconstruction missing visible physical row for id %q", string(record.ID))
-		}
-		typedValues, err := c.typedColumnPartValuesForVisibleRowAtSnapshotIntoWithCache(snap, manifestRootID, columnStoreConfig, visibleRows[visiblePos], typedColumnCache, typedScratch)
-		if err != nil {
-			return false, err
-		}
-		fullValues, err := mergeColumnReconstructionValuesInto(columnStoreConfig, visibleRows[visiblePos].Values, typedValues.Values, mergeScratch)
-		if err != nil {
-			return false, err
-		}
-		retainedDocument, err := resolveColumnRetainedPayloadAtSnapshotWithCache(snap, catalog, columnStoreConfig, record.Document, retainedSemanticCache)
-		if err != nil {
-			return false, err
-		}
-		_, reconstructed, err := reconstructColumnDocumentFromVisibleRowValuesProjectedIntoWithResolver(nil, columnStoreConfig, retainedDocument, visibleRows[visiblePos], fullValues, nil, nil, retainedTemplateResolver)
-		if err != nil {
-			return false, err
-		}
-		record.Document = reconstructed
-		next, err := fn(record)
-		if err != nil {
-			return false, err
-		}
-		if !next {
-			return false, nil
-		}
-	}
-	return truncated, nil
+	return false, it.Error()
 }
 
 func loadCollectionCatalog(snap *backenddb.Snapshot, name string) (*collectionCatalog, error) {
@@ -21255,6 +21217,10 @@ func collectionRootStoragePolicyForDB(db *backenddb.DB, meta CollectionMeta, roo
 	case collectionIndexStateRootName(meta.Name):
 		return backendRootStoragePolicy(meta.Options.IndexStateStoragePolicy)
 	case collectionColumnManifestRootName(meta.Name):
+		if meta.Options.ColumnStore != nil {
+			return backendRootStoragePolicy(meta.Options.ColumnStore.ControlRootStoragePolicy)
+		}
+	case collectionColumnRowLocatorRootName(meta.Name):
 		if meta.Options.ColumnStore != nil {
 			return backendRootStoragePolicy(meta.Options.ColumnStore.ControlRootStoragePolicy)
 		}
@@ -22373,6 +22339,10 @@ func collectionRootNames(meta CollectionMeta) []string {
 	}
 	if meta.Options.ColumnStore != nil && meta.Options.ColumnStore.Enabled {
 		out = append(out, collectionColumnManifestRootName(meta.Name))
+		// The locator maps each live primary ID to the physical row created by
+		// the same command-WAL publication. It is deliberately a separate root:
+		// primary values remain their existing raw-document/value-log payloads.
+		out = append(out, collectionColumnRowLocatorRootName(meta.Name))
 	}
 	if columnStoreRetainedPayloadUsesSemanticStreamV1(meta.Options.ColumnStore) {
 		out = append(out, collectionRetainedSemanticStreamRootName(meta.Name))
@@ -22403,6 +22373,10 @@ func collectionIndexStateRootName(collection string) string {
 
 func collectionColumnManifestRootName(collection string) string {
 	return collection + "/column/manifest"
+}
+
+func collectionColumnRowLocatorRootName(collection string) string {
+	return collection + "/column/row-locator"
 }
 
 func collectionRetainedSemanticStreamRootName(collection string) string {

--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -21008,8 +21008,6 @@ func (c *Collection) scanDocumentsFuncWithColumnReconstruction(
 	if capacity > 256 {
 		capacity = 256
 	}
-	view := newCollectionReadViewAtSnapshot(c, snap, catalog, false, "")
-	defer func() { _ = view.Close() }()
 	seen := 0
 	for it.Valid() {
 		ids := make([][]byte, 0, capacity)
@@ -21026,14 +21024,18 @@ func (c *Collection) scanDocumentsFuncWithColumnReconstruction(
 			break
 		}
 		if stats != nil {
-			stats.PhysicalPasses++
 			stats.LocatorLookupBatches++
 			if uint64(len(ids)) > stats.MaxRecordWindow {
 				stats.MaxRecordWindow = uint64(len(ids))
 			}
 		}
+		// Point-row and typed reconstruction caches are owned by the read view.
+		// Scope the view to this bounded ID window so scans spanning many
+		// immutable assets cannot retain one cache entry per asset.
+		view := newCollectionReadViewAtSnapshot(c, snap, catalog, false, "")
 		refs, err := view.LookupDocumentRowRefsByID(ids, DocumentFetchOptions{})
 		if err != nil {
+			_ = view.Close()
 			return false, err
 		}
 		if stats != nil {
@@ -21042,12 +21044,17 @@ func (c *Collection) scanDocumentsFuncWithColumnReconstruction(
 		rowRefs := make([]DocumentRowRef, len(refs.Results))
 		for i, result := range refs.Results {
 			if !result.Found {
+				_ = view.Close()
 				return false, fmt.Errorf("collections: column reconstruction missing primary row locator for id %q", string(ids[i]))
 			}
 			rowRefs[i] = result.RowRef
 		}
-		fetched, err := view.FetchDocumentsByRowRef(rowRefs, DocumentFetchOptions{})
+		fetched, err := view.fetchDocumentsByResolvedRowRef(rowRefs, DocumentFetchOptions{})
 		if err != nil {
+			_ = view.Close()
+			return false, err
+		}
+		if err := view.Close(); err != nil {
 			return false, err
 		}
 		if stats != nil {

--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -456,9 +456,14 @@ type CollectionDocumentScanStats struct {
 	PhysicalRows           uint64
 	PhysicalBytes          uint64
 	PhysicalDecodedBlocks  uint64
-	ReconstructedRows      uint64
-	MaxRecordWindow        uint64
-	MaxVisibleRowWindow    uint64
+	// LocatorLookupBatches and LocatorLookups are control-root point reads used
+	// by generic reconstruction. They are separate from whole-asset scan stats.
+	LocatorLookupBatches uint64
+	LocatorLookups       uint64
+	PointRowFetches      uint64
+	ReconstructedRows    uint64
+	MaxRecordWindow      uint64
+	MaxVisibleRowWindow  uint64
 	// MaxTypedGenerations is the peak number of resident typed generations.
 	MaxTypedGenerations uint64
 	// MaxTypedDecodedBytes is the peak owned decoded typed value state for one
@@ -20997,6 +21002,7 @@ func (c *Collection) scanDocumentsFuncWithColumnReconstruction(
 		}
 		if stats != nil {
 			stats.PhysicalPasses++
+			stats.LocatorLookupBatches++
 			if uint64(len(ids)) > stats.MaxRecordWindow {
 				stats.MaxRecordWindow = uint64(len(ids))
 			}
@@ -21004,6 +21010,9 @@ func (c *Collection) scanDocumentsFuncWithColumnReconstruction(
 		refs, err := view.LookupDocumentRowRefsByID(ids, DocumentFetchOptions{})
 		if err != nil {
 			return false, err
+		}
+		if stats != nil {
+			stats.LocatorLookups += refs.Stats.RowLocatorLookups
 		}
 		rowRefs := make([]DocumentRowRef, len(refs.Results))
 		for i, result := range refs.Results {
@@ -21015,6 +21024,9 @@ func (c *Collection) scanDocumentsFuncWithColumnReconstruction(
 		fetched, err := view.FetchDocumentsByRowRef(rowRefs, DocumentFetchOptions{})
 		if err != nil {
 			return false, err
+		}
+		if stats != nil {
+			stats.PointRowFetches += fetched.Stats.PointRowFetches
 		}
 		for _, result := range fetched.Results {
 			if !result.Found {

--- a/TreeDB/collections/column_primary_row_locator.go
+++ b/TreeDB/collections/column_primary_row_locator.go
@@ -1,0 +1,93 @@
+package collections
+
+import (
+	"encoding/binary"
+	"fmt"
+
+	backenddb "github.com/snissn/gomap/TreeDB/db"
+	"github.com/snissn/gomap/TreeDB/internal/memtable"
+)
+
+const columnPrimaryRowLocatorValueSize = 4 + 8 + 8 + 8 + 8
+
+var columnPrimaryRowLocatorMagic = [4]byte{'C', 'R', 'L', '1'}
+
+// encodeColumnPrimaryRowLocator stores only physical coordinates; the primary
+// key supplies the document ID. The locator root is co-published with the
+// primary and manifest roots, so a snapshot cannot observe a new primary value
+// without its matching locator.
+func encodeColumnPrimaryRowLocator(ref DocumentRowRef) []byte {
+	b := make([]byte, columnPrimaryRowLocatorValueSize)
+	copy(b, columnPrimaryRowLocatorMagic[:])
+	binary.BigEndian.PutUint64(b[4:], ref.Generation)
+	binary.BigEndian.PutUint64(b[12:], ref.PartID)
+	binary.BigEndian.PutUint64(b[20:], uint64(ref.RowIndex))
+	binary.BigEndian.PutUint64(b[28:], ref.AppliedCommandLSN)
+	return b
+}
+
+func decodeColumnPrimaryRowLocator(id, value []byte) (DocumentRowRef, error) {
+	if len(value) != columnPrimaryRowLocatorValueSize || string(value[:4]) != string(columnPrimaryRowLocatorMagic[:]) {
+		return DocumentRowRef{}, fmt.Errorf("collections: invalid primary row locator for id %q value=%x", string(id), value)
+	}
+	row := binary.BigEndian.Uint64(value[20:])
+	if row > uint64(^uint(0)>>1) {
+		return DocumentRowRef{}, fmt.Errorf("collections: primary row locator for id %q row index overflows int", string(id))
+	}
+	ref := DocumentRowRef{DocumentID: append([]byte(nil), id...), Generation: binary.BigEndian.Uint64(value[4:]), PartID: binary.BigEndian.Uint64(value[12:]), RowIndex: int(row), AppliedCommandLSN: binary.BigEndian.Uint64(value[28:])}
+	if err := validateDocumentRowRefForPointFetch(0, ref); err != nil {
+		return DocumentRowRef{}, fmt.Errorf("collections: primary row locator: %w", err)
+	}
+	return ref, nil
+}
+
+func buildColumnPrimaryRowLocatorDelta(plan ColumnPublishPlan, documents []columnWriteDocument, baseRoot uint64, policy backenddb.OrderedRootStoragePolicy) (backenddb.OrderedRootDeltaPublishInput, error) {
+	table, err := buildColumnPrimaryRowLocatorTable(plan, documents)
+	if err != nil {
+		return backenddb.OrderedRootDeltaPublishInput{}, err
+	}
+	return backenddb.OrderedRootDeltaPublishInput{BaseRoot: baseRoot, Iter: table.NewIterator(nil, nil), StoragePolicy: policy}, nil
+}
+
+func buildColumnPrimaryRowLocatorDeltaBatch(plan ColumnPublishPlan, documents []columnWriteDocument, baseRoot uint64, policy backenddb.OrderedRootStoragePolicy) (backenddb.OrderedRootDeltaBatchPublishInput, func(), error) {
+	table, err := buildColumnPrimaryRowLocatorTable(plan, documents)
+	if err != nil {
+		return backenddb.OrderedRootDeltaBatchPublishInput{}, func() {}, err
+	}
+	it := table.NewIterator(nil, nil)
+	delta, err := backenddb.OrderedRootDeltaBatchFromIterator(it)
+	if err != nil {
+		_ = it.Close()
+		return backenddb.OrderedRootDeltaBatchPublishInput{}, func() {}, err
+	}
+	cleanup := func() {
+		_ = delta.Close()
+		_ = it.Close()
+	}
+	return backenddb.OrderedRootDeltaBatchPublishInput{BaseRoot: baseRoot, Delta: delta, StoragePolicy: policy}, cleanup, nil
+}
+
+func buildColumnPrimaryRowLocatorTable(plan ColumnPublishPlan, documents []columnWriteDocument) (memtable.Table, error) {
+	if len(documents) != plan.Rows {
+		return nil, fmt.Errorf("collections: row locator documents=%d rows=%d", len(documents), plan.Rows)
+	}
+	table := newCollectionRunTable(len(documents))
+	for row, document := range documents {
+		if len(document.ID) == 0 {
+			return nil, fmt.Errorf("collections: row locator row %d missing document id", row)
+		}
+		if plan.Operation == ColumnPublishOperationDelete {
+			setCollectionRunValue(table, append([]byte(nil), document.ID...), nil)
+			continue
+		}
+		setCollectionRunValue(table, append([]byte(nil), document.ID...), encodeColumnPrimaryRowLocator(DocumentRowRef{Generation: plan.UpdatedActiveManifest.Generation, PartID: columnPhysicalRowAssetPartID, RowIndex: row, AppliedCommandLSN: plan.AppliedCommandLSN}))
+	}
+	table.Freeze()
+	return table, nil
+}
+
+func closeColumnPrimaryRowLocatorDelta(delta backenddb.OrderedRootDeltaPublishInput) {
+	if delta.Iter != nil {
+		_ = delta.Iter.Close()
+	}
+}

--- a/TreeDB/collections/column_primary_row_locator.go
+++ b/TreeDB/collections/column_primary_row_locator.go
@@ -77,7 +77,7 @@ func buildColumnPrimaryRowLocatorTable(plan ColumnPublishPlan, documents []colum
 			return nil, fmt.Errorf("collections: row locator row %d missing document id", row)
 		}
 		if plan.Operation == ColumnPublishOperationDelete {
-			setCollectionRunValue(table, append([]byte(nil), document.ID...), nil)
+			table.DeleteSteal(append([]byte(nil), document.ID...))
 			continue
 		}
 		setCollectionRunValue(table, append([]byte(nil), document.ID...), encodeColumnPrimaryRowLocator(DocumentRowRef{Generation: plan.UpdatedActiveManifest.Generation, PartID: columnPhysicalRowAssetPartID, RowIndex: row, AppliedCommandLSN: plan.AppliedCommandLSN}))

--- a/TreeDB/collections/column_primary_row_locator_test.go
+++ b/TreeDB/collections/column_primary_row_locator_test.go
@@ -20,3 +20,21 @@ func TestColumnPrimaryRowLocatorRoundTripAndCorruptionP3890(t *testing.T) {
 		t.Fatalf("corrupt locator err=%v want fail-closed invalid locator", err)
 	}
 }
+
+func TestColumnPrimaryRowLocatorDeleteUsesTombstoneP3890(t *testing.T) {
+	table, err := buildColumnPrimaryRowLocatorTable(
+		ColumnPublishPlan{Operation: ColumnPublishOperationDelete, Rows: 1},
+		[]columnWriteDocument{{ID: []byte("doc-7")}},
+	)
+	if err != nil {
+		t.Fatalf("build delete locator table: %v", err)
+	}
+	it := table.NewIterator(nil, nil)
+	defer func() { _ = it.Close() }()
+	if !it.Valid() || string(it.UnsafeKey()) != "doc-7" {
+		t.Fatalf("delete locator iterator valid=%t key=%q", it.Valid(), it.UnsafeKey())
+	}
+	if !it.IsDeleted() {
+		t.Fatal("delete locator entry is not a tombstone")
+	}
+}

--- a/TreeDB/collections/column_primary_row_locator_test.go
+++ b/TreeDB/collections/column_primary_row_locator_test.go
@@ -19,6 +19,9 @@ func TestColumnPrimaryRowLocatorRoundTripAndCorruptionP3890(t *testing.T) {
 	if _, err := decodeColumnPrimaryRowLocator(ref.DocumentID, encoded); err == nil || !strings.Contains(err.Error(), "invalid primary row locator") {
 		t.Fatalf("corrupt locator err=%v want fail-closed invalid locator", err)
 	}
+	if _, err := decodeColumnPrimaryRowLocator(ref.DocumentID, nil); err == nil || !strings.Contains(err.Error(), "invalid primary row locator") {
+		t.Fatalf("empty live locator err=%v want fail-closed invalid locator", err)
+	}
 }
 
 func TestColumnPrimaryRowLocatorDeleteUsesTombstoneP3890(t *testing.T) {

--- a/TreeDB/collections/column_primary_row_locator_test.go
+++ b/TreeDB/collections/column_primary_row_locator_test.go
@@ -1,0 +1,22 @@
+package collections
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestColumnPrimaryRowLocatorRoundTripAndCorruptionP3890(t *testing.T) {
+	ref := DocumentRowRef{DocumentID: []byte("doc-7"), Generation: 3, PartID: 1, RowIndex: 17, AppliedCommandLSN: 29}
+	encoded := encodeColumnPrimaryRowLocator(ref)
+	got, err := decodeColumnPrimaryRowLocator(ref.DocumentID, encoded)
+	if err != nil {
+		t.Fatalf("decode locator: %v", err)
+	}
+	if got.Generation != ref.Generation || got.PartID != ref.PartID || got.RowIndex != ref.RowIndex || got.AppliedCommandLSN != ref.AppliedCommandLSN || string(got.DocumentID) != string(ref.DocumentID) {
+		t.Fatalf("decoded locator=%+v want %+v", got, ref)
+	}
+	encoded[0] ^= 0xff
+	if _, err := decodeColumnPrimaryRowLocator(ref.DocumentID, encoded); err == nil || !strings.Contains(err.Error(), "invalid primary row locator") {
+		t.Fatalf("corrupt locator err=%v want fail-closed invalid locator", err)
+	}
+}

--- a/TreeDB/collections/column_publish_write.go
+++ b/TreeDB/collections/column_publish_write.go
@@ -168,6 +168,15 @@ func (c *Collection) publishRootDeltaGroupMaybeColumn(ordered []backenddb.Ordere
 	if appendErr != nil {
 		return 0, nil, CollectionMeta{}, nil, appendErr
 	}
+	locatorRootName := collectionColumnRowLocatorRootName(input.meta.Name)
+	locatorBaseRoot := uint64(0)
+	if input.catalog != nil {
+		locatorBaseRoot = input.catalog.rootID(locatorRootName)
+	}
+	rootNames, baseRootIDs, appendErr = appendColumnManifestRootPublishBase(rootNames, baseRootIDs, locatorRootName, locatorBaseRoot)
+	if appendErr != nil {
+		return 0, nil, CollectionMeta{}, nil, appendErr
+	}
 	preflight := c.columnPublishRootDescriptorPreflight(input, rootNames, baseRootIDs)
 	var plan ColumnPublishPlan
 	defer func() { plan.releaseStableResources() }()
@@ -202,7 +211,17 @@ func (c *Collection) publishRootDeltaGroupMaybeColumn(ordered []backenddb.Ordere
 			_ = columnDelta.Iter.Close()
 			return nil, fmt.Errorf("collections: register column publish durable resources: %w", err)
 		}
-		return []backenddb.OrderedRootDeltaPublishInput{columnDelta}, nil
+		locatorPolicy, err := collectionRootStoragePolicyForDB(c.db, input.meta, locatorRootName)
+		if err != nil {
+			_ = columnDelta.Iter.Close()
+			return nil, err
+		}
+		locatorDelta, err := buildColumnPrimaryRowLocatorDelta(plan, input.documents, locatorBaseRoot, locatorPolicy)
+		if err != nil {
+			_ = columnDelta.Iter.Close()
+			return nil, err
+		}
+		return []backenddb.OrderedRootDeltaPublishInput{columnDelta, locatorDelta}, nil
 	}
 	buildSystemDelta := func(ctx backenddb.CommandWALPublishContext, rootIDs []uint64) (iterator.UnsafeIterator, error) {
 		stageStart := time.Now()
@@ -276,6 +295,15 @@ func (c *Collection) publishRootDeltaBatchGroupMaybeColumn(ordered []backenddb.O
 	if appendErr != nil {
 		return 0, nil, CollectionMeta{}, nil, appendErr
 	}
+	locatorRootName := collectionColumnRowLocatorRootName(input.meta.Name)
+	locatorBaseRoot := uint64(0)
+	if input.catalog != nil {
+		locatorBaseRoot = input.catalog.rootID(locatorRootName)
+	}
+	rootNames, baseRootIDs, appendErr = appendColumnManifestRootPublishBase(rootNames, baseRootIDs, locatorRootName, locatorBaseRoot)
+	if appendErr != nil {
+		return 0, nil, CollectionMeta{}, nil, appendErr
+	}
 	preflight = combineOrderedRootGroupPreflight(preflight, c.columnPublishRootDescriptorPreflight(input, rootNames, baseRootIDs))
 	var plan ColumnPublishPlan
 	defer func() { plan.releaseStableResources() }()
@@ -319,7 +347,28 @@ func (c *Collection) publishRootDeltaBatchGroupMaybeColumn(ordered []backenddb.O
 			}
 			return nil, fmt.Errorf("collections: register column publish durable resources: %w", err)
 		}
-		return []backenddb.OrderedRootDeltaBatchPublishInput{columnDelta}, nil
+		locatorPolicy, err := collectionRootStoragePolicyForDB(c.db, input.meta, locatorRootName)
+		if err != nil {
+			if cleanupColumnDelta != nil {
+				cleanupColumnDelta()
+				cleanupColumnDelta = nil
+			}
+			return nil, err
+		}
+		locatorDelta, locatorCleanup, err := buildColumnPrimaryRowLocatorDeltaBatch(plan, input.documents, locatorBaseRoot, locatorPolicy)
+		if err != nil {
+			if cleanupColumnDelta != nil {
+				cleanupColumnDelta()
+				cleanupColumnDelta = nil
+			}
+			return nil, err
+		}
+		columnCleanup := cleanupColumnDelta
+		cleanupColumnDelta = func() {
+			columnCleanup()
+			locatorCleanup()
+		}
+		return []backenddb.OrderedRootDeltaBatchPublishInput{columnDelta, locatorDelta}, nil
 	}
 	buildSystemDelta := func(ctx backenddb.CommandWALPublishContext, rootIDs []uint64) (iterator.UnsafeIterator, error) {
 		stageStart := time.Now()

--- a/TreeDB/collections/column_reconstruction_monotonic_test.go
+++ b/TreeDB/collections/column_reconstruction_monotonic_test.go
@@ -264,7 +264,7 @@ func TestScanDocumentsFuncMonotonicReconstructionUpdateFallsBackP3887(t *testing
 	if err != nil {
 		t.Fatalf("ScanDocumentsFunc: %v", err)
 	}
-	if stats := col.LastDocumentScanStats(); stats.CertifiedMonotonicPath || !stats.GenericFallback || stats.PhysicalPasses != 1 {
+	if stats := col.LastDocumentScanStats(); stats.CertifiedMonotonicPath || !stats.GenericFallback || stats.PhysicalPasses != 0 || stats.LocatorLookupBatches != 1 || stats.LocatorLookups != 1 || stats.PointRowFetches != 1 {
 		t.Fatalf("scan stats=%+v want generic fallback", stats)
 	}
 	if want := `"did":"did:new"`; !bytes.Contains(got, []byte(want)) {
@@ -449,8 +449,74 @@ func TestScanDocumentsFuncMonotonicReconstructionTypedSortKeyFallsBackP3887(t *t
 	assertJSONMapEqual1875(t, got[0].Document, map[string]any{"time_us": float64(2)})
 	assertJSONMapEqual1875(t, got[1].Document, map[string]any{"time_us": float64(1)})
 	stats := col.LastDocumentScanStats()
-	if stats.CertifiedMonotonicPath || !stats.GenericFallback || stats.PhysicalPasses != 1 || stats.LocatorLookupBatches != 1 || stats.LocatorLookups != 2 || stats.PointRowFetches != 2 || stats.PhysicalRows != 0 {
+	if stats.CertifiedMonotonicPath || !stats.GenericFallback || stats.PhysicalPasses != 0 || stats.LocatorLookupBatches != 1 || stats.LocatorLookups != 2 || stats.PointRowFetches != 2 || stats.PhysicalRows != 0 {
 		t.Fatalf("scan stats=%+v want generic fallback for typed sort-key rows", stats)
+	}
+}
+
+func TestScanDocumentsFuncGenericLocatorReconstructionBoundsMultiAssetBatchesP3890(t *testing.T) {
+	dir := t.TempDir()
+	if err := backenddb.SaveFormatConfig(dir, backenddb.FormatConfig{RequiredFeatures: []string{backenddb.RequiredFeatureCommandWALV1}}); err != nil {
+		t.Fatal(err)
+	}
+	d, err := backenddb.Open(backenddb.Options{Dir: dir, DisableBackgroundPrune: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = d.Close() }()
+	cfg := &ColumnStoreConfig{
+		Enabled: true,
+		Columns: []ColumnStoreColumn{{
+			Name:      "time_us",
+			Path:      "time_us",
+			ValueType: ColumnStoreValueInt64,
+			Owner:     TypedStorageOwnerColumnPart,
+		}},
+		SortKey: []ColumnSortKey{{Column: "time_us"}},
+	}
+	mgr := NewCollectionManager(d)
+	if _, err := mgr.CreateCollection(&CollectionMeta{Name: "events", Options: CollectionOptions{ColumnStore: cfg}}); err != nil {
+		t.Fatal(err)
+	}
+	col, err := mgr.OpenCollection("events")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	const (
+		rows      = 513
+		batchRows = 171
+	)
+	for start := 0; start < rows; start += batchRows {
+		end := start + batchRows
+		ids := make([][]byte, 0, end-start)
+		docs := make([][]byte, 0, end-start)
+		for i := start; i < end; i++ {
+			ids = append(ids, []byte(fmt.Sprintf("e%04d", i)))
+			docs = append(docs, []byte(fmt.Sprintf(`{"time_us":%d,"marker":%d}`, rows-i, i)))
+		}
+		if _, err := col.InsertBatch(ids, docs); err != nil {
+			t.Fatalf("InsertBatch start=%d: %v", start, err)
+		}
+	}
+
+	seen := 0
+	truncated, err := col.ScanDocumentsFunc(rows, func(record DocumentRecord) (bool, error) {
+		wantID := fmt.Sprintf("e%04d", seen)
+		if string(record.ID) != wantID {
+			return false, fmt.Errorf("row %d id=%q want %q", seen, record.ID, wantID)
+		}
+		seen++
+		return true, nil
+	})
+	if err != nil || truncated || seen != rows {
+		t.Fatalf("scan err=%v truncated=%t rows=%d want %d", err, truncated, seen, rows)
+	}
+	stats := col.LastDocumentScanStats()
+	if stats.CertifiedMonotonicPath || !stats.GenericFallback || stats.PhysicalPasses != 0 ||
+		stats.LocatorLookupBatches != 3 || stats.LocatorLookups != rows ||
+		stats.PointRowFetches != rows || stats.MaxRecordWindow != 256 {
+		t.Fatalf("scan stats=%+v want three bounded locator windows across immutable assets", stats)
 	}
 }
 
@@ -493,7 +559,7 @@ func TestScanDocumentsFuncMonotonicReconstructionUnsupportedSelectedTypedFallsBa
 	assertJSONMapEqual1875(t, got[0].Document, map[string]any{"maybe_kind": "present", "tags": []any{float64(1), float64(2)}, "retained": "first"})
 	assertJSONMapEqual1875(t, got[1].Document, map[string]any{"tags": []any{float64(3)}, "retained": "second"})
 	stats := col.LastDocumentScanStats()
-	if stats.CertifiedMonotonicPath || !stats.GenericFallback || stats.PhysicalPasses != 1 {
+	if stats.CertifiedMonotonicPath || !stats.GenericFallback || stats.PhysicalPasses != 0 || stats.LocatorLookupBatches != 1 || stats.LocatorLookups != 2 || stats.PointRowFetches != 2 {
 		t.Fatalf("scan stats=%+v want generic fallback before selected-row typed decoding", stats)
 	}
 }

--- a/TreeDB/collections/column_reconstruction_monotonic_test.go
+++ b/TreeDB/collections/column_reconstruction_monotonic_test.go
@@ -449,7 +449,7 @@ func TestScanDocumentsFuncMonotonicReconstructionTypedSortKeyFallsBackP3887(t *t
 	assertJSONMapEqual1875(t, got[0].Document, map[string]any{"time_us": float64(2)})
 	assertJSONMapEqual1875(t, got[1].Document, map[string]any{"time_us": float64(1)})
 	stats := col.LastDocumentScanStats()
-	if stats.CertifiedMonotonicPath || !stats.GenericFallback || stats.PhysicalPasses != 1 {
+	if stats.CertifiedMonotonicPath || !stats.GenericFallback || stats.PhysicalPasses != 1 || stats.LocatorLookupBatches != 1 || stats.LocatorLookups != 2 || stats.PointRowFetches != 2 || stats.PhysicalRows != 0 {
 		t.Fatalf("scan stats=%+v want generic fallback for typed sort-key rows", stats)
 	}
 }

--- a/TreeDB/collections/column_store_compaction.go
+++ b/TreeDB/collections/column_store_compaction.go
@@ -216,20 +216,57 @@ func (c *Collection) columnStoreCompact(ctx context.Context, opts ColumnStoreCom
 	}
 	rootNames := []string{state.rootName}
 	baseRootIDs := map[string]uint64{state.rootName: state.baseRoot}
+	var locatorBaseRoot uint64
+	var locatorPolicy backenddb.OrderedRootStoragePolicy
+	var locatorIter iterator.UnsafeIterator
+	if len(rows) > 0 {
+		locatorRootName := collectionColumnRowLocatorRootName(state.meta.Name)
+		locatorBaseRoot = state.catalog.rootID(locatorRootName)
+		locatorPolicy, err = collectionRootStoragePolicyForDB(c.db, state.meta, locatorRootName)
+		if err != nil {
+			_ = deltaIter.Close()
+			return stats, cleanupPrepared(err)
+		}
+		locatorDocuments := make([]columnWriteDocument, len(rows))
+		for i := range rows {
+			locatorDocuments[i].ID = rows[i].ID
+		}
+		locatorTable, err := buildColumnPrimaryRowLocatorTable(ColumnPublishPlan{
+			Operation:             ColumnPublishOperationInsert,
+			AppliedCommandLSN:     state.cfg.RecoveryAuthoritativeAppliedCommandLSN,
+			UpdatedActiveManifest: manifest.Identity,
+			Rows:                  len(rows),
+		}, locatorDocuments)
+		if err != nil {
+			_ = deltaIter.Close()
+			return stats, cleanupPrepared(err)
+		}
+		locatorIter = locatorTable.NewIterator(nil, nil)
+		rootNames = append(rootNames, locatorRootName)
+		baseRootIDs[locatorRootName] = locatorBaseRoot
+	}
 	preflight := c.columnStoreCompactionRootDescriptorPreflight(state, rootNames, baseRootIDs)
 	// The maintenance publisher owns and releases the producer closure once it
 	// is attached to the candidate durable slot.
 	durableResources := prepared.stableResources
 	prepared.stableResources = nil
+	orderedInputs := []backenddb.StorageMaintenanceRootDeltaPublishInput{{
+		BaseRoot:                    state.baseRoot,
+		Iter:                        deltaIter,
+		StoragePolicy:               policy,
+		DurableResources:            durableResources,
+		DurableResourceRequirements: durableRequirements,
+	}}
+	if locatorIter != nil {
+		orderedInputs = append(orderedInputs, backenddb.StorageMaintenanceRootDeltaPublishInput{
+			BaseRoot:      locatorBaseRoot,
+			Iter:          locatorIter,
+			StoragePolicy: locatorPolicy,
+		})
+	}
 	newSystemRoot, rootIDs, err := c.db.PublishOrderedRootDeltaGroupWithPreflightMaintenanceSystemDeltaBuilder(
 		storagemaintenance.ColumnAssetRewritePlan(),
-		[]backenddb.StorageMaintenanceRootDeltaPublishInput{{
-			BaseRoot:                    state.baseRoot,
-			Iter:                        deltaIter,
-			StoragePolicy:               policy,
-			DurableResources:            durableResources,
-			DurableResourceRequirements: durableRequirements,
-		}},
+		orderedInputs,
 		preflight,
 		func(rootIDs []uint64) (iterator.UnsafeIterator, error) {
 			return c.buildColumnAssetRewriteSystemDeltaIteratorForMeta(state.meta, updatedMeta, state.baseCommitSeq, state.baseSystemRoot, rootNames, baseRootIDs, rootIDs)
@@ -241,8 +278,13 @@ func (c *Collection) columnStoreCompact(ctx context.Context, opts ColumnStoreCom
 		}
 		return stats, err
 	}
-	if len(rootIDs) != 1 || rootIDs[0] == 0 {
-		return stats, unexpectedOrderedRootCountError(state.meta.Name, 1, len(rootIDs))
+	if len(rootIDs) != len(rootNames) {
+		return stats, unexpectedOrderedRootCountError(state.meta.Name, len(rootNames), len(rootIDs))
+	}
+	for _, rootID := range rootIDs {
+		if rootID == 0 {
+			return stats, unexpectedOrderedRootCountError(state.meta.Name, len(rootNames), len(rootIDs))
+		}
 	}
 	stats.AssetsPublished = len(prepared.Assets)
 	stats.AggregateMetadataPublished = columnStoreCompactionAggregateMetadataAssets(prepared.Assets)

--- a/TreeDB/collections/column_store_compaction_test.go
+++ b/TreeDB/collections/column_store_compaction_test.go
@@ -140,6 +140,7 @@ func TestColumnStoreCompactQ2SortedLatestVisibleReopen1953(t *testing.T) {
 	if got := col.Meta().Options.ColumnStore.PhysicalMutationParts; got != 0 {
 		t.Fatalf("PhysicalMutationParts=%d want reset after compaction", got)
 	}
+	assertColumnStoreCompactionDocumentsReconstruct1953(t, col, live)
 	// Return guarantees the activated visible closure; the independently
 	// recoverable durable closure may already be installed by the asynchronous
 	// publisher. Require one of those two exact ownership states.
@@ -187,6 +188,7 @@ func TestColumnStoreCompactQ2SortedLatestVisibleReopen1953(t *testing.T) {
 	assertColumnStoreCompactionRefsReclaimable1953(t, col, oldRefs)
 
 	_, col, closeFn = checkpointAndReopenTypedColumnLatestVisibleFixture1953(t, dir, d, closeFn)
+	assertColumnStoreCompactionDocumentsReconstruct1953(t, col, live)
 	reopened, err := col.RunColumnPhysicalQuery(req)
 	if err != nil {
 		t.Fatalf("RunColumnPhysicalQuery(q2 after compaction reopen): %v", err)
@@ -196,6 +198,26 @@ func TestColumnStoreCompactQ2SortedLatestVisibleReopen1953(t *testing.T) {
 	}
 	if reopened.Diagnostics.MutationParts != 0 || reopened.Diagnostics.VisibilityRows != 0 || reopened.Diagnostics.DocumentMaterializations != 0 || reopened.Diagnostics.RowMaterializations != 0 {
 		t.Fatalf("q2 after compaction reopen diagnostics=%+v want insert-only typed-column path", reopened.Diagnostics)
+	}
+}
+
+func assertColumnStoreCompactionDocumentsReconstruct1953(tb testing.TB, col *Collection, want []columnPhysicalJSONBenchParityEventP0) {
+	tb.Helper()
+	records, truncated, err := col.ScanDocuments(len(want) + 1)
+	if err != nil {
+		tb.Fatalf("ScanDocuments after compaction: %v", err)
+	}
+	if truncated || len(records) != len(want) {
+		tb.Fatalf("ScanDocuments after compaction truncated=%t rows=%d want %d", truncated, len(records), len(want))
+	}
+	wantIDs := make(map[string]struct{}, len(want))
+	for i := range want {
+		wantIDs[want[i].ID] = struct{}{}
+	}
+	for i := range records {
+		if _, ok := wantIDs[string(records[i].ID)]; !ok {
+			tb.Fatalf("ScanDocuments after compaction returned unexpected id %q", records[i].ID)
+		}
 	}
 }
 

--- a/TreeDB/collections/document_materializer.go
+++ b/TreeDB/collections/document_materializer.go
@@ -489,20 +489,9 @@ func (v *CollectionReadView) lookupDocumentRowRefsByID(ids [][]byte, opts Docume
 		response.Stats.RowRefUnsupported++
 		return response, errors.New("collections: document row ref lookup requires typed-storage reconstruction support")
 	}
-	cfg := v.catalog.meta.Options.ColumnStore.copy()
-	readIntegrity := opts.ColumnAssetReadIntegrity
-	if readIntegrity == "" {
-		readIntegrity = ColumnAssetReadIntegrityVerify
-	}
-	if err := v.ensureAssetReadCaches(cfg, readIntegrity); err != nil {
-		return response, err
-	}
-	assetCountersBefore := v.assetCounters()
-	defer func() {
-		addDocumentMaterializerAssetCounterDeltas(&response.Stats, assetCountersBefore, v.assetCounters())
-	}()
-	if err := v.ensureDocumentRowLocator(cfg, readIntegrity, &response.Stats); err != nil {
-		return response, err
+	locatorRootName := collectionColumnRowLocatorRootName(v.catalog.meta.Name)
+	if v.catalog.rootID(locatorRootName) == 0 {
+		return response, fmt.Errorf("collections: primary row locator root is absent for collection %q", v.catalog.meta.Name)
 	}
 	var idArena []byte
 	for i, id := range ids {
@@ -514,12 +503,18 @@ func (v *CollectionReadView) lookupDocumentRowRefsByID(ids [][]byte, opts Docume
 		ownedID := idArena[idStart:len(idArena):len(idArena)]
 		response.Results[i].ID = ownedID
 		response.Stats.RowLocatorLookups++
-		rowRef, ok := v.rowLocator.byID[string(id)]
-		if !ok {
+		value, found, err := collectionGetAppendAtCatalogRoot(v.snapshot, v.catalog, locatorRootName, id, nil)
+		if err != nil {
+			return response, fmt.Errorf("collections: primary row locator lookup for id %q: %w", string(id), err)
+		}
+		if !found || len(value) == 0 {
 			response.Stats.RowLocatorMisses++
 			continue
 		}
-		rowRef.DocumentID = ownedID
+		rowRef, err := decodeColumnPrimaryRowLocator(ownedID, value)
+		if err != nil {
+			return response, err
+		}
 		response.Results[i].RowRef = rowRef
 		response.Results[i].Found = true
 	}
@@ -614,19 +609,30 @@ func noColumnPhysicalScanProjection(cfg ColumnStoreConfig) columnPhysicalScanPro
 }
 
 func (v *CollectionReadView) validateDocumentRowRefLatest(ref DocumentRowRef, stats *DocumentMaterializationStats) error {
-	if v == nil || v.rowLocator == nil {
-		return nil
+	if v == nil || v.catalog == nil || v.snapshot == nil {
+		return errors.New("collections: nil collection read view")
 	}
 	if stats != nil {
 		stats.RowLocatorLookups++
 	}
-	latest, ok := v.rowLocator.byID[string(ref.DocumentID)]
-	if !ok {
+	locatorRootName := collectionColumnRowLocatorRootName(v.catalog.meta.Name)
+	if v.catalog.rootID(locatorRootName) == 0 {
+		return fmt.Errorf("collections: primary row locator root is absent for collection %q", v.catalog.meta.Name)
+	}
+	value, found, err := collectionGetAppendAtCatalogRoot(v.snapshot, v.catalog, locatorRootName, ref.DocumentID, nil)
+	if err != nil {
+		return fmt.Errorf("collections: primary row locator validation for id %q: %w", string(ref.DocumentID), err)
+	}
+	if !found || len(value) == 0 {
 		if stats != nil {
 			stats.RowLocatorMisses++
 			stats.RowRefValidationFailures++
 		}
-		return fmt.Errorf("collections: document row ref for id %q is not latest-visible in snapshot", string(ref.DocumentID))
+		return fmt.Errorf("collections: document row ref for id %q is not visible in primary root", string(ref.DocumentID))
+	}
+	latest, err := decodeColumnPrimaryRowLocator(ref.DocumentID, value)
+	if err != nil {
+		return err
 	}
 	if err := validateDocumentRowRefMatchesRowRef(ref, latest); err != nil {
 		if stats != nil {
@@ -924,11 +930,6 @@ func (v *CollectionReadView) fetchColumnStoreDocumentsByRowRef(response Document
 	if err != nil {
 		return out, err
 	}
-	if view.MutationParts != 0 {
-		if err := v.ensureDocumentRowLocator(cfg, readIntegrity, &out.Stats); err != nil {
-			return out, err
-		}
-	}
 	selectedColumns := documentProjectionSelectedColumns(cfg, projection)
 	rowProjection := documentProjectionRowAssetColumns(cfg, selectedColumns)
 	typedProjection := documentProjectionTypedColumnPartSelection(cfg, selectedColumns)
@@ -948,10 +949,8 @@ func (v *CollectionReadView) fetchColumnStoreDocumentsByRowRef(response Document
 			out.Stats.RowRefValidationFailures++
 			return out, fmt.Errorf("collections: document row ref for id %q is not visible in primary root", string(out.Results[i].ID))
 		}
-		if view.MutationParts != 0 {
-			if err := v.validateDocumentRowRefLatest(refs[i], &out.Stats); err != nil {
-				return out, err
-			}
+		if err := v.validateDocumentRowRefLatest(refs[i], &out.Stats); err != nil {
+			return out, err
 		}
 		row, err := v.fetchDocumentPointRow(view, refs[i], pointProjection, &rowScratch, &out.Stats)
 		if err != nil {

--- a/TreeDB/collections/document_materializer.go
+++ b/TreeDB/collections/document_materializer.go
@@ -500,7 +500,8 @@ func (v *CollectionReadView) lookupDocumentRowRefsByID(ids [][]byte, opts Docume
 	}
 	locatorRootName := collectionColumnRowLocatorRootName(v.catalog.meta.Name)
 	if v.catalog.rootID(locatorRootName) == 0 {
-		if v.catalog.rootID(collectionPrimaryRootName(v.catalog.meta.Name)) == 0 {
+		primaryRootName := collectionPrimaryRootName(v.catalog.meta.Name)
+		if v.catalog.rootID(primaryRootName) == 0 && len(v.catalog.overlayRootIDs(primaryRootName)) == 0 {
 			response.Stats.RowLocatorLookups = uint64(len(ids))
 			response.Stats.RowLocatorMisses = uint64(len(ids))
 			return response, nil

--- a/TreeDB/collections/document_materializer.go
+++ b/TreeDB/collections/document_materializer.go
@@ -489,10 +489,6 @@ func (v *CollectionReadView) lookupDocumentRowRefsByID(ids [][]byte, opts Docume
 		response.Stats.RowRefUnsupported++
 		return response, errors.New("collections: document row ref lookup requires typed-storage reconstruction support")
 	}
-	locatorRootName := collectionColumnRowLocatorRootName(v.catalog.meta.Name)
-	if v.catalog.rootID(locatorRootName) == 0 {
-		return response, fmt.Errorf("collections: primary row locator root is absent for collection %q", v.catalog.meta.Name)
-	}
 	var idArena []byte
 	for i, id := range ids {
 		if len(id) == 0 {
@@ -500,12 +496,23 @@ func (v *CollectionReadView) lookupDocumentRowRefsByID(ids [][]byte, opts Docume
 		}
 		idStart := len(idArena)
 		idArena = append(idArena, id...)
-		ownedID := idArena[idStart:len(idArena):len(idArena)]
-		response.Results[i].ID = ownedID
+		response.Results[i].ID = idArena[idStart:len(idArena):len(idArena)]
+	}
+	locatorRootName := collectionColumnRowLocatorRootName(v.catalog.meta.Name)
+	if v.catalog.rootID(locatorRootName) == 0 {
+		if v.catalog.rootID(collectionPrimaryRootName(v.catalog.meta.Name)) == 0 {
+			response.Stats.RowLocatorLookups = uint64(len(ids))
+			response.Stats.RowLocatorMisses = uint64(len(ids))
+			return response, nil
+		}
+		return response, fmt.Errorf("collections: primary row locator root is absent for collection %q", v.catalog.meta.Name)
+	}
+	for i := range response.Results {
+		ownedID := response.Results[i].ID
 		response.Stats.RowLocatorLookups++
-		value, found, err := collectionGetAppendAtCatalogRoot(v.snapshot, v.catalog, locatorRootName, id, nil)
+		value, found, err := collectionGetAppendAtCatalogRoot(v.snapshot, v.catalog, locatorRootName, ownedID, nil)
 		if err != nil {
-			return response, fmt.Errorf("collections: primary row locator lookup for id %q: %w", string(id), err)
+			return response, fmt.Errorf("collections: primary row locator lookup for id %q: %w", string(ownedID), err)
 		}
 		if !found {
 			response.Stats.RowLocatorMisses++

--- a/TreeDB/collections/document_materializer.go
+++ b/TreeDB/collections/document_materializer.go
@@ -758,12 +758,20 @@ func (v *CollectionReadView) pointRowScanProjection(view columnPhysicalScanSnaps
 // mismatch fails the request instead of silently returning a partial batch.
 func (v *CollectionReadView) FetchDocumentsByRowRef(refs []DocumentRowRef, opts DocumentFetchOptions) (DocumentFetchResponse, error) {
 	start := time.Now()
-	response, err := v.fetchDocumentsByRowRef(refs, opts)
+	response, err := v.fetchDocumentsByRowRef(refs, opts, false)
 	response.Stats.FetchNanos = time.Since(start).Nanoseconds()
 	return response, err
 }
 
-func (v *CollectionReadView) fetchDocumentsByRowRef(refs []DocumentRowRef, opts DocumentFetchOptions) (DocumentFetchResponse, error) {
+// fetchDocumentsByResolvedRowRef is reserved for refs obtained from this read
+// view's persistent locator root. The lookup and fetch share one immutable
+// snapshot, so repeating latest-locator validation would be redundant. Primary
+// visibility and physical-row coordinate validation still fail closed below.
+func (v *CollectionReadView) fetchDocumentsByResolvedRowRef(refs []DocumentRowRef, opts DocumentFetchOptions) (DocumentFetchResponse, error) {
+	return v.fetchDocumentsByRowRef(refs, opts, true)
+}
+
+func (v *CollectionReadView) fetchDocumentsByRowRef(refs []DocumentRowRef, opts DocumentFetchOptions, locatorResolvedAtView bool) (DocumentFetchResponse, error) {
 	if err := v.validateOpen(); err != nil {
 		return DocumentFetchResponse{}, err
 	}
@@ -797,7 +805,7 @@ func (v *CollectionReadView) fetchDocumentsByRowRef(refs []DocumentRowRef, opts 
 			}
 		}
 	}
-	return v.fetchColumnStoreDocumentsByRowRef(response, refs, retained, opts, projection)
+	return v.fetchColumnStoreDocumentsByRowRef(response, refs, retained, opts, projection, locatorResolvedAtView)
 }
 
 func (v *CollectionReadView) fetchDocumentsByID(ids [][]byte, expected []*DocumentRowRef, opts DocumentFetchOptions) (DocumentFetchResponse, error) {
@@ -912,7 +920,7 @@ func (v *CollectionReadView) fetchRetainedPayloadsByID(ids [][]byte) (DocumentFe
 	return response, retained, foundCount, nil
 }
 
-func (v *CollectionReadView) fetchColumnStoreDocumentsByRowRef(response DocumentFetchResponse, refs []DocumentRowRef, retained [][]byte, opts DocumentFetchOptions, projection *documentProjection) (out DocumentFetchResponse, err error) {
+func (v *CollectionReadView) fetchColumnStoreDocumentsByRowRef(response DocumentFetchResponse, refs []DocumentRowRef, retained [][]byte, opts DocumentFetchOptions, projection *documentProjection, locatorResolvedAtView bool) (out DocumentFetchResponse, err error) {
 	out = response
 	cfg := v.catalog.meta.Options.ColumnStore.copy()
 	readIntegrity := opts.ColumnAssetReadIntegrity
@@ -949,8 +957,10 @@ func (v *CollectionReadView) fetchColumnStoreDocumentsByRowRef(response Document
 			out.Stats.RowRefValidationFailures++
 			return out, fmt.Errorf("collections: document row ref for id %q is not visible in primary root", string(out.Results[i].ID))
 		}
-		if err := v.validateDocumentRowRefLatest(refs[i], &out.Stats); err != nil {
-			return out, err
+		if !locatorResolvedAtView {
+			if err := v.validateDocumentRowRefLatest(refs[i], &out.Stats); err != nil {
+				return out, err
+			}
 		}
 		row, err := v.fetchDocumentPointRow(view, refs[i], pointProjection, &rowScratch, &out.Stats)
 		if err != nil {

--- a/TreeDB/collections/document_materializer.go
+++ b/TreeDB/collections/document_materializer.go
@@ -507,7 +507,7 @@ func (v *CollectionReadView) lookupDocumentRowRefsByID(ids [][]byte, opts Docume
 		if err != nil {
 			return response, fmt.Errorf("collections: primary row locator lookup for id %q: %w", string(id), err)
 		}
-		if !found || len(value) == 0 {
+		if !found {
 			response.Stats.RowLocatorMisses++
 			continue
 		}

--- a/TreeDB/collections/document_materializer_test.go
+++ b/TreeDB/collections/document_materializer_test.go
@@ -997,7 +997,7 @@ func TestCollectionReadViewEnsureAssetReadCachesInvalidatesDerivedRowCaches1874(
 	if _, err := view.FetchDocumentsByRowRef([]DocumentRowRef{lookup.Results[0].RowRef}, DocumentFetchOptions{}); err != nil {
 		t.Fatalf("FetchDocumentsByRowRef: %v", err)
 	}
-	if view.rowLocator == nil || view.columnSnapshotView == nil || len(view.pointRowRefs) == 0 || len(view.pointRowBlocks) == 0 || view.pointRowProjection == nil {
+	if view.columnSnapshotView == nil || len(view.pointRowRefs) == 0 || len(view.pointRowBlocks) == 0 || view.pointRowProjection == nil {
 		t.Fatalf("expected derived caches to be populated before integrity change")
 	}
 	cfg := view.columnSnapshotView.Config
@@ -1026,7 +1026,7 @@ func TestCollectionReadViewEnsureAssetReadCachesInvalidatesDerivedRowCaches1874(
 	if _, err := view.FetchDocumentsByRowRef([]DocumentRowRef{lookup.Results[0].RowRef}, DocumentFetchOptions{}); err != nil {
 		t.Fatalf("FetchDocumentsByRowRef after rebuild: %v", err)
 	}
-	if view.rowLocator == nil || view.columnSnapshotView == nil || len(view.pointRowRefs) == 0 || len(view.pointRowBlocks) == 0 || view.pointRowProjection == nil {
+	if view.columnSnapshotView == nil || len(view.pointRowRefs) == 0 || len(view.pointRowBlocks) == 0 || view.pointRowProjection == nil {
 		t.Fatalf("expected derived caches to be repopulated before close")
 	}
 	if err := view.Close(); err != nil {

--- a/TreeDB/collections/document_materializer_test.go
+++ b/TreeDB/collections/document_materializer_test.go
@@ -133,6 +133,46 @@ func TestCollectionReadViewLookupDocumentRowRefsByIDMissingLocatorWithPrimaryFai
 	}
 }
 
+func TestCollectionReadViewLookupDocumentRowRefsByIDMissingLocatorWithPrimaryOverlayFailsClosedP3890(t *testing.T) {
+	d, col := newDocumentMaterializerTestCollection(t)
+	defer func() { _ = d.Close() }()
+	if _, err := col.InsertBatch(
+		[][]byte{[]byte("e1")},
+		[][]byte{[]byte(`{"row_id":1,"kind":"alpha","score":1.5}`)},
+	); err != nil {
+		t.Fatalf("InsertBatch: %v", err)
+	}
+
+	view, err := col.OpenCollectionReadView()
+	if err != nil {
+		t.Fatalf("OpenCollectionReadView: %v", err)
+	}
+	defer func() { _ = view.Close() }()
+	primaryRootName := collectionPrimaryRootName(view.catalog.meta.Name)
+	primaryRootID := view.catalog.rootID(primaryRootName)
+	if primaryRootID == 0 {
+		t.Fatal("test requires a populated primary root")
+	}
+	catalogWithPrimaryOverlay := *view.catalog
+	catalogWithPrimaryOverlay.roots = make(map[string]uint64, len(view.catalog.roots))
+	for name, rootID := range view.catalog.roots {
+		catalogWithPrimaryOverlay.roots[name] = rootID
+	}
+	delete(catalogWithPrimaryOverlay.roots, primaryRootName)
+	delete(catalogWithPrimaryOverlay.roots, collectionColumnRowLocatorRootName(view.catalog.meta.Name))
+	catalogWithPrimaryOverlay.rootOverlays = make(map[string][]uint64, len(view.catalog.rootOverlays)+1)
+	for name, rootIDs := range view.catalog.rootOverlays {
+		catalogWithPrimaryOverlay.rootOverlays[name] = append([]uint64(nil), rootIDs...)
+	}
+	catalogWithPrimaryOverlay.rootOverlays[primaryRootName] = []uint64{primaryRootID}
+	view.catalog = &catalogWithPrimaryOverlay
+
+	if _, err := view.LookupDocumentRowRefsByID([][]byte{[]byte("e1")}, DocumentFetchOptions{}); err == nil ||
+		!strings.Contains(err.Error(), "primary row locator root is absent") {
+		t.Fatalf("LookupDocumentRowRefsByID err=%v want overlay-primary absent-locator fail-closed error", err)
+	}
+}
+
 func TestCollectionReadViewFetchDocumentsByIDColumnReconstructionParity(t *testing.T) {
 	d, col := newDocumentMaterializerTestCollection(t)
 	defer func() { _ = d.Close() }()

--- a/TreeDB/collections/document_materializer_test.go
+++ b/TreeDB/collections/document_materializer_test.go
@@ -861,7 +861,7 @@ func TestCollectionReadViewFetchDocumentsByRowRefMutationLatestVisible1874(t *te
 	if err != nil {
 		t.Fatalf("LookupDocumentRowRefsByID: %v", err)
 	}
-	if !lookup.Results[0].Found || lookup.Results[1].Found || lookup.Stats.RowLocatorLookups != 2 || lookup.Stats.RowLocatorMisses != 1 || lookup.Stats.RowLocatorBuilds != 1 {
+	if !lookup.Results[0].Found || lookup.Results[1].Found || lookup.Stats.RowLocatorLookups != 2 || lookup.Stats.RowLocatorMisses != 1 || lookup.Stats.RowLocatorBuilds != 0 {
 		t.Fatalf("lookup=%+v stats=%+v want updated e1 ref and deleted e2 miss", lookup.Results, lookup.Stats)
 	}
 	current, err := currentView.FetchDocumentsByRowRef([]DocumentRowRef{lookup.Results[0].RowRef}, DocumentFetchOptions{})

--- a/TreeDB/collections/document_materializer_test.go
+++ b/TreeDB/collections/document_materializer_test.go
@@ -71,6 +71,68 @@ func TestCollectionReadViewFetchDocumentsByIDUsesBatchViewForOwnedRetainedPayloa
 	}
 }
 
+func TestCollectionReadViewLookupDocumentRowRefsByIDEmptyCollectionReturnsMissingP3890(t *testing.T) {
+	_, d, col, def := openColumnGraphRebuildTestCollectionV2A(t, 3, 0, nil)
+	defer func() { _ = d.Close() }()
+	if _, err := col.RebuildVectorIndex(def.Name); err != nil {
+		t.Fatalf("RebuildVectorIndex empty collection: %v", err)
+	}
+
+	view, err := col.OpenCollectionReadView()
+	if err != nil {
+		t.Fatalf("OpenCollectionReadView: %v", err)
+	}
+	defer func() { _ = view.Close() }()
+
+	ids := [][]byte{[]byte("missing-a"), []byte("missing-b")}
+	got, err := view.LookupDocumentRowRefsByID(ids, DocumentFetchOptions{})
+	if err != nil {
+		t.Fatalf("LookupDocumentRowRefsByID: %v", err)
+	}
+	if len(got.Results) != len(ids) {
+		t.Fatalf("results=%d want %d", len(got.Results), len(ids))
+	}
+	for i := range ids {
+		if got.Results[i].Found || !bytes.Equal(got.Results[i].ID, ids[i]) {
+			t.Fatalf("result[%d]=%+v want owned missing id %q", i, got.Results[i], ids[i])
+		}
+	}
+	if got.Stats.DocumentsRequested != uint64(len(ids)) ||
+		got.Stats.RowLocatorLookups != uint64(len(ids)) ||
+		got.Stats.RowLocatorMisses != uint64(len(ids)) {
+		t.Fatalf("stats=%+v want requested/lookups/misses=%d", got.Stats, len(ids))
+	}
+}
+
+func TestCollectionReadViewLookupDocumentRowRefsByIDMissingLocatorWithPrimaryFailsClosedP3890(t *testing.T) {
+	d, col := newDocumentMaterializerTestCollection(t)
+	defer func() { _ = d.Close() }()
+	if _, err := col.InsertBatch(
+		[][]byte{[]byte("e1")},
+		[][]byte{[]byte(`{"row_id":1,"kind":"alpha","score":1.5}`)},
+	); err != nil {
+		t.Fatalf("InsertBatch: %v", err)
+	}
+
+	view, err := col.OpenCollectionReadView()
+	if err != nil {
+		t.Fatalf("OpenCollectionReadView: %v", err)
+	}
+	defer func() { _ = view.Close() }()
+	catalogWithoutLocator := *view.catalog
+	catalogWithoutLocator.roots = make(map[string]uint64, len(view.catalog.roots))
+	for name, rootID := range view.catalog.roots {
+		catalogWithoutLocator.roots[name] = rootID
+	}
+	delete(catalogWithoutLocator.roots, collectionColumnRowLocatorRootName(view.catalog.meta.Name))
+	view.catalog = &catalogWithoutLocator
+
+	if _, err := view.LookupDocumentRowRefsByID([][]byte{[]byte("e1")}, DocumentFetchOptions{}); err == nil ||
+		!strings.Contains(err.Error(), "primary row locator root is absent") {
+		t.Fatalf("LookupDocumentRowRefsByID err=%v want absent-locator fail-closed error", err)
+	}
+}
+
 func TestCollectionReadViewFetchDocumentsByIDColumnReconstructionParity(t *testing.T) {
 	d, col := newDocumentMaterializerTestCollection(t)
 	defer func() { _ = d.Close() }()

--- a/TreeDB/collections/typed_storage_naming_test.go
+++ b/TreeDB/collections/typed_storage_naming_test.go
@@ -421,7 +421,7 @@ var typedStorageLegacyNameAllowlist = []typedStorageLegacyNameAllowlistEntry{
 	{path: "TreeDB/collections/column_vector_graph_quantized_bench_test.go", classification: typedStorageLegacyDerived, matchingLines: 3, occurrences: 6},
 	{path: "TreeDB/collections/column_store.go", classification: typedStorageLegacyCompatibility, matchingLines: 141, occurrences: 246},
 	{path: "TreeDB/collections/column_store_compaction.go", classification: typedStorageLegacyCompatibility, matchingLines: 37, occurrences: 44},
-	{path: "TreeDB/collections/column_store_compaction_test.go", classification: typedStorageLegacyCompatibility, matchingLines: 75, occurrences: 87},
+	{path: "TreeDB/collections/column_store_compaction_test.go", classification: typedStorageLegacyCompatibility, matchingLines: 78, occurrences: 90},
 	{path: "TreeDB/collections/column_store_compatibility_api_test.go", classification: typedStorageLegacyCompatibility, matchingLines: 7, occurrences: 9},
 	{path: "TreeDB/collections/column_store_physical_accounting.go", classification: typedStorageLegacyCompatibility, matchingLines: 226, occurrences: 258},
 	{path: "TreeDB/collections/column_store_physical_accounting_test.go", classification: typedStorageLegacyCompatibility, matchingLines: 23, occurrences: 29},

--- a/TreeDB/collections/typed_storage_naming_test.go
+++ b/TreeDB/collections/typed_storage_naming_test.go
@@ -331,7 +331,7 @@ type typedStorageLegacyNameAllowlistEntry struct {
 }
 
 var typedStorageLegacyNameAllowlist = []typedStorageLegacyNameAllowlistEntry{
-	{path: "TreeDB/collections/api.go", classification: typedStorageLegacyCompatibility, matchingLines: 60, occurrences: 66},
+	{path: "TreeDB/collections/api.go", classification: typedStorageLegacyCompatibility, matchingLines: 61, occurrences: 67},
 	{path: "TreeDB/collections/bson_set_update.go", classification: typedStorageLegacyCompatibility, matchingLines: 2, occurrences: 2},
 	{path: "TreeDB/collections/column_aggregate_metadata_asset.go", classification: typedStorageLegacyDerived, matchingLines: 22, occurrences: 24},
 	{path: "TreeDB/collections/column_aggregate_metadata_asset_3121_test.go", classification: typedStorageLegacyCompatibility, matchingLines: 25, occurrences: 25},
@@ -391,7 +391,7 @@ var typedStorageLegacyNameAllowlist = []typedStorageLegacyNameAllowlistEntry{
 	{path: "TreeDB/collections/column_query_plan_test.go", classification: typedStorageLegacyCompatibility, matchingLines: 56, occurrences: 68},
 	{path: "TreeDB/collections/column_reconstruction.go", classification: typedStorageLegacyCompatibility, matchingLines: 57, occurrences: 72},
 	{path: "TreeDB/collections/column_reconstruction_monotonic.go", classification: typedStorageLegacyCompatibility, matchingLines: 6, occurrences: 8},
-	{path: "TreeDB/collections/column_reconstruction_monotonic_test.go", classification: typedStorageLegacyCompatibility, matchingLines: 15, occurrences: 26},
+	{path: "TreeDB/collections/column_reconstruction_monotonic_test.go", classification: typedStorageLegacyCompatibility, matchingLines: 19, occurrences: 30},
 	{path: "TreeDB/collections/column_reconstruction_test.go", classification: typedStorageLegacyCompatibility, matchingLines: 27, occurrences: 31},
 	{path: "TreeDB/collections/column_retained_payload_audit.go", classification: typedStorageLegacyCompatibility, matchingLines: 8, occurrences: 8},
 	{path: "TreeDB/collections/column_retained_payload_audit_test.go", classification: typedStorageLegacyCompatibility, matchingLines: 29, occurrences: 30},
@@ -401,7 +401,7 @@ var typedStorageLegacyNameAllowlist = []typedStorageLegacyNameAllowlistEntry{
 	{path: "TreeDB/collections/column_semantics.go", classification: typedStorageLegacyCompatibility, matchingLines: 34, occurrences: 34},
 	{path: "TreeDB/collections/dense_numeric_vector.go", classification: typedStorageLegacyCompatibility, matchingLines: 32, occurrences: 41},
 	{path: "TreeDB/collections/dense_numeric_vector_test.go", classification: typedStorageLegacyCompatibility, matchingLines: 35, occurrences: 38},
-	{path: "TreeDB/collections/document_materializer.go", classification: typedStorageLegacyCompatibility, matchingLines: 16, occurrences: 16},
+	{path: "TreeDB/collections/document_materializer.go", classification: typedStorageLegacyCompatibility, matchingLines: 15, occurrences: 15},
 	{path: "TreeDB/collections/document_materializer_test.go", classification: typedStorageLegacyCompatibility, matchingLines: 32, occurrences: 32},
 	{path: "TreeDB/documentservice/service.go", classification: typedStorageLegacyCompatibility, matchingLines: 5, occurrences: 7},
 	{path: "TreeDB/documentservice/service_test.go", classification: typedStorageLegacyCompatibility, matchingLines: 1, occurrences: 2},

--- a/TreeDB/collections/vector_index_search_test.go
+++ b/TreeDB/collections/vector_index_search_test.go
@@ -3505,7 +3505,7 @@ func TestSearchVectorIndexColumnGraphMaterializesDocumentsAfterTopKV4(t *testing
 	if got.Stats.DocumentsFetched != uint64(len(got.Results)) {
 		t.Fatalf("DocumentsFetched=%d want %d", got.Stats.DocumentsFetched, len(got.Results))
 	}
-	if got.Stats.DocumentRowRefStateFetches != uint64(len(got.Results)) || got.Stats.DocumentRowRefLookupFallbacks != 0 || got.Stats.DocumentRowLocatorLookups != 0 || got.Stats.DocumentRowLocatorMisses != 0 || got.Stats.DocumentPointRowFetches != uint64(len(got.Results)) || got.Stats.DocumentPointRowDecodes != uint64(len(got.Results)) {
+	if got.Stats.DocumentRowRefStateFetches != uint64(len(got.Results)) || got.Stats.DocumentRowRefLookupFallbacks != 0 || got.Stats.DocumentRowLocatorLookups != uint64(len(got.Results)) || got.Stats.DocumentRowLocatorMisses != 0 || got.Stats.DocumentPointRowFetches != uint64(len(got.Results)) || got.Stats.DocumentPointRowDecodes != uint64(len(got.Results)) {
 		t.Fatalf("stats=%+v want vector-index row refs and point row fetch per document", got.Stats)
 	}
 	if got.Stats.DocumentRowRefFallbackScans != 0 || got.Stats.DocumentVisibilityScans != 0 || got.Stats.DocumentVisibilityRowsScanned != 0 {
@@ -3824,7 +3824,7 @@ func TestOpenVectorIndexSearcherFetchesDocumentsFromBoundSnapshotV4(t *testing.T
 	if got.Stats.DocumentsFetched != 1 {
 		t.Fatalf("DocumentsFetched=%d want 1", got.Stats.DocumentsFetched)
 	}
-	if got.Stats.DocumentRowRefStateFetches != 1 || got.Stats.DocumentRowRefLookupFallbacks != 0 || got.Stats.DocumentRowLocatorLookups != 0 || got.Stats.DocumentPointRowFetches != 1 || got.Stats.DocumentPointRowDecodes != 1 || got.Stats.DocumentRowRefFallbackScans != 0 || got.Stats.DocumentVisibilityScans != 0 {
+	if got.Stats.DocumentRowRefStateFetches != 1 || got.Stats.DocumentRowRefLookupFallbacks != 0 || got.Stats.DocumentRowLocatorLookups != 1 || got.Stats.DocumentPointRowFetches != 1 || got.Stats.DocumentPointRowDecodes != 1 || got.Stats.DocumentRowRefFallbackScans != 0 || got.Stats.DocumentVisibilityScans != 0 {
 		t.Fatalf("stats=%+v want prepared IncludeDocuments to use vector-index row refs and point fetches", got.Stats)
 	}
 	if searcher.documentView == nil || searcher.documentView.assetScopeKind != mappedresource.ScopePreparedSearch {

--- a/TreeDB/docs/spec/storage-format.md
+++ b/TreeDB/docs/spec/storage-format.md
@@ -718,6 +718,26 @@ not necessarily the decoded raw block. Blocks contain at most 4096 retained
 documents; single-row insert/update batches still produce one side-root block
 and one primary locator per retained document.
 
+Column-store publications also atomically maintain a mutation-safe physical row
+locator root:
+
+```text
+Root name: <collection>/column/row-locator
+Key:       exact primary document ID bytes
+Value:
+  bytes[4]   Magic = "CRL1"
+  u64 BE     typed asset generation
+  u64 BE     typed asset part ID
+  u64 BE     zero-based row index
+  u64 BE     applied command LSN
+```
+
+The value is exactly 36 bytes. Insert and replace publications co-publish the
+primary root, typed manifest, and locator root so one snapshot cannot observe a
+primary value with a locator from another generation. Delete publications write
+an ordered-root tombstone for the document ID. Unknown magic, the wrong value
+length, an overflowing row index, or invalid physical coordinates fail closed.
+
 Raw side-root block value:
 
 ```text

--- a/TreeDB/docs/spec/storage-format.md
+++ b/TreeDB/docs/spec/storage-format.md
@@ -735,7 +735,9 @@ Value:
 The value is exactly 36 bytes. Insert and replace publications co-publish the
 primary root, typed manifest, and locator root so one snapshot cannot observe a
 primary value with a locator from another generation. Delete publications write
-an ordered-root tombstone for the document ID. Unknown magic, the wrong value
+an ordered-root tombstone for the document ID. Column asset compaction
+atomically republishes the manifest and all live locators because it rewrites
+their physical generation and row coordinates. Unknown magic, the wrong value
 length, an overflowing row index, or invalid physical coordinates fail closed.
 
 Raw side-root block value:


### PR DESCRIPTION
Closes #3890; completes the bounded generic reconstruction obligation from
#3897 and is scoped against #3067.

## What changed

- Adds a column-store-only per-collection `<collection>/column/row-locator`
  ordered root.
- Co-publishes the primary, manifest, and locator roots in one command-WAL
  publication.
- Stores generation, part ID, row index, and applied command LSN in a fixed
  36-byte `CRL1` locator value; deletes publish locator tombstones.
- Point-reads locators for lookup and public stale-ref validation, failing
  closed on absent, deleted, malformed, mismatched, or stale entries.
- Replaces generic whole-asset visibility scans with 256-ID locator windows and
  physical point-row fetches.
- Scopes read-view caches to each 256-ID window and avoids repeating locator
  validation when the private lookup and fetch share that same immutable view.
- Republishes every live row locator atomically with manifest compaction, so
  rewritten generation/part/row coordinates remain valid after reopen.
- Documents the persistent on-disk locator format.

Primary values remain raw payloads. WAL, value-log, and GC lifecycle behavior
are unchanged.

## Correctness and boundedness

- Insert/update/delete and latest-vs-old snapshot behavior.
- Malformed locator and coordinate mismatch fail-closed coverage.
- Post-compaction and reopened reconstruction coverage, including locator
  republish and an all-deleted collection.
- Public row-ref fetches continue to reject stale refs.
- Empty reconstructable collections return owned missing-ID results only when
  the locator, base primary, and primary overlay roots are all absent; a
  populated base or overlay primary with a missing locator still fails closed.
- A 513-row, three-asset generic reconstruction test proves three
  `256 + 256 + 1` locator batches, 513 point-row fetches, a maximum record
  window of 256, correct primary ordering, and zero whole-asset physical
  passes.

Latest local suites:

```text
go test ./TreeDB/db -count=1             PASS (544.889s)
go test ./TreeDB/collections -count=1    PASS (199.476s)
go test ./cmd/unified_bench -count=1     PASS (515.945s)
go test ./TreeDB/collections -count=1    PASS (364.922s at ebf51bb98)
go test ./TreeDB/collections -count=1    PASS (237.501s at 1ba4aae17)
go test ./TreeDB/collections -count=1    PASS (198.588s at f0e68a45b)
focused locator/reconstruction tests -count=3 PASS after empty-root fix
focused empty-root tests under -race     PASS
focused base/overlay empty-root tests -count=3 PASS at f0e68a45b
focused base/overlay empty-root tests under -race PASS at f0e68a45b
go vet ./TreeDB/collections              PASS
```

The empty-root review regression was captured red first with the exact absent
locator-root error, then made green while retaining a separate populated-primary
fail-closed guardrail. A second exact-head review regression was also captured
red first for a primary overlay without a locator; the empty exception now
requires both base and overlay primary state to be absent.

## Performance evidence

Public row-ref point-fetch microbenchmark, five samples at 100 iterations:

- time: +1.55% geomean, statistically noisy (`p=0.69`);
- bytes/op: +0.04% geomean;
- allocations/op: +2.88% geomean, approximately two allocations per fetched
  document from strict persistent-locator validation.

The integrated head includes the merged bounded descriptor transition proof
from #3921 and the publication optimization from #3907. Five independent runs
at `ebf51bb98`, followed by compile and warm confirmations on exact latest head
`1ba4aae17`, produced:

| run | load | publish commit | finalize candidate build | WAL-excluded durable storage |
| --- | ---: | ---: | ---: | ---: |
| 1 | 11.840 s | 5.137 s | 0.108 s | 157,367,362 B |
| 2 | 10.909 s | 4.817 s | 0.103 s | 157,367,362 B |
| 3 | 11.585 s | 5.145 s | 0.105 s | 157,372,617 B |
| 4 | 11.422 s | 5.339 s | 0.102 s | 157,372,617 B |
| 5 | 10.845 s | 4.668 s | 0.098 s | 157,367,362 B |
| 6 (`1ba4aae17`, compile) | 11.039 s | 4.628 s | 0.101 s | 157,367,362 B |
| 7 (`1ba4aae17`, warm) | 10.820 s | 4.587 s | 0.100 s | 157,367,362 B |
| 8 (`f0e68a45b`, compile) | 11.045 s | 4.838 s | 0.077 s | 157,367,362 B |
| 9 (`f0e68a45b`, warm) | 10.874 s | 4.567 s | 0.079 s | 157,367,362 B |

All nine runs pass the focused `<= 0.5 s` finalize-candidate-build gate. The
compile runs include the Go toolchain and reached 1,172,180/1,227,456 KiB
and 1,274,216 KiB whole-command RSS; the warm runs were 474,380-542,608 KiB,
including 499,240 KiB on exact latest head `f0e68a45b`. The remaining
canonical 10M load/query/resource/correctness contract remains owned by #3900.

Exact command shape:

```text
/usr/bin/time -v env PROFILE=durable DATA_DIR=/home/mikers/data/bluesky \
  ROWS=1000000 TRIES=1 GOMAP_REPLACE=/mnt/fast4tb/gomap-3906-final \
  STORAGE_LAYOUTS=column-store-full-prepared \
  QUERY_MODE=one_shot_end_to_end METADATA_MODE=no_aggregate_metadata \
  SUITE=full VALIDATE_RECONSTRUCTION=0 TREEDB_ALLOW_ERRORS=1 \
  OUT_DIR=<attempt> ./treedb/run_columnstore_benchmark.sh
```

Artifacts:

- `/mnt/fast4tb/gomap_3067_execution_20260718/3906_locator_bench`
- `/mnt/fast4tb/gomap_3067_execution_20260718/3906_locator_perf_100k`
- `/mnt/fast4tb/gomap_3067_execution_20260718/3906_exact_head_perf_20260719T193601Z`
- `/mnt/fast4tb/gomap_3067_execution_20260718/3906_exact_head_f0e68_perf_20260719T201125Z`
- `/mnt/fast4tb/gomap_3067_execution_20260718/3906_{db,collections,unified}_test.log`
