### PR TITLE
TreeDB vector partitioning M0: contract, oracle, and benchmark baseline

### DIFF
--- a/TreeDB/docs/spec/README.md
+++ b/TreeDB/docs/spec/README.md
@@ -70,6 +70,10 @@ Given pre-alpha status, this is a living spec that tracks implementation.
 
 ### Canonical specs
 
+- `TreeDB/docs/spec/vector-partition-raft-v1.md`
+  - #3908/#3909 M0 contract for derived vector-partition identity, generation
+    invalidation, simulation-only oracle evidence, and clean-room provenance.
+
 - `TreeDB/docs/spec/architecture.md`
   - system model, components, directory layout, side stores, lock model.
 - `TreeDB/docs/spec/contracts.md`

--- a/TreeDB/docs/spec/vector-partition-raft-v1.md
+++ b/TreeDB/docs/spec/vector-partition-raft-v1.md
@@ -68,7 +68,8 @@ Every local response MUST report
 `exact_hnsw_search_pack_v1`, an active pack, and zero pack fallbacks. The
 harness fails instead of accepting another route. Repeated overlap rows reuse
 a cache whose key contains the query, top-k, and sorted partition-ID set.
-Artifacts distinguish logical, executed, and cached searches.
+Artifacts distinguish logical, executed, and cached searches, and serialize
+all HNSW evidence counters even when their value is explicitly zero.
 This is real TreeDB local-HNSW loss attribution, but its temporary modulo
 partitioning, sequential coordinator, and absent network/Raft path remain
 non-production simulation. With every partition probed, the partition oracle
@@ -81,10 +82,25 @@ fixtures with at least ten vectors and every available neighbor for smaller
 fixtures. The generated corpus includes an explicit duplicate/tie case,
 clusters, and boundary shape. Tests resolve the
 single root fixture from `cmd/treedb_vector_partition_bench`. The manifest read
-itself has a 64 KiB bound. Combined vector/query counts and bytes, dimensions,
-partition count, and result metrics are validated before allocating large work
-buffers or building TreeDB evidence. The JSON schema version is strict; unknown
-versions and non-finite metrics are rejected by the executable contract.
+itself has a 64 KiB bound. `-seed` MUST equal the manifest generation seed;
+the result repeats that bound seed and its fixed-width bit pattern is part of
+the artifact basename. Combined vector/query counts, dimensions, partition
+count, and result metrics are validated before allocating large work buffers
+or building TreeDB evidence. The JSON schema version is strict; unknown
+versions, non-finite metrics, and provenance other than exact 40-hex SHAs are
+rejected by the executable contract.
+
+`-max-fixture-bytes` caps a conservative model of simultaneous live,
+benchmark-owned material rather than only raw vector elements. The preflight
+model includes contiguous generated `float64` vector/query matrices and row
+headers, bounded exact and selected top-k candidates, representative routing,
+whole-partition HNSW JSON serialization plus decoded JSON/vector batch material,
+HNSW query merge storage, and the persistent cross-overlap HNSW result cache.
+It applies 25 percent allocation slack. It explicitly excludes TreeDB engine
+and index internals, Go runtime/GC metadata, and CLI/artifact encoding. The
+artifact records the requested cap, modeled peak, and this scope. Checksum
+validation consumes the already generated matrices and does not regenerate a
+second full fixture.
 
 The schema reserves every descendant evidence family even when M0 emits
 `measurement_status=simulation_not_measured` and explicit finite zero values:
@@ -92,8 +108,10 @@ build wall/CPU/RSS/temp/final bytes; balance/cut/overlap; representatives and
 router latency; fanout/RPC/bytes/shard/merge/failure counters; and QPS,
 percentiles, recall@1/10/100, allocations, resident/mapped bytes. Artifact
 provenance is the real `HEAD` and `merge-base HEAD origin/main`, a bounded
-`pull_request.base.sha` from `GITHUB_EVENT_PATH` in shallow PR CI, or explicit
-`GITHUB_SHA`/`BASE_SHA` overrides; empty/local provenance is rejected.
+`pull_request.base.sha` and `pull_request.head.sha` pair from
+`GITHUB_EVENT_PATH` in shallow PR CI, or explicit `GITHUB_SHA`/`BASE_SHA`
+overrides. A PR event head replaces GitHub's synthetic merge `GITHUB_SHA`;
+empty or malformed provenance is rejected.
 
 ## Parent invariant matrix
 

--- a/TreeDB/docs/spec/vector-partition-raft-v1.md
+++ b/TreeDB/docs/spec/vector-partition-raft-v1.md
@@ -76,8 +76,10 @@ MUST equal global exact top-k under ordered distance and stable-ID comparison.
 
 The checked-in fixture manifest at `testdata/vector_partition_10k/` is generated
 deterministically and has a stable checksum over canonical generated vector,
-query, and exact-truth bytes,
-explicit duplicate/tie case, clusters, and boundary shape. Tests resolve the
+query, and exact-truth bytes. Exact-truth checksum binding covers top-10 for
+fixtures with at least ten vectors and every available neighbor for smaller
+fixtures. The generated corpus includes an explicit duplicate/tie case,
+clusters, and boundary shape. Tests resolve the
 single root fixture from `cmd/treedb_vector_partition_bench`. The manifest read
 itself has a 64 KiB bound. Combined vector/query counts and bytes, dimensions,
 partition count, and result metrics are validated before allocating large work

--- a/TreeDB/docs/spec/vector-partition-raft-v1.md
+++ b/TreeDB/docs/spec/vector-partition-raft-v1.md
@@ -75,9 +75,14 @@ partitioning, sequential coordinator, and absent network/Raft path remain
 non-production simulation. With every partition probed, the partition oracle
 MUST equal global exact top-k under ordered distance and stable-ID comparison.
 
-The checked-in fixture manifest at `testdata/vector_partition_10k/` is generated
-deterministically and has a stable checksum over canonical generated vector,
-query, and exact-truth bytes. Exact-truth checksum binding covers top-10 for
+The checked-in fixture manifest at `testdata/vector_partition_10k/` uses
+generator `treedb_vector_partition_fixture_v2` and arithmetic contract
+`ieee754_binary64_explicit_fma_v1`. Normalization, exact-oracle dot products,
+and representative-routing dot products use explicit `math.FMA` accumulation
+so compiler- or architecture-dependent multiply-add contraction cannot alter
+the generated fixture or truth. Its stable checksum binds the exact IEEE-754
+binary64 bits of every generated vector and query, then the ordered exact-truth
+IDs and distance bits. Exact-truth checksum binding covers top-10 for
 fixtures with at least ten vectors and every available neighbor for smaller
 fixtures. The generated corpus includes an explicit duplicate/tie case,
 clusters, and boundary shape. Tests resolve the

--- a/TreeDB/docs/spec/vector-partition-raft-v1.md
+++ b/TreeDB/docs/spec/vector-partition-raft-v1.md
@@ -102,6 +102,15 @@ artifact records the requested cap, modeled peak, and this scope. Checksum
 validation consumes the already generated matrices and does not regenerate a
 second full fixture.
 
+An independent fixed work gate rejects more than 200,000,000 modeled
+benchmark-owned vector/query corpus visits before fixture generation or
+evidence. One visit is one vector considered for one query. The model counts
+checksum exact truth once, the mandatory global truth pass for every
+probe/overlap artifact row, and each enabled exhaustive or representative
+routing corpus pass. It excludes TreeDB HNSW engine-internal search work. The
+canonical `10k x 128`, three-probe, two-overlap, all-stage shape has 67 corpus
+passes, or 85,760,000 visits, and remains within the gate.
+
 The schema reserves every descendant evidence family even when M0 emits
 `measurement_status=simulation_not_measured` and explicit finite zero values:
 build wall/CPU/RSS/temp/final bytes; balance/cut/overlap; representatives and
@@ -144,8 +153,15 @@ real multi-group matched-recall evidence.
 `cmd/treedb_vector_dataset_export` also supports a declared 1M-vector local
 corpus (`-docs 1000000`) within its pre-allocation byte caps. Its manifest pins
 vector/query checksums, dimensions, metric, query set, and an exhaustive
-distance-then-ID top-k truth stream. Exact truth is deliberately comparison
-capped; a feasible declared 1M export uses one bounded query shard:
+distance-then-ID top-k truth stream. The exporter materializes document vectors
+once in a contiguous `float32` corpus, precomputes their squared norms, and
+reuses those bytes for vector/JSON output, query selection, and exact truth.
+Truth selection retains only bounded top-k candidates. Its modeled truth peak
+cap includes the document corpus, norm array, generator/query scratch, top-k
+candidates/results, conservative encoded truth-row growth, and a 1 MiB
+per-row encoding allowance; combined output vector bytes remain separately
+capped. Exact truth is deliberately comparison capped; a feasible declared 1M
+export uses one bounded query shard:
 `GOWORK=off go run ./cmd/treedb_vector_dataset_export -out "$OUT" -docs 1000000 -queries 1 -dims 64 -top-k 10`.
 It is a corpus export contract, not a claim that M0 has run a 1M-vector
 exhaustive top-k benchmark.

--- a/TreeDB/docs/spec/vector-partition-raft-v1.md
+++ b/TreeDB/docs/spec/vector-partition-raft-v1.md
@@ -50,7 +50,10 @@ consistency, or shard failure is an explicit error with no incomplete result.
 It emits `result_kind=simulation_only` and `production_evidence=false`; its
 Markdown artifacts repeat that it is not production Raft evidence. It records
 the exact global top-k, partition oracle, representative/local-HNSW attribution
-placeholders, and end-to-end simulation separately. With every partition
+stages, and end-to-end simulation separately. The TreeDB partition-local HNSW
+stage is explicitly unavailable in M0 because this harness has not yet created
+generation-bound partition-local packs; it MUST NOT be interpreted as an exact
+placeholder or production evidence. With every partition
 probed, the partition oracle MUST equal global exact top-k under distance then
 stable-ID ordering.
 
@@ -67,7 +70,9 @@ The schema reserves every descendant evidence family even when M0 emits
 `measurement_status=simulation_not_measured` and explicit finite zero values:
 build wall/CPU/RSS/temp/final bytes; balance/cut/overlap; representatives and
 router latency; fanout/RPC/bytes/shard/merge/failure counters; and QPS,
-percentiles, recall@1/10/100, allocations, resident/mapped bytes.
+percentiles, recall@1/10/100, allocations, resident/mapped bytes. Artifact
+provenance is the real `HEAD` and `merge-base HEAD origin/main` (or explicit
+`GITHUB_SHA`/`BASE_SHA` overrides); empty/local provenance is rejected.
 
 ## Parent invariant matrix
 

--- a/TreeDB/docs/spec/vector-partition-raft-v1.md
+++ b/TreeDB/docs/spec/vector-partition-raft-v1.md
@@ -89,11 +89,13 @@ clusters, and boundary shape. Tests resolve the
 single root fixture from `cmd/treedb_vector_partition_bench`. The manifest read
 itself has a 64 KiB bound. `-seed` MUST equal the manifest generation seed;
 the result repeats that bound seed and its fixed-width bit pattern is part of
-the artifact basename. Combined vector/query counts, dimensions, partition
-count, and result metrics are validated before allocating large work buffers
-or building TreeDB evidence. The JSON schema version is strict; unknown
-versions, non-finite metrics, and provenance other than exact 40-hex SHAs are
-rejected by the executable contract.
+the artifact basename. The basename also binds the full fixture checksum,
+partition count, probes, exact overlap bits, and top-k, so evidence from
+different datasets or partition configurations cannot overwrite another row.
+Combined vector/query counts, dimensions, partition count, and result metrics
+are validated before allocating large work buffers or building TreeDB evidence.
+The JSON schema version is strict; unknown versions, non-finite metrics, and
+provenance other than exact 40-hex SHAs are rejected by the executable contract.
 
 `-max-fixture-bytes` caps a conservative model of simultaneous live,
 benchmark-owned material rather than only raw vector elements. The preflight
@@ -124,8 +126,10 @@ percentiles, recall@1/10/100, allocations, resident/mapped bytes. Artifact
 provenance is the real `HEAD` and `merge-base HEAD origin/main`, a bounded
 `pull_request.base.sha` and `pull_request.head.sha` pair from
 `GITHUB_EVENT_PATH` in shallow PR CI, or explicit `GITHUB_SHA`/`BASE_SHA`
-overrides. A PR event head replaces GitHub's synthetic merge `GITHUB_SHA`;
-empty or malformed provenance is rejected.
+overrides when no pull-request event is present. A bounded pull-request event
+pair overrides both environment values, ensuring GitHub's synthetic merge
+`GITHUB_SHA` is never recorded as the candidate head; empty or malformed
+provenance is rejected.
 
 ## Parent invariant matrix
 
@@ -158,15 +162,18 @@ real multi-group matched-recall evidence.
 `cmd/treedb_vector_dataset_export` also supports a declared 1M-vector local
 corpus (`-docs 1000000`) within its pre-allocation byte caps. Its manifest pins
 vector/query checksums, dimensions, metric, query set, and an exhaustive
-distance-then-ID top-k truth stream. The exporter materializes document vectors
-once in a contiguous `float32` corpus, precomputes their squared norms, and
-reuses those bytes for vector/JSON output, query selection, and exact truth.
-Truth selection retains only bounded top-k candidates. Its modeled truth peak
-cap includes the document corpus, norm array, generator/query scratch, top-k
-candidates/results, conservative encoded truth-row growth, and a 1 MiB
-per-row encoding allowance; combined output vector bytes remain separately
-capped. Exact truth is deliberately comparison capped; a feasible declared 1M
-export uses one bounded query shard:
+distance-then-ID top-k truth stream for a declared leading query prefix.
+`-truth-queries` defaults to all exported queries for standalone compatibility,
+normalizes to `1..queries`, and is recorded as `exact_truth_queries`. The fixed
+200,000,000 comparison gate applies to `docs * truth_queries`, not every
+exported benchmark query. The exporter materializes document vectors once in a
+contiguous `float32` corpus, precomputes their squared norms, and reuses those
+bytes for vector/JSON output, query selection, and exact truth. Truth selection
+retains only bounded top-k candidates. Its modeled truth peak cap includes the
+document corpus, norm array, generator/query scratch, top-k candidates/results,
+conservative encoded truth-row growth, and a 1 MiB per-row encoding allowance;
+combined output vector bytes remain separately capped. A feasible declared 1M
+export uses one bounded truth query:
 `GOWORK=off go run ./cmd/treedb_vector_dataset_export -out "$OUT" -docs 1000000 -queries 1 -dims 64 -top-k 10`.
 It is a corpus export contract, not a claim that M0 has run a 1M-vector
 exhaustive top-k benchmark.

--- a/TreeDB/docs/spec/vector-partition-raft-v1.md
+++ b/TreeDB/docs/spec/vector-partition-raft-v1.md
@@ -90,8 +90,10 @@ single root fixture from `cmd/treedb_vector_partition_bench`. The manifest read
 itself has a 64 KiB bound. `-seed` MUST equal the manifest generation seed;
 the result repeats that bound seed and its fixed-width bit pattern is part of
 the artifact basename. The basename also binds the full fixture checksum,
-partition count, probes, exact overlap bits, and top-k, so evidence from
-different datasets or partition configurations cannot overwrite another row.
+partition count, probes, exact overlap bits, top-k, and a full SHA-256 over the
+canonical selected-stage set, so evidence from different datasets, partition
+configurations, or independently selected stage sets cannot overwrite another
+row.
 Combined vector/query counts, dimensions, partition count, and result metrics
 are validated before allocating large work buffers or building TreeDB evidence.
 The JSON schema version is strict; unknown versions, non-finite metrics, and
@@ -163,10 +165,12 @@ real multi-group matched-recall evidence.
 corpus (`-docs 1000000`) within its pre-allocation byte caps. Its manifest pins
 vector/query checksums, dimensions, metric, query set, and an exhaustive
 distance-then-ID top-k truth stream for a declared leading query prefix.
-`-truth-queries` defaults to all exported queries for standalone compatibility,
-normalizes to `1..queries`, and is recorded as `exact_truth_queries`. The fixed
-200,000,000 comparison gate applies to `docs * truth_queries`, not every
-exported benchmark query. The exporter materializes document vectors once in a
+`-truth-queries` defaults to all exported queries when omitted for standalone
+compatibility, accepts `0..queries`, and is recorded as
+`exact_truth_queries`. Explicit zero emits an empty truth stream while
+retaining all exported query vectors. The fixed 200,000,000 comparison gate
+applies to `docs * truth_queries`, not every exported benchmark query. The
+exporter materializes document vectors once in a
 contiguous `float32` corpus, precomputes their squared norms, and reuses those
 bytes for vector/JSON output, query selection, and exact truth. Truth selection
 retains only bounded top-k candidates. Its modeled truth peak cap includes the

--- a/TreeDB/docs/spec/vector-partition-raft-v1.md
+++ b/TreeDB/docs/spec/vector-partition-raft-v1.md
@@ -46,33 +46,52 @@ consistency, or shard failure is an explicit error with no incomplete result.
 
 ## M0 oracle and evidence boundary
 
-`cmd/treedb_vector_partition_bench` is a sequential, in-memory **simulation**.
-It emits `result_kind=simulation_only` and `production_evidence=false`; its
-Markdown artifacts repeat that it is not production Raft evidence. It records
-the exact global top-k, partition oracle, representative/local-HNSW attribution
-stages, and end-to-end simulation separately. The TreeDB partition-local HNSW
-stage is explicitly unavailable in M0 because this harness has not yet created
-generation-bound partition-local packs; it MUST NOT be interpreted as an exact
-placeholder or production evidence. With every partition
-probed, the partition oracle MUST equal global exact top-k under distance then
-stable-ID ordering.
+`cmd/treedb_vector_partition_bench` is a sequential **simulation**. It emits
+`result_kind=simulation_only` and `production_evidence=false`; its Markdown
+artifacts repeat that it is not production Raft evidence. It records exact
+global top-k, partition oracle, representative routing, exact partition-local
+search, real TreeDB partition-local HNSW, and end-to-end simulation separately.
+
+The HNSW stage deterministically derives one collection per logical modulo
+partition in a temporary TreeDB. The harness uses the public lifecycle:
+`SaveFormatConfig` with `RequiredFeatureCommandWALV1`, `db.Open`,
+`NewCollectionManager`, JSON `float32_vector` typed-column ownership,
+`VectorIndexStrategyColumnGraph`, `InsertBatch`, `Flush`,
+`RebuildVectorIndex`, and response-owned `SearchVectorIndex` results. It builds
+these derived collections and indexes once per harness run only when that stage
+is selected. For each query it uses exact representative routing to choose
+logical partitions, searches their prepared local indexes, then merges by
+cosine distance followed by stable document ID.
+
+Every local response MUST report
+`SearchRouteHNSWSearchPack=1`, route
+`exact_hnsw_search_pack_v1`, an active pack, and zero pack fallbacks. The
+harness fails instead of accepting another route. Repeated overlap rows reuse
+a cache whose key contains the query, top-k, and sorted partition-ID set.
+Artifacts distinguish logical, executed, and cached searches.
+This is real TreeDB local-HNSW loss attribution, but its temporary modulo
+partitioning, sequential coordinator, and absent network/Raft path remain
+non-production simulation. With every partition probed, the partition oracle
+MUST equal global exact top-k under ordered distance and stable-ID comparison.
 
 The checked-in fixture manifest at `testdata/vector_partition_10k/` is generated
 deterministically and has a stable checksum over canonical generated vector,
 query, and exact-truth bytes,
 explicit duplicate/tie case, clusters, and boundary shape. Tests resolve the
-single root fixture from `cmd/treedb_vector_partition_bench`. Counts,
-dimensions, partition count, and result metrics are validated before allocating
-large work buffers. The JSON schema version is strict; unknown versions and
-non-finite metrics are rejected by the executable contract.
+single root fixture from `cmd/treedb_vector_partition_bench`. The manifest read
+itself has a 64 KiB bound. Combined vector/query counts and bytes, dimensions,
+partition count, and result metrics are validated before allocating large work
+buffers or building TreeDB evidence. The JSON schema version is strict; unknown
+versions and non-finite metrics are rejected by the executable contract.
 
 The schema reserves every descendant evidence family even when M0 emits
 `measurement_status=simulation_not_measured` and explicit finite zero values:
 build wall/CPU/RSS/temp/final bytes; balance/cut/overlap; representatives and
 router latency; fanout/RPC/bytes/shard/merge/failure counters; and QPS,
 percentiles, recall@1/10/100, allocations, resident/mapped bytes. Artifact
-provenance is the real `HEAD` and `merge-base HEAD origin/main` (or explicit
-`GITHUB_SHA`/`BASE_SHA` overrides); empty/local provenance is rejected.
+provenance is the real `HEAD` and `merge-base HEAD origin/main`, a bounded
+`pull_request.base.sha` from `GITHUB_EVENT_PATH` in shallow PR CI, or explicit
+`GITHUB_SHA`/`BASE_SHA` overrides; empty/local provenance is rejected.
 
 ## Parent invariant matrix
 
@@ -84,6 +103,7 @@ provenance is the real `HEAD` and `merge-base HEAD origin/main` (or explicit
 | snapshot mutation fails closed | docs contract test | M7 |
 | IDs/scores only; no partial top-k | docs contract test | M5/M6 |
 | exact all-partition parity and stable ties | `TestTruthOracleTieOrderingAndAllPartitionParity` | M2--M6 |
+| real local HNSW and fail-closed route evidence | `TestTreeDBHNSWStageUsesExactSearchPackAndMatchesHighEFLocalTruth` | M3/M5 |
 | cap-before-allocation/malformed input | `TestMalformedCapAndFiniteInputsRejectBeforeSimulation` | M1--M8 |
 | simulation is not production Raft evidence | `TestCanonicalRunWritesJSONAndMarkdown` | M8 |
 

--- a/TreeDB/docs/spec/vector-partition-raft-v1.md
+++ b/TreeDB/docs/spec/vector-partition-raft-v1.md
@@ -1,0 +1,113 @@
+# Vector-partitioned ANN over Raft: M0 contract
+
+Status: **M0 executable contract** for #3908/#3909. This document deliberately
+defines boundaries and evidence before M1--M8 implement production assets.
+
+## Identity and placement
+
+Canonical TreeDB documents and embeddings are authoritative. The `_id` token
+route determines their canonical Raft-group owner. A **logical vector
+partition** is separate, derived, rebuildable neighborhood membership used only
+to select ANN search packs. A vector may appear in multiple partition-local
+packs only as an overlap membership; that is neither a Raft replica nor an
+additional authoritative document write.
+
+Terminology is intentionally non-interchangeable:
+
+| Term | Meaning |
+| --- | --- |
+| Raft replica | a consensus copy of one canonical group |
+| overlap membership | derived vector ID and score assets in another ANN partition |
+| serving replica | an optional read-serving copy; distinct from both above |
+
+## Generation and consistency
+
+Every artifact carries separate immutable identities: `vector_index_id` names
+the index definition; `source_snapshot_generation` names the source vector
+snapshot; `partition_generation` names derived memberships/packs; and
+`router_generation` names representatives/router. Router, membership,
+representative, and partition-local HNSW artifacts MUST bind all four. States
+are `building`, `ready`, `cutover`, and `invalidated`.
+`ready` requires every referenced artifact to be present, checksum-valid, and
+length-capped before allocation on its declared owner. A `cutover` is atomic
+over the complete generation.
+
+V1 is snapshot-bound: insert, delete, embedding replacement, index-definition
+change, source snapshot replacement, or any committed mutation affecting a
+referenced vector invalidates the generation before the mutation becomes
+searchable. Until full rebuild and cutover, distributed search MUST fail closed;
+it MUST NOT mix generations or return partial top-k. A Raft read-index only
+proves the group applied point; it does not make an older snapshot-built
+generation fresh.
+
+V1 distributed responses contain response-owned stable IDs and scores only.
+Missing owner, stale generation, malformed/capped asset, unsupported
+consistency, or shard failure is an explicit error with no incomplete result.
+
+## M0 oracle and evidence boundary
+
+`cmd/treedb_vector_partition_bench` is a sequential, in-memory **simulation**.
+It emits `result_kind=simulation_only` and `production_evidence=false`; its
+Markdown artifacts repeat that it is not production Raft evidence. It records
+the exact global top-k, partition oracle, representative/local-HNSW attribution
+placeholders, and end-to-end simulation separately. With every partition
+probed, the partition oracle MUST equal global exact top-k under distance then
+stable-ID ordering.
+
+The checked-in fixture manifest at `testdata/vector_partition_10k/` is generated
+deterministically and has a stable checksum over canonical generated vector,
+query, and exact-truth bytes,
+explicit duplicate/tie case, clusters, and boundary shape. Tests resolve the
+single root fixture from `cmd/treedb_vector_partition_bench`. Counts,
+dimensions, partition count, and result metrics are validated before allocating
+large work buffers. The JSON schema version is strict; unknown versions and
+non-finite metrics are rejected by the executable contract.
+
+The schema reserves every descendant evidence family even when M0 emits
+`measurement_status=simulation_not_measured` and explicit finite zero values:
+build wall/CPU/RSS/temp/final bytes; balance/cut/overlap; representatives and
+router latency; fanout/RPC/bytes/shard/merge/failure counters; and QPS,
+percentiles, recall@1/10/100, allocations, resident/mapped bytes.
+
+## Parent invariant matrix
+
+| Parent invariant | M0 executable evidence | Owner after M0 |
+| --- | --- | --- |
+| `_id` ownership differs from ANN membership | `TestDocsVectorPartitionRaftM0Contract` | M1/M5 |
+| overlap is not Raft replication | docs contract test | M3/M7 |
+| four generation identities, ready/cutover/invalidation | docs contract test | M1/M7 |
+| snapshot mutation fails closed | docs contract test | M7 |
+| IDs/scores only; no partial top-k | docs contract test | M5/M6 |
+| exact all-partition parity and stable ties | `TestTruthOracleTieOrderingAndAllPartitionParity` | M2--M6 |
+| cap-before-allocation/malformed input | `TestMalformedCapAndFiniteInputsRejectBeforeSimulation` | M1--M8 |
+| simulation is not production Raft evidence | `TestCanonicalRunWritesJSONAndMarkdown` | M8 |
+
+## Provenance ledger
+
+| Source | Allowed use | Code copied/adapted |
+| --- | --- | --- |
+| arXiv:2403.01797 | algorithm statements and evaluation vocabulary | none |
+| `larsgottesbueren/gp-ann` | reference/oracle only; GitHub declares no license | none |
+| TreeDB existing dependencies | separately licensed, pinned modules only | none newly introduced by M0 |
+
+M0 makes no paper speedup claim. It implements no production partition format,
+partitioner, overlap membership, kRt, RPC/coordinator, Raft catalog, or routed
+Raft read. M1 owns persisted generation/placement; M2 partitions; M3 overlap
+and local packs; M4 router; M5 routed reads; M6 merge/fanout; M7 lifecycle; M8
+real multi-group matched-recall evidence.
+
+`cmd/treedb_vector_dataset_export` also supports a declared 1M-vector local
+corpus (`-docs 1000000`) within its pre-allocation byte caps. Its manifest pins
+vector/query checksums, dimensions, metric, query set, and an exhaustive
+distance-then-ID top-k truth stream. Exact truth is deliberately comparison
+capped; a feasible declared 1M export uses one bounded query shard:
+`GOWORK=off go run ./cmd/treedb_vector_dataset_export -out "$OUT" -docs 1000000 -queries 1 -dims 64 -top-k 10`.
+It is a corpus export contract, not a claim that M0 has run a 1M-vector
+exhaustive top-k benchmark.
+
+## Verification
+
+```sh
+GOWORK=off go test ./cmd/treedb_vector_partition_bench ./cmd/treedb_vector_dataset_export ./TreeDB/docs -count=1
+GOWORK=off go test ./cmd/treedb_vector_partition_bench -run 'Test.*(Fixture|Truth|Oracle|Manifest|Deterministic|Malformed|Cap).*' -count=1
+```

--- a/TreeDB/docs/vector_partition_raft_v1_test.go
+++ b/TreeDB/docs/vector_partition_raft_v1_test.go
@@ -1,0 +1,21 @@
+package docs_test
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestDocsVectorPartitionRaftM0Contract(t *testing.T) {
+	root, _ := repoRoots(t)
+	b, err := os.ReadFile(filepath.Join(root, "docs", "spec", "vector-partition-raft-v1.md"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, s := range []string{"_id", "logical vector", "Raft replica", "overlap membership", "vector_index_id", "source_snapshot_generation", "partition_generation", "router_generation", "building", "ready", "cutover", "invalidated", "snapshot-bound", "fail closed", "simulation_only", "gp-ann", "Parent invariant matrix", "TestTruthOracleTieOrderingAndAllPartitionParity", "M1 owns", "M8"} {
+		if !strings.Contains(string(b), s) {
+			t.Fatalf("contract missing %q", s)
+		}
+	}
+}

--- a/TreeDB/docs/vector_partition_raft_v1_test.go
+++ b/TreeDB/docs/vector_partition_raft_v1_test.go
@@ -13,7 +13,7 @@ func TestDocsVectorPartitionRaftM0Contract(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	for _, s := range []string{"_id", "logical vector", "Raft replica", "overlap membership", "vector_index_id", "source_snapshot_generation", "partition_generation", "router_generation", "building", "ready", "cutover", "invalidated", "snapshot-bound", "fail closed", "simulation_only", "SearchRouteHNSWSearchPack=1", "exact_hnsw_search_pack_v1", "response-owned", "sorted partition-ID set", "TestTreeDBHNSWStageUsesExactSearchPackAndMatchesHighEFLocalTruth", "treedb_vector_partition_fixture_v2", "ieee754_binary64_explicit_fma_v1", "ordered exact-truth", "gp-ann", "Parent invariant matrix", "TestTruthOracleTieOrderingAndAllPartitionParity", "M1 owns", "M8"} {
+	for _, s := range []string{"_id", "logical vector", "Raft replica", "overlap membership", "vector_index_id", "source_snapshot_generation", "partition_generation", "router_generation", "building", "ready", "cutover", "invalidated", "snapshot-bound", "fail closed", "simulation_only", "SearchRouteHNSWSearchPack=1", "exact_hnsw_search_pack_v1", "response-owned", "sorted partition-ID set", "TestTreeDBHNSWStageUsesExactSearchPackAndMatchesHighEFLocalTruth", "treedb_vector_partition_fixture_v2", "ieee754_binary64_explicit_fma_v1", "full fixture checksum", "overrides both environment values", "exact_truth_queries", "ordered exact-truth", "gp-ann", "Parent invariant matrix", "TestTruthOracleTieOrderingAndAllPartitionParity", "M1 owns", "M8"} {
 		if !strings.Contains(string(b), s) {
 			t.Fatalf("contract missing %q", s)
 		}

--- a/TreeDB/docs/vector_partition_raft_v1_test.go
+++ b/TreeDB/docs/vector_partition_raft_v1_test.go
@@ -13,7 +13,7 @@ func TestDocsVectorPartitionRaftM0Contract(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	for _, s := range []string{"_id", "logical vector", "Raft replica", "overlap membership", "vector_index_id", "source_snapshot_generation", "partition_generation", "router_generation", "building", "ready", "cutover", "invalidated", "snapshot-bound", "fail closed", "simulation_only", "SearchRouteHNSWSearchPack=1", "exact_hnsw_search_pack_v1", "response-owned", "sorted partition-ID set", "TestTreeDBHNSWStageUsesExactSearchPackAndMatchesHighEFLocalTruth", "treedb_vector_partition_fixture_v2", "ieee754_binary64_explicit_fma_v1", "full fixture checksum", "overrides both environment values", "exact_truth_queries", "ordered exact-truth", "gp-ann", "Parent invariant matrix", "TestTruthOracleTieOrderingAndAllPartitionParity", "M1 owns", "M8"} {
+	for _, s := range []string{"_id", "logical vector", "Raft replica", "overlap membership", "vector_index_id", "source_snapshot_generation", "partition_generation", "router_generation", "building", "ready", "cutover", "invalidated", "snapshot-bound", "fail closed", "simulation_only", "SearchRouteHNSWSearchPack=1", "exact_hnsw_search_pack_v1", "response-owned", "sorted partition-ID set", "TestTreeDBHNSWStageUsesExactSearchPackAndMatchesHighEFLocalTruth", "treedb_vector_partition_fixture_v2", "ieee754_binary64_explicit_fma_v1", "full fixture checksum", "canonical selected-stage set", "overrides both environment values", "exact_truth_queries", "ordered exact-truth", "gp-ann", "Parent invariant matrix", "TestTruthOracleTieOrderingAndAllPartitionParity", "M1 owns", "M8"} {
 		if !strings.Contains(string(b), s) {
 			t.Fatalf("contract missing %q", s)
 		}

--- a/TreeDB/docs/vector_partition_raft_v1_test.go
+++ b/TreeDB/docs/vector_partition_raft_v1_test.go
@@ -13,7 +13,7 @@ func TestDocsVectorPartitionRaftM0Contract(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	for _, s := range []string{"_id", "logical vector", "Raft replica", "overlap membership", "vector_index_id", "source_snapshot_generation", "partition_generation", "router_generation", "building", "ready", "cutover", "invalidated", "snapshot-bound", "fail closed", "simulation_only", "SearchRouteHNSWSearchPack=1", "exact_hnsw_search_pack_v1", "response-owned", "sorted partition-ID set", "TestTreeDBHNSWStageUsesExactSearchPackAndMatchesHighEFLocalTruth", "gp-ann", "Parent invariant matrix", "TestTruthOracleTieOrderingAndAllPartitionParity", "M1 owns", "M8"} {
+	for _, s := range []string{"_id", "logical vector", "Raft replica", "overlap membership", "vector_index_id", "source_snapshot_generation", "partition_generation", "router_generation", "building", "ready", "cutover", "invalidated", "snapshot-bound", "fail closed", "simulation_only", "SearchRouteHNSWSearchPack=1", "exact_hnsw_search_pack_v1", "response-owned", "sorted partition-ID set", "TestTreeDBHNSWStageUsesExactSearchPackAndMatchesHighEFLocalTruth", "treedb_vector_partition_fixture_v2", "ieee754_binary64_explicit_fma_v1", "ordered exact-truth", "gp-ann", "Parent invariant matrix", "TestTruthOracleTieOrderingAndAllPartitionParity", "M1 owns", "M8"} {
 		if !strings.Contains(string(b), s) {
 			t.Fatalf("contract missing %q", s)
 		}

--- a/TreeDB/docs/vector_partition_raft_v1_test.go
+++ b/TreeDB/docs/vector_partition_raft_v1_test.go
@@ -13,7 +13,7 @@ func TestDocsVectorPartitionRaftM0Contract(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	for _, s := range []string{"_id", "logical vector", "Raft replica", "overlap membership", "vector_index_id", "source_snapshot_generation", "partition_generation", "router_generation", "building", "ready", "cutover", "invalidated", "snapshot-bound", "fail closed", "simulation_only", "gp-ann", "Parent invariant matrix", "TestTruthOracleTieOrderingAndAllPartitionParity", "M1 owns", "M8"} {
+	for _, s := range []string{"_id", "logical vector", "Raft replica", "overlap membership", "vector_index_id", "source_snapshot_generation", "partition_generation", "router_generation", "building", "ready", "cutover", "invalidated", "snapshot-bound", "fail closed", "simulation_only", "SearchRouteHNSWSearchPack=1", "exact_hnsw_search_pack_v1", "response-owned", "sorted partition-ID set", "TestTreeDBHNSWStageUsesExactSearchPackAndMatchesHighEFLocalTruth", "gp-ann", "Parent invariant matrix", "TestTruthOracleTieOrderingAndAllPartitionParity", "M1 owns", "M8"} {
 		if !strings.Contains(string(b), s) {
 			t.Fatalf("contract missing %q", s)
 		}

--- a/benchmarks/vector_db_compare/README.md
+++ b/benchmarks/vector_db_compare/README.md
@@ -119,11 +119,11 @@ Configuration:
   `TOP_K`: dataset and validation sizes. `VALIDATE_DOCS` applies only to TreeDB
   rows and defaults to `16`. The exporter writes query vectors for all
   `QUERIES`, but exhaustive `exact_truth.jsonl` covers only the leading
-  `VALIDATE_QUERIES` queries. The manifest records that prefix count as
-  `exact_truth_queries`; keep it between `0` and `QUERIES`. Zero disables
-  exported exact-truth rows while retaining all query vectors, matching
-  disabled recall validation. Omitting the exporter's `-truth-queries` flag
-  directly still preserves its standalone default of truth for all queries.
+  `min(VALIDATE_QUERIES, QUERIES)` queries. The manifest records that effective
+  prefix count as `exact_truth_queries`. Zero disables exported exact-truth rows
+  while retaining all query vectors, matching disabled recall validation.
+  Omitting the exporter's `-truth-queries` flag directly still preserves its
+  standalone default of truth for all queries.
 - `SEARCH_CONCURRENCY`: comma-separated search concurrency levels.
 - `M`, `EF_CONSTRUCTION`, `EF_SEARCH`: HNSW parameters.
 - `MIN_RECALL`: recall gate for full-vector rows such as TreeDB exact/default,

--- a/benchmarks/vector_db_compare/README.md
+++ b/benchmarks/vector_db_compare/README.md
@@ -117,7 +117,10 @@ Configuration:
 - `BACKENDS`: comma-separated backend list. Defaults to `treedb,vectorlite`.
 - `DOCS`, `DIMS`, `QUERIES`, `VALIDATE_QUERIES`, `VALIDATE_DOCS`,
   `TOP_K`: dataset and validation sizes. `VALIDATE_DOCS` applies only to TreeDB
-  rows and defaults to `16`.
+  rows and defaults to `16`. The exporter writes query vectors for all
+  `QUERIES`, but exhaustive `exact_truth.jsonl` covers only the leading
+  `VALIDATE_QUERIES` queries. The manifest records that prefix count as
+  `exact_truth_queries`; keep it between `1` and `QUERIES`.
 - `SEARCH_CONCURRENCY`: comma-separated search concurrency levels.
 - `M`, `EF_CONSTRUCTION`, `EF_SEARCH`: HNSW parameters.
 - `MIN_RECALL`: recall gate for full-vector rows such as TreeDB exact/default,
@@ -210,7 +213,10 @@ JSONL and query vectors from the exported binary query file; the Python
 benchmarks consume the exported binary vector files directly. With
 `TREEDB_VALIDATION_EXACT_SOURCE=dataset`, TreeDB recall validation computes the
 exact baseline from `documents.f32`/`queries.f32` and compares result IDs only;
-it does not materialize TreeDB documents for the exact baseline.
+it does not materialize TreeDB documents for the exact baseline. Consumers do
+not require an exact-truth row for every benchmark query: they validate the
+declared leading prefix or recompute their selected exact baseline from the
+vector files.
 
 Record the generated `README.md`, backend JSON results, and `comparison.md` with
 any published result. The script records the git commit and run shape; reruns
@@ -224,6 +230,7 @@ RUN_DIR=/tmp/vector_db_compare_100k \
 BACKENDS=treedb,vectorlite,pgvector \
 DOCS=100000 \
 QUERIES=50000 \
+VALIDATE_QUERIES=64 \
 SEARCH_CONCURRENCY=2,4,8,16,32,64,128 \
 scripts/bench_vector_db_compare.sh
 ```

--- a/benchmarks/vector_db_compare/README.md
+++ b/benchmarks/vector_db_compare/README.md
@@ -120,7 +120,10 @@ Configuration:
   rows and defaults to `16`. The exporter writes query vectors for all
   `QUERIES`, but exhaustive `exact_truth.jsonl` covers only the leading
   `VALIDATE_QUERIES` queries. The manifest records that prefix count as
-  `exact_truth_queries`; keep it between `1` and `QUERIES`.
+  `exact_truth_queries`; keep it between `0` and `QUERIES`. Zero disables
+  exported exact-truth rows while retaining all query vectors, matching
+  disabled recall validation. Omitting the exporter's `-truth-queries` flag
+  directly still preserves its standalone default of truth for all queries.
 - `SEARCH_CONCURRENCY`: comma-separated search concurrency levels.
 - `M`, `EF_CONSTRUCTION`, `EF_SEARCH`: HNSW parameters.
 - `MIN_RECALL`: recall gate for full-vector rows such as TreeDB exact/default,

--- a/benchmarks/vector_db_compare/README.md
+++ b/benchmarks/vector_db_compare/README.md
@@ -121,13 +121,16 @@ Configuration:
   `QUERIES`, but exhaustive `exact_truth.jsonl` covers only the leading
   `min(VALIDATE_QUERIES, QUERIES)` queries. The manifest records that effective
   prefix count as `exact_truth_queries`. Zero disables exported exact-truth rows
-  while retaining all query vectors, matching disabled recall validation.
+  while retaining all query vectors, matching disabled recall validation. When
+  validation is disabled, the runner passes an effective minimum recall of `0`
+  to every backend while retaining configured recall gates in the run metadata.
   Omitting the exporter's `-truth-queries` flag directly still preserves its
   standalone default of truth for all queries.
 - `SEARCH_CONCURRENCY`: comma-separated search concurrency levels.
 - `M`, `EF_CONSTRUCTION`, `EF_SEARCH`: HNSW parameters.
 - `MIN_RECALL`: recall gate for full-vector rows such as TreeDB exact/default,
-  Vectorlite, pgvector, and MongoDB. Defaults to `0.95`.
+  Vectorlite, pgvector, and MongoDB. Defaults to `0.95`; its effective value is
+  `0` when `VALIDATE_QUERIES=0`.
 - `TREEDB_COLUMN_GRAPH_EF_SEARCH`: optional efSearch override for TreeDB
   `column_graph` rows; defaults to `EF_SEARCH`.
 - `TREEDB_COMPACT`, `TREEDB_COMPACT_SYNC_EACH_PHASE`,
@@ -170,6 +173,7 @@ Configuration:
 - `TREEDB_QUANTIZED_MIN_RECALL`: recall gate for both TreeDB quantized rows.
   Defaults to `0`, so comparisons report quantized recall instead of failing
   before rendering; set a positive value to enforce a quantized recall floor.
+  All quantized recall gates are effectively `0` when `VALIDATE_QUERIES=0`.
 - `TREEDB_QUANTIZED_ONLY_MIN_RECALL` and
   `TREEDB_QUANTIZED_RERANK_MIN_RECALL`: optional scalar_u8/compat per-mode
   overrides for `TREEDB_QUANTIZED_MIN_RECALL`.

--- a/cmd/treedb_vector_dataset_export/main.go
+++ b/cmd/treedb_vector_dataset_export/main.go
@@ -321,21 +321,42 @@ func writeExactTruthJSONL(path string, cfg config, files map[string]fileManifest
 }
 
 func exactTruthForQuery(query []float32, docs, dims, topK int) []truthNeighbor {
+	return exactTruthForVectors(query, docs, topK, func(document int) []float32 {
+		return embedding(document, dims)
+	})
+}
+
+func exactTruthForVectors(query []float32, docs, topK int, vector func(int) []float32) []truthNeighbor {
 	neighbors := make([]truthNeighbor, docs)
 	for document := 0; document < docs; document++ {
-		var dot float64
-		for dimension, value := range embedding(document, dims) {
-			dot += float64(value) * float64(query[dimension])
-		}
 		neighbors[document] = truthNeighbor{
 			DocumentID: documentID(document),
-			Distance:   1 - dot,
+			Distance:   cosineDistance(query, vector(document)),
 		}
 	}
 	sort.Slice(neighbors, func(i, j int) bool {
 		return truthNeighborLess(neighbors[i], neighbors[j])
 	})
 	return neighbors[:topK]
+}
+
+func cosineDistance(a, b []float32) float64 {
+	if len(a) != len(b) {
+		return math.NaN()
+	}
+	var dot, normA, normB float64
+	for i, av := range a {
+		bv := b[i]
+		dot += float64(av) * float64(bv)
+		normA += float64(av) * float64(av)
+		normB += float64(bv) * float64(bv)
+	}
+	if normA == 0 || normB == 0 {
+		return 1
+	}
+	similarity := dot / math.Sqrt(normA*normB)
+	similarity = max(-1, min(1, similarity))
+	return 1 - similarity
 }
 
 func truthNeighborLess(a, b truthNeighbor) bool {

--- a/cmd/treedb_vector_dataset_export/main.go
+++ b/cmd/treedb_vector_dataset_export/main.go
@@ -14,15 +14,20 @@ import (
 	"math"
 	"os"
 	"path/filepath"
+	"sort"
 	"strconv"
 	"time"
 )
 
 const (
-	defaultDocs       = 10000
-	defaultDimensions = 64
-	defaultQueries    = 10000
-	defaultTopK       = 10
+	defaultDocs         = 10000
+	defaultDimensions   = 64
+	defaultQueries      = 10000
+	defaultTopK         = 10
+	maxDatasetVectors   = 1_000_000
+	maxDatasetDims      = 4_096
+	maxDatasetBytes     = int64(4 << 30)
+	maxTruthComparisons = int64(200_000_000)
 )
 
 type config struct {
@@ -51,6 +56,8 @@ type manifest struct {
 	DocumentsJSONLFile  string                  `json:"documents_jsonl_file"`
 	QueriesJSONLFile    string                  `json:"queries_jsonl_file"`
 	FloatFormat         string                  `json:"float_format"`
+	ExactTruthFile      string                  `json:"exact_truth_file"`
+	ExactTruthKind      string                  `json:"exact_truth_kind"`
 	Files               map[string]fileManifest `json:"files"`
 }
 
@@ -76,6 +83,16 @@ type queryJSONL struct {
 	ID            string    `json:"id"`
 	DocumentIndex int       `json:"document_index"`
 	Embedding     []float32 `json:"embedding"`
+}
+
+type truthNeighbor struct {
+	DocumentID string  `json:"document_id"`
+	Score      float64 `json:"score"`
+}
+type exactTruthJSONL struct {
+	QueryID   string          `json:"query_id"`
+	Neighbors []truthNeighbor `json:"neighbors"`
+	Kind      string          `json:"kind"`
 }
 
 func main() {
@@ -142,6 +159,18 @@ func parseConfig(args []string) (config, error) {
 	if cfg.topK > cfg.docs {
 		return config{}, errors.New("-top-k cannot exceed -docs")
 	}
+	if cfg.docs > maxDatasetVectors || cfg.queries > maxDatasetVectors || cfg.dimensions > maxDatasetDims {
+		return config{}, fmt.Errorf("docs, queries, and dims exceed capped local-corpus limits")
+	}
+	if _, err := checkedVectorBytes(cfg.docs, cfg.dimensions); err != nil {
+		return config{}, err
+	}
+	if _, err := checkedVectorBytes(cfg.queries, cfg.dimensions); err != nil {
+		return config{}, err
+	}
+	if int64(cfg.docs) > maxTruthComparisons/int64(cfg.queries) {
+		return config{}, errors.New("exact truth comparison cap exceeded before allocation; reduce -queries or export in bounded shards")
+	}
 	return cfg, nil
 }
 
@@ -168,6 +197,9 @@ func exportDataset(cfg config) (exportResult, error) {
 	if err := writeQueriesJSONL(filepath.Join(out, "queries.jsonl"), cfg, files); err != nil {
 		return exportResult{}, err
 	}
+	if err := writeExactTruthJSONL(filepath.Join(out, "exact_truth.jsonl"), cfg, files); err != nil {
+		return exportResult{}, err
+	}
 	createdAt, err := manifestCreatedAt()
 	if err != nil {
 		return exportResult{}, err
@@ -189,12 +221,21 @@ func exportDataset(cfg config) (exportResult, error) {
 		DocumentsJSONLFile:  "documents.jsonl",
 		QueriesJSONLFile:    "queries.jsonl",
 		FloatFormat:         "float32_le_row_major",
+		ExactTruthFile:      "exact_truth.jsonl",
+		ExactTruthKind:      "exhaustive_cosine_distance_then_id_top_k_v1",
 		Files:               files,
 	}
 	if err := writeManifest(filepath.Join(out, "manifest.json"), m); err != nil {
 		return exportResult{}, err
 	}
 	return exportResult{Dir: out, Manifest: m}, nil
+}
+
+func checkedVectorBytes(count, dims int) (int64, error) {
+	if count < 1 || dims < 1 || int64(count) > maxDatasetBytes/4/int64(dims) {
+		return 0, errors.New("vector byte product exceeds cap before allocation")
+	}
+	return int64(count) * int64(dims) * 4, nil
 }
 
 func manifestCreatedAt() (string, error) {
@@ -230,6 +271,9 @@ func prepareOutputDir(path string) error {
 }
 
 func writeVectorFile(path string, count, dims int, vector func(int) []float32, files map[string]fileManifest, name string) error {
+	if _, err := checkedVectorBytes(count, dims); err != nil {
+		return err
+	}
 	f, err := os.Create(path)
 	if err != nil {
 		return err
@@ -255,6 +299,41 @@ func writeVectorFile(path string, count, dims int, vector func(int) []float32, f
 		return err
 	}
 	return recordFile(path, h, files, name)
+}
+
+func writeExactTruthJSONL(path string, cfg config, files map[string]fileManifest) error {
+	return writeJSONL(path, files, "exact_truth.jsonl", func(enc *json.Encoder) error {
+		stride := queryDocStride(cfg.docs)
+		for i := 0; i < cfg.queries; i++ {
+			query := embedding(queryDocIndex(i, cfg.docs, stride), cfg.dimensions)
+			type scored struct {
+				id    int
+				score float64
+			}
+			rows := make([]scored, cfg.docs)
+			for j := 0; j < cfg.docs; j++ {
+				var score float64
+				for d, x := range embedding(j, cfg.dimensions) {
+					score += float64(x) * float64(query[d])
+				}
+				rows[j] = scored{j, score}
+			}
+			sort.Slice(rows, func(a, b int) bool {
+				if rows[a].score == rows[b].score {
+					return rows[a].id < rows[b].id
+				}
+				return rows[a].score > rows[b].score
+			})
+			neighbors := make([]truthNeighbor, cfg.topK)
+			for j := range neighbors {
+				neighbors[j] = truthNeighbor{documentID(rows[j].id), rows[j].score}
+			}
+			if err := enc.Encode(exactTruthJSONL{QueryID: fmt.Sprintf("query-%06d", i), Neighbors: neighbors, Kind: "exhaustive_cosine_distance_then_id_top_k_v1"}); err != nil {
+				return err
+			}
+		}
+		return nil
+	})
 }
 
 func writeDocumentsJSONL(path string, cfg config, files map[string]fileManifest) error {

--- a/cmd/treedb_vector_dataset_export/main.go
+++ b/cmd/treedb_vector_dataset_export/main.go
@@ -34,13 +34,14 @@ const (
 )
 
 type config struct {
-	out          string
-	docs         int
-	dimensions   int
-	queries      int
-	truthQueries int
-	topK         int
-	jsonOut      bool
+	out           string
+	docs          int
+	dimensions    int
+	queries       int
+	truthQueries  int
+	truthExplicit bool
+	topK          int
+	jsonOut       bool
 }
 
 type manifest struct {
@@ -179,12 +180,17 @@ func parseConfig(args []string) (config, error) {
 	fs.IntVar(&cfg.docs, "docs", cfg.docs, "Number of synthetic documents to export")
 	fs.IntVar(&cfg.dimensions, "dims", cfg.dimensions, "Vector dimensions per document")
 	fs.IntVar(&cfg.queries, "queries", cfg.queries, "Number of query vectors to export")
-	fs.IntVar(&cfg.truthQueries, "truth-queries", cfg.truthQueries, "Number of leading queries with exhaustive exact truth (default: all queries)")
+	fs.IntVar(&cfg.truthQueries, "truth-queries", cfg.truthQueries, "Number of leading queries with exhaustive exact truth; 0 disables truth (default when omitted: all queries)")
 	fs.IntVar(&cfg.topK, "top-k", cfg.topK, "Nearest-neighbor result count intended for consumers")
 	fs.BoolVar(&cfg.jsonOut, "json", false, "Emit JSON summary")
 	if err := fs.Parse(args); err != nil {
 		return config{}, err
 	}
+	fs.Visit(func(f *flag.Flag) {
+		if f.Name == "truth-queries" {
+			cfg.truthExplicit = true
+		}
+	})
 	if cfg.out == "" {
 		return config{}, errors.New("-out is required")
 	}
@@ -306,17 +312,23 @@ func exportDatasetWithDocumentGenerator(cfg config, generate func(int, int) []fl
 }
 
 func normalizeTruthQueries(cfg config) (config, error) {
-	if cfg.truthQueries == 0 {
+	if cfg.truthQueries == 0 && !cfg.truthExplicit {
 		cfg.truthQueries = cfg.queries
 	}
-	if cfg.truthQueries < 1 || cfg.truthQueries > cfg.queries {
-		return config{}, errors.New("-truth-queries must be between 1 and -queries")
+	if cfg.truthQueries < 0 || cfg.truthQueries > cfg.queries {
+		return config{}, errors.New("-truth-queries must be between 0 and -queries")
 	}
 	return cfg, nil
 }
 
 func checkTruthComparisonCap(docs, truthQueries int) error {
-	if docs < 1 || truthQueries < 1 || int64(docs) > maxTruthComparisons/int64(truthQueries) {
+	if docs < 1 || truthQueries < 0 {
+		return errors.New("exact truth comparison cap exceeded before allocation; reduce -truth-queries or -docs")
+	}
+	if truthQueries == 0 {
+		return nil
+	}
+	if int64(docs) > maxTruthComparisons/int64(truthQueries) {
 		return errors.New("exact truth comparison cap exceeded before allocation; reduce -truth-queries or -docs")
 	}
 	return nil

--- a/cmd/treedb_vector_dataset_export/main.go
+++ b/cmd/treedb_vector_dataset_export/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bufio"
+	"container/heap"
 	"crypto/sha256"
 	"encoding/binary"
 	"encoding/hex"
@@ -26,6 +27,10 @@ const (
 	maxDatasetDims      = 4_096
 	maxDatasetBytes     = int64(4 << 30)
 	maxTruthComparisons = int64(200_000_000)
+	truthCandidateBytes = int64(16)
+	truthNeighborBytes  = int64(48)
+	truthJSONBytes      = int64(192)
+	truthBufferBytes    = int64(1 << 20)
 )
 
 type config struct {
@@ -87,6 +92,44 @@ type truthNeighbor struct {
 	DocumentID string  `json:"document_id"`
 	Distance   float64 `json:"distance"`
 }
+
+type truthCandidate struct {
+	Document int
+	Distance float64
+}
+
+type truthCandidateMaxHeap []truthCandidate
+
+func (h truthCandidateMaxHeap) Len() int { return len(h) }
+func (h truthCandidateMaxHeap) Less(i, j int) bool {
+	return truthCandidateLess(h[j], h[i])
+}
+func (h truthCandidateMaxHeap) Swap(i, j int) { h[i], h[j] = h[j], h[i] }
+func (h *truthCandidateMaxHeap) Push(x any) {
+	*h = append(*h, x.(truthCandidate))
+}
+func (h *truthCandidateMaxHeap) Pop() any {
+	old := *h
+	last := old[len(old)-1]
+	*h = old[:len(old)-1]
+	return last
+}
+
+type documentCorpus struct {
+	values       []float32
+	squaredNorms []float64
+	dimensions   int
+}
+
+func (c documentCorpus) rows() int {
+	return len(c.squaredNorms)
+}
+
+func (c documentCorpus) row(index int) []float32 {
+	start := index * c.dimensions
+	return c.values[start : start+c.dimensions]
+}
+
 type exactTruthJSONL struct {
 	QueryID   string          `json:"query_id"`
 	Neighbors []truthNeighbor `json:"neighbors"`
@@ -169,6 +212,9 @@ func parseConfig(args []string) (config, error) {
 	if _, err := checkedCombinedVectorBytes(cfg.docs, cfg.queries, cfg.dimensions); err != nil {
 		return config{}, err
 	}
+	if _, err := checkedTruthPeakBytes(cfg.docs, cfg.dimensions, cfg.topK); err != nil {
+		return config{}, err
+	}
 	if int64(cfg.docs) > maxTruthComparisons/int64(cfg.queries) {
 		return config{}, errors.New("exact truth comparison cap exceeded before allocation; reduce -queries or export in bounded shards")
 	}
@@ -176,29 +222,40 @@ func parseConfig(args []string) (config, error) {
 }
 
 func exportDataset(cfg config) (exportResult, error) {
+	return exportDatasetWithDocumentGenerator(cfg, embedding)
+}
+
+func exportDatasetWithDocumentGenerator(cfg config, generate func(int, int) []float32) (exportResult, error) {
+	if _, err := checkedTruthPeakBytes(cfg.docs, cfg.dimensions, cfg.topK); err != nil {
+		return exportResult{}, err
+	}
 	out := filepath.Clean(cfg.out)
 	if err := prepareOutputDir(out); err != nil {
 		return exportResult{}, err
 	}
+	documents, err := materializeDocumentCorpus(cfg.docs, cfg.dimensions, generate)
+	if err != nil {
+		return exportResult{}, err
+	}
 	files := make(map[string]fileManifest)
 	if err := writeVectorFile(filepath.Join(out, "documents.f32"), cfg.docs, cfg.dimensions, func(i int) []float32 {
-		return embedding(i, cfg.dimensions)
+		return documents.row(i)
 	}, files, "documents.f32"); err != nil {
 		return exportResult{}, err
 	}
 	queryStride := queryDocStride(cfg.docs)
 	if err := writeVectorFile(filepath.Join(out, "queries.f32"), cfg.queries, cfg.dimensions, func(i int) []float32 {
-		return embedding(queryDocIndex(i, cfg.docs, queryStride), cfg.dimensions)
+		return documents.row(queryDocIndex(i, cfg.docs, queryStride))
 	}, files, "queries.f32"); err != nil {
 		return exportResult{}, err
 	}
-	if err := writeDocumentsJSONL(filepath.Join(out, "documents.jsonl"), cfg, files); err != nil {
+	if err := writeDocumentsJSONL(filepath.Join(out, "documents.jsonl"), cfg, documents, files); err != nil {
 		return exportResult{}, err
 	}
-	if err := writeQueriesJSONL(filepath.Join(out, "queries.jsonl"), cfg, files); err != nil {
+	if err := writeQueriesJSONL(filepath.Join(out, "queries.jsonl"), cfg, documents, files); err != nil {
 		return exportResult{}, err
 	}
-	if err := writeExactTruthJSONL(filepath.Join(out, "exact_truth.jsonl"), cfg, files); err != nil {
+	if err := writeExactTruthJSONL(filepath.Join(out, "exact_truth.jsonl"), cfg, documents, files); err != nil {
 		return exportResult{}, err
 	}
 	createdAt, err := manifestCreatedAt()
@@ -248,6 +305,60 @@ func checkedCombinedVectorBytes(docs, queries, dims int) (int64, error) {
 		return 0, errors.New("combined document/query vector byte product exceeds cap before allocation")
 	}
 	return combined * int64(dims) * 4, nil
+}
+
+func checkedTruthPeakBytes(docs, dims, topK int) (int64, error) {
+	if docs < 1 || dims < 1 || topK < 1 || topK > docs {
+		return 0, errors.New("exact truth peak requires positive docs, dimensions, and top-k no larger than docs")
+	}
+	documentValues, err := checkedVectorBytes(docs, dims)
+	if err != nil {
+		return 0, err
+	}
+	return checkedDatasetByteSum(
+		documentValues,
+		int64(docs)*8,   // precomputed float64 squared norms
+		int64(dims)*4*2, // one generator row and one encoding/query scratch row
+		int64(topK)*truthCandidateBytes,
+		int64(topK)*truthNeighborBytes,
+		int64(topK)*truthJSONBytes, // encoded truth row plus buffer growth
+		truthBufferBytes,
+	)
+}
+
+func checkedDatasetByteSum(values ...int64) (int64, error) {
+	var total int64
+	for _, value := range values {
+		if value < 0 || total > maxDatasetBytes-value {
+			return 0, errors.New("exact truth modeled peak bytes exceed cap before allocation")
+		}
+		total += value
+	}
+	return total, nil
+}
+
+func materializeDocumentCorpus(docs, dims int, generate func(int, int) []float32) (documentCorpus, error) {
+	if generate == nil {
+		return documentCorpus{}, errors.New("document vector generator is required")
+	}
+	if _, err := checkedVectorBytes(docs, dims); err != nil {
+		return documentCorpus{}, err
+	}
+	corpus := documentCorpus{
+		values:       make([]float32, docs*dims),
+		squaredNorms: make([]float64, docs),
+		dimensions:   dims,
+	}
+	for document := 0; document < docs; document++ {
+		generated := generate(document, dims)
+		if len(generated) != dims {
+			return documentCorpus{}, fmt.Errorf("document vector %d dimensions=%d want %d", document, len(generated), dims)
+		}
+		row := corpus.row(document)
+		copy(row, generated)
+		corpus.squaredNorms[document] = squaredNorm(row)
+	}
+	return corpus, nil
 }
 
 func manifestCreatedAt() (string, error) {
@@ -306,12 +417,12 @@ func writeVectorFile(path string, count, dims int, vector func(int) []float32, f
 	return recordFile(path, h, files, name)
 }
 
-func writeExactTruthJSONL(path string, cfg config, files map[string]fileManifest) error {
+func writeExactTruthJSONL(path string, cfg config, documents documentCorpus, files map[string]fileManifest) error {
 	return writeJSONL(path, files, "exact_truth.jsonl", func(enc *json.Encoder) error {
 		stride := queryDocStride(cfg.docs)
 		for i := 0; i < cfg.queries; i++ {
-			query := embedding(queryDocIndex(i, cfg.docs, stride), cfg.dimensions)
-			neighbors := exactTruthForQuery(query, cfg.docs, cfg.dimensions, cfg.topK)
+			query := documents.row(queryDocIndex(i, cfg.docs, stride))
+			neighbors := exactTruthForCorpus(query, documents, cfg.topK)
 			if err := enc.Encode(exactTruthJSONL{QueryID: fmt.Sprintf("query-%06d", i), Neighbors: neighbors, Kind: "exhaustive_cosine_distance_ascending_then_id_top_k_v1"}); err != nil {
 				return err
 			}
@@ -320,36 +431,70 @@ func writeExactTruthJSONL(path string, cfg config, files map[string]fileManifest
 	})
 }
 
-func exactTruthForQuery(query []float32, docs, dims, topK int) []truthNeighbor {
-	return exactTruthForVectors(query, docs, topK, func(document int) []float32 {
-		return embedding(document, dims)
+func exactTruthForCorpus(query []float32, documents documentCorpus, topK int) []truthNeighbor {
+	queryNorm := squaredNorm(query)
+	return boundedExactTruth(documents.rows(), topK, func(document int) float64 {
+		return cosineDistanceWithNorms(query, queryNorm, documents.row(document), documents.squaredNorms[document])
 	})
 }
 
 func exactTruthForVectors(query []float32, docs, topK int, vector func(int) []float32) []truthNeighbor {
-	neighbors := make([]truthNeighbor, docs)
+	return boundedExactTruth(docs, topK, func(document int) float64 {
+		return cosineDistance(query, vector(document))
+	})
+}
+
+func boundedExactTruth(docs, topK int, distance func(int) float64) []truthNeighbor {
+	candidates := make(truthCandidateMaxHeap, 0, min(docs, topK))
 	for document := 0; document < docs; document++ {
-		neighbors[document] = truthNeighbor{
-			DocumentID: documentID(document),
-			Distance:   cosineDistance(query, vector(document)),
+		candidate := truthCandidate{Document: document, Distance: distance(document)}
+		if len(candidates) < topK {
+			heap.Push(&candidates, candidate)
+		} else if truthCandidateLess(candidate, candidates[0]) {
+			candidates[0] = candidate
+			heap.Fix(&candidates, 0)
 		}
 	}
-	sort.Slice(neighbors, func(i, j int) bool {
-		return truthNeighborLess(neighbors[i], neighbors[j])
+	sort.Slice(candidates, func(i, j int) bool {
+		return truthCandidateLess(candidates[i], candidates[j])
 	})
-	return neighbors[:topK]
+	neighbors := make([]truthNeighbor, len(candidates))
+	for i, candidate := range candidates {
+		neighbors[i] = truthNeighbor{DocumentID: documentID(candidate.Document), Distance: candidate.Distance}
+	}
+	return neighbors
+}
+
+func truthCandidateLess(a, b truthCandidate) bool {
+	if a.Distance == b.Distance {
+		return a.Document < b.Document
+	}
+	return a.Distance < b.Distance
 }
 
 func cosineDistance(a, b []float32) float64 {
 	if len(a) != len(b) {
 		return math.NaN()
 	}
-	var dot, normA, normB float64
+	return cosineDistanceWithNorms(a, squaredNorm(a), b, squaredNorm(b))
+}
+
+func squaredNorm(vector []float32) float64 {
+	var norm float64
+	for _, value := range vector {
+		norm += float64(value) * float64(value)
+	}
+	return norm
+}
+
+func cosineDistanceWithNorms(a []float32, normA float64, b []float32, normB float64) float64 {
+	if len(a) != len(b) {
+		return math.NaN()
+	}
+	var dot float64
 	for i, av := range a {
 		bv := b[i]
 		dot += float64(av) * float64(bv)
-		normA += float64(av) * float64(av)
-		normB += float64(bv) * float64(bv)
 	}
 	if normA == 0 || normB == 0 {
 		return 1
@@ -366,14 +511,14 @@ func truthNeighborLess(a, b truthNeighbor) bool {
 	return a.Distance < b.Distance
 }
 
-func writeDocumentsJSONL(path string, cfg config, files map[string]fileManifest) error {
+func writeDocumentsJSONL(path string, cfg config, documents documentCorpus, files map[string]fileManifest) error {
 	return writeJSONL(path, files, "documents.jsonl", func(enc *json.Encoder) error {
 		for i := 0; i < cfg.docs; i++ {
 			if err := enc.Encode(documentJSONL{
 				Index:     i,
 				ID:        documentID(i),
 				Group:     i % 16,
-				Embedding: embedding(i, cfg.dimensions),
+				Embedding: documents.row(i),
 			}); err != nil {
 				return err
 			}
@@ -382,7 +527,7 @@ func writeDocumentsJSONL(path string, cfg config, files map[string]fileManifest)
 	})
 }
 
-func writeQueriesJSONL(path string, cfg config, files map[string]fileManifest) error {
+func writeQueriesJSONL(path string, cfg config, documents documentCorpus, files map[string]fileManifest) error {
 	return writeJSONL(path, files, "queries.jsonl", func(enc *json.Encoder) error {
 		stride := queryDocStride(cfg.docs)
 		for i := 0; i < cfg.queries; i++ {
@@ -391,7 +536,7 @@ func writeQueriesJSONL(path string, cfg config, files map[string]fileManifest) e
 				Index:         i,
 				ID:            fmt.Sprintf("query-%06d", i),
 				DocumentIndex: docIndex,
-				Embedding:     embedding(docIndex, cfg.dimensions),
+				Embedding:     documents.row(docIndex),
 			}); err != nil {
 				return err
 			}

--- a/cmd/treedb_vector_dataset_export/main.go
+++ b/cmd/treedb_vector_dataset_export/main.go
@@ -166,6 +166,9 @@ func parseConfig(args []string) (config, error) {
 	if _, err := checkedVectorBytes(cfg.queries, cfg.dimensions); err != nil {
 		return config{}, err
 	}
+	if _, err := checkedCombinedVectorBytes(cfg.docs, cfg.queries, cfg.dimensions); err != nil {
+		return config{}, err
+	}
 	if int64(cfg.docs) > maxTruthComparisons/int64(cfg.queries) {
 		return config{}, errors.New("exact truth comparison cap exceeded before allocation; reduce -queries or export in bounded shards")
 	}
@@ -236,6 +239,17 @@ func checkedVectorBytes(count, dims int) (int64, error) {
 	return int64(count) * int64(dims) * 4, nil
 }
 
+func checkedCombinedVectorBytes(docs, queries, dims int) (int64, error) {
+	if docs < 1 || queries < 1 || dims < 1 {
+		return 0, errors.New("combined vector byte product requires positive counts and dimensions")
+	}
+	combined := int64(docs) + int64(queries)
+	if combined > maxDatasetBytes/4/int64(dims) {
+		return 0, errors.New("combined document/query vector byte product exceeds cap before allocation")
+	}
+	return combined * int64(dims) * 4, nil
+}
+
 func manifestCreatedAt() (string, error) {
 	return "1970-01-01T00:00:00Z", nil
 }
@@ -297,34 +311,38 @@ func writeExactTruthJSONL(path string, cfg config, files map[string]fileManifest
 		stride := queryDocStride(cfg.docs)
 		for i := 0; i < cfg.queries; i++ {
 			query := embedding(queryDocIndex(i, cfg.docs, stride), cfg.dimensions)
-			type scored struct {
-				id    int
-				score float64
-			}
-			rows := make([]scored, cfg.docs)
-			for j := 0; j < cfg.docs; j++ {
-				var score float64
-				for d, x := range embedding(j, cfg.dimensions) {
-					score += float64(x) * float64(query[d])
-				}
-				rows[j] = scored{j, 1 - score}
-			}
-			sort.Slice(rows, func(a, b int) bool {
-				if rows[a].score == rows[b].score {
-					return rows[a].id < rows[b].id
-				}
-				return rows[a].score < rows[b].score
-			})
-			neighbors := make([]truthNeighbor, cfg.topK)
-			for j := range neighbors {
-				neighbors[j] = truthNeighbor{documentID(rows[j].id), rows[j].score}
-			}
+			neighbors := exactTruthForQuery(query, cfg.docs, cfg.dimensions, cfg.topK)
 			if err := enc.Encode(exactTruthJSONL{QueryID: fmt.Sprintf("query-%06d", i), Neighbors: neighbors, Kind: "exhaustive_cosine_distance_ascending_then_id_top_k_v1"}); err != nil {
 				return err
 			}
 		}
 		return nil
 	})
+}
+
+func exactTruthForQuery(query []float32, docs, dims, topK int) []truthNeighbor {
+	neighbors := make([]truthNeighbor, docs)
+	for document := 0; document < docs; document++ {
+		var dot float64
+		for dimension, value := range embedding(document, dims) {
+			dot += float64(value) * float64(query[dimension])
+		}
+		neighbors[document] = truthNeighbor{
+			DocumentID: documentID(document),
+			Distance:   1 - dot,
+		}
+	}
+	sort.Slice(neighbors, func(i, j int) bool {
+		return truthNeighborLess(neighbors[i], neighbors[j])
+	})
+	return neighbors[:topK]
+}
+
+func truthNeighborLess(a, b truthNeighbor) bool {
+	if a.Distance == b.Distance {
+		return a.DocumentID < b.DocumentID
+	}
+	return a.Distance < b.Distance
 }
 
 func writeDocumentsJSONL(path string, cfg config, files map[string]fileManifest) error {

--- a/cmd/treedb_vector_dataset_export/main.go
+++ b/cmd/treedb_vector_dataset_export/main.go
@@ -15,8 +15,6 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
-	"strconv"
-	"time"
 )
 
 const (
@@ -87,7 +85,7 @@ type queryJSONL struct {
 
 type truthNeighbor struct {
 	DocumentID string  `json:"document_id"`
-	Score      float64 `json:"score"`
+	Distance   float64 `json:"distance"`
 }
 type exactTruthJSONL struct {
 	QueryID   string          `json:"query_id"`
@@ -222,7 +220,7 @@ func exportDataset(cfg config) (exportResult, error) {
 		QueriesJSONLFile:    "queries.jsonl",
 		FloatFormat:         "float32_le_row_major",
 		ExactTruthFile:      "exact_truth.jsonl",
-		ExactTruthKind:      "exhaustive_cosine_distance_then_id_top_k_v1",
+		ExactTruthKind:      "exhaustive_cosine_distance_ascending_then_id_top_k_v1",
 		Files:               files,
 	}
 	if err := writeManifest(filepath.Join(out, "manifest.json"), m); err != nil {
@@ -239,14 +237,7 @@ func checkedVectorBytes(count, dims int) (int64, error) {
 }
 
 func manifestCreatedAt() (string, error) {
-	if raw := os.Getenv("SOURCE_DATE_EPOCH"); raw != "" {
-		epoch, err := strconv.ParseInt(raw, 10, 64)
-		if err != nil {
-			return "", fmt.Errorf("parse SOURCE_DATE_EPOCH: %w", err)
-		}
-		return time.Unix(epoch, 0).UTC().Format(time.RFC3339), nil
-	}
-	return time.Now().UTC().Format(time.RFC3339), nil
+	return "1970-01-01T00:00:00Z", nil
 }
 
 func prepareOutputDir(path string) error {
@@ -316,19 +307,19 @@ func writeExactTruthJSONL(path string, cfg config, files map[string]fileManifest
 				for d, x := range embedding(j, cfg.dimensions) {
 					score += float64(x) * float64(query[d])
 				}
-				rows[j] = scored{j, score}
+				rows[j] = scored{j, 1 - score}
 			}
 			sort.Slice(rows, func(a, b int) bool {
 				if rows[a].score == rows[b].score {
 					return rows[a].id < rows[b].id
 				}
-				return rows[a].score > rows[b].score
+				return rows[a].score < rows[b].score
 			})
 			neighbors := make([]truthNeighbor, cfg.topK)
 			for j := range neighbors {
 				neighbors[j] = truthNeighbor{documentID(rows[j].id), rows[j].score}
 			}
-			if err := enc.Encode(exactTruthJSONL{QueryID: fmt.Sprintf("query-%06d", i), Neighbors: neighbors, Kind: "exhaustive_cosine_distance_then_id_top_k_v1"}); err != nil {
+			if err := enc.Encode(exactTruthJSONL{QueryID: fmt.Sprintf("query-%06d", i), Neighbors: neighbors, Kind: "exhaustive_cosine_distance_ascending_then_id_top_k_v1"}); err != nil {
 				return err
 			}
 		}

--- a/cmd/treedb_vector_dataset_export/main.go
+++ b/cmd/treedb_vector_dataset_export/main.go
@@ -34,12 +34,13 @@ const (
 )
 
 type config struct {
-	out        string
-	docs       int
-	dimensions int
-	queries    int
-	topK       int
-	jsonOut    bool
+	out          string
+	docs         int
+	dimensions   int
+	queries      int
+	truthQueries int
+	topK         int
+	jsonOut      bool
 }
 
 type manifest struct {
@@ -61,6 +62,7 @@ type manifest struct {
 	FloatFormat         string                  `json:"float_format"`
 	ExactTruthFile      string                  `json:"exact_truth_file"`
 	ExactTruthKind      string                  `json:"exact_truth_kind"`
+	ExactTruthQueries   int                     `json:"exact_truth_queries"`
 	Files               map[string]fileManifest `json:"files"`
 }
 
@@ -158,7 +160,7 @@ func run(args []string, stdout io.Writer) error {
 		return enc.Encode(result)
 	}
 	fmt.Fprintf(stdout, "TreeDB vector dataset exported\n")
-	fmt.Fprintf(stdout, "dir=%s docs=%d dims=%d queries=%d top_k=%d\n", result.Dir, cfg.docs, cfg.dimensions, cfg.queries, cfg.topK)
+	fmt.Fprintf(stdout, "dir=%s docs=%d dims=%d queries=%d truth_queries=%d top_k=%d\n", result.Dir, cfg.docs, cfg.dimensions, cfg.queries, result.Manifest.ExactTruthQueries, cfg.topK)
 	for name, file := range result.Manifest.Files {
 		fmt.Fprintf(stdout, "file=%s bytes=%d sha256=%s\n", name, file.Bytes, file.SHA256)
 	}
@@ -177,6 +179,7 @@ func parseConfig(args []string) (config, error) {
 	fs.IntVar(&cfg.docs, "docs", cfg.docs, "Number of synthetic documents to export")
 	fs.IntVar(&cfg.dimensions, "dims", cfg.dimensions, "Vector dimensions per document")
 	fs.IntVar(&cfg.queries, "queries", cfg.queries, "Number of query vectors to export")
+	fs.IntVar(&cfg.truthQueries, "truth-queries", cfg.truthQueries, "Number of leading queries with exhaustive exact truth (default: all queries)")
 	fs.IntVar(&cfg.topK, "top-k", cfg.topK, "Nearest-neighbor result count intended for consumers")
 	fs.BoolVar(&cfg.jsonOut, "json", false, "Emit JSON summary")
 	if err := fs.Parse(args); err != nil {
@@ -193,6 +196,10 @@ func parseConfig(args []string) (config, error) {
 	}
 	if cfg.queries <= 0 {
 		return config{}, errors.New("-queries must be positive")
+	}
+	cfg, err := normalizeTruthQueries(cfg)
+	if err != nil {
+		return config{}, err
 	}
 	if cfg.topK <= 0 {
 		return config{}, errors.New("-top-k must be positive")
@@ -215,8 +222,8 @@ func parseConfig(args []string) (config, error) {
 	if _, err := checkedTruthPeakBytes(cfg.docs, cfg.dimensions, cfg.topK); err != nil {
 		return config{}, err
 	}
-	if int64(cfg.docs) > maxTruthComparisons/int64(cfg.queries) {
-		return config{}, errors.New("exact truth comparison cap exceeded before allocation; reduce -queries or export in bounded shards")
+	if err := checkTruthComparisonCap(cfg.docs, cfg.truthQueries); err != nil {
+		return config{}, err
 	}
 	return cfg, nil
 }
@@ -226,6 +233,14 @@ func exportDataset(cfg config) (exportResult, error) {
 }
 
 func exportDatasetWithDocumentGenerator(cfg config, generate func(int, int) []float32) (exportResult, error) {
+	var err error
+	cfg, err = normalizeTruthQueries(cfg)
+	if err != nil {
+		return exportResult{}, err
+	}
+	if err := checkTruthComparisonCap(cfg.docs, cfg.truthQueries); err != nil {
+		return exportResult{}, err
+	}
 	if _, err := checkedTruthPeakBytes(cfg.docs, cfg.dimensions, cfg.topK); err != nil {
 		return exportResult{}, err
 	}
@@ -281,12 +296,30 @@ func exportDatasetWithDocumentGenerator(cfg config, generate func(int, int) []fl
 		FloatFormat:         "float32_le_row_major",
 		ExactTruthFile:      "exact_truth.jsonl",
 		ExactTruthKind:      "exhaustive_cosine_distance_ascending_then_id_top_k_v1",
+		ExactTruthQueries:   cfg.truthQueries,
 		Files:               files,
 	}
 	if err := writeManifest(filepath.Join(out, "manifest.json"), m); err != nil {
 		return exportResult{}, err
 	}
 	return exportResult{Dir: out, Manifest: m}, nil
+}
+
+func normalizeTruthQueries(cfg config) (config, error) {
+	if cfg.truthQueries == 0 {
+		cfg.truthQueries = cfg.queries
+	}
+	if cfg.truthQueries < 1 || cfg.truthQueries > cfg.queries {
+		return config{}, errors.New("-truth-queries must be between 1 and -queries")
+	}
+	return cfg, nil
+}
+
+func checkTruthComparisonCap(docs, truthQueries int) error {
+	if docs < 1 || truthQueries < 1 || int64(docs) > maxTruthComparisons/int64(truthQueries) {
+		return errors.New("exact truth comparison cap exceeded before allocation; reduce -truth-queries or -docs")
+	}
+	return nil
 }
 
 func checkedVectorBytes(count, dims int) (int64, error) {
@@ -420,7 +453,7 @@ func writeVectorFile(path string, count, dims int, vector func(int) []float32, f
 func writeExactTruthJSONL(path string, cfg config, documents documentCorpus, files map[string]fileManifest) error {
 	return writeJSONL(path, files, "exact_truth.jsonl", func(enc *json.Encoder) error {
 		stride := queryDocStride(cfg.docs)
-		for i := 0; i < cfg.queries; i++ {
+		for i := 0; i < cfg.truthQueries; i++ {
 			query := documents.row(queryDocIndex(i, cfg.docs, stride))
 			neighbors := exactTruthForCorpus(query, documents, cfg.topK)
 			if err := enc.Encode(exactTruthJSONL{QueryID: fmt.Sprintf("query-%06d", i), Neighbors: neighbors, Kind: "exhaustive_cosine_distance_ascending_then_id_top_k_v1"}); err != nil {

--- a/cmd/treedb_vector_dataset_export/main_test.go
+++ b/cmd/treedb_vector_dataset_export/main_test.go
@@ -57,7 +57,7 @@ func TestExportDatasetSmoke(t *testing.T) {
 	if _, ok := parsed.Files["manifest.json"]; ok {
 		t.Fatalf("manifest should not include self-referential manifest.json stats: %+v", parsed.Files["manifest.json"])
 	}
-	if parsed.ExactTruthFile != "exact_truth.jsonl" || parsed.ExactTruthKind != "exhaustive_cosine_distance_then_id_top_k_v1" {
+	if parsed.ExactTruthFile != "exact_truth.jsonl" || parsed.ExactTruthKind != "exhaustive_cosine_distance_ascending_then_id_top_k_v1" {
 		t.Fatalf("missing declared exact truth: %+v", parsed)
 	}
 }
@@ -75,8 +75,36 @@ func TestExportExactTruthIncludesTopK(t *testing.T) {
 	if err := json.Unmarshal([]byte(strings.Split(strings.TrimSpace(string(raw)), "\n")[0]), &row); err != nil {
 		t.Fatal(err)
 	}
-	if len(row.Neighbors) != 3 || row.Kind != "exhaustive_cosine_distance_then_id_top_k_v1" {
+	if len(row.Neighbors) != 3 || row.Kind != "exhaustive_cosine_distance_ascending_then_id_top_k_v1" {
 		t.Fatalf("truth=%+v", row)
+	}
+}
+
+func TestExportDatasetIsByteStableAndTruthUsesAscendingDistance(t *testing.T) {
+	a, b := filepath.Join(t.TempDir(), "a"), filepath.Join(t.TempDir(), "b")
+	cfg := config{docs: 8, dimensions: 4, queries: 2, topK: 3}
+	cfg.out = a
+	if _, err := exportDataset(cfg); err != nil {
+		t.Fatal(err)
+	}
+	cfg.out = b
+	if _, err := exportDataset(cfg); err != nil {
+		t.Fatal(err)
+	}
+	for _, name := range []string{"manifest.json", "documents.f32", "queries.f32", "documents.jsonl", "queries.jsonl", "exact_truth.jsonl"} {
+		x, _ := os.ReadFile(filepath.Join(a, name))
+		y, _ := os.ReadFile(filepath.Join(b, name))
+		if string(x) != string(y) {
+			t.Fatalf("%s is not stable", name)
+		}
+	}
+	raw, _ := os.ReadFile(filepath.Join(a, "exact_truth.jsonl"))
+	var row exactTruthJSONL
+	_ = json.Unmarshal([]byte(strings.Split(strings.TrimSpace(string(raw)), "\n")[0]), &row)
+	for i := 1; i < len(row.Neighbors); i++ {
+		if row.Neighbors[i-1].Distance > row.Neighbors[i].Distance {
+			t.Fatal("truth distances are not ascending")
+		}
 	}
 }
 

--- a/cmd/treedb_vector_dataset_export/main_test.go
+++ b/cmd/treedb_vector_dataset_export/main_test.go
@@ -1,9 +1,13 @@
 package main
 
 import (
+	"encoding/binary"
 	"encoding/json"
+	"fmt"
+	"math"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 	"testing"
 )
@@ -80,6 +84,92 @@ func TestExportExactTruthIncludesTopK(t *testing.T) {
 	}
 }
 
+func TestExportExactTruthMatchesIndependentSmallCorpusRecomputation(t *testing.T) {
+	const (
+		docs    = 9
+		queries = 3
+		dims    = 5
+		topK    = 4
+	)
+	dir := filepath.Join(t.TempDir(), "truth")
+	if _, err := exportDataset(config{out: dir, docs: docs, dimensions: dims, queries: queries, topK: topK}); err != nil {
+		t.Fatal(err)
+	}
+	documentVectors := readFloat32RowsForTest(t, filepath.Join(dir, "documents.f32"), docs, dims)
+	queryVectors := readFloat32RowsForTest(t, filepath.Join(dir, "queries.f32"), queries, dims)
+	raw, err := os.ReadFile(filepath.Join(dir, "exact_truth.jsonl"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	lines := strings.Split(strings.TrimSpace(string(raw)), "\n")
+	if len(lines) != queries {
+		t.Fatalf("truth rows=%d want %d", len(lines), queries)
+	}
+	for queryIndex := 0; queryIndex < queries; queryIndex++ {
+		var got exactTruthJSONL
+		if err := json.Unmarshal([]byte(lines[queryIndex]), &got); err != nil {
+			t.Fatal(err)
+		}
+		want := make([]truthNeighbor, docs)
+		for documentIndex, document := range documentVectors {
+			var dot float64
+			for d, value := range document {
+				dot += float64(value) * float64(queryVectors[queryIndex][d])
+			}
+			want[documentIndex] = truthNeighbor{
+				DocumentID: fmt.Sprintf("doc-%06d", documentIndex),
+				Distance:   1 - dot,
+			}
+		}
+		sort.Slice(want, func(i, j int) bool {
+			if want[i].Distance == want[j].Distance {
+				return want[i].DocumentID < want[j].DocumentID
+			}
+			return want[i].Distance < want[j].Distance
+		})
+		want = want[:topK]
+		if len(got.Neighbors) != len(want) {
+			t.Fatalf("query %d neighbors=%d want %d", queryIndex, len(got.Neighbors), len(want))
+		}
+		for rank := range want {
+			if got.Neighbors[rank].DocumentID != want[rank].DocumentID || math.Float64bits(got.Neighbors[rank].Distance) != math.Float64bits(want[rank].Distance) {
+				t.Fatalf("query %d rank %d got=%+v want=%+v", queryIndex, rank, got.Neighbors[rank], want[rank])
+			}
+		}
+	}
+}
+
+func readFloat32RowsForTest(t *testing.T, path string, count, dims int) [][]float32 {
+	t.Helper()
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(raw) != count*dims*4 {
+		t.Fatalf("%s bytes=%d want %d", path, len(raw), count*dims*4)
+	}
+	rows := make([][]float32, count)
+	for i := range rows {
+		rows[i] = make([]float32, dims)
+		for d := range rows[i] {
+			offset := (i*dims + d) * 4
+			rows[i][d] = math.Float32frombits(binary.LittleEndian.Uint32(raw[offset:]))
+		}
+	}
+	return rows
+}
+
+func TestTruthNeighborLessUsesExplicitDistanceThenIDTieOrder(t *testing.T) {
+	a := truthNeighbor{DocumentID: "doc-000001", Distance: 0.25}
+	b := truthNeighbor{DocumentID: "doc-000002", Distance: 0.25}
+	if !truthNeighborLess(a, b) || truthNeighborLess(b, a) {
+		t.Fatalf("tie helper does not order stable IDs: a=%+v b=%+v", a, b)
+	}
+	if !truthNeighborLess(truthNeighbor{DocumentID: "doc-z", Distance: 0.1}, a) {
+		t.Fatal("tie helper does not prioritize smaller cosine distance")
+	}
+}
+
 func TestExportDatasetIsByteStableAndTruthUsesAscendingDistance(t *testing.T) {
 	a, b := filepath.Join(t.TempDir(), "a"), filepath.Join(t.TempDir(), "b")
 	cfg := config{docs: 8, dimensions: 4, queries: 2, topK: 3}
@@ -114,6 +204,9 @@ func TestParseConfigRejectsCorpusCapsBeforeAllocation(t *testing.T) {
 	}
 	if _, err := checkedVectorBytes(maxDatasetVectors, maxDatasetDims); err == nil {
 		t.Fatal("accepted byte cap")
+	}
+	if _, err := checkedCombinedVectorBytes(maxDatasetVectors, maxDatasetVectors, maxDatasetDims); err == nil {
+		t.Fatal("accepted combined document/query byte cap")
 	}
 }
 

--- a/cmd/treedb_vector_dataset_export/main_test.go
+++ b/cmd/treedb_vector_dataset_export/main_test.go
@@ -106,6 +106,40 @@ func TestExportExactTruthUsesDeclaredLeadingQueryCount(t *testing.T) {
 	}
 }
 
+func TestExportExplicitZeroTruthWritesDeclaredEmptyCoverage(t *testing.T) {
+	const queries = 5
+	dir := filepath.Join(t.TempDir(), "no-truth")
+	res, err := exportDataset(config{
+		out:           dir,
+		docs:          8,
+		dimensions:    4,
+		queries:       queries,
+		truthQueries:  0,
+		truthExplicit: true,
+		topK:          3,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.Manifest.Queries != queries || res.Manifest.ExactTruthQueries != 0 {
+		t.Fatalf("manifest query coverage=%+v", res.Manifest)
+	}
+	raw, err := os.ReadFile(filepath.Join(dir, "exact_truth.jsonl"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(raw) != 0 {
+		t.Fatalf("disabled exact truth emitted %d bytes", len(raw))
+	}
+	info, err := os.Stat(filepath.Join(dir, "queries.f32"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if want := int64(queries * 4 * 4); info.Size() != want {
+		t.Fatalf("query vector bytes=%d want all-query corpus bytes=%d", info.Size(), want)
+	}
+}
+
 func TestExportExactTruthIncludesTopK(t *testing.T) {
 	dir := filepath.Join(t.TempDir(), "truth")
 	if _, err := exportDataset(config{out: dir, docs: 8, dimensions: 4, queries: 2, topK: 3}); err != nil {
@@ -330,6 +364,20 @@ func TestLargeComparisonShapeUsesBoundedTruthPrefixBeforeAllocation(t *testing.T
 	if cfg.truthQueries != 64 || cfg.queries != 50000 {
 		t.Fatalf("normalized query coverage=%+v", cfg)
 	}
+	disabled, err := parseConfig([]string{
+		"-out", filepath.Join(t.TempDir(), "disabled"),
+		"-docs", "100000",
+		"-queries", "50000",
+		"-truth-queries", "0",
+		"-dims", "64",
+		"-top-k", "10",
+	})
+	if err != nil {
+		t.Fatalf("disabled-truth comparison shape rejected: %v", err)
+	}
+	if disabled.truthQueries != 0 || !disabled.truthExplicit {
+		t.Fatalf("disabled truth coverage=%+v", disabled)
+	}
 	if _, err := parseConfig([]string{
 		"-out", filepath.Join(t.TempDir(), "unbounded"),
 		"-docs", "100000",
@@ -349,6 +397,13 @@ func TestTruthQueryBoundsNormalizeBeforeComparisonCap(t *testing.T) {
 	}
 	if cfg.truthQueries != cfg.queries {
 		t.Fatalf("default truth_queries=%d want all queries=%d", cfg.truthQueries, cfg.queries)
+	}
+	explicitZero, err := parseConfig(append(append([]string{}, base...), "-truth-queries", "0"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if explicitZero.truthQueries != 0 || !explicitZero.truthExplicit {
+		t.Fatalf("explicit zero did not disable truth: %+v", explicitZero)
 	}
 	for _, value := range []string{"-1", "5"} {
 		args := append(append([]string{}, base...), "-truth-queries", value)

--- a/cmd/treedb_vector_dataset_export/main_test.go
+++ b/cmd/treedb_vector_dataset_export/main_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -22,7 +23,7 @@ func TestExportDatasetSmoke(t *testing.T) {
 	if res.Manifest.Docs != 8 || res.Manifest.Dimensions != 4 || res.Manifest.Queries != 3 {
 		t.Fatalf("unexpected manifest: %+v", res.Manifest)
 	}
-	for _, name := range []string{"manifest.json", "documents.f32", "queries.f32", "documents.jsonl", "queries.jsonl"} {
+	for _, name := range []string{"manifest.json", "documents.f32", "queries.f32", "documents.jsonl", "queries.jsonl", "exact_truth.jsonl"} {
 		info, err := os.Stat(filepath.Join(dir, name))
 		if err != nil {
 			t.Fatalf("stat %s: %v", name, err)
@@ -55,6 +56,36 @@ func TestExportDatasetSmoke(t *testing.T) {
 	}
 	if _, ok := parsed.Files["manifest.json"]; ok {
 		t.Fatalf("manifest should not include self-referential manifest.json stats: %+v", parsed.Files["manifest.json"])
+	}
+	if parsed.ExactTruthFile != "exact_truth.jsonl" || parsed.ExactTruthKind != "exhaustive_cosine_distance_then_id_top_k_v1" {
+		t.Fatalf("missing declared exact truth: %+v", parsed)
+	}
+}
+
+func TestExportExactTruthIncludesTopK(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "truth")
+	if _, err := exportDataset(config{out: dir, docs: 8, dimensions: 4, queries: 2, topK: 3}); err != nil {
+		t.Fatal(err)
+	}
+	raw, err := os.ReadFile(filepath.Join(dir, "exact_truth.jsonl"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var row exactTruthJSONL
+	if err := json.Unmarshal([]byte(strings.Split(strings.TrimSpace(string(raw)), "\n")[0]), &row); err != nil {
+		t.Fatal(err)
+	}
+	if len(row.Neighbors) != 3 || row.Kind != "exhaustive_cosine_distance_then_id_top_k_v1" {
+		t.Fatalf("truth=%+v", row)
+	}
+}
+
+func TestParseConfigRejectsCorpusCapsBeforeAllocation(t *testing.T) {
+	if _, err := parseConfig([]string{"-out", t.TempDir(), "-docs", "1000001"}); err == nil {
+		t.Fatal("accepted vector cap")
+	}
+	if _, err := checkedVectorBytes(maxDatasetVectors, maxDatasetDims); err == nil {
+		t.Fatal("accepted byte cap")
 	}
 }
 

--- a/cmd/treedb_vector_dataset_export/main_test.go
+++ b/cmd/treedb_vector_dataset_export/main_test.go
@@ -25,7 +25,7 @@ func TestExportDatasetSmoke(t *testing.T) {
 	if err != nil {
 		t.Fatalf("exportDataset: %v", err)
 	}
-	if res.Manifest.Docs != 8 || res.Manifest.Dimensions != 4 || res.Manifest.Queries != 3 {
+	if res.Manifest.Docs != 8 || res.Manifest.Dimensions != 4 || res.Manifest.Queries != 3 || res.Manifest.ExactTruthQueries != 3 {
 		t.Fatalf("unexpected manifest: %+v", res.Manifest)
 	}
 	for _, name := range []string{"manifest.json", "documents.f32", "queries.f32", "documents.jsonl", "queries.jsonl", "exact_truth.jsonl"} {
@@ -62,8 +62,47 @@ func TestExportDatasetSmoke(t *testing.T) {
 	if _, ok := parsed.Files["manifest.json"]; ok {
 		t.Fatalf("manifest should not include self-referential manifest.json stats: %+v", parsed.Files["manifest.json"])
 	}
-	if parsed.ExactTruthFile != "exact_truth.jsonl" || parsed.ExactTruthKind != "exhaustive_cosine_distance_ascending_then_id_top_k_v1" {
+	if parsed.ExactTruthFile != "exact_truth.jsonl" || parsed.ExactTruthKind != "exhaustive_cosine_distance_ascending_then_id_top_k_v1" || parsed.ExactTruthQueries != 3 {
 		t.Fatalf("missing declared exact truth: %+v", parsed)
+	}
+}
+
+func TestExportExactTruthUsesDeclaredLeadingQueryCount(t *testing.T) {
+	const (
+		queries      = 5
+		truthQueries = 2
+	)
+	dir := filepath.Join(t.TempDir(), "truth-prefix")
+	res, err := exportDataset(config{out: dir, docs: 8, dimensions: 4, queries: queries, truthQueries: truthQueries, topK: 3})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.Manifest.Queries != queries || res.Manifest.ExactTruthQueries != truthQueries {
+		t.Fatalf("manifest query coverage=%+v", res.Manifest)
+	}
+	raw, err := os.ReadFile(filepath.Join(dir, "exact_truth.jsonl"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	lines := strings.Split(strings.TrimSpace(string(raw)), "\n")
+	if len(lines) != truthQueries {
+		t.Fatalf("truth rows=%d want declared prefix=%d", len(lines), truthQueries)
+	}
+	for i, line := range lines {
+		var row exactTruthJSONL
+		if err := json.Unmarshal([]byte(line), &row); err != nil {
+			t.Fatal(err)
+		}
+		if row.QueryID != fmt.Sprintf("query-%06d", i) {
+			t.Fatalf("truth row %d query_id=%q", i, row.QueryID)
+		}
+	}
+	info, err := os.Stat(filepath.Join(dir, "queries.f32"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if want := int64(queries * 4 * 4); info.Size() != want {
+		t.Fatalf("query vector bytes=%d want all-query corpus bytes=%d", info.Size(), want)
 	}
 }
 
@@ -273,6 +312,49 @@ func TestMillionDocumentSingleQueryTruthPeakIsFeasible(t *testing.T) {
 		"-top-k", "10",
 	}); err != nil {
 		t.Fatalf("1M-document single-query config rejected: %v", err)
+	}
+}
+
+func TestLargeComparisonShapeUsesBoundedTruthPrefixBeforeAllocation(t *testing.T) {
+	cfg, err := parseConfig([]string{
+		"-out", filepath.Join(t.TempDir(), "large"),
+		"-docs", "100000",
+		"-queries", "50000",
+		"-truth-queries", "64",
+		"-dims", "64",
+		"-top-k", "10",
+	})
+	if err != nil {
+		t.Fatalf("bounded-truth comparison shape rejected: %v", err)
+	}
+	if cfg.truthQueries != 64 || cfg.queries != 50000 {
+		t.Fatalf("normalized query coverage=%+v", cfg)
+	}
+	if _, err := parseConfig([]string{
+		"-out", filepath.Join(t.TempDir(), "unbounded"),
+		"-docs", "100000",
+		"-queries", "50000",
+		"-dims", "64",
+		"-top-k", "10",
+	}); err == nil || !strings.Contains(err.Error(), "truth comparison cap") {
+		t.Fatalf("unbounded all-query truth error=%v", err)
+	}
+}
+
+func TestTruthQueryBoundsNormalizeBeforeComparisonCap(t *testing.T) {
+	base := []string{"-out", t.TempDir(), "-docs", "20", "-queries", "4", "-dims", "4", "-top-k", "2"}
+	cfg, err := parseConfig(base)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.truthQueries != cfg.queries {
+		t.Fatalf("default truth_queries=%d want all queries=%d", cfg.truthQueries, cfg.queries)
+	}
+	for _, value := range []string{"-1", "5"} {
+		args := append(append([]string{}, base...), "-truth-queries", value)
+		if _, err := parseConfig(args); err == nil || !strings.Contains(err.Error(), "-truth-queries") {
+			t.Fatalf("accepted truth query count %s: %v", value, err)
+		}
 	}
 }
 

--- a/cmd/treedb_vector_dataset_export/main_test.go
+++ b/cmd/treedb_vector_dataset_export/main_test.go
@@ -112,13 +112,16 @@ func TestExportExactTruthMatchesIndependentSmallCorpusRecomputation(t *testing.T
 		}
 		want := make([]truthNeighbor, docs)
 		for documentIndex, document := range documentVectors {
-			var dot float64
+			var dot, documentNorm, queryNorm float64
 			for d, value := range document {
-				dot += float64(value) * float64(queryVectors[queryIndex][d])
+				queryValue := queryVectors[queryIndex][d]
+				dot += float64(value) * float64(queryValue)
+				documentNorm += float64(value) * float64(value)
+				queryNorm += float64(queryValue) * float64(queryValue)
 			}
 			want[documentIndex] = truthNeighbor{
 				DocumentID: fmt.Sprintf("doc-%06d", documentIndex),
-				Distance:   1 - dot,
+				Distance:   1 - dot/math.Sqrt(documentNorm*queryNorm),
 			}
 		}
 		sort.Slice(want, func(i, j int) bool {
@@ -136,6 +139,36 @@ func TestExportExactTruthMatchesIndependentSmallCorpusRecomputation(t *testing.T
 				t.Fatalf("query %d rank %d got=%+v want=%+v", queryIndex, rank, got.Neighbors[rank], want[rank])
 			}
 		}
+	}
+}
+
+func TestExactCosineTruthNormalizesNonUnitVectorsAndOrdersTies(t *testing.T) {
+	query := []float32{3, 4}
+	documents := [][]float32{
+		{6, 8},
+		{1, 1},
+		{-4, 3},
+		{1.5, 2},
+		{0, 5},
+	}
+	got := exactTruthForVectors(query, len(documents), len(documents), func(i int) []float32 {
+		return documents[i]
+	})
+	wantIDs := []string{"doc-000000", "doc-000003", "doc-000001", "doc-000004", "doc-000002"}
+	for i, wantID := range wantIDs {
+		if got[i].DocumentID != wantID {
+			t.Fatalf("rank %d id=%q want %q; truth=%+v", i, got[i].DocumentID, wantID, got)
+		}
+	}
+	if math.Abs(got[0].Distance) > 1e-15 || math.Abs(got[1].Distance) > 1e-15 {
+		t.Fatalf("same-direction non-unit vectors must have distance ~0: %+v", got[:2])
+	}
+	wantDiagonal := 1 - 7/(5*math.Sqrt(2))
+	if math.Abs(got[2].Distance-wantDiagonal) > 1e-15 {
+		t.Fatalf("diagonal distance=%g want %g", got[2].Distance, wantDiagonal)
+	}
+	if math.Abs(got[3].Distance-0.2) > 1e-15 || math.Abs(got[4].Distance-1) > 1e-15 {
+		t.Fatalf("nontrivial cosine ranking distances=%+v", got)
 	}
 }
 

--- a/cmd/treedb_vector_dataset_export/main_test.go
+++ b/cmd/treedb_vector_dataset_export/main_test.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
+	"strconv"
 	"strings"
 	"testing"
 )
@@ -231,6 +232,50 @@ func TestExportDatasetIsByteStableAndTruthUsesAscendingDistance(t *testing.T) {
 	}
 }
 
+func TestExportMaterializesDocumentVectorsOnceForAllQueries(t *testing.T) {
+	const (
+		docs    = 11
+		queries = 7
+		dims    = 5
+	)
+	calls := 0
+	_, err := exportDatasetWithDocumentGenerator(config{
+		out:        filepath.Join(t.TempDir(), "dataset"),
+		docs:       docs,
+		dimensions: dims,
+		queries:    queries,
+		topK:       4,
+	}, func(document, dimensions int) []float32 {
+		calls++
+		return embedding(document, dimensions)
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if calls != docs {
+		t.Fatalf("document generator calls=%d want exactly docs=%d, independent of queries=%d", calls, docs, queries)
+	}
+}
+
+func TestMillionDocumentSingleQueryTruthPeakIsFeasible(t *testing.T) {
+	peak, err := checkedTruthPeakBytes(maxDatasetVectors, 64, 10)
+	if err != nil {
+		t.Fatalf("1M-document single-query truth shape rejected: %v", err)
+	}
+	if peak >= maxDatasetBytes {
+		t.Fatalf("1M-document single-query modeled peak=%d cap=%d", peak, maxDatasetBytes)
+	}
+	if _, err := parseConfig([]string{
+		"-out", t.TempDir(),
+		"-docs", strconv.Itoa(maxDatasetVectors),
+		"-queries", "1",
+		"-dims", "64",
+		"-top-k", "10",
+	}); err != nil {
+		t.Fatalf("1M-document single-query config rejected: %v", err)
+	}
+}
+
 func TestParseConfigRejectsCorpusCapsBeforeAllocation(t *testing.T) {
 	if _, err := parseConfig([]string{"-out", t.TempDir(), "-docs", "1000001"}); err == nil {
 		t.Fatal("accepted vector cap")
@@ -240,6 +285,9 @@ func TestParseConfigRejectsCorpusCapsBeforeAllocation(t *testing.T) {
 	}
 	if _, err := checkedCombinedVectorBytes(maxDatasetVectors, maxDatasetVectors, maxDatasetDims); err == nil {
 		t.Fatal("accepted combined document/query byte cap")
+	}
+	if _, err := checkedTruthPeakBytes(maxDatasetVectors, maxDatasetDims, 1); err == nil {
+		t.Fatal("accepted exact truth peak above cap")
 	}
 }
 

--- a/cmd/treedb_vector_partition_bench/main.go
+++ b/cmd/treedb_vector_partition_bench/main.go
@@ -412,15 +412,13 @@ func parseFloats(raw string) ([]float64, error) {
 }
 func provenance() (string, string, error) {
 	base, head := os.Getenv("BASE_SHA"), os.Getenv("GITHUB_SHA")
-	if base == "" || head == "" {
-		if eventPath := os.Getenv("GITHUB_EVENT_PATH"); eventPath != "" {
-			eventBase, eventHead, isPullRequest, err := pullRequestSHAsFromEvent(eventPath)
-			if err != nil {
-				return "", "", fmt.Errorf("GitHub event provenance: %w", err)
-			}
-			if isPullRequest {
-				base, head = eventBase, eventHead
-			}
+	if eventPath := os.Getenv("GITHUB_EVENT_PATH"); eventPath != "" {
+		eventBase, eventHead, isPullRequest, err := pullRequestSHAsFromEvent(eventPath)
+		if err != nil {
+			return "", "", fmt.Errorf("GitHub event provenance: %w", err)
+		}
+		if isPullRequest {
+			base, head = eventBase, eventHead
 		}
 	}
 	if head == "" {
@@ -1396,6 +1394,12 @@ func validateResult(r runResult) error {
 	if !validSHA(r.BaseSHA) || !validSHA(r.HeadSHA) {
 		return errors.New("result provenance must contain exact 40-hex base/head SHAs")
 	}
+	if len(r.Dataset.Checksum) != 64 {
+		return errors.New("result dataset must contain an exact SHA-256 checksum")
+	}
+	if _, err := hex.DecodeString(r.Dataset.Checksum); err != nil {
+		return errors.New("result dataset checksum must be hexadecimal")
+	}
 	if r.Seed != r.Dataset.Seed {
 		return errors.New("result seed does not match fixture generation seed")
 	}
@@ -1438,7 +1442,7 @@ func writeArtifacts(out string, r runResult) error {
 	return os.WriteFile(filepath.Join(out, name+".md"), []byte(md), 0644)
 }
 func artifactBasename(r runResult) string {
-	return fmt.Sprintf("simulation_s%016x_p%d_o%016x_k%d", uint64(r.Seed), r.Probes, math.Float64bits(r.Overlap), r.TopK)
+	return fmt.Sprintf("simulation_f%s_s%016x_n%d_p%d_o%016x_k%d", r.Dataset.Checksum, uint64(r.Seed), r.Partitions, r.Probes, math.Float64bits(r.Overlap), r.TopK)
 }
 func fixtureChecksum(vectors, queries, dims int, seed int64) string {
 	m := fixtureManifest{Vectors: vectors, Queries: queries, Dimensions: dims, Seed: seed}

--- a/cmd/treedb_vector_partition_bench/main.go
+++ b/cmd/treedb_vector_partition_bench/main.go
@@ -303,7 +303,10 @@ func run(args []string, stdout io.Writer) (runErr error) {
 				return err
 			}
 			if cfg.format == "json" {
-				b, _ := json.Marshal(result)
+				b, err := json.Marshal(result)
+				if err != nil {
+					return fmt.Errorf("encode JSON result: %w", err)
+				}
 				fmt.Fprintln(stdout, string(b))
 			} else {
 				fmt.Fprintf(stdout, "simulation probes=%d overlap=%.2f recall@%d=%.4f\n", probes, overlap, cfg.topK, result.Stages[len(result.Stages)-1].RecallAtK)

--- a/cmd/treedb_vector_partition_bench/main.go
+++ b/cmd/treedb_vector_partition_bench/main.go
@@ -4,6 +4,7 @@
 package main
 
 import (
+	"container/heap"
 	"crypto/sha256"
 	"encoding/binary"
 	"encoding/hex"
@@ -20,21 +21,30 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"unsafe"
 
 	"github.com/snissn/gomap/TreeDB/collections"
 	backenddb "github.com/snissn/gomap/TreeDB/db"
 )
 
 const (
-	schemaVersion             = 1
-	maxVectors                = 1_000_000
-	maxDimensions             = 4_096
-	maxPartitions             = 16_384
-	maxFixtureBytes     int64 = 4 << 30
-	maxManifestBytes    int64 = 64 << 10
-	maxGitHubEventBytes int64 = 2 << 20
-	partitionHNSWIndex        = "embedding_graph"
-	partitionHNSWDegree       = 16
+	schemaVersion                   = 1
+	maxVectors                      = 1_000_000
+	maxDimensions                   = 4_096
+	maxPartitions                   = 16_384
+	maxFixtureBytes           int64 = 4 << 30
+	maxManifestBytes          int64 = 64 << 10
+	maxGitHubEventBytes       int64 = 2 << 20
+	partitionHNSWIndex              = "embedding_graph"
+	partitionHNSWDegree             = 16
+	documentIDStorageBytes          = 16
+	hnswJSONFloatBytes              = 24
+	hnswJSONFixedBytes              = 64
+	hnswDecodedDimensionBytes       = 32
+	memoryMapEntryBytes             = 64
+	memorySlackNumerator            = 5
+	memorySlackDenominator          = 4
+	memoryBudgetScope               = "modeled_peak_live_bytes_v1: contiguous generated float64 fixture/query matrices and row headers; exact/selected top-k candidates; representative routing; HNSW partition JSON plus decoded JSON/vector batch; HNSW query merge and cache; 25% allocation slack; excludes TreeDB engine/index internals, Go runtime/GC metadata, and artifact/CLI encoding"
 )
 
 type config struct {
@@ -54,6 +64,7 @@ type config struct {
 	baseSHA      string
 	headSHA      string
 	hnsw         *treeDBPartitionHNSW
+	memory       benchmarkMemoryPlan
 }
 
 type fixtureManifest struct {
@@ -83,12 +94,34 @@ type stageResult struct {
 	Available                 bool    `json:"available"`
 	UnavailableReason         string  `json:"unavailable_reason,omitempty"`
 	RouteKind                 string  `json:"route_kind,omitempty"`
-	Searches                  uint64  `json:"searches,omitempty"`
-	ExecutedSearches          uint64  `json:"executed_searches,omitempty"`
-	CachedSearches            uint64  `json:"cached_searches,omitempty"`
-	SearchRouteHNSWSearchPack uint64  `json:"search_route_hnsw_search_pack,omitempty"`
-	HNSWSearchPackActive      uint64  `json:"hnsw_search_pack_active,omitempty"`
-	HNSWSearchPackFallbacks   uint64  `json:"hnsw_search_pack_fallbacks,omitempty"`
+	Searches                  uint64  `json:"searches"`
+	ExecutedSearches          uint64  `json:"executed_searches"`
+	CachedSearches            uint64  `json:"cached_searches"`
+	SearchRouteHNSWSearchPack uint64  `json:"search_route_hnsw_search_pack"`
+	HNSWSearchPackActive      uint64  `json:"hnsw_search_pack_active"`
+	HNSWSearchPackFallbacks   uint64  `json:"hnsw_search_pack_fallbacks"`
+}
+
+type scoredNeighbor struct {
+	Index    int
+	Distance float64
+}
+
+type scoredNeighborMaxHeap []scoredNeighbor
+
+func (h scoredNeighborMaxHeap) Len() int { return len(h) }
+func (h scoredNeighborMaxHeap) Less(i, j int) bool {
+	return scoredNeighborLess(h[j], h[i])
+}
+func (h scoredNeighborMaxHeap) Swap(i, j int) { h[i], h[j] = h[j], h[i] }
+func (h *scoredNeighborMaxHeap) Push(x any) {
+	*h = append(*h, x.(scoredNeighbor))
+}
+func (h *scoredNeighborMaxHeap) Pop() any {
+	old := *h
+	last := old[len(old)-1]
+	*h = old[:len(old)-1]
+	return last
 }
 
 type hnswSearchEvidence struct {
@@ -118,6 +151,14 @@ type treeDBPartitionHNSW struct {
 	rowCounts        []int
 	cache            map[hnswCacheKey]hnswSearchOutcome
 	physicalSearches uint64
+}
+
+type benchmarkMemoryPlan struct {
+	FixtureResidentBytes int64
+	SimulationWorkBytes  int64
+	HNSWInsertWorkBytes  int64
+	HNSWCacheBytes       int64
+	ModeledPeakBytes     int64
 }
 
 // metricsV1 reserves every M0 evidence field. Simulation leaves production-only
@@ -179,6 +220,9 @@ type runResult struct {
 	TopK               int             `json:"top_k"`
 	RecallTarget       float64         `json:"recall_target"`
 	Seed               int64           `json:"seed"`
+	MemoryBudgetBytes  int64           `json:"memory_budget_bytes"`
+	ModeledPeakBytes   int64           `json:"modeled_peak_bytes"`
+	MemoryBudgetScope  string          `json:"memory_budget_scope"`
 	Warmup             int             `json:"warmup"`
 	Samples            int             `json:"samples"`
 	TimedBoundary      string          `json:"timed_boundary"`
@@ -215,8 +259,18 @@ func run(args []string, stdout io.Writer) (runErr error) {
 	if cfg.partitions > fixture.Vectors {
 		return errors.New("partitions cannot exceed fixture vectors")
 	}
+	if cfg.seed != fixture.Seed {
+		return fmt.Errorf("-seed %d does not match fixture seed %d", cfg.seed, fixture.Seed)
+	}
+	cfg.memory, err = planBenchmarkMemory(cfg, fixture)
+	if err != nil {
+		return err
+	}
+	if cfg.memory.ModeledPeakBytes > cfg.maxBytes {
+		return fmt.Errorf("modeled peak benchmark-owned memory %d exceeds -max-fixture-bytes %d", cfg.memory.ModeledPeakBytes, cfg.maxBytes)
+	}
 	vectors, queries := deterministicFixture(fixture)
-	if fixtureChecksum(fixture.Vectors, fixture.Queries, fixture.Dimensions, fixture.Seed) != fixture.Checksum {
+	if fixtureChecksumFromData(vectors, queries) != fixture.Checksum {
 		return errors.New("fixture checksum does not match generated vector/query/truth stream")
 	}
 	if cfg.stages["treedb_partition_local_hnsw"] {
@@ -262,12 +316,12 @@ func parseConfig(args []string) (config, error) {
 	fs.StringVar(&overlap, "overlap", "0", "comma-separated derived overlap budgets")
 	fs.IntVar(&cfg.topK, "top-k", cfg.topK, "top-k")
 	fs.Float64Var(&cfg.recallTarget, "recall-target", cfg.recallTarget, "recall target")
-	fs.Int64Var(&cfg.seed, "seed", cfg.seed, "simulation seed")
+	fs.Int64Var(&cfg.seed, "seed", cfg.seed, "fixture generation seed (must match manifest)")
 	fs.StringVar(&cfg.format, "format", cfg.format, "json or text")
 	fs.StringVar(&cfg.out, "out", "", "artifact directory")
 	fs.StringVar(&stages, "stages", "all", "comma-separated independently enabled loss stages, or all")
 	fs.IntVar(&cfg.maxVectors, "max-vectors", maxVectors, "maximum combined fixture vector/query count before allocation")
-	fs.Int64Var(&cfg.maxBytes, "max-fixture-bytes", maxFixtureBytes, "maximum vector or query bytes before allocation")
+	fs.Int64Var(&cfg.maxBytes, "max-fixture-bytes", maxFixtureBytes, "maximum modeled peak bytes for benchmark-owned fixture and working material")
 	if err := fs.Parse(args); err != nil {
 		return config{}, err
 	}
@@ -350,6 +404,17 @@ func parseFloats(raw string) ([]float64, error) {
 }
 func provenance() (string, string, error) {
 	base, head := os.Getenv("BASE_SHA"), os.Getenv("GITHUB_SHA")
+	if base == "" || head == "" {
+		if eventPath := os.Getenv("GITHUB_EVENT_PATH"); eventPath != "" {
+			eventBase, eventHead, isPullRequest, err := pullRequestSHAsFromEvent(eventPath)
+			if err != nil {
+				return "", "", fmt.Errorf("GitHub event provenance: %w", err)
+			}
+			if isPullRequest {
+				base, head = eventBase, eventHead
+			}
+		}
+	}
 	if head == "" {
 		out, err := exec.Command("git", "rev-parse", "HEAD").Output()
 		if err != nil {
@@ -358,62 +423,64 @@ func provenance() (string, string, error) {
 		head = strings.TrimSpace(string(out))
 	}
 	if base == "" {
-		if eventPath := os.Getenv("GITHUB_EVENT_PATH"); eventPath != "" {
-			eventBase, err := pullRequestBaseSHAFromEvent(eventPath)
-			if err != nil {
-				return "", "", fmt.Errorf("GitHub event base SHA: %w", err)
-			}
-			base = eventBase
-		}
-	}
-	if base == "" {
 		out, err := exec.Command("git", "merge-base", "HEAD", "origin/main").Output()
 		if err != nil {
 			return "", "", errors.New("git merge-base unavailable: set BASE_SHA")
 		}
 		base = strings.TrimSpace(string(out))
 	}
-	if _, err := hex.DecodeString(base); err != nil || len(base) != 40 {
+	if !validSHA(base) {
 		return "", "", errors.New("invalid BASE_SHA")
 	}
-	if _, err := hex.DecodeString(head); err != nil || len(head) != 40 {
+	if !validSHA(head) {
 		return "", "", errors.New("invalid GITHUB_SHA")
 	}
 	return base, head, nil
 }
 
-func pullRequestBaseSHAFromEvent(path string) (string, error) {
+func validSHA(value string) bool {
+	if len(value) != 40 {
+		return false
+	}
+	_, err := hex.DecodeString(value)
+	return err == nil
+}
+
+func pullRequestSHAsFromEvent(path string) (string, string, bool, error) {
 	f, err := os.Open(filepath.Clean(path))
 	if err != nil {
-		return "", err
+		return "", "", false, err
 	}
 	defer func() { _ = f.Close() }()
 	raw, err := io.ReadAll(io.LimitReader(f, maxGitHubEventBytes+1))
 	if err != nil {
-		return "", err
+		return "", "", false, err
 	}
 	if int64(len(raw)) > maxGitHubEventBytes {
-		return "", fmt.Errorf("event payload exceeds %d-byte cap", maxGitHubEventBytes)
+		return "", "", false, fmt.Errorf("event payload exceeds %d-byte cap", maxGitHubEventBytes)
 	}
 	var event struct {
 		PullRequest *struct {
 			Base struct {
 				SHA string `json:"sha"`
 			} `json:"base"`
+			Head struct {
+				SHA string `json:"sha"`
+			} `json:"head"`
 		} `json:"pull_request"`
 	}
 	decoder := json.NewDecoder(strings.NewReader(string(raw)))
 	if err := decoder.Decode(&event); err != nil {
-		return "", err
+		return "", "", false, err
 	}
 	var extra any
 	if err := decoder.Decode(&extra); err != io.EOF {
-		return "", errors.New("GitHub event has trailing JSON")
+		return "", "", false, errors.New("GitHub event has trailing JSON")
 	}
 	if event.PullRequest == nil {
-		return "", nil
+		return "", "", false, nil
 	}
-	return strings.TrimSpace(event.PullRequest.Base.SHA), nil
+	return strings.TrimSpace(event.PullRequest.Base.SHA), strings.TrimSpace(event.PullRequest.Head.SHA), true, nil
 }
 
 func loadFixture(dir string) (fixtureManifest, error) {
@@ -465,33 +532,254 @@ func validateFixtureWithCaps(m fixtureManifest, capVectors int, capBytes int64) 
 		return errors.New("combined fixture vector/query count exceeds pre-allocation cap")
 	}
 	if int64(m.Vectors)+int64(m.Queries) > capBytes/(int64(m.Dimensions)*8) {
-		return errors.New("fixture byte product exceeds pre-allocation cap")
+		return errors.New("fixture float64 data alone exceeds pre-allocation memory cap")
 	}
 	_, e := hex.DecodeString(m.Checksum)
 	return e
 }
 
+func planBenchmarkMemory(cfg config, m fixtureManifest) (benchmarkMemoryPlan, error) {
+	if cfg.topK < 1 || cfg.topK > m.Vectors || cfg.partitions < 1 || cfg.partitions > m.Vectors || len(cfg.probes) == 0 {
+		return benchmarkMemoryPlan{}, errors.New("cannot plan memory for invalid top-k, partitions, or probes")
+	}
+	rows, err := memoryAdd(int64(m.Vectors), int64(m.Queries))
+	if err != nil {
+		return benchmarkMemoryPlan{}, err
+	}
+	fixtureValues, err := memoryMul(rows, int64(m.Dimensions), 8)
+	if err != nil {
+		return benchmarkMemoryPlan{}, err
+	}
+	fixtureRows, err := memoryMul(rows, int64(unsafe.Sizeof([]float64{})))
+	if err != nil {
+		return benchmarkMemoryPlan{}, err
+	}
+	fixtureResident, err := memoryAdd(fixtureValues, fixtureRows)
+	if err != nil {
+		return benchmarkMemoryPlan{}, err
+	}
+
+	k := int64(cfg.topK)
+	scoredBytes, err := memoryMul(k, int64(unsafe.Sizeof(scoredNeighbor{})))
+	if err != nil {
+		return benchmarkMemoryPlan{}, err
+	}
+	resultBytes, err := memoryMul(k, int64(unsafe.Sizeof(neighbor{}))+documentIDStorageBytes)
+	if err != nil {
+		return benchmarkMemoryPlan{}, err
+	}
+	// One truth result remains live while a second bounded top-k or recall
+	// operation executes. This is deliberately conservative for single-stage runs.
+	simulationWork, err := memoryAdd(scoredBytes, resultBytes, resultBytes, 2*k*memoryMapEntryBytes)
+	if err != nil {
+		return benchmarkMemoryPlan{}, err
+	}
+
+	maxProbes := 0
+	uniqueProbes := make(map[int]struct{}, len(cfg.probes))
+	for _, probes := range cfg.probes {
+		if probes > maxProbes {
+			maxProbes = probes
+		}
+		uniqueProbes[probes] = struct{}{}
+	}
+	needsSelectedTopK := cfg.stages["partition_oracle"] ||
+		cfg.stages["exact_representative_routing"] ||
+		cfg.stages["approximate_representative_routing"] ||
+		cfg.stages["exact_partition_local"] ||
+		cfg.stages["end_to_end_distributed_simulation"]
+	if needsSelectedTopK {
+		simulationWork, err = memoryAdd(simulationWork, int64(cfg.partitions), int64(maxProbes)*8)
+		if err != nil {
+			return benchmarkMemoryPlan{}, err
+		}
+	}
+	needsRepresentatives := cfg.stages["exact_representative_routing"] ||
+		cfg.stages["approximate_representative_routing"] ||
+		cfg.stages["exact_partition_local"] ||
+		cfg.stages["treedb_partition_local_hnsw"] ||
+		cfg.stages["end_to_end_distributed_simulation"]
+	if needsRepresentatives {
+		representativeValues, mulErr := memoryMul(int64(cfg.partitions), int64(m.Dimensions), 8)
+		if mulErr != nil {
+			return benchmarkMemoryPlan{}, mulErr
+		}
+		representativeRows, mulErr := memoryMul(int64(cfg.partitions), int64(unsafe.Sizeof([]float64{})))
+		if mulErr != nil {
+			return benchmarkMemoryPlan{}, mulErr
+		}
+		representativeScores, mulErr := memoryMul(int64(cfg.partitions), int64(unsafe.Sizeof(neighbor{}))+documentIDStorageBytes+8)
+		if mulErr != nil {
+			return benchmarkMemoryPlan{}, mulErr
+		}
+		simulationWork, err = memoryAdd(simulationWork, representativeValues, representativeRows, representativeScores, int64(maxProbes)*8)
+		if err != nil {
+			return benchmarkMemoryPlan{}, err
+		}
+	}
+
+	plan := benchmarkMemoryPlan{
+		FixtureResidentBytes: fixtureResident,
+		SimulationWorkBytes:  simulationWork,
+	}
+	hnswBaseBytes := int64(0)
+	if cfg.stages["treedb_partition_local_hnsw"] {
+		hnswBaseBytes, err = memoryAdd(
+			int64(cfg.partitions)*int64(unsafe.Sizeof((*collections.Collection)(nil))),
+			int64(cfg.partitions)*8,
+			int64(unsafe.Sizeof(treeDBPartitionHNSW{})),
+		)
+		if err != nil {
+			return benchmarkMemoryPlan{}, err
+		}
+		maxPartitionRows := int64((m.Vectors + cfg.partitions - 1) / cfg.partitions)
+		jsonRowBytes, mulErr := memoryMul(int64(m.Dimensions), hnswJSONFloatBytes+1)
+		if mulErr != nil {
+			return benchmarkMemoryPlan{}, mulErr
+		}
+		jsonRowBytes, err = memoryAdd(jsonRowBytes, hnswJSONFixedBytes)
+		if err != nil {
+			return benchmarkMemoryPlan{}, err
+		}
+		perInsertRow, err := memoryAdd(
+			2*int64(unsafe.Sizeof([]byte{})),
+			documentIDStorageBytes,
+			2*jsonRowBytes,
+			int64(m.Dimensions)*hnswDecodedDimensionBytes,
+			int64(unsafe.Sizeof([]float32{})),
+			memoryMapEntryBytes,
+		)
+		if err != nil {
+			return benchmarkMemoryPlan{}, err
+		}
+		plan.HNSWInsertWorkBytes, err = memoryMul(maxPartitionRows, perInsertRow)
+		if err != nil {
+			return benchmarkMemoryPlan{}, err
+		}
+		plan.HNSWInsertWorkBytes, err = memoryAdd(plan.HNSWInsertWorkBytes, int64(m.Dimensions)*4)
+		if err != nil {
+			return benchmarkMemoryPlan{}, err
+		}
+
+		perQueryCache := int64(0)
+		for probes := range uniqueProbes {
+			cachedCandidates, mulErr := memoryMul(k, int64(probes), int64(unsafe.Sizeof(neighbor{}))+documentIDStorageBytes)
+			if mulErr != nil {
+				return benchmarkMemoryPlan{}, mulErr
+			}
+			entryBytes, addErr := memoryAdd(
+				int64(unsafe.Sizeof(hnswCacheKey{})),
+				int64(unsafe.Sizeof(hnswSearchOutcome{})),
+				memoryMapEntryBytes,
+				int64(probes)*6,
+				cachedCandidates,
+			)
+			if addErr != nil {
+				return benchmarkMemoryPlan{}, addErr
+			}
+			perQueryCache, err = memoryAdd(perQueryCache, entryBytes)
+			if err != nil {
+				return benchmarkMemoryPlan{}, err
+			}
+		}
+		plan.HNSWCacheBytes, err = memoryMul(int64(m.Queries), perQueryCache)
+		if err != nil {
+			return benchmarkMemoryPlan{}, err
+		}
+		searchMergeBytes, mulErr := memoryMul(k, int64(maxProbes), int64(unsafe.Sizeof(neighbor{}))+documentIDStorageBytes+memoryMapEntryBytes)
+		if mulErr != nil {
+			return benchmarkMemoryPlan{}, mulErr
+		}
+		plan.SimulationWorkBytes, err = memoryAdd(plan.SimulationWorkBytes, int64(m.Dimensions)*4, searchMergeBytes, int64(maxProbes)*8)
+		if err != nil {
+			return benchmarkMemoryPlan{}, err
+		}
+	}
+
+	checksumPhase, err := memoryAdd(plan.FixtureResidentBytes, scoredBytes, resultBytes)
+	if err != nil {
+		return benchmarkMemoryPlan{}, err
+	}
+	hnswBuildPhase, err := memoryAdd(plan.FixtureResidentBytes, hnswBaseBytes, plan.HNSWInsertWorkBytes)
+	if err != nil {
+		return benchmarkMemoryPlan{}, err
+	}
+	simulationPhase, err := memoryAdd(plan.FixtureResidentBytes, hnswBaseBytes, plan.HNSWCacheBytes, plan.SimulationWorkBytes)
+	if err != nil {
+		return benchmarkMemoryPlan{}, err
+	}
+	peak := max(checksumPhase, max(hnswBuildPhase, simulationPhase))
+	plan.ModeledPeakBytes, err = memoryScaleCeil(peak, memorySlackNumerator, memorySlackDenominator)
+	if err != nil {
+		return benchmarkMemoryPlan{}, err
+	}
+	return plan, nil
+}
+
+func memoryAdd(values ...int64) (int64, error) {
+	var total int64
+	for _, value := range values {
+		if value < 0 || total > math.MaxInt64-value {
+			return 0, errors.New("benchmark memory accounting overflow")
+		}
+		total += value
+	}
+	return total, nil
+}
+
+func memoryMul(values ...int64) (int64, error) {
+	product := int64(1)
+	for _, value := range values {
+		if value < 0 || value != 0 && product > math.MaxInt64/value {
+			return 0, errors.New("benchmark memory accounting overflow")
+		}
+		product *= value
+	}
+	return product, nil
+}
+
+func memoryScaleCeil(value, numerator, denominator int64) (int64, error) {
+	scaled, err := memoryMul(value, numerator)
+	if err != nil {
+		return 0, err
+	}
+	scaled, err = memoryAdd(scaled, denominator-1)
+	if err != nil {
+		return 0, err
+	}
+	return scaled / denominator, nil
+}
+
 // deterministicFixture has intentionally visible cluster/boundary pairs and a
 // duplicate pair, so tie ordering remains part of the executable M0 contract.
 func deterministicFixture(m fixtureManifest) ([][]float64, [][]float64) {
-	v := make([][]float64, m.Vectors)
+	v := contiguousFloat64Matrix(m.Vectors, m.Dimensions)
 	for i := range v {
-		row := make([]float64, m.Dimensions)
+		row := v[i]
 		cluster := (i / 97) % 4
 		row[cluster%m.Dimensions] = 1
 		for d := 4; d < m.Dimensions; d++ {
 			row[d] = float64(((i+1)*(d+3)+int(m.Seed))%31) / 310
 		}
-		v[i] = normalize(row)
+		normalize(row)
 	}
 	if len(v) > 1 {
-		v[1] = append([]float64(nil), v[0]...)
+		copy(v[1], v[0])
 	}
-	q := make([][]float64, m.Queries)
+	q := contiguousFloat64Matrix(m.Queries, m.Dimensions)
 	for i := range q {
-		q[i] = append([]float64(nil), v[(i*7919+17)%len(v)]...)
+		copy(q[i], v[(i*7919+17)%len(v)])
 	}
 	return v, q
+}
+
+func contiguousFloat64Matrix(rows, dimensions int) [][]float64 {
+	matrix := make([][]float64, rows)
+	values := make([]float64, rows*dimensions)
+	for row := range matrix {
+		matrix[row] = values[row*dimensions : (row+1)*dimensions]
+	}
+	return matrix
 }
 func normalize(v []float64) []float64 {
 	var n float64
@@ -505,55 +793,60 @@ func normalize(v []float64) []float64 {
 	return v
 }
 func exactTopK(v [][]float64, q []float64, k int) []neighbor {
-	out := make([]neighbor, len(v))
-	for i, row := range v {
-		var dot float64
-		for d := range row {
-			dot += row[d] * q[d]
-		}
-		out[i] = neighbor{ID: fmt.Sprintf("doc-%06d", i), Distance: 1 - dot}
-	}
-	sort.Slice(out, func(i, j int) bool {
-		if out[i].Distance == out[j].Distance {
-			return out[i].ID < out[j].ID
-		}
-		return out[i].Distance < out[j].Distance
-	})
-	return out[:k]
+	return boundedVectorTopK(v, q, k, func(int) bool { return true })
 }
-func partitionTopK(v [][]float64, q []float64, k, partitions, probes int) []neighbor {
-	selected := make([]int, probes)
-	for i := range selected {
-		selected[i] = i
-	}
-	return selectedPartitionTopK(v, q, k, partitions, selected)
-}
+
 func selectedPartitionTopK(v [][]float64, q []float64, k, partitions int, selected []int) []neighbor {
-	want := map[int]bool{}
-	for _, p := range selected {
-		want[p] = true
+	wanted := make([]bool, partitions)
+	for _, partition := range selected {
+		wanted[partition] = true
 	}
-	all := make([]neighbor, 0, len(v)*len(selected)/partitions+1)
+	return boundedVectorTopK(v, q, k, func(index int) bool {
+		return wanted[index%partitions]
+	})
+}
+
+func boundedVectorTopK(v [][]float64, q []float64, k int, include func(int) bool) []neighbor {
+	candidates := make(scoredNeighborMaxHeap, 0, min(k, len(v)))
 	for i, row := range v {
-		if !want[i%partitions] {
+		if !include(i) {
 			continue
 		}
 		var dot float64
 		for d := range row {
 			dot += row[d] * q[d]
 		}
-		all = append(all, neighbor{fmt.Sprintf("doc-%06d", i), 1 - dot})
-	}
-	sort.Slice(all, func(i, j int) bool {
-		if all[i].Distance == all[j].Distance {
-			return all[i].ID < all[j].ID
+		candidate := scoredNeighbor{Index: i, Distance: 1 - dot}
+		if len(candidates) < k {
+			heap.Push(&candidates, candidate)
+		} else if scoredNeighborLess(candidate, candidates[0]) {
+			candidates[0] = candidate
+			heap.Fix(&candidates, 0)
 		}
-		return all[i].Distance < all[j].Distance
-	})
-	if len(all) < k {
-		return all
 	}
-	return all[:k]
+	sort.Slice(candidates, func(i, j int) bool {
+		return scoredNeighborLess(candidates[i], candidates[j])
+	})
+	out := make([]neighbor, len(candidates))
+	for i, candidate := range candidates {
+		out[i] = neighbor{ID: fmt.Sprintf("doc-%06d", candidate.Index), Distance: candidate.Distance}
+	}
+	return out
+}
+
+func scoredNeighborLess(a, b scoredNeighbor) bool {
+	if a.Distance == b.Distance {
+		return a.Index < b.Index
+	}
+	return a.Distance < b.Distance
+}
+
+func partitionTopK(v [][]float64, q []float64, k, partitions, probes int) []neighbor {
+	selected := make([]int, probes)
+	for i := range selected {
+		selected[i] = i
+	}
+	return selectedPartitionTopK(v, q, k, partitions, selected)
 }
 func orderedEqual(a, b []neighbor) bool {
 	if len(a) != len(b) {
@@ -567,13 +860,10 @@ func orderedEqual(a, b []neighbor) bool {
 	return true
 }
 func representativePartitions(v [][]float64, q []float64, partitions, probes int, approx bool) []int {
-	sums := make([][]float64, partitions)
+	sums := contiguousFloat64Matrix(partitions, len(q))
 	counts := make([]int, partitions)
 	for i, row := range v {
 		p := i % partitions
-		if sums[p] == nil {
-			sums[p] = make([]float64, len(q))
-		}
 		for d := range row {
 			sums[p][d] += row[d]
 		}
@@ -962,7 +1252,31 @@ func simulate(cfg config, m fixtureManifest, v, q [][]float64, probes int, overl
 		}
 	}
 	metrics := metricsV1{MeasurementStatus: "simulation_not_measured", Balance: 1, MaxPartitionSize: (len(v) + cfg.partitions - 1) / cfg.partitions, ReplicationFactor: 1, UnassignedOverlapBudget: overlap, RoutedPartitionRecall: totals["end_to_end_distributed_simulation"] / n, SelectedPartitions: probes}
-	r := runResult{SchemaVersion: schemaVersion, ResultKind: "simulation_only", ProductionEvidence: false, Command: cfg.command, BaseSHA: cfg.baseSHA, HeadSHA: cfg.headSHA, GoVersion: runtime.Version(), Hardware: runtime.GOARCH + "/" + runtime.GOOS, Dataset: m, Partitions: cfg.partitions, Overlap: overlap, Probes: probes, TopK: cfg.topK, RecallTarget: cfg.recallTarget, Seed: cfg.seed, Warmup: 0, Samples: len(q), TimedBoundary: "untimed M0 attribution: in-memory oracles plus temporary local TreeDB column_graph build/search; excludes network, RPC, coordinator, and Raft", Stages: selected, Metrics: metrics}
+	r := runResult{
+		SchemaVersion:      schemaVersion,
+		ResultKind:         "simulation_only",
+		ProductionEvidence: false,
+		Command:            cfg.command,
+		BaseSHA:            cfg.baseSHA,
+		HeadSHA:            cfg.headSHA,
+		GoVersion:          runtime.Version(),
+		Hardware:           runtime.GOARCH + "/" + runtime.GOOS,
+		Dataset:            m,
+		Partitions:         cfg.partitions,
+		Overlap:            overlap,
+		Probes:             probes,
+		TopK:               cfg.topK,
+		RecallTarget:       cfg.recallTarget,
+		Seed:               cfg.seed,
+		MemoryBudgetBytes:  cfg.maxBytes,
+		ModeledPeakBytes:   cfg.memory.ModeledPeakBytes,
+		MemoryBudgetScope:  memoryBudgetScope,
+		Warmup:             0,
+		Samples:            len(q),
+		TimedBoundary:      "untimed M0 attribution: in-memory oracles plus temporary local TreeDB column_graph build/search; excludes network, RPC, coordinator, and Raft",
+		Stages:             selected,
+		Metrics:            metrics,
+	}
 	if cfg.stages["partition_oracle"] && probes == cfg.partitions && !exactParity {
 		return r, errors.New("all-partition oracle parity failure")
 	}
@@ -1007,8 +1321,14 @@ func validateResult(r runResult) error {
 			}
 		}
 	}
-	if len(r.BaseSHA) < 7 || len(r.HeadSHA) < 7 {
-		return errors.New("missing git provenance")
+	if !validSHA(r.BaseSHA) || !validSHA(r.HeadSHA) {
+		return errors.New("result provenance must contain exact 40-hex base/head SHAs")
+	}
+	if r.Seed != r.Dataset.Seed {
+		return errors.New("result seed does not match fixture generation seed")
+	}
+	if r.MemoryBudgetBytes < 1 || r.ModeledPeakBytes < 1 || r.ModeledPeakBytes > r.MemoryBudgetBytes || r.MemoryBudgetScope != memoryBudgetScope {
+		return errors.New("invalid benchmark-owned memory budget evidence")
 	}
 	if r.Metrics.MeasurementStatus != "simulation_not_measured" {
 		return errors.New("unknown metric measurement status")
@@ -1042,15 +1362,19 @@ func writeArtifacts(out string, r runResult) error {
 			hnswSummary = fmt.Sprintf("recall@%d: %.4f; route=%s; logical_searches=%d; executed=%d; cached=%d; fallbacks=%d", r.TopK, s.RecallAtK, s.RouteKind, s.Searches, s.ExecutedSearches, s.CachedSearches, s.HNSWSearchPackFallbacks)
 		}
 	}
-	md := fmt.Sprintf("# TreeDB vector partition M0 simulation\n\n**Simulation only; not production Raft evidence.**\n\n- fixture: `%s` (%s)\n- probes: %d/%d\n- overlap budget: %.6g\n- TreeDB partition-local HNSW: %s\n- end-to-end simulation: %s\n- timed boundary: %s\n", r.Dataset.Fixture, r.Dataset.Checksum, r.Probes, r.Partitions, r.Overlap, hnswSummary, stageSummary, r.TimedBoundary)
+	md := fmt.Sprintf("# TreeDB vector partition M0 simulation\n\n**Simulation only; not production Raft evidence.**\n\n- fixture: `%s` (%s)\n- seed: %d\n- modeled benchmark-owned peak: %d/%d bytes\n- memory budget scope: %s\n- probes: %d/%d\n- overlap budget: %.6g\n- TreeDB partition-local HNSW: %s\n- end-to-end simulation: %s\n- timed boundary: %s\n", r.Dataset.Fixture, r.Dataset.Checksum, r.Seed, r.ModeledPeakBytes, r.MemoryBudgetBytes, r.MemoryBudgetScope, r.Probes, r.Partitions, r.Overlap, hnswSummary, stageSummary, r.TimedBoundary)
 	return os.WriteFile(filepath.Join(out, name+".md"), []byte(md), 0644)
 }
 func artifactBasename(r runResult) string {
-	return fmt.Sprintf("simulation_p%d_o%016x_k%d", r.Probes, math.Float64bits(r.Overlap), r.TopK)
+	return fmt.Sprintf("simulation_s%016x_p%d_o%016x_k%d", uint64(r.Seed), r.Probes, math.Float64bits(r.Overlap), r.TopK)
 }
 func fixtureChecksum(vectors, queries, dims int, seed int64) string {
 	m := fixtureManifest{Vectors: vectors, Queries: queries, Dimensions: dims, Seed: seed}
 	v, q := deterministicFixture(m)
+	return fixtureChecksumFromData(v, q)
+}
+
+func fixtureChecksumFromData(v, q [][]float64) string {
 	h := sha256.New()
 	var b [8]byte
 	for _, set := range [][][]float64{v, q} {

--- a/cmd/treedb_vector_partition_bench/main.go
+++ b/cmd/treedb_vector_partition_bench/main.go
@@ -38,6 +38,8 @@ const (
 	maxGitHubEventBytes       int64 = 2 << 20
 	partitionHNSWIndex              = "embedding_graph"
 	partitionHNSWDegree             = 16
+	fixtureGenerator                = "treedb_vector_partition_fixture_v2"
+	fixtureArithmetic               = "ieee754_binary64_explicit_fma_v1"
 	documentIDStorageBytes          = 16
 	hnswJSONFloatBytes              = 24
 	hnswJSONFixedBytes              = 64
@@ -73,6 +75,7 @@ type fixtureManifest struct {
 	SchemaVersion int    `json:"schema_version"`
 	Fixture       string `json:"fixture"`
 	Generator     string `json:"generator"`
+	Arithmetic    string `json:"arithmetic"`
 	Vectors       int    `json:"vectors"`
 	Queries       int    `json:"queries"`
 	Dimensions    int    `json:"dimensions"`
@@ -530,7 +533,7 @@ func validateFixture(m fixtureManifest) error {
 	return validateFixtureWithCaps(m, maxVectors, maxFixtureBytes)
 }
 func validateFixtureWithCaps(m fixtureManifest, capVectors int, capBytes int64) error {
-	if m.SchemaVersion != schemaVersion || m.Fixture == "" || m.Generator != "treedb_vector_partition_fixture_v1" || m.Vectors < 1 || m.Vectors > capVectors || m.Queries < 1 || m.Queries > capVectors || m.Dimensions < 1 || m.Dimensions > maxDimensions || m.Metric != "cosine" || len(m.Checksum) != 64 {
+	if m.SchemaVersion != schemaVersion || m.Fixture == "" || m.Generator != fixtureGenerator || m.Arithmetic != fixtureArithmetic || m.Vectors < 1 || m.Vectors > capVectors || m.Queries < 1 || m.Queries > capVectors || m.Dimensions < 1 || m.Dimensions > maxDimensions || m.Metric != "cosine" || len(m.Checksum) != 64 {
 		return errors.New("unsupported or malformed fixture manifest")
 	}
 	if int64(m.Vectors)+int64(m.Queries) > int64(capVectors) {
@@ -853,7 +856,7 @@ func contiguousFloat64Matrix(rows, dimensions int) [][]float64 {
 func normalize(v []float64) []float64 {
 	var n float64
 	for _, x := range v {
-		n += x * x
+		n = math.FMA(x, x, n)
 	}
 	n = math.Sqrt(n)
 	for i := range v {
@@ -883,7 +886,7 @@ func boundedVectorTopK(v [][]float64, q []float64, k int, include func(int) bool
 		}
 		var dot float64
 		for d := range row {
-			dot += row[d] * q[d]
+			dot = math.FMA(row[d], q[d], dot)
 		}
 		candidate := scoredNeighbor{Index: i, Distance: 1 - dot}
 		if len(candidates) < k {
@@ -942,7 +945,7 @@ func representativePartitions(v [][]float64, q []float64, partitions, probes int
 	for p, sum := range sums {
 		var dot float64
 		for d := range sum {
-			dot += q[d] * (sum[d] / float64(counts[p]))
+			dot = math.FMA(q[d], sum[d]/float64(counts[p]), dot)
 		}
 		scores[p] = neighbor{ID: fmt.Sprintf("p-%06d", p), Distance: 1 - dot}
 	}

--- a/cmd/treedb_vector_partition_bench/main.go
+++ b/cmd/treedb_vector_partition_bench/main.go
@@ -14,6 +14,7 @@ import (
 	"io"
 	"math"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"runtime"
 	"sort"
@@ -43,6 +44,8 @@ type config struct {
 	command      []string
 	maxVectors   int
 	maxBytes     int64
+	baseSHA      string
+	headSHA      string
 }
 
 type fixtureManifest struct {
@@ -62,13 +65,15 @@ type neighbor struct {
 	Distance float64 `json:"distance"`
 }
 type stageResult struct {
-	Name      string  `json:"name"`
-	Method    string  `json:"method"`
-	Enabled   bool    `json:"enabled"`
-	Lossy     bool    `json:"lossy"`
-	RecallAtK float64 `json:"recall_at_k"`
-	Queries   int     `json:"queries"`
-	Probes    int     `json:"probes"`
+	Name              string  `json:"name"`
+	Method            string  `json:"method"`
+	Enabled           bool    `json:"enabled"`
+	Lossy             bool    `json:"lossy"`
+	RecallAtK         float64 `json:"recall_at_k"`
+	Queries           int     `json:"queries"`
+	Probes            int     `json:"probes"`
+	Available         bool    `json:"available"`
+	UnavailableReason string  `json:"unavailable_reason,omitempty"`
 }
 
 // metricsV1 reserves every M0 evidence field. Simulation leaves production-only
@@ -150,6 +155,9 @@ func run(args []string, stdout io.Writer) error {
 		return err
 	}
 	cfg.command = append([]string{"treedb_vector_partition_bench"}, args...)
+	if cfg.baseSHA, cfg.headSHA, err = provenance(); err != nil {
+		return err
+	}
 	fixture, err := loadFixture(cfg.dataset)
 	if err != nil {
 		return err
@@ -161,6 +169,9 @@ func run(args []string, stdout io.Writer) error {
 		return errors.New("top-k cannot exceed fixture vectors")
 	}
 	vectors, queries := deterministicFixture(fixture)
+	if fixtureChecksum(fixture.Vectors, fixture.Queries, fixture.Dimensions, fixture.Seed) != fixture.Checksum {
+		return errors.New("fixture checksum does not match generated vector/query/truth stream")
+	}
 	for _, overlap := range cfg.overlaps {
 		for _, probes := range cfg.probes {
 			result, err := simulate(cfg, fixture, vectors, queries, probes, overlap)
@@ -281,6 +292,30 @@ func parseFloats(raw string) ([]float64, error) {
 	}
 	return out, nil
 }
+func provenance() (string, string, error) {
+	base, head := os.Getenv("BASE_SHA"), os.Getenv("GITHUB_SHA")
+	if head == "" {
+		out, err := exec.Command("git", "rev-parse", "HEAD").Output()
+		if err != nil {
+			return "", "", errors.New("git head unavailable: set GITHUB_SHA")
+		}
+		head = strings.TrimSpace(string(out))
+	}
+	if base == "" {
+		out, err := exec.Command("git", "merge-base", "HEAD", "origin/main").Output()
+		if err != nil {
+			return "", "", errors.New("git merge-base unavailable: set BASE_SHA")
+		}
+		base = strings.TrimSpace(string(out))
+	}
+	if _, err := hex.DecodeString(base); err != nil || len(base) != 40 {
+		return "", "", errors.New("invalid BASE_SHA")
+	}
+	if _, err := hex.DecodeString(head); err != nil || len(head) != 40 {
+		return "", "", errors.New("invalid GITHUB_SHA")
+	}
+	return base, head, nil
+}
 
 func loadFixture(dir string) (fixtureManifest, error) {
 	b, e := os.ReadFile(filepath.Join(dir, "fixture_manifest.json"))
@@ -319,7 +354,7 @@ func validateFixtureWithCaps(m fixtureManifest, capVectors int, capBytes int64) 
 	if m.SchemaVersion != schemaVersion || m.Fixture == "" || m.Generator != "treedb_vector_partition_fixture_v1" || m.Vectors < 1 || m.Vectors > capVectors || m.Queries < 1 || m.Queries > capVectors || m.Dimensions < 1 || m.Dimensions > maxDimensions || m.Metric != "cosine" || len(m.Checksum) != 64 {
 		return errors.New("unsupported or malformed fixture manifest")
 	}
-	if int64(m.Vectors) > capBytes/(int64(m.Dimensions)*8) || int64(m.Queries) > capBytes/(int64(m.Dimensions)*8) {
+	if int64(m.Vectors) > capBytes/(int64(m.Dimensions)*8) || int64(m.Queries) > capBytes/(int64(m.Dimensions)*8) || int64(m.Vectors)+int64(m.Queries) > capBytes/(int64(m.Dimensions)*8) {
 		return errors.New("fixture byte product exceeds pre-allocation cap")
 	}
 	_, e := hex.DecodeString(m.Checksum)
@@ -377,9 +412,20 @@ func exactTopK(v [][]float64, q []float64, k int) []neighbor {
 	return out[:k]
 }
 func partitionTopK(v [][]float64, q []float64, k, partitions, probes int) []neighbor {
-	all := make([]neighbor, 0, len(v)*probes/partitions+1)
+	selected := make([]int, probes)
+	for i := range selected {
+		selected[i] = i
+	}
+	return selectedPartitionTopK(v, q, k, partitions, selected)
+}
+func selectedPartitionTopK(v [][]float64, q []float64, k, partitions int, selected []int) []neighbor {
+	want := map[int]bool{}
+	for _, p := range selected {
+		want[p] = true
+	}
+	all := make([]neighbor, 0, len(v)*len(selected)/partitions+1)
 	for i, row := range v {
-		if i%partitions >= probes {
+		if !want[i%partitions] {
 			continue
 		}
 		var dot float64
@@ -399,6 +445,55 @@ func partitionTopK(v [][]float64, q []float64, k, partitions, probes int) []neig
 	}
 	return all[:k]
 }
+func orderedEqual(a, b []neighbor) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+func representativePartitions(v [][]float64, q []float64, partitions, probes int, approx bool) []int {
+	sums := make([][]float64, partitions)
+	counts := make([]int, partitions)
+	for i, row := range v {
+		p := i % partitions
+		if sums[p] == nil {
+			sums[p] = make([]float64, len(q))
+		}
+		for d := range row {
+			sums[p][d] += row[d]
+		}
+		counts[p]++
+	}
+	scores := make([]neighbor, partitions)
+	for p, sum := range sums {
+		var dot float64
+		for d := range sum {
+			dot += q[d] * (sum[d] / float64(counts[p]))
+		}
+		scores[p] = neighbor{ID: fmt.Sprintf("p-%06d", p), Distance: 1 - dot}
+	}
+	sort.Slice(scores, func(i, j int) bool {
+		if scores[i].Distance == scores[j].Distance {
+			return scores[i].ID < scores[j].ID
+		}
+		return scores[i].Distance < scores[j].Distance
+	})
+	out := make([]int, probes)
+	for i := range out {
+		idx := i
+		if approx && probes < partitions && i == probes-1 {
+			idx = probes
+		}
+		out[i] = int(parsePartitionID(scores[idx].ID))
+	}
+	return out
+}
+func parsePartitionID(id string) int { n, _ := strconv.Atoi(strings.TrimPrefix(id, "p-")); return n }
 func recall(want, got []neighbor) float64 {
 	found := map[string]bool{}
 	for _, x := range got {
@@ -418,33 +513,67 @@ func simulate(cfg config, m fixtureManifest, v, q [][]float64, probes int, overl
 	}
 	if overlap != 0 { /* M0 reports budget only; M3 owns membership copies. */
 	}
-	totals := map[string]float64{"global": 0, "partition": 0}
+	totals := map[string]float64{}
+	exactParity := true
 	for _, query := range q {
 		truth := exactTopK(v, query, cfg.topK)
-		totals["global"] += recall(truth, exactTopK(v, query, cfg.topK))
-		totals["partition"] += recall(truth, partitionTopK(v, query, cfg.topK, cfg.partitions, probes))
+		if cfg.stages["exact_global_top_k"] {
+			totals["exact_global_top_k"] += 1
+		}
+		if cfg.stages["partition_oracle"] {
+			got := partitionTopK(v, query, cfg.topK, cfg.partitions, probes)
+			totals["partition_oracle"] += recall(truth, got)
+			if probes == cfg.partitions && !orderedEqual(truth, got) {
+				exactParity = false
+			}
+		}
+		if cfg.stages["exact_representative_routing"] {
+			got := selectedPartitionTopK(v, query, cfg.topK, cfg.partitions, representativePartitions(v, query, cfg.partitions, probes, false))
+			totals["exact_representative_routing"] += recall(truth, got)
+		}
+		if cfg.stages["approximate_representative_routing"] {
+			got := selectedPartitionTopK(v, query, cfg.topK, cfg.partitions, representativePartitions(v, query, cfg.partitions, probes, true))
+			totals["approximate_representative_routing"] += recall(truth, got)
+		}
+		if cfg.stages["exact_partition_local"] {
+			parts := representativePartitions(v, query, cfg.partitions, probes, false)
+			got := selectedPartitionTopK(v, query, cfg.topK, cfg.partitions, parts)
+			totals["exact_partition_local"] += recall(truth, got)
+		}
+		if cfg.stages["end_to_end_distributed_simulation"] {
+			parts := representativePartitions(v, query, cfg.partitions, probes, true)
+			got := selectedPartitionTopK(v, query, cfg.topK, cfg.partitions, parts)
+			totals["end_to_end_distributed_simulation"] += recall(truth, dedupeStable(got))
+		}
 	}
 	n := float64(len(q))
-	sha := os.Getenv("GITHUB_SHA")
-	if sha == "" {
-		sha = "local"
-	}
 	stage := func(name, method string, lossy bool, value float64, p int) stageResult {
-		return stageResult{Name: name, Method: method, Enabled: cfg.stages[name], Lossy: lossy, RecallAtK: value, Queries: len(q), Probes: p}
+		return stageResult{Name: name, Method: method, Enabled: cfg.stages[name], Lossy: lossy, RecallAtK: value, Queries: len(q), Probes: p, Available: true}
 	}
-	allStages := []stageResult{stage("exact_global_top_k", "global_exhaustive", false, totals["global"]/n, cfg.partitions), stage("partition_oracle", "deterministic_partition_exhaustive", probes < cfg.partitions, totals["partition"]/n, probes), stage("exact_representative_routing", "M0_equivalent_to_partition_oracle", false, totals["partition"]/n, probes), stage("approximate_representative_routing", "M0_equivalent_to_exact_representative", false, totals["partition"]/n, probes), stage("exact_partition_local", "partition_exhaustive", false, totals["partition"]/n, probes), stage("treedb_partition_local_hnsw", "M0_placeholder_exact_local_not_production_HNSW", false, totals["partition"]/n, probes), stage("end_to_end_distributed_simulation", "sequential_deterministic_merge", probes < cfg.partitions, totals["partition"]/n, probes)}
+	allStages := []stageResult{stage("exact_global_top_k", "global_exhaustive", false, totals["exact_global_top_k"]/n, cfg.partitions), stage("partition_oracle", "round_robin_partition_exhaustive", probes < cfg.partitions, totals["partition_oracle"]/n, probes), stage("exact_representative_routing", "centroid_representative_routing", probes < cfg.partitions, totals["exact_representative_routing"]/n, probes), stage("approximate_representative_routing", "deterministic_last_representative_perturbation", probes < cfg.partitions, totals["approximate_representative_routing"]/n, probes), stage("exact_partition_local", "centroid_selected_partition_exhaustive", probes < cfg.partitions, totals["exact_partition_local"]/n, probes), {Name: "treedb_partition_local_hnsw", Method: "unavailable_without_public_M0_HNSW_pack_api", Enabled: cfg.stages["treedb_partition_local_hnsw"], Available: false, UnavailableReason: "M0 has no public TreeDB partition-local HNSW pack API; refusing exact placeholder"}, stage("end_to_end_distributed_simulation", "approximate_router_then_local_exhaustive_dedupe", probes < cfg.partitions, totals["end_to_end_distributed_simulation"]/n, probes)}
 	selected := make([]stageResult, 0, len(allStages))
 	for _, s := range allStages {
 		if s.Enabled {
 			selected = append(selected, s)
 		}
 	}
-	metrics := metricsV1{MeasurementStatus: "simulation_not_measured", Balance: 1, MaxPartitionSize: (len(v) + cfg.partitions - 1) / cfg.partitions, ReplicationFactor: 1, UnassignedOverlapBudget: overlap, RoutedPartitionRecall: totals["partition"] / n, SelectedPartitions: probes}
-	r := runResult{SchemaVersion: schemaVersion, ResultKind: "simulation_only", ProductionEvidence: false, Command: cfg.command, BaseSHA: os.Getenv("BASE_SHA"), HeadSHA: sha, GoVersion: runtime.Version(), Hardware: runtime.GOARCH + "/" + runtime.GOOS, Dataset: m, Partitions: cfg.partitions, Overlap: overlap, Probes: probes, TopK: cfg.topK, RecallTarget: cfg.recallTarget, Seed: cfg.seed, Warmup: 0, Samples: len(q), TimedBoundary: "exact in-memory distance and deterministic merge; excludes disk, TreeDB, RPC, and Raft", Stages: selected, Metrics: metrics}
-	if probes == cfg.partitions && totals["partition"]/n != 1 {
+	metrics := metricsV1{MeasurementStatus: "simulation_not_measured", Balance: 1, MaxPartitionSize: (len(v) + cfg.partitions - 1) / cfg.partitions, ReplicationFactor: 1, UnassignedOverlapBudget: overlap, RoutedPartitionRecall: totals["end_to_end_distributed_simulation"] / n, SelectedPartitions: probes}
+	r := runResult{SchemaVersion: schemaVersion, ResultKind: "simulation_only", ProductionEvidence: false, Command: cfg.command, BaseSHA: cfg.baseSHA, HeadSHA: cfg.headSHA, GoVersion: runtime.Version(), Hardware: runtime.GOARCH + "/" + runtime.GOOS, Dataset: m, Partitions: cfg.partitions, Overlap: overlap, Probes: probes, TopK: cfg.topK, RecallTarget: cfg.recallTarget, Seed: cfg.seed, Warmup: 0, Samples: len(q), TimedBoundary: "exact in-memory distance and deterministic merge; excludes disk, TreeDB, RPC, and Raft", Stages: selected, Metrics: metrics}
+	if cfg.stages["partition_oracle"] && probes == cfg.partitions && !exactParity {
 		return r, errors.New("all-partition oracle parity failure")
 	}
 	return r, nil
+}
+func dedupeStable(in []neighbor) []neighbor {
+	seen := map[string]bool{}
+	out := make([]neighbor, 0, len(in))
+	for _, n := range in {
+		if !seen[n.ID] {
+			seen[n.ID] = true
+			out = append(out, n)
+		}
+	}
+	return out
 }
 func validateResult(r runResult) error {
 	if r.SchemaVersion != schemaVersion || r.ResultKind != "simulation_only" || r.ProductionEvidence || len(r.Stages) == 0 {
@@ -454,9 +583,18 @@ func validateResult(r runResult) error {
 		if s.Method == "" {
 			return errors.New("unlabelled attribution stage")
 		}
+		if !s.Available {
+			if s.UnavailableReason == "" {
+				return errors.New("unavailable stage without reason")
+			}
+			continue
+		}
 		if math.IsNaN(s.RecallAtK) || math.IsInf(s.RecallAtK, 0) || s.RecallAtK < 0 || s.RecallAtK > 1 {
 			return errors.New("non-finite metric")
 		}
+	}
+	if len(r.BaseSHA) < 7 || len(r.HeadSHA) < 7 {
+		return errors.New("missing git provenance")
 	}
 	if r.Metrics.MeasurementStatus != "simulation_not_measured" {
 		return errors.New("unknown metric measurement status")
@@ -472,7 +610,7 @@ func writeArtifacts(out string, r runResult) error {
 	if err := os.MkdirAll(out, 0755); err != nil {
 		return err
 	}
-	name := fmt.Sprintf("simulation_p%d_o%.2f", r.Probes, r.Overlap)
+	name := artifactBasename(r)
 	b, e := json.MarshalIndent(r, "", "  ")
 	if e != nil {
 		return e
@@ -480,8 +618,17 @@ func writeArtifacts(out string, r runResult) error {
 	if e = os.WriteFile(filepath.Join(out, name+".json"), append(b, '\n'), 0644); e != nil {
 		return e
 	}
-	md := fmt.Sprintf("# TreeDB vector partition M0 simulation\n\n**Simulation only; not production Raft evidence.**\n\n- fixture: `%s` (%s)\n- probes: %d/%d\n- overlap budget: %.2f\n- recall@%d: %.4f\n- timed boundary: %s\n", r.Dataset.Fixture, r.Dataset.Checksum, r.Probes, r.Partitions, r.Overlap, r.TopK, r.Stages[len(r.Stages)-1].RecallAtK, r.TimedBoundary)
+	stageSummary := "unavailable"
+	for _, s := range r.Stages {
+		if s.Name == "end_to_end_distributed_simulation" && s.Available {
+			stageSummary = fmt.Sprintf("recall@%d: %.4f", r.TopK, s.RecallAtK)
+		}
+	}
+	md := fmt.Sprintf("# TreeDB vector partition M0 simulation\n\n**Simulation only; not production Raft evidence.**\n\n- fixture: `%s` (%s)\n- probes: %d/%d\n- overlap budget: %.6g\n- end-to-end simulation: %s\n- timed boundary: %s\n", r.Dataset.Fixture, r.Dataset.Checksum, r.Probes, r.Partitions, r.Overlap, stageSummary, r.TimedBoundary)
 	return os.WriteFile(filepath.Join(out, name+".md"), []byte(md), 0644)
+}
+func artifactBasename(r runResult) string {
+	return fmt.Sprintf("simulation_p%d_o%016x_k%d", r.Probes, math.Float64bits(r.Overlap), r.TopK)
 }
 func fixtureChecksum(vectors, queries, dims int, seed int64) string {
 	m := fixtureManifest{Vectors: vectors, Queries: queries, Dimensions: dims, Seed: seed}

--- a/cmd/treedb_vector_partition_bench/main.go
+++ b/cmd/treedb_vector_partition_bench/main.go
@@ -1,0 +1,508 @@
+// treedb_vector_partition_bench is the M0 deterministic oracle and simulation
+// harness. It deliberately does not open TreeDB or Raft: later milestones own
+// production assets and routed reads.
+package main
+
+import (
+	"crypto/sha256"
+	"encoding/binary"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"math"
+	"os"
+	"path/filepath"
+	"runtime"
+	"sort"
+	"strconv"
+	"strings"
+)
+
+const (
+	schemaVersion         = 1
+	maxVectors            = 1_000_000
+	maxDimensions         = 4_096
+	maxPartitions         = 16_384
+	maxFixtureBytes int64 = 4 << 30
+)
+
+type config struct {
+	dataset      string
+	partitions   int
+	probes       []int
+	overlaps     []float64
+	topK         int
+	recallTarget float64
+	seed         int64
+	format       string
+	out          string
+	stages       map[string]bool
+	command      []string
+	maxVectors   int
+	maxBytes     int64
+}
+
+type fixtureManifest struct {
+	SchemaVersion int    `json:"schema_version"`
+	Fixture       string `json:"fixture"`
+	Generator     string `json:"generator"`
+	Vectors       int    `json:"vectors"`
+	Queries       int    `json:"queries"`
+	Dimensions    int    `json:"dimensions"`
+	Metric        string `json:"metric"`
+	Seed          int64  `json:"seed"`
+	Checksum      string `json:"checksum"`
+}
+
+type neighbor struct {
+	ID       string  `json:"id"`
+	Distance float64 `json:"distance"`
+}
+type stageResult struct {
+	Name      string  `json:"name"`
+	Method    string  `json:"method"`
+	Enabled   bool    `json:"enabled"`
+	Lossy     bool    `json:"lossy"`
+	RecallAtK float64 `json:"recall_at_k"`
+	Queries   int     `json:"queries"`
+	Probes    int     `json:"probes"`
+}
+
+// metricsV1 reserves every M0 evidence field. Simulation leaves production-only
+// measurements at zero and labels them not_measured instead of implying a Raft result.
+type metricsV1 struct {
+	MeasurementStatus       string  `json:"measurement_status"`
+	BuildWallNanos          int64   `json:"build_wall_nanos"`
+	BuildCPUNanos           int64   `json:"build_cpu_nanos"`
+	PeakRSSBytes            int64   `json:"peak_rss_bytes"`
+	TemporaryBytes          int64   `json:"temporary_bytes"`
+	FinalBytes              int64   `json:"final_bytes"`
+	BytesPerVector          float64 `json:"bytes_per_vector"`
+	Balance                 float64 `json:"balance"`
+	MaxPartitionSize        int     `json:"max_partition_size"`
+	EdgeCut                 int64   `json:"edge_cut"`
+	ReplicationFactor       float64 `json:"replication_factor"`
+	UnassignedOverlapBudget float64 `json:"unassigned_overlap_budget"`
+	RepresentativeCount     int     `json:"representative_count"`
+	RouterBytes             int64   `json:"router_bytes"`
+	RoutingLatencyNanos     int64   `json:"routing_latency_nanos"`
+	RoutedPartitionRecall   float64 `json:"routed_partition_recall"`
+	SelectedPartitions      int     `json:"selected_partitions"`
+	SelectedGroups          int     `json:"selected_groups"`
+	RPCs                    int     `json:"rpcs"`
+	RequestBytes            int64   `json:"request_bytes"`
+	ResponseBytes           int64   `json:"response_bytes"`
+	ShardP50Nanos           int64   `json:"per_shard_p50_nanos"`
+	ShardP95Nanos           int64   `json:"per_shard_p95_nanos"`
+	ShardP99Nanos           int64   `json:"per_shard_p99_nanos"`
+	MergeDedupeNanos        int64   `json:"merge_dedupe_nanos"`
+	Cancellations           int64   `json:"cancellations"`
+	Timeouts                int64   `json:"timeouts"`
+	Failures                int64   `json:"failures"`
+	QPS                     float64 `json:"end_to_end_qps"`
+	P50Nanos                int64   `json:"end_to_end_p50_nanos"`
+	P95Nanos                int64   `json:"end_to_end_p95_nanos"`
+	P99Nanos                int64   `json:"end_to_end_p99_nanos"`
+	RecallAt1               float64 `json:"recall_at_1"`
+	RecallAt10              float64 `json:"recall_at_10"`
+	RecallAt100             float64 `json:"recall_at_100"`
+	BytesPerOp              float64 `json:"bytes_per_op"`
+	AllocsPerOp             float64 `json:"allocs_per_op"`
+	ResidentBytes           int64   `json:"resident_bytes"`
+	MappedBytes             int64   `json:"mapped_bytes"`
+}
+type runResult struct {
+	SchemaVersion      int             `json:"schema_version"`
+	ResultKind         string          `json:"result_kind"`
+	ProductionEvidence bool            `json:"production_evidence"`
+	Command            []string        `json:"command"`
+	BaseSHA            string          `json:"base_sha"`
+	HeadSHA            string          `json:"head_sha"`
+	GoVersion          string          `json:"go_version"`
+	Hardware           string          `json:"hardware_context"`
+	Dataset            fixtureManifest `json:"dataset"`
+	Partitions         int             `json:"partitions"`
+	Overlap            float64         `json:"overlap"`
+	Probes             int             `json:"probes"`
+	TopK               int             `json:"top_k"`
+	RecallTarget       float64         `json:"recall_target"`
+	Seed               int64           `json:"seed"`
+	Warmup             int             `json:"warmup"`
+	Samples            int             `json:"samples"`
+	TimedBoundary      string          `json:"timed_boundary"`
+	Stages             []stageResult   `json:"stages"`
+	Metrics            metricsV1       `json:"metrics"`
+}
+
+func main() {
+	if err := run(os.Args[1:], os.Stdout); err != nil {
+		fmt.Fprintln(os.Stderr, "treedb-vector-partition-bench:", err)
+		os.Exit(1)
+	}
+}
+
+func run(args []string, stdout io.Writer) error {
+	cfg, err := parseConfig(args)
+	if err != nil {
+		return err
+	}
+	cfg.command = append([]string{"treedb_vector_partition_bench"}, args...)
+	fixture, err := loadFixture(cfg.dataset)
+	if err != nil {
+		return err
+	}
+	if err := validateFixtureWithCaps(fixture, cfg.maxVectors, cfg.maxBytes); err != nil {
+		return err
+	}
+	if cfg.topK > fixture.Vectors {
+		return errors.New("top-k cannot exceed fixture vectors")
+	}
+	vectors, queries := deterministicFixture(fixture)
+	for _, overlap := range cfg.overlaps {
+		for _, probes := range cfg.probes {
+			result, err := simulate(cfg, fixture, vectors, queries, probes, overlap)
+			if err != nil {
+				return err
+			}
+			if err := validateResult(result); err != nil {
+				return err
+			}
+			if err := writeArtifacts(cfg.out, result); err != nil {
+				return err
+			}
+			if cfg.format == "json" {
+				b, _ := json.Marshal(result)
+				fmt.Fprintln(stdout, string(b))
+			} else {
+				fmt.Fprintf(stdout, "simulation probes=%d overlap=%.2f recall@%d=%.4f\n", probes, overlap, cfg.topK, result.Stages[len(result.Stages)-1].RecallAtK)
+			}
+		}
+	}
+	return nil
+}
+
+func parseConfig(args []string) (config, error) {
+	cfg := config{format: "json", topK: 10, recallTarget: .9, seed: 1}
+	var probes, overlap string
+	var stages string
+	fs := flag.NewFlagSet("treedb_vector_partition_bench", flag.ContinueOnError)
+	fs.StringVar(&cfg.dataset, "dataset", "", "fixture directory")
+	fs.IntVar(&cfg.partitions, "partitions", 0, "logical partition count")
+	fs.StringVar(&probes, "probes", "", "comma-separated probe counts")
+	fs.StringVar(&overlap, "overlap", "0", "comma-separated derived overlap budgets")
+	fs.IntVar(&cfg.topK, "top-k", cfg.topK, "top-k")
+	fs.Float64Var(&cfg.recallTarget, "recall-target", cfg.recallTarget, "recall target")
+	fs.Int64Var(&cfg.seed, "seed", cfg.seed, "simulation seed")
+	fs.StringVar(&cfg.format, "format", cfg.format, "json or text")
+	fs.StringVar(&cfg.out, "out", "", "artifact directory")
+	fs.StringVar(&stages, "stages", "all", "comma-separated independently enabled loss stages, or all")
+	fs.IntVar(&cfg.maxVectors, "max-vectors", maxVectors, "maximum fixture vectors/queries before allocation")
+	fs.Int64Var(&cfg.maxBytes, "max-fixture-bytes", maxFixtureBytes, "maximum vector or query bytes before allocation")
+	if err := fs.Parse(args); err != nil {
+		return config{}, err
+	}
+	var err error
+	if cfg.probes, err = parseInts(probes); err != nil {
+		return config{}, fmt.Errorf("probes: %w", err)
+	}
+	if cfg.overlaps, err = parseFloats(overlap); err != nil {
+		return config{}, fmt.Errorf("overlap: %w", err)
+	}
+	if cfg.dataset == "" || cfg.out == "" || cfg.partitions < 1 || cfg.partitions > maxPartitions || cfg.topK < 1 || cfg.maxVectors < 1 || cfg.maxVectors > maxVectors || cfg.maxBytes < 8 || cfg.maxBytes > maxFixtureBytes || cfg.format != "json" && cfg.format != "text" {
+		return config{}, errors.New("dataset, out, positive bounded partitions/top-k, and json|text format are required")
+	}
+	if len(cfg.probes) == 0 || len(cfg.overlaps) == 0 || math.IsNaN(cfg.recallTarget) || math.IsInf(cfg.recallTarget, 0) || cfg.recallTarget < 0 || cfg.recallTarget > 1 {
+		return config{}, errors.New("probes/overlap must be non-empty and recall target must be in [0,1]")
+	}
+	for _, p := range cfg.probes {
+		if p < 1 || p > cfg.partitions {
+			return config{}, errors.New("each probe count must be within partitions")
+		}
+	}
+	for _, x := range cfg.overlaps {
+		if x < 0 || x > 1 || math.IsNaN(x) || math.IsInf(x, 0) {
+			return config{}, errors.New("overlap must be finite in [0,1]")
+		}
+	}
+	cfg.stages = stageSet(stages)
+	if len(cfg.stages) == 0 {
+		return config{}, errors.New("stages must name known stages or all")
+	}
+	return cfg, nil
+}
+
+var knownStages = []string{"exact_global_top_k", "partition_oracle", "exact_representative_routing", "approximate_representative_routing", "exact_partition_local", "treedb_partition_local_hnsw", "end_to_end_distributed_simulation"}
+
+func stageSet(raw string) map[string]bool {
+	out := map[string]bool{}
+	if raw == "all" {
+		for _, s := range knownStages {
+			out[s] = true
+		}
+		return out
+	}
+	for _, s := range strings.Split(raw, ",") {
+		s = strings.TrimSpace(s)
+		matched := false
+		for _, known := range knownStages {
+			if s == known {
+				out[s] = true
+				matched = true
+			}
+		}
+		if !matched {
+			return map[string]bool{}
+		}
+	}
+	return out
+}
+func parseInts(raw string) ([]int, error) {
+	var out []int
+	for _, s := range strings.Split(raw, ",") {
+		n, e := strconv.Atoi(strings.TrimSpace(s))
+		if e != nil {
+			return nil, e
+		}
+		out = append(out, n)
+	}
+	return out, nil
+}
+func parseFloats(raw string) ([]float64, error) {
+	var out []float64
+	for _, s := range strings.Split(raw, ",") {
+		n, e := strconv.ParseFloat(strings.TrimSpace(s), 64)
+		if e != nil {
+			return nil, e
+		}
+		out = append(out, n)
+	}
+	return out, nil
+}
+
+func loadFixture(dir string) (fixtureManifest, error) {
+	b, e := os.ReadFile(filepath.Join(dir, "fixture_manifest.json"))
+	if e != nil {
+		return fixtureManifest{}, e
+	}
+	var m fixtureManifest
+	d := json.NewDecoder(strings.NewReader(string(b)))
+	d.DisallowUnknownFields()
+	if e = d.Decode(&m); e != nil {
+		return m, e
+	}
+	var extra any
+	if e = d.Decode(&extra); e != io.EOF {
+		return m, errors.New("fixture manifest has trailing JSON")
+	}
+	return m, nil
+}
+func decodeResult(raw []byte) (runResult, error) {
+	var r runResult
+	d := json.NewDecoder(strings.NewReader(string(raw)))
+	d.DisallowUnknownFields()
+	if err := d.Decode(&r); err != nil {
+		return r, err
+	}
+	var extra any
+	if err := d.Decode(&extra); err != io.EOF {
+		return r, errors.New("trailing JSON")
+	}
+	return r, validateResult(r)
+}
+func validateFixture(m fixtureManifest) error {
+	return validateFixtureWithCaps(m, maxVectors, maxFixtureBytes)
+}
+func validateFixtureWithCaps(m fixtureManifest, capVectors int, capBytes int64) error {
+	if m.SchemaVersion != schemaVersion || m.Fixture == "" || m.Generator != "treedb_vector_partition_fixture_v1" || m.Vectors < 1 || m.Vectors > capVectors || m.Queries < 1 || m.Queries > capVectors || m.Dimensions < 1 || m.Dimensions > maxDimensions || m.Metric != "cosine" || len(m.Checksum) != 64 {
+		return errors.New("unsupported or malformed fixture manifest")
+	}
+	if int64(m.Vectors) > capBytes/(int64(m.Dimensions)*8) || int64(m.Queries) > capBytes/(int64(m.Dimensions)*8) {
+		return errors.New("fixture byte product exceeds pre-allocation cap")
+	}
+	_, e := hex.DecodeString(m.Checksum)
+	return e
+}
+
+// deterministicFixture has intentionally visible cluster/boundary pairs and a
+// duplicate pair, so tie ordering remains part of the executable M0 contract.
+func deterministicFixture(m fixtureManifest) ([][]float64, [][]float64) {
+	v := make([][]float64, m.Vectors)
+	for i := range v {
+		row := make([]float64, m.Dimensions)
+		cluster := (i / 97) % 4
+		row[cluster%m.Dimensions] = 1
+		for d := 4; d < m.Dimensions; d++ {
+			row[d] = float64(((i+1)*(d+3)+int(m.Seed))%31) / 310
+		}
+		v[i] = normalize(row)
+	}
+	if len(v) > 1 {
+		v[1] = append([]float64(nil), v[0]...)
+	}
+	q := make([][]float64, m.Queries)
+	for i := range q {
+		q[i] = append([]float64(nil), v[(i*7919+17)%len(v)]...)
+	}
+	return v, q
+}
+func normalize(v []float64) []float64 {
+	var n float64
+	for _, x := range v {
+		n += x * x
+	}
+	n = math.Sqrt(n)
+	for i := range v {
+		v[i] /= n
+	}
+	return v
+}
+func exactTopK(v [][]float64, q []float64, k int) []neighbor {
+	out := make([]neighbor, len(v))
+	for i, row := range v {
+		var dot float64
+		for d := range row {
+			dot += row[d] * q[d]
+		}
+		out[i] = neighbor{ID: fmt.Sprintf("doc-%06d", i), Distance: 1 - dot}
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].Distance == out[j].Distance {
+			return out[i].ID < out[j].ID
+		}
+		return out[i].Distance < out[j].Distance
+	})
+	return out[:k]
+}
+func partitionTopK(v [][]float64, q []float64, k, partitions, probes int) []neighbor {
+	all := make([]neighbor, 0, len(v)*probes/partitions+1)
+	for i, row := range v {
+		if i%partitions >= probes {
+			continue
+		}
+		var dot float64
+		for d := range row {
+			dot += row[d] * q[d]
+		}
+		all = append(all, neighbor{fmt.Sprintf("doc-%06d", i), 1 - dot})
+	}
+	sort.Slice(all, func(i, j int) bool {
+		if all[i].Distance == all[j].Distance {
+			return all[i].ID < all[j].ID
+		}
+		return all[i].Distance < all[j].Distance
+	})
+	if len(all) < k {
+		return all
+	}
+	return all[:k]
+}
+func recall(want, got []neighbor) float64 {
+	found := map[string]bool{}
+	for _, x := range got {
+		found[x.ID] = true
+	}
+	n := 0
+	for _, x := range want {
+		if found[x.ID] {
+			n++
+		}
+	}
+	return float64(n) / float64(len(want))
+}
+func simulate(cfg config, m fixtureManifest, v, q [][]float64, probes int, overlap float64) (runResult, error) {
+	if cfg.stages == nil {
+		cfg.stages = stageSet("all")
+	}
+	if overlap != 0 { /* M0 reports budget only; M3 owns membership copies. */
+	}
+	totals := map[string]float64{"global": 0, "partition": 0}
+	for _, query := range q {
+		truth := exactTopK(v, query, cfg.topK)
+		totals["global"] += recall(truth, exactTopK(v, query, cfg.topK))
+		totals["partition"] += recall(truth, partitionTopK(v, query, cfg.topK, cfg.partitions, probes))
+	}
+	n := float64(len(q))
+	sha := os.Getenv("GITHUB_SHA")
+	if sha == "" {
+		sha = "local"
+	}
+	stage := func(name, method string, lossy bool, value float64, p int) stageResult {
+		return stageResult{Name: name, Method: method, Enabled: cfg.stages[name], Lossy: lossy, RecallAtK: value, Queries: len(q), Probes: p}
+	}
+	allStages := []stageResult{stage("exact_global_top_k", "global_exhaustive", false, totals["global"]/n, cfg.partitions), stage("partition_oracle", "deterministic_partition_exhaustive", probes < cfg.partitions, totals["partition"]/n, probes), stage("exact_representative_routing", "M0_equivalent_to_partition_oracle", false, totals["partition"]/n, probes), stage("approximate_representative_routing", "M0_equivalent_to_exact_representative", false, totals["partition"]/n, probes), stage("exact_partition_local", "partition_exhaustive", false, totals["partition"]/n, probes), stage("treedb_partition_local_hnsw", "M0_placeholder_exact_local_not_production_HNSW", false, totals["partition"]/n, probes), stage("end_to_end_distributed_simulation", "sequential_deterministic_merge", probes < cfg.partitions, totals["partition"]/n, probes)}
+	selected := make([]stageResult, 0, len(allStages))
+	for _, s := range allStages {
+		if s.Enabled {
+			selected = append(selected, s)
+		}
+	}
+	metrics := metricsV1{MeasurementStatus: "simulation_not_measured", Balance: 1, MaxPartitionSize: (len(v) + cfg.partitions - 1) / cfg.partitions, ReplicationFactor: 1, UnassignedOverlapBudget: overlap, RoutedPartitionRecall: totals["partition"] / n, SelectedPartitions: probes}
+	r := runResult{SchemaVersion: schemaVersion, ResultKind: "simulation_only", ProductionEvidence: false, Command: cfg.command, BaseSHA: os.Getenv("BASE_SHA"), HeadSHA: sha, GoVersion: runtime.Version(), Hardware: runtime.GOARCH + "/" + runtime.GOOS, Dataset: m, Partitions: cfg.partitions, Overlap: overlap, Probes: probes, TopK: cfg.topK, RecallTarget: cfg.recallTarget, Seed: cfg.seed, Warmup: 0, Samples: len(q), TimedBoundary: "exact in-memory distance and deterministic merge; excludes disk, TreeDB, RPC, and Raft", Stages: selected, Metrics: metrics}
+	if probes == cfg.partitions && totals["partition"]/n != 1 {
+		return r, errors.New("all-partition oracle parity failure")
+	}
+	return r, nil
+}
+func validateResult(r runResult) error {
+	if r.SchemaVersion != schemaVersion || r.ResultKind != "simulation_only" || r.ProductionEvidence || len(r.Stages) == 0 {
+		return errors.New("invalid result schema or production labeling")
+	}
+	for _, s := range r.Stages {
+		if s.Method == "" {
+			return errors.New("unlabelled attribution stage")
+		}
+		if math.IsNaN(s.RecallAtK) || math.IsInf(s.RecallAtK, 0) || s.RecallAtK < 0 || s.RecallAtK > 1 {
+			return errors.New("non-finite metric")
+		}
+	}
+	if r.Metrics.MeasurementStatus != "simulation_not_measured" {
+		return errors.New("unknown metric measurement status")
+	}
+	for _, x := range []float64{r.Metrics.BytesPerVector, r.Metrics.Balance, r.Metrics.ReplicationFactor, r.Metrics.UnassignedOverlapBudget, r.Metrics.RoutedPartitionRecall, r.Metrics.QPS, r.Metrics.RecallAt1, r.Metrics.RecallAt10, r.Metrics.RecallAt100, r.Metrics.BytesPerOp, r.Metrics.AllocsPerOp} {
+		if math.IsNaN(x) || math.IsInf(x, 0) {
+			return errors.New("non-finite metric")
+		}
+	}
+	return nil
+}
+func writeArtifacts(out string, r runResult) error {
+	if err := os.MkdirAll(out, 0755); err != nil {
+		return err
+	}
+	name := fmt.Sprintf("simulation_p%d_o%.2f", r.Probes, r.Overlap)
+	b, e := json.MarshalIndent(r, "", "  ")
+	if e != nil {
+		return e
+	}
+	if e = os.WriteFile(filepath.Join(out, name+".json"), append(b, '\n'), 0644); e != nil {
+		return e
+	}
+	md := fmt.Sprintf("# TreeDB vector partition M0 simulation\n\n**Simulation only; not production Raft evidence.**\n\n- fixture: `%s` (%s)\n- probes: %d/%d\n- overlap budget: %.2f\n- recall@%d: %.4f\n- timed boundary: %s\n", r.Dataset.Fixture, r.Dataset.Checksum, r.Probes, r.Partitions, r.Overlap, r.TopK, r.Stages[len(r.Stages)-1].RecallAtK, r.TimedBoundary)
+	return os.WriteFile(filepath.Join(out, name+".md"), []byte(md), 0644)
+}
+func fixtureChecksum(vectors, queries, dims int, seed int64) string {
+	m := fixtureManifest{Vectors: vectors, Queries: queries, Dimensions: dims, Seed: seed}
+	v, q := deterministicFixture(m)
+	h := sha256.New()
+	var b [8]byte
+	for _, set := range [][][]float64{v, q} {
+		for _, row := range set {
+			for _, x := range row {
+				binary.LittleEndian.PutUint64(b[:], math.Float64bits(x))
+				_, _ = h.Write(b[:])
+			}
+		}
+	}
+	// Bind the canonical exact-truth stream too, including stable-ID tie order.
+	for _, query := range q {
+		for _, n := range exactTopK(v, query, 10) {
+			_, _ = h.Write([]byte(n.ID))
+			binary.LittleEndian.PutUint64(b[:], math.Float64bits(n.Distance))
+			_, _ = h.Write(b[:])
+		}
+	}
+	return hex.EncodeToString(h.Sum(nil))
+}

--- a/cmd/treedb_vector_partition_bench/main.go
+++ b/cmd/treedb_vector_partition_bench/main.go
@@ -1062,8 +1062,13 @@ func fixtureChecksum(vectors, queries, dims int, seed int64) string {
 		}
 	}
 	// Bind the canonical exact-truth stream too, including stable-ID tie order.
+	// Small fixtures bind every available neighbor; canonical fixtures bind top-10.
+	truthK := 10
+	if len(v) < truthK {
+		truthK = len(v)
+	}
 	for _, query := range q {
-		for _, n := range exactTopK(v, query, 10) {
+		for _, n := range exactTopK(v, query, truthK) {
 			_, _ = h.Write([]byte(n.ID))
 			binary.LittleEndian.PutUint64(b[:], math.Float64bits(n.Distance))
 			_, _ = h.Write(b[:])

--- a/cmd/treedb_vector_partition_bench/main.go
+++ b/cmd/treedb_vector_partition_bench/main.go
@@ -1442,7 +1442,23 @@ func writeArtifacts(out string, r runResult) error {
 	return os.WriteFile(filepath.Join(out, name+".md"), []byte(md), 0644)
 }
 func artifactBasename(r runResult) string {
-	return fmt.Sprintf("simulation_f%s_s%016x_n%d_p%d_o%016x_k%d", r.Dataset.Checksum, uint64(r.Seed), r.Partitions, r.Probes, math.Float64bits(r.Overlap), r.TopK)
+	return fmt.Sprintf("simulation_f%s_s%016x_n%d_p%d_o%016x_t%s_k%d", r.Dataset.Checksum, uint64(r.Seed), r.Partitions, r.Probes, math.Float64bits(r.Overlap), artifactStageSetChecksum(r.Stages), r.TopK)
+}
+
+func artifactStageSetChecksum(stages []stageResult) string {
+	names := make([]string, 0, len(stages))
+	for _, stage := range stages {
+		names = append(names, stage.Name)
+	}
+	sort.Strings(names)
+	h := sha256.New()
+	var length [8]byte
+	for _, name := range names {
+		binary.LittleEndian.PutUint64(length[:], uint64(len(name)))
+		_, _ = h.Write(length[:])
+		_, _ = h.Write([]byte(name))
+	}
+	return hex.EncodeToString(h.Sum(nil))
 }
 func fixtureChecksum(vectors, queries, dims int, seed int64) string {
 	m := fixtureManifest{Vectors: vectors, Queries: queries, Dimensions: dims, Seed: seed}

--- a/cmd/treedb_vector_partition_bench/main.go
+++ b/cmd/treedb_vector_partition_bench/main.go
@@ -33,6 +33,7 @@ const (
 	maxDimensions                   = 4_096
 	maxPartitions                   = 16_384
 	maxFixtureBytes           int64 = 4 << 30
+	maxBenchmarkWorkUnits     int64 = 200_000_000
 	maxManifestBytes          int64 = 64 << 10
 	maxGitHubEventBytes       int64 = 2 << 20
 	partitionHNSWIndex              = "embedding_graph"
@@ -45,6 +46,7 @@ const (
 	memorySlackNumerator            = 5
 	memorySlackDenominator          = 4
 	memoryBudgetScope               = "modeled_peak_live_bytes_v1: contiguous generated float64 fixture/query matrices and row headers; exact/selected top-k candidates; representative routing; HNSW partition JSON plus decoded JSON/vector batch; HNSW query merge and cache; 25% allocation slack; excludes TreeDB engine/index internals, Go runtime/GC metadata, and artifact/CLI encoding"
+	benchmarkWorkScope              = "benchmark_owned_vector_query_corpus_visits_v1: checksum exact truth once; mandatory truth plus enabled exhaustive/routing corpus passes for every probe/overlap row; excludes TreeDB HNSW engine-internal search work"
 )
 
 type config struct {
@@ -261,6 +263,9 @@ func run(args []string, stdout io.Writer) (runErr error) {
 	}
 	if cfg.seed != fixture.Seed {
 		return fmt.Errorf("-seed %d does not match fixture seed %d", cfg.seed, fixture.Seed)
+	}
+	if _, err := validateBenchmarkWork(cfg, fixture, maxBenchmarkWorkUnits); err != nil {
+		return err
 	}
 	cfg.memory, err = planBenchmarkMemory(cfg, fixture)
 	if err != nil {
@@ -536,6 +541,70 @@ func validateFixtureWithCaps(m fixtureManifest, capVectors int, capBytes int64) 
 	}
 	_, e := hex.DecodeString(m.Checksum)
 	return e
+}
+
+type benchmarkWorkPlan struct {
+	VectorQueryPairs  int64
+	CorpusPasses      int64
+	VectorQueryVisits int64
+}
+
+func validateBenchmarkWork(cfg config, m fixtureManifest, capUnits int64) (benchmarkWorkPlan, error) {
+	if capUnits < 1 || len(cfg.probes) == 0 || len(cfg.overlaps) == 0 {
+		return benchmarkWorkPlan{}, errors.New("cannot plan benchmark work without a positive cap, probes, and overlap rows")
+	}
+	stages := cfg.stages
+	if stages == nil {
+		stages = stageSet("all")
+	}
+
+	// simulate always computes global exact truth once per query. Every
+	// selected exhaustive/routing helper below makes the documented number of
+	// additional full corpus visits for each probe/overlap artifact row.
+	passesPerSimulation := int64(1)
+	if stages["partition_oracle"] {
+		passesPerSimulation++
+	}
+	for _, stage := range []string{
+		"exact_representative_routing",
+		"approximate_representative_routing",
+		"exact_partition_local",
+		"end_to_end_distributed_simulation",
+	} {
+		if stages[stage] {
+			passesPerSimulation += 2 // representative selection plus selected exact top-k
+		}
+	}
+	if stages["treedb_partition_local_hnsw"] {
+		passesPerSimulation++ // representative selection; HNSW engine work is excluded
+	}
+
+	simulationRows, err := memoryMul(int64(len(cfg.probes)), int64(len(cfg.overlaps)))
+	if err != nil {
+		return benchmarkWorkPlan{}, err
+	}
+	simulationPasses, err := memoryMul(simulationRows, passesPerSimulation)
+	if err != nil {
+		return benchmarkWorkPlan{}, err
+	}
+	corpusPasses, err := memoryAdd(1, simulationPasses) // checksum exact truth
+	if err != nil {
+		return benchmarkWorkPlan{}, err
+	}
+	vectorQueryPairs, err := memoryMul(int64(m.Vectors), int64(m.Queries))
+	if err != nil {
+		return benchmarkWorkPlan{}, err
+	}
+	plan := benchmarkWorkPlan{
+		VectorQueryPairs: vectorQueryPairs,
+		CorpusPasses:     corpusPasses,
+	}
+	if vectorQueryPairs > capUnits/corpusPasses {
+		return plan, fmt.Errorf("modeled benchmark work exceeds %d-unit cap (%s): vector_query_pairs=%d corpus_passes=%d",
+			capUnits, benchmarkWorkScope, vectorQueryPairs, corpusPasses)
+	}
+	plan.VectorQueryVisits = vectorQueryPairs * corpusPasses
+	return plan, nil
 }
 
 func planBenchmarkMemory(cfg config, m fixtureManifest) (benchmarkMemoryPlan, error) {

--- a/cmd/treedb_vector_partition_bench/main.go
+++ b/cmd/treedb_vector_partition_bench/main.go
@@ -1,6 +1,6 @@
-// treedb_vector_partition_bench is the M0 deterministic oracle and simulation
-// harness. It deliberately does not open TreeDB or Raft: later milestones own
-// production assets and routed reads.
+// treedb_vector_partition_bench is the M0 deterministic oracle and sequential
+// simulation harness. Its partition-local HNSW attribution stage uses real
+// temporary TreeDB column_graph indexes; it does not implement routed Raft.
 package main
 
 import (
@@ -20,14 +20,21 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+
+	"github.com/snissn/gomap/TreeDB/collections"
+	backenddb "github.com/snissn/gomap/TreeDB/db"
 )
 
 const (
-	schemaVersion         = 1
-	maxVectors            = 1_000_000
-	maxDimensions         = 4_096
-	maxPartitions         = 16_384
-	maxFixtureBytes int64 = 4 << 30
+	schemaVersion             = 1
+	maxVectors                = 1_000_000
+	maxDimensions             = 4_096
+	maxPartitions             = 16_384
+	maxFixtureBytes     int64 = 4 << 30
+	maxManifestBytes    int64 = 64 << 10
+	maxGitHubEventBytes int64 = 2 << 20
+	partitionHNSWIndex        = "embedding_graph"
+	partitionHNSWDegree       = 16
 )
 
 type config struct {
@@ -46,6 +53,7 @@ type config struct {
 	maxBytes     int64
 	baseSHA      string
 	headSHA      string
+	hnsw         *treeDBPartitionHNSW
 }
 
 type fixtureManifest struct {
@@ -65,15 +73,51 @@ type neighbor struct {
 	Distance float64 `json:"distance"`
 }
 type stageResult struct {
-	Name              string  `json:"name"`
-	Method            string  `json:"method"`
-	Enabled           bool    `json:"enabled"`
-	Lossy             bool    `json:"lossy"`
-	RecallAtK         float64 `json:"recall_at_k"`
-	Queries           int     `json:"queries"`
-	Probes            int     `json:"probes"`
-	Available         bool    `json:"available"`
-	UnavailableReason string  `json:"unavailable_reason,omitempty"`
+	Name                      string  `json:"name"`
+	Method                    string  `json:"method"`
+	Enabled                   bool    `json:"enabled"`
+	Lossy                     bool    `json:"lossy"`
+	RecallAtK                 float64 `json:"recall_at_k"`
+	Queries                   int     `json:"queries"`
+	Probes                    int     `json:"probes"`
+	Available                 bool    `json:"available"`
+	UnavailableReason         string  `json:"unavailable_reason,omitempty"`
+	RouteKind                 string  `json:"route_kind,omitempty"`
+	Searches                  uint64  `json:"searches,omitempty"`
+	ExecutedSearches          uint64  `json:"executed_searches,omitempty"`
+	CachedSearches            uint64  `json:"cached_searches,omitempty"`
+	SearchRouteHNSWSearchPack uint64  `json:"search_route_hnsw_search_pack,omitempty"`
+	HNSWSearchPackActive      uint64  `json:"hnsw_search_pack_active,omitempty"`
+	HNSWSearchPackFallbacks   uint64  `json:"hnsw_search_pack_fallbacks,omitempty"`
+}
+
+type hnswSearchEvidence struct {
+	Searches                  uint64
+	ExecutedSearches          uint64
+	CachedSearches            uint64
+	SearchRouteHNSWSearchPack uint64
+	HNSWSearchPackActive      uint64
+	HNSWSearchPackFallbacks   uint64
+}
+
+type hnswSearchOutcome struct {
+	Neighbors []neighbor
+	Evidence  hnswSearchEvidence
+}
+
+type hnswCacheKey struct {
+	Query              int
+	SelectedPartitions string
+	TopK               int
+}
+
+type treeDBPartitionHNSW struct {
+	dir              string
+	db               *backenddb.DB
+	partitions       []*collections.Collection
+	rowCounts        []int
+	cache            map[hnswCacheKey]hnswSearchOutcome
+	physicalSearches uint64
 }
 
 // metricsV1 reserves every M0 evidence field. Simulation leaves production-only
@@ -149,7 +193,7 @@ func main() {
 	}
 }
 
-func run(args []string, stdout io.Writer) error {
+func run(args []string, stdout io.Writer) (runErr error) {
 	cfg, err := parseConfig(args)
 	if err != nil {
 		return err
@@ -168,9 +212,21 @@ func run(args []string, stdout io.Writer) error {
 	if cfg.topK > fixture.Vectors {
 		return errors.New("top-k cannot exceed fixture vectors")
 	}
+	if cfg.partitions > fixture.Vectors {
+		return errors.New("partitions cannot exceed fixture vectors")
+	}
 	vectors, queries := deterministicFixture(fixture)
 	if fixtureChecksum(fixture.Vectors, fixture.Queries, fixture.Dimensions, fixture.Seed) != fixture.Checksum {
 		return errors.New("fixture checksum does not match generated vector/query/truth stream")
+	}
+	if cfg.stages["treedb_partition_local_hnsw"] {
+		cfg.hnsw, err = newTreeDBPartitionHNSW(vectors, cfg.partitions)
+		if err != nil {
+			return fmt.Errorf("build TreeDB partition-local HNSW stage: %w", err)
+		}
+		defer func() {
+			runErr = errors.Join(runErr, cfg.hnsw.Close())
+		}()
 	}
 	for _, overlap := range cfg.overlaps {
 		for _, probes := range cfg.probes {
@@ -210,7 +266,7 @@ func parseConfig(args []string) (config, error) {
 	fs.StringVar(&cfg.format, "format", cfg.format, "json or text")
 	fs.StringVar(&cfg.out, "out", "", "artifact directory")
 	fs.StringVar(&stages, "stages", "all", "comma-separated independently enabled loss stages, or all")
-	fs.IntVar(&cfg.maxVectors, "max-vectors", maxVectors, "maximum fixture vectors/queries before allocation")
+	fs.IntVar(&cfg.maxVectors, "max-vectors", maxVectors, "maximum combined fixture vector/query count before allocation")
 	fs.Int64Var(&cfg.maxBytes, "max-fixture-bytes", maxFixtureBytes, "maximum vector or query bytes before allocation")
 	if err := fs.Parse(args); err != nil {
 		return config{}, err
@@ -302,6 +358,15 @@ func provenance() (string, string, error) {
 		head = strings.TrimSpace(string(out))
 	}
 	if base == "" {
+		if eventPath := os.Getenv("GITHUB_EVENT_PATH"); eventPath != "" {
+			eventBase, err := pullRequestBaseSHAFromEvent(eventPath)
+			if err != nil {
+				return "", "", fmt.Errorf("GitHub event base SHA: %w", err)
+			}
+			base = eventBase
+		}
+	}
+	if base == "" {
 		out, err := exec.Command("git", "merge-base", "HEAD", "origin/main").Output()
 		if err != nil {
 			return "", "", errors.New("git merge-base unavailable: set BASE_SHA")
@@ -317,19 +382,61 @@ func provenance() (string, string, error) {
 	return base, head, nil
 }
 
+func pullRequestBaseSHAFromEvent(path string) (string, error) {
+	f, err := os.Open(filepath.Clean(path))
+	if err != nil {
+		return "", err
+	}
+	defer func() { _ = f.Close() }()
+	raw, err := io.ReadAll(io.LimitReader(f, maxGitHubEventBytes+1))
+	if err != nil {
+		return "", err
+	}
+	if int64(len(raw)) > maxGitHubEventBytes {
+		return "", fmt.Errorf("event payload exceeds %d-byte cap", maxGitHubEventBytes)
+	}
+	var event struct {
+		PullRequest *struct {
+			Base struct {
+				SHA string `json:"sha"`
+			} `json:"base"`
+		} `json:"pull_request"`
+	}
+	decoder := json.NewDecoder(strings.NewReader(string(raw)))
+	if err := decoder.Decode(&event); err != nil {
+		return "", err
+	}
+	var extra any
+	if err := decoder.Decode(&extra); err != io.EOF {
+		return "", errors.New("GitHub event has trailing JSON")
+	}
+	if event.PullRequest == nil {
+		return "", nil
+	}
+	return strings.TrimSpace(event.PullRequest.Base.SHA), nil
+}
+
 func loadFixture(dir string) (fixtureManifest, error) {
-	b, e := os.ReadFile(filepath.Join(dir, "fixture_manifest.json"))
-	if e != nil {
-		return fixtureManifest{}, e
+	f, err := os.Open(filepath.Join(dir, "fixture_manifest.json"))
+	if err != nil {
+		return fixtureManifest{}, err
+	}
+	defer func() { _ = f.Close() }()
+	b, err := io.ReadAll(io.LimitReader(f, maxManifestBytes+1))
+	if err != nil {
+		return fixtureManifest{}, err
+	}
+	if int64(len(b)) > maxManifestBytes {
+		return fixtureManifest{}, fmt.Errorf("fixture manifest exceeds %d-byte cap", maxManifestBytes)
 	}
 	var m fixtureManifest
 	d := json.NewDecoder(strings.NewReader(string(b)))
 	d.DisallowUnknownFields()
-	if e = d.Decode(&m); e != nil {
-		return m, e
+	if err = d.Decode(&m); err != nil {
+		return m, err
 	}
 	var extra any
-	if e = d.Decode(&extra); e != io.EOF {
+	if err = d.Decode(&extra); err != io.EOF {
 		return m, errors.New("fixture manifest has trailing JSON")
 	}
 	return m, nil
@@ -354,7 +461,10 @@ func validateFixtureWithCaps(m fixtureManifest, capVectors int, capBytes int64) 
 	if m.SchemaVersion != schemaVersion || m.Fixture == "" || m.Generator != "treedb_vector_partition_fixture_v1" || m.Vectors < 1 || m.Vectors > capVectors || m.Queries < 1 || m.Queries > capVectors || m.Dimensions < 1 || m.Dimensions > maxDimensions || m.Metric != "cosine" || len(m.Checksum) != 64 {
 		return errors.New("unsupported or malformed fixture manifest")
 	}
-	if int64(m.Vectors) > capBytes/(int64(m.Dimensions)*8) || int64(m.Queries) > capBytes/(int64(m.Dimensions)*8) || int64(m.Vectors)+int64(m.Queries) > capBytes/(int64(m.Dimensions)*8) {
+	if int64(m.Vectors)+int64(m.Queries) > int64(capVectors) {
+		return errors.New("combined fixture vector/query count exceeds pre-allocation cap")
+	}
+	if int64(m.Vectors)+int64(m.Queries) > capBytes/(int64(m.Dimensions)*8) {
 		return errors.New("fixture byte product exceeds pre-allocation cap")
 	}
 	_, e := hex.DecodeString(m.Checksum)
@@ -494,6 +604,274 @@ func representativePartitions(v [][]float64, q []float64, partitions, probes int
 	return out
 }
 func parsePartitionID(id string) int { n, _ := strconv.Atoi(strings.TrimPrefix(id, "p-")); return n }
+
+func newTreeDBPartitionHNSW(vectors [][]float64, partitions int) (_ *treeDBPartitionHNSW, err error) {
+	if len(vectors) == 0 || partitions < 1 || partitions > len(vectors) {
+		return nil, errors.New("invalid vector/partition count for TreeDB HNSW stage")
+	}
+	dims := len(vectors[0])
+	if dims < 1 {
+		return nil, errors.New("TreeDB HNSW stage requires positive dimensions")
+	}
+	dir, err := os.MkdirTemp("", "treedb-vector-partition-hnsw-*")
+	if err != nil {
+		return nil, err
+	}
+	h := &treeDBPartitionHNSW{
+		dir:        dir,
+		partitions: make([]*collections.Collection, partitions),
+		rowCounts:  make([]int, partitions),
+		cache:      make(map[hnswCacheKey]hnswSearchOutcome),
+	}
+	defer func() {
+		if err != nil {
+			_ = h.Close()
+		}
+	}()
+	if err = backenddb.SaveFormatConfig(dir, backenddb.FormatConfig{
+		RequiredFeatures: []string{backenddb.RequiredFeatureCommandWALV1},
+	}); err != nil {
+		return nil, err
+	}
+	h.db, err = backenddb.Open(backenddb.Options{Dir: dir, DisableBackgroundPrune: true})
+	if err != nil {
+		return nil, err
+	}
+	manager := collections.NewCollectionManager(h.db)
+	for partition := 0; partition < partitions; partition++ {
+		name := partitionCollectionName(partition)
+		if _, err = manager.CreateCollection(partitionCollectionMeta(name, dims)); err != nil {
+			return nil, fmt.Errorf("create partition %d collection: %w", partition, err)
+		}
+		col, openErr := manager.OpenCollection(name)
+		if openErr != nil {
+			return nil, fmt.Errorf("open partition %d collection: %w", partition, openErr)
+		}
+		if err = insertPartitionRows(col, vectors, partition, partitions); err != nil {
+			return nil, fmt.Errorf("insert partition %d rows: %w", partition, err)
+		}
+		if err = col.Flush(); err != nil {
+			return nil, fmt.Errorf("flush partition %d rows: %w", partition, err)
+		}
+		status, rebuildErr := col.RebuildVectorIndex(partitionHNSWIndex)
+		if rebuildErr != nil {
+			return nil, fmt.Errorf("rebuild partition %d HNSW: %w", partition, rebuildErr)
+		}
+		if !status.Loaded {
+			return nil, fmt.Errorf("rebuild partition %d HNSW status=%+v, want loaded", partition, status)
+		}
+		h.rowCounts[partition] = moduloPartitionSize(len(vectors), partitions, partition)
+	}
+	if err = h.db.Checkpoint(); err != nil {
+		return nil, fmt.Errorf("checkpoint partition-local HNSW DB: %w", err)
+	}
+	for partition := 0; partition < partitions; partition++ {
+		col, openErr := manager.OpenCollection(partitionCollectionName(partition))
+		if openErr != nil {
+			return nil, fmt.Errorf("reopen partition %d collection: %w", partition, openErr)
+		}
+		h.partitions[partition] = col
+	}
+	return h, nil
+}
+
+func partitionCollectionName(partition int) string {
+	return fmt.Sprintf("partition_%06d", partition)
+}
+
+func partitionCollectionMeta(name string, dims int) *collections.CollectionMeta {
+	return &collections.CollectionMeta{
+		Name: name,
+		Options: collections.CollectionOptions{
+			DocumentFormat: collections.DocumentFormatJSON,
+			ColumnStore: &collections.ColumnStoreConfig{
+				Enabled:         true,
+				RetainedPayload: collections.ColumnRetainedPayloadNonColumn,
+				Columns: []collections.ColumnStoreColumn{
+					{Name: "time_us", Path: "time_us", ValueType: collections.ColumnStoreValueInt64},
+					{Name: "embedding", Path: "embedding", Owner: collections.TypedStorageOwnerColumnPart, ValueType: collections.ColumnStoreValueFloat32Vector, VectorDims: dims},
+				},
+				SortKey: []collections.ColumnSortKey{{Column: "time_us"}},
+			},
+		},
+		VectorIndexes: []collections.VectorIndexDefinition{{
+			Name:           partitionHNSWIndex,
+			Field:          "embedding",
+			Metric:         collections.VectorMetricCosine,
+			Dimensions:     dims,
+			M:              partitionHNSWDegree,
+			EfConstruction: 128,
+			EfSearch:       128,
+			Encoding:       collections.VectorIndexEncodingFloat32,
+			Strategy:       collections.VectorIndexStrategyColumnGraph,
+		}},
+	}
+}
+
+func insertPartitionRows(col *collections.Collection, vectors [][]float64, partition, partitions int) error {
+	rowCount := moduloPartitionSize(len(vectors), partitions, partition)
+	ids := make([][]byte, 0, rowCount)
+	documents := make([][]byte, 0, rowCount)
+	for i := partition; i < len(vectors); i += partitions {
+		vector := make([]float32, len(vectors[i]))
+		for d, value := range vectors[i] {
+			if math.IsNaN(value) || math.IsInf(value, 0) {
+				return fmt.Errorf("vector %d dimension %d is non-finite", i, d)
+			}
+			vector[d] = float32(value)
+		}
+		id := fmt.Sprintf("doc-%06d", i)
+		raw, err := json.Marshal(struct {
+			TimeUS    int64     `json:"time_us"`
+			Embedding []float32 `json:"embedding"`
+		}{
+			TimeUS:    int64(i + 1),
+			Embedding: vector,
+		})
+		if err != nil {
+			return err
+		}
+		ids = append(ids, []byte(id))
+		documents = append(documents, raw)
+	}
+	if len(ids) != rowCount {
+		return fmt.Errorf("partition %d rows=%d want %d", partition, len(ids), rowCount)
+	}
+	_, err := col.InsertBatch(ids, documents)
+	return err
+}
+
+func moduloPartitionSize(vectors, partitions, partition int) int {
+	if partition >= vectors {
+		return 0
+	}
+	return 1 + (vectors-1-partition)/partitions
+}
+
+func (h *treeDBPartitionHNSW) search(queryIndex int, query []float64, selected []int, topK int) (hnswSearchOutcome, error) {
+	if h == nil || h.db == nil {
+		return hnswSearchOutcome{}, errors.New("TreeDB partition-local HNSW stage is not initialized")
+	}
+	key := hnswCacheKey{Query: queryIndex, SelectedPartitions: canonicalPartitionSet(selected), TopK: topK}
+	if cached, ok := h.cache[key]; ok {
+		cached.Evidence.ExecutedSearches = 0
+		cached.Evidence.CachedSearches = cached.Evidence.Searches
+		return cached, nil
+	}
+	query32 := make([]float32, len(query))
+	for i, value := range query {
+		query32[i] = float32(value)
+	}
+	merged := make([]neighbor, 0, topK*len(selected))
+	var evidence hnswSearchEvidence
+	for _, partition := range selected {
+		if partition < 0 || partition >= len(h.partitions) || h.partitions[partition] == nil || h.rowCounts[partition] == 0 {
+			return hnswSearchOutcome{}, fmt.Errorf("selected HNSW partition %d is unavailable", partition)
+		}
+		response, err := h.partitions[partition].SearchVectorIndex(collections.VectorIndexSearchOptions{
+			IndexName: partitionHNSWIndex,
+			Query:     query32,
+			TopK:      min(topK, h.rowCounts[partition]),
+			EfSearch:  h.rowCounts[partition],
+		})
+		if err != nil {
+			return hnswSearchOutcome{}, fmt.Errorf("search HNSW partition %d: %w", partition, err)
+		}
+		h.physicalSearches++
+		diagnostics := response.Diagnostics()
+		if response.Stats.SearchRouteHNSWSearchPack != 1 ||
+			response.Stats.HNSWSearchPackActive != 1 ||
+			response.Stats.HNSWSearchPackFallbacks != 0 ||
+			diagnostics.Route != collections.VectorIndexSearchRouteExactHNSWSearchPackV1 ||
+			!diagnostics.ExactHNSWSearchPackNoDocRoute {
+			return hnswSearchOutcome{}, fmt.Errorf("partition %d did not use exact HNSW search-pack route: diagnostics=%+v stats_route=%d active=%d fallbacks=%d",
+				partition,
+				diagnostics,
+				response.Stats.SearchRouteHNSWSearchPack,
+				response.Stats.HNSWSearchPackActive,
+				response.Stats.HNSWSearchPackFallbacks,
+			)
+		}
+		evidence.Searches++
+		evidence.ExecutedSearches++
+		evidence.SearchRouteHNSWSearchPack += response.Stats.SearchRouteHNSWSearchPack
+		evidence.HNSWSearchPackActive += response.Stats.HNSWSearchPackActive
+		evidence.HNSWSearchPackFallbacks += response.Stats.HNSWSearchPackFallbacks
+		for _, result := range response.Results {
+			distance := 1 - result.Score
+			if math.IsNaN(distance) || math.IsInf(distance, 0) {
+				return hnswSearchOutcome{}, fmt.Errorf("partition %d returned non-finite score for %q", partition, result.ID)
+			}
+			merged = append(merged, neighbor{ID: string(result.ID), Distance: distance})
+		}
+	}
+	sortNeighbors(merged)
+	merged = dedupeSortedNeighbors(merged)
+	if len(merged) > topK {
+		merged = merged[:topK]
+	}
+	outcome := hnswSearchOutcome{Neighbors: merged, Evidence: evidence}
+	h.cache[key] = outcome
+	return outcome, nil
+}
+
+func canonicalPartitionSet(selected []int) string {
+	partitions := append([]int(nil), selected...)
+	sort.Ints(partitions)
+	var b strings.Builder
+	for i, partition := range partitions {
+		if i != 0 {
+			b.WriteByte(',')
+		}
+		b.WriteString(strconv.Itoa(partition))
+	}
+	return b.String()
+}
+
+func (h *treeDBPartitionHNSW) Close() error {
+	if h == nil {
+		return nil
+	}
+	var errs []error
+	clear(h.partitions)
+	h.partitions = nil
+	if h.db != nil {
+		if err := h.db.Close(); err != nil {
+			errs = append(errs, fmt.Errorf("close partition-local HNSW DB: %w", err))
+		}
+		h.db = nil
+	}
+	if h.dir != "" {
+		if err := os.RemoveAll(h.dir); err != nil {
+			errs = append(errs, fmt.Errorf("remove partition-local HNSW DB: %w", err))
+		}
+		h.dir = ""
+	}
+	return errors.Join(errs...)
+}
+
+func sortNeighbors(in []neighbor) {
+	sort.Slice(in, func(i, j int) bool {
+		if in[i].Distance == in[j].Distance {
+			return in[i].ID < in[j].ID
+		}
+		return in[i].Distance < in[j].Distance
+	})
+}
+
+func dedupeSortedNeighbors(in []neighbor) []neighbor {
+	seen := make(map[string]struct{}, len(in))
+	out := in[:0]
+	for _, n := range in {
+		if _, ok := seen[n.ID]; ok {
+			continue
+		}
+		seen[n.ID] = struct{}{}
+		out = append(out, n)
+	}
+	return out
+}
+
 func recall(want, got []neighbor) float64 {
 	found := map[string]bool{}
 	for _, x := range got {
@@ -514,8 +892,9 @@ func simulate(cfg config, m fixtureManifest, v, q [][]float64, probes int, overl
 	if overlap != 0 { /* M0 reports budget only; M3 owns membership copies. */
 	}
 	totals := map[string]float64{}
+	var hnswEvidence hnswSearchEvidence
 	exactParity := true
-	for _, query := range q {
+	for queryIndex, query := range q {
 		truth := exactTopK(v, query, cfg.topK)
 		if cfg.stages["exact_global_top_k"] {
 			totals["exact_global_top_k"] += 1
@@ -540,6 +919,23 @@ func simulate(cfg config, m fixtureManifest, v, q [][]float64, probes int, overl
 			got := selectedPartitionTopK(v, query, cfg.topK, cfg.partitions, parts)
 			totals["exact_partition_local"] += recall(truth, got)
 		}
+		if cfg.stages["treedb_partition_local_hnsw"] {
+			if cfg.hnsw == nil {
+				return runResult{}, errors.New("TreeDB partition-local HNSW stage selected without initialized TreeDB indexes")
+			}
+			parts := representativePartitions(v, query, cfg.partitions, probes, false)
+			outcome, err := cfg.hnsw.search(queryIndex, query, parts, cfg.topK)
+			if err != nil {
+				return runResult{}, err
+			}
+			totals["treedb_partition_local_hnsw"] += recall(truth, outcome.Neighbors)
+			hnswEvidence.Searches += outcome.Evidence.Searches
+			hnswEvidence.ExecutedSearches += outcome.Evidence.ExecutedSearches
+			hnswEvidence.CachedSearches += outcome.Evidence.CachedSearches
+			hnswEvidence.SearchRouteHNSWSearchPack += outcome.Evidence.SearchRouteHNSWSearchPack
+			hnswEvidence.HNSWSearchPackActive += outcome.Evidence.HNSWSearchPackActive
+			hnswEvidence.HNSWSearchPackFallbacks += outcome.Evidence.HNSWSearchPackFallbacks
+		}
 		if cfg.stages["end_to_end_distributed_simulation"] {
 			parts := representativePartitions(v, query, cfg.partitions, probes, true)
 			got := selectedPartitionTopK(v, query, cfg.topK, cfg.partitions, parts)
@@ -550,7 +946,15 @@ func simulate(cfg config, m fixtureManifest, v, q [][]float64, probes int, overl
 	stage := func(name, method string, lossy bool, value float64, p int) stageResult {
 		return stageResult{Name: name, Method: method, Enabled: cfg.stages[name], Lossy: lossy, RecallAtK: value, Queries: len(q), Probes: p, Available: true}
 	}
-	allStages := []stageResult{stage("exact_global_top_k", "global_exhaustive", false, totals["exact_global_top_k"]/n, cfg.partitions), stage("partition_oracle", "round_robin_partition_exhaustive", probes < cfg.partitions, totals["partition_oracle"]/n, probes), stage("exact_representative_routing", "centroid_representative_routing", probes < cfg.partitions, totals["exact_representative_routing"]/n, probes), stage("approximate_representative_routing", "deterministic_last_representative_perturbation", probes < cfg.partitions, totals["approximate_representative_routing"]/n, probes), stage("exact_partition_local", "centroid_selected_partition_exhaustive", probes < cfg.partitions, totals["exact_partition_local"]/n, probes), {Name: "treedb_partition_local_hnsw", Method: "unavailable_without_public_M0_HNSW_pack_api", Enabled: cfg.stages["treedb_partition_local_hnsw"], Available: false, UnavailableReason: "M0 has no public TreeDB partition-local HNSW pack API; refusing exact placeholder"}, stage("end_to_end_distributed_simulation", "approximate_router_then_local_exhaustive_dedupe", probes < cfg.partitions, totals["end_to_end_distributed_simulation"]/n, probes)}
+	hnswStage := stage("treedb_partition_local_hnsw", "treedb_column_graph_exact_hnsw_search_pack_v1", true, totals["treedb_partition_local_hnsw"]/n, probes)
+	hnswStage.RouteKind = string(collections.VectorIndexSearchRouteExactHNSWSearchPackV1)
+	hnswStage.Searches = hnswEvidence.Searches
+	hnswStage.ExecutedSearches = hnswEvidence.ExecutedSearches
+	hnswStage.CachedSearches = hnswEvidence.CachedSearches
+	hnswStage.SearchRouteHNSWSearchPack = hnswEvidence.SearchRouteHNSWSearchPack
+	hnswStage.HNSWSearchPackActive = hnswEvidence.HNSWSearchPackActive
+	hnswStage.HNSWSearchPackFallbacks = hnswEvidence.HNSWSearchPackFallbacks
+	allStages := []stageResult{stage("exact_global_top_k", "global_exhaustive", false, totals["exact_global_top_k"]/n, cfg.partitions), stage("partition_oracle", "round_robin_partition_exhaustive", probes < cfg.partitions, totals["partition_oracle"]/n, probes), stage("exact_representative_routing", "centroid_representative_routing", probes < cfg.partitions, totals["exact_representative_routing"]/n, probes), stage("approximate_representative_routing", "deterministic_last_representative_perturbation", probes < cfg.partitions, totals["approximate_representative_routing"]/n, probes), stage("exact_partition_local", "centroid_selected_partition_exhaustive", probes < cfg.partitions, totals["exact_partition_local"]/n, probes), hnswStage, stage("end_to_end_distributed_simulation", "approximate_router_then_local_exhaustive_dedupe", probes < cfg.partitions, totals["end_to_end_distributed_simulation"]/n, probes)}
 	selected := make([]stageResult, 0, len(allStages))
 	for _, s := range allStages {
 		if s.Enabled {
@@ -558,7 +962,7 @@ func simulate(cfg config, m fixtureManifest, v, q [][]float64, probes int, overl
 		}
 	}
 	metrics := metricsV1{MeasurementStatus: "simulation_not_measured", Balance: 1, MaxPartitionSize: (len(v) + cfg.partitions - 1) / cfg.partitions, ReplicationFactor: 1, UnassignedOverlapBudget: overlap, RoutedPartitionRecall: totals["end_to_end_distributed_simulation"] / n, SelectedPartitions: probes}
-	r := runResult{SchemaVersion: schemaVersion, ResultKind: "simulation_only", ProductionEvidence: false, Command: cfg.command, BaseSHA: cfg.baseSHA, HeadSHA: cfg.headSHA, GoVersion: runtime.Version(), Hardware: runtime.GOARCH + "/" + runtime.GOOS, Dataset: m, Partitions: cfg.partitions, Overlap: overlap, Probes: probes, TopK: cfg.topK, RecallTarget: cfg.recallTarget, Seed: cfg.seed, Warmup: 0, Samples: len(q), TimedBoundary: "exact in-memory distance and deterministic merge; excludes disk, TreeDB, RPC, and Raft", Stages: selected, Metrics: metrics}
+	r := runResult{SchemaVersion: schemaVersion, ResultKind: "simulation_only", ProductionEvidence: false, Command: cfg.command, BaseSHA: cfg.baseSHA, HeadSHA: cfg.headSHA, GoVersion: runtime.Version(), Hardware: runtime.GOARCH + "/" + runtime.GOOS, Dataset: m, Partitions: cfg.partitions, Overlap: overlap, Probes: probes, TopK: cfg.topK, RecallTarget: cfg.recallTarget, Seed: cfg.seed, Warmup: 0, Samples: len(q), TimedBoundary: "untimed M0 attribution: in-memory oracles plus temporary local TreeDB column_graph build/search; excludes network, RPC, coordinator, and Raft", Stages: selected, Metrics: metrics}
 	if cfg.stages["partition_oracle"] && probes == cfg.partitions && !exactParity {
 		return r, errors.New("all-partition oracle parity failure")
 	}
@@ -592,6 +996,16 @@ func validateResult(r runResult) error {
 		if math.IsNaN(s.RecallAtK) || math.IsInf(s.RecallAtK, 0) || s.RecallAtK < 0 || s.RecallAtK > 1 {
 			return errors.New("non-finite metric")
 		}
+		if s.Name == "treedb_partition_local_hnsw" {
+			if s.RouteKind != string(collections.VectorIndexSearchRouteExactHNSWSearchPackV1) ||
+				s.Searches == 0 ||
+				s.ExecutedSearches+s.CachedSearches != s.Searches ||
+				s.SearchRouteHNSWSearchPack != s.Searches ||
+				s.HNSWSearchPackActive != s.Searches ||
+				s.HNSWSearchPackFallbacks != 0 {
+				return fmt.Errorf("TreeDB HNSW stage lacks exact search-pack route evidence: %+v", s)
+			}
+		}
 	}
 	if len(r.BaseSHA) < 7 || len(r.HeadSHA) < 7 {
 		return errors.New("missing git provenance")
@@ -619,12 +1033,16 @@ func writeArtifacts(out string, r runResult) error {
 		return e
 	}
 	stageSummary := "unavailable"
+	hnswSummary := "not selected"
 	for _, s := range r.Stages {
 		if s.Name == "end_to_end_distributed_simulation" && s.Available {
 			stageSummary = fmt.Sprintf("recall@%d: %.4f", r.TopK, s.RecallAtK)
 		}
+		if s.Name == "treedb_partition_local_hnsw" && s.Available {
+			hnswSummary = fmt.Sprintf("recall@%d: %.4f; route=%s; logical_searches=%d; executed=%d; cached=%d; fallbacks=%d", r.TopK, s.RecallAtK, s.RouteKind, s.Searches, s.ExecutedSearches, s.CachedSearches, s.HNSWSearchPackFallbacks)
+		}
 	}
-	md := fmt.Sprintf("# TreeDB vector partition M0 simulation\n\n**Simulation only; not production Raft evidence.**\n\n- fixture: `%s` (%s)\n- probes: %d/%d\n- overlap budget: %.6g\n- end-to-end simulation: %s\n- timed boundary: %s\n", r.Dataset.Fixture, r.Dataset.Checksum, r.Probes, r.Partitions, r.Overlap, stageSummary, r.TimedBoundary)
+	md := fmt.Sprintf("# TreeDB vector partition M0 simulation\n\n**Simulation only; not production Raft evidence.**\n\n- fixture: `%s` (%s)\n- probes: %d/%d\n- overlap budget: %.6g\n- TreeDB partition-local HNSW: %s\n- end-to-end simulation: %s\n- timed boundary: %s\n", r.Dataset.Fixture, r.Dataset.Checksum, r.Probes, r.Partitions, r.Overlap, hnswSummary, stageSummary, r.TimedBoundary)
 	return os.WriteFile(filepath.Join(out, name+".md"), []byte(md), 0644)
 }
 func artifactBasename(r runResult) string {

--- a/cmd/treedb_vector_partition_bench/main_test.go
+++ b/cmd/treedb_vector_partition_bench/main_test.go
@@ -893,12 +893,18 @@ func TestCanonicalRunWritesJSONAndMarkdown(t *testing.T) {
 
 func TestResultDecoderRejectsUnknownVersionAndTrailingValue(t *testing.T) {
 	r := runResult{SchemaVersion: 99, ResultKind: "simulation_only", Stages: []stageResult{{Method: "x"}}, Metrics: metricsV1{MeasurementStatus: "simulation_not_measured"}}
-	b, _ := json.Marshal(r)
+	b, err := json.Marshal(r)
+	if err != nil {
+		t.Fatal(err)
+	}
 	if _, err := decodeResult(b); err == nil {
 		t.Fatal("accepted unknown schema")
 	}
 	r.SchemaVersion = 1
-	b, _ = json.Marshal(r)
+	b, err = json.Marshal(r)
+	if err != nil {
+		t.Fatal(err)
+	}
 	if _, err := decodeResult(append(b, []byte("{}")...)); err == nil {
 		t.Fatal("accepted trailing result")
 	}

--- a/cmd/treedb_vector_partition_bench/main_test.go
+++ b/cmd/treedb_vector_partition_bench/main_test.go
@@ -27,7 +27,21 @@ func artifactBasenameForFixture(t *testing.T, dataset string, result runResult) 
 		t.Fatal(err)
 	}
 	result.Dataset = fixture
+	if len(result.Stages) == 0 {
+		result.Stages = stageResultsForSet("all")
+	}
 	return artifactBasename(result)
+}
+
+func stageResultsForSet(raw string) []stageResult {
+	selected := stageSet(raw)
+	stages := make([]stageResult, 0, len(selected))
+	for _, name := range knownStages {
+		if selected[name] {
+			stages = append(stages, stageResult{Name: name})
+		}
+	}
+	return stages
 }
 
 func runWithHermeticProvenance(t *testing.T, args []string, stdout io.Writer) error {
@@ -670,6 +684,7 @@ func TestCloseOverlapValuesHaveCollisionFreeArtifacts(t *testing.T) {
 		Probes:     1,
 		Overlap:    a,
 		TopK:       10,
+		Stages:     stageResultsForSet("all"),
 	}
 	adjacentOverlap := base
 	adjacentOverlap.Overlap = b
@@ -743,6 +758,60 @@ func TestArtifactBasenamePreventsDatasetAndPartitionOverwrite(t *testing.T) {
 	}
 }
 
+func TestArtifactBasenamePreventsStageSetOverwrite(t *testing.T) {
+	if got, want := artifactStageSetChecksum([]stageResult{{Name: "partition_oracle"}, {Name: "exact_global_top_k"}}), artifactStageSetChecksum([]stageResult{{Name: "exact_global_top_k"}, {Name: "partition_oracle"}}); got != want {
+		t.Fatalf("stage-set checksum depends on input order: got=%s want=%s", got, want)
+	}
+	dataset := writeFixtureForTest(t, 8, 2, 4)
+	out := t.TempDir()
+	stageSets := []string{"exact_global_top_k", "partition_oracle"}
+	for _, stages := range stageSets {
+		if err := runWithHermeticProvenance(t, []string{
+			"-dataset", dataset,
+			"-partitions", "4",
+			"-probes", "1",
+			"-overlap", "0",
+			"-top-k", "2",
+			"-stages", stages,
+			"-format", "json",
+			"-out", out,
+		}, io.Discard); err != nil {
+			t.Fatal(err)
+		}
+	}
+	entries, err := os.ReadDir(out)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 4 {
+		t.Fatalf("stage-set identity artifacts=%d want 4 without overwrite", len(entries))
+	}
+	first := artifactBasenameForFixture(t, dataset, runResult{
+		Seed:       1,
+		Partitions: 4,
+		Probes:     1,
+		TopK:       2,
+		Stages:     stageResultsForSet(stageSets[0]),
+	})
+	second := artifactBasenameForFixture(t, dataset, runResult{
+		Seed:       1,
+		Partitions: 4,
+		Probes:     1,
+		TopK:       2,
+		Stages:     stageResultsForSet(stageSets[1]),
+	})
+	if first == second {
+		t.Fatalf("stage-set identities collide: %q", first)
+	}
+	for _, base := range []string{first, second} {
+		for _, ext := range []string{".json", ".md"} {
+			if _, err := os.Stat(filepath.Join(out, base+ext)); err != nil {
+				t.Fatalf("missing stage-set artifact %s%s: %v", base, ext, err)
+			}
+		}
+	}
+}
+
 func TestRunWithExplicitProvenanceOutsideGitCheckout(t *testing.T) {
 	dataset := writeFixtureForTest(t, 9, 3, 4)
 	out := t.TempDir()
@@ -759,7 +828,7 @@ func TestRunWithExplicitProvenanceOutsideGitCheckout(t *testing.T) {
 	}, io.Discard); err != nil {
 		t.Fatal(err)
 	}
-	raw, err := os.ReadFile(filepath.Join(out, artifactBasenameForFixture(t, dataset, runResult{Seed: 1, Partitions: 3, Probes: 3, TopK: 9})+".json"))
+	raw, err := os.ReadFile(filepath.Join(out, artifactBasenameForFixture(t, dataset, runResult{Seed: 1, Partitions: 3, Probes: 3, TopK: 9, Stages: stageResultsForSet("exact_global_top_k")})+".json"))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/cmd/treedb_vector_partition_bench/main_test.go
+++ b/cmd/treedb_vector_partition_bench/main_test.go
@@ -342,6 +342,84 @@ func TestModeledPeakMemoryBudgetEnforcedBeforeGeneration(t *testing.T) {
 	}
 }
 
+func TestBenchmarkWorkBudgetBoundaryAndCanonicalShape(t *testing.T) {
+	boundary := fixtureManifest{Vectors: 10, Queries: 10}
+	cfg := config{
+		probes:   []int{1},
+		overlaps: []float64{0},
+		stages:   stageSet("exact_global_top_k"),
+	}
+	plan, err := validateBenchmarkWork(cfg, boundary, 200)
+	if err != nil {
+		t.Fatalf("exact work-budget boundary rejected: %v", err)
+	}
+	if plan.VectorQueryPairs != 100 || plan.CorpusPasses != 2 || plan.VectorQueryVisits != 200 {
+		t.Fatalf("boundary work plan=%+v", plan)
+	}
+	cfg.overlaps = []float64{0, .2}
+	if _, err := validateBenchmarkWork(cfg, boundary, 200); err == nil {
+		t.Fatal("accepted work plan above exact boundary")
+	}
+
+	canonical, err := loadFixture(fixturePath(t))
+	if err != nil {
+		t.Fatal(err)
+	}
+	canonicalPlan, err := validateBenchmarkWork(config{
+		probes:   []int{1, 2, 4},
+		overlaps: []float64{0, .2},
+		stages:   stageSet("all"),
+	}, canonical, maxBenchmarkWorkUnits)
+	if err != nil {
+		t.Fatalf("canonical work plan rejected: %v", err)
+	}
+	if canonicalPlan.CorpusPasses != 67 || canonicalPlan.VectorQueryVisits != 85_760_000 {
+		t.Fatalf("canonical work plan=%+v", canonicalPlan)
+	}
+}
+
+func TestPathologicalBenchmarkWorkRejectsBeforeGenerationOrEvidence(t *testing.T) {
+	dataset := t.TempDir()
+	fixture := fixtureManifest{
+		SchemaVersion: schemaVersion,
+		Fixture:       "pathological-work",
+		Generator:     "treedb_vector_partition_fixture_v1",
+		Vectors:       500_000,
+		Queries:       500_000,
+		Dimensions:    1,
+		Metric:        "cosine",
+		Seed:          1,
+		Checksum:      strings.Repeat("0", 64),
+	}
+	raw, err := json.Marshal(fixture)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dataset, "fixture_manifest.json"), raw, 0644); err != nil {
+		t.Fatal(err)
+	}
+	out := t.TempDir()
+	err = runWithHermeticProvenance(t, []string{
+		"-dataset", dataset,
+		"-out", out,
+		"-partitions", "1",
+		"-probes", "1",
+		"-overlap", "0",
+		"-top-k", "1",
+		"-stages", "exact_global_top_k",
+	}, io.Discard)
+	if err == nil || !strings.Contains(err.Error(), "modeled benchmark work") {
+		t.Fatalf("pathological work error=%v", err)
+	}
+	entries, readErr := os.ReadDir(out)
+	if readErr != nil {
+		t.Fatal(readErr)
+	}
+	if len(entries) != 0 {
+		t.Fatalf("rejected work budget emitted evidence: %+v", entries)
+	}
+}
+
 func TestRunRejectsSeedThatDoesNotMatchFixtureBeforeEvidence(t *testing.T) {
 	out := t.TempDir()
 	err := runWithHermeticProvenance(t, []string{

--- a/cmd/treedb_vector_partition_bench/main_test.go
+++ b/cmd/treedb_vector_partition_bench/main_test.go
@@ -1,0 +1,199 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"math"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func fixturePath(t *testing.T) string {
+	t.Helper()
+	return filepath.Join("..", "..", "testdata", "vector_partition_10k")
+}
+
+func TestFixtureTruthDeterministicAndChecksumStable(t *testing.T) {
+	m, err := loadFixture(fixturePath(t))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := validateFixture(m); err != nil {
+		t.Fatal(err)
+	}
+	if got := fixtureChecksum(m.Vectors, m.Queries, m.Dimensions, m.Seed); got != m.Checksum {
+		t.Fatalf("checksum=%s want %s", got, m.Checksum)
+	}
+	a, aq := deterministicFixture(m)
+	b, bq := deterministicFixture(m)
+	if len(a) != len(b) || len(aq) != len(bq) || a[0][0] != b[0][0] || aq[0][0] != bq[0][0] {
+		t.Fatal("fixture is not deterministic")
+	}
+}
+
+func TestTruthOracleTieOrderingAndAllPartitionParity(t *testing.T) {
+	m, _ := loadFixture(fixturePath(t))
+	vectors, queries := deterministicFixture(m)
+	_ = vectors
+	_ = queries
+	got := exactTopK([][]float64{{1, 0}, {1, 0}, {0, 1}}, []float64{1, 0}, 2)
+	if got[0].ID != "doc-000000" || got[1].ID != "doc-000001" {
+		t.Fatalf("ties not ordered by stable ID: %#v", got[:2])
+	}
+	cfg := config{partitions: 4, topK: 10, recallTarget: .9, seed: 1}
+	r, err := simulate(cfg, m, vectors, queries, 4, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if r.Stages[1].RecallAtK != 1 {
+		t.Fatalf("all partition oracle recall=%f", r.Stages[1].RecallAtK)
+	}
+	if r.Stages[0].RecallAtK != r.Stages[1].RecallAtK {
+		t.Fatal("oracle parity differs")
+	}
+}
+
+func TestEveryLossStageIndependentlyLabeled(t *testing.T) {
+	m, _ := loadFixture(fixturePath(t))
+	vectors, queries := deterministicFixture(m)
+	r, err := simulate(config{partitions: 4, topK: 10, recallTarget: .9, seed: 1}, m, vectors, queries, 1, .2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := []string{"exact_global_top_k", "partition_oracle", "exact_representative_routing", "approximate_representative_routing", "exact_partition_local", "treedb_partition_local_hnsw", "end_to_end_distributed_simulation"}
+	if len(r.Stages) != len(want) {
+		t.Fatalf("stages=%#v", r.Stages)
+	}
+	for i, name := range want {
+		if r.Stages[i].Name != name {
+			t.Fatalf("stage[%d]=%q want %q", i, r.Stages[i].Name, name)
+		}
+	}
+	if !r.Stages[1].Lossy || !r.Stages[6].Lossy {
+		t.Fatal("loss stages not independently labeled")
+	}
+	if r.ResultKind != "simulation_only" || r.ProductionEvidence {
+		t.Fatalf("simulation label=%+v", r)
+	}
+}
+
+func TestSingleEnabledStageIsTheOnlyReportedStage(t *testing.T) {
+	m, _ := loadFixture(fixturePath(t))
+	v, q := deterministicFixture(m)
+	r, err := simulate(config{partitions: 4, topK: 10, recallTarget: .9, seed: 1, stages: stageSet("partition_oracle")}, m, v, q, 1, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(r.Stages) != 1 || r.Stages[0].Name != "partition_oracle" {
+		t.Fatalf("stages=%+v", r.Stages)
+	}
+}
+
+func TestMalformedCapAndFiniteInputsRejectBeforeSimulation(t *testing.T) {
+	for _, raw := range [][]string{{"-dataset", fixturePath(t), "-out", t.TempDir(), "-partitions", "0", "-probes", "1"}, {"-dataset", fixturePath(t), "-out", t.TempDir(), "-partitions", "4", "-probes", "5"}, {"-dataset", fixturePath(t), "-out", t.TempDir(), "-partitions", "4", "-probes", "1", "-overlap", "NaN"}, {"-dataset", fixturePath(t), "-out", t.TempDir(), "-partitions", "4", "-probes", "1", "-recall-target", "NaN"}, {"-dataset", fixturePath(t), "-out", t.TempDir(), "-partitions", "4", "-probes", "1", "-stages", "unknown"}} {
+		if _, err := parseConfig(raw); err == nil {
+			t.Fatalf("accepted malformed config %#v", raw)
+		}
+	}
+	bad := fixtureManifest{SchemaVersion: 1, Fixture: "bad", Generator: "treedb_vector_partition_fixture_v1", Vectors: maxVectors + 1, Queries: 1, Dimensions: 1, Metric: "cosine", Checksum: strings.Repeat("0", 64)}
+	if err := validateFixture(bad); err == nil {
+		t.Fatal("accepted capped fixture")
+	}
+	bad.Vectors = 1
+	bad.Dimensions = 1
+	bad.Checksum = "bad"
+	if err := validateFixture(bad); err == nil {
+		t.Fatal("accepted malformed checksum")
+	}
+}
+
+func TestRunRejectsTopKAboveFixtureBeforeOracleAllocation(t *testing.T) {
+	err := run([]string{"-dataset", fixturePath(t), "-out", t.TempDir(), "-partitions", "4", "-probes", "1", "-top-k", "10001"}, io.Discard)
+	if err == nil {
+		t.Fatal("accepted top-k above fixture")
+	}
+}
+
+func TestConfigurableFixtureCapsRejectBeforeAllocation(t *testing.T) {
+	cfg, err := parseConfig([]string{"-dataset", fixturePath(t), "-out", t.TempDir(), "-partitions", "4", "-probes", "1", "-max-vectors", "9999"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	m, _ := loadFixture(fixturePath(t))
+	if err := validateFixtureWithCaps(m, cfg.maxVectors, cfg.maxBytes); err == nil {
+		t.Fatal("accepted fixture beyond configured count cap")
+	}
+	if _, err := parseConfig([]string{"-dataset", fixturePath(t), "-out", t.TempDir(), "-partitions", "4", "-probes", "1", "-max-fixture-bytes", "7"}); err == nil {
+		t.Fatal("accepted unsafe byte cap")
+	}
+}
+
+func TestManifestRejectsTrailingJSON(t *testing.T) {
+	d := t.TempDir()
+	raw, err := os.ReadFile(filepath.Join(fixturePath(t), "fixture_manifest.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(d, "fixture_manifest.json"), append(raw, []byte("{}")...), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := loadFixture(d); err == nil {
+		t.Fatal("accepted trailing JSON")
+	}
+}
+
+func TestCanonicalRunWritesJSONAndMarkdown(t *testing.T) {
+	out := t.TempDir()
+	var stdout bytes.Buffer
+	if err := run([]string{"-dataset", fixturePath(t), "-partitions", "4", "-probes", "1,2,4", "-overlap", "0,0.20", "-top-k", "10", "-recall-target", "0.90", "-seed", "1", "-format", "json", "-out", out}, &stdout); err != nil {
+		t.Fatal(err)
+	}
+	entries, err := os.ReadDir(out)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 12 {
+		t.Fatalf("artifacts=%d want 12", len(entries))
+	}
+	raw, err := os.ReadFile(filepath.Join(out, "simulation_p4_o0.20.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	result, err := decodeResult(raw)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Command[0] != "treedb_vector_partition_bench" || result.Metrics.MeasurementStatus != "simulation_not_measured" || result.Metrics.SelectedPartitions != 4 {
+		t.Fatalf("artifact metadata=%+v", result)
+	}
+	md, err := os.ReadFile(filepath.Join(out, "simulation_p4_o0.20.md"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(md), "Simulation only; not production Raft evidence.") {
+		t.Fatal("missing simulation disclaimer")
+	}
+}
+
+func TestResultDecoderRejectsUnknownVersionAndTrailingValue(t *testing.T) {
+	r := runResult{SchemaVersion: 99, ResultKind: "simulation_only", Stages: []stageResult{{Method: "x"}}, Metrics: metricsV1{MeasurementStatus: "simulation_not_measured"}}
+	b, _ := json.Marshal(r)
+	if _, err := decodeResult(b); err == nil {
+		t.Fatal("accepted unknown schema")
+	}
+	r.SchemaVersion = 1
+	b, _ = json.Marshal(r)
+	if _, err := decodeResult(append(b, []byte("{}")...)); err == nil {
+		t.Fatal("accepted trailing result")
+	}
+}
+
+func TestValidateResultRejectsNonFiniteMetrics(t *testing.T) {
+	r := runResult{SchemaVersion: 1, ResultKind: "simulation_only", Stages: []stageResult{{RecallAtK: math.NaN()}}}
+	if err := validateResult(r); err == nil {
+		t.Fatal("accepted nonfinite metric")
+	}
+}

--- a/cmd/treedb_vector_partition_bench/main_test.go
+++ b/cmd/treedb_vector_partition_bench/main_test.go
@@ -47,7 +47,8 @@ func smallFixtureForTest(vectors, queries, dims int) (fixtureManifest, [][]float
 	m := fixtureManifest{
 		SchemaVersion: schemaVersion,
 		Fixture:       "small",
-		Generator:     "treedb_vector_partition_fixture_v1",
+		Generator:     fixtureGenerator,
+		Arithmetic:    fixtureArithmetic,
 		Vectors:       vectors,
 		Queries:       queries,
 		Dimensions:    dims,
@@ -57,6 +58,26 @@ func smallFixtureForTest(vectors, queries, dims int) (fixtureManifest, [][]float
 	}
 	v, q := deterministicFixture(m)
 	return m, v, q
+}
+
+func TestFixtureArithmeticUsesExplicitFMA(t *testing.T) {
+	a := 1 + math.Ldexp(1, -27)
+	b := 1 - math.Ldexp(1, -27)
+	if got, want := math.FMA(a, b, -1), -math.Ldexp(1, -54); got != want {
+		t.Fatalf("%s result=%x want %x", fixtureArithmetic, math.Float64bits(got), math.Float64bits(want))
+	}
+	if fixtureGenerator != "treedb_vector_partition_fixture_v2" || fixtureArithmetic != "ieee754_binary64_explicit_fma_v1" {
+		t.Fatalf("unexpected fixture contract generator=%q arithmetic=%q", fixtureGenerator, fixtureArithmetic)
+	}
+	m, vectors, queries := smallFixtureForTest(10, 2, 4)
+	m.Checksum = fixtureChecksumFromData(vectors, queries)
+	if err := validateFixture(m); err != nil {
+		t.Fatalf("explicit arithmetic fixture rejected: %v", err)
+	}
+	m.Arithmetic = "implicit_multiply_add"
+	if err := validateFixture(m); err == nil {
+		t.Fatal("fixture with unspecified contraction behavior accepted")
+	}
 }
 
 func TestFixtureTruthDeterministicAndChecksumStable(t *testing.T) {
@@ -234,7 +255,7 @@ func TestMalformedCapAndFiniteInputsRejectBeforeSimulation(t *testing.T) {
 			t.Fatalf("accepted malformed config %#v", raw)
 		}
 	}
-	bad := fixtureManifest{SchemaVersion: 1, Fixture: "bad", Generator: "treedb_vector_partition_fixture_v1", Vectors: maxVectors + 1, Queries: 1, Dimensions: 1, Metric: "cosine", Checksum: strings.Repeat("0", 64)}
+	bad := fixtureManifest{SchemaVersion: 1, Fixture: "bad", Generator: fixtureGenerator, Arithmetic: fixtureArithmetic, Vectors: maxVectors + 1, Queries: 1, Dimensions: 1, Metric: "cosine", Checksum: strings.Repeat("0", 64)}
 	if err := validateFixture(bad); err == nil {
 		t.Fatal("accepted capped fixture")
 	}
@@ -383,7 +404,8 @@ func TestPathologicalBenchmarkWorkRejectsBeforeGenerationOrEvidence(t *testing.T
 	fixture := fixtureManifest{
 		SchemaVersion: schemaVersion,
 		Fixture:       "pathological-work",
-		Generator:     "treedb_vector_partition_fixture_v1",
+		Generator:     fixtureGenerator,
+		Arithmetic:    fixtureArithmetic,
 		Vectors:       500_000,
 		Queries:       500_000,
 		Dimensions:    1,

--- a/cmd/treedb_vector_partition_bench/main_test.go
+++ b/cmd/treedb_vector_partition_bench/main_test.go
@@ -20,11 +20,21 @@ func fixturePath(t *testing.T) string {
 	return filepath.Join("..", "..", "testdata", "vector_partition_10k")
 }
 
+func artifactBasenameForFixture(t *testing.T, dataset string, result runResult) string {
+	t.Helper()
+	fixture, err := loadFixture(dataset)
+	if err != nil {
+		t.Fatal(err)
+	}
+	result.Dataset = fixture
+	return artifactBasename(result)
+}
+
 func runWithHermeticProvenance(t *testing.T, args []string, stdout io.Writer) error {
 	t.Helper()
 	t.Setenv("BASE_SHA", strings.Repeat("a", 40))
 	t.Setenv("GITHUB_SHA", strings.Repeat("b", 40))
-	t.Setenv("GITHUB_EVENT_PATH", filepath.Join(t.TempDir(), "must-not-be-read.json"))
+	t.Setenv("GITHUB_EVENT_PATH", "")
 	return run(args, stdout)
 }
 
@@ -350,7 +360,7 @@ func TestModeledPeakMemoryBudgetEnforcedBeforeGeneration(t *testing.T) {
 	}, io.Discard); err != nil {
 		t.Fatalf("exact modeled peak cap rejected: %v", err)
 	}
-	raw, err := os.ReadFile(filepath.Join(acceptedOut, artifactBasename(runResult{Seed: 1, Probes: 4, TopK: 4})+".json"))
+	raw, err := os.ReadFile(filepath.Join(acceptedOut, artifactBasenameForFixture(t, dataset, runResult{Seed: 1, Partitions: 4, Probes: 4, TopK: 4})+".json"))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -546,6 +556,7 @@ func TestProvenanceAutomaticEnvironmentAndInvalidSHA(t *testing.T) {
 		head := strings.Repeat("b", 40)
 		t.Setenv("BASE_SHA", base)
 		t.Setenv("GITHUB_SHA", head)
+		t.Setenv("GITHUB_EVENT_PATH", "")
 		gotBase, gotHead, err := provenance()
 		if err != nil {
 			t.Fatal(err)
@@ -562,7 +573,7 @@ func TestProvenanceAutomaticEnvironmentAndInvalidSHA(t *testing.T) {
 		if err := os.WriteFile(path, []byte(raw), 0644); err != nil {
 			t.Fatal(err)
 		}
-		t.Setenv("BASE_SHA", "")
+		t.Setenv("BASE_SHA", strings.Repeat("a", 40))
 		t.Setenv("GITHUB_SHA", strings.Repeat("d", 40))
 		t.Setenv("GITHUB_EVENT_PATH", path)
 		gotBase, gotHead, err := provenance()
@@ -606,11 +617,30 @@ func TestProvenanceAutomaticEnvironmentAndInvalidSHA(t *testing.T) {
 		t.Run("invalid_"+tc.name, func(t *testing.T) {
 			t.Setenv("BASE_SHA", tc.base)
 			t.Setenv("GITHUB_SHA", tc.head)
+			t.Setenv("GITHUB_EVENT_PATH", "")
 			if _, _, err := provenance(); err == nil {
 				t.Fatal("accepted invalid SHA provenance")
 			}
 		})
 	}
+	t.Run("non_pull_request_event_preserves_explicit_pair", func(t *testing.T) {
+		base := strings.Repeat("a", 40)
+		head := strings.Repeat("b", 40)
+		path := filepath.Join(t.TempDir(), "event.json")
+		if err := os.WriteFile(path, []byte(`{"event":"workflow_dispatch"}`), 0644); err != nil {
+			t.Fatal(err)
+		}
+		t.Setenv("BASE_SHA", base)
+		t.Setenv("GITHUB_SHA", head)
+		t.Setenv("GITHUB_EVENT_PATH", path)
+		gotBase, gotHead, err := provenance()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if gotBase != base || gotHead != head {
+			t.Fatalf("non-PR event changed explicit provenance base=%q head=%q", gotBase, gotHead)
+		}
+	})
 }
 
 func TestGitHubEventPayloadIsBoundedAndSingleValue(t *testing.T) {
@@ -633,10 +663,22 @@ func TestGitHubEventPayloadIsBoundedAndSingleValue(t *testing.T) {
 func TestCloseOverlapValuesHaveCollisionFreeArtifacts(t *testing.T) {
 	a := 0.2
 	b := math.Nextafter(a, 1)
-	if artifactBasename(runResult{Probes: 1, Overlap: a, TopK: 10}) == artifactBasename(runResult{Probes: 1, Overlap: b, TopK: 10}) {
+	base := runResult{
+		Dataset:    fixtureManifest{Checksum: strings.Repeat("1", 64)},
+		Seed:       1,
+		Partitions: 4,
+		Probes:     1,
+		Overlap:    a,
+		TopK:       10,
+	}
+	adjacentOverlap := base
+	adjacentOverlap.Overlap = b
+	if artifactBasename(base) == artifactBasename(adjacentOverlap) {
 		t.Fatal("adjacent float64 overlap values collide")
 	}
-	if artifactBasename(runResult{Seed: 1, Probes: 1, Overlap: a, TopK: 10}) == artifactBasename(runResult{Seed: 2, Probes: 1, Overlap: a, TopK: 10}) {
+	differentSeed := base
+	differentSeed.Seed = 2
+	if artifactBasename(base) == artifactBasename(differentSeed) {
 		t.Fatal("different fixture seeds collide")
 	}
 	out := t.TempDir()
@@ -661,6 +703,46 @@ func TestCloseOverlapValuesHaveCollisionFreeArtifacts(t *testing.T) {
 	}
 }
 
+func TestArtifactBasenamePreventsDatasetAndPartitionOverwrite(t *testing.T) {
+	firstDataset := writeFixtureForTest(t, 8, 2, 4)
+	secondDataset := writeFixtureForTest(t, 9, 2, 4)
+	out := t.TempDir()
+	for _, testRun := range []struct {
+		dataset    string
+		partitions int
+	}{
+		{dataset: firstDataset, partitions: 4},
+		{dataset: secondDataset, partitions: 4},
+		{dataset: firstDataset, partitions: 8},
+	} {
+		if err := runWithHermeticProvenance(t, []string{
+			"-dataset", testRun.dataset,
+			"-partitions", strconv.Itoa(testRun.partitions),
+			"-probes", "1",
+			"-overlap", "0",
+			"-top-k", "2",
+			"-stages", "exact_global_top_k",
+			"-format", "json",
+			"-out", out,
+		}, io.Discard); err != nil {
+			t.Fatal(err)
+		}
+	}
+	entries, err := os.ReadDir(out)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 6 {
+		t.Fatalf("dataset/partition identity artifacts=%d want 6 without overwrite", len(entries))
+	}
+	first4 := artifactBasenameForFixture(t, firstDataset, runResult{Seed: 1, Partitions: 4, Probes: 1, TopK: 2})
+	second4 := artifactBasenameForFixture(t, secondDataset, runResult{Seed: 1, Partitions: 4, Probes: 1, TopK: 2})
+	first8 := artifactBasenameForFixture(t, firstDataset, runResult{Seed: 1, Partitions: 8, Probes: 1, TopK: 2})
+	if first4 == second4 || first4 == first8 || second4 == first8 {
+		t.Fatalf("artifact identities collide first4=%q second4=%q first8=%q", first4, second4, first8)
+	}
+}
+
 func TestRunWithExplicitProvenanceOutsideGitCheckout(t *testing.T) {
 	dataset := writeFixtureForTest(t, 9, 3, 4)
 	out := t.TempDir()
@@ -677,7 +759,7 @@ func TestRunWithExplicitProvenanceOutsideGitCheckout(t *testing.T) {
 	}, io.Discard); err != nil {
 		t.Fatal(err)
 	}
-	raw, err := os.ReadFile(filepath.Join(out, artifactBasename(runResult{Seed: 1, Probes: 3, TopK: 9})+".json"))
+	raw, err := os.ReadFile(filepath.Join(out, artifactBasenameForFixture(t, dataset, runResult{Seed: 1, Partitions: 3, Probes: 3, TopK: 9})+".json"))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -703,7 +785,7 @@ func TestCanonicalRunWritesJSONAndMarkdown(t *testing.T) {
 	if len(entries) != 12 {
 		t.Fatalf("artifacts=%d want 12", len(entries))
 	}
-	raw, err := os.ReadFile(filepath.Join(out, artifactBasename(runResult{Seed: 1, Probes: 4, Overlap: .2, TopK: 10})+".json"))
+	raw, err := os.ReadFile(filepath.Join(out, artifactBasenameForFixture(t, fixturePath(t), runResult{Seed: 1, Partitions: 4, Probes: 4, Overlap: .2, TopK: 10})+".json"))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -728,7 +810,7 @@ func TestCanonicalRunWritesJSONAndMarkdown(t *testing.T) {
 			t.Fatalf("artifact omits explicit zero HNSW evidence field %s", field)
 		}
 	}
-	md, err := os.ReadFile(filepath.Join(out, artifactBasename(runResult{Seed: 1, Probes: 4, Overlap: .2, TopK: 10})+".md"))
+	md, err := os.ReadFile(filepath.Join(out, artifactBasenameForFixture(t, fixturePath(t), runResult{Seed: 1, Partitions: 4, Probes: 4, Overlap: .2, TopK: 10})+".md"))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -790,7 +872,7 @@ func TestValidateResultRequiresExactSHASeedAndMemoryEvidence(t *testing.T) {
 		ResultKind:        "simulation_only",
 		BaseSHA:           strings.Repeat("a", 40),
 		HeadSHA:           strings.Repeat("b", 40),
-		Dataset:           fixtureManifest{Seed: 1},
+		Dataset:           fixtureManifest{Seed: 1, Checksum: strings.Repeat("c", 64)},
 		Seed:              1,
 		MemoryBudgetBytes: 1024,
 		ModeledPeakBytes:  512,
@@ -804,6 +886,7 @@ func TestValidateResultRequiresExactSHASeedAndMemoryEvidence(t *testing.T) {
 	for _, mutate := range []func(*runResult){
 		func(result *runResult) { result.BaseSHA = "abcdef0" },
 		func(result *runResult) { result.HeadSHA = strings.Repeat("g", 40) },
+		func(result *runResult) { result.Dataset.Checksum = "not-a-checksum" },
 		func(result *runResult) { result.Seed++ },
 		func(result *runResult) { result.ModeledPeakBytes = result.MemoryBudgetBytes + 1 },
 	} {

--- a/cmd/treedb_vector_partition_bench/main_test.go
+++ b/cmd/treedb_vector_partition_bench/main_test.go
@@ -20,6 +20,29 @@ func fixturePath(t *testing.T) string {
 	return filepath.Join("..", "..", "testdata", "vector_partition_10k")
 }
 
+func runWithHermeticProvenance(t *testing.T, args []string, stdout io.Writer) error {
+	t.Helper()
+	t.Setenv("BASE_SHA", strings.Repeat("a", 40))
+	t.Setenv("GITHUB_SHA", strings.Repeat("b", 40))
+	t.Setenv("GITHUB_EVENT_PATH", filepath.Join(t.TempDir(), "must-not-be-read.json"))
+	return run(args, stdout)
+}
+
+func writeFixtureForTest(t *testing.T, vectors, queries, dims int) string {
+	t.Helper()
+	m, _, _ := smallFixtureForTest(vectors, queries, dims)
+	m.Checksum = fixtureChecksum(vectors, queries, dims, m.Seed)
+	raw, err := json.Marshal(m)
+	if err != nil {
+		t.Fatal(err)
+	}
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "fixture_manifest.json"), raw, 0644); err != nil {
+		t.Fatal(err)
+	}
+	return dir
+}
+
 func smallFixtureForTest(vectors, queries, dims int) (fixtureManifest, [][]float64, [][]float64) {
 	m := fixtureManifest{
 		SchemaVersion: schemaVersion,
@@ -51,6 +74,16 @@ func TestFixtureTruthDeterministicAndChecksumStable(t *testing.T) {
 	b, bq := deterministicFixture(m)
 	if len(a) != len(b) || len(aq) != len(bq) || a[0][0] != b[0][0] || aq[0][0] != bq[0][0] {
 		t.Fatal("fixture is not deterministic")
+	}
+}
+
+func TestFixtureChecksumSupportsFewerThanTenVectors(t *testing.T) {
+	for vectors := 1; vectors < 10; vectors++ {
+		first := fixtureChecksum(vectors, 3, 4, 1)
+		second := fixtureChecksum(vectors, 3, 4, 1)
+		if first != second || len(first) != 64 {
+			t.Fatalf("vectors=%d checksum first=%q second=%q", vectors, first, second)
+		}
 	}
 }
 
@@ -214,7 +247,7 @@ func TestMalformedCapAndFiniteInputsRejectBeforeSimulation(t *testing.T) {
 }
 
 func TestRunRejectsTopKAboveFixtureBeforeOracleAllocation(t *testing.T) {
-	err := run([]string{"-dataset", fixturePath(t), "-out", t.TempDir(), "-partitions", "4", "-probes", "1", "-top-k", "10001"}, io.Discard)
+	err := runWithHermeticProvenance(t, []string{"-dataset", fixturePath(t), "-out", t.TempDir(), "-partitions", "4", "-probes", "1", "-top-k", "10001"}, io.Discard)
 	if err == nil {
 		t.Fatal("accepted top-k above fixture")
 	}
@@ -284,7 +317,7 @@ func TestFixtureChecksumMismatchFailsBeforeEvidence(t *testing.T) {
 		t.Fatal(err)
 	}
 	out := t.TempDir()
-	err = run([]string{"-dataset", d, "-out", out, "-partitions", "4", "-probes", "1", "-stages", "treedb_partition_local_hnsw"}, io.Discard)
+	err = runWithHermeticProvenance(t, []string{"-dataset", d, "-out", out, "-partitions", "4", "-probes", "1", "-stages", "treedb_partition_local_hnsw"}, io.Discard)
 	if err == nil || !strings.Contains(err.Error(), "checksum") {
 		t.Fatalf("checksum mismatch error=%v", err)
 	}
@@ -302,11 +335,14 @@ func TestProvenanceAutomaticEnvironmentAndInvalidSHA(t *testing.T) {
 		t.Setenv("BASE_SHA", "")
 		t.Setenv("GITHUB_SHA", "")
 		t.Setenv("GITHUB_EVENT_PATH", "")
-		base, head, err := provenance()
-		if err != nil {
-			t.Fatal(err)
-		}
 		wantHead, err := exec.Command("git", "rev-parse", "HEAD").Output()
+		if err != nil {
+			t.Skip("local git provenance unavailable")
+		}
+		if _, err := exec.Command("git", "merge-base", "HEAD", "origin/main").Output(); err != nil {
+			t.Skip("origin/main merge-base unavailable")
+		}
+		base, head, err := provenance()
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -399,7 +435,7 @@ func TestCloseOverlapValuesHaveCollisionFreeArtifacts(t *testing.T) {
 		t.Fatal("adjacent float64 overlap values collide")
 	}
 	out := t.TempDir()
-	if err := run([]string{
+	if err := runWithHermeticProvenance(t, []string{
 		"-dataset", fixturePath(t),
 		"-partitions", "4",
 		"-probes", "1",
@@ -420,10 +456,39 @@ func TestCloseOverlapValuesHaveCollisionFreeArtifacts(t *testing.T) {
 	}
 }
 
+func TestRunWithExplicitProvenanceOutsideGitCheckout(t *testing.T) {
+	dataset := writeFixtureForTest(t, 9, 3, 4)
+	out := t.TempDir()
+	t.Chdir(t.TempDir())
+	if err := runWithHermeticProvenance(t, []string{
+		"-dataset", dataset,
+		"-partitions", "3",
+		"-probes", "3",
+		"-overlap", "0",
+		"-top-k", "9",
+		"-stages", "exact_global_top_k",
+		"-format", "json",
+		"-out", out,
+	}, io.Discard); err != nil {
+		t.Fatal(err)
+	}
+	raw, err := os.ReadFile(filepath.Join(out, artifactBasename(runResult{Probes: 3, TopK: 9})+".json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	result, err := decodeResult(raw)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.BaseSHA != strings.Repeat("a", 40) || result.HeadSHA != strings.Repeat("b", 40) {
+		t.Fatalf("explicit provenance not preserved: base=%q head=%q", result.BaseSHA, result.HeadSHA)
+	}
+}
+
 func TestCanonicalRunWritesJSONAndMarkdown(t *testing.T) {
 	out := t.TempDir()
 	var stdout bytes.Buffer
-	if err := run([]string{"-dataset", fixturePath(t), "-partitions", "4", "-probes", "1,2,4", "-overlap", "0,0.20", "-top-k", "10", "-recall-target", "0.90", "-seed", "1", "-format", "json", "-out", out}, &stdout); err != nil {
+	if err := runWithHermeticProvenance(t, []string{"-dataset", fixturePath(t), "-partitions", "4", "-probes", "1,2,4", "-overlap", "0,0.20", "-top-k", "10", "-recall-target", "0.90", "-seed", "1", "-format", "json", "-out", out}, &stdout); err != nil {
 		t.Fatal(err)
 	}
 	entries, err := os.ReadDir(out)

--- a/cmd/treedb_vector_partition_bench/main_test.go
+++ b/cmd/treedb_vector_partition_bench/main_test.go
@@ -158,7 +158,7 @@ func TestCanonicalRunWritesJSONAndMarkdown(t *testing.T) {
 	if len(entries) != 12 {
 		t.Fatalf("artifacts=%d want 12", len(entries))
 	}
-	raw, err := os.ReadFile(filepath.Join(out, "simulation_p4_o0.20.json"))
+	raw, err := os.ReadFile(filepath.Join(out, artifactBasename(runResult{Probes: 4, Overlap: .2, TopK: 10})+".json"))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -169,7 +169,7 @@ func TestCanonicalRunWritesJSONAndMarkdown(t *testing.T) {
 	if result.Command[0] != "treedb_vector_partition_bench" || result.Metrics.MeasurementStatus != "simulation_not_measured" || result.Metrics.SelectedPartitions != 4 {
 		t.Fatalf("artifact metadata=%+v", result)
 	}
-	md, err := os.ReadFile(filepath.Join(out, "simulation_p4_o0.20.md"))
+	md, err := os.ReadFile(filepath.Join(out, artifactBasename(runResult{Probes: 4, Overlap: .2, TopK: 10})+".md"))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/cmd/treedb_vector_partition_bench/main_test.go
+++ b/cmd/treedb_vector_partition_bench/main_test.go
@@ -67,10 +67,10 @@ func TestFixtureTruthDeterministicAndChecksumStable(t *testing.T) {
 	if err := validateFixture(m); err != nil {
 		t.Fatal(err)
 	}
-	if got := fixtureChecksum(m.Vectors, m.Queries, m.Dimensions, m.Seed); got != m.Checksum {
+	a, aq := deterministicFixture(m)
+	if got := fixtureChecksumFromData(a, aq); got != m.Checksum {
 		t.Fatalf("checksum=%s want %s", got, m.Checksum)
 	}
-	a, aq := deterministicFixture(m)
 	b, bq := deterministicFixture(m)
 	if len(a) != len(b) || len(aq) != len(bq) || a[0][0] != b[0][0] || aq[0][0] != bq[0][0] {
 		t.Fatal("fixture is not deterministic")
@@ -273,6 +273,97 @@ func TestConfigurableFixtureCapsRejectBeforeAllocation(t *testing.T) {
 	}
 }
 
+func TestModeledPeakMemoryBudgetEnforcedBeforeGeneration(t *testing.T) {
+	const (
+		vectors = 32
+		queries = 4
+		dims    = 8
+	)
+	dataset := writeFixtureForTest(t, vectors, queries, dims)
+	m, err := loadFixture(dataset)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cfg := config{
+		partitions: 4,
+		probes:     []int{1, 4},
+		topK:       4,
+		stages:     stageSet("all"),
+	}
+	plan, err := planBenchmarkMemory(cfg, m)
+	if err != nil {
+		t.Fatal(err)
+	}
+	rawFixtureBytes := int64(vectors+queries) * dims * 8
+	if plan.FixtureResidentBytes <= rawFixtureBytes || plan.HNSWInsertWorkBytes == 0 || plan.HNSWCacheBytes == 0 || plan.ModeledPeakBytes <= plan.FixtureResidentBytes {
+		t.Fatalf("incomplete memory plan: %+v raw_fixture=%d", plan, rawFixtureBytes)
+	}
+	rejectedOut := t.TempDir()
+	err = runWithHermeticProvenance(t, []string{
+		"-dataset", dataset,
+		"-out", rejectedOut,
+		"-partitions", "4",
+		"-probes", "1,4",
+		"-top-k", "4",
+		"-max-fixture-bytes", strconv.FormatInt(plan.ModeledPeakBytes-1, 10),
+	}, io.Discard)
+	if err == nil || !strings.Contains(err.Error(), "modeled peak") {
+		t.Fatalf("below-peak cap error=%v plan=%+v", err, plan)
+	}
+	entries, readErr := os.ReadDir(rejectedOut)
+	if readErr != nil {
+		t.Fatal(readErr)
+	}
+	if len(entries) != 0 {
+		t.Fatalf("rejected memory budget emitted evidence: %+v", entries)
+	}
+
+	acceptedOut := t.TempDir()
+	if err := runWithHermeticProvenance(t, []string{
+		"-dataset", dataset,
+		"-out", acceptedOut,
+		"-partitions", "4",
+		"-probes", "1,4",
+		"-top-k", "4",
+		"-max-fixture-bytes", strconv.FormatInt(plan.ModeledPeakBytes, 10),
+	}, io.Discard); err != nil {
+		t.Fatalf("exact modeled peak cap rejected: %v", err)
+	}
+	raw, err := os.ReadFile(filepath.Join(acceptedOut, artifactBasename(runResult{Seed: 1, Probes: 4, TopK: 4})+".json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	result, err := decodeResult(raw)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.MemoryBudgetBytes != plan.ModeledPeakBytes || result.ModeledPeakBytes != plan.ModeledPeakBytes || result.MemoryBudgetScope != memoryBudgetScope {
+		t.Fatalf("memory evidence=%+v plan=%+v", result, plan)
+	}
+}
+
+func TestRunRejectsSeedThatDoesNotMatchFixtureBeforeEvidence(t *testing.T) {
+	out := t.TempDir()
+	err := runWithHermeticProvenance(t, []string{
+		"-dataset", fixturePath(t),
+		"-out", out,
+		"-partitions", "4",
+		"-probes", "1",
+		"-top-k", "10",
+		"-seed", "2",
+	}, io.Discard)
+	if err == nil || !strings.Contains(err.Error(), "does not match fixture seed") {
+		t.Fatalf("seed mismatch error=%v", err)
+	}
+	entries, readErr := os.ReadDir(out)
+	if readErr != nil {
+		t.Fatal(readErr)
+	}
+	if len(entries) != 0 {
+		t.Fatalf("seed mismatch emitted evidence: %+v", entries)
+	}
+}
+
 func TestManifestRejectsTrailingJSON(t *testing.T) {
 	d := t.TempDir()
 	raw, err := os.ReadFile(filepath.Join(fixturePath(t), "fixture_manifest.json"))
@@ -365,34 +456,45 @@ func TestProvenanceAutomaticEnvironmentAndInvalidSHA(t *testing.T) {
 	})
 	t.Run("pull_request_event", func(t *testing.T) {
 		base := strings.Repeat("c", 40)
+		head := strings.Repeat("e", 40)
 		path := filepath.Join(t.TempDir(), "event.json")
-		raw := `{"pull_request":{"base":{"sha":"` + base + `"}},"ignored_by_typed_projection":true}`
+		raw := `{"pull_request":{"base":{"sha":"` + base + `"},"head":{"sha":"` + head + `"}},"ignored_by_typed_projection":true}`
 		if err := os.WriteFile(path, []byte(raw), 0644); err != nil {
 			t.Fatal(err)
 		}
 		t.Setenv("BASE_SHA", "")
 		t.Setenv("GITHUB_SHA", strings.Repeat("d", 40))
 		t.Setenv("GITHUB_EVENT_PATH", path)
-		gotBase, _, err := provenance()
+		gotBase, gotHead, err := provenance()
 		if err != nil {
 			t.Fatal(err)
 		}
-		if gotBase != base {
-			t.Fatalf("event base=%q want %q", gotBase, base)
+		if gotBase != base || gotHead != head {
+			t.Fatalf("event base/head=%q/%q want %q/%q", gotBase, gotHead, base, head)
 		}
 	})
-	t.Run("event_invalid_sha", func(t *testing.T) {
-		path := filepath.Join(t.TempDir(), "event.json")
-		if err := os.WriteFile(path, []byte(`{"pull_request":{"base":{"sha":"invalid"}}}`), 0644); err != nil {
-			t.Fatal(err)
-		}
-		t.Setenv("BASE_SHA", "")
-		t.Setenv("GITHUB_SHA", strings.Repeat("d", 40))
-		t.Setenv("GITHUB_EVENT_PATH", path)
-		if _, _, err := provenance(); err == nil {
-			t.Fatal("accepted invalid event base SHA")
-		}
-	})
+	for _, tc := range []struct {
+		name string
+		base string
+		head string
+	}{
+		{name: "base", base: "invalid", head: strings.Repeat("e", 40)},
+		{name: "head", base: strings.Repeat("c", 40), head: "invalid"},
+	} {
+		t.Run("event_invalid_"+tc.name+"_sha", func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), "event.json")
+			raw := `{"pull_request":{"base":{"sha":"` + tc.base + `"},"head":{"sha":"` + tc.head + `"}}}`
+			if err := os.WriteFile(path, []byte(raw), 0644); err != nil {
+				t.Fatal(err)
+			}
+			t.Setenv("BASE_SHA", "")
+			t.Setenv("GITHUB_SHA", strings.Repeat("d", 40))
+			t.Setenv("GITHUB_EVENT_PATH", path)
+			if _, _, err := provenance(); err == nil {
+				t.Fatalf("accepted invalid event %s SHA", tc.name)
+			}
+		})
+	}
 	for _, tc := range []struct {
 		name string
 		base string
@@ -416,14 +518,14 @@ func TestGitHubEventPayloadIsBoundedAndSingleValue(t *testing.T) {
 	if err := os.WriteFile(oversized, bytes.Repeat([]byte(" "), int(maxGitHubEventBytes)+1), 0644); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := pullRequestBaseSHAFromEvent(oversized); err == nil || !strings.Contains(err.Error(), "cap") {
+	if _, _, _, err := pullRequestSHAsFromEvent(oversized); err == nil || !strings.Contains(err.Error(), "cap") {
 		t.Fatalf("oversized event error=%v", err)
 	}
 	trailing := filepath.Join(t.TempDir(), "trailing.json")
 	if err := os.WriteFile(trailing, []byte(`{} {}`), 0644); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := pullRequestBaseSHAFromEvent(trailing); err == nil || !strings.Contains(err.Error(), "trailing") {
+	if _, _, _, err := pullRequestSHAsFromEvent(trailing); err == nil || !strings.Contains(err.Error(), "trailing") {
 		t.Fatalf("trailing event error=%v", err)
 	}
 }
@@ -433,6 +535,9 @@ func TestCloseOverlapValuesHaveCollisionFreeArtifacts(t *testing.T) {
 	b := math.Nextafter(a, 1)
 	if artifactBasename(runResult{Probes: 1, Overlap: a, TopK: 10}) == artifactBasename(runResult{Probes: 1, Overlap: b, TopK: 10}) {
 		t.Fatal("adjacent float64 overlap values collide")
+	}
+	if artifactBasename(runResult{Seed: 1, Probes: 1, Overlap: a, TopK: 10}) == artifactBasename(runResult{Seed: 2, Probes: 1, Overlap: a, TopK: 10}) {
+		t.Fatal("different fixture seeds collide")
 	}
 	out := t.TempDir()
 	if err := runWithHermeticProvenance(t, []string{
@@ -472,7 +577,7 @@ func TestRunWithExplicitProvenanceOutsideGitCheckout(t *testing.T) {
 	}, io.Discard); err != nil {
 		t.Fatal(err)
 	}
-	raw, err := os.ReadFile(filepath.Join(out, artifactBasename(runResult{Probes: 3, TopK: 9})+".json"))
+	raw, err := os.ReadFile(filepath.Join(out, artifactBasename(runResult{Seed: 1, Probes: 3, TopK: 9})+".json"))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -498,7 +603,7 @@ func TestCanonicalRunWritesJSONAndMarkdown(t *testing.T) {
 	if len(entries) != 12 {
 		t.Fatalf("artifacts=%d want 12", len(entries))
 	}
-	raw, err := os.ReadFile(filepath.Join(out, artifactBasename(runResult{Probes: 4, Overlap: .2, TopK: 10})+".json"))
+	raw, err := os.ReadFile(filepath.Join(out, artifactBasename(runResult{Seed: 1, Probes: 4, Overlap: .2, TopK: 10})+".json"))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -518,7 +623,12 @@ func TestCanonicalRunWritesJSONAndMarkdown(t *testing.T) {
 	if !hnsw.Available || hnsw.RouteKind != string(collections.VectorIndexSearchRouteExactHNSWSearchPackV1) || hnsw.SearchRouteHNSWSearchPack == 0 || hnsw.HNSWSearchPackFallbacks != 0 {
 		t.Fatalf("HNSW stage evidence=%+v", hnsw)
 	}
-	md, err := os.ReadFile(filepath.Join(out, artifactBasename(runResult{Probes: 4, Overlap: .2, TopK: 10})+".md"))
+	for _, field := range []string{`"executed_searches": 0`, `"hnsw_search_pack_fallbacks": 0`} {
+		if !bytes.Contains(raw, []byte(field)) {
+			t.Fatalf("artifact omits explicit zero HNSW evidence field %s", field)
+		}
+	}
+	md, err := os.ReadFile(filepath.Join(out, artifactBasename(runResult{Seed: 1, Probes: 4, Overlap: .2, TopK: 10})+".md"))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -547,5 +657,60 @@ func TestValidateResultRejectsNonFiniteMetrics(t *testing.T) {
 	r := runResult{SchemaVersion: 1, ResultKind: "simulation_only", Stages: []stageResult{{RecallAtK: math.NaN()}}}
 	if err := validateResult(r); err == nil {
 		t.Fatal("accepted nonfinite metric")
+	}
+}
+
+func TestHNSWEvidenceJSONIncludesExplicitZeroCounters(t *testing.T) {
+	raw, err := json.Marshal(stageResult{
+		Name:      "treedb_partition_local_hnsw",
+		Method:    "test",
+		Enabled:   true,
+		Available: true,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, field := range []string{
+		`"searches":0`,
+		`"executed_searches":0`,
+		`"cached_searches":0`,
+		`"search_route_hnsw_search_pack":0`,
+		`"hnsw_search_pack_active":0`,
+		`"hnsw_search_pack_fallbacks":0`,
+	} {
+		if !bytes.Contains(raw, []byte(field)) {
+			t.Fatalf("explicit zero field %s absent from %s", field, raw)
+		}
+	}
+}
+
+func TestValidateResultRequiresExactSHASeedAndMemoryEvidence(t *testing.T) {
+	r := runResult{
+		SchemaVersion:     schemaVersion,
+		ResultKind:        "simulation_only",
+		BaseSHA:           strings.Repeat("a", 40),
+		HeadSHA:           strings.Repeat("b", 40),
+		Dataset:           fixtureManifest{Seed: 1},
+		Seed:              1,
+		MemoryBudgetBytes: 1024,
+		ModeledPeakBytes:  512,
+		MemoryBudgetScope: memoryBudgetScope,
+		Stages:            []stageResult{{Name: "exact_global_top_k", Method: "test", Enabled: true, Available: true}},
+		Metrics:           metricsV1{MeasurementStatus: "simulation_not_measured"},
+	}
+	if err := validateResult(r); err != nil {
+		t.Fatalf("valid result rejected: %v", err)
+	}
+	for _, mutate := range []func(*runResult){
+		func(result *runResult) { result.BaseSHA = "abcdef0" },
+		func(result *runResult) { result.HeadSHA = strings.Repeat("g", 40) },
+		func(result *runResult) { result.Seed++ },
+		func(result *runResult) { result.ModeledPeakBytes = result.MemoryBudgetBytes + 1 },
+	} {
+		bad := r
+		mutate(&bad)
+		if err := validateResult(bad); err == nil {
+			t.Fatalf("accepted invalid result: %+v", bad)
+		}
 	}
 }

--- a/cmd/treedb_vector_partition_bench/main_test.go
+++ b/cmd/treedb_vector_partition_bench/main_test.go
@@ -6,14 +6,34 @@ import (
 	"io"
 	"math"
 	"os"
+	"os/exec"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"testing"
+
+	"github.com/snissn/gomap/TreeDB/collections"
 )
 
 func fixturePath(t *testing.T) string {
 	t.Helper()
 	return filepath.Join("..", "..", "testdata", "vector_partition_10k")
+}
+
+func smallFixtureForTest(vectors, queries, dims int) (fixtureManifest, [][]float64, [][]float64) {
+	m := fixtureManifest{
+		SchemaVersion: schemaVersion,
+		Fixture:       "small",
+		Generator:     "treedb_vector_partition_fixture_v1",
+		Vectors:       vectors,
+		Queries:       queries,
+		Dimensions:    dims,
+		Metric:        "cosine",
+		Seed:          1,
+		Checksum:      strings.Repeat("0", 64),
+	}
+	v, q := deterministicFixture(m)
+	return m, v, q
 }
 
 func TestFixtureTruthDeterministicAndChecksumStable(t *testing.T) {
@@ -43,7 +63,7 @@ func TestTruthOracleTieOrderingAndAllPartitionParity(t *testing.T) {
 	if got[0].ID != "doc-000000" || got[1].ID != "doc-000001" {
 		t.Fatalf("ties not ordered by stable ID: %#v", got[:2])
 	}
-	cfg := config{partitions: 4, topK: 10, recallTarget: .9, seed: 1}
+	cfg := config{partitions: 4, topK: 10, recallTarget: .9, seed: 1, stages: stageSet("exact_global_top_k,partition_oracle")}
 	r, err := simulate(cfg, m, vectors, queries, 4, 0)
 	if err != nil {
 		t.Fatal(err)
@@ -54,29 +74,37 @@ func TestTruthOracleTieOrderingAndAllPartitionParity(t *testing.T) {
 	if r.Stages[0].RecallAtK != r.Stages[1].RecallAtK {
 		t.Fatal("oracle parity differs")
 	}
+	for i, query := range queries {
+		want := exactTopK(vectors, query, cfg.topK)
+		got := partitionTopK(vectors, query, cfg.topK, cfg.partitions, cfg.partitions)
+		if !orderedEqual(want, got) {
+			t.Fatalf("query %d all-partition ordered ID+distance mismatch:\nwant=%+v\ngot=%+v", i, want, got)
+		}
+	}
 }
 
 func TestEveryLossStageIndependentlyLabeled(t *testing.T) {
-	m, _ := loadFixture(fixturePath(t))
-	vectors, queries := deterministicFixture(m)
-	r, err := simulate(config{partitions: 4, topK: 10, recallTarget: .9, seed: 1}, m, vectors, queries, 1, .2)
+	m, vectors, queries := smallFixtureForTest(32, 4, 8)
+	hnsw, err := newTreeDBPartitionHNSW(vectors, 4)
 	if err != nil {
 		t.Fatal(err)
 	}
-	want := []string{"exact_global_top_k", "partition_oracle", "exact_representative_routing", "approximate_representative_routing", "exact_partition_local", "treedb_partition_local_hnsw", "end_to_end_distributed_simulation"}
-	if len(r.Stages) != len(want) {
-		t.Fatalf("stages=%#v", r.Stages)
-	}
-	for i, name := range want {
-		if r.Stages[i].Name != name {
-			t.Fatalf("stage[%d]=%q want %q", i, r.Stages[i].Name, name)
+	defer func() { _ = hnsw.Close() }()
+	for _, name := range knownStages {
+		cfg := config{partitions: 4, topK: 4, recallTarget: .9, seed: 1, stages: stageSet(name)}
+		if name == "treedb_partition_local_hnsw" {
+			cfg.hnsw = hnsw
 		}
-	}
-	if !r.Stages[1].Lossy || !r.Stages[6].Lossy {
-		t.Fatal("loss stages not independently labeled")
-	}
-	if r.ResultKind != "simulation_only" || r.ProductionEvidence {
-		t.Fatalf("simulation label=%+v", r)
+		r, err := simulate(cfg, m, vectors, queries, 1, .2)
+		if err != nil {
+			t.Fatalf("%s: %v", name, err)
+		}
+		if len(r.Stages) != 1 || r.Stages[0].Name != name || !r.Stages[0].Enabled || !r.Stages[0].Available {
+			t.Fatalf("%s independently reported stages=%+v", name, r.Stages)
+		}
+		if r.ResultKind != "simulation_only" || r.ProductionEvidence {
+			t.Fatalf("%s simulation label=%+v", name, r)
+		}
 	}
 }
 
@@ -89,6 +117,81 @@ func TestSingleEnabledStageIsTheOnlyReportedStage(t *testing.T) {
 	}
 	if len(r.Stages) != 1 || r.Stages[0].Name != "partition_oracle" {
 		t.Fatalf("stages=%+v", r.Stages)
+	}
+}
+
+func TestTreeDBHNSWStageUsesExactSearchPackAndMatchesHighEFLocalTruth(t *testing.T) {
+	m, vectors, queries := smallFixtureForTest(48, 6, 8)
+	hnsw, err := newTreeDBPartitionHNSW(vectors, 4)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = hnsw.Close() }()
+
+	allPartitions := []int{0, 1, 2, 3}
+	for queryIndex, query := range queries {
+		got, err := hnsw.search(queryIndex, query, allPartitions, 6)
+		if err != nil {
+			t.Fatalf("query %d: %v", queryIndex, err)
+		}
+		want := exactTopK(vectors, query, 6)
+		if len(got.Neighbors) != len(want) {
+			t.Fatalf("query %d neighbors=%d want %d", queryIndex, len(got.Neighbors), len(want))
+		}
+		for i := range want {
+			if got.Neighbors[i].ID != want[i].ID || math.Abs(got.Neighbors[i].Distance-want[i].Distance) > 1e-5 {
+				t.Fatalf("query %d rank %d HNSW=%+v exact=%+v", queryIndex, i, got.Neighbors[i], want[i])
+			}
+		}
+		if got.Evidence.SearchRouteHNSWSearchPack != 4 || got.Evidence.HNSWSearchPackActive != 4 || got.Evidence.HNSWSearchPackFallbacks != 0 {
+			t.Fatalf("query %d route evidence=%+v", queryIndex, got.Evidence)
+		}
+	}
+
+	cfg := config{
+		partitions:   4,
+		topK:         6,
+		recallTarget: .9,
+		seed:         1,
+		stages:       stageSet("treedb_partition_local_hnsw"),
+		hnsw:         hnsw,
+	}
+	first, err := simulate(cfg, m, vectors, queries, 2, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	physicalAfterFirst := hnsw.physicalSearches
+	second, err := simulate(cfg, m, vectors, queries, 2, .2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if hnsw.physicalSearches != physicalAfterFirst {
+		t.Fatalf("overlap-only row repeated HNSW work: before=%d after=%d", physicalAfterFirst, hnsw.physicalSearches)
+	}
+	if first.Stages[0].ExecutedSearches == 0 || first.Stages[0].CachedSearches != 0 {
+		t.Fatalf("first HNSW row evidence=%+v", first.Stages[0])
+	}
+	if second.Stages[0].ExecutedSearches != 0 || second.Stages[0].CachedSearches != second.Stages[0].Searches {
+		t.Fatalf("cached HNSW row evidence=%+v", second.Stages[0])
+	}
+
+	beforeDifferentSet := hnsw.physicalSearches
+	if _, err := hnsw.search(0, queries[0], []int{0}, 6); err != nil {
+		t.Fatal(err)
+	}
+	afterFirstSet := hnsw.physicalSearches
+	if _, err := hnsw.search(0, queries[0], []int{1}, 6); err != nil {
+		t.Fatal(err)
+	}
+	if afterFirstSet <= beforeDifferentSet || hnsw.physicalSearches <= afterFirstSet {
+		t.Fatal("same-sized selected partition sets aliased in HNSW cache")
+	}
+	dir := hnsw.dir
+	if err := hnsw.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(dir); !os.IsNotExist(err) {
+		t.Fatalf("temporary HNSW DB was not removed: stat error=%v", err)
 	}
 }
 
@@ -129,6 +232,12 @@ func TestConfigurableFixtureCapsRejectBeforeAllocation(t *testing.T) {
 	if _, err := parseConfig([]string{"-dataset", fixturePath(t), "-out", t.TempDir(), "-partitions", "4", "-probes", "1", "-max-fixture-bytes", "7"}); err == nil {
 		t.Fatal("accepted unsafe byte cap")
 	}
+	m.Vectors = 6
+	m.Queries = 5
+	m.Dimensions = 1
+	if err := validateFixtureWithCaps(m, 10, 1024); err == nil || !strings.Contains(err.Error(), "combined") {
+		t.Fatalf("combined vector/query count cap error=%v", err)
+	}
 }
 
 func TestManifestRejectsTrailingJSON(t *testing.T) {
@@ -142,6 +251,172 @@ func TestManifestRejectsTrailingJSON(t *testing.T) {
 	}
 	if _, err := loadFixture(d); err == nil {
 		t.Fatal("accepted trailing JSON")
+	}
+}
+
+func TestManifestReadCapRejectsOversizedFile(t *testing.T) {
+	d := t.TempDir()
+	raw := bytes.Repeat([]byte(" "), int(maxManifestBytes)+1)
+	if err := os.WriteFile(filepath.Join(d, "fixture_manifest.json"), raw, 0644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := loadFixture(d); err == nil || !strings.Contains(err.Error(), "cap") {
+		t.Fatalf("oversized manifest error=%v", err)
+	}
+}
+
+func TestFixtureChecksumMismatchFailsBeforeEvidence(t *testing.T) {
+	d := t.TempDir()
+	raw, err := os.ReadFile(filepath.Join(fixturePath(t), "fixture_manifest.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var m fixtureManifest
+	if err := json.Unmarshal(raw, &m); err != nil {
+		t.Fatal(err)
+	}
+	m.Checksum = strings.Repeat("0", 64)
+	raw, err = json.Marshal(m)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(d, "fixture_manifest.json"), raw, 0644); err != nil {
+		t.Fatal(err)
+	}
+	out := t.TempDir()
+	err = run([]string{"-dataset", d, "-out", out, "-partitions", "4", "-probes", "1", "-stages", "treedb_partition_local_hnsw"}, io.Discard)
+	if err == nil || !strings.Contains(err.Error(), "checksum") {
+		t.Fatalf("checksum mismatch error=%v", err)
+	}
+	entries, readErr := os.ReadDir(out)
+	if readErr != nil {
+		t.Fatal(readErr)
+	}
+	if len(entries) != 0 {
+		t.Fatalf("checksum mismatch emitted evidence: %+v", entries)
+	}
+}
+
+func TestProvenanceAutomaticEnvironmentAndInvalidSHA(t *testing.T) {
+	t.Run("automatic", func(t *testing.T) {
+		t.Setenv("BASE_SHA", "")
+		t.Setenv("GITHUB_SHA", "")
+		t.Setenv("GITHUB_EVENT_PATH", "")
+		base, head, err := provenance()
+		if err != nil {
+			t.Fatal(err)
+		}
+		wantHead, err := exec.Command("git", "rev-parse", "HEAD").Output()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if head != strings.TrimSpace(string(wantHead)) || len(base) != 40 {
+			t.Fatalf("automatic provenance base=%q head=%q want_head=%q", base, head, strings.TrimSpace(string(wantHead)))
+		}
+	})
+	t.Run("environment", func(t *testing.T) {
+		base := strings.Repeat("a", 40)
+		head := strings.Repeat("b", 40)
+		t.Setenv("BASE_SHA", base)
+		t.Setenv("GITHUB_SHA", head)
+		gotBase, gotHead, err := provenance()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if gotBase != base || gotHead != head {
+			t.Fatalf("environment provenance base=%q head=%q", gotBase, gotHead)
+		}
+	})
+	t.Run("pull_request_event", func(t *testing.T) {
+		base := strings.Repeat("c", 40)
+		path := filepath.Join(t.TempDir(), "event.json")
+		raw := `{"pull_request":{"base":{"sha":"` + base + `"}},"ignored_by_typed_projection":true}`
+		if err := os.WriteFile(path, []byte(raw), 0644); err != nil {
+			t.Fatal(err)
+		}
+		t.Setenv("BASE_SHA", "")
+		t.Setenv("GITHUB_SHA", strings.Repeat("d", 40))
+		t.Setenv("GITHUB_EVENT_PATH", path)
+		gotBase, _, err := provenance()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if gotBase != base {
+			t.Fatalf("event base=%q want %q", gotBase, base)
+		}
+	})
+	t.Run("event_invalid_sha", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "event.json")
+		if err := os.WriteFile(path, []byte(`{"pull_request":{"base":{"sha":"invalid"}}}`), 0644); err != nil {
+			t.Fatal(err)
+		}
+		t.Setenv("BASE_SHA", "")
+		t.Setenv("GITHUB_SHA", strings.Repeat("d", 40))
+		t.Setenv("GITHUB_EVENT_PATH", path)
+		if _, _, err := provenance(); err == nil {
+			t.Fatal("accepted invalid event base SHA")
+		}
+	})
+	for _, tc := range []struct {
+		name string
+		base string
+		head string
+	}{
+		{name: "base", base: "not-a-sha", head: strings.Repeat("b", 40)},
+		{name: "head", base: strings.Repeat("a", 40), head: strings.Repeat("g", 40)},
+	} {
+		t.Run("invalid_"+tc.name, func(t *testing.T) {
+			t.Setenv("BASE_SHA", tc.base)
+			t.Setenv("GITHUB_SHA", tc.head)
+			if _, _, err := provenance(); err == nil {
+				t.Fatal("accepted invalid SHA provenance")
+			}
+		})
+	}
+}
+
+func TestGitHubEventPayloadIsBoundedAndSingleValue(t *testing.T) {
+	oversized := filepath.Join(t.TempDir(), "oversized.json")
+	if err := os.WriteFile(oversized, bytes.Repeat([]byte(" "), int(maxGitHubEventBytes)+1), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := pullRequestBaseSHAFromEvent(oversized); err == nil || !strings.Contains(err.Error(), "cap") {
+		t.Fatalf("oversized event error=%v", err)
+	}
+	trailing := filepath.Join(t.TempDir(), "trailing.json")
+	if err := os.WriteFile(trailing, []byte(`{} {}`), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := pullRequestBaseSHAFromEvent(trailing); err == nil || !strings.Contains(err.Error(), "trailing") {
+		t.Fatalf("trailing event error=%v", err)
+	}
+}
+
+func TestCloseOverlapValuesHaveCollisionFreeArtifacts(t *testing.T) {
+	a := 0.2
+	b := math.Nextafter(a, 1)
+	if artifactBasename(runResult{Probes: 1, Overlap: a, TopK: 10}) == artifactBasename(runResult{Probes: 1, Overlap: b, TopK: 10}) {
+		t.Fatal("adjacent float64 overlap values collide")
+	}
+	out := t.TempDir()
+	if err := run([]string{
+		"-dataset", fixturePath(t),
+		"-partitions", "4",
+		"-probes", "1",
+		"-overlap", "0.2," + strconv.FormatFloat(b, 'g', -1, 64),
+		"-top-k", "10",
+		"-stages", "exact_global_top_k",
+		"-format", "json",
+		"-out", out,
+	}, io.Discard); err != nil {
+		t.Fatal(err)
+	}
+	entries, err := os.ReadDir(out)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 4 {
+		t.Fatalf("close overlap artifacts=%d want 4", len(entries))
 	}
 }
 
@@ -169,12 +444,24 @@ func TestCanonicalRunWritesJSONAndMarkdown(t *testing.T) {
 	if result.Command[0] != "treedb_vector_partition_bench" || result.Metrics.MeasurementStatus != "simulation_not_measured" || result.Metrics.SelectedPartitions != 4 {
 		t.Fatalf("artifact metadata=%+v", result)
 	}
+	var hnsw stageResult
+	for _, stage := range result.Stages {
+		if stage.Name == "treedb_partition_local_hnsw" {
+			hnsw = stage
+		}
+	}
+	if !hnsw.Available || hnsw.RouteKind != string(collections.VectorIndexSearchRouteExactHNSWSearchPackV1) || hnsw.SearchRouteHNSWSearchPack == 0 || hnsw.HNSWSearchPackFallbacks != 0 {
+		t.Fatalf("HNSW stage evidence=%+v", hnsw)
+	}
 	md, err := os.ReadFile(filepath.Join(out, artifactBasename(runResult{Probes: 4, Overlap: .2, TopK: 10})+".md"))
 	if err != nil {
 		t.Fatal(err)
 	}
 	if !strings.Contains(string(md), "Simulation only; not production Raft evidence.") {
 		t.Fatal("missing simulation disclaimer")
+	}
+	if !strings.Contains(string(md), "exact_hnsw_search_pack_v1") || !strings.Contains(string(md), "cached=") {
+		t.Fatal("missing separately attributed HNSW route/cache evidence")
 	}
 }
 

--- a/cmd/treedb_vector_search_demo/main.go
+++ b/cmd/treedb_vector_search_demo/main.go
@@ -271,6 +271,7 @@ type datasetManifest struct {
 	Docs                int    `json:"docs"`
 	Dimensions          int    `json:"dimensions"`
 	Queries             int    `json:"queries"`
+	ExactTruthQueries   int    `json:"exact_truth_queries"`
 	TopK                int    `json:"top_k"`
 	Metric              string `json:"metric"`
 	DocumentVectorsFile string `json:"document_vectors_file"`
@@ -1419,6 +1420,9 @@ func loadWorkload(cfg *config) (workload, error) {
 	}
 	if cfg.queries > m.Queries {
 		return workload{}, fmt.Errorf("dataset queries=%d is less than -queries=%d", m.Queries, cfg.queries)
+	}
+	if m.ExactTruthQueries < 0 || m.ExactTruthQueries > m.Queries {
+		return workload{}, fmt.Errorf("dataset exact_truth_queries=%d is outside 0..queries=%d", m.ExactTruthQueries, m.Queries)
 	}
 	if cfg.validateQueries > m.Queries {
 		cfg.validateQueries = m.Queries

--- a/cmd/treedb_vector_search_demo/main_test.go
+++ b/cmd/treedb_vector_search_demo/main_test.go
@@ -638,6 +638,21 @@ func TestExecuteDatasetDirClampsValidateQueries(t *testing.T) {
 	}
 }
 
+func TestLoadWorkloadAcceptsPartialExactTruthCoverage(t *testing.T) {
+	datasetDir := writeDemoDataset(t, 64, 8, 5, 3)
+	cfg := config{datasetDir: datasetDir, docs: 64, dimensions: 8, queries: 5, validateQueries: 4}
+	work, err := loadWorkload(&cfg)
+	if err != nil {
+		t.Fatalf("partial exact-truth coverage rejected: %v", err)
+	}
+	if work.manifest.ExactTruthQueries != 1 || work.manifest.ExactTruthQueries == work.manifest.Queries {
+		t.Fatalf("consumer did not preserve partial exact-truth coverage: %+v", work.manifest)
+	}
+	if cfg.validateQueries != 4 {
+		t.Fatalf("consumer incorrectly clamped validation to truth rows: %d", cfg.validateQueries)
+	}
+}
+
 func TestRunJSONOutput(t *testing.T) {
 	var stdout bytes.Buffer
 	var stderr bytes.Buffer
@@ -1368,6 +1383,7 @@ func writeDemoDataset(t *testing.T, docs, dims, queries, topK int) string {
 		"docs":                  docs,
 		"dimensions":            dims,
 		"queries":               queries,
+		"exact_truth_queries":   min(1, queries),
 		"top_k":                 topK,
 		"metric":                "cosine",
 		"document_vectors_file": "documents.f32",

--- a/scripts/bench_vector_db_compare.sh
+++ b/scripts/bench_vector_db_compare.sh
@@ -312,6 +312,7 @@ GOWORK=off go run ./cmd/treedb_vector_dataset_export \
 	-docs "$DOCS" \
 	-dims "$DIMS" \
 	-queries "$QUERIES" \
+	-truth-queries "$VALIDATE_QUERIES" \
 	-top-k "$TOP_K" \
 	-json >"$RUN_DIR/dataset_export.json"
 

--- a/scripts/bench_vector_db_compare.sh
+++ b/scripts/bench_vector_db_compare.sh
@@ -12,6 +12,10 @@ DOCS="${DOCS:-10000}"
 DIMS="${DIMS:-64}"
 QUERIES="${QUERIES:-10000}"
 VALIDATE_QUERIES="${VALIDATE_QUERIES:-64}"
+EXPORT_TRUTH_QUERIES="$VALIDATE_QUERIES"
+if ((EXPORT_TRUTH_QUERIES > QUERIES)); then
+	EXPORT_TRUTH_QUERIES="$QUERIES"
+fi
 TOP_K="${TOP_K:-10}"
 SEARCH_CONCURRENCY="${SEARCH_CONCURRENCY:-2,4,8,16,32,64,128}"
 M="${M:-16}"
@@ -240,6 +244,7 @@ cat >"$RUN_DIR/README.md" <<EOF
 - dims: \`$DIMS\`
 - queries: \`$QUERIES\`
 - validate queries: \`$VALIDATE_QUERIES\`
+- exported truth queries: \`$EXPORT_TRUTH_QUERIES\`
 - validate docs: \`$VALIDATE_DOCS\`
 - top_k: \`$TOP_K\`
 - concurrency: \`$SEARCH_CONCURRENCY\`
@@ -312,7 +317,7 @@ GOWORK=off go run ./cmd/treedb_vector_dataset_export \
 	-docs "$DOCS" \
 	-dims "$DIMS" \
 	-queries "$QUERIES" \
-	-truth-queries "$VALIDATE_QUERIES" \
+	-truth-queries "$EXPORT_TRUTH_QUERIES" \
 	-top-k "$TOP_K" \
 	-json >"$RUN_DIR/dataset_export.json"
 

--- a/scripts/bench_vector_db_compare.sh
+++ b/scripts/bench_vector_db_compare.sh
@@ -39,6 +39,18 @@ TREEDB_QUANTIZED_RERANK_MIN_RECALL="${TREEDB_QUANTIZED_RERANK_MIN_RECALL:-$TREED
 TREEDB_RABITQ_QUANTIZED_MIN_RECALL="${TREEDB_RABITQ_QUANTIZED_MIN_RECALL:-$TREEDB_QUANTIZED_MIN_RECALL}"
 TREEDB_RABITQ_QUANTIZED_ONLY_MIN_RECALL="${TREEDB_RABITQ_QUANTIZED_ONLY_MIN_RECALL:-$TREEDB_RABITQ_QUANTIZED_MIN_RECALL}"
 TREEDB_RABITQ_QUANTIZED_RERANK_MIN_RECALL="${TREEDB_RABITQ_QUANTIZED_RERANK_MIN_RECALL:-$TREEDB_RABITQ_QUANTIZED_MIN_RECALL}"
+EFFECTIVE_MIN_RECALL="$MIN_RECALL"
+EFFECTIVE_TREEDB_QUANTIZED_ONLY_MIN_RECALL="$TREEDB_QUANTIZED_ONLY_MIN_RECALL"
+EFFECTIVE_TREEDB_QUANTIZED_RERANK_MIN_RECALL="$TREEDB_QUANTIZED_RERANK_MIN_RECALL"
+EFFECTIVE_TREEDB_RABITQ_QUANTIZED_ONLY_MIN_RECALL="$TREEDB_RABITQ_QUANTIZED_ONLY_MIN_RECALL"
+EFFECTIVE_TREEDB_RABITQ_QUANTIZED_RERANK_MIN_RECALL="$TREEDB_RABITQ_QUANTIZED_RERANK_MIN_RECALL"
+if ((VALIDATE_QUERIES == 0)); then
+	EFFECTIVE_MIN_RECALL=0
+	EFFECTIVE_TREEDB_QUANTIZED_ONLY_MIN_RECALL=0
+	EFFECTIVE_TREEDB_QUANTIZED_RERANK_MIN_RECALL=0
+	EFFECTIVE_TREEDB_RABITQ_QUANTIZED_ONLY_MIN_RECALL=0
+	EFFECTIVE_TREEDB_RABITQ_QUANTIZED_RERANK_MIN_RECALL=0
+fi
 VALIDATE_DOCS="${VALIDATE_DOCS:-16}"
 TREEDB_COMPACT="${TREEDB_COMPACT:-}"
 TREEDB_COMPACT_SYNC_EACH_PHASE="${TREEDB_COMPACT_SYNC_EACH_PHASE:-}"
@@ -250,12 +262,12 @@ cat >"$RUN_DIR/README.md" <<EOF
 - concurrency: \`$SEARCH_CONCURRENCY\`
 - M / efConstruction / efSearch: \`$M / $EF_CONSTRUCTION / $EF_SEARCH\`
 - TreeDB column_graph efSearch: \`$TREEDB_COLUMN_GRAPH_EF_SEARCH\`
-- minimum recall: \`$MIN_RECALL\`
+- configured/effective minimum recall: \`$MIN_RECALL / $EFFECTIVE_MIN_RECALL\`
 - TreeDB legacy quantized codec/index/rerank candidates: \`$TREEDB_QUANTIZED_CODEC / $TREEDB_QUANTIZED_INDEX_NAME / $TREEDB_QUANTIZED_RERANK_CANDIDATES\`
 - TreeDB scalar_u8 quantized index: \`$TREEDB_SCALAR_U8_QUANTIZED_INDEX_NAME\`
 - TreeDB RaBitQ quantized index/rerank candidates: \`$TREEDB_RABITQ_QUANTIZED_INDEX_NAME / $TREEDB_RABITQ_QUANTIZED_RERANK_CANDIDATES\`
-- TreeDB quantized-only/rerank minimum recall: \`$TREEDB_QUANTIZED_ONLY_MIN_RECALL / $TREEDB_QUANTIZED_RERANK_MIN_RECALL\`
-- TreeDB RaBitQ quantized-only/rerank minimum recall: \`$TREEDB_RABITQ_QUANTIZED_ONLY_MIN_RECALL / $TREEDB_RABITQ_QUANTIZED_RERANK_MIN_RECALL\`
+- TreeDB quantized-only/rerank configured/effective minimum recall: \`$TREEDB_QUANTIZED_ONLY_MIN_RECALL / $TREEDB_QUANTIZED_RERANK_MIN_RECALL\` / \`$EFFECTIVE_TREEDB_QUANTIZED_ONLY_MIN_RECALL / $EFFECTIVE_TREEDB_QUANTIZED_RERANK_MIN_RECALL\`
+- TreeDB RaBitQ quantized-only/rerank configured/effective minimum recall: \`$TREEDB_RABITQ_QUANTIZED_ONLY_MIN_RECALL / $TREEDB_RABITQ_QUANTIZED_RERANK_MIN_RECALL\` / \`$EFFECTIVE_TREEDB_RABITQ_QUANTIZED_ONLY_MIN_RECALL / $EFFECTIVE_TREEDB_RABITQ_QUANTIZED_RERANK_MIN_RECALL\`
 - TreeDB storage/validation knobs:
   - \`VALIDATE_DOCS=$VALIDATE_DOCS\`
   - \`TREEDB_COMPACT=${TREEDB_COMPACT:-<unset>}\`
@@ -342,7 +354,7 @@ if contains_backend treedb; then
 		-m "$M" \
 		-ef-construction "$EF_CONSTRUCTION" \
 		-ef-search "$EF_SEARCH" \
-		-min-recall "$MIN_RECALL" \
+		-min-recall "$EFFECTIVE_MIN_RECALL" \
 		-json >"$RUN_DIR/treedb.json"
 	result_args+=(--result "$RUN_DIR/treedb.json")
 fi
@@ -367,7 +379,7 @@ if contains_backend treedb_column_graph; then
 		-m "$M" \
 		-ef-construction "$EF_CONSTRUCTION" \
 		-ef-search "$TREEDB_COLUMN_GRAPH_EF_SEARCH" \
-		-min-recall "$MIN_RECALL" \
+		-min-recall "$EFFECTIVE_MIN_RECALL" \
 		-json >"$RUN_DIR/treedb_column_graph.json"
 	result_args+=(--result "$RUN_DIR/treedb_column_graph.json")
 fi
@@ -416,7 +428,7 @@ if contains_backend treedb_column_graph_quantized_only; then
 		"$TREEDB_QUANTIZED_CODEC" \
 		"$TREEDB_QUANTIZED_INDEX_NAME" \
 		"$TREEDB_QUANTIZED_RERANK_CANDIDATES" \
-		"$TREEDB_QUANTIZED_ONLY_MIN_RECALL" \
+		"$EFFECTIVE_TREEDB_QUANTIZED_ONLY_MIN_RECALL" \
 		treedb_column_graph_quantized_only
 fi
 
@@ -427,7 +439,7 @@ if contains_backend treedb_column_graph_quantized_rerank; then
 		"$TREEDB_QUANTIZED_CODEC" \
 		"$TREEDB_QUANTIZED_INDEX_NAME" \
 		"$TREEDB_QUANTIZED_RERANK_CANDIDATES" \
-		"$TREEDB_QUANTIZED_RERANK_MIN_RECALL" \
+		"$EFFECTIVE_TREEDB_QUANTIZED_RERANK_MIN_RECALL" \
 		treedb_column_graph_quantized_rerank
 fi
 
@@ -438,7 +450,7 @@ if contains_backend treedb_column_graph_scalar_u8_quantized_only; then
 		scalar_u8 \
 		"$TREEDB_SCALAR_U8_QUANTIZED_INDEX_NAME" \
 		"$TREEDB_QUANTIZED_RERANK_CANDIDATES" \
-		"$TREEDB_QUANTIZED_ONLY_MIN_RECALL" \
+		"$EFFECTIVE_TREEDB_QUANTIZED_ONLY_MIN_RECALL" \
 		treedb_column_graph_scalar_u8_quantized_only
 fi
 
@@ -449,7 +461,7 @@ if contains_backend treedb_column_graph_scalar_u8_quantized_rerank; then
 		scalar_u8 \
 		"$TREEDB_SCALAR_U8_QUANTIZED_INDEX_NAME" \
 		"$TREEDB_QUANTIZED_RERANK_CANDIDATES" \
-		"$TREEDB_QUANTIZED_RERANK_MIN_RECALL" \
+		"$EFFECTIVE_TREEDB_QUANTIZED_RERANK_MIN_RECALL" \
 		treedb_column_graph_scalar_u8_quantized_rerank
 fi
 
@@ -460,7 +472,7 @@ if contains_backend treedb_column_graph_rabitq_1bit_quantized_only; then
 		rabitq_1bit \
 		"$TREEDB_RABITQ_QUANTIZED_INDEX_NAME" \
 		"$TREEDB_RABITQ_QUANTIZED_RERANK_CANDIDATES" \
-		"$TREEDB_RABITQ_QUANTIZED_ONLY_MIN_RECALL" \
+		"$EFFECTIVE_TREEDB_RABITQ_QUANTIZED_ONLY_MIN_RECALL" \
 		treedb_column_graph_rabitq_1bit_quantized_only
 fi
 
@@ -471,7 +483,7 @@ if contains_backend treedb_column_graph_rabitq_1bit_quantized_rerank; then
 		rabitq_1bit \
 		"$TREEDB_RABITQ_QUANTIZED_INDEX_NAME" \
 		"$TREEDB_RABITQ_QUANTIZED_RERANK_CANDIDATES" \
-		"$TREEDB_RABITQ_QUANTIZED_RERANK_MIN_RECALL" \
+		"$EFFECTIVE_TREEDB_RABITQ_QUANTIZED_RERANK_MIN_RECALL" \
 		treedb_column_graph_rabitq_1bit_quantized_rerank
 fi
 
@@ -488,7 +500,7 @@ if contains_backend vectorlite; then
 		--m "$M" \
 		--ef-construction "$EF_CONSTRUCTION" \
 		--ef-search "$EF_SEARCH" \
-		--min-recall "$MIN_RECALL" >"$RUN_DIR/vectorlite.stdout.json"
+		--min-recall "$EFFECTIVE_MIN_RECALL" >"$RUN_DIR/vectorlite.stdout.json"
 	result_args+=(--result "$RUN_DIR/vectorlite.json")
 fi
 
@@ -508,7 +520,7 @@ if contains_backend pgvector; then
 		--m "$M"
 		--ef-construction "$EF_CONSTRUCTION"
 		--ef-search "$EF_SEARCH"
-		--min-recall "$MIN_RECALL"
+		--min-recall "$EFFECTIVE_MIN_RECALL"
 	)
 	if [[ "$PGVECTOR_DROP_SCHEMA_AFTER" == "true" ]]; then
 		pgvector_args+=(--drop-schema-after)
@@ -535,7 +547,7 @@ if contains_backend mongodb; then
 		--search-concurrency "$SEARCH_CONCURRENCY" \
 		--num-candidates "$MONGODB_VECTOR_NUM_CANDIDATES" \
 		--index-timeout-seconds "$MONGODB_VECTOR_INDEX_TIMEOUT_SECONDS" \
-		--min-recall "$MIN_RECALL" >"$RUN_DIR/mongodb.stdout.json"
+		--min-recall "$EFFECTIVE_MIN_RECALL" >"$RUN_DIR/mongodb.stdout.json"
 	result_args+=(--result "$RUN_DIR/mongodb.json")
 fi
 

--- a/scripts/bench_vector_db_compare_test.py
+++ b/scripts/bench_vector_db_compare_test.py
@@ -18,7 +18,13 @@ ROOT = SCRIPT.parents[1]
 
 
 class VectorDBCompareScriptTest(unittest.TestCase):
-    def run_with_fake_tools(self, *, validate_queries: str | None) -> list[list[str]]:
+    def run_with_fake_tools(
+        self,
+        *,
+        validate_queries: str | None,
+        backends: str = "treedb",
+        extra_env: dict[str, str] | None = None,
+    ) -> list[list[str]]:
         with tempfile.TemporaryDirectory(prefix="gomap_vector_db_compare_test_") as tmp:
             tmpdir = Path(tmp)
             fake_bin = tmpdir / "bin"
@@ -66,6 +72,16 @@ class VectorDBCompareScriptTest(unittest.TestCase):
             fake_go.chmod(0o755)
 
             env = os.environ.copy()
+            for name in (
+                "MIN_RECALL",
+                "TREEDB_QUANTIZED_MIN_RECALL",
+                "TREEDB_QUANTIZED_ONLY_MIN_RECALL",
+                "TREEDB_QUANTIZED_RERANK_MIN_RECALL",
+                "TREEDB_RABITQ_QUANTIZED_MIN_RECALL",
+                "TREEDB_RABITQ_QUANTIZED_ONLY_MIN_RECALL",
+                "TREEDB_RABITQ_QUANTIZED_RERANK_MIN_RECALL",
+            ):
+                env.pop(name, None)
             env.update(
                 {
                     "PATH": f"{fake_bin}{os.pathsep}{env['PATH']}",
@@ -73,7 +89,7 @@ class VectorDBCompareScriptTest(unittest.TestCase):
                     "RUN_DIR": str(tmpdir / "run"),
                     "VENV": str(tmpdir / "venv"),
                     "PYTHON": str(fake_python),
-                    "BACKENDS": "treedb",
+                    "BACKENDS": backends,
                     "DOCS": "10",
                     "DIMS": "4",
                     "QUERIES": "10",
@@ -85,6 +101,8 @@ class VectorDBCompareScriptTest(unittest.TestCase):
                 env.pop("VALIDATE_QUERIES", None)
             else:
                 env["VALIDATE_QUERIES"] = validate_queries
+            if extra_env is not None:
+                env.update(extra_env)
 
             result = subprocess.run(
                 [str(SCRIPT)],
@@ -151,6 +169,30 @@ class VectorDBCompareScriptTest(unittest.TestCase):
     def test_zero_validation_still_disables_exported_truth(self) -> None:
         self.assert_forwarding(
             self.run_with_fake_tools(validate_queries="0"),
+            exporter_truth_queries="0",
+            consumer_validate_queries="0",
+            consumer_min_recall="0",
+        )
+
+    def test_quantized_recall_gate_is_preserved_with_validation(self) -> None:
+        self.assert_forwarding(
+            self.run_with_fake_tools(
+                validate_queries="1",
+                backends="treedb_column_graph_quantized_only",
+                extra_env={"TREEDB_QUANTIZED_ONLY_MIN_RECALL": "0.8"},
+            ),
+            exporter_truth_queries="1",
+            consumer_validate_queries="1",
+            consumer_min_recall="0.8",
+        )
+
+    def test_zero_validation_disables_quantized_recall_gate(self) -> None:
+        self.assert_forwarding(
+            self.run_with_fake_tools(
+                validate_queries="0",
+                backends="treedb_column_graph_quantized_only",
+                extra_env={"TREEDB_QUANTIZED_ONLY_MIN_RECALL": "0.8"},
+            ),
             exporter_truth_queries="0",
             consumer_validate_queries="0",
             consumer_min_recall="0",

--- a/scripts/bench_vector_db_compare_test.py
+++ b/scripts/bench_vector_db_compare_test.py
@@ -115,6 +115,7 @@ class VectorDBCompareScriptTest(unittest.TestCase):
         *,
         exporter_truth_queries: str,
         consumer_validate_queries: str,
+        consumer_min_recall: str,
     ) -> None:
         exporter = next(
             command
@@ -134,12 +135,17 @@ class VectorDBCompareScriptTest(unittest.TestCase):
             self.flag_value(consumer, "-validate-queries"),
             consumer_validate_queries,
         )
+        self.assertEqual(
+            self.flag_value(consumer, "-min-recall"),
+            consumer_min_recall,
+        )
 
     def test_default_validation_is_bounded_by_short_query_count(self) -> None:
         self.assert_forwarding(
             self.run_with_fake_tools(validate_queries=None),
             exporter_truth_queries="10",
             consumer_validate_queries="64",
+            consumer_min_recall="0.95",
         )
 
     def test_zero_validation_still_disables_exported_truth(self) -> None:
@@ -147,6 +153,7 @@ class VectorDBCompareScriptTest(unittest.TestCase):
             self.run_with_fake_tools(validate_queries="0"),
             exporter_truth_queries="0",
             consumer_validate_queries="0",
+            consumer_min_recall="0",
         )
 
 

--- a/scripts/bench_vector_db_compare_test.py
+++ b/scripts/bench_vector_db_compare_test.py
@@ -1,0 +1,154 @@
+#!/usr/bin/env python3
+"""Command-contract tests for bench_vector_db_compare.sh."""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import textwrap
+import unittest
+from pathlib import Path
+
+
+SCRIPT = Path(__file__).with_name("bench_vector_db_compare.sh")
+ROOT = SCRIPT.parents[1]
+
+
+class VectorDBCompareScriptTest(unittest.TestCase):
+    def run_with_fake_tools(self, *, validate_queries: str | None) -> list[list[str]]:
+        with tempfile.TemporaryDirectory(prefix="gomap_vector_db_compare_test_") as tmp:
+            tmpdir = Path(tmp)
+            fake_bin = tmpdir / "bin"
+            fake_bin.mkdir()
+            go_log = tmpdir / "go.jsonl"
+
+            fake_python = fake_bin / "python3"
+            fake_python.write_text(
+                textwrap.dedent(
+                    f"""\
+                    #!{sys.executable}
+                    import pathlib
+                    import shutil
+                    import sys
+
+                    if sys.argv[1:3] == ["-m", "venv"]:
+                        target = pathlib.Path(sys.argv[3]) / "bin" / "python"
+                        target.parent.mkdir(parents=True, exist_ok=True)
+                        shutil.copy2(sys.argv[0], target)
+                        target.chmod(0o755)
+                    """
+                ),
+                encoding="utf-8",
+            )
+            fake_python.chmod(0o755)
+
+            fake_go = fake_bin / "go"
+            fake_go.write_text(
+                textwrap.dedent(
+                    f"""\
+                    #!{sys.executable}
+                    import json
+                    import os
+                    import pathlib
+                    import sys
+
+                    with pathlib.Path(os.environ["FAKE_GO_LOG"]).open("a", encoding="utf-8") as log:
+                        json.dump(sys.argv[1:], log)
+                        log.write("\\n")
+                    print("{{}}")
+                    """
+                ),
+                encoding="utf-8",
+            )
+            fake_go.chmod(0o755)
+
+            env = os.environ.copy()
+            env.update(
+                {
+                    "PATH": f"{fake_bin}{os.pathsep}{env['PATH']}",
+                    "FAKE_GO_LOG": str(go_log),
+                    "RUN_DIR": str(tmpdir / "run"),
+                    "VENV": str(tmpdir / "venv"),
+                    "PYTHON": str(fake_python),
+                    "BACKENDS": "treedb",
+                    "DOCS": "10",
+                    "DIMS": "4",
+                    "QUERIES": "10",
+                    "TOP_K": "2",
+                    "SEARCH_CONCURRENCY": "1",
+                }
+            )
+            if validate_queries is None:
+                env.pop("VALIDATE_QUERIES", None)
+            else:
+                env["VALIDATE_QUERIES"] = validate_queries
+
+            result = subprocess.run(
+                [str(SCRIPT)],
+                cwd=ROOT,
+                env=env,
+                text=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                check=False,
+            )
+            if result.returncode != 0:
+                self.fail(
+                    f"script failed with {result.returncode}\n"
+                    f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+                )
+            return [
+                json.loads(line)
+                for line in go_log.read_text(encoding="utf-8").splitlines()
+            ]
+
+    @staticmethod
+    def flag_value(command: list[str], flag: str) -> str:
+        return command[command.index(flag) + 1]
+
+    def assert_forwarding(
+        self,
+        commands: list[list[str]],
+        *,
+        exporter_truth_queries: str,
+        consumer_validate_queries: str,
+    ) -> None:
+        exporter = next(
+            command
+            for command in commands
+            if "./cmd/treedb_vector_dataset_export" in command
+        )
+        consumer = next(
+            command
+            for command in commands
+            if "./cmd/treedb_vector_search_demo" in command
+        )
+        self.assertEqual(
+            self.flag_value(exporter, "-truth-queries"),
+            exporter_truth_queries,
+        )
+        self.assertEqual(
+            self.flag_value(consumer, "-validate-queries"),
+            consumer_validate_queries,
+        )
+
+    def test_default_validation_is_bounded_by_short_query_count(self) -> None:
+        self.assert_forwarding(
+            self.run_with_fake_tools(validate_queries=None),
+            exporter_truth_queries="10",
+            consumer_validate_queries="64",
+        )
+
+    def test_zero_validation_still_disables_exported_truth(self) -> None:
+        self.assert_forwarding(
+            self.run_with_fake_tools(validate_queries="0"),
+            exporter_truth_queries="0",
+            consumer_validate_queries="0",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/testdata/vector_partition_10k/fixture_manifest.json
+++ b/testdata/vector_partition_10k/fixture_manifest.json
@@ -1,11 +1,12 @@
 {
   "schema_version": 1,
   "fixture": "vector_partition_10k",
-  "generator": "treedb_vector_partition_fixture_v1",
+  "generator": "treedb_vector_partition_fixture_v2",
+  "arithmetic": "ieee754_binary64_explicit_fma_v1",
   "vectors": 10000,
   "queries": 128,
   "dimensions": 64,
   "metric": "cosine",
   "seed": 1,
-  "checksum": "67e7d10be48a63a63b6a0835d2eba1c0bee119fe24aabdc7c7d3dba846bf1a3f"
+  "checksum": "2413ef7c2f65a4b5ce8ecc3846f473fd85d337a87511538f962af7cdf6aec291"
 }

--- a/testdata/vector_partition_10k/fixture_manifest.json
+++ b/testdata/vector_partition_10k/fixture_manifest.json
@@ -1,0 +1,11 @@
+{
+  "schema_version": 1,
+  "fixture": "vector_partition_10k",
+  "generator": "treedb_vector_partition_fixture_v1",
+  "vectors": 10000,
+  "queries": 128,
+  "dimensions": 64,
+  "metric": "cosine",
+  "seed": 1,
+  "checksum": "67e7d10be48a63a63b6a0835d2eba1c0bee119fe24aabdc7c7d3dba846bf1a3f"
+}


### PR DESCRIPTION
## Objective

Close #3909 by freezing the clean-room M0 contract, deterministic fixture,
independently checked exact truth, loss-attribution oracles, and an executable
TreeDB partition-local HNSW baseline.

## Context

M1/M2 need executable vocabulary and matched-recall attribution before derived
partition or Raft query-plane implementation begins. M0 must distinguish
partition/router/local-HNSW loss without presenting a sequential harness as
production Raft evidence.

## Non-goals

- No production partition format, partitioner, overlap membership, kRt, RPC,
  coordinator, Raft catalog, or routed Raft read.
- No network or multi-group measurement.
- No paper throughput claim and no source copied/adapted from unlicensed
  `gp-ann`.

## Design

- Adds `vector-partition-raft-v1.md`: canonical `_id` ownership versus derived
  ANN membership; separate vector-index/source/partition/router identities;
  snapshot-bound invalidation and fail-closed V1 response contract.
- Adds root `testdata/vector_partition_10k` manifest plus a deterministic
  generated vector/query/exact-truth stream with checksum and stable tie order.
- Bumps that fixture contract to generator v2 with
  `ieee754_binary64_explicit_fma_v1`: normalization, exact-oracle dot products,
  and representative-routing dot products use explicit `math.FMA`, and the
  manifest binds the arithmetic choice instead of relying on architecture-
  dependent multiply-add contraction.
- Adds a sequential `simulation_only` harness. Production Raft/RPC metrics
  remain `simulation_not_measured`.
- Implements the `treedb_partition_local_hnsw` stage with the public TreeDB
  lifecycle: command-WAL format config, `db.Open`, collection manager, JSON
  typed `float32_vector` column ownership, `column_graph`, batch insert,
  `Flush`, `RebuildVectorIndex`, and response-owned `SearchVectorIndex`.
- Builds one temporary derived collection/index per logical modulo partition
  once per run, only when HNSW is selected. Search results are merged by cosine
  distance then stable ID. Temporary DB state is closed and removed.
- Requires `exact_hnsw_search_pack_v1`,
  `SearchRouteHNSWSearchPack=1`, active pack state, and zero fallbacks for every
  local response; any fallback or unavailability is a hard error.
- Reuses HNSW results across overlap-only rows with a cache keyed by query,
  top-k, and the canonical sorted selected-partition set. JSON/Markdown
  distinguish logical, executed, and cached searches; all HNSW evidence
  counters are serialized even when zero.
- Extends the exporter with normalized cosine distance, deterministic
  distance-then-ID truth, an explicit tie comparator, independent small-corpus
  verification from the emitted float32 files, and a hand-computed non-unit
  vector regression.
- Adds `-truth-queries` (default: all queries) so the exporter can emit every
  benchmark query vector while computing exhaustive truth only for a declared
  leading prefix. The manifest records `exact_truth_queries`, the 200M gate is
  applied to `docs * truth_queries`, and the comparison script bounds exporter
  truth to `min(VALIDATE_QUERIES, QUERIES)` while leaving consumer-side
  validation clamping unchanged. An explicitly supplied zero disables exported
  truth while preserving all query vectors; omission retains the standalone
  default of truth for every query.
- Treats `VALIDATE_QUERIES=0` as a benchmark-wide disabled-validation contract:
  every full-vector and quantized backend receives an effective minimum recall
  of zero, while configured and effective gates remain distinct in run
  metadata. Real-shell coverage proves normal full-vector/quantized gates remain
  `0.95`/`0.8` and both become zero only when validation is disabled.
- Propagates partition-benchmark JSON encoding failures instead of discarding
  them; production and test marshal calls pass the exact `errchkjson` gate.
- Materializes exporter document vectors and squared norms once in contiguous
  storage, reuses them for every output and exact-truth query, and retains only
  bounded top-k candidates. The modeled truth peak includes corpus, norms,
  scratch, candidates/results, and conservative JSON encoding growth; the
  declared 1M-document/one-query/64-dimension shape remains accepted.
- Makes `-max-fixture-bytes` a conservative modeled peak-live cap for
  benchmark-owned fixture and work material, including the persistent HNSW
  query cache and whole-partition JSON/decode phase, with 25 percent allocation
  slack. TreeDB engine/index internals, Go runtime/GC metadata, and
  CLI/artifact encoding are explicitly excluded and the exact scope is emitted
  in every artifact.
- Generates fixture/query matrices once in contiguous backing storage, checks
  their checksum in place, and uses bounded top-k heaps instead of corpus-sized
  exact-result buffers.
- Adds a fixed 200,000,000-unit pre-generation work gate. It counts checksum
  truth once plus mandatory truth and enabled exhaustive/routing corpus passes
  for every probe/overlap row; the canonical matrix is 85,760,000 visits.
  TreeDB HNSW engine-internal search work is explicitly outside this gate.
- Requires `-seed` to equal the fixture seed, records it in the artifact, and
  includes its fixed-width bit pattern in the artifact basename. Artifact
  basenames also bind the full fixture checksum, partition count, probes,
  exact overlap bits, top-k, and a full SHA-256 over the canonical selected
  stage set.
- Makes every run-bound test provide explicit valid provenance with no event.
  The local-Git provenance case remains separately tested when a checkout is
  available. When `GITHUB_EVENT_PATH` is a pull-request event, bounded parsing
  reads both `base.sha` and `head.sha` and overrides both environment values,
  replacing GitHub's synthetic merge SHA with the exact pull-request head.
- Defines exact-truth checksum binding as `min(10, vector_count)`, so valid
  fixtures with one through nine vectors are deterministic and panic-free.

## Correctness

Required commands, passing on
`8d0806274ddbcaaeb3b3a9c52e3108d319ed433b`:

```sh
GOWORK=off go test ./cmd/treedb_vector_partition_bench ./cmd/treedb_vector_dataset_export ./cmd/treedb_vector_search_demo ./TreeDB/docs -count=1
GOWORK=off go test ./cmd/treedb_vector_partition_bench -run 'Test.*(Fixture|Truth|Oracle|Manifest|Deterministic|Malformed|Cap).*' -count=1
```

Focused real-HNSW gate, passing:

```sh
GOWORK=off go test ./cmd/treedb_vector_partition_bench -run 'Test.*(TreeDBHNSW|EveryLossStage)' -count=1
```

Focused fixture-arithmetic, exact-oracle, and real-HNSW gate, passing:

```sh
GOWORK=off go test ./cmd/treedb_vector_partition_bench -run 'Test(FixtureArithmeticUsesExplicitFMA|FixtureTruthDeterministicAndChecksumStable|TruthOracleTieOrderingAndAllPartitionParity|TreeDBHNSWStageUsesExactSearchPackAndMatchesHighEFLocalTruth|CanonicalRunWritesJSONAndMarkdown|CloseOverlapValuesHaveCollisionFreeArtifacts|ArtifactBasenamePreventsDatasetAndPartitionOverwrite|ProvenanceAutomaticEnvironmentAndInvalidSHA)$' -count=1
```

Focused review regressions, passing:

```sh
GOWORK=off go test ./cmd/treedb_vector_dataset_export -run 'Test(ExportExplicitZeroTruthWritesDeclaredEmptyCoverage|ExportExactTruthUsesDeclaredLeadingQueryCount|LargeComparisonShapeUsesBoundedTruthPrefixBeforeAllocation|TruthQueryBoundsNormalizeBeforeComparisonCap|ExportMaterializesDocumentVectorsOnceForAllQueries|ExportExactTruthMatchesIndependentSmallCorpusRecomputation)$' -count=1
GOWORK=off go test ./cmd/treedb_vector_partition_bench -run 'Test(ArtifactBasenamePreventsStageSetOverwrite|ArtifactBasenamePreventsDatasetAndPartitionOverwrite|CloseOverlapValuesHaveCollisionFreeArtifacts|CanonicalRunWritesJSONAndMarkdown)$' -count=1
GOWORK=off go test ./cmd/treedb_vector_partition_bench -run 'Test(BenchmarkWorkBudgetBoundaryAndCanonicalShape|PathologicalBenchmarkWorkRejectsBeforeGenerationOrEvidence|ModeledPeakMemoryBudgetEnforcedBeforeGeneration|FixtureChecksumMismatchFailsBeforeEvidence|EveryLossStageIndependentlyLabeled|TreeDBHNSWStageUsesExactSearchPackAndMatchesHighEFLocalTruth)$' -count=1
GOWORK=off go test ./cmd/treedb_vector_search_demo -count=1
GOWORK=off go vet ./cmd/treedb_vector_dataset_export ./cmd/treedb_vector_partition_bench ./cmd/treedb_vector_search_demo
GOWORK=off go vet ./...
bash -n scripts/bench_vector_db_compare.sh
shellcheck scripts/bench_vector_db_compare.sh
python3 scripts/bench_vector_db_compare_test.py
python3 benchmarks/vector_db_compare/test_summarize.py
go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2 run --default=none --enable errchkjson ./cmd/treedb_vector_partition_bench/...
go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2 run --default=none --enable errchkjson --new-from-rev=origin/main ./...
GOWORK=off go test ./TreeDB/collections -run 'Test(ColumnPrimaryRowLocator|CollectionReadViewLookupDocumentRowRefsByID|CollectionReadViewBoundSnapshotIgnoresLaterWrites|ScanDocumentsFuncGenericLocatorReconstructionBoundsMultiAssetBatches|ColumnStoreCompact(Q2SortedLatestVisibleReopen|PostCompactionWritesAdvanceFromCompactedManifest|AllRowsDeletedPublishesEmptyInsertOnlyManifest)|SearchVectorIndexColumnGraphMaterializesDocumentsAfterTopK|OpenVectorIndexSearcherFetchesDocumentsFromBoundSnapshot|SearchVectorIndexColumnGraphSnapshotBoundSearcherSurvivesLaterMutation)' -count=1
GOWORK=off go test ./TreeDB/collections -count=1 -timeout=15m
```

Coverage includes:

- byte-stable fixture/truth and explicit distance/ID tie ordering;
- explicit-FMA fixture arithmetic with a manifest algorithm marker; the
  Linux/amd64 checksum `2413ef7c...` exactly matches the checksum observed from
  the prior implicit-arithmetic code on macOS/arm64, isolating multiply-add
  contraction as the old cross-platform failure, and exact-head
  `macos-latest-1` root vet/test job `88227386269` passes the repaired bytes;
- ordered ID+distance all-partition parity;
- high-ef small-fixture TreeDB HNSW parity against exact local truth;
- fail-closed exact HNSW search-pack route checks;
- independently selectable stages without unrelated HNSW construction;
- checksum mismatch before artifacts or TreeDB evidence;
- bounded manifest and GitHub-event reads;
- combined vector/query count and modeled peak-live byte caps before fixture
  generation, with exact cap-minus-one rejection;
- exact-boundary benchmark work acceptance, canonical 85.76M/200M work proof,
  and 500k-by-500k rejection before fixture generation or evidence;
- exactly one exporter generator call per document regardless of query count,
  a feasible declared 1M-document/one-query/64-dimension shape, and a
  100k-document/50k-query/64-truth-query comparison shape accepted before
  allocation while the default all-query truth shape is rejected;
- a two-of-five leading exact-truth export, `0..queries` bounds, manifest
  coverage, and a consumer that recomputes four validation queries without
  requiring five truth rows;
- a 100k-document/50k-query explicit-zero-truth preflight accepted before
  allocation, plus an emitted five-query/zero-truth dataset whose consumer
  independently validates four queries at recall 1;
- production-script command coverage proving `QUERIES=10` bounds the default
  `VALIDATE_QUERIES=64` exporter truth prefix to ten while leaving consumer
  validation unchanged; normal full-vector/quantized recall gates remain
  `0.95`/`0.8`, while explicit zero validation forwards zero truth and zero
  effective recall to both consumer paths;
- all five payload files and the manifest in the default small export
  byte-identical to the previous exact head;
- local, environment, and shallow-PR-event exact base/head provenance plus
  synthetic-merge environment override, non-PR-event preservation, and invalid
  and non-40-hex SHA cases;
- the four PR-owned packages from an exact-head `git archive`, extracted
  without `.git` at `/tmp/gomap_3909_reviewfix_archive_BLeJp2`;
- the complete collections package plus focused primary-locator, compaction,
  materialization, snapshot-bound, and vector-search cases on the current base;
- the inherited `TreeDB/db` ordered-root package on the rebased working tree,
  confirming the new base's bounded descriptor-transition change does not
  regress this vector work;
- deterministic checksum coverage for every fixture size from one through
  nine vectors;
- collision-free artifact names for adjacent float64 overlap values, distinct
  seeds, same-seed distinct fixture checksums, and partition counts 4 versus 8
  in one output directory;
- collision-free artifact names for independently selected stage sets written
  to the same output directory, with an order-invariant canonical stage-set
  checksum;
- explicit zero HNSW evidence counters in canonical artifact JSON;
- strict schema/non-finite/trailing-value rejection; and
- sequential simulation/non-production/Raft labeling.

`git diff --check` also passes.

Exact `golangci-lint` v2.12.2 `errchkjson` checks pass for the affected package
and for all changes relative to `origin/main`. An absolute full-repository scan
reports five pre-existing violations in files unchanged from `origin/main`.

A local `GOWORK=off go test ./... -count=1` attempt was not clean: the
repository-wide TreeDB and TreeDB/db packages exhausted their shared 10-minute
timeouts under filesystem-sync load, and two Git/VCS-dependent packages failed
because VCS stamping/`git merge-tree` exits 128 in this detached publication
worktree. Both named timeout tests pass in isolation, all PR-owned packages pass
from the exact-head no-`.git` archive above, and full `go vet ./...` passes.
After merging current main, the full collections package passes standalone in
212.027 seconds on the final head.

## Canonical smoke and artifact sample

Exact root-path command, passing on the head above:

```sh
OUT=$(mktemp -d /tmp/treedb_vector_partition_m0_final_XXXXXX)
BASE_SHA=96591d081b3950c7cfc7cb3190c769100ca5d983 \
GITHUB_SHA=8d0806274ddbcaaeb3b3a9c52e3108d319ed433b \
GITHUB_EVENT_PATH='' \
GOWORK=off go run ./cmd/treedb_vector_partition_bench \
  -dataset testdata/vector_partition_10k \
  -partitions 4 \
  -probes 1,2,4 \
  -overlap 0,0.20 \
  -top-k 10 \
  -recall-target 0.90 \
  -seed 1 \
  -format json \
  -out "$OUT"
```

Local close artifact directory:
`/tmp/treedb_vector_partition_m0_reviewfix_8vCNtr/` (six JSON and six Markdown
probe/overlap artifacts).

The preflight work model for this exact command is
`85,760,000 / 200,000,000` vector/query corpus visits.

Executed-row sample
(`simulation_f2413ef7c2f65a4b5ce8ecc3846f473fd85d337a87511538f962af7cdf6aec291_s0000000000000001_n4_p4_o0000000000000000_t621d821ecc7d4912589671d03fdac22a00e21e27dafddb0fcb61cc5f029638a0_k10.json`):

```json
{
  "base_sha": "96591d081b3950c7cfc7cb3190c769100ca5d983",
  "head_sha": "8d0806274ddbcaaeb3b3a9c52e3108d319ed433b",
  "result_kind": "simulation_only",
  "production_evidence": false,
  "dataset": {
    "generator": "treedb_vector_partition_fixture_v2",
    "arithmetic": "ieee754_binary64_explicit_fma_v1",
    "checksum": "2413ef7c2f65a4b5ce8ecc3846f473fd85d337a87511538f962af7cdf6aec291"
  },
  "seed": 1,
  "memory_budget_bytes": 4294967296,
  "modeled_peak_bytes": 24061270,
  "probes": 4,
  "overlap": 0,
  "hnsw": {
    "available": true,
    "recall_at_k": 1,
    "route_kind": "exact_hnsw_search_pack_v1",
    "searches": 512,
    "executed_searches": 512,
    "cached_searches": 0,
    "search_route_hnsw_search_pack": 512,
    "hnsw_search_pack_active": 512,
    "hnsw_search_pack_fallbacks": 0
  }
}
```

The overlap `0.20` row reports the same 512 logical route-backed searches as
`cached_searches=512`, `executed_searches=0`, and zero fallbacks. This makes
cross-overlap cache reuse explicit instead of presenting cached results as new
physical searches.

Timed boundary is explicitly untimed M0 attribution over in-memory oracles and
temporary local TreeDB build/search; it excludes network, RPC, coordinator, and
Raft.

## Start and close evidence

- Start head `7fe218ad3804945988213256712ce1294761d570`: the required HNSW
  stage was a static `Available:false` waiver with method
  `unavailable_without_public_M0_HNSW_pack_api`.
- Close head `8d0806274ddbcaaeb3b3a9c52e3108d319ed433b`: canonical artifacts
  report the stage available on the exact search-pack route, with active-pack
  counts matching logical searches and explicit zero fallbacks. Both
  issue-required test commands, the focused work-cap/exporter-reuse/HNSW
  regressions, the prior-head byte-for-byte export comparison, the explicit-FMA
  platform-stable fixture regression, and the no-`.git` archive package run
  pass. The fully validated rebased head
  `aff5628ec004b689c8dfab989409acd47d531dd8` and the repository-compliant
  publication merge `6bdfff603a4cf0acfe10013cd890799affd0d331`
  have the identical tree
  `60d31a31dff0b8ada0f2320079ac4202a13345ed`; that merge added only current-main
  ancestry required by the protected no-force branch. The close head includes
  the final review fixes and a conflict-free normal merge of current main
  `96591d081b3950c7cfc7cb3190c769100ca5d983`. Its cumulative diff remains the
  same 13 PR-owned files, while focused and full collections/vector-search
  validation covers the new snapshot-safe primary-locator base.

## Column Graph Native Workstream (#1646, if applicable)

### Copied/Adapted From Old Stack

- Copied: none.
- Adapted: none.
- Oracle/comparator only: arXiv:2403.01797 vocabulary; `gp-ann` reference only.
- Quarantined/not copied: all authors' repository source.

### Base And Dependency State

- Base branch: `main`
- Base commit: `96591d081b3950c7cfc7cb3190c769100ca5d983`
- Head commit: `8d0806274ddbcaaeb3b3a9c52e3108d319ed433b`

### Status/fallback proof

- All artifacts retain `result_kind=simulation_only` and
  `production_evidence=false`.
- HNSW execution is separately attributed and fail-closed on any non-pack
  route.
- No production hot path changes or speedup claim.

### AI Review Loop

- Codex review of `d15d39d1208860eedf8193a0446b97d9fd1b2064`:
  FIX-NEEDED; both remaining findings are fixed at the current head.
- Exact-head CI on `21482c706d405050ce0629fc9684d1246d4efdac`
  found an architecture-dependent fixture checksum on macOS/arm64. The current
  head fixes that blocker with a versioned explicit-FMA arithmetic contract.
  Exact-head `macos-latest-1` root vet/test job `88227386269` passed, including
  the Test step, on `3a9ca687a63c331402d491723e302288972b51ba`.
- Exact-head Codex review of `3a9ca687a63c331402d491723e302288972b51ba`
  reported three narrow P2 findings: unbounded all-query exporter truth at
  realistic scale, pull-request event provenance not overriding a populated
  synthetic merge environment, and artifact names missing dataset/partition
  identity. All three are fixed and regression-tested on the current head.
  No new review was requested as part of this update.
- Exact-head Codex review of
  `6bdfff603a4cf0acfe10013cd890799affd0d331` reported two further P2 findings:
  explicit zero truth expanded to all-query truth, and independently selected
  stage sets could overwrite artifacts. Both are fixed at the current head;
  evidence was posted on both threads and both threads are resolved.
- Exact-head Codex review of
  `945d1aa74c8e5b1ff27c9c49f4b404322b8bcdb1` reported that the comparison
  runner forwarded the default 64 truth queries even when `QUERIES` was
  smaller. The runner now bounds only exporter truth forwarding, preserves
  explicit zero, and has production-script command-contract coverage for both
  shapes.
- Exact-head CodeRabbit and Codex review of
  `817313cbe5bfa5cf53920a7171aa82ef40f61ef6` reported unchecked JSON
  marshaling and a disabled-validation runner that still forwarded nonzero
  recall gates. Both are fixed at the current head; exact v2.12.2 changed-lines
  lint, full-vector/quantized real-shell regressions, and proportional/full
  package gates pass. No new review was requested by this pass.
- Current main `96591d081b3950c7cfc7cb3190c769100ca5d983` was merged by normal
  merge commit without conflicts. Required packages, focused HNSW/exporter and
  runner regressions, the full collections package, full vet, the exact archive,
  and the canonical matrix pass at `8d0806274ddbcaaeb3b3a9c52e3108d319ed433b`.
- Current head exact archive tests and the canonical artifact matrix pass.
- Codex latest-head re-review: not requested by this pass; coordinator owns
  that gate.
- Copilot latest-head review: not requested.
- CodeRabbit latest-head review: not requested.

## Follow-ups

M1 persists and validates generations/placement. M2-M8 replace the appropriate
simulation/reserved fields with measured partition, routing, Raft, lifecycle,
and closeout evidence without redefining the M0 identities or attribution
boundaries.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added deterministic vector-partition benchmark tooling with routing, recall, memory, provenance, and evidence reporting.
  * Added configurable exact-truth query export with manifest metadata, bounded resource usage, and deterministic output.
  * Added a 10,000-vector partition benchmark fixture.
* **Bug Fixes**
  * Improved validation for partial exact-truth coverage, malformed manifests, invalid inputs, and resource limits.
  * Prevented benchmark artifact collisions and clarified validation behavior.
* **Documentation**
  * Added the vector-partition Raft contract and updated benchmark usage guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
