### PR TITLE
db: prove bounded collection descriptor transitions

### DIFF
--- a/TreeDB/db/ordered_root_publish.go
+++ b/TreeDB/db/ordered_root_publish.go
@@ -1082,7 +1082,7 @@ func orderedRootDeltaMayChangeCollectionRootDescriptors(delta *batch.Batch) bool
 	return false
 }
 
-func (db *DB) orderedRootCollectionDescriptorTransitionsCovered(idx *indexGen, baseSystemRoot, newSystemRoot uint64, baseRoots, newRoots []uint64) bool {
+func (db *DB) orderedRootCollectionDescriptorTransitionsCovered(idx *indexGen, userRoot, baseSystemRoot, newSystemRoot uint64, baseRoots, newRoots []uint64) bool {
 	if db == nil || idx == nil || idx.pager == nil || baseSystemRoot == 0 || newSystemRoot == 0 || len(baseRoots) != len(newRoots) {
 		return false
 	}
@@ -1117,6 +1117,14 @@ func (db *DB) orderedRootCollectionDescriptorTransitionsCovered(idx *indexGen, b
 		for _, rootID := range newEntries[i].sourceRootIDs {
 			newReachable[rootID] = struct{}{}
 		}
+	}
+	if userRoot != 0 {
+		// The primary user root is unchanged by these grouped collection
+		// publications and participates in both maintenance closures. A
+		// descriptor transition that aliases it cannot be represented by the
+		// per-root replacement delta alone, so retain the exact projection.
+		baseReachable[userRoot] = struct{}{}
+		newReachable[userRoot] = struct{}{}
 	}
 	type rootTransition struct {
 		base uint64
@@ -2874,7 +2882,7 @@ func (db *DB) publishOrderedRootDeltaGroupWithCommandWALContextAndSystemDeltaBui
 			for idx := range allOrdered {
 				baseRoots[idx] = allOrdered[idx].BaseRoot
 			}
-			if db.orderedRootCollectionDescriptorTransitionsCovered(idxGen, baseSystemRoot, rootID, baseRoots, rootIDs) {
+			if db.orderedRootCollectionDescriptorTransitionsCovered(idxGen, userRoot, baseSystemRoot, rootID, baseRoots, rootIDs) {
 				systemRefDelta.requiresCandidateProjection = false
 			} else {
 				exactValueLogRefDelta = false
@@ -3891,7 +3899,7 @@ func (db *DB) publishOrderedRootDeltaBatchGroupWithCommandWALContextAndSystemDel
 			for idx := range allOrdered {
 				baseRoots[idx] = allOrdered[idx].BaseRoot
 			}
-			if db.orderedRootCollectionDescriptorTransitionsCovered(idxGen, baseSystemRoot, rootID, baseRoots, rootIDs) {
+			if db.orderedRootCollectionDescriptorTransitionsCovered(idxGen, userRoot, baseSystemRoot, rootID, baseRoots, rootIDs) {
 				systemRefDelta.requiresCandidateProjection = false
 			} else {
 				exactValueLogRefDelta = false

--- a/TreeDB/db/ordered_root_publish.go
+++ b/TreeDB/db/ordered_root_publish.go
@@ -1105,9 +1105,31 @@ func (db *DB) orderedRootCollectionDescriptorTransitionsCovered(idx *indexGen, b
 		return false
 	}
 	baseByKey := make(map[string][]uint64, len(baseEntries))
+	baseReachable := make(map[uint64]struct{})
 	for i := range baseEntries {
 		baseByKey[string(baseEntries[i].key)] = baseEntries[i].sourceRootIDs
+		for _, rootID := range baseEntries[i].sourceRootIDs {
+			baseReachable[rootID] = struct{}{}
+		}
 	}
+	newReachable := make(map[uint64]struct{})
+	for i := range newEntries {
+		for _, rootID := range newEntries[i].sourceRootIDs {
+			newReachable[rootID] = struct{}{}
+		}
+	}
+	type rootTransition struct {
+		base uint64
+		next uint64
+	}
+	publishedTransitions := make(map[rootTransition]int, len(baseRoots))
+	for i := range baseRoots {
+		if baseRoots[i] != newRoots[i] {
+			publishedTransitions[rootTransition{base: baseRoots[i], next: newRoots[i]}]++
+		}
+	}
+	baseToNew := make(map[uint64]uint64)
+	newToBase := make(map[uint64]uint64)
 	changed := false
 	for i := range newEntries {
 		baseRootIDs, ok := baseByKey[string(newEntries[i].key)]
@@ -1119,16 +1141,28 @@ func (db *DB) orderedRootCollectionDescriptorTransitionsCovered(idx *indexGen, b
 			if baseRootID == newRootID {
 				continue
 			}
-			covered := false
-			for publishIdx := range baseRoots {
-				if baseRoots[publishIdx] == baseRootID && newRoots[publishIdx] == newRootID {
-					covered = true
-					break
-				}
-			}
-			if !covered {
+			// The merged per-root ref deltas describe replacement of one
+			// reachable root by one new reachable root. Reject alias splits,
+			// joins, and partial retargets where either side remains reachable;
+			// those set-level changes are not represented by a bijective delta.
+			if _, remainsReachable := newReachable[baseRootID]; remainsReachable {
 				return false
 			}
+			if _, alreadyReachable := baseReachable[newRootID]; alreadyReachable {
+				return false
+			}
+			transition := rootTransition{base: baseRootID, next: newRootID}
+			if publishedTransitions[transition] != 1 {
+				return false
+			}
+			if mapped, ok := baseToNew[baseRootID]; ok && mapped != newRootID {
+				return false
+			}
+			if mapped, ok := newToBase[newRootID]; ok && mapped != baseRootID {
+				return false
+			}
+			baseToNew[baseRootID] = newRootID
+			newToBase[newRootID] = baseRootID
 			changed = true
 		}
 		delete(baseByKey, string(newEntries[i].key))

--- a/TreeDB/db/ordered_root_publish.go
+++ b/TreeDB/db/ordered_root_publish.go
@@ -1128,6 +1128,7 @@ func (db *DB) orderedRootCollectionDescriptorTransitionsCovered(idx *indexGen, b
 			publishedTransitions[rootTransition{base: baseRoots[i], next: newRoots[i]}]++
 		}
 	}
+	consumedTransitions := make(map[rootTransition]struct{}, len(publishedTransitions))
 	baseToNew := make(map[uint64]uint64)
 	newToBase := make(map[uint64]uint64)
 	changed := false
@@ -1163,11 +1164,14 @@ func (db *DB) orderedRootCollectionDescriptorTransitionsCovered(idx *indexGen, b
 			}
 			baseToNew[baseRootID] = newRootID
 			newToBase[newRootID] = baseRootID
+			consumedTransitions[transition] = struct{}{}
 			changed = true
 		}
 		delete(baseByKey, string(newEntries[i].key))
 	}
-	return changed && len(baseByKey) == 0
+	return changed &&
+		len(baseByKey) == 0 &&
+		len(consumedTransitions) == len(publishedTransitions)
 }
 
 func orderedRootRangeOverlapsPrefix(start, end, prefix, prefixEnd []byte) bool {

--- a/TreeDB/db/ordered_root_publish.go
+++ b/TreeDB/db/ordered_root_publish.go
@@ -2,6 +2,7 @@ package db
 
 import (
 	"bytes"
+	"context"
 	"errors"
 	"fmt"
 	"sort"
@@ -1079,6 +1080,60 @@ func orderedRootDeltaMayChangeCollectionRootDescriptors(delta *batch.Batch) bool
 		}
 	}
 	return false
+}
+
+func (db *DB) orderedRootCollectionDescriptorTransitionsCovered(idx *indexGen, baseSystemRoot, newSystemRoot uint64, baseRoots, newRoots []uint64) bool {
+	if db == nil || idx == nil || idx.pager == nil || baseSystemRoot == 0 || newSystemRoot == 0 || len(baseRoots) != len(newRoots) {
+		return false
+	}
+	// Descriptor values may themselves be value-log pointers. The publication
+	// path holds writeMu while both roots and all producer-reported segments are
+	// stable, so the live manager can resolve them without refreshing inventory.
+	// Missing, unregistered, or malformed pointers still fail this proof closed.
+	baseEntries, err := vacuumCollectCollectionEntriesFromRoot(context.Background(), idx.pager, db.valueLogManager, baseSystemRoot)
+	if err != nil {
+		return false
+	}
+	newEntries, err := vacuumCollectCollectionEntriesFromRoot(context.Background(), idx.pager, db.valueLogManager, newSystemRoot)
+	if err != nil {
+		return false
+	}
+	if len(baseEntries) == 0 || len(baseEntries) != len(newEntries) {
+		// Cold attachment, removal, and key-set changes retain the exact
+		// candidate scanner. The bounded proof only covers warm retargeting of
+		// an already-attached descriptor set.
+		return false
+	}
+	baseByKey := make(map[string][]uint64, len(baseEntries))
+	for i := range baseEntries {
+		baseByKey[string(baseEntries[i].key)] = baseEntries[i].sourceRootIDs
+	}
+	changed := false
+	for i := range newEntries {
+		baseRootIDs, ok := baseByKey[string(newEntries[i].key)]
+		if !ok || len(baseRootIDs) != len(newEntries[i].sourceRootIDs) {
+			return false
+		}
+		for rootIdx, newRootID := range newEntries[i].sourceRootIDs {
+			baseRootID := baseRootIDs[rootIdx]
+			if baseRootID == newRootID {
+				continue
+			}
+			covered := false
+			for publishIdx := range baseRoots {
+				if baseRoots[publishIdx] == baseRootID && newRoots[publishIdx] == newRootID {
+					covered = true
+					break
+				}
+			}
+			if !covered {
+				return false
+			}
+			changed = true
+		}
+		delete(baseByKey, string(newEntries[i].key))
+	}
+	return changed && len(baseByKey) == 0
 }
 
 func orderedRootRangeOverlapsPrefix(start, end, prefix, prefixEnd []byte) bool {
@@ -2607,7 +2662,8 @@ func (db *DB) publishOrderedRootDeltaGroupWithCommandWALContextAndSystemDeltaBui
 		err = ErrCommandWALUnsupported
 		return 0, nil, err
 	}
-	if db.idx.Load() == nil {
+	idxGen := db.idx.Load()
+	if idxGen == nil {
 		err = errOrderedRootPublishMissingIndex
 		return 0, nil, err
 	}
@@ -2776,7 +2832,15 @@ func (db *DB) publishOrderedRootDeltaGroupWithCommandWALContextAndSystemDeltaBui
 		exactValueLogRefDelta = false
 	} else {
 		if systemRefDelta.requiresCandidateProjection {
-			exactValueLogRefDelta = false
+			baseRoots := make([]uint64, len(allOrdered))
+			for idx := range allOrdered {
+				baseRoots[idx] = allOrdered[idx].BaseRoot
+			}
+			if db.orderedRootCollectionDescriptorTransitionsCovered(idxGen, baseSystemRoot, rootID, baseRoots, rootIDs) {
+				systemRefDelta.requiresCandidateProjection = false
+			} else {
+				exactValueLogRefDelta = false
+			}
 		}
 		mergeValueLogRefDeltaInto(&vlogRefDelta, systemRefDelta)
 		releaseValueLogRefDelta(systemRefDelta)
@@ -3785,7 +3849,15 @@ func (db *DB) publishOrderedRootDeltaBatchGroupWithCommandWALContextAndSystemDel
 		exactValueLogRefDelta = false
 	} else {
 		if systemRefDelta.requiresCandidateProjection {
-			exactValueLogRefDelta = false
+			baseRoots := make([]uint64, len(allOrdered))
+			for idx := range allOrdered {
+				baseRoots[idx] = allOrdered[idx].BaseRoot
+			}
+			if db.orderedRootCollectionDescriptorTransitionsCovered(idxGen, baseSystemRoot, rootID, baseRoots, rootIDs) {
+				systemRefDelta.requiresCandidateProjection = false
+			} else {
+				exactValueLogRefDelta = false
+			}
 		}
 		mergeValueLogRefDeltaInto(&vlogRefDelta, systemRefDelta)
 		releaseValueLogRefDelta(systemRefDelta)

--- a/TreeDB/db/ordered_root_publish.go
+++ b/TreeDB/db/ordered_root_publish.go
@@ -1098,6 +1098,25 @@ func (db *DB) orderedRootCollectionDescriptorTransitionsCovered(idx *indexGen, u
 	if err != nil {
 		return false
 	}
+	return orderedRootCollectionDescriptorTransitionsCoveredEntries(
+		baseEntries,
+		newEntries,
+		userRoot,
+		baseSystemRoot,
+		newSystemRoot,
+		baseRoots,
+		newRoots,
+	)
+}
+
+func orderedRootCollectionDescriptorTransitionsCoveredEntries(
+	baseEntries, newEntries []collectionEntry,
+	userRoot, baseSystemRoot, newSystemRoot uint64,
+	baseRoots, newRoots []uint64,
+) bool {
+	if baseSystemRoot == 0 || newSystemRoot == 0 || len(baseRoots) != len(newRoots) {
+		return false
+	}
 	if len(baseEntries) == 0 || len(baseEntries) != len(newEntries) {
 		// Cold attachment, removal, and key-set changes retain the exact
 		// candidate scanner. The bounded proof only covers warm retargeting of
@@ -1118,6 +1137,21 @@ func (db *DB) orderedRootCollectionDescriptorTransitionsCovered(idx *indexGen, u
 			newReachable[rootID] = struct{}{}
 		}
 	}
+	if _, aliasesSystemRoot := baseReachable[baseSystemRoot]; aliasesSystemRoot {
+		// The system-root delta and the grouped collection-root delta would
+		// otherwise split one deduplicated maintenance root into two changes.
+		return false
+	}
+	if _, aliasesSystemRoot := newReachable[newSystemRoot]; aliasesSystemRoot {
+		// Likewise, joining a collection transition into the new system root
+		// cannot be represented by independently merged ref deltas.
+		return false
+	}
+	// Include the implicit system-root transition in the cross-role
+	// reachability checks below. This also rejects transitions that reuse the
+	// old system root as a new collection root or vice versa.
+	baseReachable[baseSystemRoot] = struct{}{}
+	newReachable[newSystemRoot] = struct{}{}
 	if userRoot != 0 {
 		// The primary user root is unchanged by these grouped collection
 		// publications and participates in both maintenance closures. A

--- a/TreeDB/db/ordered_root_publish_test.go
+++ b/TreeDB/db/ordered_root_publish_test.go
@@ -530,6 +530,52 @@ func TestOrderedRootCollectionDescriptorTransitionsCoveredResolvesPointerBackedD
 	}
 }
 
+func TestOrderedRootCollectionDescriptorTransitionsCoveredRejectsAliasFanOut(t *testing.T) {
+	dir := t.TempDir()
+	db, err := Open(Options{Dir: dir})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer db.Close()
+
+	baseSystemTable := mustFrozenRawMemtable(t,
+		collectionRootDescriptorPrefix+"alias-a", encodeMaintenanceRootID(101),
+		collectionRootDescriptorPrefix+"alias-b", encodeMaintenanceRootID(101),
+	)
+	baseSystemRoot, _, _, _, _, err := db.publishOrderedRootIterator(
+		0,
+		baseSystemTable.NewIterator(nil, nil),
+		systemRootOrderedPublishOptions(db),
+		false,
+	)
+	if err != nil {
+		t.Fatalf("publish base system root: %v", err)
+	}
+	newSystemTable := mustFrozenRawMemtable(t,
+		collectionRootDescriptorPrefix+"alias-a", encodeMaintenanceRootID(201),
+		collectionRootDescriptorPrefix+"alias-b", encodeMaintenanceRootID(202),
+	)
+	newSystemRoot, _, _, _, _, err := db.publishOrderedRootIterator(
+		baseSystemRoot,
+		newSystemTable.NewIterator(nil, nil),
+		systemRootOrderedPublishOptions(db),
+		false,
+	)
+	if err != nil {
+		t.Fatalf("publish new system root: %v", err)
+	}
+
+	if db.orderedRootCollectionDescriptorTransitionsCovered(
+		db.idx.Load(),
+		baseSystemRoot,
+		newSystemRoot,
+		[]uint64{101, 101},
+		[]uint64{201, 202},
+	) {
+		t.Fatal("alias fan-out descriptor transition unexpectedly covered")
+	}
+}
+
 func TestOrderedRootCommandWALAcceptedWaitFailureDoesNotPoisonOpenHandle(t *testing.T) {
 	tests := []struct {
 		name    string

--- a/TreeDB/db/ordered_root_publish_test.go
+++ b/TreeDB/db/ordered_root_publish_test.go
@@ -521,6 +521,7 @@ func TestOrderedRootCollectionDescriptorTransitionsCoveredResolvesPointerBackedD
 
 	if !db.orderedRootCollectionDescriptorTransitionsCovered(
 		db.idx.Load(),
+		0,
 		baseSystemRoot,
 		newSystemRoot,
 		[]uint64{baseRoot},
@@ -567,6 +568,7 @@ func TestOrderedRootCollectionDescriptorTransitionsCoveredRejectsAliasFanOut(t *
 
 	if db.orderedRootCollectionDescriptorTransitionsCovered(
 		db.idx.Load(),
+		0,
 		baseSystemRoot,
 		newSystemRoot,
 		[]uint64{101, 101},
@@ -611,12 +613,58 @@ func TestOrderedRootCollectionDescriptorTransitionsCoveredRejectsUnconsumedGroup
 
 	if db.orderedRootCollectionDescriptorTransitionsCovered(
 		db.idx.Load(),
+		0,
 		baseSystemRoot,
 		newSystemRoot,
 		[]uint64{101, 301},
 		[]uint64{201, 302},
 	) {
 		t.Fatal("descriptor proof unexpectedly covered an unconsumed grouped transition")
+	}
+}
+
+func TestOrderedRootCollectionDescriptorTransitionsCoveredRejectsPrimaryRootAlias(t *testing.T) {
+	dir := t.TempDir()
+	db, err := Open(Options{Dir: dir})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer db.Close()
+
+	baseSystemTable := mustFrozenRawMemtable(t,
+		collectionRootDescriptorPrefix+"primary-alias", encodeMaintenanceRootID(101),
+	)
+	baseSystemRoot, _, _, _, _, err := db.publishOrderedRootIterator(
+		0,
+		baseSystemTable.NewIterator(nil, nil),
+		systemRootOrderedPublishOptions(db),
+		false,
+	)
+	if err != nil {
+		t.Fatalf("publish base system root: %v", err)
+	}
+	newSystemTable := mustFrozenRawMemtable(t,
+		collectionRootDescriptorPrefix+"primary-alias", encodeMaintenanceRootID(201),
+	)
+	newSystemRoot, _, _, _, _, err := db.publishOrderedRootIterator(
+		baseSystemRoot,
+		newSystemTable.NewIterator(nil, nil),
+		systemRootOrderedPublishOptions(db),
+		false,
+	)
+	if err != nil {
+		t.Fatalf("publish new system root: %v", err)
+	}
+
+	if db.orderedRootCollectionDescriptorTransitionsCovered(
+		db.idx.Load(),
+		101,
+		baseSystemRoot,
+		newSystemRoot,
+		[]uint64{101},
+		[]uint64{201},
+	) {
+		t.Fatal("descriptor proof unexpectedly covered a root still reachable through the primary user root")
 	}
 }
 

--- a/TreeDB/db/ordered_root_publish_test.go
+++ b/TreeDB/db/ordered_root_publish_test.go
@@ -576,6 +576,50 @@ func TestOrderedRootCollectionDescriptorTransitionsCoveredRejectsAliasFanOut(t *
 	}
 }
 
+func TestOrderedRootCollectionDescriptorTransitionsCoveredRejectsUnconsumedGroupTransition(t *testing.T) {
+	dir := t.TempDir()
+	db, err := Open(Options{Dir: dir})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer db.Close()
+
+	baseSystemTable := mustFrozenRawMemtable(t,
+		collectionRootDescriptorPrefix+"consumed", encodeMaintenanceRootID(101),
+	)
+	baseSystemRoot, _, _, _, _, err := db.publishOrderedRootIterator(
+		0,
+		baseSystemTable.NewIterator(nil, nil),
+		systemRootOrderedPublishOptions(db),
+		false,
+	)
+	if err != nil {
+		t.Fatalf("publish base system root: %v", err)
+	}
+	newSystemTable := mustFrozenRawMemtable(t,
+		collectionRootDescriptorPrefix+"consumed", encodeMaintenanceRootID(201),
+	)
+	newSystemRoot, _, _, _, _, err := db.publishOrderedRootIterator(
+		baseSystemRoot,
+		newSystemTable.NewIterator(nil, nil),
+		systemRootOrderedPublishOptions(db),
+		false,
+	)
+	if err != nil {
+		t.Fatalf("publish new system root: %v", err)
+	}
+
+	if db.orderedRootCollectionDescriptorTransitionsCovered(
+		db.idx.Load(),
+		baseSystemRoot,
+		newSystemRoot,
+		[]uint64{101, 301},
+		[]uint64{201, 302},
+	) {
+		t.Fatal("descriptor proof unexpectedly covered an unconsumed grouped transition")
+	}
+}
+
 func TestOrderedRootCommandWALAcceptedWaitFailureDoesNotPoisonOpenHandle(t *testing.T) {
 	tests := []struct {
 		name    string

--- a/TreeDB/db/ordered_root_publish_test.go
+++ b/TreeDB/db/ordered_root_publish_test.go
@@ -335,6 +335,201 @@ func TestPublishOrderedRootDeltaGroupWithCommandWALContextProjectsCollectionDesc
 	}
 }
 
+func TestPublishOrderedRootCommandWALContextWarmCoveredDescriptorTransitionAvoidsCandidateScan(t *testing.T) {
+	tests := []struct {
+		name    string
+		publish func(*testing.T, *DB, uint64, string) uint64
+	}{
+		{
+			name: "iterator-group",
+			publish: func(t *testing.T, db *DB, baseRoot uint64, commandKey string) uint64 {
+				t.Helper()
+				rootDelta := mustFrozenSystemMemtable(t, "sys/1024", "value-updated")
+				if baseRoot == 0 {
+					rootDelta = mustFrozenSystemMemtable(t, systemRangeKVs(2048, nil)...)
+				}
+				_, rootIDs, err := db.PublishOrderedRootDeltaGroupWithCommandWALContextAndSystemDeltaBuilder(
+					[]OrderedRootDeltaPublishInput{{BaseRoot: baseRoot, Iter: rootDelta.NewIterator(nil, nil)}},
+					mustRawKVCommandWALIntent(t, db, commandKey, "1"),
+					func(_ CommandWALPublishContext, rootIDs []uint64) (iterator.UnsafeIterator, error) {
+						return mustFrozenRawMemtable(t,
+							collectionRootDescriptorPrefix+"covered-iterator",
+							encodeMaintenanceRootID(rootIDs[0]),
+						).NewIterator(nil, nil), nil
+					},
+				)
+				if err != nil {
+					t.Fatalf("publish iterator base root %d: %v", baseRoot, err)
+				}
+				return rootIDs[0]
+			},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			dir := t.TempDir()
+			enableCommandWALFormat(t, dir)
+			db := openCommandWALDB(t, dir)
+			defer db.Close()
+
+			baseRoot := test.publish(t, db, 0, "cmd/covered-base")
+			if _, err := db.referencedValueLogSegments(context.Background()); err != nil {
+				t.Fatalf("prime value-log reference tracker: %v", err)
+			}
+			var scans atomic.Int64
+			db.testScanCandidateExternalReferencesHook = func() { scans.Add(1) }
+			newRoot := test.publish(t, db, baseRoot, "cmd/covered-warm")
+			db.testScanCandidateExternalReferencesHook = nil
+			if newRoot == baseRoot {
+				t.Fatalf("warm publish root=%d want a distinct root transition", newRoot)
+			}
+			if got := scans.Load(); got != 0 {
+				t.Fatalf("warm covered descriptor candidate dependency scans=%d want 0", got)
+			}
+		})
+	}
+}
+
+func TestPublishOrderedRootCommandWALContextWarmUnmatchedDescriptorTransitionRetainsCandidateScan(t *testing.T) {
+	dir := t.TempDir()
+	enableCommandWALFormat(t, dir)
+	db := openCommandWALDB(t, dir)
+	defer db.Close()
+
+	publish := func(baseRoot uint64, descriptorRoot uint64, commandKey string) uint64 {
+		t.Helper()
+		rootDelta := mustFrozenSystemMemtable(t, "sys/1024", "value-updated")
+		if baseRoot == 0 {
+			rootDelta = mustFrozenSystemMemtable(t, systemRangeKVs(2048, nil)...)
+		}
+		_, rootIDs, err := db.PublishOrderedRootDeltaGroupWithCommandWALContextAndSystemDeltaBuilder(
+			[]OrderedRootDeltaPublishInput{{BaseRoot: baseRoot, Iter: rootDelta.NewIterator(nil, nil)}},
+			mustRawKVCommandWALIntent(t, db, commandKey, "1"),
+			func(_ CommandWALPublishContext, rootIDs []uint64) (iterator.UnsafeIterator, error) {
+				rootID := descriptorRoot
+				if rootID == 0 {
+					rootID = rootIDs[0]
+				}
+				return mustFrozenRawMemtable(t,
+					collectionRootDescriptorPrefix+"unmatched-iterator",
+					encodeMaintenanceRootID(rootID),
+				).NewIterator(nil, nil), nil
+			},
+		)
+		if err != nil {
+			t.Fatalf("publish iterator base root %d: %v", baseRoot, err)
+		}
+		return rootIDs[0]
+	}
+
+	baseRoot := publish(0, 0, "cmd/unmatched-base")
+	if _, err := db.referencedValueLogSegments(context.Background()); err != nil {
+		t.Fatalf("prime value-log reference tracker: %v", err)
+	}
+	unrelatedTable := mustFrozenSystemMemtable(t, "unrelated/root", "value")
+	unrelatedRoot, _, _, _, _, err := db.publishOrderedRootIterator(
+		0,
+		unrelatedTable.NewIterator(nil, nil),
+		systemRootOrderedPublishOptions(db),
+		false,
+	)
+	if err != nil {
+		t.Fatalf("publish unrelated root: %v", err)
+	}
+
+	var scans atomic.Int64
+	db.testScanCandidateExternalReferencesHook = func() { scans.Add(1) }
+	newRoot := publish(baseRoot, unrelatedRoot, "cmd/unmatched-warm")
+	db.testScanCandidateExternalReferencesHook = nil
+	if newRoot == baseRoot {
+		t.Fatalf("warm publish root=%d want a distinct grouped root transition", newRoot)
+	}
+	if got := scans.Load(); got != 1 {
+		t.Fatalf("unmatched descriptor candidate dependency scans=%d want 1", got)
+	}
+}
+
+func TestOrderedRootCollectionDescriptorTransitionsCoveredResolvesPointerBackedDescriptors(t *testing.T) {
+	dir := t.TempDir()
+	db, err := Open(Options{Dir: dir, ValueLog: ValueLogOptions{PointerThreshold: 1}})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer db.Close()
+
+	baseTable := mustFrozenSystemMemtable(t, systemRangeKVs(2048, nil)...)
+	baseRoot, _, _, _, _, err := db.publishOrderedRootIterator(
+		0,
+		baseTable.NewIterator(nil, nil),
+		systemRootOrderedPublishOptions(db),
+		false,
+	)
+	if err != nil {
+		t.Fatalf("publish base collection root: %v", err)
+	}
+	newTable := mustFrozenSystemMemtable(t, "sys/1024", "value-updated")
+	newRoot, _, _, _, _, err := db.publishOrderedRootIterator(
+		baseRoot,
+		newTable.NewIterator(nil, nil),
+		systemRootOrderedPublishOptions(db),
+		false,
+	)
+	if err != nil {
+		t.Fatalf("publish new collection root: %v", err)
+	}
+	if newRoot == baseRoot {
+		t.Fatalf("collection root transition=%d want distinct roots", newRoot)
+	}
+
+	appendDescriptor := func(seq uint32, rootID uint64) page.ValuePtr {
+		var encoded [8]byte
+		binary.BigEndian.PutUint64(encoded[:], rootID)
+		return appendPointersInNewSegment(t, dir, 0, seq, uint64(seq)*1000, 1, func(int) []byte {
+			return encoded[:]
+		})[0]
+	}
+	descriptorKey := collectionRootDescriptorPrefix + "pointer-backed"
+	basePtr := appendDescriptor(191, baseRoot)
+	if err := db.RefreshValueLogSet(); err != nil {
+		t.Fatalf("refresh base descriptor segment: %v", err)
+	}
+	baseSystemTable := mustFrozenSystemPointerMemtable(t, descriptorKey, basePtr)
+	baseSystemRoot, _, _, _, _, err := db.publishOrderedRootIterator(
+		0,
+		baseSystemTable.NewIterator(nil, nil),
+		systemRootOrderedPublishOptions(db),
+		false,
+	)
+	if err != nil {
+		t.Fatalf("publish base system root: %v", err)
+	}
+
+	newPtr := appendDescriptor(192, newRoot)
+	if err := db.RefreshValueLogSet(); err != nil {
+		t.Fatalf("refresh new descriptor segment: %v", err)
+	}
+	newSystemTable := mustFrozenSystemPointerMemtable(t, descriptorKey, newPtr)
+	newSystemRoot, _, _, _, _, err := db.publishOrderedRootIterator(
+		baseSystemRoot,
+		newSystemTable.NewIterator(nil, nil),
+		systemRootOrderedPublishOptions(db),
+		false,
+	)
+	if err != nil {
+		t.Fatalf("publish new system root: %v", err)
+	}
+
+	if !db.orderedRootCollectionDescriptorTransitionsCovered(
+		db.idx.Load(),
+		baseSystemRoot,
+		newSystemRoot,
+		[]uint64{baseRoot},
+		[]uint64{newRoot},
+	) {
+		t.Fatal("pointer-backed exact descriptor transition was not covered")
+	}
+}
+
 func TestOrderedRootCommandWALAcceptedWaitFailureDoesNotPoisonOpenHandle(t *testing.T) {
 	tests := []struct {
 		name    string

--- a/TreeDB/db/ordered_root_publish_test.go
+++ b/TreeDB/db/ordered_root_publish_test.go
@@ -668,6 +668,59 @@ func TestOrderedRootCollectionDescriptorTransitionsCoveredRejectsPrimaryRootAlia
 	}
 }
 
+func TestOrderedRootCollectionDescriptorTransitionsCoveredRejectsSystemRootAlias(t *testing.T) {
+	tests := []struct {
+		name                          string
+		baseDescriptor, newDescriptor uint64
+		baseSystemRoot, newSystemRoot uint64
+	}{
+		{
+			name:           "base descriptor aliases base system root",
+			baseDescriptor: 101, newDescriptor: 201,
+			baseSystemRoot: 101, newSystemRoot: 301,
+		},
+		{
+			name:           "new descriptor aliases new system root",
+			baseDescriptor: 101, newDescriptor: 301,
+			baseSystemRoot: 201, newSystemRoot: 301,
+		},
+		{
+			name:           "new descriptor reuses base system root",
+			baseDescriptor: 101, newDescriptor: 201,
+			baseSystemRoot: 201, newSystemRoot: 301,
+		},
+		{
+			name:           "base descriptor aliases new system root",
+			baseDescriptor: 301, newDescriptor: 201,
+			baseSystemRoot: 101, newSystemRoot: 301,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			baseEntries := []collectionEntry{{
+				key:           []byte(collectionRootDescriptorPrefix + "system-alias"),
+				sourceRootIDs: []uint64{tc.baseDescriptor},
+			}}
+			newEntries := []collectionEntry{{
+				key:           []byte(collectionRootDescriptorPrefix + "system-alias"),
+				sourceRootIDs: []uint64{tc.newDescriptor},
+			}}
+
+			if orderedRootCollectionDescriptorTransitionsCoveredEntries(
+				baseEntries,
+				newEntries,
+				0,
+				tc.baseSystemRoot,
+				tc.newSystemRoot,
+				[]uint64{tc.baseDescriptor},
+				[]uint64{tc.newDescriptor},
+			) {
+				t.Fatal("descriptor proof unexpectedly covered a grouped transition aliased by a system root")
+			}
+		})
+	}
+}
+
 func TestOrderedRootCommandWALAcceptedWaitFailureDoesNotPoisonOpenHandle(t *testing.T) {
 	tests := []struct {
 		name    string


### PR DESCRIPTION
Closes #3919

Parent: #3067

## What changed

- compare collection-root descriptor vectors at the old and candidate system
  roots using descriptor-prefix scans only;
- accept a changed descriptor root only when its exact `BaseRoot -> rootID`
  pair was published by the same ordered group;
- resolve pointer-backed descriptors through the live persistent value-log
  manager while publication holds the write lock;
- clear descriptor-driven candidate projection only after that proof;
- retain the exact candidate scan for cold, removed, malformed, unresolvable,
  or unmatched transitions.

This is deliberately narrower than changing generic candidate construction or
the batch-materialized path's separate warm old-pointer fallback.

## Test-first evidence

The initial warm iterator-group test failed with:

```text
warm covered descriptor candidate dependency scans=1 want 0
```

The final focused coverage runs the covered transition, unmatched fallback,
cold attachment fallback, pointer-backed descriptor proof, and existing exact
value-log projection tests 10 times:

```text
go test ./TreeDB/db -run '^(TestOrderedRootCollectionDescriptorTransitionsCoveredRejectsSystemRootAlias|TestOrderedRootCollectionDescriptorTransitionsCoveredRejectsPrimaryRootAlias|TestOrderedRootCollectionDescriptorTransitionsCoveredRejectsUnconsumedGroupTransition|TestOrderedRootCollectionDescriptorTransitionsCoveredRejectsAliasFanOut|TestOrderedRootCollectionDescriptorTransitionsCoveredResolvesPointerBackedDescriptors|TestPublishOrderedRootCommandWALContextWarmCoveredDescriptorTransitionAvoidsCandidateScan|TestPublishOrderedRootCommandWALContextWarmUnmatchedDescriptorTransitionRetainsCandidateScan|TestPublishOrderedRootDeltaGroupWithCommandWALContextProjectsCollectionDescriptorReachability|TestPublishOrderedRootDeltaGroupWithCommandWALContextPreservesExactValueLogProjection)$' -count=10
ok github.com/snissn/gomap/TreeDB/db
```

Pointer/reopen focused coverage also passes at count 3:

```text
go test ./TreeDB -run '^(TestReopenVerify_DurableWALForcedValueLogPointers|TestPowerLossCertificationAuthoritativeResourcesPublicReopen|TestOpenFreshCompositeCloseReopenPreservesValue|TestUpdateSyncPointerValuePersistsAfterCheckpointReopen)$' -count=3
ok github.com/snissn/gomap/TreeDB
```

## Integrated 1M performance evidence

Identical durable full-prepared JSONBench runs used JSONBench `4df524e`, the
merged #3906 integration head, one-shot queries, no aggregate metadata,
reconstruction validation disabled, and WAL-excluded durable storage.

Before this change, integrated #3906 candidate construction was about 13.78s
and total load was about 24.0-27.2s. Five after runs:

| run | load | commit | candidate construction | storage |
| --- | ---: | ---: | ---: | ---: |
| 1 | 11.460s | 4.942s | 0.107s | 157,372,617 B |
| 2 | 10.466s | 4.630s | 0.094s | 157,372,617 B |
| 3 | 10.939s | 4.841s | 0.101s | 157,367,362 B |
| 4 | 10.497s | 4.601s | 0.094s | 157,372,617 B |
| 5 | 10.828s | 4.844s | 0.101s | 157,367,362 B |

Candidate construction is 94-107ms, below the 500ms gate. Storage remains in
the identical 157.37MB range. Warm-process peak RSS for runs 2-5 was
475,652-512,908 KiB; run 1 included Go compilation and peaked at 1,217,836 KiB.
The proof allocates only descriptor-count-sized vectors/maps and does not scale
with document count.

Artifact:

`/mnt/fast4tb/gomap_3067_execution_20260718/3919_integrated_perf_v2_20260719T174852Z`

## Review hardening

Codex identified that individually matching descriptor pairs were insufficient
when aliases fan out or fan in. A new test first reproduced the unsafe
acceptance:

```text
alias fan-out descriptor transition unexpectedly covered
```

The proof now requires a one-to-one reachable-root-set transition, rejects
partial aliases where either old roots remain or new roots were already
reachable, and rejects duplicate grouped transition pairs. Focused tests pass
at count 10.

Three post-fix integrated 1M runs retained the performance result:

| run | load | commit | candidate construction | storage |
| --- | ---: | ---: | ---: | ---: |
| 1 | 11.402s | 5.162s | 0.100s | 157,372,617 B |
| 2 | 10.804s | 4.899s | 0.096s | 157,367,362 B |
| 3 | 11.360s | 4.965s | 0.112s | 157,372,617 B |

Post-fix artifact:

`/mnt/fast4tb/gomap_3067_execution_20260718/3919_alias_fix_perf_20260719T181400Z`

The exact-head review then identified that an otherwise valid descriptor
transition could leave an extra non-noop grouped transition unconsumed. A new
test first reproduced that unsafe acceptance:

```text
descriptor proof unexpectedly covered an unconsumed grouped transition
```

The proof now records every descriptor-consumed transition and requires that
set to equal the complete non-noop grouped transition set. Extra grouped roots
therefore retain the exact candidate scan.

Five integrated 1M runs after this fix recorded candidate construction of
0.100s / 0.100s / 0.609s / 0.100s / 0.095s (median 0.100s), with load
11.174s / 10.967s / 13.015s / 10.770s / 10.232s. Four of five remained in the
95-100ms band; the single 609ms co-run outlier did not reproduce. Durable
WAL-excluded storage remained 157,367,362-157,372,617 bytes.

Final exact-head artifact:

`/mnt/fast4tb/gomap_3067_execution_20260718/3919_p2_fix_perf_20260719T182635Z`

The following exact-head review found a further alias boundary: a descriptor
root can also remain reachable through the unchanged primary user root. The
new primary-alias test first failed with:

```text
descriptor proof unexpectedly covered a root still reachable through the primary user root
```

The publication snapshot user root is now included in both old and new
maintenance reachability sets, so any such alias fails closed into exact
candidate projection. The expanded focused suite passes at count 10.

Three post-fix integrated 1M runs kept candidate construction at
0.102s / 0.097s / 0.099s and storage at
157,367,362-157,372,617 bytes. Load was 13.938s / 10.890s / 10.999s; the first
run's commit phase was a one-off 7.392s versus 4.771s / 4.580s in the following
runs, while the descriptor proof remained stable.

Final primary-alias-fix artifact:

`/mnt/fast4tb/gomap_3067_execution_20260718/3919_primary_alias_fix_perf_20260719T184100Z`

The executor's independent exact-head audit then identified the analogous
system-root role alias: maintenance closure deduplicates the current system root
and a descriptor pointing to that same root, while separately merged deltas
would model two transitions. A pure transition-proof test first failed with:

```text
descriptor proof unexpectedly covered a grouped transition aliased by the system root
```

The proof now rejects descriptor aliases of either side of the implicit
`baseSystemRoot -> newSystemRoot` transition, including split, join, and
cross-role reuse shapes. Three final integrated 1M runs recorded candidate
construction of 0.106s / 0.110s / 0.100s, load of
11.197s / 11.245s / 11.162s, and identical 157,372,617-byte WAL-excluded
storage.

Final system-alias-fix artifact:

`/mnt/fast4tb/gomap_3067_execution_20260718/3919_system_alias_fix_perf_20260719T185555Z`

## Boundary

- no WAL, vlog persistence, GC, leaf-generation, checkpoint, or recovery
  semantic changes;
- no broad storage pruning;
- unproved descriptor transitions continue to fail closed into the exact scan.
