### PR TITLE
TreeDB vector partitioning M2: deterministic offline graph builder

### DIFF
--- a/TreeDB/docs/spec/README.md
+++ b/TreeDB/docs/spec/README.md
@@ -170,6 +170,9 @@ Given pre-alpha status, this is a living spec that tracks implementation.
   - issue #2483 final vector-search docs closeout index for accepted exact FP32,
     scalar_u8, RaBitQ, and BRQ evidence, #2487 snapshot rows, no-promote
     caveats, and #2494 crossover-pending status.
+- `TreeDB/docs/spec/vector-partition-m2.md`
+  - issue #3911 clean-room offline dense-ball graph sketch, deterministic
+    balanced reference backend, artifact validation, and M0 builder command.
 - `TreeDB/docs/spec/quantized-prepared-hnsw-closeout-2588.md`
   - issue #2588 closeout for the #2584 prepared HNSW quantized fast-path stack,
     including #2591 10k x 768 gate rows, exact FP32 guardrails, promoted

--- a/TreeDB/docs/spec/artifacts/vector-partition-m2-evidence-v1.json
+++ b/TreeDB/docs/spec/artifacts/vector-partition-m2-evidence-v1.json
@@ -2,6 +2,8 @@
   "schema_version": 1,
   "kind": "treedb_vector_partition_m2_reproduction_evidence",
   "note": "Compact reviewer-accessible evidence. Generated artifacts remain host-local; commands and digests reproduce and verify them.",
+  "implementation_commit": "7a5d61e60cec2c55ea8befe656e76631742b4b1d",
+  "implementation_commit_note": "All three fresh runs used binaries built from this exact implementation commit. Commit cec947921b190ef9370de9e1542040a962c086c5 refreshed only documentation/evidence and changed no implementation files.",
   "canonical_manifest_digest_definition": "SHA-256 of json.Marshal on the decoded typed exporter manifest, including the sorted file map. This is the logical canonical manifest digest used in source_id, not a hash of manifest.json bytes.",
   "runs": [
     {

--- a/TreeDB/docs/spec/artifacts/vector-partition-m2-evidence-v1.json
+++ b/TreeDB/docs/spec/artifacts/vector-partition-m2-evidence-v1.json
@@ -1,0 +1,37 @@
+{
+  "schema_version": 1,
+  "kind": "treedb_vector_partition_m2_reproduction_evidence",
+  "note": "Compact reviewer-accessible evidence. Generated artifacts remain host-local; commands and digests reproduce and verify them.",
+  "runs": [
+    {
+      "name": "10k",
+      "docs": 10000,
+      "queries": 16,
+      "dimensions": 64,
+      "dataset_manifest_sha256": "ea980008813897107cd1a150b96e2ef497ec4d26b815dbbc5f9b8d6ddef6ed58",
+      "source_checksum": "64bc8b935db050e2cb126f6e1bca6e4378d56464b0141128726b3445d4a34b62",
+      "artifact_sha256": "c270226154a4e7410bb4140d63abfe36bebc0d0de9cdbf7c894298225d76c935",
+      "report_sha256": "bdf23beae34a8b7cabb1551c7e6cbe8f0626f8238e2b96932fe2700ba3e2bb2e"
+    },
+    {
+      "name": "100k",
+      "docs": 100000,
+      "queries": 8,
+      "dimensions": 16,
+      "dataset_manifest_sha256": "04ab185b349d794b034550b117d9cbc20dff8131bb1c1986e63d52191240c2ec",
+      "source_checksum": "e56afe5df826acc8ab2bea01b09c3676a7ccf2cbf2743a46a0f63ce741ffd0c3",
+      "artifact_sha256": "627778e026d177320e4aace2f32883aa1656c1d36f9f5005d1d9e41f55fdc3ae",
+      "report_sha256": "caf95d82c8664f4c3f47fa0e6a9375934b66f50f5cbc339ff1f28eae82a646ac"
+    },
+    {
+      "name": "1m",
+      "docs": 1000000,
+      "queries": 1,
+      "dimensions": 16,
+      "dataset_manifest_sha256": "a7814b879e2e5d49c9038502fe7c7eb26fa5b2917af72b87d2d1321f66ab2f5b",
+      "source_checksum": "b6f7ce2ab91728cd869139672d8e902618f792e4cb10a8679bfc6612146f7f42",
+      "artifact_sha256": "f76fba39db8a51fb11b669962b92a97d64956f75a76137cea0e80cbe42d42413",
+      "report_sha256": "87b425892a5e62befcee67951451ee9f1980abceba7d3eabc1537d14fc11f794"
+    }
+  ]
+}

--- a/TreeDB/docs/spec/artifacts/vector-partition-m2-evidence-v1.json
+++ b/TreeDB/docs/spec/artifacts/vector-partition-m2-evidence-v1.json
@@ -2,8 +2,8 @@
   "schema_version": 1,
   "kind": "treedb_vector_partition_m2_reproduction_evidence",
   "note": "Compact reviewer-accessible evidence. Generated artifacts remain host-local; commands and digests reproduce and verify them.",
-  "implementation_commit": "23683ea4ddd2e2da6e267a4983b73d285eb65f5f",
-  "implementation_commit_note": "All three fresh runs used binaries built from this exact implementation commit. Earlier docs/evidence commits through f34b5b1b817d95e33c8e46221935f5482d9aacd0 changed no implementation files.",
+  "implementation_commit": "58db38e173093126e5b1ef3c92d79e160d63b0cf",
+  "implementation_commit_note": "All three fresh runs used binaries built from this exact commit after rebasing onto origin/main 3e225cb99. The following evidence commit changes only documentation/evidence.",
   "canonical_manifest_digest_definition": "SHA-256 of json.Marshal on the decoded typed exporter manifest, including the sorted file map. This is the logical canonical manifest digest used in source_id, not a hash of manifest.json bytes.",
   "runs": [
     {
@@ -14,7 +14,7 @@
       "canonical_manifest_digest": "ea980008813897107cd1a150b96e2ef497ec4d26b815dbbc5f9b8d6ddef6ed58",
       "source_checksum": "64bc8b935db050e2cb126f6e1bca6e4378d56464b0141128726b3445d4a34b62",
       "artifact_sha256": "c270226154a4e7410bb4140d63abfe36bebc0d0de9cdbf7c894298225d76c935",
-      "report_sha256": "e54c94c4d513f72b61de964df6f5f81c9591dd46a57aeab0e3383a03c6249c26"
+      "report_sha256": "8e9b411983de00468172a2f2cfdc863dfca332eb13a95034e88e44f4a140f5fe"
     },
     {
       "name": "100k",
@@ -24,7 +24,7 @@
       "canonical_manifest_digest": "04ab185b349d794b034550b117d9cbc20dff8131bb1c1986e63d52191240c2ec",
       "source_checksum": "e56afe5df826acc8ab2bea01b09c3676a7ccf2cbf2743a46a0f63ce741ffd0c3",
       "artifact_sha256": "627778e026d177320e4aace2f32883aa1656c1d36f9f5005d1d9e41f55fdc3ae",
-      "report_sha256": "2f935403a2b5d499f85cf7b367b510f31795919579655d7247992d2884196490"
+      "report_sha256": "edb8aed70d4ea45ff160d9c90c05d7d591199885e4cf64cef35705e109ce7a38"
     },
     {
       "name": "1m",
@@ -34,7 +34,7 @@
       "canonical_manifest_digest": "a7814b879e2e5d49c9038502fe7c7eb26fa5b2917af72b87d2d1321f66ab2f5b",
       "source_checksum": "b6f7ce2ab91728cd869139672d8e902618f792e4cb10a8679bfc6612146f7f42",
       "artifact_sha256": "f76fba39db8a51fb11b669962b92a97d64956f75a76137cea0e80cbe42d42413",
-      "report_sha256": "4d9a92f6d8aaaf0aca6c2a4398e9af0ddc6847be4fda9a405913bf6161aa8156"
+      "report_sha256": "86501b152bd43242d2c53f0640aed52658a44045aa856b8dfb4041f4c1a9adcf"
     }
   ]
 }

--- a/TreeDB/docs/spec/artifacts/vector-partition-m2-evidence-v1.json
+++ b/TreeDB/docs/spec/artifacts/vector-partition-m2-evidence-v1.json
@@ -2,8 +2,8 @@
   "schema_version": 1,
   "kind": "treedb_vector_partition_m2_reproduction_evidence",
   "note": "Compact reviewer-accessible evidence. Generated artifacts remain host-local; commands and digests reproduce and verify them.",
-  "implementation_commit": "9bab19104ecd223c6c15c67469b6cdb8748e802e",
-  "implementation_commit_note": "All three fresh runs used binaries built from this exact implementation commit. Earlier commits cec947921b190ef9370de9e1542040a962c086c5 and e2869cd31c37d24ee18cae86a0cb6a578ff52513 refreshed only documentation/evidence and changed no implementation files.",
+  "implementation_commit": "23683ea4ddd2e2da6e267a4983b73d285eb65f5f",
+  "implementation_commit_note": "All three fresh runs used binaries built from this exact implementation commit. Earlier docs/evidence commits through f34b5b1b817d95e33c8e46221935f5482d9aacd0 changed no implementation files.",
   "canonical_manifest_digest_definition": "SHA-256 of json.Marshal on the decoded typed exporter manifest, including the sorted file map. This is the logical canonical manifest digest used in source_id, not a hash of manifest.json bytes.",
   "runs": [
     {
@@ -14,7 +14,7 @@
       "canonical_manifest_digest": "ea980008813897107cd1a150b96e2ef497ec4d26b815dbbc5f9b8d6ddef6ed58",
       "source_checksum": "64bc8b935db050e2cb126f6e1bca6e4378d56464b0141128726b3445d4a34b62",
       "artifact_sha256": "c270226154a4e7410bb4140d63abfe36bebc0d0de9cdbf7c894298225d76c935",
-      "report_sha256": "42138984601bf18776af8a33391d535a222e9c58496453551eb1807bddba2e53"
+      "report_sha256": "e54c94c4d513f72b61de964df6f5f81c9591dd46a57aeab0e3383a03c6249c26"
     },
     {
       "name": "100k",
@@ -24,7 +24,7 @@
       "canonical_manifest_digest": "04ab185b349d794b034550b117d9cbc20dff8131bb1c1986e63d52191240c2ec",
       "source_checksum": "e56afe5df826acc8ab2bea01b09c3676a7ccf2cbf2743a46a0f63ce741ffd0c3",
       "artifact_sha256": "627778e026d177320e4aace2f32883aa1656c1d36f9f5005d1d9e41f55fdc3ae",
-      "report_sha256": "bdab9c4628efea5f12b52d59c05b09686f88e892e5ad3aa44bc9de6d49feb390"
+      "report_sha256": "2f935403a2b5d499f85cf7b367b510f31795919579655d7247992d2884196490"
     },
     {
       "name": "1m",
@@ -34,7 +34,7 @@
       "canonical_manifest_digest": "a7814b879e2e5d49c9038502fe7c7eb26fa5b2917af72b87d2d1321f66ab2f5b",
       "source_checksum": "b6f7ce2ab91728cd869139672d8e902618f792e4cb10a8679bfc6612146f7f42",
       "artifact_sha256": "f76fba39db8a51fb11b669962b92a97d64956f75a76137cea0e80cbe42d42413",
-      "report_sha256": "9c00d6ef6c364840ac0e63f74954352e0730f5360ac715845d602407ce8faa46"
+      "report_sha256": "4d9a92f6d8aaaf0aca6c2a4398e9af0ddc6847be4fda9a405913bf6161aa8156"
     }
   ]
 }

--- a/TreeDB/docs/spec/artifacts/vector-partition-m2-evidence-v1.json
+++ b/TreeDB/docs/spec/artifacts/vector-partition-m2-evidence-v1.json
@@ -3,7 +3,7 @@
   "kind": "treedb_vector_partition_m2_reproduction_evidence",
   "note": "Compact reviewer-accessible evidence. Generated artifacts remain host-local; commands and digests reproduce and verify them.",
   "implementation_commit": "58db38e173093126e5b1ef3c92d79e160d63b0cf",
-  "implementation_commit_note": "All three fresh runs used binaries built from this exact commit after rebasing onto origin/main 3e225cb99. The following evidence commit changes only documentation/evidence.",
+  "implementation_commit_note": "All three fresh runs used binaries built from this exact commit after merging origin/main 3e225cb99. The following evidence commit changes only documentation/evidence.",
   "canonical_manifest_digest_definition": "SHA-256 of json.Marshal on the decoded typed exporter manifest, including the sorted file map. This is the logical canonical manifest digest used in source_id, not a hash of manifest.json bytes.",
   "runs": [
     {

--- a/TreeDB/docs/spec/artifacts/vector-partition-m2-evidence-v1.json
+++ b/TreeDB/docs/spec/artifacts/vector-partition-m2-evidence-v1.json
@@ -2,36 +2,37 @@
   "schema_version": 1,
   "kind": "treedb_vector_partition_m2_reproduction_evidence",
   "note": "Compact reviewer-accessible evidence. Generated artifacts remain host-local; commands and digests reproduce and verify them.",
+  "canonical_manifest_digest_definition": "SHA-256 of json.Marshal on the decoded typed exporter manifest, including the sorted file map. This is the logical canonical manifest digest used in source_id, not a hash of manifest.json bytes.",
   "runs": [
     {
       "name": "10k",
       "docs": 10000,
       "queries": 16,
       "dimensions": 64,
-      "dataset_manifest_sha256": "ea980008813897107cd1a150b96e2ef497ec4d26b815dbbc5f9b8d6ddef6ed58",
+      "canonical_manifest_digest": "ea980008813897107cd1a150b96e2ef497ec4d26b815dbbc5f9b8d6ddef6ed58",
       "source_checksum": "64bc8b935db050e2cb126f6e1bca6e4378d56464b0141128726b3445d4a34b62",
       "artifact_sha256": "c270226154a4e7410bb4140d63abfe36bebc0d0de9cdbf7c894298225d76c935",
-      "report_sha256": "bdf23beae34a8b7cabb1551c7e6cbe8f0626f8238e2b96932fe2700ba3e2bb2e"
+      "report_sha256": "f3f4bdaa28c1714a9ff345e820cf47f7dbafbfee4d047d620121929ec498abca"
     },
     {
       "name": "100k",
       "docs": 100000,
       "queries": 8,
       "dimensions": 16,
-      "dataset_manifest_sha256": "04ab185b349d794b034550b117d9cbc20dff8131bb1c1986e63d52191240c2ec",
+      "canonical_manifest_digest": "04ab185b349d794b034550b117d9cbc20dff8131bb1c1986e63d52191240c2ec",
       "source_checksum": "e56afe5df826acc8ab2bea01b09c3676a7ccf2cbf2743a46a0f63ce741ffd0c3",
       "artifact_sha256": "627778e026d177320e4aace2f32883aa1656c1d36f9f5005d1d9e41f55fdc3ae",
-      "report_sha256": "caf95d82c8664f4c3f47fa0e6a9375934b66f50f5cbc339ff1f28eae82a646ac"
+      "report_sha256": "8ab20305d25060a6fdab43cc1de910c8a302400fc491725c0139eb9ee423de55"
     },
     {
       "name": "1m",
       "docs": 1000000,
       "queries": 1,
       "dimensions": 16,
-      "dataset_manifest_sha256": "a7814b879e2e5d49c9038502fe7c7eb26fa5b2917af72b87d2d1321f66ab2f5b",
+      "canonical_manifest_digest": "a7814b879e2e5d49c9038502fe7c7eb26fa5b2917af72b87d2d1321f66ab2f5b",
       "source_checksum": "b6f7ce2ab91728cd869139672d8e902618f792e4cb10a8679bfc6612146f7f42",
       "artifact_sha256": "f76fba39db8a51fb11b669962b92a97d64956f75a76137cea0e80cbe42d42413",
-      "report_sha256": "87b425892a5e62befcee67951451ee9f1980abceba7d3eabc1537d14fc11f794"
+      "report_sha256": "c7164fb947cd1f6f1cf0e5774c6edde7652f25384e40cf897f1ba5ce4a1df59b"
     }
   ]
 }

--- a/TreeDB/docs/spec/artifacts/vector-partition-m2-evidence-v1.json
+++ b/TreeDB/docs/spec/artifacts/vector-partition-m2-evidence-v1.json
@@ -2,8 +2,8 @@
   "schema_version": 1,
   "kind": "treedb_vector_partition_m2_reproduction_evidence",
   "note": "Compact reviewer-accessible evidence. Generated artifacts remain host-local; commands and digests reproduce and verify them.",
-  "implementation_commit": "7a5d61e60cec2c55ea8befe656e76631742b4b1d",
-  "implementation_commit_note": "All three fresh runs used binaries built from this exact implementation commit. Commit cec947921b190ef9370de9e1542040a962c086c5 refreshed only documentation/evidence and changed no implementation files.",
+  "implementation_commit": "9bab19104ecd223c6c15c67469b6cdb8748e802e",
+  "implementation_commit_note": "All three fresh runs used binaries built from this exact implementation commit. Earlier commits cec947921b190ef9370de9e1542040a962c086c5 and e2869cd31c37d24ee18cae86a0cb6a578ff52513 refreshed only documentation/evidence and changed no implementation files.",
   "canonical_manifest_digest_definition": "SHA-256 of json.Marshal on the decoded typed exporter manifest, including the sorted file map. This is the logical canonical manifest digest used in source_id, not a hash of manifest.json bytes.",
   "runs": [
     {
@@ -14,7 +14,7 @@
       "canonical_manifest_digest": "ea980008813897107cd1a150b96e2ef497ec4d26b815dbbc5f9b8d6ddef6ed58",
       "source_checksum": "64bc8b935db050e2cb126f6e1bca6e4378d56464b0141128726b3445d4a34b62",
       "artifact_sha256": "c270226154a4e7410bb4140d63abfe36bebc0d0de9cdbf7c894298225d76c935",
-      "report_sha256": "f3f4bdaa28c1714a9ff345e820cf47f7dbafbfee4d047d620121929ec498abca"
+      "report_sha256": "42138984601bf18776af8a33391d535a222e9c58496453551eb1807bddba2e53"
     },
     {
       "name": "100k",
@@ -24,7 +24,7 @@
       "canonical_manifest_digest": "04ab185b349d794b034550b117d9cbc20dff8131bb1c1986e63d52191240c2ec",
       "source_checksum": "e56afe5df826acc8ab2bea01b09c3676a7ccf2cbf2743a46a0f63ce741ffd0c3",
       "artifact_sha256": "627778e026d177320e4aace2f32883aa1656c1d36f9f5005d1d9e41f55fdc3ae",
-      "report_sha256": "8ab20305d25060a6fdab43cc1de910c8a302400fc491725c0139eb9ee423de55"
+      "report_sha256": "bdab9c4628efea5f12b52d59c05b09686f88e892e5ad3aa44bc9de6d49feb390"
     },
     {
       "name": "1m",
@@ -34,7 +34,7 @@
       "canonical_manifest_digest": "a7814b879e2e5d49c9038502fe7c7eb26fa5b2917af72b87d2d1321f66ab2f5b",
       "source_checksum": "b6f7ce2ab91728cd869139672d8e902618f792e4cb10a8679bfc6612146f7f42",
       "artifact_sha256": "f76fba39db8a51fb11b669962b92a97d64956f75a76137cea0e80cbe42d42413",
-      "report_sha256": "c7164fb947cd1f6f1cf0e5774c6edde7652f25384e40cf897f1ba5ce4a1df59b"
+      "report_sha256": "9c00d6ef6c364840ac0e63f74954352e0730f5360ac715845d602407ce8faa46"
     }
   ]
 }

--- a/TreeDB/docs/spec/vector-partition-m2.md
+++ b/TreeDB/docs/spec/vector-partition-m2.md
@@ -23,10 +23,11 @@ oversized, unknown-field, trailing, and non-canonical JSON; a backend cannot
 publish a forged metric report.
 
 An optional external adapter (`RunExternalJSON`) is offline only. It receives
-an explicit command, private input/output paths, context cancellation, and an
-output-byte cap. It removes the entire private temporary directory on command
-failure, cancellation, timeout, malformed output, or success. No external
-partitioner is currently selected or required.
+an explicit command, private input/output paths, context cancellation, a
+fully bound expected source snapshot, and an output-byte cap. It removes the
+entire private temporary directory on command failure, cancellation, timeout,
+malformed output, or success. No external partitioner is currently selected or
+required.
 
 ## Reproducible M0 fixture invocation
 
@@ -52,8 +53,11 @@ input/output command, resource limits, and independent validator evidence.
 `treedb_vector_dataset_export` manifest plus checksummed `documents.f32` and
 `queries.f32` source files. It rejects malformed manifests, altered checksums,
 wrong float dimensions, corpus byte overruns, and unsupported identity
-contracts before corpus allocation. The builder emits an immutable artifact
-and a JSON report containing wall/CPU time, peak RSS, temp/final bytes,
+contracts before corpus allocation. Graph construction also enforces a global
+distance-evaluation budget and chunks non-progressing skew buckets
+deterministically; leaf top-k selection is bounded by degree rather than leaf
+size. The builder emits an immutable artifact and a JSON report containing
+load, build, quality, and total-command wall time, build CPU time, peak RSS, temp/final bytes,
 bytes/vector, balance, graph degree/cut/hash-cut, sampled graph-neighbor
 recall, and fixed-probe partition-oracle and hash baseline recall@10.
 
@@ -62,12 +66,12 @@ host. They are offline quality/resource evidence, not a server speed claim:
 
 | corpus and builder configuration | wall | peak RSS | artifact bytes/vector | graph recall sample | partition recall@10 / hash | cap/balance |
 |---|---:|---:|---:|---:|---:|---:|
-| 10k x 64, r4/d16/leaf128, 16 parts, 2 probes | 1.597s CPU 1.901s | 34.6 MB | 95.59 | 0.809 (64 samples) | 0.863 / 0.413 | 1.0512 |
-| 100k x 16, r2/d8/leaf64, 16 parts, 4 probes | 2.888s CPU 5.016s | 108.4 MB | 64.62 | 0.759 (64 samples) | 1.000 / 0.588 | 1.0048 |
-| 1M x 16, r2/d8/leaf64, 16 parts, 4 probes | 34.927s CPU 58.008s | 1.330 GB | 72.47 | 0.781 (64 samples) | 1.000 / 0.700 | 1.000112 |
+| 10k x 64, r4/d16/leaf128, 16 parts, 2 probes | build 1.237s / total 1.360s, CPU 1.365s | 33.3 MB | 95.59 | 0.809 (64 samples) | 0.863 / 0.413 | 1.0512 |
+| 100k x 16, r2/d8/leaf64, 16 parts, 4 probes | build 1.937s / total 2.437s, CPU 2.466s | 118.4 MB | 64.62 | 0.759 (64 samples) | 1.000 / 0.588 | 1.0048 |
+| 1M x 16, r2/d8/leaf64, 16 parts, 4 probes | build 22.335s / total 27.234s, CPU 27.750s | 1.068 GB | 72.47 | 0.781 (64 samples) | 1.000 / 0.700 | 1.000112 |
 
 The 1M artifact was
-`/tmp/treedb_m2_final1m_HPRB/vector_partition_9274f9f3d7b900dd.json`
+`/tmp/treedb_m2_final1m_rzfX/vector_partition_9274f9f3d7b900dd.json`
 (SHA-256 `9274f9f3d7b900dd931881c2ce544b68ac6ddac198008ab307c6b57469f62ec1`);
 the matching report sits beside it. Its deterministic source corpus is
 `/tmp/treedb_m2_export1m_rHdo`, generated with:
@@ -95,6 +99,11 @@ quality row is therefore scoped to that declared one-query fixed-budget corpus,
 not a population-level claim. The 10k and 100k rows use 16 and 8 deterministic
 query vectors respectively. `FinalBytes` is artifact plus compact provenance
 report bytes; reports no longer embed or print a duplicate artifact payload.
-The final 1M report records graph build 30.488s, backend partition 0.310s,
-validation 2.336s, temporary disk 0 bytes, artifact 72,473,746 bytes, report
-2,415 bytes, and final output 72,476,161 bytes.
+The final 1M report records load 0.264s, graph build 18.736s, backend
+partition 0.313s, validation 1.544s, quality 0.989s, temporary disk 0 bytes,
+artifact 72,473,746 bytes, report 2,513 bytes, and final output 72,476,259
+bytes.
+
+Peak RSS is `/proc/self/status` `VmHWM` for the builder process. It includes
+the loaded corpus, graph, assignment, quality-oracle work, Go runtime and GC;
+it does not represent a TreeDB server resident-memory claim.

--- a/TreeDB/docs/spec/vector-partition-m2.md
+++ b/TreeDB/docs/spec/vector-partition-m2.md
@@ -85,6 +85,8 @@ The exact handoff artifacts (artifact then compact report) were:
 These paths are host-local handoff locations, while the manifest/source digest,
 exact commands, and compact report fields make the run reproducible without
 committing a 45 MB generated artifact.
+The durable reviewer-accessible digest ledger is
+`TreeDB/docs/spec/artifacts/vector-partition-m2-evidence-v1.json`.
 
 The 1M artifact was
 `/tmp/treedb_m2_final1m6_IqbC/vector_partition_f76fba39db8a51fb.json`
@@ -93,6 +95,8 @@ the matching report sits beside it. Its deterministic source corpus is
 `/tmp/treedb_m2_export1m_rHdo`, generated with:
 
 ```sh
+DATASET=$(mktemp -d /tmp/treedb_m2_dataset1m_XXXXXX)
+OUT=$(mktemp -d /tmp/treedb_m2_out1m_XXXXXX)
 GOWORK=off go run ./cmd/treedb_vector_dataset_export \
   -out "$DATASET" -docs 1000000 -queries 1 -dims 16 -truth-queries 0
 GOWORK=off go run ./cmd/treedb_vector_partition_build \
@@ -103,11 +107,15 @@ GOWORK=off go run ./cmd/treedb_vector_partition_build \
 The other exact runs were:
 
 ```sh
+DATASET_10K=$(mktemp -d /tmp/treedb_m2_dataset10k_XXXXXX)
+OUT_10K=$(mktemp -d /tmp/treedb_m2_out10k_XXXXXX)
 GOWORK=off go run ./cmd/treedb_vector_dataset_export \
   -out "$DATASET_10K" -docs 10000 -queries 16 -dims 64 -truth-queries 0
 GOWORK=off go run ./cmd/treedb_vector_partition_build \
   -dataset "$DATASET_10K" -out "$OUT_10K" -partitions 16 -probes 2 -seed 1 \
   -repetitions 4 -degree 16 -max-leaf-bucket 128
+DATASET_100K=$(mktemp -d /tmp/treedb_m2_dataset100k_XXXXXX)
+OUT_100K=$(mktemp -d /tmp/treedb_m2_out100k_XXXXXX)
 GOWORK=off go run ./cmd/treedb_vector_dataset_export \
   -out "$DATASET_100K" -docs 100000 -queries 8 -dims 16 -truth-queries 0
 GOWORK=off go run ./cmd/treedb_vector_partition_build \

--- a/TreeDB/docs/spec/vector-partition-m2.md
+++ b/TreeDB/docs/spec/vector-partition-m2.md
@@ -70,8 +70,10 @@ input/output command, resource limits, and independent validator evidence.
 `queries.f32` source files. It rejects malformed manifests, altered checksums,
 wrong float dimensions, non-finite or non-unit-normalized float32 rows, corpus
 byte overruns, and unsupported identity contracts before corpus allocation.
-It loads and validates all declared query rows but caps quality evaluation to
-the first 128 deterministic queries. Graph construction enforces global scalar
+It streams and validates all declared query rows (including checksum, exact
+size, and trailing-byte checks) but retains only the first 128 deterministic
+queries for quality evaluation; query-memory use therefore does not scale with
+the declared query-row count. Graph construction enforces global scalar
 distance work (including dimensions), bounded partition work, and chunks non-progressing skew buckets
 deterministically; leaf top-k selection is bounded by degree rather than leaf
 size. The builder emits an immutable artifact and a JSON report containing

--- a/TreeDB/docs/spec/vector-partition-m2.md
+++ b/TreeDB/docs/spec/vector-partition-m2.md
@@ -1,0 +1,47 @@
+# Vector partitioning M2: offline graph and balanced artifact
+
+M2 supplies an offline, clean-room builder at
+`TreeDB/internal/vectorpartition` and a command-facing shim at
+`TreeDB/vectorpartition`. It is not a TreeDB server feature, Raft manifest,
+router, overlap implementation, or runtime FFI.
+
+The reference builder accepts finite, equal-dimension cosine vectors with
+unique stable IDs. It orders IDs canonically, repeatedly samples pivots from a
+seeded permutation, permits the two nearest pivots at depth zero, uses one
+nearest pivot at deeper levels, chunks degenerate duplicate buckets, computes
+exact neighbors in bounded leaves, and unions them into a bounded directed
+graph. `symmetric=false` is the sole supported policy in v1; it is recorded in
+the artifact rather than pretending bounded reverse insertion is symmetric.
+
+The deterministic `treedb_reference_greedy_v1` backend is CI-safe and has no
+third-party backend provenance: its license is the repository license. It
+assigns every ordinal exactly once while enforcing
+`ceil((1 + imbalance) * vectors / partitions)`. `ValidateArtifact` independently
+checks canonical IDs, graph ordinals/self/duplicates/degree, assignment range,
+coverage, cap, and recomputed metrics. `DecodeArtifact` additionally rejects
+oversized, unknown-field, trailing, and non-canonical JSON; a backend cannot
+publish a forged metric report.
+
+An optional external adapter (`RunExternalJSON`) is offline only. It receives
+an explicit command, private input/output paths, context cancellation, and an
+output-byte cap. It removes the entire private temporary directory on command
+failure, cancellation, timeout, malformed output, or success. No external
+partitioner is currently selected or required.
+
+## Reproducible M0 fixture invocation
+
+```sh
+OUT=$(mktemp -d /tmp/treedb_vector_partition_m2_XXXXXX)
+GOWORK=off go run ./cmd/treedb_vector_partition_bench \
+  -dataset testdata/vector_partition_10k -stage partition \
+  -partitions 16 -imbalance 0.05 -seed 1 -format json -out "$OUT"
+```
+
+This writes `vector_partition_artifact_v1.json` (canonical immutable artifact)
+and `vector_partition_build_v1.json` (measured build wall time plus digest).
+The latter is a local offline builder report, not production routing or a
+universal speedup claim. The command's existing `-stage simulation` remains
+the M0 sequential simulator and continues to use its frozen M0 vocabulary.
+
+Before a production backend can be chosen, pin its version, source and license,
+input/output command, resource limits, and independent validator evidence.

--- a/TreeDB/docs/spec/vector-partition-m2.md
+++ b/TreeDB/docs/spec/vector-partition-m2.md
@@ -45,3 +45,42 @@ the M0 sequential simulator and continues to use its frozen M0 vocabulary.
 
 Before a production backend can be chosen, pin its version, source and license,
 input/output command, resource limits, and independent validator evidence.
+
+## Exporter-corpus builder and reproducibility evidence
+
+`cmd/treedb_vector_partition_build` consumes the repository-owned
+`treedb_vector_dataset_export` manifest plus checksummed `documents.f32` and
+`queries.f32` source files. It rejects malformed manifests, altered checksums,
+wrong float dimensions, corpus byte overruns, and unsupported identity
+contracts before corpus allocation. The builder emits an immutable artifact
+and a JSON report containing wall/CPU time, peak RSS, temp/final bytes,
+bytes/vector, balance, graph degree/cut/hash-cut, sampled graph-neighbor
+recall, and fixed-probe partition-oracle and hash baseline recall@10.
+
+The following local, deterministic exporter corpus runs were captured on this
+host. They are offline quality/resource evidence, not a server speed claim:
+
+| corpus and builder configuration | wall | peak RSS | artifact bytes/vector | graph recall sample | partition recall@10 / hash | cap/balance |
+|---|---:|---:|---:|---:|---:|---:|
+| 10k x 64, r4/d16/leaf128, 16 parts, 2 probes | 1.560s | 36.2 MB | 95.59 | 0.900 | 0.594 / 0.163 | 1.0512 |
+| 100k x 16, r2/d8/leaf64, 16 parts, 4 probes | 3.023s | 112.1 MB | 64.62 | 0.775 | 0.475 / 0.250 | 1.0048 |
+| 1M x 16, r2/d8/leaf64, 16 parts, 4 probes | 34.266s | 1.443 GB | 72.47 | 0.794 | 0.300 / 0.100 | 1.000112 |
+
+The 1M artifact was
+`/tmp/treedb_m2_build1m_7jEG/vector_partition_9274f9f3d7b900dd.json`
+(SHA-256 `9274f9f3d7b900dd931881c2ce544b68ac6ddac198008ab307c6b57469f62ec1`);
+the matching report sits beside it. Its deterministic source corpus is
+`/tmp/treedb_m2_export1m_rHdo`, generated with:
+
+```sh
+GOWORK=off go run ./cmd/treedb_vector_dataset_export \
+  -out "$DATASET" -docs 1000000 -queries 1 -dims 16 -truth-queries 0
+GOWORK=off go run ./cmd/treedb_vector_partition_build \
+  -dataset "$DATASET" -out "$OUT" -partitions 16 -probes 4 -seed 1 \
+  -repetitions 2 -degree 8 -max-leaf-bucket 64
+```
+
+At the same fixed four-probe candidate budget, the declared 1M corpus clears
+the M2 quality gate (`0.300 > 0.100` recall@10). The lower-budget 100k
+two-probe/r1/d4 attempt failed (`0.113 <= 0.150`) and was not substituted for
+the reported four-probe gate.

--- a/TreeDB/docs/spec/vector-partition-m2.md
+++ b/TreeDB/docs/spec/vector-partition-m2.md
@@ -39,8 +39,9 @@ GOWORK=off go run ./cmd/treedb_vector_partition_bench \
   -partitions 16 -imbalance 0.05 -seed 1 -format json -out "$OUT"
 ```
 
-This writes `vector_partition_artifact_v1.json` (canonical immutable artifact)
-and `vector_partition_build_v1.json` (measured build wall time plus digest).
+This writes digest/provenance-named canonical artifact and compact build-report
+JSON files (not the false fixed filenames `vector_partition_artifact_v1.json`
+or `vector_partition_build_v1.json`).
 The latter is a local offline builder report, not production routing or a
 universal speedup claim. The command's existing `-stage simulation` remains
 the M0 sequential simulator and continues to use its frozen M0 vocabulary.
@@ -69,12 +70,24 @@ host. They are offline quality/resource evidence, not a server speed claim:
 
 | corpus and builder configuration | wall | peak RSS | artifact bytes/vector | graph recall sample | partition recall@10 / hash | cap/balance |
 |---|---:|---:|---:|---:|---:|---:|
-| 10k x 64, r4/d16/leaf128, 16 parts, 2 probes | build 1.466s / total 1.609s, build/total CPU 1.476/1.624s | 34.1 MB | 95.59 | 0.809 (64 samples) | 0.863 / 0.413 | 1.0512 |
-| 100k x 16, r2/d8/leaf64, 16 parts, 4 probes | build 2.316s / total 2.840s, build/total CPU 2.374/2.909s | 108.1 MB | 64.62 | 0.759 (64 samples) | 1.000 / 0.588 | 1.00608 |
-| 1M x 16, r1/d4/leaf32, 16 parts, 4 probes | build 11.234s / total 14.631s, build/total CPU 11.697/15.313s | 1.192 GB | 44.67 | 0.394 (64 samples) | 1.000 / 0.700 | 1.000000 |
+| 10k x 64, r4/d16/leaf128, 16 parts, 2 probes | build 4.271s / total 4.485s, build/total CPU 4.104/4.296s | 34.2 MB | 95.59 | 0.809 (64 samples) | 0.863 / 0.413 | 1.0512 |
+| 100k x 16, r2/d8/leaf64, 16 parts, 4 probes | build 4.517s / total 5.065s, build/total CPU 4.569/5.133s | 105.1 MB | 64.62 | 0.759 (64 samples) | 1.000 / 0.588 | 1.00608 |
+| 1M x 16, r1/d4/leaf32, 16 parts, 4 probes | build 21.766s / total 25.325s, build/total CPU 22.228/25.862s | 1.123 GB | 44.67 | 0.394 (64 samples) | 1.000 / 0.700 | 1.000000 |
+
+The exact handoff artifacts (artifact then compact report) were:
+
+| corpus | artifact path and SHA-256 | report path |
+|---|---|---|
+| 10k | `/tmp/treedb_m2_final10k4_q8zh/vector_partition_c270226154a4e741.json` `c270226154a4e7410bb4140d63abfe36bebc0d0de9cdbf7c894298225d76c935` | `/tmp/treedb_m2_final10k4_q8zh/vector_partition_report_c270226154a4e741.json` |
+| 100k | `/tmp/treedb_m2_final100k4_FPsO/vector_partition_627778e026d17732.json` `627778e026d177320e4aace2f32883aa1656c1d36f9f5005d1d9e41f55fdc3ae` | `/tmp/treedb_m2_final100k4_FPsO/vector_partition_report_627778e026d17732.json` |
+| 1M | `/tmp/treedb_m2_final1m6_IqbC/vector_partition_f76fba39db8a51fb.json` `f76fba39db8a51fb11b669962b92a97d64956f75a76137cea0e80cbe42d42413` | `/tmp/treedb_m2_final1m6_IqbC/vector_partition_report_f76fba39db8a51fb.json` |
+
+These paths are host-local handoff locations, while the manifest/source digest,
+exact commands, and compact report fields make the run reproducible without
+committing a 45 MB generated artifact.
 
 The 1M artifact was
-`/tmp/treedb_m2_final1m5_WF6G/vector_partition_f76fba39db8a51fb.json`
+`/tmp/treedb_m2_final1m6_IqbC/vector_partition_f76fba39db8a51fb.json`
 (SHA-256 `f76fba39db8a51fb11b669962b92a97d64956f75a76137cea0e80cbe42d42413`);
 the matching report sits beside it. Its deterministic source corpus is
 `/tmp/treedb_m2_export1m_rHdo`, generated with:
@@ -85,6 +98,21 @@ GOWORK=off go run ./cmd/treedb_vector_dataset_export \
 GOWORK=off go run ./cmd/treedb_vector_partition_build \
   -dataset "$DATASET" -out "$OUT" -partitions 16 -probes 4 -seed 1 \
   -repetitions 1 -degree 4 -max-leaf-bucket 32
+```
+
+The other exact runs were:
+
+```sh
+GOWORK=off go run ./cmd/treedb_vector_dataset_export \
+  -out "$DATASET_10K" -docs 10000 -queries 16 -dims 64 -truth-queries 0
+GOWORK=off go run ./cmd/treedb_vector_partition_build \
+  -dataset "$DATASET_10K" -out "$OUT_10K" -partitions 16 -probes 2 -seed 1 \
+  -repetitions 4 -degree 16 -max-leaf-bucket 128
+GOWORK=off go run ./cmd/treedb_vector_dataset_export \
+  -out "$DATASET_100K" -docs 100000 -queries 8 -dims 16 -truth-queries 0
+GOWORK=off go run ./cmd/treedb_vector_partition_build \
+  -dataset "$DATASET_100K" -out "$OUT_100K" -partitions 16 -probes 4 -seed 1 \
+  -repetitions 2 -degree 8 -max-leaf-bucket 64
 ```
 
 The reported recall is a true M2 partition oracle: global exact top-10 first
@@ -102,9 +130,9 @@ quality row is therefore scoped to that declared one-query fixed-budget corpus,
 not a population-level claim. The 10k and 100k rows use 16 and 8 deterministic
 query vectors respectively. `FinalBytes` is artifact plus compact provenance
 report bytes; reports no longer embed or print a duplicate artifact payload.
-The final 1M report records load 0.302s, graph build 9.148s, backend
-partition 0.221s, validation 0.804s, quality 1.052s, temporary disk 0 bytes,
-artifact 44,672,391 bytes, report 2,544 bytes, and final output 44,674,935
+The final 1M report records load 0.338s, graph build 19.185s, backend
+partition 0.271s, validation 0.812s, quality 1.113s, temporary disk 0 bytes,
+artifact 44,672,391 bytes, report 2,545 bytes, and final output 44,674,936
 bytes.
 
 Peak RSS is `/proc/self/status` `VmHWM` for the builder process. It includes

--- a/TreeDB/docs/spec/vector-partition-m2.md
+++ b/TreeDB/docs/spec/vector-partition-m2.md
@@ -62,12 +62,12 @@ host. They are offline quality/resource evidence, not a server speed claim:
 
 | corpus and builder configuration | wall | peak RSS | artifact bytes/vector | graph recall sample | partition recall@10 / hash | cap/balance |
 |---|---:|---:|---:|---:|---:|---:|
-| 10k x 64, r4/d16/leaf128, 16 parts, 2 probes | 1.560s | 36.2 MB | 95.59 | 0.900 | 0.594 / 0.163 | 1.0512 |
-| 100k x 16, r2/d8/leaf64, 16 parts, 4 probes | 3.023s | 112.1 MB | 64.62 | 0.775 | 0.475 / 0.250 | 1.0048 |
-| 1M x 16, r2/d8/leaf64, 16 parts, 4 probes | 36.872s CPU 45.743s | 1.325 GB | 72.47 | 0.794 | 0.300 / 0.100 | 1.000112 |
+| 10k x 64, r4/d16/leaf128, 16 parts, 2 probes | 1.597s CPU 1.901s | 34.6 MB | 95.59 | 0.809 (64 samples) | 0.863 / 0.413 | 1.0512 |
+| 100k x 16, r2/d8/leaf64, 16 parts, 4 probes | 2.888s CPU 5.016s | 108.4 MB | 64.62 | 0.759 (64 samples) | 1.000 / 0.588 | 1.0048 |
+| 1M x 16, r2/d8/leaf64, 16 parts, 4 probes | 34.927s CPU 58.008s | 1.330 GB | 72.47 | 0.781 (64 samples) | 1.000 / 0.700 | 1.000112 |
 
 The 1M artifact was
-`/tmp/treedb_m2_build1m_cpu_WYHa/vector_partition_9274f9f3d7b900dd.json`
+`/tmp/treedb_m2_final1m_HPRB/vector_partition_9274f9f3d7b900dd.json`
 (SHA-256 `9274f9f3d7b900dd931881c2ce544b68ac6ddac198008ab307c6b57469f62ec1`);
 the matching report sits beside it. Its deterministic source corpus is
 `/tmp/treedb_m2_export1m_rHdo`, generated with:
@@ -80,7 +80,21 @@ GOWORK=off go run ./cmd/treedb_vector_partition_build \
   -repetitions 2 -degree 8 -max-leaf-bucket 64
 ```
 
+The reported recall is a true M2 partition oracle: global exact top-10 first
+selects the partitions containing the most truth neighbors (stable partition
+ID ties), then the same selected-partition exact scan runs for graph and
+stable-hash assignments. It deliberately contains no centroid/router loss.
 At the same fixed four-probe candidate budget, the declared 1M corpus clears
-the M2 quality gate (`0.300 > 0.100` recall@10). The lower-budget 100k
+the M2 quality gate (`1.000 > 0.700` recall@10). The lower-budget 100k
 two-probe/r1/d4 attempt failed (`0.113 <= 0.150`) and was not substituted for
 the reported four-probe gate.
+
+The 1M exporter shape intentionally has **one deterministic query** and no
+exporter truth stream (the builder computes its own exact query truth); its
+quality row is therefore scoped to that declared one-query fixed-budget corpus,
+not a population-level claim. The 10k and 100k rows use 16 and 8 deterministic
+query vectors respectively. `FinalBytes` is artifact plus compact provenance
+report bytes; reports no longer embed or print a duplicate artifact payload.
+The final 1M report records graph build 30.488s, backend partition 0.310s,
+validation 2.336s, temporary disk 0 bytes, artifact 72,473,746 bytes, report
+2,415 bytes, and final output 72,476,161 bytes.

--- a/TreeDB/docs/spec/vector-partition-m2.md
+++ b/TreeDB/docs/spec/vector-partition-m2.md
@@ -74,17 +74,17 @@ host. They are offline quality/resource evidence, not a server speed claim:
 
 | corpus and builder configuration | wall | peak RSS | artifact bytes/vector | graph recall sample | partition recall@10 / hash | cap/balance |
 |---|---:|---:|---:|---:|---:|---:|
-| 10k x 64, r4/d16/leaf128, 16 parts, 2 probes | build 3.794s / total 3.921s, build/total CPU 3.796/3.928s | 34.6 MB | 95.59 | 0.809 (64 samples) | 0.863 / 0.413 | 1.0512 |
-| 100k x 16, r2/d8/leaf64, 16 parts, 4 probes | build 4.427s / total 4.970s, build/total CPU 4.473/5.029s | 102.5 MB | 64.62 | 0.759 (64 samples) | 1.000 / 0.588 | 1.00608 |
-| 1M x 16, r1/d4/leaf32, 16 parts, 4 probes | build 22.401s / total 27.450s, build/total CPU 22.567/27.283s | 1.220 GB | 44.67 | 0.394 (64 samples) | 1.000 / 0.700 | 1.000000 |
+| 10k x 64, r4/d16/leaf128, 16 parts, 2 probes | build 3.370s / total 3.496s, build/total CPU 3.380/3.509s | 35.0 MB | 95.59 | 0.809 (64 samples) | 0.863 / 0.413 | 1.0512 |
+| 100k x 16, r2/d8/leaf64, 16 parts, 4 probes | build 4.312s / total 4.842s, build/total CPU 4.381/4.921s | 101.4 MB | 64.62 | 0.759 (64 samples) | 1.000 / 0.588 | 1.00608 |
+| 1M x 16, r1/d4/leaf32, 16 parts, 4 probes | build 22.442s / total 26.407s, build/total CPU 22.314/26.189s | 1.149 GB | 44.67 | 0.394 (64 samples) | 1.000 / 0.700 | 1.000000 |
 
 The exact handoff artifacts (artifact then compact report) were:
 
 | corpus | artifact path and SHA-256 | report path |
 |---|---|---|
-| 10k | `/tmp/treedb_m2_out10k_final2_a9i1NQ/vector_partition_c270226154a4e741.json` `c270226154a4e7410bb4140d63abfe36bebc0d0de9cdbf7c894298225d76c935` | `/tmp/treedb_m2_out10k_final2_a9i1NQ/vector_partition_report_c270226154a4e741.json` |
-| 100k | `/tmp/treedb_m2_out100k_final2_QEWiPc/vector_partition_627778e026d17732.json` `627778e026d177320e4aace2f32883aa1656c1d36f9f5005d1d9e41f55fdc3ae` | `/tmp/treedb_m2_out100k_final2_QEWiPc/vector_partition_report_627778e026d17732.json` |
-| 1M | `/tmp/treedb_m2_out1m_final2_nJ3Cq0/vector_partition_f76fba39db8a51fb.json` `f76fba39db8a51fb11b669962b92a97d64956f75a76137cea0e80cbe42d42413` | `/tmp/treedb_m2_out1m_final2_nJ3Cq0/vector_partition_report_f76fba39db8a51fb.json` |
+| 10k | `/tmp/treedb_m2_out10k_final3_kfQnKC/vector_partition_c270226154a4e741.json` `c270226154a4e7410bb4140d63abfe36bebc0d0de9cdbf7c894298225d76c935` | `/tmp/treedb_m2_out10k_final3_kfQnKC/vector_partition_report_c270226154a4e741.json` |
+| 100k | `/tmp/treedb_m2_out100k_final3_ZuzVN8/vector_partition_627778e026d17732.json` `627778e026d177320e4aace2f32883aa1656c1d36f9f5005d1d9e41f55fdc3ae` | `/tmp/treedb_m2_out100k_final3_ZuzVN8/vector_partition_report_627778e026d17732.json` |
+| 1M | `/tmp/treedb_m2_out1m_final3_YRn2qI/vector_partition_f76fba39db8a51fb.json` `f76fba39db8a51fb11b669962b92a97d64956f75a76137cea0e80cbe42d42413` | `/tmp/treedb_m2_out1m_final3_YRn2qI/vector_partition_report_f76fba39db8a51fb.json` |
 
 These paths are host-local handoff locations, while the canonical manifest/source digest,
 exact commands, and compact report fields make the run reproducible without
@@ -97,17 +97,18 @@ which is the logical manifest binding used in `source_id`; it is explicitly
 not the raw `manifest.json` file-byte hash. The manifest itself lists the raw
 SHA-256 and byte count for every exported corpus file.
 All three runs used binaries built from implementation commit
-`7a5d61e60cec2c55ea8befe656e76631742b4b1d`. The following commit
-`cec947921b190ef9370de9e1542040a962c086c5` refreshed only this documentation
-and the evidence ledger; it changed no implementation files. This separates
+`9bab19104ecd223c6c15c67469b6cdb8748e802e`. The earlier commits
+`cec947921b190ef9370de9e1542040a962c086c5` and
+`e2869cd31c37d24ee18cae86a0cb6a578ff52513` refreshed only documentation and
+the evidence ledger; they changed no implementation files. This separates
 the exact algorithm binding from the necessarily later commit that records its
 measurements.
 
 The 1M artifact was
-`/tmp/treedb_m2_out1m_final2_nJ3Cq0/vector_partition_f76fba39db8a51fb.json`
+`/tmp/treedb_m2_out1m_final3_YRn2qI/vector_partition_f76fba39db8a51fb.json`
 (SHA-256 `f76fba39db8a51fb11b669962b92a97d64956f75a76137cea0e80cbe42d42413`);
 the matching report sits beside it. Its deterministic source corpus is
-`/tmp/treedb_m2_dataset1m_final2_1gEVgP`, generated with:
+`/tmp/treedb_m2_dataset1m_final3_81AtXu`, generated with:
 
 ```sh
 DATASET=$(mktemp -d /tmp/treedb_m2_dataset1m_XXXXXX)
@@ -153,9 +154,9 @@ quality row is therefore scoped to that declared one-query fixed-budget corpus,
 not a population-level claim. The 10k and 100k rows use 16 and 8 deterministic
 query vectors respectively. `FinalBytes` is artifact plus compact provenance
 report bytes; reports no longer embed or print a duplicate artifact payload.
-The final 1M report records load 0.427s, graph build 19.371s, backend
-partition 0.104s, validation 1.428s, quality 1.096s, temporary disk 0 bytes,
-artifact 44,672,391 bytes, report 2,552 bytes, and final output 44,674,943
+The final 1M report records load 0.623s, graph build 20.379s, backend
+partition 0.102s, validation 0.800s, quality 1.103s, temporary disk 0 bytes,
+artifact 44,672,391 bytes, report 2,551 bytes, and final output 44,674,942
 bytes.
 
 Peak RSS is `/proc/self/status` `VmHWM` for the builder process. It includes

--- a/TreeDB/docs/spec/vector-partition-m2.md
+++ b/TreeDB/docs/spec/vector-partition-m2.md
@@ -22,14 +22,17 @@ coverage, cap, and recomputed metrics. `DecodeArtifact` additionally rejects
 oversized, unknown-field, trailing, and non-canonical JSON; a backend cannot
 publish a forged metric report.
 
-The usable optional external adapter (`RunExternalJSONForSource`) is offline
-only; the unbound `RunExternalJSON` deliberately errors. It receives
+The usable optional external adapter (`RunExternalJSONForRequestWithLimits`) is
+offline only; source-only and unbound entrypoints deliberately error because
+they cannot bind a response to the requested graph. It receives
 an explicit command, private input/output paths, context cancellation, a
-fully bound expected source snapshot, and independent request/output-byte
-caps. The default request cap is derived from bounded M2 graph ordinals and
+fully validated requested artifact (source, IDs, config, and graph), and
+independent request/output-byte caps. The default request cap is derived from bounded M2 graph ordinals and
 worst-case JSON escaping for IDs and source/backend identity fields; callers
 may set a smaller request cap without inflating the
-output cap. It removes the
+output cap. The input bytes must be the requested artifact's exact canonical
+JSON, so the graph being executed and the graph to which the response is bound
+are the same object. It removes the
 entire private temporary directory on command failure, cancellation, timeout,
 malformed output, or success. On Unix it also kills the dedicated process group
 after `Wait`, including when the root exits normally while a same-group child

--- a/TreeDB/docs/spec/vector-partition-m2.md
+++ b/TreeDB/docs/spec/vector-partition-m2.md
@@ -74,17 +74,17 @@ host. They are offline quality/resource evidence, not a server speed claim:
 
 | corpus and builder configuration | wall | peak RSS | artifact bytes/vector | graph recall sample | partition recall@10 / hash | cap/balance |
 |---|---:|---:|---:|---:|---:|---:|
-| 10k x 64, r4/d16/leaf128, 16 parts, 2 probes | build 3.500s / total 3.662s, build/total CPU 3.504/3.671s | 34.7 MB | 95.59 | 0.809 (64 samples) | 0.863 / 0.413 | 1.0512 |
-| 100k x 16, r2/d8/leaf64, 16 parts, 4 probes | build 6.387s / total 6.901s, build/total CPU 5.905/6.435s | 103.5 MB | 64.62 | 0.759 (64 samples) | 1.000 / 0.588 | 1.00608 |
-| 1M x 16, r1/d4/leaf32, 16 parts, 4 probes | build 20.451s / total 23.731s, build/total CPU 20.923/24.386s | 1.244 GB | 44.67 | 0.394 (64 samples) | 1.000 / 0.700 | 1.000000 |
+| 10k x 64, r4/d16/leaf128, 16 parts, 2 probes | build 3.400s / total 3.524s, build/total CPU 3.414/3.543s | 34.5 MB | 95.59 | 0.809 (64 samples) | 0.863 / 0.413 | 1.0512 |
+| 100k x 16, r2/d8/leaf64, 16 parts, 4 probes | build 4.184s / total 4.693s, build/total CPU 4.239/4.762s | 102.9 MB | 64.62 | 0.759 (64 samples) | 1.000 / 0.588 | 1.00608 |
+| 1M x 16, r1/d4/leaf32, 16 parts, 4 probes | build 20.667s / total 23.977s, build/total CPU 21.141/24.577s | 1.245 GB | 44.67 | 0.394 (64 samples) | 1.000 / 0.700 | 1.000000 |
 
 The exact handoff artifacts (artifact then compact report) were:
 
 | corpus | artifact path and SHA-256 | report path |
 |---|---|---|
-| 10k | `/tmp/treedb_m2_out10k_final4_rcOIjD/vector_partition_c270226154a4e741.json` `c270226154a4e7410bb4140d63abfe36bebc0d0de9cdbf7c894298225d76c935` | `/tmp/treedb_m2_out10k_final4_rcOIjD/vector_partition_report_c270226154a4e741.json` |
-| 100k | `/tmp/treedb_m2_out100k_final4_Zan6Uv/vector_partition_627778e026d17732.json` `627778e026d177320e4aace2f32883aa1656c1d36f9f5005d1d9e41f55fdc3ae` | `/tmp/treedb_m2_out100k_final4_Zan6Uv/vector_partition_report_627778e026d17732.json` |
-| 1M | `/tmp/treedb_m2_out1m_final4_Tc8db4/vector_partition_f76fba39db8a51fb.json` `f76fba39db8a51fb11b669962b92a97d64956f75a76137cea0e80cbe42d42413` | `/tmp/treedb_m2_out1m_final4_Tc8db4/vector_partition_report_f76fba39db8a51fb.json` |
+| 10k | `/tmp/treedb_m2_out10k_final6_EEB82V/vector_partition_c270226154a4e741.json` `c270226154a4e7410bb4140d63abfe36bebc0d0de9cdbf7c894298225d76c935` | `/tmp/treedb_m2_out10k_final6_EEB82V/vector_partition_report_c270226154a4e741.json` |
+| 100k | `/tmp/treedb_m2_out100k_final6_JOpR05/vector_partition_627778e026d17732.json` `627778e026d177320e4aace2f32883aa1656c1d36f9f5005d1d9e41f55fdc3ae` | `/tmp/treedb_m2_out100k_final6_JOpR05/vector_partition_report_627778e026d17732.json` |
+| 1M | `/tmp/treedb_m2_out1m_final6_mZHdfj/vector_partition_f76fba39db8a51fb.json` `f76fba39db8a51fb11b669962b92a97d64956f75a76137cea0e80cbe42d42413` | `/tmp/treedb_m2_out1m_final6_mZHdfj/vector_partition_report_f76fba39db8a51fb.json` |
 
 These paths are host-local handoff locations, while the canonical manifest/source digest,
 exact commands, and compact report fields make the run reproducible without
@@ -97,17 +97,17 @@ which is the logical manifest binding used in `source_id`; it is explicitly
 not the raw `manifest.json` file-byte hash. The manifest itself lists the raw
 SHA-256 and byte count for every exported corpus file.
 All three runs used binaries built from implementation commit
-`23683ea4ddd2e2da6e267a4983b73d285eb65f5f`. Earlier docs/evidence commits
-through `f34b5b1b817d95e33c8e46221935f5482d9aacd0` changed no implementation
-files. This separates
+`58db38e173093126e5b1ef3c92d79e160d63b0cf`, after merging
+`origin/main` `3e225cb99`. The following evidence commit changes only
+documentation/evidence. This separates
 the exact algorithm binding from the necessarily later commit that records its
 measurements.
 
 The 1M artifact was
-`/tmp/treedb_m2_out1m_final4_Tc8db4/vector_partition_f76fba39db8a51fb.json`
+`/tmp/treedb_m2_out1m_final5_pG2Xts/vector_partition_f76fba39db8a51fb.json`
 (SHA-256 `f76fba39db8a51fb11b669962b92a97d64956f75a76137cea0e80cbe42d42413`);
 the matching report sits beside it. Its deterministic source corpus is
-`/tmp/treedb_m2_dataset1m_final4_Qvn2ew`, generated with:
+`/tmp/treedb_m2_dataset1m_final5_nC3l7B`, generated with:
 
 ```sh
 DATASET=$(mktemp -d /tmp/treedb_m2_dataset1m_XXXXXX)
@@ -153,11 +153,15 @@ quality row is therefore scoped to that declared one-query fixed-budget corpus,
 not a population-level claim. The 10k and 100k rows use 16 and 8 deterministic
 query vectors respectively. `FinalBytes` is artifact plus compact provenance
 report bytes; reports no longer embed or print a duplicate artifact payload.
-The final 1M report records load 0.296s, graph build 18.533s, backend
-partition 0.096s, validation 0.773s, quality 0.993s, temporary disk 0 bytes,
-artifact 44,672,391 bytes, report 2,549 bytes, and final output 44,674,940
+The final 1M report records load 0.293s, graph build 18.665s, backend
+partition 0.099s, validation 0.812s, quality 1.012s, temporary disk 0 bytes,
+artifact 44,672,391 bytes, report 2,638 bytes, and final output 44,675,029
 bytes.
 
+CPU and RSS values are emitted only when their corresponding `*_available`
+flag is true. CPU is collected through Unix `getrusage`; peak RSS is Linux
+`/proc/self/status` `VmHWM`. On unsupported platforms the value is omitted and
+the availability flag is false rather than treating zero as a measurement.
 Peak RSS is `/proc/self/status` `VmHWM` for the builder process. It includes
 the loaded corpus, graph, assignment, quality-oracle work, Go runtime and GC;
 it does not represent a TreeDB server resident-memory claim.

--- a/TreeDB/docs/spec/vector-partition-m2.md
+++ b/TreeDB/docs/spec/vector-partition-m2.md
@@ -74,17 +74,17 @@ host. They are offline quality/resource evidence, not a server speed claim:
 
 | corpus and builder configuration | wall | peak RSS | artifact bytes/vector | graph recall sample | partition recall@10 / hash | cap/balance |
 |---|---:|---:|---:|---:|---:|---:|
-| 10k x 64, r4/d16/leaf128, 16 parts, 2 probes | build 3.370s / total 3.496s, build/total CPU 3.380/3.509s | 35.0 MB | 95.59 | 0.809 (64 samples) | 0.863 / 0.413 | 1.0512 |
-| 100k x 16, r2/d8/leaf64, 16 parts, 4 probes | build 4.312s / total 4.842s, build/total CPU 4.381/4.921s | 101.4 MB | 64.62 | 0.759 (64 samples) | 1.000 / 0.588 | 1.00608 |
-| 1M x 16, r1/d4/leaf32, 16 parts, 4 probes | build 22.442s / total 26.407s, build/total CPU 22.314/26.189s | 1.149 GB | 44.67 | 0.394 (64 samples) | 1.000 / 0.700 | 1.000000 |
+| 10k x 64, r4/d16/leaf128, 16 parts, 2 probes | build 3.500s / total 3.662s, build/total CPU 3.504/3.671s | 34.7 MB | 95.59 | 0.809 (64 samples) | 0.863 / 0.413 | 1.0512 |
+| 100k x 16, r2/d8/leaf64, 16 parts, 4 probes | build 6.387s / total 6.901s, build/total CPU 5.905/6.435s | 103.5 MB | 64.62 | 0.759 (64 samples) | 1.000 / 0.588 | 1.00608 |
+| 1M x 16, r1/d4/leaf32, 16 parts, 4 probes | build 20.451s / total 23.731s, build/total CPU 20.923/24.386s | 1.244 GB | 44.67 | 0.394 (64 samples) | 1.000 / 0.700 | 1.000000 |
 
 The exact handoff artifacts (artifact then compact report) were:
 
 | corpus | artifact path and SHA-256 | report path |
 |---|---|---|
-| 10k | `/tmp/treedb_m2_out10k_final3_kfQnKC/vector_partition_c270226154a4e741.json` `c270226154a4e7410bb4140d63abfe36bebc0d0de9cdbf7c894298225d76c935` | `/tmp/treedb_m2_out10k_final3_kfQnKC/vector_partition_report_c270226154a4e741.json` |
-| 100k | `/tmp/treedb_m2_out100k_final3_ZuzVN8/vector_partition_627778e026d17732.json` `627778e026d177320e4aace2f32883aa1656c1d36f9f5005d1d9e41f55fdc3ae` | `/tmp/treedb_m2_out100k_final3_ZuzVN8/vector_partition_report_627778e026d17732.json` |
-| 1M | `/tmp/treedb_m2_out1m_final3_YRn2qI/vector_partition_f76fba39db8a51fb.json` `f76fba39db8a51fb11b669962b92a97d64956f75a76137cea0e80cbe42d42413` | `/tmp/treedb_m2_out1m_final3_YRn2qI/vector_partition_report_f76fba39db8a51fb.json` |
+| 10k | `/tmp/treedb_m2_out10k_final4_rcOIjD/vector_partition_c270226154a4e741.json` `c270226154a4e7410bb4140d63abfe36bebc0d0de9cdbf7c894298225d76c935` | `/tmp/treedb_m2_out10k_final4_rcOIjD/vector_partition_report_c270226154a4e741.json` |
+| 100k | `/tmp/treedb_m2_out100k_final4_Zan6Uv/vector_partition_627778e026d17732.json` `627778e026d177320e4aace2f32883aa1656c1d36f9f5005d1d9e41f55fdc3ae` | `/tmp/treedb_m2_out100k_final4_Zan6Uv/vector_partition_report_627778e026d17732.json` |
+| 1M | `/tmp/treedb_m2_out1m_final4_Tc8db4/vector_partition_f76fba39db8a51fb.json` `f76fba39db8a51fb11b669962b92a97d64956f75a76137cea0e80cbe42d42413` | `/tmp/treedb_m2_out1m_final4_Tc8db4/vector_partition_report_f76fba39db8a51fb.json` |
 
 These paths are host-local handoff locations, while the canonical manifest/source digest,
 exact commands, and compact report fields make the run reproducible without
@@ -97,18 +97,17 @@ which is the logical manifest binding used in `source_id`; it is explicitly
 not the raw `manifest.json` file-byte hash. The manifest itself lists the raw
 SHA-256 and byte count for every exported corpus file.
 All three runs used binaries built from implementation commit
-`9bab19104ecd223c6c15c67469b6cdb8748e802e`. The earlier commits
-`cec947921b190ef9370de9e1542040a962c086c5` and
-`e2869cd31c37d24ee18cae86a0cb6a578ff52513` refreshed only documentation and
-the evidence ledger; they changed no implementation files. This separates
+`23683ea4ddd2e2da6e267a4983b73d285eb65f5f`. Earlier docs/evidence commits
+through `f34b5b1b817d95e33c8e46221935f5482d9aacd0` changed no implementation
+files. This separates
 the exact algorithm binding from the necessarily later commit that records its
 measurements.
 
 The 1M artifact was
-`/tmp/treedb_m2_out1m_final3_YRn2qI/vector_partition_f76fba39db8a51fb.json`
+`/tmp/treedb_m2_out1m_final4_Tc8db4/vector_partition_f76fba39db8a51fb.json`
 (SHA-256 `f76fba39db8a51fb11b669962b92a97d64956f75a76137cea0e80cbe42d42413`);
 the matching report sits beside it. Its deterministic source corpus is
-`/tmp/treedb_m2_dataset1m_final3_81AtXu`, generated with:
+`/tmp/treedb_m2_dataset1m_final4_Qvn2ew`, generated with:
 
 ```sh
 DATASET=$(mktemp -d /tmp/treedb_m2_dataset1m_XXXXXX)
@@ -154,9 +153,9 @@ quality row is therefore scoped to that declared one-query fixed-budget corpus,
 not a population-level claim. The 10k and 100k rows use 16 and 8 deterministic
 query vectors respectively. `FinalBytes` is artifact plus compact provenance
 report bytes; reports no longer embed or print a duplicate artifact payload.
-The final 1M report records load 0.623s, graph build 20.379s, backend
-partition 0.102s, validation 0.800s, quality 1.103s, temporary disk 0 bytes,
-artifact 44,672,391 bytes, report 2,551 bytes, and final output 44,674,942
+The final 1M report records load 0.296s, graph build 18.533s, backend
+partition 0.096s, validation 0.773s, quality 0.993s, temporary disk 0 bytes,
+artifact 44,672,391 bytes, report 2,549 bytes, and final output 44,674,940
 bytes.
 
 Peak RSS is `/proc/self/status` `VmHWM` for the builder process. It includes

--- a/TreeDB/docs/spec/vector-partition-m2.md
+++ b/TreeDB/docs/spec/vector-partition-m2.md
@@ -22,7 +22,8 @@ coverage, cap, and recomputed metrics. `DecodeArtifact` additionally rejects
 oversized, unknown-field, trailing, and non-canonical JSON; a backend cannot
 publish a forged metric report.
 
-An optional external adapter (`RunExternalJSON`) is offline only. It receives
+The usable optional external adapter (`RunExternalJSONForSource`) is offline
+only; the unbound `RunExternalJSON` deliberately errors. It receives
 an explicit command, private input/output paths, context cancellation, a
 fully bound expected source snapshot, and an output-byte cap. It removes the
 entire private temporary directory on command failure, cancellation, timeout,
@@ -52,12 +53,14 @@ input/output command, resource limits, and independent validator evidence.
 `cmd/treedb_vector_partition_build` consumes the repository-owned
 `treedb_vector_dataset_export` manifest plus checksummed `documents.f32` and
 `queries.f32` source files. It rejects malformed manifests, altered checksums,
-wrong float dimensions, corpus byte overruns, and unsupported identity
-contracts before corpus allocation. Graph construction also enforces a global
-distance-evaluation budget and chunks non-progressing skew buckets
+wrong float dimensions, non-finite or non-unit-normalized float32 rows, corpus
+byte overruns, and unsupported identity contracts before corpus allocation.
+It loads and validates all declared query rows but caps quality evaluation to
+the first 128 deterministic queries. Graph construction enforces global scalar
+distance work (including dimensions), bounded partition work, and chunks non-progressing skew buckets
 deterministically; leaf top-k selection is bounded by degree rather than leaf
 size. The builder emits an immutable artifact and a JSON report containing
-load, build, quality, and total-command wall time, build CPU time, peak RSS, temp/final bytes,
+load, build, quality, and total-command wall time, build and total-command CPU time, peak RSS, temp/final bytes,
 bytes/vector, balance, graph degree/cut/hash-cut, sampled graph-neighbor
 recall, and fixed-probe partition-oracle and hash baseline recall@10.
 
@@ -66,13 +69,13 @@ host. They are offline quality/resource evidence, not a server speed claim:
 
 | corpus and builder configuration | wall | peak RSS | artifact bytes/vector | graph recall sample | partition recall@10 / hash | cap/balance |
 |---|---:|---:|---:|---:|---:|---:|
-| 10k x 64, r4/d16/leaf128, 16 parts, 2 probes | build 1.237s / total 1.360s, CPU 1.365s | 33.3 MB | 95.59 | 0.809 (64 samples) | 0.863 / 0.413 | 1.0512 |
-| 100k x 16, r2/d8/leaf64, 16 parts, 4 probes | build 1.937s / total 2.437s, CPU 2.466s | 118.4 MB | 64.62 | 0.759 (64 samples) | 1.000 / 0.588 | 1.0048 |
-| 1M x 16, r2/d8/leaf64, 16 parts, 4 probes | build 22.335s / total 27.234s, CPU 27.750s | 1.068 GB | 72.47 | 0.781 (64 samples) | 1.000 / 0.700 | 1.000112 |
+| 10k x 64, r4/d16/leaf128, 16 parts, 2 probes | build 1.466s / total 1.609s, build/total CPU 1.476/1.624s | 34.1 MB | 95.59 | 0.809 (64 samples) | 0.863 / 0.413 | 1.0512 |
+| 100k x 16, r2/d8/leaf64, 16 parts, 4 probes | build 2.316s / total 2.840s, build/total CPU 2.374/2.909s | 108.1 MB | 64.62 | 0.759 (64 samples) | 1.000 / 0.588 | 1.00608 |
+| 1M x 16, r1/d4/leaf32, 16 parts, 4 probes | build 11.234s / total 14.631s, build/total CPU 11.697/15.313s | 1.192 GB | 44.67 | 0.394 (64 samples) | 1.000 / 0.700 | 1.000000 |
 
 The 1M artifact was
-`/tmp/treedb_m2_final1m_rzfX/vector_partition_9274f9f3d7b900dd.json`
-(SHA-256 `9274f9f3d7b900dd931881c2ce544b68ac6ddac198008ab307c6b57469f62ec1`);
+`/tmp/treedb_m2_final1m5_WF6G/vector_partition_f76fba39db8a51fb.json`
+(SHA-256 `f76fba39db8a51fb11b669962b92a97d64956f75a76137cea0e80cbe42d42413`);
 the matching report sits beside it. Its deterministic source corpus is
 `/tmp/treedb_m2_export1m_rHdo`, generated with:
 
@@ -81,7 +84,7 @@ GOWORK=off go run ./cmd/treedb_vector_dataset_export \
   -out "$DATASET" -docs 1000000 -queries 1 -dims 16 -truth-queries 0
 GOWORK=off go run ./cmd/treedb_vector_partition_build \
   -dataset "$DATASET" -out "$OUT" -partitions 16 -probes 4 -seed 1 \
-  -repetitions 2 -degree 8 -max-leaf-bucket 64
+  -repetitions 1 -degree 4 -max-leaf-bucket 32
 ```
 
 The reported recall is a true M2 partition oracle: global exact top-10 first
@@ -99,9 +102,9 @@ quality row is therefore scoped to that declared one-query fixed-budget corpus,
 not a population-level claim. The 10k and 100k rows use 16 and 8 deterministic
 query vectors respectively. `FinalBytes` is artifact plus compact provenance
 report bytes; reports no longer embed or print a duplicate artifact payload.
-The final 1M report records load 0.264s, graph build 18.736s, backend
-partition 0.313s, validation 1.544s, quality 0.989s, temporary disk 0 bytes,
-artifact 72,473,746 bytes, report 2,513 bytes, and final output 72,476,259
+The final 1M report records load 0.302s, graph build 9.148s, backend
+partition 0.221s, validation 0.804s, quality 1.052s, temporary disk 0 bytes,
+artifact 44,672,391 bytes, report 2,544 bytes, and final output 44,674,935
 bytes.
 
 Peak RSS is `/proc/self/status` `VmHWM` for the builder process. It includes

--- a/TreeDB/docs/spec/vector-partition-m2.md
+++ b/TreeDB/docs/spec/vector-partition-m2.md
@@ -96,6 +96,12 @@ decoded typed exporter manifest (including its canonically ordered file map),
 which is the logical manifest binding used in `source_id`; it is explicitly
 not the raw `manifest.json` file-byte hash. The manifest itself lists the raw
 SHA-256 and byte count for every exported corpus file.
+All three runs used binaries built from implementation commit
+`7a5d61e60cec2c55ea8befe656e76631742b4b1d`. The following commit
+`cec947921b190ef9370de9e1542040a962c086c5` refreshed only this documentation
+and the evidence ledger; it changed no implementation files. This separates
+the exact algorithm binding from the necessarily later commit that records its
+measurements.
 
 The 1M artifact was
 `/tmp/treedb_m2_out1m_final2_nJ3Cq0/vector_partition_f76fba39db8a51fb.json`

--- a/TreeDB/docs/spec/vector-partition-m2.md
+++ b/TreeDB/docs/spec/vector-partition-m2.md
@@ -27,7 +27,8 @@ only; the unbound `RunExternalJSON` deliberately errors. It receives
 an explicit command, private input/output paths, context cancellation, a
 fully bound expected source snapshot, and independent request/output-byte
 caps. The default request cap is derived from bounded M2 graph ordinals and
-ID serialization; callers may set a smaller request cap without inflating the
+worst-case JSON escaping for IDs and source/backend identity fields; callers
+may set a smaller request cap without inflating the
 output cap. It removes the
 entire private temporary directory on command failure, cancellation, timeout,
 malformed output, or success. On Unix it also kills the dedicated process group

--- a/TreeDB/docs/spec/vector-partition-m2.md
+++ b/TreeDB/docs/spec/vector-partition-m2.md
@@ -25,7 +25,10 @@ publish a forged metric report.
 The usable optional external adapter (`RunExternalJSONForSource`) is offline
 only; the unbound `RunExternalJSON` deliberately errors. It receives
 an explicit command, private input/output paths, context cancellation, a
-fully bound expected source snapshot, and an output-byte cap. It removes the
+fully bound expected source snapshot, and independent request/output-byte
+caps. The default request cap is derived from bounded M2 graph ordinals and
+ID serialization; callers may set a smaller request cap without inflating the
+output cap. It removes the
 entire private temporary directory on command failure, cancellation, timeout,
 malformed output, or success. On Unix it also kills the dedicated process group
 after `Wait`, including when the root exits normally while a same-group child

--- a/TreeDB/docs/spec/vector-partition-m2.md
+++ b/TreeDB/docs/spec/vector-partition-m2.md
@@ -20,7 +20,10 @@ assigns every ordinal exactly once while enforcing
 checks canonical IDs, graph ordinals/self/duplicates/degree, assignment range,
 coverage, cap, and recomputed metrics. `DecodeArtifact` additionally rejects
 oversized, unknown-field, trailing, and non-canonical JSON; a backend cannot
-publish a forged metric report.
+publish a forged metric report. Every graph row is an array: zero-degree rows
+are encoded as `[]`, never `null`; strict decoding rejects `null` rather than
+normalizing it. This structural rule keeps canonical request binding and
+artifact digests stable for isolated vectors.
 
 The usable optional external adapter (`RunExternalJSONForRequestWithLimits`) is
 offline only; source-only and unbound entrypoints deliberately error because

--- a/TreeDB/docs/spec/vector-partition-m2.md
+++ b/TreeDB/docs/spec/vector-partition-m2.md
@@ -64,10 +64,10 @@ host. They are offline quality/resource evidence, not a server speed claim:
 |---|---:|---:|---:|---:|---:|---:|
 | 10k x 64, r4/d16/leaf128, 16 parts, 2 probes | 1.560s | 36.2 MB | 95.59 | 0.900 | 0.594 / 0.163 | 1.0512 |
 | 100k x 16, r2/d8/leaf64, 16 parts, 4 probes | 3.023s | 112.1 MB | 64.62 | 0.775 | 0.475 / 0.250 | 1.0048 |
-| 1M x 16, r2/d8/leaf64, 16 parts, 4 probes | 34.266s | 1.443 GB | 72.47 | 0.794 | 0.300 / 0.100 | 1.000112 |
+| 1M x 16, r2/d8/leaf64, 16 parts, 4 probes | 36.872s CPU 45.743s | 1.325 GB | 72.47 | 0.794 | 0.300 / 0.100 | 1.000112 |
 
 The 1M artifact was
-`/tmp/treedb_m2_build1m_7jEG/vector_partition_9274f9f3d7b900dd.json`
+`/tmp/treedb_m2_build1m_cpu_WYHa/vector_partition_9274f9f3d7b900dd.json`
 (SHA-256 `9274f9f3d7b900dd931881c2ce544b68ac6ddac198008ab307c6b57469f62ec1`);
 the matching report sits beside it. Its deterministic source corpus is
 `/tmp/treedb_m2_export1m_rHdo`, generated with:

--- a/TreeDB/docs/spec/vector-partition-m2.md
+++ b/TreeDB/docs/spec/vector-partition-m2.md
@@ -27,7 +27,11 @@ only; the unbound `RunExternalJSON` deliberately errors. It receives
 an explicit command, private input/output paths, context cancellation, a
 fully bound expected source snapshot, and an output-byte cap. It removes the
 entire private temporary directory on command failure, cancellation, timeout,
-malformed output, or success. No external partitioner is currently selected or
+malformed output, or success. On Unix it also kills the dedicated process group
+after `Wait`, including when the root exits normally while a same-group child
+holds an inherited pipe. A child that deliberately calls `setsid` escapes that
+OS process-group boundary; the portable Go adapter cannot claim containment of
+such hostile descendants. No external partitioner is currently selected or
 required.
 
 ## Reproducible M0 fixture invocation
@@ -70,38 +74,43 @@ host. They are offline quality/resource evidence, not a server speed claim:
 
 | corpus and builder configuration | wall | peak RSS | artifact bytes/vector | graph recall sample | partition recall@10 / hash | cap/balance |
 |---|---:|---:|---:|---:|---:|---:|
-| 10k x 64, r4/d16/leaf128, 16 parts, 2 probes | build 4.271s / total 4.485s, build/total CPU 4.104/4.296s | 34.2 MB | 95.59 | 0.809 (64 samples) | 0.863 / 0.413 | 1.0512 |
-| 100k x 16, r2/d8/leaf64, 16 parts, 4 probes | build 4.517s / total 5.065s, build/total CPU 4.569/5.133s | 105.1 MB | 64.62 | 0.759 (64 samples) | 1.000 / 0.588 | 1.00608 |
-| 1M x 16, r1/d4/leaf32, 16 parts, 4 probes | build 21.766s / total 25.325s, build/total CPU 22.228/25.862s | 1.123 GB | 44.67 | 0.394 (64 samples) | 1.000 / 0.700 | 1.000000 |
+| 10k x 64, r4/d16/leaf128, 16 parts, 2 probes | build 3.794s / total 3.921s, build/total CPU 3.796/3.928s | 34.6 MB | 95.59 | 0.809 (64 samples) | 0.863 / 0.413 | 1.0512 |
+| 100k x 16, r2/d8/leaf64, 16 parts, 4 probes | build 4.427s / total 4.970s, build/total CPU 4.473/5.029s | 102.5 MB | 64.62 | 0.759 (64 samples) | 1.000 / 0.588 | 1.00608 |
+| 1M x 16, r1/d4/leaf32, 16 parts, 4 probes | build 22.401s / total 27.450s, build/total CPU 22.567/27.283s | 1.220 GB | 44.67 | 0.394 (64 samples) | 1.000 / 0.700 | 1.000000 |
 
 The exact handoff artifacts (artifact then compact report) were:
 
 | corpus | artifact path and SHA-256 | report path |
 |---|---|---|
-| 10k | `/tmp/treedb_m2_final10k4_q8zh/vector_partition_c270226154a4e741.json` `c270226154a4e7410bb4140d63abfe36bebc0d0de9cdbf7c894298225d76c935` | `/tmp/treedb_m2_final10k4_q8zh/vector_partition_report_c270226154a4e741.json` |
-| 100k | `/tmp/treedb_m2_final100k4_FPsO/vector_partition_627778e026d17732.json` `627778e026d177320e4aace2f32883aa1656c1d36f9f5005d1d9e41f55fdc3ae` | `/tmp/treedb_m2_final100k4_FPsO/vector_partition_report_627778e026d17732.json` |
-| 1M | `/tmp/treedb_m2_final1m6_IqbC/vector_partition_f76fba39db8a51fb.json` `f76fba39db8a51fb11b669962b92a97d64956f75a76137cea0e80cbe42d42413` | `/tmp/treedb_m2_final1m6_IqbC/vector_partition_report_f76fba39db8a51fb.json` |
+| 10k | `/tmp/treedb_m2_out10k_final2_a9i1NQ/vector_partition_c270226154a4e741.json` `c270226154a4e7410bb4140d63abfe36bebc0d0de9cdbf7c894298225d76c935` | `/tmp/treedb_m2_out10k_final2_a9i1NQ/vector_partition_report_c270226154a4e741.json` |
+| 100k | `/tmp/treedb_m2_out100k_final2_QEWiPc/vector_partition_627778e026d17732.json` `627778e026d177320e4aace2f32883aa1656c1d36f9f5005d1d9e41f55fdc3ae` | `/tmp/treedb_m2_out100k_final2_QEWiPc/vector_partition_report_627778e026d17732.json` |
+| 1M | `/tmp/treedb_m2_out1m_final2_nJ3Cq0/vector_partition_f76fba39db8a51fb.json` `f76fba39db8a51fb11b669962b92a97d64956f75a76137cea0e80cbe42d42413` | `/tmp/treedb_m2_out1m_final2_nJ3Cq0/vector_partition_report_f76fba39db8a51fb.json` |
 
-These paths are host-local handoff locations, while the manifest/source digest,
+These paths are host-local handoff locations, while the canonical manifest/source digest,
 exact commands, and compact report fields make the run reproducible without
 committing a 45 MB generated artifact.
 The durable reviewer-accessible digest ledger is
 `TreeDB/docs/spec/artifacts/vector-partition-m2-evidence-v1.json`.
+Its `canonical_manifest_digest` is the SHA-256 of `json.Marshal` on the
+decoded typed exporter manifest (including its canonically ordered file map),
+which is the logical manifest binding used in `source_id`; it is explicitly
+not the raw `manifest.json` file-byte hash. The manifest itself lists the raw
+SHA-256 and byte count for every exported corpus file.
 
 The 1M artifact was
-`/tmp/treedb_m2_final1m6_IqbC/vector_partition_f76fba39db8a51fb.json`
+`/tmp/treedb_m2_out1m_final2_nJ3Cq0/vector_partition_f76fba39db8a51fb.json`
 (SHA-256 `f76fba39db8a51fb11b669962b92a97d64956f75a76137cea0e80cbe42d42413`);
 the matching report sits beside it. Its deterministic source corpus is
-`/tmp/treedb_m2_export1m_rHdo`, generated with:
+`/tmp/treedb_m2_dataset1m_final2_1gEVgP`, generated with:
 
 ```sh
 DATASET=$(mktemp -d /tmp/treedb_m2_dataset1m_XXXXXX)
 OUT=$(mktemp -d /tmp/treedb_m2_out1m_XXXXXX)
 GOWORK=off go run ./cmd/treedb_vector_dataset_export \
-  -out "$DATASET" -docs 1000000 -queries 1 -dims 16 -truth-queries 0
+  -out "$DATASET" -docs 1000000 -queries 1 -dims 16 -top-k 10 -truth-queries 0 -json=false
 GOWORK=off go run ./cmd/treedb_vector_partition_build \
   -dataset "$DATASET" -out "$OUT" -partitions 16 -probes 4 -seed 1 \
-  -repetitions 1 -degree 4 -max-leaf-bucket 32
+  -repetitions 1 -pivots 8 -degree 4 -max-leaf-bucket 32 -imbalance 0.05
 ```
 
 The other exact runs were:
@@ -110,17 +119,17 @@ The other exact runs were:
 DATASET_10K=$(mktemp -d /tmp/treedb_m2_dataset10k_XXXXXX)
 OUT_10K=$(mktemp -d /tmp/treedb_m2_out10k_XXXXXX)
 GOWORK=off go run ./cmd/treedb_vector_dataset_export \
-  -out "$DATASET_10K" -docs 10000 -queries 16 -dims 64 -truth-queries 0
+  -out "$DATASET_10K" -docs 10000 -queries 16 -dims 64 -top-k 10 -truth-queries 0 -json=false
 GOWORK=off go run ./cmd/treedb_vector_partition_build \
   -dataset "$DATASET_10K" -out "$OUT_10K" -partitions 16 -probes 2 -seed 1 \
-  -repetitions 4 -degree 16 -max-leaf-bucket 128
+  -repetitions 4 -pivots 8 -degree 16 -max-leaf-bucket 128 -imbalance 0.05
 DATASET_100K=$(mktemp -d /tmp/treedb_m2_dataset100k_XXXXXX)
 OUT_100K=$(mktemp -d /tmp/treedb_m2_out100k_XXXXXX)
 GOWORK=off go run ./cmd/treedb_vector_dataset_export \
-  -out "$DATASET_100K" -docs 100000 -queries 8 -dims 16 -truth-queries 0
+  -out "$DATASET_100K" -docs 100000 -queries 8 -dims 16 -top-k 10 -truth-queries 0 -json=false
 GOWORK=off go run ./cmd/treedb_vector_partition_build \
   -dataset "$DATASET_100K" -out "$OUT_100K" -partitions 16 -probes 4 -seed 1 \
-  -repetitions 2 -degree 8 -max-leaf-bucket 64
+  -repetitions 2 -pivots 8 -degree 8 -max-leaf-bucket 64 -imbalance 0.05
 ```
 
 The reported recall is a true M2 partition oracle: global exact top-10 first
@@ -138,9 +147,9 @@ quality row is therefore scoped to that declared one-query fixed-budget corpus,
 not a population-level claim. The 10k and 100k rows use 16 and 8 deterministic
 query vectors respectively. `FinalBytes` is artifact plus compact provenance
 report bytes; reports no longer embed or print a duplicate artifact payload.
-The final 1M report records load 0.338s, graph build 19.185s, backend
-partition 0.271s, validation 0.812s, quality 1.113s, temporary disk 0 bytes,
-artifact 44,672,391 bytes, report 2,545 bytes, and final output 44,674,936
+The final 1M report records load 0.427s, graph build 19.371s, backend
+partition 0.104s, validation 1.428s, quality 1.096s, temporary disk 0 bytes,
+artifact 44,672,391 bytes, report 2,552 bytes, and final output 44,674,943
 bytes.
 
 Peak RSS is `/proc/self/status` `VmHWM` for the builder process. It includes

--- a/TreeDB/internal/vectorpartition/external_cleanup_other.go
+++ b/TreeDB/internal/vectorpartition/external_cleanup_other.go
@@ -1,0 +1,8 @@
+//go:build !unix
+
+package vectorpartition
+
+import "os/exec"
+
+// Non-Unix platforms retain CommandContext's portable root-process handling.
+func cleanupExternalCommand(cmd *exec.Cmd) {}

--- a/TreeDB/internal/vectorpartition/external_cleanup_unix.go
+++ b/TreeDB/internal/vectorpartition/external_cleanup_unix.go
@@ -1,0 +1,18 @@
+//go:build unix
+
+package vectorpartition
+
+import (
+	"os/exec"
+	"syscall"
+)
+
+// cleanupExternalCommand is intentionally called after Wait on every result.
+// A child may still hold an inherited pipe even after the root process exits.
+// A process that deliberately calls setsid escapes this process-group boundary;
+// Go's portable exec API cannot contain that hostile case.
+func cleanupExternalCommand(cmd *exec.Cmd) {
+	if cmd.Process != nil {
+		_ = syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL)
+	}
+}

--- a/TreeDB/internal/vectorpartition/external_cleanup_unix_test.go
+++ b/TreeDB/internal/vectorpartition/external_cleanup_unix_test.go
@@ -5,6 +5,7 @@ package vectorpartition
 import (
 	"context"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -35,16 +36,38 @@ func TestExternalBackendRootExitKillsProcessGroupMember(t *testing.T) {
 	}
 	deadline := time.Now().Add(250 * time.Millisecond)
 	for {
-		err = syscall.Kill(pid, 0)
-		if err == syscall.ESRCH {
+		stopped, probeErr := processStoppedOrZombie(pid)
+		if probeErr != nil {
+			t.Fatalf("probe child pid %d: %v", pid, probeErr)
+		}
+		if stopped {
 			return
 		}
-		if err != nil {
-			t.Fatalf("probe child pid %d: %v", pid, err)
-		}
 		if time.Now().After(deadline) {
-			t.Fatalf("root-exited descendant %d still alive after process-group cleanup", pid)
+			t.Fatalf("root-exited descendant %d still running after process-group cleanup", pid)
 		}
 		time.Sleep(5 * time.Millisecond)
 	}
+}
+
+// processStoppedOrZombie distinguishes an executing orphan from a process
+// already stopped by SIGKILL but awaiting reaping by PID 1. kill(pid, 0) alone
+// reports both as extant. POSIX ps exposes the process state across supported
+// Unix test targets; a Z state proves the descendant is no longer running.
+func processStoppedOrZombie(pid int) (bool, error) {
+	if err := syscall.Kill(pid, 0); err != nil {
+		if err == syscall.ESRCH {
+			return true, nil
+		}
+		return false, err
+	}
+	out, err := exec.Command("ps", "-o", "stat=", "-p", strconv.Itoa(pid)).Output()
+	if err != nil {
+		if _, ok := err.(*exec.ExitError); ok {
+			return true, nil
+		}
+		return false, err
+	}
+	state := strings.TrimSpace(string(out))
+	return state == "" || strings.HasPrefix(state, "Z"), nil
 }

--- a/TreeDB/internal/vectorpartition/external_cleanup_unix_test.go
+++ b/TreeDB/internal/vectorpartition/external_cleanup_unix_test.go
@@ -1,0 +1,50 @@
+//go:build unix
+
+package vectorpartition
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+)
+
+func TestExternalBackendRootExitKillsProcessGroupMember(t *testing.T) {
+	root := t.TempDir()
+	pidDir := t.TempDir()
+	pidFile := filepath.Join(pidDir, "child.pid")
+	t.Setenv("TMPDIR", root)
+	t.Setenv("TREE_DB_CHILD_PID", pidFile)
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	_, err := RunExternalJSONForSource(ctx, []string{"sh", "-c", "printf '{' > \"$1\"; (sleep 5) & echo $! > \"$TREE_DB_CHILD_PID\"; exit 0"}, []byte("{}"), 1024, Source{SourceID: "expected", Checksum: strings.Repeat("0", 64), Vectors: 1, Dimensions: 1, Metric: "cosine"})
+	if err == nil {
+		t.Fatal("root-exited backend accepted")
+	}
+	raw, readErr := os.ReadFile(pidFile)
+	if readErr != nil {
+		t.Fatal(readErr)
+	}
+	pid, parseErr := strconv.Atoi(strings.TrimSpace(string(raw)))
+	if parseErr != nil || pid < 1 {
+		t.Fatalf("invalid child pid %q: %v", raw, parseErr)
+	}
+	deadline := time.Now().Add(250 * time.Millisecond)
+	for {
+		err = syscall.Kill(pid, 0)
+		if err == syscall.ESRCH {
+			return
+		}
+		if err != nil {
+			t.Fatalf("probe child pid %d: %v", pid, err)
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("root-exited descendant %d still alive after process-group cleanup", pid)
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+}

--- a/TreeDB/internal/vectorpartition/external_cleanup_unix_test.go
+++ b/TreeDB/internal/vectorpartition/external_cleanup_unix_test.go
@@ -22,7 +22,15 @@ func TestExternalBackendRootExitKillsProcessGroupMember(t *testing.T) {
 	t.Setenv("TREE_DB_CHILD_PID", pidFile)
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
-	_, err := RunExternalJSONForSource(ctx, []string{"sh", "-c", "printf '{' > \"$1\"; (sleep 5) & echo $! > \"$TREE_DB_CHILD_PID\"; exit 0"}, []byte("{}"), 1024, Source{SourceID: "expected", Checksum: strings.Repeat("0", 64), Vectors: 1, Dimensions: 1, Metric: "cosine"})
+	request, buildErr := Build(fixture(), config())
+	if buildErr != nil {
+		t.Fatal(buildErr)
+	}
+	requestRaw, marshalErr := CanonicalJSON(request)
+	if marshalErr != nil {
+		t.Fatal(marshalErr)
+	}
+	_, err := RunExternalJSONForRequestWithLimits(ctx, []string{"sh", "-c", "printf '{' > \"$1\"; (sleep 5) & echo $! > \"$TREE_DB_CHILD_PID\"; exit 0"}, requestRaw, ExternalJSONLimits{MaxInput: len(requestRaw), MaxOutput: 1024}, request)
 	if err == nil {
 		t.Fatal("root-exited backend accepted")
 	}

--- a/TreeDB/internal/vectorpartition/external_process_other.go
+++ b/TreeDB/internal/vectorpartition/external_process_other.go
@@ -1,0 +1,12 @@
+//go:build !unix
+
+package vectorpartition
+
+import (
+	"os/exec"
+	"time"
+)
+
+// Windows and other platforms retain CommandContext's portable process kill;
+// WaitDelay still bounds descendant-held pipe cleanup.
+func configureExternalCommand(cmd *exec.Cmd) { cmd.WaitDelay = 100 * time.Millisecond }

--- a/TreeDB/internal/vectorpartition/external_process_unix.go
+++ b/TreeDB/internal/vectorpartition/external_process_unix.go
@@ -9,7 +9,7 @@ import (
 )
 
 // configureExternalCommand places the backend in its own process group. A
-// context timeout therefore terminates descendants which retain inherited I/O
+// context timeout terminates members of that group which retain inherited I/O
 // pipes, while WaitDelay bounds any remaining pipe-drain wait.
 func configureExternalCommand(cmd *exec.Cmd) {
 	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}

--- a/TreeDB/internal/vectorpartition/external_process_unix.go
+++ b/TreeDB/internal/vectorpartition/external_process_unix.go
@@ -1,0 +1,23 @@
+//go:build unix
+
+package vectorpartition
+
+import (
+	"os/exec"
+	"syscall"
+	"time"
+)
+
+// configureExternalCommand places the backend in its own process group. A
+// context timeout therefore terminates descendants which retain inherited I/O
+// pipes, while WaitDelay bounds any remaining pipe-drain wait.
+func configureExternalCommand(cmd *exec.Cmd) {
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	cmd.WaitDelay = 100 * time.Millisecond
+	cmd.Cancel = func() error {
+		if cmd.Process == nil {
+			return nil
+		}
+		return syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL)
+	}
+}

--- a/TreeDB/internal/vectorpartition/vectorpartition.go
+++ b/TreeDB/internal/vectorpartition/vectorpartition.go
@@ -400,6 +400,9 @@ func validateInput(v []Vector, dimensions int) error {
 
 // ValidateConfig validates bounded offline builder options before corpus I/O.
 func ValidateConfig(c Config) error {
+	if c.Symmetric {
+		return errors.New("symmetric graph policy is not supported")
+	}
 	if c.Metric != "cosine" || c.Repetitions < 1 || c.Repetitions > maxRepetitions || c.Pivots < 2 || c.Pivots > maxPivots || c.MaxLeafBucket < 2 || c.MaxLeafBucket > maxLeafBucket || c.Degree < 1 || c.Degree > maxDegree || c.Partitions < 1 || c.Partitions > maxPartitions || !finite(c.Imbalance) || c.Imbalance < 0 || c.Imbalance > 1 || c.MaxVectors < 1 || c.MaxVectors > maxVectors || c.MaxEdges < 1 || c.MaxEdges > maxEdges {
 		return errors.New("invalid vector partition configuration")
 	}
@@ -494,9 +497,6 @@ func buildGraph(v []Vector, c Config) (Graph, error) {
 		if len(g.Neighbors[i]) > c.Degree {
 			g.Neighbors[i] = g.Neighbors[i][:c.Degree]
 		}
-	}
-	if c.Symmetric {
-		return Graph{}, errors.New("symmetric graph policy is not supported by bounded reference backend")
 	}
 	return g, nil
 }
@@ -867,9 +867,6 @@ func ValidateArtifact(a Artifact) error {
 	if err := validateGraph(a.Graph, len(a.IDs), a.Config.Degree); err != nil {
 		return err
 	}
-	if a.Config.Symmetric {
-		return errors.New("symmetric graph policy is not supported")
-	}
 	var totalIDBytes int
 	for i, id := range a.IDs {
 		if id == "" || !utf8.ValidString(id) || i > 0 && id <= a.IDs[i-1] {
@@ -913,6 +910,9 @@ func validateAssignment(assignment []int, n int, c Config) ([]int, error) {
 	return loads, nil
 }
 func validateArtifactConfig(ids []string, c Config) error {
+	if c.Symmetric {
+		return errors.New("symmetric graph policy is not supported")
+	}
 	if c.Metric != "cosine" || c.Repetitions < 1 || c.Repetitions > maxRepetitions || c.Pivots < 2 || c.Pivots > maxPivots || c.MaxLeafBucket < 2 || c.MaxLeafBucket > maxLeafBucket || c.Degree < 1 || c.Degree > maxDegree || c.Partitions < 1 || c.Partitions > maxPartitions || !finite(c.Imbalance) || c.Imbalance < 0 || c.Imbalance > 1 || c.MaxVectors < 1 || c.MaxVectors > maxVectors || c.MaxEdges < 1 || c.MaxEdges > maxEdges || len(ids) < c.Partitions || len(ids) > c.MaxVectors {
 		return errors.New("invalid artifact configuration")
 	}

--- a/TreeDB/internal/vectorpartition/vectorpartition.go
+++ b/TreeDB/internal/vectorpartition/vectorpartition.go
@@ -146,6 +146,11 @@ func BuildWithPartitionerPhased(vectors []Vector, cfg Config, source Source, bac
 	if err := validateInput(vectors, cfg); err != nil {
 		return Artifact{}, phases, err
 	}
+	if isReferencePartitioner(backend) {
+		if err := ValidateReferenceInputShape(cfg, len(vectors), len(vectors[0].Values)); err != nil {
+			return Artifact{}, phases, err
+		}
+	}
 	v := append([]Vector(nil), vectors...)
 	sort.Slice(v, func(i, j int) bool { return v[i].ID < v[j].ID })
 	for i := 1; i < len(v); i++ {
@@ -331,10 +336,25 @@ func ValidateInputShape(c Config, vectors, dimensions int) error {
 	return nil
 }
 
-// graphDistanceWorkExceeds accounts for the shape-fixed first-carve pivot
-// comparisons and the worst bounded leaf comparisons in every repetition.
-// Recursive carve work is geometry-dependent and remains guarded by
-// distanceBudget at runtime.
+// ValidateReferenceInputShape adds the repository reference partitioner's
+// deterministic work cap to the graph/input shape checks. Other backends may
+// have distinct work contracts and are intentionally not charged this bound.
+func ValidateReferenceInputShape(c Config, vectors, dimensions int) error {
+	if err := ValidateInputShape(c, vectors, dimensions); err != nil {
+		return err
+	}
+	if partitionWorkExceeded(vectors, c.Partitions, c.Degree) {
+		return errors.New("partition work bound exceeded before allocation")
+	}
+	return nil
+}
+
+// graphDistanceWorkExceeds accounts for every shape-fixed graph phase: the
+// first-carve pivot comparisons, plus the bounded leaf comparisons. At depth
+// zero carveDepth deliberately puts each vector in both its closest and
+// second-closest bucket, so two leaf memberships are possible whenever there
+// are at least two top-level pivots. Recursive carve work is
+// geometry-dependent and remains guarded by distanceBudget at runtime.
 func graphDistanceWorkExceeds(c Config, vectors, dimensions int) bool {
 	topLevelPivots := 0
 	if vectors > c.MaxLeafBucket {
@@ -344,8 +364,13 @@ func graphDistanceWorkExceeds(c Config, vectors, dimensions int) bool {
 		return true
 	}
 	topLevelPivotWork := int64(vectors) * int64(topLevelPivots) * int64(c.Repetitions) * int64(dimensions)
+	topLevelMemberships := 1
+	if topLevelPivots >= 2 {
+		// carveDepth adds the closest and second-closest top-level bucket.
+		topLevelMemberships = 2
+	}
 	leafComparisons := max(0, min(c.MaxLeafBucket, vectors)-1)
-	return exceedsProduct(maxDistanceWork-topLevelPivotWork, int64(vectors), int64(leafComparisons), int64(c.Repetitions), int64(dimensions))
+	return exceedsProduct(maxDistanceWork-topLevelPivotWork, int64(vectors), int64(topLevelMemberships), int64(leafComparisons), int64(c.Repetitions), int64(dimensions))
 }
 func finite(x float64) bool { return !math.IsNaN(x) && !math.IsInf(x, 0) }
 

--- a/TreeDB/internal/vectorpartition/vectorpartition.go
+++ b/TreeDB/internal/vectorpartition/vectorpartition.go
@@ -20,6 +20,7 @@ import (
 	"path/filepath"
 	"sort"
 	"strings"
+	"time"
 )
 
 const (
@@ -85,6 +86,11 @@ type Source struct {
 	Dimensions int    `json:"dimensions"`
 	Metric     string `json:"metric"`
 }
+type PhaseMetrics struct {
+	GraphBuildNanos       int64
+	BackendPartitionNanos int64
+	ValidationNanos       int64
+}
 type Artifact struct {
 	SchemaVersion  int      `json:"schema_version"`
 	Backend        string   `json:"backend"`
@@ -117,27 +123,36 @@ func Build(vectors []Vector, cfg Config) (Artifact, error) {
 // partitioner's result is never trusted: graph, assignment, source and metrics
 // are independently validated before the artifact is returned.
 func BuildWithPartitioner(vectors []Vector, cfg Config, source Source, backend Partitioner) (Artifact, error) {
+	a, _, err := BuildWithPartitionerPhased(vectors, cfg, source, backend)
+	return a, err
+}
+func BuildWithPartitionerPhased(vectors []Vector, cfg Config, source Source, backend Partitioner) (Artifact, PhaseMetrics, error) {
+	var phases PhaseMetrics
 	if backend == nil || backend.Name() == "" || backend.License() == "" || len(backend.License()) > 1024 {
-		return Artifact{}, errors.New("partition backend identity is required")
+		return Artifact{}, phases, errors.New("partition backend identity is required")
 	}
 	if err := validateInput(vectors, cfg); err != nil {
-		return Artifact{}, err
+		return Artifact{}, phases, err
 	}
 	v := append([]Vector(nil), vectors...)
 	sort.Slice(v, func(i, j int) bool { return v[i].ID < v[j].ID })
 	for i := 1; i < len(v); i++ {
 		if v[i].ID == v[i-1].ID {
-			return Artifact{}, fmt.Errorf("duplicate vector ID %q", v[i].ID)
+			return Artifact{}, phases, fmt.Errorf("duplicate vector ID %q", v[i].ID)
 		}
 	}
+	started := time.Now()
 	g, err := buildGraph(v, cfg)
+	phases.GraphBuildNanos = time.Since(started).Nanoseconds()
 	if err != nil {
-		return Artifact{}, err
+		return Artifact{}, phases, err
 	}
 	cap := partitionCap(len(v), cfg.Partitions, cfg.Imbalance)
+	started = time.Now()
 	a, err := backend.Partition(g, cfg.Partitions, cap)
+	phases.BackendPartitionNanos = time.Since(started).Nanoseconds()
 	if err != nil {
-		return Artifact{}, err
+		return Artifact{}, phases, err
 	}
 	ids := make([]string, len(v))
 	for i := range v {
@@ -145,14 +160,17 @@ func BuildWithPartitioner(vectors []Vector, cfg Config, source Source, backend P
 	}
 	computed := sourceFor(v, cfg.Metric, source.SourceID)
 	if source.Checksum != "" && source != computed {
-		return Artifact{}, errors.New("source identity does not match input snapshot")
+		return Artifact{}, phases, errors.New("source identity does not match input snapshot")
 	}
 	art := Artifact{SchemaVersion: SchemaVersion, Backend: backend.Name(), BackendLicense: backend.License(), Source: computed, Config: cfg, IDs: ids, Graph: g, Assignment: a}
 	art.Metrics = metrics(art)
+	started = time.Now()
 	if err := ValidateArtifact(art); err != nil {
-		return Artifact{}, err
+		phases.ValidationNanos = time.Since(started).Nanoseconds()
+		return Artifact{}, phases, err
 	}
-	return art, nil
+	phases.ValidationNanos = time.Since(started).Nanoseconds()
+	return art, phases, nil
 }
 
 func sourceFor(v []Vector, metric, id string) Source {

--- a/TreeDB/internal/vectorpartition/vectorpartition.go
+++ b/TreeDB/internal/vectorpartition/vectorpartition.go
@@ -22,6 +22,7 @@ import (
 	"sort"
 	"strings"
 	"time"
+	"unicode/utf8"
 )
 
 const (
@@ -277,7 +278,7 @@ func validateInput(v []Vector, c Config) error {
 	dims := 0
 	totalIDBytes := 0
 	for _, x := range v {
-		if x.ID == "" || len(x.ID) > maxIDBytes || totalIDBytes > maxTotalIDBytes-len(x.ID) {
+		if x.ID == "" || !utf8.ValidString(x.ID) || len(x.ID) > maxIDBytes || totalIDBytes > maxTotalIDBytes-len(x.ID) {
 			return errors.New("empty vector ID")
 		}
 		totalIDBytes += len(x.ID)
@@ -324,10 +325,27 @@ func ValidateInputShape(c Config, vectors, dimensions int) error {
 	if int64(vectors)*int64(c.Degree) > int64(c.MaxEdges) || int64(vectors)*int64(c.Degree) > int64(c.MaxEdges)/int64(c.Repetitions) {
 		return errors.New("configured graph edge bound exceeded before allocation")
 	}
-	if exceedsProduct(maxDistanceWork, int64(vectors), int64(c.MaxLeafBucket), int64(c.Repetitions), int64(dimensions)) {
+	if graphDistanceWorkExceeds(c, vectors, dimensions) {
 		return errors.New("configured graph scalar-work bound exceeded before allocation")
 	}
 	return nil
+}
+
+// graphDistanceWorkExceeds accounts for the shape-fixed first-carve pivot
+// comparisons and the worst bounded leaf comparisons in every repetition.
+// Recursive carve work is geometry-dependent and remains guarded by
+// distanceBudget at runtime.
+func graphDistanceWorkExceeds(c Config, vectors, dimensions int) bool {
+	topLevelPivots := 0
+	if vectors > c.MaxLeafBucket {
+		topLevelPivots = min(c.Pivots, vectors)
+	}
+	if exceedsProduct(maxDistanceWork, int64(vectors), int64(topLevelPivots), int64(c.Repetitions), int64(dimensions)) {
+		return true
+	}
+	topLevelPivotWork := int64(vectors) * int64(topLevelPivots) * int64(c.Repetitions) * int64(dimensions)
+	leafComparisons := max(0, min(c.MaxLeafBucket, vectors)-1)
+	return exceedsProduct(maxDistanceWork-topLevelPivotWork, int64(vectors), int64(leafComparisons), int64(c.Repetitions), int64(dimensions))
 }
 func finite(x float64) bool { return !math.IsNaN(x) && !math.IsInf(x, 0) }
 
@@ -734,7 +752,7 @@ func ValidateArtifact(a Artifact) error {
 	}
 	var totalIDBytes int
 	for i, id := range a.IDs {
-		if id == "" || i > 0 && id <= a.IDs[i-1] {
+		if id == "" || !utf8.ValidString(id) || i > 0 && id <= a.IDs[i-1] {
 			return errors.New("IDs not unique canonical order")
 		}
 		if len(id) > maxIDBytes || totalIDBytes > maxTotalIDBytes-len(id) {

--- a/TreeDB/internal/vectorpartition/vectorpartition.go
+++ b/TreeDB/internal/vectorpartition/vectorpartition.go
@@ -705,8 +705,8 @@ func ValidateArtifact(a Artifact) error {
 	if err := validateGraph(a.Graph, len(a.IDs), a.Config.Degree); err != nil {
 		return err
 	}
-	if a.Config.Symmetric && !hasReciprocalEdges(a.Graph) {
-		return errors.New("symmetric graph has non-reciprocal edge")
+	if a.Config.Symmetric {
+		return errors.New("symmetric graph policy is not supported")
 	}
 	var totalIDBytes int
 	for i, id := range a.IDs {
@@ -749,16 +749,6 @@ func validateAssignment(assignment []int, n int, c Config) ([]int, error) {
 		}
 	}
 	return loads, nil
-}
-func hasReciprocalEdges(g Graph) bool {
-	for i, ns := range g.Neighbors {
-		for _, j := range ns {
-			if at := sort.SearchInts(g.Neighbors[j], i); at == len(g.Neighbors[j]) || g.Neighbors[j][at] != i {
-				return false
-			}
-		}
-	}
-	return true
 }
 func validateArtifactConfig(ids []string, c Config) error {
 	if c.Metric != "cosine" || c.Repetitions < 1 || c.Repetitions > maxRepetitions || c.Pivots < 2 || c.Pivots > maxPivots || c.MaxLeafBucket < 2 || c.MaxLeafBucket > maxLeafBucket || c.Degree < 1 || c.Degree > maxDegree || c.Partitions < 1 || c.Partitions > maxPartitions || !finite(c.Imbalance) || c.Imbalance < 0 || c.Imbalance > 1 || c.MaxVectors < 1 || c.MaxVectors > maxVectors || c.MaxEdges < 1 || c.MaxEdges > maxEdges || len(ids) < c.Partitions || len(ids) > c.MaxVectors {

--- a/TreeDB/internal/vectorpartition/vectorpartition.go
+++ b/TreeDB/internal/vectorpartition/vectorpartition.go
@@ -485,17 +485,21 @@ func (ReferencePartitioner) Partition(g Graph, parts, cap int) ([]int, error) {
 	if err := validateGraph(g, n, maxVectors); err != nil {
 		return nil, err
 	}
-	if partitionWorkExceeded(n, parts, maxGraphDegree(g)) {
+	degree := maxGraphDegree(g)
+	if partitionWorkExceeded(n, parts, degree) {
 		return nil, errors.New("partition work bound exceeded before allocation")
 	}
-	order := make([]int, n)
-	for i := range order {
-		order[i] = i
+	// Degree is bounded, so bucket ordering is a deterministic O(n+degree)
+	// replacement for comparison sorting: each ordinal enters exactly one bucket
+	// and ascending insertion order supplies the ordinal tie-break.
+	buckets := make([][]int, degree+1)
+	for node, ns := range g.Neighbors {
+		buckets[len(ns)] = append(buckets[len(ns)], node)
 	}
-	sort.Slice(order, func(i, j int) bool {
-		a, b := order[i], order[j]
-		return len(g.Neighbors[a]) > len(g.Neighbors[b]) || len(g.Neighbors[a]) == len(g.Neighbors[b]) && a < b
-	})
+	order := make([]int, 0, n)
+	for d := degree; d >= 0; d-- {
+		order = append(order, buckets[d]...)
+	}
 	out := make([]int, n)
 	for i := range out {
 		out[i] = -1
@@ -568,14 +572,10 @@ func maxGraphDegree(g Graph) int {
 }
 func partitionWorkExceeded(n, parts, degree int) bool {
 	// Account for validateGraph and maxGraphDegree scans (two degree scans),
-	// the initial degree sort (provable O(n log2 n) comparison ceiling), and
-	// each node's partition scan, candidate-mark pass, and affinity scans.
-	// Scratch indexing removes hidden duplicate-search/sort work.
-	logN := int64(0)
-	for x := n; x > 1; x = (x + 1) / 2 {
-		logN++
-	}
-	perNode := 2*int64(degree+1) + int64(parts) + int64(degree) + int64(degree)*int64(degree+1) + logN
+	// bounded degree-bucket construction/order (two node operations), and each
+	// node's partition scan, candidate-mark pass, and affinity scans. No
+	// comparison sort remains, so every charged term is an explicit loop bound.
+	perNode := 2*int64(degree+1) + 2 + int64(parts) + int64(degree) + int64(degree)*int64(degree+1)
 	return exceedsProduct(maxPartitionWork, int64(n), perNode)
 }
 func exceedsProduct(limit int64, values ...int64) bool {

--- a/TreeDB/internal/vectorpartition/vectorpartition.go
+++ b/TreeDB/internal/vectorpartition/vectorpartition.go
@@ -567,14 +567,15 @@ func maxGraphDegree(g Graph) int {
 	return max
 }
 func partitionWorkExceeded(n, parts, degree int) bool {
-	// Account for the initial degree sort plus each node's partition scan,
-	// candidate-mark pass, and affinity scans. Scratch indexing removes hidden
-	// duplicate-search/sort work from the candidate path.
+	// Account for validateGraph and maxGraphDegree scans (two degree scans),
+	// the initial degree sort (provable O(n log2 n) comparison ceiling), and
+	// each node's partition scan, candidate-mark pass, and affinity scans.
+	// Scratch indexing removes hidden duplicate-search/sort work.
 	logN := int64(0)
 	for x := n; x > 1; x = (x + 1) / 2 {
 		logN++
 	}
-	perNode := int64(parts) + int64(degree) + int64(degree)*int64(degree+1) + logN
+	perNode := 2*int64(degree+1) + int64(parts) + int64(degree) + int64(degree)*int64(degree+1) + logN
 	return exceedsProduct(maxPartitionWork, int64(n), perNode)
 }
 func exceedsProduct(limit int64, values ...int64) bool {

--- a/TreeDB/internal/vectorpartition/vectorpartition.go
+++ b/TreeDB/internal/vectorpartition/vectorpartition.go
@@ -19,6 +19,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"sort"
+	"strings"
 )
 
 const (
@@ -100,11 +101,13 @@ type Artifact struct {
 // ordinals only; ValidateArtifact independently verifies every invariant.
 type Partitioner interface {
 	Name() string
+	License() string
 	Partition(Graph, int, int) ([]int, error)
 }
 type ReferencePartitioner struct{}
 
-func (ReferencePartitioner) Name() string { return "treedb_reference_greedy_v1" }
+func (ReferencePartitioner) Name() string    { return "treedb_reference_greedy_v1" }
+func (ReferencePartitioner) License() string { return "TreeDB repository license" }
 
 func Build(vectors []Vector, cfg Config) (Artifact, error) {
 	return BuildWithPartitioner(vectors, cfg, Source{SourceID: "inline_vectors_v1"}, ReferencePartitioner{})
@@ -114,7 +117,7 @@ func Build(vectors []Vector, cfg Config) (Artifact, error) {
 // partitioner's result is never trusted: graph, assignment, source and metrics
 // are independently validated before the artifact is returned.
 func BuildWithPartitioner(vectors []Vector, cfg Config, source Source, backend Partitioner) (Artifact, error) {
-	if backend == nil || backend.Name() == "" {
+	if backend == nil || backend.Name() == "" || backend.License() == "" || len(backend.License()) > 1024 {
 		return Artifact{}, errors.New("partition backend identity is required")
 	}
 	if err := validateInput(vectors, cfg); err != nil {
@@ -144,7 +147,7 @@ func BuildWithPartitioner(vectors []Vector, cfg Config, source Source, backend P
 	if source.Checksum != "" && source != computed {
 		return Artifact{}, errors.New("source identity does not match input snapshot")
 	}
-	art := Artifact{SchemaVersion: SchemaVersion, Backend: backend.Name(), BackendLicense: "TreeDB clean-room reference implementation (repository license)", Source: computed, Config: cfg, IDs: ids, Graph: g, Assignment: a}
+	art := Artifact{SchemaVersion: SchemaVersion, Backend: backend.Name(), BackendLicense: backend.License(), Source: computed, Config: cfg, IDs: ids, Graph: g, Assignment: a}
 	art.Metrics = metrics(art)
 	if err := ValidateArtifact(art); err != nil {
 		return Artifact{}, err
@@ -155,9 +158,16 @@ func BuildWithPartitioner(vectors []Vector, cfg Config, source Source, backend P
 func sourceFor(v []Vector, metric, id string) Source {
 	h := sha256.New()
 	var b [8]byte
+	binary.BigEndian.PutUint64(b[:], uint64(len(v)))
+	h.Write(b[:])
+	binary.BigEndian.PutUint64(b[:], uint64(len(v[0].Values)))
+	h.Write(b[:])
+	h.Write([]byte(metric))
+	h.Write([]byte{0})
 	for _, x := range v {
+		binary.BigEndian.PutUint64(b[:], uint64(len(x.ID)))
+		h.Write(b[:])
 		h.Write([]byte(x.ID))
-		h.Write([]byte{0})
 		for _, f := range x.Values {
 			binary.BigEndian.PutUint64(b[:], math.Float64bits(f))
 			h.Write(b[:])
@@ -424,7 +434,7 @@ func stableIDPartition(id string, partitions int) int {
 }
 
 func ValidateArtifact(a Artifact) error {
-	if a.SchemaVersion != SchemaVersion || a.Backend == "" || len(a.Backend) > 256 || a.BackendLicense == "" || len(a.BackendLicense) > 1024 || a.Source.SourceID == "" || len(a.Source.SourceID) > 1024 || len(a.Source.Checksum) != 64 || a.Source.Vectors != len(a.IDs) || a.Source.Dimensions < 1 || a.Source.Metric != a.Config.Metric || len(a.IDs) == 0 || len(a.IDs) != len(a.Graph.Neighbors) || len(a.IDs) != len(a.Assignment) {
+	if a.SchemaVersion != SchemaVersion || a.Backend == "" || len(a.Backend) > 256 || a.BackendLicense == "" || len(a.BackendLicense) > 1024 || a.Source.SourceID == "" || len(a.Source.SourceID) > 1024 || len(a.Source.Checksum) != 64 || strings.ToLower(a.Source.Checksum) != a.Source.Checksum || a.Source.Vectors != len(a.IDs) || a.Source.Dimensions < 1 || a.Source.Metric != a.Config.Metric || len(a.IDs) == 0 || len(a.IDs) != len(a.Graph.Neighbors) || len(a.IDs) != len(a.Assignment) {
 		return errors.New("malformed partition artifact")
 	}
 	if err := validateInput(makeVectors(a.IDs, a.Graph.Neighbors), a.Config); err != nil {
@@ -449,7 +459,7 @@ func ValidateArtifact(a Artifact) error {
 		return errors.New("invalid source checksum")
 	}
 	for _, n := range loads {
-		if n > cap {
+		if n == 0 || n > cap {
 			return errors.New("partition cap exceeded")
 		}
 	}
@@ -523,10 +533,26 @@ func DecodeArtifact(raw []byte, maxBytes int) (Artifact, error) {
 	return a, nil
 }
 
+// DecodeArtifactForSource additionally binds untrusted backend output to the
+// source snapshot supplied by the caller.
+func DecodeArtifactForSource(raw []byte, maxBytes int, expected Source) (Artifact, error) {
+	a, err := DecodeArtifact(raw, maxBytes)
+	if err != nil {
+		return Artifact{}, err
+	}
+	if a.Source != expected {
+		return Artifact{}, errors.New("backend artifact source does not match expected snapshot")
+	}
+	return a, nil
+}
+
 // RunExternalJSON is an optional offline adapter seam. It never becomes a
 // TreeDB runtime dependency. Its output is written to a private temp path and
 // removed on cancellation, timeout, command failure, or invalid output.
 func RunExternalJSON(ctx context.Context, command []string, input []byte, maxOutput int) (Artifact, error) {
+	return RunExternalJSONForSource(ctx, command, input, maxOutput, Source{})
+}
+func RunExternalJSONForSource(ctx context.Context, command []string, input []byte, maxOutput int, expected Source) (Artifact, error) {
 	if ctx == nil {
 		return Artifact{}, errors.New("external backend requires context deadline")
 	}
@@ -566,6 +592,9 @@ func RunExternalJSON(ctx context.Context, command []string, input []byte, maxOut
 	}
 	if len(raw) > maxOutput {
 		return Artifact{}, errors.New("external partition backend output exceeds cap")
+	}
+	if expected.SourceID != "" {
+		return DecodeArtifactForSource(raw, maxOutput, expected)
 	}
 	return DecodeArtifact(raw, maxOutput)
 }

--- a/TreeDB/internal/vectorpartition/vectorpartition.go
+++ b/TreeDB/internal/vectorpartition/vectorpartition.go
@@ -40,11 +40,63 @@ const (
 	maxDistanceWork  = int64(20_000_000_000) // scalar cosine dimensions
 	maxPartitionWork = int64(250_000_000)
 	maxCarveDepth    = 64
-	// External JSON can carry every bounded graph ordinal (up to nine bytes each
-	// in canonical JSON), all bounded ID bytes, and one bounded per-vector field.
-	// This is a request/output ceiling, separate from a caller's output cap.
-	maxExternalJSONBytes = maxTotalIDBytes + maxEdges*9 + maxVectors*16
 )
+
+const externalJSONFixedSyntaxBytes = 1 << 20
+
+var maxExternalJSONBytes = mustExternalJSONByteBound(maxTotalIDBytes, maxEdges, maxVectors)
+
+// externalJSONByteBound conservatively bounds a serialized M2 graph request or
+// artifact. JSON control bytes may escape to six bytes, so ID, source ID,
+// backend name, and backend license all receive that multiplier. Graph
+// ordinals, per-vector syntax, and a fixed field/syntax reserve are charged
+// separately with checked integer arithmetic.
+func externalJSONByteBound(totalIDBytes, edges, vectors int) (int, bool) {
+	if totalIDBytes < 0 || edges < 0 || vectors < 0 {
+		return 0, false
+	}
+	total := 0
+	add := func(n int) bool {
+		if n < 0 || total > math.MaxInt-n {
+			return false
+		}
+		total += n
+		return true
+	}
+	mul := func(a, b int) (int, bool) {
+		if a < 0 || b < 0 || a != 0 && b > math.MaxInt/a {
+			return 0, false
+		}
+		return a * b, true
+	}
+	escapedIDs, ok := mul(totalIDBytes, 6)
+	if !ok || !add(escapedIDs) {
+		return 0, false
+	}
+	// The largest caller-controlled non-vector identity fields are SourceID,
+	// backend Name, and backend License.
+	escapedIdentities, ok := mul(1024+256+1024, 6)
+	if !ok || !add(escapedIdentities) {
+		return 0, false
+	}
+	graph, ok := mul(edges, 9) // ordinal, comma, and conservative syntax slack
+	if !ok || !add(graph) {
+		return 0, false
+	}
+	perVector, ok := mul(vectors, 32) // IDs/arrays/assignment/metric syntax
+	if !ok || !add(perVector) || !add(externalJSONFixedSyntaxBytes) {
+		return 0, false
+	}
+	return total, true
+}
+
+func mustExternalJSONByteBound(totalIDBytes, edges, vectors int) int {
+	bound, ok := externalJSONByteBound(totalIDBytes, edges, vectors)
+	if !ok {
+		panic("external JSON byte bound overflow")
+	}
+	return bound
+}
 
 // Vector IDs must be unique and are canonically ordered before construction.
 type Vector struct {
@@ -148,7 +200,7 @@ func BuildWithPartitionerPhased(vectors []Vector, cfg Config, source Source, bac
 		return Artifact{}, phases, errors.New("partition backend identity is required")
 	}
 	backendName, backendLicense := backend.Name(), backend.License()
-	if backendName == "" || len(backendName) > 256 || backendLicense == "" || len(backendLicense) > 1024 {
+	if backendName == "" || !utf8.ValidString(backendName) || len(backendName) > 256 || backendLicense == "" || !utf8.ValidString(backendLicense) || len(backendLicense) > 1024 {
 		return Artifact{}, phases, errors.New("partition backend identity is required")
 	}
 	if err := validateRequestedSource(source); err != nil {
@@ -245,7 +297,7 @@ func isReferencePartitioner(backend Partitioner) bool {
 	}
 }
 func validateRequestedSource(s Source) error {
-	if s.SourceID == "" || len(s.SourceID) > 1024 {
+	if s.SourceID == "" || !utf8.ValidString(s.SourceID) || len(s.SourceID) > 1024 {
 		return errors.New("source ID is required")
 	}
 	if s == (Source{SourceID: s.SourceID}) {
@@ -785,7 +837,7 @@ func stableIDPartition(id string, partitions int) int {
 }
 
 func ValidateArtifact(a Artifact) error {
-	if a.SchemaVersion != SchemaVersion || a.Backend == "" || len(a.Backend) > 256 || a.BackendLicense == "" || len(a.BackendLicense) > 1024 || a.Source.SourceID == "" || len(a.Source.SourceID) > 1024 || len(a.Source.Checksum) != 64 || strings.ToLower(a.Source.Checksum) != a.Source.Checksum || a.Source.Vectors != len(a.IDs) || a.Source.Dimensions < 1 || a.Source.Dimensions > maxDimensions || a.Source.Metric != a.Config.Metric || len(a.IDs) == 0 || len(a.IDs) != len(a.Graph.Neighbors) || len(a.IDs) != len(a.Assignment) {
+	if a.SchemaVersion != SchemaVersion || a.Backend == "" || !utf8.ValidString(a.Backend) || len(a.Backend) > 256 || a.BackendLicense == "" || !utf8.ValidString(a.BackendLicense) || len(a.BackendLicense) > 1024 || a.Source.SourceID == "" || !utf8.ValidString(a.Source.SourceID) || len(a.Source.SourceID) > 1024 || len(a.Source.Checksum) != 64 || strings.ToLower(a.Source.Checksum) != a.Source.Checksum || a.Source.Vectors != len(a.IDs) || a.Source.Dimensions < 1 || a.Source.Dimensions > maxDimensions || a.Source.Metric != a.Config.Metric || len(a.IDs) == 0 || len(a.IDs) != len(a.Graph.Neighbors) || len(a.IDs) != len(a.Assignment) {
 		return errors.New("malformed partition artifact")
 	}
 	if err := validateArtifactConfig(a.IDs, a.Config); err != nil {
@@ -889,6 +941,9 @@ func DecodeArtifact(raw []byte, maxBytes int) (Artifact, error) {
 	if maxBytes < 1 || len(raw) > maxBytes {
 		return Artifact{}, errors.New("partition artifact exceeds byte cap")
 	}
+	if !utf8.Valid(raw) {
+		return Artifact{}, errors.New("partition artifact contains invalid UTF-8")
+	}
 	var a Artifact
 	d := json.NewDecoder(bytes.NewReader(raw))
 	d.DisallowUnknownFields()
@@ -915,6 +970,9 @@ func DecodeArtifact(raw []byte, maxBytes int) (Artifact, error) {
 // DecodeArtifactForSource additionally binds untrusted backend output to the
 // source snapshot supplied by the caller.
 func DecodeArtifactForSource(raw []byte, maxBytes int, expected Source) (Artifact, error) {
+	if err := validateExpectedSource(expected); err != nil {
+		return Artifact{}, err
+	}
 	a, err := DecodeArtifact(raw, maxBytes)
 	if err != nil {
 		return Artifact{}, err
@@ -995,7 +1053,7 @@ func RunExternalJSONForSourceWithLimits(ctx context.Context, command []string, i
 }
 
 func validateExpectedSource(s Source) error {
-	if s.SourceID == "" || len(s.SourceID) > 1024 || len(s.Checksum) != 64 || strings.ToLower(s.Checksum) != s.Checksum || s.Vectors < 1 || s.Vectors > maxVectors || s.Dimensions < 1 || s.Dimensions > maxDimensions || s.Metric != "cosine" {
+	if s.SourceID == "" || !utf8.ValidString(s.SourceID) || len(s.SourceID) > 1024 || len(s.Checksum) != 64 || strings.ToLower(s.Checksum) != s.Checksum || s.Vectors < 1 || s.Vectors > maxVectors || s.Dimensions < 1 || s.Dimensions > maxDimensions || s.Metric != "cosine" {
 		return errors.New("invalid expected source binding")
 	}
 	if _, err := hex.DecodeString(s.Checksum); err != nil {

--- a/TreeDB/internal/vectorpartition/vectorpartition.go
+++ b/TreeDB/internal/vectorpartition/vectorpartition.go
@@ -160,7 +160,14 @@ func BuildWithPartitionerPhased(vectors []Vector, cfg Config, source Source, bac
 	}
 	cap := partitionCap(len(v), cfg.Partitions, cfg.Imbalance)
 	started = time.Now()
-	a, err := backend.Partition(g, cfg.Partitions, cap)
+	backendGraph := g
+	if !isReferencePartitioner(backend) {
+		backendGraph, err = cloneGraphBounded(g, cfg.MaxEdges)
+		if err != nil {
+			return Artifact{}, phases, err
+		}
+	}
+	a, err := backend.Partition(backendGraph, cfg.Partitions, cap)
 	phases.BackendPartitionNanos = time.Since(started).Nanoseconds()
 	if err != nil {
 		return Artifact{}, phases, err
@@ -185,6 +192,41 @@ func BuildWithPartitionerPhased(vectors []Vector, cfg Config, source Source, bac
 	}
 	phases.ValidationNanos = time.Since(started).Nanoseconds()
 	return art, phases, nil
+}
+
+// Non-reference in-process backends receive an isolated graph because Graph
+// contains mutable nested slices. The canonical graph remains the one built
+// from vectors and recorded in the artifact. The clone has exact backing
+// storage and is bounded by the already-validated MaxVectors/MaxEdges limits.
+func cloneGraphBounded(g Graph, maxEdges int) (Graph, error) {
+	if len(g.Neighbors) > maxVectors || maxEdges < 0 {
+		return Graph{}, errors.New("backend graph copy exceeds bounds")
+	}
+	total := 0
+	for _, neighbors := range g.Neighbors {
+		if len(neighbors) > maxEdges-total {
+			return Graph{}, errors.New("backend graph copy exceeds edge bound")
+		}
+		total += len(neighbors)
+	}
+	clone := Graph{Neighbors: make([][]int, len(g.Neighbors))}
+	backing := make([]int, total)
+	at := 0
+	for i, neighbors := range g.Neighbors {
+		clone.Neighbors[i] = backing[at : at+len(neighbors) : at+len(neighbors)]
+		copy(clone.Neighbors[i], neighbors)
+		at += len(neighbors)
+	}
+	return clone, nil
+}
+
+func isReferencePartitioner(backend Partitioner) bool {
+	switch backend.(type) {
+	case ReferencePartitioner, *ReferencePartitioner:
+		return true
+	default:
+		return false
+	}
 }
 func validateRequestedSource(s Source) error {
 	if s.SourceID == "" || len(s.SourceID) > 1024 {

--- a/TreeDB/internal/vectorpartition/vectorpartition.go
+++ b/TreeDB/internal/vectorpartition/vectorpartition.go
@@ -494,8 +494,17 @@ func (ReferencePartitioner) Partition(g Graph, parts, cap int) ([]int, error) {
 	}
 	// Degree is bounded, so bucket ordering is a deterministic O(n+degree)
 	// replacement for comparison sorting: each ordinal enters exactly one bucket
-	// and ascending insertion order supplies the ordinal tie-break.
+	// and ascending insertion order supplies the ordinal tie-break. Count first
+	// so every bucket has exact backing capacity: this avoids Go slice-growth
+	// copies and makes the pre-allocation work contract structural.
+	degreeCounts := make([]int, degree+1)
+	for _, ns := range g.Neighbors {
+		degreeCounts[len(ns)]++
+	}
 	buckets := make([][]int, degree+1)
+	for d, count := range degreeCounts {
+		buckets[d] = make([]int, 0, count)
+	}
 	for node, ns := range g.Neighbors {
 		buckets[len(ns)] = append(buckets[len(ns)], node)
 	}
@@ -573,21 +582,20 @@ func partitionWorkUnits(n, parts, degree int) (int64, bool) {
 		return 0, true
 	}
 	// Deliberately overcount every loop/allocation family. Per-node work charges
-	// validation (degree+1); bucket append plus amortized backing growth (2);
-	// order backing zeroing plus append (2); output backing zeroing plus -1
-	// initialization (2); candidate reset (1); assignment/load update (1); the
-	// partition scan; candidate construction including the least-loaded choice
-	// (degree+1); its outer scoring iteration (degree+1); and affinity rescans.
-	// Global setup covers zeroing loads and marks, the reserve pass, and
-	// initialization/iteration/allocation for degree buckets and candidate
-	// backing. An accepted shape therefore stays below this conservative declared
-	// cap even if a future implementation detail adds constant work.
-	perNode := int64(degree+1) + 8 + int64(parts) + 2*int64(degree+1) + int64(degree)*int64(degree+1)
+	// validation (degree+1); the degree-frequency pass (1); exact bucket backing
+	// zeroing and fill (2); order backing zeroing plus append (2); output backing
+	// zeroing plus -1 initialization (2); candidate reset (1); assignment/load
+	// update (1); the partition scan; candidate construction including the
+	// least-loaded choice (degree+1); its outer scoring iteration (degree+1);
+	// and affinity rescans. Global setup covers loads/marks zeroing, reserve,
+	// and degree-count/bucket/order/candidate slice initialization or iteration.
+	// Exact bucket capacities eliminate runtime-dependent slice-growth copies.
+	perNode := int64(degree+1) + 9 + int64(parts) + 2*int64(degree+1) + int64(degree)*int64(degree+1)
 	if int64(n) != 0 && perNode > math.MaxInt64/int64(n) {
 		return 0, true
 	}
 	work := int64(n) * perNode
-	global := 3*int64(parts) + 3*int64(degree+1)
+	global := 3*int64(parts) + 5*int64(degree+1)
 	if global < 0 || work > math.MaxInt64-global {
 		return 0, true
 	}

--- a/TreeDB/internal/vectorpartition/vectorpartition.go
+++ b/TreeDB/internal/vectorpartition/vectorpartition.go
@@ -482,10 +482,13 @@ func (ReferencePartitioner) Partition(g Graph, parts, cap int) ([]int, error) {
 	if parts < 1 || cap < 1 || n < parts {
 		return nil, errors.New("invalid partition request")
 	}
-	if err := validateGraph(g, n, maxVectors); err != nil {
+	if n > maxVectors {
+		return nil, errors.New("partition vector bound exceeded before allocation")
+	}
+	degree, err := validateGraphAndDegree(g, n, maxDegree)
+	if err != nil {
 		return nil, err
 	}
-	degree := maxGraphDegree(g)
 	if partitionWorkExceeded(n, parts, degree) {
 		return nil, errors.New("partition work bound exceeded before allocation")
 	}
@@ -506,7 +509,7 @@ func (ReferencePartitioner) Partition(g Graph, parts, cap int) ([]int, error) {
 	}
 	loads := make([]int, parts)
 	marks := make([]int, parts)
-	candidates := make([]int, 0, maxGraphDegree(g)+1)
+	candidates := make([]int, 0, degree+1)
 	// Reserve one ordinal for each partition before affinity scoring. This
 	// matches ValidateArtifact's exact-coverage invariant even on graphs whose
 	// edges all prefer a small subset of partitions.
@@ -561,22 +564,31 @@ func (ReferencePartitioner) Partition(g Graph, parts, cap int) ([]int, error) {
 	}
 	return out, nil
 }
-func maxGraphDegree(g Graph) int {
-	max := 0
-	for _, ns := range g.Neighbors {
-		if len(ns) > max {
-			max = len(ns)
-		}
-	}
-	return max
-}
 func partitionWorkExceeded(n, parts, degree int) bool {
-	// Account for validateGraph and maxGraphDegree scans (two degree scans),
-	// bounded degree-bucket construction/order (two node operations), and each
-	// node's partition scan, candidate-mark pass, and affinity scans. No
-	// comparison sort remains, so every charged term is an explicit loop bound.
-	perNode := 2*int64(degree+1) + 2 + int64(parts) + int64(degree) + int64(degree)*int64(degree+1)
-	return exceedsProduct(maxPartitionWork, int64(n), perNode)
+	work, overflow := partitionWorkUnits(n, parts, degree)
+	return overflow || work > maxPartitionWork
+}
+func partitionWorkUnits(n, parts, degree int) (int64, bool) {
+	if n < 0 || parts < 0 || degree < 0 {
+		return 0, true
+	}
+	// Deliberately overcount every loop/allocation family. Per-node work covers
+	// validation (degree+1), bucket fill/order, output zeroing/initialization,
+	// candidate reset/assignment, the partition scan, neighbor marking, and
+	// affinity rescans. Global setup covers zeroing loads and marks, the reserve
+	// pass, and initialization/iteration/allocation for degree buckets and the
+	// candidate buffer. An accepted shape therefore stays below this conservative
+	// declared cap even if a future implementation detail adds constant work.
+	perNode := int64(degree+1) + 6 + int64(parts) + int64(degree) + int64(degree)*int64(degree+1)
+	if int64(n) != 0 && perNode > math.MaxInt64/int64(n) {
+		return 0, true
+	}
+	work := int64(n) * perNode
+	global := 3*int64(parts) + 3*int64(degree+1)
+	if global < 0 || work > math.MaxInt64-global {
+		return 0, true
+	}
+	return work + global, false
 }
 func exceedsProduct(limit int64, values ...int64) bool {
 	p := int64(1)
@@ -705,22 +717,30 @@ func validateArtifactConfig(ids []string, c Config) error {
 	return nil
 }
 func validateGraph(g Graph, n, degree int) error {
+	_, err := validateGraphAndDegree(g, n, degree)
+	return err
+}
+func validateGraphAndDegree(g Graph, n, degree int) (int, error) {
 	if len(g.Neighbors) != n {
-		return errors.New("graph node count mismatch")
+		return 0, errors.New("graph node count mismatch")
 	}
+	maxObservedDegree := 0
 	for i, ns := range g.Neighbors {
 		if len(ns) > degree {
-			return errors.New("degree cap exceeded")
+			return 0, errors.New("degree cap exceeded")
+		}
+		if len(ns) > maxObservedDegree {
+			maxObservedDegree = len(ns)
 		}
 		previous := -1
 		for _, j := range ns {
 			if j < 0 || j >= n || j == i || j <= previous {
-				return errors.New("invalid graph edge")
+				return 0, errors.New("invalid graph edge")
 			}
 			previous = j
 		}
 	}
-	return nil
+	return maxObservedDegree, nil
 }
 
 func CanonicalJSON(a Artifact) ([]byte, error) {
@@ -806,7 +826,12 @@ func RunExternalJSONForSource(ctx context.Context, command []string, input []byt
 	configureExternalCommand(cmd)
 	stderr := &cappedBuffer{limit: maxOutput}
 	cmd.Stderr = stderr
-	if e := cmd.Run(); e != nil {
+	e := cmd.Run()
+	// CommandContext only invokes Cancel while the root process is running.
+	// Always clear the private process group after Wait as well, so a root that
+	// exits normally cannot leave a pipe-holding child behind.
+	cleanupExternalCommand(cmd)
+	if e != nil {
 		return Artifact{}, fmt.Errorf("external partition backend: %w: %s", e, bytes.TrimSpace(stderr.Bytes()))
 	}
 	if stderr.exceeded {

--- a/TreeDB/internal/vectorpartition/vectorpartition.go
+++ b/TreeDB/internal/vectorpartition/vectorpartition.go
@@ -266,11 +266,8 @@ func sourceFor(v []Vector, metric, id string) Source {
 }
 
 func validateInput(v []Vector, c Config) error {
-	if c.Metric != "cosine" || c.Repetitions < 1 || c.Repetitions > maxRepetitions || c.Pivots < 2 || c.Pivots > maxPivots || c.MaxLeafBucket < 2 || c.MaxLeafBucket > maxLeafBucket || c.Degree < 1 || c.Degree > maxDegree || c.Partitions < 1 || c.Partitions > maxPartitions || !finite(c.Imbalance) || c.Imbalance < 0 || c.Imbalance > 1 || c.MaxVectors < 1 || c.MaxVectors > maxVectors || c.MaxEdges < 1 || c.MaxEdges > maxEdges {
-		return errors.New("invalid vector partition configuration")
-	}
-	if len(v) < c.Partitions || len(v) > c.MaxVectors {
-		return errors.New("vector count outside configured bounds")
+	if err := ValidateConfig(c); err != nil {
+		return err
 	}
 	dims := 0
 	totalIDBytes := 0
@@ -297,10 +294,32 @@ func validateInput(v []Vector, c Config) error {
 			return errors.New("zero-norm vector")
 		}
 	}
-	if int64(len(v))*int64(c.Degree) > int64(c.MaxEdges) || int64(len(v))*int64(c.Degree) > int64(c.MaxEdges)/int64(c.Repetitions) {
+	return ValidateInputShape(c, len(v), dims)
+}
+
+// ValidateConfig validates bounded offline builder options before corpus I/O.
+func ValidateConfig(c Config) error {
+	if c.Metric != "cosine" || c.Repetitions < 1 || c.Repetitions > maxRepetitions || c.Pivots < 2 || c.Pivots > maxPivots || c.MaxLeafBucket < 2 || c.MaxLeafBucket > maxLeafBucket || c.Degree < 1 || c.Degree > maxDegree || c.Partitions < 1 || c.Partitions > maxPartitions || !finite(c.Imbalance) || c.Imbalance < 0 || c.Imbalance > 1 || c.MaxVectors < 1 || c.MaxVectors > maxVectors || c.MaxEdges < 1 || c.MaxEdges > maxEdges {
+		return errors.New("invalid vector partition configuration")
+	}
+	return nil
+}
+
+// ValidateInputShape checks count-derived graph bounds before vector allocation.
+func ValidateInputShape(c Config, vectors, dimensions int) error {
+	if err := ValidateConfig(c); err != nil {
+		return err
+	}
+	if vectors < c.Partitions || vectors > c.MaxVectors {
+		return errors.New("vector count outside configured bounds")
+	}
+	if dimensions < 1 || dimensions > maxDimensions {
+		return errors.New("invalid vector dimensions")
+	}
+	if int64(vectors)*int64(c.Degree) > int64(c.MaxEdges) || int64(vectors)*int64(c.Degree) > int64(c.MaxEdges)/int64(c.Repetitions) {
 		return errors.New("configured graph edge bound exceeded before allocation")
 	}
-	if exceedsProduct(maxDistanceWork, int64(len(v)), int64(c.MaxLeafBucket), int64(c.Repetitions), int64(dims)) {
+	if exceedsProduct(maxDistanceWork, int64(vectors), int64(c.MaxLeafBucket), int64(c.Repetitions), int64(dimensions)) {
 		return errors.New("configured graph scalar-work bound exceeded before allocation")
 	}
 	return nil

--- a/TreeDB/internal/vectorpartition/vectorpartition.go
+++ b/TreeDB/internal/vectorpartition/vectorpartition.go
@@ -4,15 +4,21 @@
 package vectorpartition
 
 import (
+	"bytes"
+	"context"
 	"crypto/sha256"
+	"encoding/binary"
 	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"math"
 	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
 	"sort"
-	"time"
 )
 
 const (
@@ -46,19 +52,19 @@ type Config struct {
 }
 
 func DefaultConfig() Config {
-	return Config{Metric: "cosine", Seed: 1, Repetitions: 4, Pivots: 8, MaxLeafBucket: 128, Degree: 16, Partitions: 16, Imbalance: .05, Symmetric: true, MaxVectors: maxVectors, MaxEdges: maxEdges}
+	return Config{Metric: "cosine", Seed: 1, Repetitions: 4, Pivots: 8, MaxLeafBucket: 128, Degree: 16, Partitions: 16, Imbalance: .05, Symmetric: false, MaxVectors: maxVectors, MaxEdges: maxEdges}
 }
 
 type Graph struct {
 	Neighbors [][]int `json:"neighbors"`
 }
 type Metrics struct {
-	BuildNanos       int64 `json:"build_nanos"`
-	GraphEdges       int   `json:"graph_edges"`
-	MaxDegree        int   `json:"max_degree"`
-	EdgeCut          int   `json:"edge_cut"`
-	MaxPartitionSize int   `json:"max_partition_size"`
-	Cap              int   `json:"cap"`
+	GraphEdges          int `json:"graph_edges"`
+	MaxDegree           int `json:"max_degree"`
+	EdgeCut             int `json:"edge_cut"`
+	StableIDHashEdgeCut int `json:"stable_id_hash_edge_cut"`
+	MaxPartitionSize    int `json:"max_partition_size"`
+	Cap                 int `json:"cap"`
 }
 type Artifact struct {
 	SchemaVersion  int      `json:"schema_version"`
@@ -82,7 +88,6 @@ type ReferencePartitioner struct{}
 func (ReferencePartitioner) Name() string { return "treedb_reference_greedy_v1" }
 
 func Build(vectors []Vector, cfg Config) (Artifact, error) {
-	start := time.Now()
 	if err := validateInput(vectors, cfg); err != nil {
 		return Artifact{}, err
 	}
@@ -108,9 +113,6 @@ func Build(vectors []Vector, cfg Config) (Artifact, error) {
 	}
 	art := Artifact{SchemaVersion: SchemaVersion, Backend: ReferencePartitioner{}.Name(), BackendLicense: "TreeDB clean-room reference implementation (repository license)", Config: cfg, IDs: ids, Graph: g, Assignment: a}
 	art.Metrics = metrics(art)
-	// Timings are run-report data rather than immutable artifact data. Keeping
-	// this field zero makes CanonicalJSON byte-identical for identical input.
-	_ = start
 	if err := ValidateArtifact(art); err != nil {
 		return Artifact{}, err
 	}
@@ -144,7 +146,7 @@ func validateInput(v []Vector, c Config) error {
 			}
 		}
 	}
-	if int64(len(v))*int64(c.Degree) > int64(c.MaxEdges) {
+	if int64(len(v))*int64(c.Degree) > int64(c.MaxEdges) || int64(len(v))*int64(c.Degree) > int64(c.MaxEdges)/int64(c.Repetitions) {
 		return errors.New("configured graph edge bound exceeded before allocation")
 	}
 	return nil
@@ -155,12 +157,12 @@ func buildGraph(v []Vector, c Config) (Graph, error) {
 	n := len(v)
 	sets := make([]map[int]struct{}, n)
 	for i := range sets {
-		sets[i] = make(map[int]struct{}, c.Degree*c.Repetitions)
+		sets[i] = make(map[int]struct{}, c.Degree)
 	}
 	for rep := 0; rep < c.Repetitions; rep++ {
 		r := rand.New(rand.NewSource(c.Seed + int64(rep)*0x9e3779b))
 		order := r.Perm(n)
-		if err := carve(v, order, c, sets); err != nil {
+		if err := carveDepth(v, order, c, sets, 0); err != nil {
 			return Graph{}, err
 		}
 	}
@@ -176,27 +178,17 @@ func buildGraph(v []Vector, c Config) (Graph, error) {
 			g.Neighbors[i] = g.Neighbors[i][:c.Degree]
 		}
 	}
-	if c.Symmetric { // symmetric policy is bounded by retaining mutual/lowest ordinal candidates deterministically.
-		for i := range g.Neighbors {
-			for _, j := range g.Neighbors[i] {
-				addBounded(&g.Neighbors[j], i, c.Degree)
-			}
-		}
-		for i := range g.Neighbors {
-			sort.Ints(g.Neighbors[i])
-			if len(g.Neighbors[i]) > c.Degree {
-				g.Neighbors[i] = g.Neighbors[i][:c.Degree]
-			}
-		}
+	if c.Symmetric {
+		return Graph{}, errors.New("symmetric graph policy is not supported by bounded reference backend")
 	}
 	return g, nil
 }
-func carve(v []Vector, ids []int, c Config, sets []map[int]struct{}) error {
+func carveDepth(v []Vector, ids []int, c Config, sets []map[int]struct{}, depth int) error {
 	if len(ids) <= c.MaxLeafBucket {
 		for _, i := range ids {
 			nearest := nearest(v, ids, i, c.Degree)
 			for _, j := range nearest {
-				sets[i][j] = struct{}{}
+				addSetBounded(sets[i], j, c.Degree)
 			}
 		}
 		return nil
@@ -205,28 +197,36 @@ func carve(v []Vector, ids []int, c Config, sets []map[int]struct{}) error {
 	pivots := append([]int(nil), ids[:k]...)
 	buckets := make([][]int, k)
 	for _, i := range ids {
-		best := 0
+		best, second := 0, -1
 		bestD := distance(v[i].Values, v[pivots[0]].Values)
 		for p := 1; p < k; p++ {
 			d := distance(v[i].Values, v[pivots[p]].Values)
 			if d < bestD || d == bestD && pivots[p] < pivots[best] {
-				best, bestD = p, d
+				second, best, bestD = best, p, d
+			} else if second < 0 || d < distance(v[i].Values, v[pivots[second]].Values) || d == distance(v[i].Values, v[pivots[second]].Values) && pivots[p] < pivots[second] {
+				second = p
 			}
 		}
 		buckets[best] = append(buckets[best], i)
+		// The paper sketch allows one-or-more nearest top-level pivots. The
+		// reference intentionally adds exactly one bounded extra membership at
+		// depth zero; deeper levels use one pivot to keep work bounded.
+		if depth == 0 && second >= 0 {
+			buckets[second] = append(buckets[second], i)
+		}
 	}
 	for _, b := range buckets {
 		if len(b) == len(ids) { // duplicate/skew progress guarantee: deterministic chunking.
 			for start := 0; start < len(b); start += c.MaxLeafBucket {
 				end := min(start+c.MaxLeafBucket, len(b))
-				if err := carve(v, b[start:end], c, sets); err != nil {
+				if err := carveDepth(v, b[start:end], c, sets, depth+1); err != nil {
 					return err
 				}
 			}
 			continue
 		}
 		if len(b) > 0 {
-			if err := carve(v, b, c, sets); err != nil {
+			if err := carveDepth(v, b, c, sets, depth+1); err != nil {
 				return err
 			}
 		}
@@ -266,16 +266,23 @@ func distance(a, b []float64) float64 {
 	}
 	return 1 - dot/math.Sqrt(na*nb)
 }
-func addBounded(a *[]int, x, cap int) {
-	for _, v := range *a {
-		if v == x {
-			return
+func addSetBounded(s map[int]struct{}, x, cap int) {
+	if _, ok := s[x]; ok {
+		return
+	}
+	if len(s) < cap {
+		s[x] = struct{}{}
+		return
+	}
+	worst := -1
+	for v := range s {
+		if v > worst {
+			worst = v
 		}
 	}
-	*a = append(*a, x)
-	sort.Ints(*a)
-	if len(*a) > cap {
-		*a = (*a)[:cap]
+	if x < worst {
+		delete(s, worst)
+		s[x] = struct{}{}
 	}
 }
 
@@ -283,6 +290,9 @@ func (ReferencePartitioner) Partition(g Graph, parts, cap int) ([]int, error) {
 	n := len(g.Neighbors)
 	if parts < 1 || cap < 1 || n < parts {
 		return nil, errors.New("invalid partition request")
+	}
+	if err := validateGraph(g, n, maxVectors); err != nil {
+		return nil, err
 	}
 	order := make([]int, n)
 	for i := range order {
@@ -333,6 +343,9 @@ func metrics(a Artifact) Metrics {
 			if a.Assignment[i] != a.Assignment[j] {
 				m.EdgeCut++
 			}
+			if stableIDPartition(a.IDs[i], a.Config.Partitions) != stableIDPartition(a.IDs[j], a.Config.Partitions) {
+				m.StableIDHashEdgeCut++
+			}
 		}
 	}
 	for p := 0; p < a.Config.Partitions; p++ {
@@ -348,6 +361,10 @@ func metrics(a Artifact) Metrics {
 	}
 	return m
 }
+func stableIDPartition(id string, partitions int) int {
+	sum := sha256.Sum256([]byte(id))
+	return int(binary.BigEndian.Uint64(sum[:8]) % uint64(partitions))
+}
 
 func ValidateArtifact(a Artifact) error {
 	if a.SchemaVersion != SchemaVersion || a.Backend == "" || len(a.IDs) == 0 || len(a.IDs) != len(a.Graph.Neighbors) || len(a.IDs) != len(a.Assignment) {
@@ -355,6 +372,9 @@ func ValidateArtifact(a Artifact) error {
 	}
 	if err := validateInput(makeVectors(a.IDs, a.Graph.Neighbors), a.Config); err != nil {
 		return fmt.Errorf("artifact config: %w", err)
+	}
+	if err := validateGraph(a.Graph, len(a.IDs), a.Config.Degree); err != nil {
+		return err
 	}
 	cap := partitionCap(len(a.IDs), a.Config.Partitions, a.Config.Imbalance)
 	loads := make([]int, a.Config.Partitions)
@@ -367,20 +387,32 @@ func ValidateArtifact(a Artifact) error {
 			return errors.New("assignment out of range")
 		}
 		loads[p]++
-		seen := map[int]bool{}
-		for _, j := range a.Graph.Neighbors[i] {
-			if j < 0 || j >= len(a.IDs) || j == i || seen[j] {
-				return errors.New("invalid graph edge")
-			}
-			seen[j] = true
-		}
-		if len(a.Graph.Neighbors[i]) > a.Config.Degree {
-			return errors.New("degree cap exceeded")
-		}
 	}
 	for _, n := range loads {
 		if n > cap {
 			return errors.New("partition cap exceeded")
+		}
+	}
+	m := metrics(a)
+	if a.Metrics.GraphEdges != m.GraphEdges || a.Metrics.MaxDegree != m.MaxDegree || a.Metrics.EdgeCut != m.EdgeCut || a.Metrics.StableIDHashEdgeCut != m.StableIDHashEdgeCut || a.Metrics.MaxPartitionSize != m.MaxPartitionSize || a.Metrics.Cap != m.Cap {
+		return errors.New("artifact metrics do not match graph and assignment")
+	}
+	return nil
+}
+func validateGraph(g Graph, n, degree int) error {
+	if len(g.Neighbors) != n {
+		return errors.New("graph node count mismatch")
+	}
+	for i, ns := range g.Neighbors {
+		if len(ns) > degree {
+			return errors.New("degree cap exceeded")
+		}
+		seen := map[int]bool{}
+		for _, j := range ns {
+			if j < 0 || j >= n || j == i || seen[j] {
+				return errors.New("invalid graph edge")
+			}
+			seen[j] = true
 		}
 	}
 	return nil
@@ -399,6 +431,72 @@ func CanonicalJSON(a Artifact) ([]byte, error) {
 		return nil, err
 	}
 	return json.Marshal(a)
+}
+
+// DecodeArtifact is a strict bounded decoder for offline backend output. It
+// rejects unknown fields, trailing bytes, non-canonical encodings, and output
+// whose independently recomputed metrics do not match its graph/assignment.
+func DecodeArtifact(raw []byte, maxBytes int) (Artifact, error) {
+	if maxBytes < 1 || len(raw) > maxBytes {
+		return Artifact{}, errors.New("partition artifact exceeds byte cap")
+	}
+	var a Artifact
+	d := json.NewDecoder(bytes.NewReader(raw))
+	d.DisallowUnknownFields()
+	if err := d.Decode(&a); err != nil {
+		return Artifact{}, err
+	}
+	var extra any
+	if err := d.Decode(&extra); err != io.EOF {
+		return Artifact{}, errors.New("partition artifact has trailing JSON")
+	}
+	if err := ValidateArtifact(a); err != nil {
+		return Artifact{}, err
+	}
+	canonical, err := CanonicalJSON(a)
+	if err != nil {
+		return Artifact{}, err
+	}
+	if !bytes.Equal(raw, canonical) {
+		return Artifact{}, errors.New("partition artifact is not canonical JSON")
+	}
+	return a, nil
+}
+
+// RunExternalJSON is an optional offline adapter seam. It never becomes a
+// TreeDB runtime dependency. Its output is written to a private temp path and
+// removed on cancellation, timeout, command failure, or invalid output.
+func RunExternalJSON(ctx context.Context, command []string, input []byte, maxOutput int) (Artifact, error) {
+	if len(command) == 0 || maxOutput < 1 {
+		return Artifact{}, errors.New("invalid external backend command")
+	}
+	dir, err := os.MkdirTemp("", "treedb-vectorpartition-backend-*")
+	if err != nil {
+		return Artifact{}, err
+	}
+	defer os.RemoveAll(dir)
+	in := filepath.Join(dir, "input.json")
+	out := filepath.Join(dir, "output.json")
+	if err = os.WriteFile(in, input, 0600); err != nil {
+		return Artifact{}, err
+	}
+	cmd := exec.CommandContext(ctx, command[0], append(command[1:], in, out)...)
+	if b, e := cmd.CombinedOutput(); e != nil {
+		return Artifact{}, fmt.Errorf("external partition backend: %w: %s", e, bytes.TrimSpace(b))
+	}
+	f, e := os.Open(out)
+	if e != nil {
+		return Artifact{}, e
+	}
+	defer f.Close()
+	raw, e := io.ReadAll(io.LimitReader(f, int64(maxOutput)+1))
+	if e != nil {
+		return Artifact{}, e
+	}
+	if len(raw) > maxOutput {
+		return Artifact{}, errors.New("external partition backend output exceeds cap")
+	}
+	return DecodeArtifact(raw, maxOutput)
 }
 func Digest(a Artifact) (string, error) {
 	b, e := CanonicalJSON(a)

--- a/TreeDB/internal/vectorpartition/vectorpartition.go
+++ b/TreeDB/internal/vectorpartition/vectorpartition.go
@@ -251,6 +251,9 @@ func validateInput(v []Vector, c Config) error {
 				return errors.New("non-finite vector value")
 			}
 		}
+		if !nonZeroFiniteNorm(x.Values) {
+			return errors.New("zero-norm vector")
+		}
 	}
 	if int64(len(v))*int64(c.Degree) > int64(c.MaxEdges) || int64(len(v))*int64(c.Degree) > int64(c.MaxEdges)/int64(c.Repetitions) {
 		return errors.New("configured graph edge bound exceeded before allocation")
@@ -400,16 +403,36 @@ func nearest(v []Vector, ids []int, target, k int, budget *distanceBudget) ([]ca
 	return []candidate(a), nil
 }
 func distance(a, b []float64) float64 {
-	var dot, na, nb float64
+	var scaleA, scaleB float64
 	for i := range a {
-		dot = math.FMA(a[i], b[i], dot)
-		na = math.FMA(a[i], a[i], na)
-		nb = math.FMA(b[i], b[i], nb)
+		scaleA = math.Max(scaleA, math.Abs(a[i]))
+		scaleB = math.Max(scaleB, math.Abs(b[i]))
 	}
-	if na == 0 || nb == 0 {
+	if scaleA == 0 || scaleB == 0 {
 		return 1
 	}
-	return 1 - dot/math.Sqrt(na*nb)
+	var dot, na, nb float64
+	for i := range a {
+		av, bv := a[i]/scaleA, b[i]/scaleB
+		dot = math.FMA(av, bv, dot)
+		na = math.FMA(av, av, na)
+		nb = math.FMA(bv, bv, nb)
+	}
+	cosine := dot / (math.Sqrt(na) * math.Sqrt(nb))
+	if cosine > 1 {
+		cosine = 1
+	}
+	if cosine < -1 {
+		cosine = -1
+	}
+	return 1 - cosine
+}
+func nonZeroFiniteNorm(values []float64) bool {
+	var scale float64
+	for _, value := range values {
+		scale = math.Max(scale, math.Abs(value))
+	}
+	return scale > 0 && finite(scale)
 }
 
 type candidate struct {
@@ -478,6 +501,8 @@ func (ReferencePartitioner) Partition(g Graph, parts, cap int) ([]int, error) {
 		out[i] = -1
 	}
 	loads := make([]int, parts)
+	marks := make([]int, parts)
+	candidates := make([]int, 0, maxGraphDegree(g)+1)
 	// Reserve one ordinal for each partition before affinity scoring. This
 	// matches ValidateArtifact's exact-coverage invariant even on graphs whose
 	// edges all prefer a small subset of partitions.
@@ -490,7 +515,8 @@ func (ReferencePartitioner) Partition(g Graph, parts, cap int) ([]int, error) {
 		// affinity. Add the globally least-loaded admissible partition so a
 		// zero-affinity choice remains deterministic and balanced without a
 		// partitions-by-degree scan for every node.
-		candidates := make([]int, 0, len(g.Neighbors[node])+1)
+		candidates = candidates[:0]
+		stamp := node + 1
 		least := -1
 		for p := 0; p < parts; p++ {
 			if loads[p] < cap && (least < 0 || loads[p] < loads[least] || loads[p] == loads[least] && p < least) {
@@ -499,24 +525,18 @@ func (ReferencePartitioner) Partition(g Graph, parts, cap int) ([]int, error) {
 		}
 		if least >= 0 {
 			candidates = append(candidates, least)
+			marks[least] = stamp
 		}
 		for _, to := range g.Neighbors[node] {
 			p := out[to]
 			if p < 0 || loads[p] >= cap {
 				continue
 			}
-			seen := false
-			for _, existing := range candidates {
-				if existing == p {
-					seen = true
-					break
-				}
-			}
-			if !seen {
+			if marks[p] != stamp {
+				marks[p] = stamp
 				candidates = append(candidates, p)
 			}
 		}
-		sort.Ints(candidates)
 		best, bscore := -1, -1
 		for _, p := range candidates {
 			score := 0
@@ -547,9 +567,14 @@ func maxGraphDegree(g Graph) int {
 	return max
 }
 func partitionWorkExceeded(n, parts, degree int) bool {
-	// Per node: one partition scan plus at most degree+1 candidate scores,
-	// each examining at most degree edges.
-	perNode := int64(parts) + int64(degree+1)*int64(degree+1)
+	// Account for the initial degree sort plus each node's partition scan,
+	// candidate-mark pass, and affinity scans. Scratch indexing removes hidden
+	// duplicate-search/sort work from the candidate path.
+	logN := int64(0)
+	for x := n; x > 1; x = (x + 1) / 2 {
+		logN++
+	}
+	perNode := int64(parts) + int64(degree) + int64(degree)*int64(degree+1) + logN
 	return exceedsProduct(maxPartitionWork, int64(n), perNode)
 }
 func exceedsProduct(limit int64, values ...int64) bool {
@@ -777,6 +802,7 @@ func RunExternalJSONForSource(ctx context.Context, command []string, input []byt
 		return Artifact{}, err
 	}
 	cmd := exec.CommandContext(ctx, command[0], append(command[1:], in, out)...)
+	configureExternalCommand(cmd)
 	stderr := &cappedBuffer{limit: maxOutput}
 	cmd.Stderr = stderr
 	if e := cmd.Run(); e != nil {

--- a/TreeDB/internal/vectorpartition/vectorpartition.go
+++ b/TreeDB/internal/vectorpartition/vectorpartition.go
@@ -1015,9 +1015,9 @@ func RunExternalJSONForSource(ctx context.Context, command []string, input []byt
 	return Artifact{}, errors.New("external backend requires requested artifact binding")
 }
 
-// RunExternalJSONForSourceWithLimits runs an optional backend with separately
-// bounded request and response files. It is for callers that need a smaller
-// request cap than the M2-derived default without weakening the output cap.
+// RunExternalJSONForSourceWithLimits fails closed without running a backend:
+// source-only binding cannot prove an output used the requested graph. Use
+// RunExternalJSONForRequestWithLimits with the exact requested artifact.
 func RunExternalJSONForSourceWithLimits(ctx context.Context, command []string, input []byte, limits ExternalJSONLimits, expected Source) (Artifact, error) {
 	if err := validateExpectedSource(expected); err != nil {
 		return Artifact{}, err

--- a/TreeDB/internal/vectorpartition/vectorpartition.go
+++ b/TreeDB/internal/vectorpartition/vectorpartition.go
@@ -19,6 +19,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"reflect"
 	"sort"
 	"strings"
 	"time"
@@ -983,6 +984,24 @@ func DecodeArtifactForSource(raw []byte, maxBytes int, expected Source) (Artifac
 	return a, nil
 }
 
+// DecodeArtifactForRequest binds an external backend response to the exact
+// deterministic corpus, IDs, configuration, and graph supplied to it. The
+// assignment intentionally remains backend output, but must satisfy the
+// independent artifact validator.
+func DecodeArtifactForRequest(raw []byte, maxBytes int, request Artifact) (Artifact, error) {
+	if err := ValidateArtifact(request); err != nil {
+		return Artifact{}, fmt.Errorf("invalid external backend request: %w", err)
+	}
+	a, err := DecodeArtifactForSource(raw, maxBytes, request.Source)
+	if err != nil {
+		return Artifact{}, err
+	}
+	if !reflect.DeepEqual(a.IDs, request.IDs) || a.Config != request.Config || !reflect.DeepEqual(a.Graph, request.Graph) {
+		return Artifact{}, errors.New("backend artifact does not match requested graph/configuration")
+	}
+	return a, nil
+}
+
 // RunExternalJSON is an optional offline adapter seam. It never becomes a
 // TreeDB runtime dependency. Its output is written to a private temp path and
 // removed on cancellation, timeout, command failure, or invalid output.
@@ -990,13 +1009,31 @@ func RunExternalJSON(ctx context.Context, command []string, input []byte, maxOut
 	return Artifact{}, errors.New("external backend requires expected source binding")
 }
 func RunExternalJSONForSource(ctx context.Context, command []string, input []byte, maxOutput int, expected Source) (Artifact, error) {
-	return RunExternalJSONForSourceWithLimits(ctx, command, input, ExternalJSONLimits{MaxInput: maxExternalJSONBytes, MaxOutput: maxOutput}, expected)
+	if err := validateExpectedSource(expected); err != nil {
+		return Artifact{}, err
+	}
+	return Artifact{}, errors.New("external backend requires requested artifact binding")
 }
 
 // RunExternalJSONForSourceWithLimits runs an optional backend with separately
 // bounded request and response files. It is for callers that need a smaller
 // request cap than the M2-derived default without weakening the output cap.
 func RunExternalJSONForSourceWithLimits(ctx context.Context, command []string, input []byte, limits ExternalJSONLimits, expected Source) (Artifact, error) {
+	if err := validateExpectedSource(expected); err != nil {
+		return Artifact{}, err
+	}
+	return Artifact{}, errors.New("external backend requires requested artifact binding")
+}
+
+// RunExternalJSONForRequestWithLimits runs an optional backend with separately
+// bounded request/response files and binds its response to request's exact
+// deterministic graph and configuration.
+func RunExternalJSONForRequestWithLimits(ctx context.Context, command []string, input []byte, limits ExternalJSONLimits, request Artifact) (Artifact, error) {
+	canonicalRequest, err := CanonicalJSON(request)
+	if err != nil {
+		return Artifact{}, fmt.Errorf("invalid external backend request: %w", err)
+	}
+	expected := request.Source
 	if err := validateExpectedSource(expected); err != nil {
 		return Artifact{}, err
 	}
@@ -1011,6 +1048,9 @@ func RunExternalJSONForSourceWithLimits(ctx context.Context, command []string, i
 	}
 	if len(input) > limits.MaxInput {
 		return Artifact{}, errors.New("external partition backend input exceeds cap")
+	}
+	if !bytes.Equal(input, canonicalRequest) {
+		return Artifact{}, errors.New("external backend input does not match requested artifact")
 	}
 	dir, err := os.MkdirTemp("", "treedb-vectorpartition-backend-*")
 	if err != nil {
@@ -1049,7 +1089,7 @@ func RunExternalJSONForSourceWithLimits(ctx context.Context, command []string, i
 	if len(raw) > limits.MaxOutput {
 		return Artifact{}, errors.New("external partition backend output exceeds cap")
 	}
-	return DecodeArtifactForSource(raw, limits.MaxOutput, expected)
+	return DecodeArtifactForRequest(raw, limits.MaxOutput, request)
 }
 
 func validateExpectedSource(s Source) error {

--- a/TreeDB/internal/vectorpartition/vectorpartition.go
+++ b/TreeDB/internal/vectorpartition/vectorpartition.go
@@ -269,6 +269,11 @@ func validateInput(v []Vector, c Config) error {
 	if err := ValidateConfig(c); err != nil {
 		return err
 	}
+	// Reject count-derived allocation abuse before examining a caller-owned
+	// element. Dimensions still require the post-scan shape validation below.
+	if len(v) < c.Partitions || len(v) > c.MaxVectors {
+		return errors.New("vector count outside configured bounds")
+	}
 	dims := 0
 	totalIDBytes := 0
 	for _, x := range v {

--- a/TreeDB/internal/vectorpartition/vectorpartition.go
+++ b/TreeDB/internal/vectorpartition/vectorpartition.go
@@ -5,6 +5,7 @@ package vectorpartition
 
 import (
 	"bytes"
+	"container/heap"
 	"context"
 	"crypto/sha256"
 	"encoding/binary"
@@ -24,19 +25,20 @@ import (
 )
 
 const (
-	SchemaVersion   = 1
-	maxVectors      = 1_000_000
-	maxDimensions   = 4096
-	maxEdges        = 64_000_000
-	maxRepetitions  = 32
-	maxPivots       = 1024
-	maxLeafBucket   = 65536
-	maxDegree       = 1024
-	maxPartitions   = 16384
-	maxIDBytes      = 1 << 20
-	maxTotalIDBytes = 64 << 20
-	maxDistanceWork = int64(1_000_000_000)
-	maxCarveDepth   = 64
+	SchemaVersion    = 1
+	maxVectors       = 1_000_000
+	maxDimensions    = 4096
+	maxEdges         = 64_000_000
+	maxRepetitions   = 32
+	maxPivots        = 1024
+	maxLeafBucket    = 65536
+	maxDegree        = 1024
+	maxPartitions    = 16384
+	maxIDBytes       = 1 << 20
+	maxTotalIDBytes  = 64 << 20
+	maxDistanceWork  = int64(20_000_000_000) // scalar cosine dimensions
+	maxPartitionWork = int64(250_000_000)
+	maxCarveDepth    = 64
 )
 
 // Vector IDs must be unique and are canonically ordered before construction.
@@ -130,8 +132,15 @@ func BuildWithPartitioner(vectors []Vector, cfg Config, source Source, backend P
 }
 func BuildWithPartitionerPhased(vectors []Vector, cfg Config, source Source, backend Partitioner) (Artifact, PhaseMetrics, error) {
 	var phases PhaseMetrics
-	if backend == nil || backend.Name() == "" || backend.License() == "" || len(backend.License()) > 1024 {
+	if backend == nil {
 		return Artifact{}, phases, errors.New("partition backend identity is required")
+	}
+	backendName, backendLicense := backend.Name(), backend.License()
+	if backendName == "" || len(backendName) > 256 || backendLicense == "" || len(backendLicense) > 1024 {
+		return Artifact{}, phases, errors.New("partition backend identity is required")
+	}
+	if err := validateRequestedSource(source); err != nil {
+		return Artifact{}, phases, err
 	}
 	if err := validateInput(vectors, cfg); err != nil {
 		return Artifact{}, phases, err
@@ -156,15 +165,18 @@ func BuildWithPartitionerPhased(vectors []Vector, cfg Config, source Source, bac
 	if err != nil {
 		return Artifact{}, phases, err
 	}
+	if _, err := validateAssignment(a, len(v), cfg); err != nil {
+		return Artifact{}, phases, fmt.Errorf("partition backend assignment: %w", err)
+	}
 	ids := make([]string, len(v))
 	for i := range v {
 		ids[i] = v[i].ID
 	}
 	computed := sourceFor(v, cfg.Metric, source.SourceID)
-	if source.Checksum != "" && source != computed {
+	if source != (Source{SourceID: source.SourceID}) && source != computed {
 		return Artifact{}, phases, errors.New("source identity does not match input snapshot")
 	}
-	art := Artifact{SchemaVersion: SchemaVersion, Backend: backend.Name(), BackendLicense: backend.License(), Source: computed, Config: cfg, IDs: ids, Graph: g, Assignment: a}
+	art := Artifact{SchemaVersion: SchemaVersion, Backend: backendName, BackendLicense: backendLicense, Source: computed, Config: cfg, IDs: ids, Graph: g, Assignment: a}
 	art.Metrics = metrics(art)
 	started = time.Now()
 	if err := ValidateArtifact(art); err != nil {
@@ -173,6 +185,21 @@ func BuildWithPartitionerPhased(vectors []Vector, cfg Config, source Source, bac
 	}
 	phases.ValidationNanos = time.Since(started).Nanoseconds()
 	return art, phases, nil
+}
+func validateRequestedSource(s Source) error {
+	if s.SourceID == "" || len(s.SourceID) > 1024 {
+		return errors.New("source ID is required")
+	}
+	if s == (Source{SourceID: s.SourceID}) {
+		return nil
+	}
+	if len(s.Checksum) != 64 || strings.ToLower(s.Checksum) != s.Checksum || s.Vectors < 1 || s.Vectors > maxVectors || s.Dimensions < 1 || s.Dimensions > maxDimensions || s.Metric != "cosine" {
+		return errors.New("partial source identity is not allowed")
+	}
+	if _, err := hex.DecodeString(s.Checksum); err != nil {
+		return errors.New("partial source identity is not allowed")
+	}
+	return nil
 }
 
 func sourceFor(v []Vector, metric, id string) Source {
@@ -225,8 +252,11 @@ func validateInput(v []Vector, c Config) error {
 			}
 		}
 	}
-	if int64(len(v))*int64(c.Degree) > int64(c.MaxEdges) || int64(len(v))*int64(c.Degree) > int64(c.MaxEdges)/int64(c.Repetitions) || int64(len(v))*int64(c.MaxLeafBucket)*int64(c.Repetitions) > maxDistanceWork {
+	if int64(len(v))*int64(c.Degree) > int64(c.MaxEdges) || int64(len(v))*int64(c.Degree) > int64(c.MaxEdges)/int64(c.Repetitions) {
 		return errors.New("configured graph edge bound exceeded before allocation")
+	}
+	if exceedsProduct(maxDistanceWork, int64(len(v)), int64(c.MaxLeafBucket), int64(c.Repetitions), int64(dims)) {
+		return errors.New("configured graph scalar-work bound exceeded before allocation")
 	}
 	return nil
 }
@@ -264,7 +294,7 @@ func buildGraph(v []Vector, c Config) (Graph, error) {
 	return g, nil
 }
 
-// distanceBudget bounds every cosine evaluation in the pivot and leaf phases.
+// distanceBudget bounds scalar operations in the pivot and leaf phases.
 // It is runtime-enforced because input geometry, rather than configuration
 // alone, determines recursive bucket shape.
 type distanceBudget struct{ remaining int64 }
@@ -297,7 +327,7 @@ func carveDepth(v []Vector, ids []int, c Config, sets []map[int]float64, depth i
 	pivots := append([]int(nil), ids[:k]...)
 	buckets := make([][]int, k)
 	for _, i := range ids {
-		if err := budget.take(int64(k)); err != nil {
+		if err := budget.take(int64(k) * int64(len(v[i].Values))); err != nil {
 			return err
 		}
 		var distances [maxPivots]float64
@@ -349,30 +379,25 @@ func carveChunks(v []Vector, ids []int, c Config, sets []map[int]float64, depth 
 	return nil
 }
 func nearest(v []Vector, ids []int, target, k int, budget *distanceBudget) ([]candidate, error) {
-	a := make([]candidate, 0, min(k, len(ids)-1))
+	a := make(candidateMaxHeap, 0, min(k, len(ids)-1))
 	for _, j := range ids {
 		if j != target {
-			if err := budget.take(1); err != nil {
+			if err := budget.take(int64(len(v[target].Values))); err != nil {
 				return nil, err
 			}
 			c := candidate{j, distance(v[target].Values, v[j].Values)}
 			if len(a) < k {
-				a = append(a, c)
+				heap.Push(&a, c)
 				continue
 			}
-			worst := 0
-			for x := 1; x < len(a); x++ {
-				if a[worst].x < a[x].x || a[worst].x == a[x].x && a[worst].i < a[x].i {
-					worst = x
-				}
-			}
-			if c.x < a[worst].x || c.x == a[worst].x && c.i < a[worst].i {
-				a[worst] = c
+			if candidateBetter(c, a[0]) {
+				a[0] = c
+				heap.Fix(&a, 0)
 			}
 		}
 	}
 	sort.Slice(a, func(i, j int) bool { return a[i].x < a[j].x || a[i].x == a[j].x && a[i].i < a[j].i })
-	return a, nil
+	return []candidate(a), nil
 }
 func distance(a, b []float64) float64 {
 	var dot, na, nb float64
@@ -391,6 +416,19 @@ type candidate struct {
 	i int
 	x float64
 }
+type candidateMaxHeap []candidate
+
+func (h candidateMaxHeap) Len() int           { return len(h) }
+func (h candidateMaxHeap) Less(i, j int) bool { return candidateBetter(h[j], h[i]) }
+func (h candidateMaxHeap) Swap(i, j int)      { h[i], h[j] = h[j], h[i] }
+func (h *candidateMaxHeap) Push(x any)        { *h = append(*h, x.(candidate)) }
+func (h *candidateMaxHeap) Pop() any {
+	old := *h
+	x := old[len(old)-1]
+	*h = old[:len(old)-1]
+	return x
+}
+func candidateBetter(a, b candidate) bool { return a.x < b.x || a.x == b.x && a.i < b.i }
 
 func addCandidateBounded(s map[int]float64, x int, d float64, cap int) {
 	if old, ok := s[x]; ok {
@@ -424,6 +462,9 @@ func (ReferencePartitioner) Partition(g Graph, parts, cap int) ([]int, error) {
 	if err := validateGraph(g, n, maxVectors); err != nil {
 		return nil, err
 	}
+	if partitionWorkExceeded(n, parts, maxGraphDegree(g)) {
+		return nil, errors.New("partition work bound exceeded before allocation")
+	}
 	order := make([]int, n)
 	for i := range order {
 		order[i] = i
@@ -437,12 +478,47 @@ func (ReferencePartitioner) Partition(g Graph, parts, cap int) ([]int, error) {
 		out[i] = -1
 	}
 	loads := make([]int, parts)
-	for _, node := range order {
-		best, bscore := -1, -1
+	// Reserve one ordinal for each partition before affinity scoring. This
+	// matches ValidateArtifact's exact-coverage invariant even on graphs whose
+	// edges all prefer a small subset of partitions.
+	for partition := 0; partition < parts; partition++ {
+		out[order[partition]] = partition
+		loads[partition] = 1
+	}
+	for _, node := range order[parts:] {
+		// Only partitions already represented by a neighbor can have a positive
+		// affinity. Add the globally least-loaded admissible partition so a
+		// zero-affinity choice remains deterministic and balanced without a
+		// partitions-by-degree scan for every node.
+		candidates := make([]int, 0, len(g.Neighbors[node])+1)
+		least := -1
 		for p := 0; p < parts; p++ {
-			if loads[p] >= cap {
+			if loads[p] < cap && (least < 0 || loads[p] < loads[least] || loads[p] == loads[least] && p < least) {
+				least = p
+			}
+		}
+		if least >= 0 {
+			candidates = append(candidates, least)
+		}
+		for _, to := range g.Neighbors[node] {
+			p := out[to]
+			if p < 0 || loads[p] >= cap {
 				continue
 			}
+			seen := false
+			for _, existing := range candidates {
+				if existing == p {
+					seen = true
+					break
+				}
+			}
+			if !seen {
+				candidates = append(candidates, p)
+			}
+		}
+		sort.Ints(candidates)
+		best, bscore := -1, -1
+		for _, p := range candidates {
 			score := 0
 			for _, to := range g.Neighbors[node] {
 				if out[to] == p {
@@ -460,6 +536,31 @@ func (ReferencePartitioner) Partition(g Graph, parts, cap int) ([]int, error) {
 		loads[best]++
 	}
 	return out, nil
+}
+func maxGraphDegree(g Graph) int {
+	max := 0
+	for _, ns := range g.Neighbors {
+		if len(ns) > max {
+			max = len(ns)
+		}
+	}
+	return max
+}
+func partitionWorkExceeded(n, parts, degree int) bool {
+	// Per node: one partition scan plus at most degree+1 candidate scores,
+	// each examining at most degree edges.
+	perNode := int64(parts) + int64(degree+1)*int64(degree+1)
+	return exceedsProduct(maxPartitionWork, int64(n), perNode)
+}
+func exceedsProduct(limit int64, values ...int64) bool {
+	p := int64(1)
+	for _, value := range values {
+		if value < 0 || value != 0 && p > limit/value {
+			return true
+		}
+		p *= value
+	}
+	return p > limit
 }
 func partitionCap(n, p int, e float64) int { return int(math.Ceil((1 + e) * float64(n) / float64(p))) }
 func metrics(a Artifact) Metrics {
@@ -513,8 +614,9 @@ func ValidateArtifact(a Artifact) error {
 	if err := validateGraph(a.Graph, len(a.IDs), a.Config.Degree); err != nil {
 		return err
 	}
-	cap := partitionCap(len(a.IDs), a.Config.Partitions, a.Config.Imbalance)
-	loads := make([]int, a.Config.Partitions)
+	if a.Config.Symmetric && !hasReciprocalEdges(a.Graph) {
+		return errors.New("symmetric graph has non-reciprocal edge")
+	}
 	var totalIDBytes int
 	for i, id := range a.IDs {
 		if id == "" || i > 0 && id <= a.IDs[i-1] {
@@ -524,25 +626,48 @@ func ValidateArtifact(a Artifact) error {
 			return errors.New("artifact ID bytes exceed cap")
 		}
 		totalIDBytes += len(id)
-		p := a.Assignment[i]
-		if p < 0 || p >= a.Config.Partitions {
-			return errors.New("assignment out of range")
-		}
-		loads[p]++
 	}
 	if _, err := hex.DecodeString(a.Source.Checksum); err != nil {
 		return errors.New("invalid source checksum")
 	}
-	for _, n := range loads {
-		if n == 0 || n > cap {
-			return errors.New("partition cap exceeded")
-		}
+	loads, err := validateAssignment(a.Assignment, len(a.IDs), a.Config)
+	if err != nil {
+		return err
 	}
 	m := metricsWithLoads(a, loads)
 	if a.Metrics.GraphEdges != m.GraphEdges || a.Metrics.MaxDegree != m.MaxDegree || a.Metrics.EdgeCut != m.EdgeCut || a.Metrics.StableIDHashEdgeCut != m.StableIDHashEdgeCut || a.Metrics.MaxPartitionSize != m.MaxPartitionSize || a.Metrics.Cap != m.Cap {
 		return errors.New("artifact metrics do not match graph and assignment")
 	}
 	return nil
+}
+func validateAssignment(assignment []int, n int, c Config) ([]int, error) {
+	if len(assignment) != n {
+		return nil, errors.New("assignment length mismatch")
+	}
+	cap := partitionCap(n, c.Partitions, c.Imbalance)
+	loads := make([]int, c.Partitions)
+	for _, p := range assignment {
+		if p < 0 || p >= c.Partitions {
+			return nil, errors.New("assignment out of range")
+		}
+		loads[p]++
+	}
+	for _, n := range loads {
+		if n == 0 || n > cap {
+			return nil, errors.New("partition cap exceeded")
+		}
+	}
+	return loads, nil
+}
+func hasReciprocalEdges(g Graph) bool {
+	for i, ns := range g.Neighbors {
+		for _, j := range ns {
+			if at := sort.SearchInts(g.Neighbors[j], i); at == len(g.Neighbors[j]) || g.Neighbors[j][at] != i {
+				return false
+			}
+		}
+	}
+	return true
 }
 func validateArtifactConfig(ids []string, c Config) error {
 	if c.Metric != "cosine" || c.Repetitions < 1 || c.Repetitions > maxRepetitions || c.Pivots < 2 || c.Pivots > maxPivots || c.MaxLeafBucket < 2 || c.MaxLeafBucket > maxLeafBucket || c.Degree < 1 || c.Degree > maxDegree || c.Partitions < 1 || c.Partitions > maxPartitions || !finite(c.Imbalance) || c.Imbalance < 0 || c.Imbalance > 1 || c.MaxVectors < 1 || c.MaxVectors > maxVectors || c.MaxEdges < 1 || c.MaxEdges > maxEdges || len(ids) < c.Partitions || len(ids) > c.MaxVectors {

--- a/TreeDB/internal/vectorpartition/vectorpartition.go
+++ b/TreeDB/internal/vectorpartition/vectorpartition.go
@@ -154,13 +154,12 @@ func BuildWithPartitionerPhased(vectors []Vector, cfg Config, source Source, bac
 	if err := validateRequestedSource(source); err != nil {
 		return Artifact{}, phases, err
 	}
-	if err := validateInput(vectors, cfg); err != nil {
+	dimensions, err := preflightInputShape(vectors, cfg, backend)
+	if err != nil {
 		return Artifact{}, phases, err
 	}
-	if isReferencePartitioner(backend) {
-		if err := ValidateReferenceInputShape(cfg, len(vectors), len(vectors[0].Values)); err != nil {
-			return Artifact{}, phases, err
-		}
+	if err := validateInput(vectors, dimensions); err != nil {
+		return Artifact{}, phases, err
 	}
 	v := append([]Vector(nil), vectors...)
 	sort.Slice(v, func(i, j int) bool { return v[i].ID < v[j].ID })
@@ -282,31 +281,43 @@ func sourceFor(v []Vector, metric, id string) Source {
 	return Source{SourceID: id, Checksum: hex.EncodeToString(h.Sum(nil)), Vectors: len(v), Dimensions: len(v[0].Values), Metric: metric}
 }
 
-func validateInput(v []Vector, c Config) error {
+// preflightInputShape derives the declared dimension from the first vector only
+// after count validation, then runs every selected-backend shape gate before
+// inspecting caller-owned IDs or scalar values. Later vectors are checked for
+// exactly this dimension before their values are read by validateInput.
+func preflightInputShape(v []Vector, c Config, backend Partitioner) (int, error) {
 	if err := ValidateConfig(c); err != nil {
-		return err
+		return 0, err
 	}
-	// Reject count-derived allocation abuse before examining a caller-owned
-	// element. Dimensions still require the post-scan shape validation below.
 	if len(v) < c.Partitions || len(v) > c.MaxVectors {
-		return errors.New("vector count outside configured bounds")
+		return 0, errors.New("vector count outside configured bounds")
 	}
-	dims := 0
+	dimensions := len(v[0].Values)
+	if err := ValidateInputShape(c, len(v), dimensions); err != nil {
+		return 0, err
+	}
+	if isReferencePartitioner(backend) {
+		if err := ValidateReferenceInputShape(c, len(v), dimensions); err != nil {
+			return 0, err
+		}
+	}
+	return dimensions, nil
+}
+
+// validateInput validates every vector after preflightInputShape has bounded
+// the aggregate shape. Dimension equality is intentionally checked before ID
+// or scalar inspection for each vector, preventing a heterogeneous later
+// vector from evading the declared-dimension bound.
+func validateInput(v []Vector, dimensions int) error {
 	totalIDBytes := 0
 	for _, x := range v {
+		if len(x.Values) != dimensions {
+			return errors.New("wrong vector dimension")
+		}
 		if x.ID == "" || !utf8.ValidString(x.ID) || len(x.ID) > maxIDBytes || totalIDBytes > maxTotalIDBytes-len(x.ID) {
 			return errors.New("empty vector ID")
 		}
 		totalIDBytes += len(x.ID)
-		if dims == 0 {
-			dims = len(x.Values)
-			if dims < 1 || dims > maxDimensions {
-				return errors.New("invalid vector dimensions")
-			}
-		}
-		if len(x.Values) != dims {
-			return errors.New("wrong vector dimension")
-		}
 		for _, n := range x.Values {
 			if !finite(n) {
 				return errors.New("non-finite vector value")
@@ -316,7 +327,7 @@ func validateInput(v []Vector, c Config) error {
 			return errors.New("zero-norm vector")
 		}
 	}
-	return ValidateInputShape(c, len(v), dims)
+	return nil
 }
 
 // ValidateConfig validates bounded offline builder options before corpus I/O.

--- a/TreeDB/internal/vectorpartition/vectorpartition.go
+++ b/TreeDB/internal/vectorpartition/vectorpartition.go
@@ -40,6 +40,10 @@ const (
 	maxDistanceWork  = int64(20_000_000_000) // scalar cosine dimensions
 	maxPartitionWork = int64(250_000_000)
 	maxCarveDepth    = 64
+	// External JSON can carry every bounded graph ordinal (up to nine bytes each
+	// in canonical JSON), all bounded ID bytes, and one bounded per-vector field.
+	// This is a request/output ceiling, separate from a caller's output cap.
+	maxExternalJSONBytes = maxTotalIDBytes + maxEdges*9 + maxVectors*16
 )
 
 // Vector IDs must be unique and are canonically ordered before construction.
@@ -106,6 +110,13 @@ type Artifact struct {
 	Graph          Graph    `json:"graph"`
 	Assignment     []int    `json:"assignment"`
 	Metrics        Metrics  `json:"metrics"`
+}
+
+// ExternalJSONLimits independently bounds the private request file and the
+// backend response/stderr. Both must remain within the M2 serialization cap.
+type ExternalJSONLimits struct {
+	MaxInput  int
+	MaxOutput int
 }
 
 // Partitioner is the deliberately narrow backend seam. Implementations return
@@ -910,6 +921,13 @@ func RunExternalJSON(ctx context.Context, command []string, input []byte, maxOut
 	return Artifact{}, errors.New("external backend requires expected source binding")
 }
 func RunExternalJSONForSource(ctx context.Context, command []string, input []byte, maxOutput int, expected Source) (Artifact, error) {
+	return RunExternalJSONForSourceWithLimits(ctx, command, input, ExternalJSONLimits{MaxInput: maxExternalJSONBytes, MaxOutput: maxOutput}, expected)
+}
+
+// RunExternalJSONForSourceWithLimits runs an optional backend with separately
+// bounded request and response files. It is for callers that need a smaller
+// request cap than the M2-derived default without weakening the output cap.
+func RunExternalJSONForSourceWithLimits(ctx context.Context, command []string, input []byte, limits ExternalJSONLimits, expected Source) (Artifact, error) {
 	if err := validateExpectedSource(expected); err != nil {
 		return Artifact{}, err
 	}
@@ -919,8 +937,11 @@ func RunExternalJSONForSource(ctx context.Context, command []string, input []byt
 	if _, ok := ctx.Deadline(); !ok {
 		return Artifact{}, errors.New("external backend requires context deadline")
 	}
-	if len(command) == 0 || maxOutput < 1 || len(input) > maxOutput {
+	if len(command) == 0 || limits.MaxInput < 1 || limits.MaxInput > maxExternalJSONBytes || limits.MaxOutput < 1 || limits.MaxOutput > maxExternalJSONBytes {
 		return Artifact{}, errors.New("invalid external backend command")
+	}
+	if len(input) > limits.MaxInput {
+		return Artifact{}, errors.New("external partition backend input exceeds cap")
 	}
 	dir, err := os.MkdirTemp("", "treedb-vectorpartition-backend-*")
 	if err != nil {
@@ -934,7 +955,7 @@ func RunExternalJSONForSource(ctx context.Context, command []string, input []byt
 	}
 	cmd := exec.CommandContext(ctx, command[0], append(command[1:], in, out)...)
 	configureExternalCommand(cmd)
-	stderr := &cappedBuffer{limit: maxOutput}
+	stderr := &cappedBuffer{limit: limits.MaxOutput}
 	cmd.Stderr = stderr
 	e := cmd.Run()
 	// CommandContext only invokes Cancel while the root process is running.
@@ -952,14 +973,14 @@ func RunExternalJSONForSource(ctx context.Context, command []string, input []byt
 		return Artifact{}, e
 	}
 	defer f.Close()
-	raw, e := io.ReadAll(io.LimitReader(f, int64(maxOutput)+1))
+	raw, e := io.ReadAll(io.LimitReader(f, int64(limits.MaxOutput)+1))
 	if e != nil {
 		return Artifact{}, e
 	}
-	if len(raw) > maxOutput {
+	if len(raw) > limits.MaxOutput {
 		return Artifact{}, errors.New("external partition backend output exceeds cap")
 	}
-	return DecodeArtifactForSource(raw, maxOutput, expected)
+	return DecodeArtifactForSource(raw, limits.MaxOutput, expected)
 }
 
 func validateExpectedSource(s Source) error {

--- a/TreeDB/internal/vectorpartition/vectorpartition.go
+++ b/TreeDB/internal/vectorpartition/vectorpartition.go
@@ -572,14 +572,17 @@ func partitionWorkUnits(n, parts, degree int) (int64, bool) {
 	if n < 0 || parts < 0 || degree < 0 {
 		return 0, true
 	}
-	// Deliberately overcount every loop/allocation family. Per-node work covers
-	// validation (degree+1), bucket fill/order, output zeroing/initialization,
-	// candidate reset/assignment, the partition scan, neighbor marking, and
-	// affinity rescans. Global setup covers zeroing loads and marks, the reserve
-	// pass, and initialization/iteration/allocation for degree buckets and the
-	// candidate buffer. An accepted shape therefore stays below this conservative
-	// declared cap even if a future implementation detail adds constant work.
-	perNode := int64(degree+1) + 6 + int64(parts) + int64(degree) + int64(degree)*int64(degree+1)
+	// Deliberately overcount every loop/allocation family. Per-node work charges
+	// validation (degree+1); bucket append plus amortized backing growth (2);
+	// order backing zeroing plus append (2); output backing zeroing plus -1
+	// initialization (2); candidate reset (1); assignment/load update (1); the
+	// partition scan; candidate construction including the least-loaded choice
+	// (degree+1); its outer scoring iteration (degree+1); and affinity rescans.
+	// Global setup covers zeroing loads and marks, the reserve pass, and
+	// initialization/iteration/allocation for degree buckets and candidate
+	// backing. An accepted shape therefore stays below this conservative declared
+	// cap even if a future implementation detail adds constant work.
+	perNode := int64(degree+1) + 8 + int64(parts) + 2*int64(degree+1) + int64(degree)*int64(degree+1)
 	if int64(n) != 0 && perNode > math.MaxInt64/int64(n) {
 		return 0, true
 	}

--- a/TreeDB/internal/vectorpartition/vectorpartition.go
+++ b/TreeDB/internal/vectorpartition/vectorpartition.go
@@ -373,8 +373,17 @@ func validateInput(v []Vector, dimensions int) error {
 		if len(x.Values) != dimensions {
 			return errors.New("wrong vector dimension")
 		}
-		if x.ID == "" || !utf8.ValidString(x.ID) || len(x.ID) > maxIDBytes || totalIDBytes > maxTotalIDBytes-len(x.ID) {
+		if x.ID == "" {
 			return errors.New("empty vector ID")
+		}
+		if !utf8.ValidString(x.ID) {
+			return errors.New("invalid UTF-8 vector ID")
+		}
+		if len(x.ID) > maxIDBytes {
+			return errors.New("vector ID exceeds per-ID byte cap")
+		}
+		if totalIDBytes > maxTotalIDBytes-len(x.ID) {
+			return errors.New("vector ID aggregate bytes exceed cap")
 		}
 		totalIDBytes += len(x.ID)
 		for _, n := range x.Values {

--- a/TreeDB/internal/vectorpartition/vectorpartition.go
+++ b/TreeDB/internal/vectorpartition/vectorpartition.go
@@ -22,10 +22,17 @@ import (
 )
 
 const (
-	SchemaVersion = 1
-	maxVectors    = 1_000_000
-	maxDimensions = 4096
-	maxEdges      = 64_000_000
+	SchemaVersion   = 1
+	maxVectors      = 1_000_000
+	maxDimensions   = 4096
+	maxEdges        = 64_000_000
+	maxRepetitions  = 32
+	maxPivots       = 1024
+	maxLeafBucket   = 65536
+	maxDegree       = 1024
+	maxPartitions   = 16384
+	maxIDBytes      = 1 << 20
+	maxDistanceWork = int64(1_000_000_000)
 )
 
 // Vector IDs must be unique and are canonically ordered before construction.
@@ -160,7 +167,7 @@ func sourceFor(v []Vector, metric, id string) Source {
 }
 
 func validateInput(v []Vector, c Config) error {
-	if c.Metric != "cosine" || c.Repetitions < 1 || c.Pivots < 2 || c.MaxLeafBucket < 2 || c.Degree < 1 || c.Partitions < 1 || !finite(c.Imbalance) || c.Imbalance < 0 || c.Imbalance > 1 || c.MaxVectors < 1 || c.MaxVectors > maxVectors || c.MaxEdges < 1 || c.MaxEdges > maxEdges {
+	if c.Metric != "cosine" || c.Repetitions < 1 || c.Repetitions > maxRepetitions || c.Pivots < 2 || c.Pivots > maxPivots || c.MaxLeafBucket < 2 || c.MaxLeafBucket > maxLeafBucket || c.Degree < 1 || c.Degree > maxDegree || c.Partitions < 1 || c.Partitions > maxPartitions || !finite(c.Imbalance) || c.Imbalance < 0 || c.Imbalance > 1 || c.MaxVectors < 1 || c.MaxVectors > maxVectors || c.MaxEdges < 1 || c.MaxEdges > maxEdges {
 		return errors.New("invalid vector partition configuration")
 	}
 	if len(v) < c.Partitions || len(v) > c.MaxVectors {
@@ -168,7 +175,7 @@ func validateInput(v []Vector, c Config) error {
 	}
 	dims := 0
 	for _, x := range v {
-		if x.ID == "" {
+		if x.ID == "" || len(x.ID) > maxIDBytes {
 			return errors.New("empty vector ID")
 		}
 		if dims == 0 {
@@ -186,7 +193,7 @@ func validateInput(v []Vector, c Config) error {
 			}
 		}
 	}
-	if int64(len(v))*int64(c.Degree) > int64(c.MaxEdges) || int64(len(v))*int64(c.Degree) > int64(c.MaxEdges)/int64(c.Repetitions) {
+	if int64(len(v))*int64(c.Degree) > int64(c.MaxEdges) || int64(len(v))*int64(c.Degree) > int64(c.MaxEdges)/int64(c.Repetitions) || int64(len(v))*int64(c.MaxLeafBucket)*int64(c.Repetitions) > maxDistanceWork {
 		return errors.New("configured graph edge bound exceeded before allocation")
 	}
 	return nil

--- a/TreeDB/internal/vectorpartition/vectorpartition.go
+++ b/TreeDB/internal/vectorpartition/vectorpartition.go
@@ -282,6 +282,12 @@ func cloneGraphBounded(g Graph, maxEdges int) (Graph, error) {
 	backing := make([]int, total)
 	at := 0
 	for i, neighbors := range g.Neighbors {
+		if len(neighbors) == 0 {
+			// Keep the canonical JSON graph shape stable: a zero-degree row is
+			// an empty array, never a nil slice serialized as null.
+			clone.Neighbors[i] = make([]int, 0)
+			continue
+		}
 		clone.Neighbors[i] = backing[at : at+len(neighbors) : at+len(neighbors)]
 		copy(clone.Neighbors[i], neighbors)
 		at += len(neighbors)
@@ -464,6 +470,11 @@ func buildGraph(v []Vector, c Config) (Graph, error) {
 		}
 	}
 	g := Graph{Neighbors: make([][]int, n)}
+	for i := range g.Neighbors {
+		// Canonical artifacts represent every zero-degree row as [] rather
+		// than null, including isolated vectors.
+		g.Neighbors[i] = make([]int, 0)
+	}
 	for i, s := range sets {
 		for j := range s {
 			if i != j {
@@ -911,6 +922,9 @@ func validateGraphAndDegree(g Graph, n, degree int) (int, error) {
 	}
 	maxObservedDegree := 0
 	for i, ns := range g.Neighbors {
+		if ns == nil {
+			return 0, errors.New("graph neighbor row must be an array")
+		}
 		if len(ns) > degree {
 			return 0, errors.New("degree cap exceeded")
 		}

--- a/TreeDB/internal/vectorpartition/vectorpartition.go
+++ b/TreeDB/internal/vectorpartition/vectorpartition.go
@@ -66,10 +66,22 @@ type Metrics struct {
 	MaxPartitionSize    int `json:"max_partition_size"`
 	Cap                 int `json:"cap"`
 }
+
+// Source binds an artifact to the exact immutable input snapshot. SourceID is
+// caller supplied (for example exporter manifest digest); Checksum is computed
+// over canonical stable-ID/vector bits and never accepted on trust.
+type Source struct {
+	SourceID   string `json:"source_id"`
+	Checksum   string `json:"checksum"`
+	Vectors    int    `json:"vectors"`
+	Dimensions int    `json:"dimensions"`
+	Metric     string `json:"metric"`
+}
 type Artifact struct {
 	SchemaVersion  int      `json:"schema_version"`
 	Backend        string   `json:"backend"`
 	BackendLicense string   `json:"backend_license"`
+	Source         Source   `json:"source"`
 	Config         Config   `json:"config"`
 	IDs            []string `json:"ids"`
 	Graph          Graph    `json:"graph"`
@@ -88,6 +100,16 @@ type ReferencePartitioner struct{}
 func (ReferencePartitioner) Name() string { return "treedb_reference_greedy_v1" }
 
 func Build(vectors []Vector, cfg Config) (Artifact, error) {
+	return BuildWithPartitioner(vectors, cfg, Source{SourceID: "inline_vectors_v1"}, ReferencePartitioner{})
+}
+
+// BuildWithPartitioner is the usable offline backend seam. The supplied
+// partitioner's result is never trusted: graph, assignment, source and metrics
+// are independently validated before the artifact is returned.
+func BuildWithPartitioner(vectors []Vector, cfg Config, source Source, backend Partitioner) (Artifact, error) {
+	if backend == nil || backend.Name() == "" {
+		return Artifact{}, errors.New("partition backend identity is required")
+	}
 	if err := validateInput(vectors, cfg); err != nil {
 		return Artifact{}, err
 	}
@@ -103,7 +125,7 @@ func Build(vectors []Vector, cfg Config) (Artifact, error) {
 		return Artifact{}, err
 	}
 	cap := partitionCap(len(v), cfg.Partitions, cfg.Imbalance)
-	a, err := ReferencePartitioner{}.Partition(g, cfg.Partitions, cap)
+	a, err := backend.Partition(g, cfg.Partitions, cap)
 	if err != nil {
 		return Artifact{}, err
 	}
@@ -111,12 +133,30 @@ func Build(vectors []Vector, cfg Config) (Artifact, error) {
 	for i := range v {
 		ids[i] = v[i].ID
 	}
-	art := Artifact{SchemaVersion: SchemaVersion, Backend: ReferencePartitioner{}.Name(), BackendLicense: "TreeDB clean-room reference implementation (repository license)", Config: cfg, IDs: ids, Graph: g, Assignment: a}
+	computed := sourceFor(v, cfg.Metric, source.SourceID)
+	if source.Checksum != "" && source != computed {
+		return Artifact{}, errors.New("source identity does not match input snapshot")
+	}
+	art := Artifact{SchemaVersion: SchemaVersion, Backend: backend.Name(), BackendLicense: "TreeDB clean-room reference implementation (repository license)", Source: computed, Config: cfg, IDs: ids, Graph: g, Assignment: a}
 	art.Metrics = metrics(art)
 	if err := ValidateArtifact(art); err != nil {
 		return Artifact{}, err
 	}
 	return art, nil
+}
+
+func sourceFor(v []Vector, metric, id string) Source {
+	h := sha256.New()
+	var b [8]byte
+	for _, x := range v {
+		h.Write([]byte(x.ID))
+		h.Write([]byte{0})
+		for _, f := range x.Values {
+			binary.BigEndian.PutUint64(b[:], math.Float64bits(f))
+			h.Write(b[:])
+		}
+	}
+	return Source{SourceID: id, Checksum: hex.EncodeToString(h.Sum(nil)), Vectors: len(v), Dimensions: len(v[0].Values), Metric: metric}
 }
 
 func validateInput(v []Vector, c Config) error {
@@ -155,9 +195,9 @@ func finite(x float64) bool { return !math.IsNaN(x) && !math.IsInf(x, 0) }
 
 func buildGraph(v []Vector, c Config) (Graph, error) {
 	n := len(v)
-	sets := make([]map[int]struct{}, n)
+	sets := make([]map[int]float64, n)
 	for i := range sets {
-		sets[i] = make(map[int]struct{}, c.Degree)
+		sets[i] = make(map[int]float64, c.Degree)
 	}
 	for rep := 0; rep < c.Repetitions; rep++ {
 		r := rand.New(rand.NewSource(c.Seed + int64(rep)*0x9e3779b))
@@ -183,12 +223,12 @@ func buildGraph(v []Vector, c Config) (Graph, error) {
 	}
 	return g, nil
 }
-func carveDepth(v []Vector, ids []int, c Config, sets []map[int]struct{}, depth int) error {
+func carveDepth(v []Vector, ids []int, c Config, sets []map[int]float64, depth int) error {
 	if len(ids) <= c.MaxLeafBucket {
 		for _, i := range ids {
 			nearest := nearest(v, ids, i, c.Degree)
-			for _, j := range nearest {
-				addSetBounded(sets[i], j, c.Degree)
+			for _, candidate := range nearest {
+				addCandidateBounded(sets[i], candidate.i, candidate.x, c.Degree)
 			}
 		}
 		return nil
@@ -233,7 +273,7 @@ func carveDepth(v []Vector, ids []int, c Config, sets []map[int]struct{}, depth 
 	}
 	return nil
 }
-func nearest(v []Vector, ids []int, target, k int) []int {
+func nearest(v []Vector, ids []int, target, k int) []candidate {
 	type d struct {
 		i int
 		x float64
@@ -248,9 +288,9 @@ func nearest(v []Vector, ids []int, target, k int) []int {
 	if len(a) > k {
 		a = a[:k]
 	}
-	out := make([]int, len(a))
+	out := make([]candidate, len(a))
 	for i := range a {
-		out[i] = a[i].i
+		out[i] = candidate{a[i].i, a[i].x}
 	}
 	return out
 }
@@ -266,23 +306,33 @@ func distance(a, b []float64) float64 {
 	}
 	return 1 - dot/math.Sqrt(na*nb)
 }
-func addSetBounded(s map[int]struct{}, x, cap int) {
-	if _, ok := s[x]; ok {
+
+type candidate struct {
+	i int
+	x float64
+}
+
+func addCandidateBounded(s map[int]float64, x int, d float64, cap int) {
+	if old, ok := s[x]; ok {
+		if d < old {
+			s[x] = d
+		}
 		return
 	}
 	if len(s) < cap {
-		s[x] = struct{}{}
+		s[x] = d
 		return
 	}
 	worst := -1
-	for v := range s {
-		if v > worst {
-			worst = v
+	worstD := -1.0
+	for i, v := range s {
+		if v > worstD || v == worstD && i > worst {
+			worst, worstD = i, v
 		}
 	}
-	if x < worst {
+	if d < worstD || d == worstD && x < worst {
 		delete(s, worst)
-		s[x] = struct{}{}
+		s[x] = d
 	}
 }
 
@@ -367,7 +417,7 @@ func stableIDPartition(id string, partitions int) int {
 }
 
 func ValidateArtifact(a Artifact) error {
-	if a.SchemaVersion != SchemaVersion || a.Backend == "" || len(a.IDs) == 0 || len(a.IDs) != len(a.Graph.Neighbors) || len(a.IDs) != len(a.Assignment) {
+	if a.SchemaVersion != SchemaVersion || a.Backend == "" || len(a.Backend) > 256 || a.BackendLicense == "" || len(a.BackendLicense) > 1024 || a.Source.SourceID == "" || len(a.Source.SourceID) > 1024 || len(a.Source.Checksum) != 64 || a.Source.Vectors != len(a.IDs) || a.Source.Dimensions < 1 || a.Source.Metric != a.Config.Metric || len(a.IDs) == 0 || len(a.IDs) != len(a.Graph.Neighbors) || len(a.IDs) != len(a.Assignment) {
 		return errors.New("malformed partition artifact")
 	}
 	if err := validateInput(makeVectors(a.IDs, a.Graph.Neighbors), a.Config); err != nil {
@@ -388,6 +438,9 @@ func ValidateArtifact(a Artifact) error {
 		}
 		loads[p]++
 	}
+	if _, err := hex.DecodeString(a.Source.Checksum); err != nil {
+		return errors.New("invalid source checksum")
+	}
 	for _, n := range loads {
 		if n > cap {
 			return errors.New("partition cap exceeded")
@@ -407,12 +460,12 @@ func validateGraph(g Graph, n, degree int) error {
 		if len(ns) > degree {
 			return errors.New("degree cap exceeded")
 		}
-		seen := map[int]bool{}
+		previous := -1
 		for _, j := range ns {
-			if j < 0 || j >= n || j == i || seen[j] {
+			if j < 0 || j >= n || j == i || j <= previous {
 				return errors.New("invalid graph edge")
 			}
-			seen[j] = true
+			previous = j
 		}
 	}
 	return nil
@@ -467,7 +520,13 @@ func DecodeArtifact(raw []byte, maxBytes int) (Artifact, error) {
 // TreeDB runtime dependency. Its output is written to a private temp path and
 // removed on cancellation, timeout, command failure, or invalid output.
 func RunExternalJSON(ctx context.Context, command []string, input []byte, maxOutput int) (Artifact, error) {
-	if len(command) == 0 || maxOutput < 1 {
+	if ctx == nil {
+		return Artifact{}, errors.New("external backend requires context deadline")
+	}
+	if _, ok := ctx.Deadline(); !ok {
+		return Artifact{}, errors.New("external backend requires context deadline")
+	}
+	if len(command) == 0 || maxOutput < 1 || len(input) > maxOutput {
 		return Artifact{}, errors.New("invalid external backend command")
 	}
 	dir, err := os.MkdirTemp("", "treedb-vectorpartition-backend-*")
@@ -481,8 +540,13 @@ func RunExternalJSON(ctx context.Context, command []string, input []byte, maxOut
 		return Artifact{}, err
 	}
 	cmd := exec.CommandContext(ctx, command[0], append(command[1:], in, out)...)
-	if b, e := cmd.CombinedOutput(); e != nil {
-		return Artifact{}, fmt.Errorf("external partition backend: %w: %s", e, bytes.TrimSpace(b))
+	stderr := &cappedBuffer{limit: maxOutput}
+	cmd.Stderr = stderr
+	if e := cmd.Run(); e != nil {
+		return Artifact{}, fmt.Errorf("external partition backend: %w: %s", e, bytes.TrimSpace(stderr.Bytes()))
+	}
+	if stderr.exceeded {
+		return Artifact{}, errors.New("external partition backend stderr exceeds cap")
 	}
 	f, e := os.Open(out)
 	if e != nil {
@@ -497,6 +561,20 @@ func RunExternalJSON(ctx context.Context, command []string, input []byte, maxOut
 		return Artifact{}, errors.New("external partition backend output exceeds cap")
 	}
 	return DecodeArtifact(raw, maxOutput)
+}
+
+type cappedBuffer struct {
+	bytes.Buffer
+	limit    int
+	exceeded bool
+}
+
+func (b *cappedBuffer) Write(p []byte) (int, error) {
+	if len(p) > b.limit-b.Len() {
+		b.exceeded = true
+		return len(p), nil
+	}
+	return b.Buffer.Write(p)
 }
 func Digest(a Artifact) (string, error) {
 	b, e := CanonicalJSON(a)

--- a/TreeDB/internal/vectorpartition/vectorpartition.go
+++ b/TreeDB/internal/vectorpartition/vectorpartition.go
@@ -34,7 +34,9 @@ const (
 	maxDegree       = 1024
 	maxPartitions   = 16384
 	maxIDBytes      = 1 << 20
+	maxTotalIDBytes = 64 << 20
 	maxDistanceWork = int64(1_000_000_000)
+	maxCarveDepth   = 64
 )
 
 // Vector IDs must be unique and are canonically ordered before construction.
@@ -202,10 +204,12 @@ func validateInput(v []Vector, c Config) error {
 		return errors.New("vector count outside configured bounds")
 	}
 	dims := 0
+	totalIDBytes := 0
 	for _, x := range v {
-		if x.ID == "" || len(x.ID) > maxIDBytes {
+		if x.ID == "" || len(x.ID) > maxIDBytes || totalIDBytes > maxTotalIDBytes-len(x.ID) {
 			return errors.New("empty vector ID")
 		}
+		totalIDBytes += len(x.ID)
 		if dims == 0 {
 			dims = len(x.Values)
 			if dims < 1 || dims > maxDimensions {
@@ -234,10 +238,11 @@ func buildGraph(v []Vector, c Config) (Graph, error) {
 	for i := range sets {
 		sets[i] = make(map[int]float64, c.Degree)
 	}
+	budget := distanceBudget{remaining: maxDistanceWork}
 	for rep := 0; rep < c.Repetitions; rep++ {
 		r := rand.New(rand.NewSource(c.Seed + int64(rep)*0x9e3779b))
 		order := r.Perm(n)
-		if err := carveDepth(v, order, c, sets, 0); err != nil {
+		if err := carveDepth(v, order, c, sets, 0, &budget); err != nil {
 			return Graph{}, err
 		}
 	}
@@ -258,10 +263,27 @@ func buildGraph(v []Vector, c Config) (Graph, error) {
 	}
 	return g, nil
 }
-func carveDepth(v []Vector, ids []int, c Config, sets []map[int]float64, depth int) error {
+
+// distanceBudget bounds every cosine evaluation in the pivot and leaf phases.
+// It is runtime-enforced because input geometry, rather than configuration
+// alone, determines recursive bucket shape.
+type distanceBudget struct{ remaining int64 }
+
+func (b *distanceBudget) take(n int64) error {
+	if n < 0 || n > b.remaining {
+		return errors.New("graph distance-work budget exceeded")
+	}
+	b.remaining -= n
+	return nil
+}
+
+func carveDepth(v []Vector, ids []int, c Config, sets []map[int]float64, depth int, budget *distanceBudget) error {
 	if len(ids) <= c.MaxLeafBucket {
 		for _, i := range ids {
-			nearest := nearest(v, ids, i, c.Degree)
+			nearest, err := nearest(v, ids, i, c.Degree, budget)
+			if err != nil {
+				return err
+			}
 			for _, candidate := range nearest {
 				addCandidateBounded(sets[i], candidate.i, candidate.x, c.Degree)
 			}
@@ -269,16 +291,26 @@ func carveDepth(v []Vector, ids []int, c Config, sets []map[int]float64, depth i
 		return nil
 	}
 	k := min(c.Pivots, len(ids))
+	if depth >= maxCarveDepth {
+		return carveChunks(v, ids, c, sets, depth, budget)
+	}
 	pivots := append([]int(nil), ids[:k]...)
 	buckets := make([][]int, k)
 	for _, i := range ids {
+		if err := budget.take(int64(k)); err != nil {
+			return err
+		}
+		var distances [maxPivots]float64
+		for p := range pivots {
+			distances[p] = distance(v[i].Values, v[pivots[p]].Values)
+		}
 		best, second := 0, -1
-		bestD := distance(v[i].Values, v[pivots[0]].Values)
+		bestD := distances[0]
 		for p := 1; p < k; p++ {
-			d := distance(v[i].Values, v[pivots[p]].Values)
+			d := distances[p]
 			if d < bestD || d == bestD && pivots[p] < pivots[best] {
 				second, best, bestD = best, p, d
-			} else if second < 0 || d < distance(v[i].Values, v[pivots[second]].Values) || d == distance(v[i].Values, v[pivots[second]].Values) && pivots[p] < pivots[second] {
+			} else if second < 0 || d < distances[second] || d == distances[second] && pivots[p] < pivots[second] {
 				second = p
 			}
 		}
@@ -291,43 +323,56 @@ func carveDepth(v []Vector, ids []int, c Config, sets []map[int]float64, depth i
 		}
 	}
 	for _, b := range buckets {
-		if len(b) == len(ids) { // duplicate/skew progress guarantee: deterministic chunking.
-			for start := 0; start < len(b); start += c.MaxLeafBucket {
-				end := min(start+c.MaxLeafBucket, len(b))
-				if err := carveDepth(v, b[start:end], c, sets, depth+1); err != nil {
-					return err
-				}
+		// A n-1 bucket can otherwise recurse one ordinal at a time on skewed
+		// geometry. Chunk the current membership deterministically instead.
+		if len(b) >= len(ids)-1 {
+			if err := carveChunks(v, b, c, sets, depth, budget); err != nil {
+				return err
 			}
 			continue
 		}
 		if len(b) > 0 {
-			if err := carveDepth(v, b, c, sets, depth+1); err != nil {
+			if err := carveDepth(v, b, c, sets, depth+1, budget); err != nil {
 				return err
 			}
 		}
 	}
 	return nil
 }
-func nearest(v []Vector, ids []int, target, k int) []candidate {
-	type d struct {
-		i int
-		x float64
+func carveChunks(v []Vector, ids []int, c Config, sets []map[int]float64, depth int, budget *distanceBudget) error {
+	for start := 0; start < len(ids); start += c.MaxLeafBucket {
+		end := min(start+c.MaxLeafBucket, len(ids))
+		if err := carveDepth(v, ids[start:end], c, sets, depth+1, budget); err != nil {
+			return err
+		}
 	}
-	a := make([]d, 0, len(ids)-1)
+	return nil
+}
+func nearest(v []Vector, ids []int, target, k int, budget *distanceBudget) ([]candidate, error) {
+	a := make([]candidate, 0, min(k, len(ids)-1))
 	for _, j := range ids {
 		if j != target {
-			a = append(a, d{j, distance(v[target].Values, v[j].Values)})
+			if err := budget.take(1); err != nil {
+				return nil, err
+			}
+			c := candidate{j, distance(v[target].Values, v[j].Values)}
+			if len(a) < k {
+				a = append(a, c)
+				continue
+			}
+			worst := 0
+			for x := 1; x < len(a); x++ {
+				if a[worst].x < a[x].x || a[worst].x == a[x].x && a[worst].i < a[x].i {
+					worst = x
+				}
+			}
+			if c.x < a[worst].x || c.x == a[worst].x && c.i < a[worst].i {
+				a[worst] = c
+			}
 		}
 	}
 	sort.Slice(a, func(i, j int) bool { return a[i].x < a[j].x || a[i].x == a[j].x && a[i].i < a[j].i })
-	if len(a) > k {
-		a = a[:k]
-	}
-	out := make([]candidate, len(a))
-	for i := range a {
-		out[i] = candidate{a[i].i, a[i].x}
-	}
-	return out
+	return a, nil
 }
 func distance(a, b []float64) float64 {
 	var dot, na, nb float64
@@ -418,7 +463,20 @@ func (ReferencePartitioner) Partition(g Graph, parts, cap int) ([]int, error) {
 }
 func partitionCap(n, p int, e float64) int { return int(math.Ceil((1 + e) * float64(n) / float64(p))) }
 func metrics(a Artifact) Metrics {
+	return metricsWithLoads(a, nil)
+}
+
+// metricsWithLoads accepts a validated assignment histogram when available so
+// validation does not need a second partitions-sized scan to compute the same
+// maximum load.
+func metricsWithLoads(a Artifact, loads []int) Metrics {
 	m := Metrics{Cap: partitionCap(len(a.IDs), a.Config.Partitions, a.Config.Imbalance)}
+	if loads == nil {
+		loads = make([]int, a.Config.Partitions)
+		for _, p := range a.Assignment {
+			loads[p]++
+		}
+	}
 	for i, ns := range a.Graph.Neighbors {
 		m.GraphEdges += len(ns)
 		if len(ns) > m.MaxDegree {
@@ -433,13 +491,7 @@ func metrics(a Artifact) Metrics {
 			}
 		}
 	}
-	for p := 0; p < a.Config.Partitions; p++ {
-		n := 0
-		for _, x := range a.Assignment {
-			if x == p {
-				n++
-			}
-		}
+	for _, n := range loads {
 		if n > m.MaxPartitionSize {
 			m.MaxPartitionSize = n
 		}
@@ -452,10 +504,10 @@ func stableIDPartition(id string, partitions int) int {
 }
 
 func ValidateArtifact(a Artifact) error {
-	if a.SchemaVersion != SchemaVersion || a.Backend == "" || len(a.Backend) > 256 || a.BackendLicense == "" || len(a.BackendLicense) > 1024 || a.Source.SourceID == "" || len(a.Source.SourceID) > 1024 || len(a.Source.Checksum) != 64 || strings.ToLower(a.Source.Checksum) != a.Source.Checksum || a.Source.Vectors != len(a.IDs) || a.Source.Dimensions < 1 || a.Source.Metric != a.Config.Metric || len(a.IDs) == 0 || len(a.IDs) != len(a.Graph.Neighbors) || len(a.IDs) != len(a.Assignment) {
+	if a.SchemaVersion != SchemaVersion || a.Backend == "" || len(a.Backend) > 256 || a.BackendLicense == "" || len(a.BackendLicense) > 1024 || a.Source.SourceID == "" || len(a.Source.SourceID) > 1024 || len(a.Source.Checksum) != 64 || strings.ToLower(a.Source.Checksum) != a.Source.Checksum || a.Source.Vectors != len(a.IDs) || a.Source.Dimensions < 1 || a.Source.Dimensions > maxDimensions || a.Source.Metric != a.Config.Metric || len(a.IDs) == 0 || len(a.IDs) != len(a.Graph.Neighbors) || len(a.IDs) != len(a.Assignment) {
 		return errors.New("malformed partition artifact")
 	}
-	if err := validateInput(makeVectors(a.IDs, a.Graph.Neighbors), a.Config); err != nil {
+	if err := validateArtifactConfig(a.IDs, a.Config); err != nil {
 		return fmt.Errorf("artifact config: %w", err)
 	}
 	if err := validateGraph(a.Graph, len(a.IDs), a.Config.Degree); err != nil {
@@ -463,10 +515,15 @@ func ValidateArtifact(a Artifact) error {
 	}
 	cap := partitionCap(len(a.IDs), a.Config.Partitions, a.Config.Imbalance)
 	loads := make([]int, a.Config.Partitions)
+	var totalIDBytes int
 	for i, id := range a.IDs {
 		if id == "" || i > 0 && id <= a.IDs[i-1] {
 			return errors.New("IDs not unique canonical order")
 		}
+		if len(id) > maxIDBytes || totalIDBytes > maxTotalIDBytes-len(id) {
+			return errors.New("artifact ID bytes exceed cap")
+		}
+		totalIDBytes += len(id)
 		p := a.Assignment[i]
 		if p < 0 || p >= a.Config.Partitions {
 			return errors.New("assignment out of range")
@@ -481,9 +538,18 @@ func ValidateArtifact(a Artifact) error {
 			return errors.New("partition cap exceeded")
 		}
 	}
-	m := metrics(a)
+	m := metricsWithLoads(a, loads)
 	if a.Metrics.GraphEdges != m.GraphEdges || a.Metrics.MaxDegree != m.MaxDegree || a.Metrics.EdgeCut != m.EdgeCut || a.Metrics.StableIDHashEdgeCut != m.StableIDHashEdgeCut || a.Metrics.MaxPartitionSize != m.MaxPartitionSize || a.Metrics.Cap != m.Cap {
 		return errors.New("artifact metrics do not match graph and assignment")
+	}
+	return nil
+}
+func validateArtifactConfig(ids []string, c Config) error {
+	if c.Metric != "cosine" || c.Repetitions < 1 || c.Repetitions > maxRepetitions || c.Pivots < 2 || c.Pivots > maxPivots || c.MaxLeafBucket < 2 || c.MaxLeafBucket > maxLeafBucket || c.Degree < 1 || c.Degree > maxDegree || c.Partitions < 1 || c.Partitions > maxPartitions || !finite(c.Imbalance) || c.Imbalance < 0 || c.Imbalance > 1 || c.MaxVectors < 1 || c.MaxVectors > maxVectors || c.MaxEdges < 1 || c.MaxEdges > maxEdges || len(ids) < c.Partitions || len(ids) > c.MaxVectors {
+		return errors.New("invalid artifact configuration")
+	}
+	if int64(len(ids))*int64(c.Degree) > int64(c.MaxEdges) || int64(len(ids))*int64(c.Degree) > int64(c.MaxEdges)/int64(c.Repetitions) {
+		return errors.New("artifact graph bound exceeded")
 	}
 	return nil
 }
@@ -506,14 +572,6 @@ func validateGraph(g Graph, n, degree int) error {
 	return nil
 }
 
-// makeVectors supplies structural validation without allocating payload-sized copies.
-func makeVectors(ids []string, g [][]int) []Vector {
-	v := make([]Vector, len(ids))
-	for i := range v {
-		v[i] = Vector{ID: ids[i], Values: []float64{0}}
-	}
-	return v
-}
 func CanonicalJSON(a Artifact) ([]byte, error) {
 	if err := ValidateArtifact(a); err != nil {
 		return nil, err
@@ -568,9 +626,12 @@ func DecodeArtifactForSource(raw []byte, maxBytes int, expected Source) (Artifac
 // TreeDB runtime dependency. Its output is written to a private temp path and
 // removed on cancellation, timeout, command failure, or invalid output.
 func RunExternalJSON(ctx context.Context, command []string, input []byte, maxOutput int) (Artifact, error) {
-	return RunExternalJSONForSource(ctx, command, input, maxOutput, Source{})
+	return Artifact{}, errors.New("external backend requires expected source binding")
 }
 func RunExternalJSONForSource(ctx context.Context, command []string, input []byte, maxOutput int, expected Source) (Artifact, error) {
+	if err := validateExpectedSource(expected); err != nil {
+		return Artifact{}, err
+	}
 	if ctx == nil {
 		return Artifact{}, errors.New("external backend requires context deadline")
 	}
@@ -611,10 +672,17 @@ func RunExternalJSONForSource(ctx context.Context, command []string, input []byt
 	if len(raw) > maxOutput {
 		return Artifact{}, errors.New("external partition backend output exceeds cap")
 	}
-	if expected.SourceID != "" {
-		return DecodeArtifactForSource(raw, maxOutput, expected)
+	return DecodeArtifactForSource(raw, maxOutput, expected)
+}
+
+func validateExpectedSource(s Source) error {
+	if s.SourceID == "" || len(s.SourceID) > 1024 || len(s.Checksum) != 64 || strings.ToLower(s.Checksum) != s.Checksum || s.Vectors < 1 || s.Vectors > maxVectors || s.Dimensions < 1 || s.Dimensions > maxDimensions || s.Metric != "cosine" {
+		return errors.New("invalid expected source binding")
 	}
-	return DecodeArtifact(raw, maxOutput)
+	if _, err := hex.DecodeString(s.Checksum); err != nil {
+		return errors.New("invalid expected source binding")
+	}
+	return nil
 }
 
 type cappedBuffer struct {

--- a/TreeDB/internal/vectorpartition/vectorpartition.go
+++ b/TreeDB/internal/vectorpartition/vectorpartition.go
@@ -1,0 +1,416 @@
+// Package vectorpartition builds a bounded, deterministic offline vector graph
+// and a disjoint balanced partition artifact. It is deliberately independent
+// of TreeDB collection and Raft lifecycle code.
+package vectorpartition
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"math"
+	"math/rand"
+	"sort"
+	"time"
+)
+
+const (
+	SchemaVersion = 1
+	maxVectors    = 1_000_000
+	maxDimensions = 4096
+	maxEdges      = 64_000_000
+)
+
+// Vector IDs must be unique and are canonically ordered before construction.
+type Vector struct {
+	ID     string
+	Values []float64
+}
+
+// Config makes the clean-room sketch controls explicit. The reference backend
+// is intentionally in-process and deterministic, so CI never needs a native
+// partitioner or runtime FFI.
+type Config struct {
+	Metric        string  `json:"metric"`
+	Seed          int64   `json:"seed"`
+	Repetitions   int     `json:"repetitions"`
+	Pivots        int     `json:"pivots"`
+	MaxLeafBucket int     `json:"max_leaf_bucket"`
+	Degree        int     `json:"degree"`
+	Partitions    int     `json:"partitions"`
+	Imbalance     float64 `json:"imbalance"`
+	Symmetric     bool    `json:"symmetric"`
+	MaxVectors    int     `json:"max_vectors"`
+	MaxEdges      int     `json:"max_edges"`
+}
+
+func DefaultConfig() Config {
+	return Config{Metric: "cosine", Seed: 1, Repetitions: 4, Pivots: 8, MaxLeafBucket: 128, Degree: 16, Partitions: 16, Imbalance: .05, Symmetric: true, MaxVectors: maxVectors, MaxEdges: maxEdges}
+}
+
+type Graph struct {
+	Neighbors [][]int `json:"neighbors"`
+}
+type Metrics struct {
+	BuildNanos       int64 `json:"build_nanos"`
+	GraphEdges       int   `json:"graph_edges"`
+	MaxDegree        int   `json:"max_degree"`
+	EdgeCut          int   `json:"edge_cut"`
+	MaxPartitionSize int   `json:"max_partition_size"`
+	Cap              int   `json:"cap"`
+}
+type Artifact struct {
+	SchemaVersion  int      `json:"schema_version"`
+	Backend        string   `json:"backend"`
+	BackendLicense string   `json:"backend_license"`
+	Config         Config   `json:"config"`
+	IDs            []string `json:"ids"`
+	Graph          Graph    `json:"graph"`
+	Assignment     []int    `json:"assignment"`
+	Metrics        Metrics  `json:"metrics"`
+}
+
+// Partitioner is the deliberately narrow backend seam. Implementations return
+// ordinals only; ValidateArtifact independently verifies every invariant.
+type Partitioner interface {
+	Name() string
+	Partition(Graph, int, int) ([]int, error)
+}
+type ReferencePartitioner struct{}
+
+func (ReferencePartitioner) Name() string { return "treedb_reference_greedy_v1" }
+
+func Build(vectors []Vector, cfg Config) (Artifact, error) {
+	start := time.Now()
+	if err := validateInput(vectors, cfg); err != nil {
+		return Artifact{}, err
+	}
+	v := append([]Vector(nil), vectors...)
+	sort.Slice(v, func(i, j int) bool { return v[i].ID < v[j].ID })
+	for i := 1; i < len(v); i++ {
+		if v[i].ID == v[i-1].ID {
+			return Artifact{}, fmt.Errorf("duplicate vector ID %q", v[i].ID)
+		}
+	}
+	g, err := buildGraph(v, cfg)
+	if err != nil {
+		return Artifact{}, err
+	}
+	cap := partitionCap(len(v), cfg.Partitions, cfg.Imbalance)
+	a, err := ReferencePartitioner{}.Partition(g, cfg.Partitions, cap)
+	if err != nil {
+		return Artifact{}, err
+	}
+	ids := make([]string, len(v))
+	for i := range v {
+		ids[i] = v[i].ID
+	}
+	art := Artifact{SchemaVersion: SchemaVersion, Backend: ReferencePartitioner{}.Name(), BackendLicense: "TreeDB clean-room reference implementation (repository license)", Config: cfg, IDs: ids, Graph: g, Assignment: a}
+	art.Metrics = metrics(art)
+	// Timings are run-report data rather than immutable artifact data. Keeping
+	// this field zero makes CanonicalJSON byte-identical for identical input.
+	_ = start
+	if err := ValidateArtifact(art); err != nil {
+		return Artifact{}, err
+	}
+	return art, nil
+}
+
+func validateInput(v []Vector, c Config) error {
+	if c.Metric != "cosine" || c.Repetitions < 1 || c.Pivots < 2 || c.MaxLeafBucket < 2 || c.Degree < 1 || c.Partitions < 1 || !finite(c.Imbalance) || c.Imbalance < 0 || c.Imbalance > 1 || c.MaxVectors < 1 || c.MaxVectors > maxVectors || c.MaxEdges < 1 || c.MaxEdges > maxEdges {
+		return errors.New("invalid vector partition configuration")
+	}
+	if len(v) < c.Partitions || len(v) > c.MaxVectors {
+		return errors.New("vector count outside configured bounds")
+	}
+	dims := 0
+	for _, x := range v {
+		if x.ID == "" {
+			return errors.New("empty vector ID")
+		}
+		if dims == 0 {
+			dims = len(x.Values)
+			if dims < 1 || dims > maxDimensions {
+				return errors.New("invalid vector dimensions")
+			}
+		}
+		if len(x.Values) != dims {
+			return errors.New("wrong vector dimension")
+		}
+		for _, n := range x.Values {
+			if !finite(n) {
+				return errors.New("non-finite vector value")
+			}
+		}
+	}
+	if int64(len(v))*int64(c.Degree) > int64(c.MaxEdges) {
+		return errors.New("configured graph edge bound exceeded before allocation")
+	}
+	return nil
+}
+func finite(x float64) bool { return !math.IsNaN(x) && !math.IsInf(x, 0) }
+
+func buildGraph(v []Vector, c Config) (Graph, error) {
+	n := len(v)
+	sets := make([]map[int]struct{}, n)
+	for i := range sets {
+		sets[i] = make(map[int]struct{}, c.Degree*c.Repetitions)
+	}
+	for rep := 0; rep < c.Repetitions; rep++ {
+		r := rand.New(rand.NewSource(c.Seed + int64(rep)*0x9e3779b))
+		order := r.Perm(n)
+		if err := carve(v, order, c, sets); err != nil {
+			return Graph{}, err
+		}
+	}
+	g := Graph{Neighbors: make([][]int, n)}
+	for i, s := range sets {
+		for j := range s {
+			if i != j {
+				g.Neighbors[i] = append(g.Neighbors[i], j)
+			}
+		}
+		sort.Ints(g.Neighbors[i])
+		if len(g.Neighbors[i]) > c.Degree {
+			g.Neighbors[i] = g.Neighbors[i][:c.Degree]
+		}
+	}
+	if c.Symmetric { // symmetric policy is bounded by retaining mutual/lowest ordinal candidates deterministically.
+		for i := range g.Neighbors {
+			for _, j := range g.Neighbors[i] {
+				addBounded(&g.Neighbors[j], i, c.Degree)
+			}
+		}
+		for i := range g.Neighbors {
+			sort.Ints(g.Neighbors[i])
+			if len(g.Neighbors[i]) > c.Degree {
+				g.Neighbors[i] = g.Neighbors[i][:c.Degree]
+			}
+		}
+	}
+	return g, nil
+}
+func carve(v []Vector, ids []int, c Config, sets []map[int]struct{}) error {
+	if len(ids) <= c.MaxLeafBucket {
+		for _, i := range ids {
+			nearest := nearest(v, ids, i, c.Degree)
+			for _, j := range nearest {
+				sets[i][j] = struct{}{}
+			}
+		}
+		return nil
+	}
+	k := min(c.Pivots, len(ids))
+	pivots := append([]int(nil), ids[:k]...)
+	buckets := make([][]int, k)
+	for _, i := range ids {
+		best := 0
+		bestD := distance(v[i].Values, v[pivots[0]].Values)
+		for p := 1; p < k; p++ {
+			d := distance(v[i].Values, v[pivots[p]].Values)
+			if d < bestD || d == bestD && pivots[p] < pivots[best] {
+				best, bestD = p, d
+			}
+		}
+		buckets[best] = append(buckets[best], i)
+	}
+	for _, b := range buckets {
+		if len(b) == len(ids) { // duplicate/skew progress guarantee: deterministic chunking.
+			for start := 0; start < len(b); start += c.MaxLeafBucket {
+				end := min(start+c.MaxLeafBucket, len(b))
+				if err := carve(v, b[start:end], c, sets); err != nil {
+					return err
+				}
+			}
+			continue
+		}
+		if len(b) > 0 {
+			if err := carve(v, b, c, sets); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+func nearest(v []Vector, ids []int, target, k int) []int {
+	type d struct {
+		i int
+		x float64
+	}
+	a := make([]d, 0, len(ids)-1)
+	for _, j := range ids {
+		if j != target {
+			a = append(a, d{j, distance(v[target].Values, v[j].Values)})
+		}
+	}
+	sort.Slice(a, func(i, j int) bool { return a[i].x < a[j].x || a[i].x == a[j].x && a[i].i < a[j].i })
+	if len(a) > k {
+		a = a[:k]
+	}
+	out := make([]int, len(a))
+	for i := range a {
+		out[i] = a[i].i
+	}
+	return out
+}
+func distance(a, b []float64) float64 {
+	var dot, na, nb float64
+	for i := range a {
+		dot = math.FMA(a[i], b[i], dot)
+		na = math.FMA(a[i], a[i], na)
+		nb = math.FMA(b[i], b[i], nb)
+	}
+	if na == 0 || nb == 0 {
+		return 1
+	}
+	return 1 - dot/math.Sqrt(na*nb)
+}
+func addBounded(a *[]int, x, cap int) {
+	for _, v := range *a {
+		if v == x {
+			return
+		}
+	}
+	*a = append(*a, x)
+	sort.Ints(*a)
+	if len(*a) > cap {
+		*a = (*a)[:cap]
+	}
+}
+
+func (ReferencePartitioner) Partition(g Graph, parts, cap int) ([]int, error) {
+	n := len(g.Neighbors)
+	if parts < 1 || cap < 1 || n < parts {
+		return nil, errors.New("invalid partition request")
+	}
+	order := make([]int, n)
+	for i := range order {
+		order[i] = i
+	}
+	sort.Slice(order, func(i, j int) bool {
+		a, b := order[i], order[j]
+		return len(g.Neighbors[a]) > len(g.Neighbors[b]) || len(g.Neighbors[a]) == len(g.Neighbors[b]) && a < b
+	})
+	out := make([]int, n)
+	for i := range out {
+		out[i] = -1
+	}
+	loads := make([]int, parts)
+	for _, node := range order {
+		best, bscore := -1, -1
+		for p := 0; p < parts; p++ {
+			if loads[p] >= cap {
+				continue
+			}
+			score := 0
+			for _, to := range g.Neighbors[node] {
+				if out[to] == p {
+					score++
+				}
+			}
+			if score > bscore || score == bscore && (best < 0 || loads[p] < loads[best] || loads[p] == loads[best] && p < best) {
+				best, bscore = p, score
+			}
+		}
+		if best < 0 {
+			return nil, errors.New("partition cap prevents exact coverage")
+		}
+		out[node] = best
+		loads[best]++
+	}
+	return out, nil
+}
+func partitionCap(n, p int, e float64) int { return int(math.Ceil((1 + e) * float64(n) / float64(p))) }
+func metrics(a Artifact) Metrics {
+	m := Metrics{Cap: partitionCap(len(a.IDs), a.Config.Partitions, a.Config.Imbalance)}
+	for i, ns := range a.Graph.Neighbors {
+		m.GraphEdges += len(ns)
+		if len(ns) > m.MaxDegree {
+			m.MaxDegree = len(ns)
+		}
+		for _, j := range ns {
+			if a.Assignment[i] != a.Assignment[j] {
+				m.EdgeCut++
+			}
+		}
+	}
+	for p := 0; p < a.Config.Partitions; p++ {
+		n := 0
+		for _, x := range a.Assignment {
+			if x == p {
+				n++
+			}
+		}
+		if n > m.MaxPartitionSize {
+			m.MaxPartitionSize = n
+		}
+	}
+	return m
+}
+
+func ValidateArtifact(a Artifact) error {
+	if a.SchemaVersion != SchemaVersion || a.Backend == "" || len(a.IDs) == 0 || len(a.IDs) != len(a.Graph.Neighbors) || len(a.IDs) != len(a.Assignment) {
+		return errors.New("malformed partition artifact")
+	}
+	if err := validateInput(makeVectors(a.IDs, a.Graph.Neighbors), a.Config); err != nil {
+		return fmt.Errorf("artifact config: %w", err)
+	}
+	cap := partitionCap(len(a.IDs), a.Config.Partitions, a.Config.Imbalance)
+	loads := make([]int, a.Config.Partitions)
+	for i, id := range a.IDs {
+		if id == "" || i > 0 && id <= a.IDs[i-1] {
+			return errors.New("IDs not unique canonical order")
+		}
+		p := a.Assignment[i]
+		if p < 0 || p >= a.Config.Partitions {
+			return errors.New("assignment out of range")
+		}
+		loads[p]++
+		seen := map[int]bool{}
+		for _, j := range a.Graph.Neighbors[i] {
+			if j < 0 || j >= len(a.IDs) || j == i || seen[j] {
+				return errors.New("invalid graph edge")
+			}
+			seen[j] = true
+		}
+		if len(a.Graph.Neighbors[i]) > a.Config.Degree {
+			return errors.New("degree cap exceeded")
+		}
+	}
+	for _, n := range loads {
+		if n > cap {
+			return errors.New("partition cap exceeded")
+		}
+	}
+	return nil
+}
+
+// makeVectors supplies structural validation without allocating payload-sized copies.
+func makeVectors(ids []string, g [][]int) []Vector {
+	v := make([]Vector, len(ids))
+	for i := range v {
+		v[i] = Vector{ID: ids[i], Values: []float64{0}}
+	}
+	return v
+}
+func CanonicalJSON(a Artifact) ([]byte, error) {
+	if err := ValidateArtifact(a); err != nil {
+		return nil, err
+	}
+	return json.Marshal(a)
+}
+func Digest(a Artifact) (string, error) {
+	b, e := CanonicalJSON(a)
+	if e != nil {
+		return "", e
+	}
+	s := sha256.Sum256(b)
+	return hex.EncodeToString(s[:]), nil
+}
+func min(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}

--- a/TreeDB/internal/vectorpartition/vectorpartition_test.go
+++ b/TreeDB/internal/vectorpartition/vectorpartition_test.go
@@ -483,6 +483,32 @@ func TestZeroDegreeGraphRowsAreCanonicalEmptyArrays(t *testing.T) {
 	}
 }
 
+func TestValidateInputReportsSpecificIDFailures(t *testing.T) {
+	chunk := strings.Repeat("x", maxIDBytes)
+	aggregate := make([]Vector, maxTotalIDBytes/maxIDBytes+1)
+	for i := range aggregate {
+		aggregate[i] = Vector{ID: chunk, Values: []float64{1}}
+	}
+	cases := []struct {
+		name string
+		v    []Vector
+		want string
+	}{
+		{name: "empty", v: []Vector{{ID: "", Values: []float64{1}}}, want: "empty vector ID"},
+		{name: "invalid UTF-8", v: []Vector{{ID: string([]byte{0xff}), Values: []float64{1}}}, want: "invalid UTF-8 vector ID"},
+		{name: "per-ID cap", v: []Vector{{ID: strings.Repeat("x", maxIDBytes+1), Values: []float64{1}}}, want: "vector ID exceeds per-ID byte cap"},
+		{name: "aggregate cap", v: aggregate, want: "vector ID aggregate bytes exceed cap"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := validateInput(tc.v, 1)
+			if err == nil || err.Error() != tc.want {
+				t.Fatalf("validateInput error=%v want %q", err, tc.want)
+			}
+		})
+	}
+}
+
 func TestStrictDecoderRejectsNonCanonicalAndMetricForgery(t *testing.T) {
 	a, err := Build(fixture(), config())
 	if err != nil {

--- a/TreeDB/internal/vectorpartition/vectorpartition_test.go
+++ b/TreeDB/internal/vectorpartition/vectorpartition_test.go
@@ -173,6 +173,40 @@ func TestInputShapePreflightCountsTopLevelPivotWork(t *testing.T) {
 		t.Fatalf("pivot-work shape error=%v; expected scalar-work rejection", err)
 	}
 }
+
+func TestInputShapePreflightCountsTopLevelOverlapLeafWork(t *testing.T) {
+	c := DefaultConfig()
+	c.Partitions = 1
+	c.Repetitions = 1
+	c.Pivots = 2
+	c.MaxLeafBucket = 65_536
+	c.Degree = 1
+	if err := ValidateInputShape(c, 150_000, 1); err != nil {
+		t.Fatalf("overlap-work shape below cap rejected: %v", err)
+	}
+	if err := ValidateInputShape(c, 300_000, 1); err == nil || !strings.Contains(err.Error(), "scalar-work") {
+		t.Fatalf("overlap-work shape error=%v; expected scalar-work rejection", err)
+	}
+}
+
+func TestReferenceInputShapeSharesReferencePartitionWorkGate(t *testing.T) {
+	c := DefaultConfig()
+	c.Partitions = 238
+	c.Repetitions = 1
+	c.Pivots = 2
+	c.MaxLeafBucket = 2
+	c.Degree = 1
+	const vectors = 1_000_000
+	if !partitionWorkExceeded(vectors, c.Partitions, c.Degree) {
+		t.Fatal("test shape must exceed the reference partition work cap")
+	}
+	if err := ValidateInputShape(c, vectors, 1); err != nil {
+		t.Fatalf("generic shape preflight unexpectedly rejected reference-only shape: %v", err)
+	}
+	if err := ValidateReferenceInputShape(c, vectors, 1); err == nil || !strings.Contains(err.Error(), "partition work") {
+		t.Fatalf("reference shape error=%v; expected partition-work rejection", err)
+	}
+}
 func TestValidatorRejectsCorruptBackendOutput(t *testing.T) {
 	a, e := Build(fixture(), config())
 	if e != nil {

--- a/TreeDB/internal/vectorpartition/vectorpartition_test.go
+++ b/TreeDB/internal/vectorpartition/vectorpartition_test.go
@@ -254,6 +254,27 @@ func TestExternalBackendStartedCancellationCleansPrivateTemp(t *testing.T) {
 		t.Fatalf("backend temporary directory leaked after start: %v", entries)
 	}
 }
+func TestExternalBackendDeadlineKillsPipeHoldingDescendant(t *testing.T) {
+	root := t.TempDir()
+	t.Setenv("TMPDIR", root)
+	ctx, cancel := context.WithTimeout(context.Background(), 75*time.Millisecond)
+	defer cancel()
+	started := time.Now()
+	_, err := RunExternalJSONForSource(ctx, []string{"sh", "-c", "printf '{' > \"$1\"; (sleep 5) & wait"}, []byte("{}"), 1024, Source{SourceID: "expected", Checksum: strings.Repeat("0", 64), Vectors: 1, Dimensions: 1, Metric: "cosine"})
+	if err == nil {
+		t.Fatal("pipe-holding descendant accepted")
+	}
+	if elapsed := time.Since(started); elapsed > 750*time.Millisecond {
+		t.Fatalf("deadline return too slow: %s", elapsed)
+	}
+	entries, readErr := os.ReadDir(root)
+	if readErr != nil {
+		t.Fatal(readErr)
+	}
+	if len(entries) != 0 {
+		t.Fatalf("descendant temp cleanup leaked: %v", entries)
+	}
+}
 func TestExternalBackendRequiresDeadline(t *testing.T) {
 	if _, err := RunExternalJSON(context.Background(), []string{"true"}, []byte("{}"), 1024); err == nil {
 		t.Fatal("deadline-less backend accepted")
@@ -447,5 +468,14 @@ func TestMetricsHighPartitionCountUsesAssignmentHistogram(t *testing.T) {
 	a.Metrics = metrics(a)
 	if err := ValidateArtifact(a); err != nil {
 		t.Fatal(err)
+	}
+}
+func TestCosineDistanceHandlesHugeFiniteAndRejectsZeroNorm(t *testing.T) {
+	if d := distance([]float64{math.MaxFloat64, math.MaxFloat64}, []float64{math.MaxFloat64, math.MaxFloat64}); !finite(d) || math.Abs(d) > 1e-12 {
+		t.Fatalf("unstable huge cosine distance: %v", d)
+	}
+	c := config()
+	if _, err := Build([]Vector{{ID: "a", Values: []float64{0, 0}}, {ID: "b", Values: []float64{1, 0}}}, c); err == nil {
+		t.Fatal("zero norm accepted")
 	}
 }

--- a/TreeDB/internal/vectorpartition/vectorpartition_test.go
+++ b/TreeDB/internal/vectorpartition/vectorpartition_test.go
@@ -386,6 +386,19 @@ func TestReferencePartitionerRejectsExcessiveWork(t *testing.T) {
 		t.Fatal("unbounded partition work accepted")
 	}
 }
+func TestPartitionWorkAccountsForValidatorAndOrderingPasses(t *testing.T) {
+	// The former estimate charged only parts+d+d*(d+1)+log2(n), which would
+	// accept this shape (249,681,744 units) while omitting validator and ordering
+	// passes. Degree buckets make the new exact loop bound reject it.
+	const n, parts, degree = 234, 16_384, 1_024
+	oldPerNode := int64(parts + degree + degree*(degree+1) + 8)
+	if oldPerNode*int64(n) > maxPartitionWork {
+		t.Fatal("test no longer distinguishes old accounting")
+	}
+	if !partitionWorkExceeded(n, parts, degree) {
+		t.Fatal("validator/order work omitted from cap")
+	}
+}
 func TestLeafNearestTieBreaksByOrdinal(t *testing.T) {
 	v := []Vector{{"a", []float64{1, 0}}, {"b", []float64{0, 1}}, {"c", []float64{0, -1}}, {"d", []float64{-1, 0}}}
 	got, err := nearest(v, []int{0, 1, 2, 3}, 0, 2, &distanceBudget{remaining: 100})

--- a/TreeDB/internal/vectorpartition/vectorpartition_test.go
+++ b/TreeDB/internal/vectorpartition/vectorpartition_test.go
@@ -170,7 +170,8 @@ func TestExternalBackendRequiresDeadline(t *testing.T) {
 
 type badPartitioner struct{}
 
-func (badPartitioner) Name() string { return "bad" }
+func (badPartitioner) Name() string    { return "bad" }
+func (badPartitioner) License() string { return "test license" }
 func (badPartitioner) Partition(g Graph, parts, cap int) ([]int, error) {
 	return make([]int, len(g.Neighbors)), nil
 }

--- a/TreeDB/internal/vectorpartition/vectorpartition_test.go
+++ b/TreeDB/internal/vectorpartition/vectorpartition_test.go
@@ -232,6 +232,102 @@ func TestBuildAndArtifactRejectInvalidUTF8IDs(t *testing.T) {
 	}
 }
 
+func TestIdentityStringsRejectInvalidUTF8BeforeBackendEffects(t *testing.T) {
+	invalid := string([]byte{0xff})
+	for _, tc := range []struct {
+		name    string
+		source  Source
+		backend identityPartitioner
+	}{
+		{name: "source ID", source: Source{SourceID: invalid}, backend: identityPartitioner{name: "backend", license: "license"}},
+		{name: "backend name", source: Source{SourceID: "source"}, backend: identityPartitioner{name: invalid, license: "license"}},
+		{name: "backend license", source: Source{SourceID: "source"}, backend: identityPartitioner{name: "backend", license: invalid}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			called := false
+			tc.backend.called = &called
+			_, err := BuildWithPartitioner(fixture(), config(), tc.source, tc.backend)
+			if err == nil {
+				t.Fatal("invalid UTF-8 identity accepted")
+			}
+			if called {
+				t.Fatal("invalid UTF-8 identity reached backend")
+			}
+		})
+	}
+}
+
+func TestArtifactIdentityStringsRejectInvalidUTF8AndDecodeStrictly(t *testing.T) {
+	a, err := Build(fixture(), config())
+	if err != nil {
+		t.Fatal(err)
+	}
+	raw, err := CanonicalJSON(a)
+	if err != nil {
+		t.Fatal(err)
+	}
+	invalid := string([]byte{0xff})
+	for _, tc := range []struct {
+		name   string
+		valid  string
+		mutate func(*Artifact)
+	}{
+		{name: "source ID", valid: a.Source.SourceID, mutate: func(x *Artifact) { x.Source.SourceID = invalid }},
+		{name: "backend name", valid: a.Backend, mutate: func(x *Artifact) { x.Backend = invalid }},
+		{name: "backend license", valid: a.BackendLicense, mutate: func(x *Artifact) { x.BackendLicense = invalid }},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			forged := a
+			tc.mutate(&forged)
+			if err := ValidateArtifact(forged); err == nil {
+				t.Fatal("ValidateArtifact accepted invalid UTF-8 identity")
+			}
+			if _, err := CanonicalJSON(forged); err == nil {
+				t.Fatal("CanonicalJSON accepted invalid UTF-8 identity")
+			}
+			invalidRaw := bytes.Replace(raw, []byte("\""+tc.valid+"\""), []byte{'"', 0xff, '"'}, 1)
+			if bytes.Equal(invalidRaw, raw) {
+				t.Fatal("test did not forge identity bytes")
+			}
+			if _, err := DecodeArtifact(invalidRaw, len(invalidRaw)); err == nil {
+				t.Fatal("DecodeArtifact accepted invalid UTF-8 identity bytes")
+			}
+		})
+	}
+	invalidExpected := a.Source
+	invalidExpected.SourceID = invalid
+	if _, err := DecodeArtifactForSource(raw, len(raw), invalidExpected); err == nil {
+		t.Fatal("DecodeArtifactForSource accepted invalid expected source ID")
+	}
+}
+
+func TestUnicodeIdentityStringsRoundTripCanonically(t *testing.T) {
+	canonical, err := Build(fixture(), config())
+	if err != nil {
+		t.Fatal(err)
+	}
+	sourceID, backendName, backendLicense := "source-東京", "backend-雪", "license-λ"
+	a, err := BuildWithPartitioner(fixture(), config(), Source{SourceID: sourceID}, identityPartitioner{name: backendName, license: backendLicense, assignment: canonical.Assignment})
+	if err != nil {
+		t.Fatal(err)
+	}
+	raw, err := CanonicalJSON(a)
+	if err != nil {
+		t.Fatal(err)
+	}
+	decoded, err := DecodeArtifact(raw, len(raw))
+	if err != nil {
+		t.Fatal(err)
+	}
+	again, err := CanonicalJSON(decoded)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(raw, again) || decoded.Source.SourceID != sourceID || decoded.Backend != backendName || decoded.BackendLicense != backendLicense {
+		t.Fatalf("unicode identities did not round trip canonically: decoded=%+v", decoded)
+	}
+}
+
 func TestInputShapePreflightCountsTopLevelPivotWork(t *testing.T) {
 	c := DefaultConfig()
 	c.Partitions = 1
@@ -504,6 +600,41 @@ func TestExternalBackendRejectsInputCapBeforeExecution(t *testing.T) {
 	}
 }
 
+func TestExternalRequestBoundAccountsForEscapedIdentities(t *testing.T) {
+	bound, ok := externalJSONByteBound(4, 0, 1)
+	if !ok || bound < 6*4 {
+		t.Fatalf("escaped identity bound=%d ok=%v", bound, ok)
+	}
+	if maxExternalJSONBytes < 6*maxTotalIDBytes {
+		t.Fatalf("production request cap=%d undercharges escaped IDs", maxExternalJSONBytes)
+	}
+	a, err := Build(fixture(), config())
+	if err != nil {
+		t.Fatal(err)
+	}
+	raw, err := CanonicalJSON(a)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Four control-byte IDs require six escaped bytes each in JSON. The bounded
+	// request reaches the backend at its explicit cap rather than being rejected
+	// by the global request ceiling.
+	input := []byte(`{"ids":["\u0000\u0001\u0002\u0003"]}`)
+	if len(input) > bound {
+		t.Fatalf("escaped request length=%d exceeds modeled bound=%d", len(input), bound)
+	}
+	t.Setenv("TREE_DB_TEST_RESPONSE", string(raw))
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	if _, err := RunExternalJSONForSourceWithLimits(ctx, []string{"sh", "-c", "printf '%s' \"$TREE_DB_TEST_RESPONSE\" > \"$1\""}, input, ExternalJSONLimits{MaxInput: len(input), MaxOutput: len(raw)}, a.Source); err != nil {
+		t.Fatalf("escaped bounded input rejected before backend: %v", err)
+	}
+	_, err = RunExternalJSONForSourceWithLimits(ctx, []string{"definitely-not-an-executable"}, input, ExternalJSONLimits{MaxInput: len(input) - 1, MaxOutput: len(raw)}, a.Source)
+	if err == nil || !strings.Contains(err.Error(), "input exceeds cap") {
+		t.Fatalf("one-over input cap reached backend or returned wrong error: %v", err)
+	}
+}
+
 func TestExternalBackendStillRejectsOutputOverflow(t *testing.T) {
 	a, err := Build(fixture(), config())
 	if err != nil {
@@ -565,6 +696,21 @@ type assignmentPartitioner struct{ assignment []int }
 func (p assignmentPartitioner) Name() string    { return "assignment-test" }
 func (p assignmentPartitioner) License() string { return "test" }
 func (p assignmentPartitioner) Partition(Graph, int, int) ([]int, error) {
+	return p.assignment, nil
+}
+
+type identityPartitioner struct {
+	name, license string
+	assignment    []int
+	called        *bool
+}
+
+func (p identityPartitioner) Name() string    { return p.name }
+func (p identityPartitioner) License() string { return p.license }
+func (p identityPartitioner) Partition(Graph, int, int) ([]int, error) {
+	if p.called != nil {
+		*p.called = true
+	}
 	return p.assignment, nil
 }
 

--- a/TreeDB/internal/vectorpartition/vectorpartition_test.go
+++ b/TreeDB/internal/vectorpartition/vectorpartition_test.go
@@ -8,6 +8,7 @@ import (
 	"math"
 	"os"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"testing"
 	"time"
@@ -349,6 +350,74 @@ func (p assignmentPartitioner) Name() string    { return "assignment-test" }
 func (p assignmentPartitioner) License() string { return "test" }
 func (p assignmentPartitioner) Partition(Graph, int, int) ([]int, error) {
 	return p.assignment, nil
+}
+
+type mutatingPartitioner struct {
+	assignment []int
+	err        error
+}
+
+func (mutatingPartitioner) Name() string    { return (ReferencePartitioner{}).Name() }
+func (mutatingPartitioner) License() string { return (ReferencePartitioner{}).License() }
+func (p mutatingPartitioner) Partition(g Graph, _ int, _ int) ([]int, error) {
+	for i, neighbors := range g.Neighbors {
+		if len(neighbors) > 1 {
+			neighbors[0], neighbors[len(neighbors)-1] = neighbors[len(neighbors)-1], neighbors[0]
+			g.Neighbors[i] = neighbors[:1]
+		} else {
+			g.Neighbors[i] = nil
+		}
+	}
+	if p.err != nil {
+		return nil, p.err
+	}
+	return append([]int(nil), p.assignment...), nil
+}
+
+func TestBuildWithPartitionerPreservesCanonicalGraphAgainstMutation(t *testing.T) {
+	canonical, err := Build(fixture(), config())
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, err := BuildWithPartitioner(fixture(), config(), Source{SourceID: "inline_vectors_v1"}, mutatingPartitioner{assignment: canonical.Assignment})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(got.Graph, canonical.Graph) {
+		t.Fatalf("backend mutation changed canonical graph: got=%v want=%v", got.Graph, canonical.Graph)
+	}
+	if got.Metrics != canonical.Metrics {
+		t.Fatalf("backend mutation changed canonical metrics: got=%+v want=%+v", got.Metrics, canonical.Metrics)
+	}
+	if gotDigest, wantDigest := mustDigest(t, got), mustDigest(t, canonical); gotDigest != wantDigest {
+		t.Fatalf("backend mutation changed canonical artifact digest: got=%s want=%s", gotDigest, wantDigest)
+	}
+}
+
+func TestBuildWithPartitionerFailsClosedAfterMutatingBackendFailure(t *testing.T) {
+	_, err := BuildWithPartitioner(fixture(), config(), Source{SourceID: "inline_vectors_v1"}, mutatingPartitioner{err: fmt.Errorf("backend failure")})
+	if err == nil || !strings.Contains(err.Error(), "backend failure") {
+		t.Fatalf("mutating backend failure accepted: %v", err)
+	}
+	_, err = BuildWithPartitioner(fixture(), config(), Source{SourceID: "inline_vectors_v1"}, mutatingPartitioner{assignment: make([]int, len(fixture()))})
+	if err == nil {
+		t.Fatal("mutating backend malformed assignment accepted")
+	}
+}
+
+func TestCloneGraphBoundedUsesIndependentExactBacking(t *testing.T) {
+	original := Graph{Neighbors: [][]int{{1, 2}, {0}}}
+	clone, err := cloneGraphBounded(original, 3)
+	if err != nil {
+		t.Fatal(err)
+	}
+	clone.Neighbors[0][0] = 99
+	if original.Neighbors[0][0] != 1 {
+		t.Fatalf("backend graph clone aliases canonical graph: %v", original)
+	}
+	if _, err := cloneGraphBounded(original, 2); err == nil {
+		t.Fatal("oversized backend graph copy accepted")
+	}
 }
 func TestBuildFailsClosedOnMalformedBackendAssignment(t *testing.T) {
 	for _, assignment := range [][]int{nil, {0}, {0, 1, 0, 1, 0, 1, 0}, {-1, 0, 0, 1, 1, 0}, {2, 0, 0, 1, 1, 0}} {

--- a/TreeDB/internal/vectorpartition/vectorpartition_test.go
+++ b/TreeDB/internal/vectorpartition/vectorpartition_test.go
@@ -116,6 +116,21 @@ func TestMalformedFailsClosed(t *testing.T) {
 		}
 	}
 }
+
+func TestBuildRejectsOverCapBeforeVectorElementValidation(t *testing.T) {
+	sharedValues := make([]float64, maxDimensions)
+	sharedValues[0] = math.NaN()
+	vectors := make([]Vector, maxVectors+1)
+	for i := range vectors {
+		// Every entry shares the same backing values; if Build scans even one
+		// element, its empty ID/non-finite value would produce a different error.
+		vectors[i] = Vector{Values: sharedValues}
+	}
+	_, err := Build(vectors, DefaultConfig())
+	if err == nil || !strings.Contains(err.Error(), "vector count outside configured bounds") {
+		t.Fatalf("Build error=%v; count cap must reject before element validation", err)
+	}
+}
 func TestValidatorRejectsCorruptBackendOutput(t *testing.T) {
 	a, e := Build(fixture(), config())
 	if e != nil {

--- a/TreeDB/internal/vectorpartition/vectorpartition_test.go
+++ b/TreeDB/internal/vectorpartition/vectorpartition_test.go
@@ -4,9 +4,11 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"fmt"
 	"math"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 )
@@ -65,6 +67,29 @@ func TestGraphDegreeAndCapOnDuplicateSkew(t *testing.T) {
 	}
 	if a.Metrics.MaxPartitionSize > a.Metrics.Cap {
 		t.Fatal("partition cap")
+	}
+}
+func TestSkewedPivotBucketsUseDeterministicChunkFallback(t *testing.T) {
+	v := make([]Vector, 128)
+	for i := range v {
+		// Identical directions force a single pivot bucket; this formerly
+		// exercised unbounded recursive depth on sufficiently skewed inputs.
+		v[i] = Vector{ID: fmt.Sprintf("skew-%03d", i), Values: []float64{1, 0}}
+	}
+	c := config()
+	c.MaxLeafBucket = 8
+	c.Degree = 4
+	c.MaxVectors = len(v)
+	c.MaxEdges = 1024
+	a, err := Build(v, c)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := ValidateArtifact(a); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := nearest(v, []int{0, 1, 2}, 0, 2, &distanceBudget{remaining: 1}); err == nil {
+		t.Fatal("leaf distance-work budget was not enforced")
 	}
 }
 func TestMalformedFailsClosed(t *testing.T) {
@@ -148,7 +173,7 @@ func TestExternalBackendCancellationCleansPrivateTemp(t *testing.T) {
 	t.Setenv("TMPDIR", root)
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	cancel()
-	_, err := RunExternalJSON(ctx, []string{"sh", "-c", "sleep 1"}, []byte("{}"), 1024)
+	_, err := RunExternalJSONForSource(ctx, []string{"sh", "-c", "sleep 1"}, []byte("{}"), 1024, Source{SourceID: "expected", Checksum: strings.Repeat("0", 64), Vectors: 1, Dimensions: 1, Metric: "cosine"})
 	if err == nil {
 		t.Fatal("cancelled backend accepted")
 	}
@@ -165,6 +190,36 @@ func TestExternalBackendCancellationCleansPrivateTemp(t *testing.T) {
 func TestExternalBackendRequiresDeadline(t *testing.T) {
 	if _, err := RunExternalJSON(context.Background(), []string{"true"}, []byte("{}"), 1024); err == nil {
 		t.Fatal("deadline-less backend accepted")
+	}
+}
+
+func TestExternalBackendRejectsUnboundExpectedSourceBeforeExecution(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	for _, source := range []Source{
+		{},
+		{SourceID: "only-id"},
+		{SourceID: "id", Checksum: strings.Repeat("0", 64), Vectors: 1, Dimensions: 1, Metric: "l2"},
+	} {
+		if _, err := RunExternalJSONForSource(ctx, []string{"definitely-not-an-executable"}, []byte("{}"), 1024, source); err == nil || !strings.Contains(err.Error(), "invalid expected source binding") {
+			t.Fatalf("unbound expected source reached backend: source=%+v err=%v", source, err)
+		}
+	}
+}
+
+func TestDecodeArtifactForSourceRejectsForgedSource(t *testing.T) {
+	a, err := Build(fixture(), config())
+	if err != nil {
+		t.Fatal(err)
+	}
+	raw, err := CanonicalJSON(a)
+	if err != nil {
+		t.Fatal(err)
+	}
+	expected := a.Source
+	expected.Checksum = strings.Repeat("f", 64)
+	if _, err := DecodeArtifactForSource(raw, len(raw), expected); err == nil {
+		t.Fatal("forged expected source accepted")
 	}
 }
 
@@ -202,5 +257,39 @@ func TestBoundedUnionKeepsClosestNotLowestOrdinal(t *testing.T) {
 	}
 	if _, ok := s[99]; !ok {
 		t.Fatal("closest candidate lost")
+	}
+}
+func TestArtifactRejectsOversizedIDsAndSourceDimensions(t *testing.T) {
+	a, err := Build(fixture(), config())
+	if err != nil {
+		t.Fatal(err)
+	}
+	a.Source.Dimensions = 5000
+	if err := ValidateArtifact(a); err == nil {
+		t.Fatal("oversized source dimensions accepted")
+	}
+	a, err = Build(fixture(), config())
+	if err != nil {
+		t.Fatal(err)
+	}
+	a.IDs[0] = strings.Repeat("x", maxIDBytes+1)
+	if err := ValidateArtifact(a); err == nil {
+		t.Fatal("oversized ID accepted")
+	}
+}
+
+func TestMetricsHighPartitionCountUsesAssignmentHistogram(t *testing.T) {
+	const n = 16_384
+	ids := make([]string, n)
+	assignment := make([]int, n)
+	for i := range ids {
+		ids[i] = fmt.Sprintf("doc-%06d", i)
+		assignment[i] = i
+	}
+	c := Config{Metric: "cosine", Seed: 1, Repetitions: 1, Pivots: 2, MaxLeafBucket: 2, Degree: 1, Partitions: n, Imbalance: .05, MaxVectors: n, MaxEdges: n}
+	a := Artifact{SchemaVersion: SchemaVersion, Backend: "test", BackendLicense: "test", Source: Source{SourceID: "test", Checksum: strings.Repeat("0", 64), Vectors: n, Dimensions: 1, Metric: "cosine"}, Config: c, IDs: ids, Graph: Graph{Neighbors: make([][]int, n)}, Assignment: assignment}
+	a.Metrics = metrics(a)
+	if err := ValidateArtifact(a); err != nil {
+		t.Fatal(err)
 	}
 }

--- a/TreeDB/internal/vectorpartition/vectorpartition_test.go
+++ b/TreeDB/internal/vectorpartition/vectorpartition_test.go
@@ -578,13 +578,13 @@ func TestExternalBackendSeparatesInputAndOutputCaps(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	input := bytes.Repeat([]byte("x"), len(raw)+1)
+	input := raw
 	t.Setenv("TREE_DB_TEST_RESPONSE", string(raw))
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
-	got, err := RunExternalJSONForSourceWithLimits(ctx, []string{"sh", "-c", "printf '%s' \"$TREE_DB_TEST_RESPONSE\" > \"$1\""}, input, ExternalJSONLimits{MaxInput: len(input), MaxOutput: len(raw)}, a.Source)
+	got, err := RunExternalJSONForRequestWithLimits(ctx, []string{"sh", "-c", "printf '%s' \"$TREE_DB_TEST_RESPONSE\" > \"$1\""}, input, ExternalJSONLimits{MaxInput: len(input), MaxOutput: len(raw)}, a)
 	if err != nil {
-		t.Fatalf("larger bounded input with compact response rejected: %v", err)
+		t.Fatalf("canonical requested artifact rejected: %v", err)
 	}
 	if !reflect.DeepEqual(got, a) {
 		t.Fatal("external backend response changed")
@@ -592,9 +592,13 @@ func TestExternalBackendSeparatesInputAndOutputCaps(t *testing.T) {
 }
 
 func TestExternalBackendRejectsInputCapBeforeExecution(t *testing.T) {
+	a, err := Build(fixture(), config())
+	if err != nil {
+		t.Fatal(err)
+	}
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
-	_, err := RunExternalJSONForSourceWithLimits(ctx, []string{"definitely-not-an-executable"}, []byte("{}"), ExternalJSONLimits{MaxInput: 1, MaxOutput: 1024}, Source{SourceID: "expected", Checksum: strings.Repeat("0", 64), Vectors: 1, Dimensions: 1, Metric: "cosine"})
+	_, err = RunExternalJSONForRequestWithLimits(ctx, []string{"definitely-not-an-executable"}, []byte("{}"), ExternalJSONLimits{MaxInput: 1, MaxOutput: 1024}, a)
 	if err == nil || !strings.Contains(err.Error(), "input exceeds cap") {
 		t.Fatalf("over-input cap reached backend or returned wrong error: %v", err)
 	}
@@ -612,24 +616,29 @@ func TestExternalRequestBoundAccountsForEscapedIdentities(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	raw, err := CanonicalJSON(a)
+	// Six control-byte IDs require six escaped bytes each in JSON. The bounded
+	// request reaches the backend at its explicit cap rather than being rejected
+	// by the global request ceiling.
+	request := a
+	request.IDs = append([]string(nil), a.IDs...)
+	for i := range request.IDs {
+		request.IDs[i] = string([]byte{0, byte('a' + i)})
+	}
+	request.Metrics = metrics(request)
+	input, err := CanonicalJSON(request)
 	if err != nil {
 		t.Fatal(err)
 	}
-	// Four control-byte IDs require six escaped bytes each in JSON. The bounded
-	// request reaches the backend at its explicit cap rather than being rejected
-	// by the global request ceiling.
-	input := []byte(`{"ids":["\u0000\u0001\u0002\u0003"]}`)
 	if len(input) > bound {
 		t.Fatalf("escaped request length=%d exceeds modeled bound=%d", len(input), bound)
 	}
-	t.Setenv("TREE_DB_TEST_RESPONSE", string(raw))
+	t.Setenv("TREE_DB_TEST_RESPONSE", string(input))
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
-	if _, err := RunExternalJSONForSourceWithLimits(ctx, []string{"sh", "-c", "printf '%s' \"$TREE_DB_TEST_RESPONSE\" > \"$1\""}, input, ExternalJSONLimits{MaxInput: len(input), MaxOutput: len(raw)}, a.Source); err != nil {
+	if _, err := RunExternalJSONForRequestWithLimits(ctx, []string{"sh", "-c", "printf '%s' \"$TREE_DB_TEST_RESPONSE\" > \"$1\""}, input, ExternalJSONLimits{MaxInput: len(input), MaxOutput: len(input)}, request); err != nil {
 		t.Fatalf("escaped bounded input rejected before backend: %v", err)
 	}
-	_, err = RunExternalJSONForSourceWithLimits(ctx, []string{"definitely-not-an-executable"}, input, ExternalJSONLimits{MaxInput: len(input) - 1, MaxOutput: len(raw)}, a.Source)
+	_, err = RunExternalJSONForRequestWithLimits(ctx, []string{"definitely-not-an-executable"}, input, ExternalJSONLimits{MaxInput: len(input) - 1, MaxOutput: len(input)}, request)
 	if err == nil || !strings.Contains(err.Error(), "input exceeds cap") {
 		t.Fatalf("one-over input cap reached backend or returned wrong error: %v", err)
 	}
@@ -647,7 +656,7 @@ func TestExternalBackendStillRejectsOutputOverflow(t *testing.T) {
 	t.Setenv("TREE_DB_TEST_RESPONSE", string(raw))
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
-	_, err = RunExternalJSONForSourceWithLimits(ctx, []string{"sh", "-c", "printf '%s' \"$TREE_DB_TEST_RESPONSE\" > \"$1\""}, []byte("{}"), ExternalJSONLimits{MaxInput: 2, MaxOutput: len(raw) - 1}, a.Source)
+	_, err = RunExternalJSONForRequestWithLimits(ctx, []string{"sh", "-c", "printf '%s' \"$TREE_DB_TEST_RESPONSE\" > \"$1\""}, raw, ExternalJSONLimits{MaxInput: len(raw), MaxOutput: len(raw) - 1}, a)
 	if err == nil || !strings.Contains(err.Error(), "output exceeds cap") {
 		t.Fatalf("output overflow accepted or wrong error: %v", err)
 	}
@@ -680,6 +689,83 @@ func TestDecodeArtifactForSourceRejectsForgedSource(t *testing.T) {
 	expected.Checksum = strings.Repeat("f", 64)
 	if _, err := DecodeArtifactForSource(raw, len(raw), expected); err == nil {
 		t.Fatal("forged expected source accepted")
+	}
+}
+
+func TestDecodeArtifactForRequestBindsGraphConfigAndIDs(t *testing.T) {
+	request, err := Build(fixture(), config())
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertRejected := func(t *testing.T, response Artifact) {
+		t.Helper()
+		response.Metrics = metrics(response)
+		raw, err := CanonicalJSON(response)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if _, err := DecodeArtifactForRequest(raw, len(raw), request); err == nil || !strings.Contains(err.Error(), "requested graph/configuration") {
+			t.Fatalf("forged requested binding accepted: %v", err)
+		}
+	}
+	t.Run("IDs", func(t *testing.T) {
+		response := request
+		response.IDs = append([]string(nil), request.IDs...)
+		response.IDs[0] = response.IDs[0] + "-changed"
+		assertRejected(t, response)
+	})
+	t.Run("config", func(t *testing.T) {
+		response := request
+		response.Config.Seed++
+		assertRejected(t, response)
+	})
+	t.Run("graph", func(t *testing.T) {
+		response := request
+		response.Graph.Neighbors = make([][]int, len(request.Graph.Neighbors))
+		assertRejected(t, response)
+	})
+	// Assignment is the intended backend result. A different valid assignment
+	// remains supported as long as it is self-consistent and the request graph,
+	// IDs, config, and corpus source remain exact.
+	response := request
+	response.Assignment = append([]int(nil), request.Assignment...)
+	left, right := -1, -1
+	for i, p := range response.Assignment {
+		if p == 0 && left < 0 {
+			left = i
+		}
+		if p == 1 && right < 0 {
+			right = i
+		}
+	}
+	if left < 0 || right < 0 {
+		t.Fatal("fixture did not cover both partitions")
+	}
+	response.Assignment[left], response.Assignment[right] = response.Assignment[right], response.Assignment[left]
+	response.Metrics = metrics(response)
+	raw, err := CanonicalJSON(response)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got, err := DecodeArtifactForRequest(raw, len(raw), request); err != nil || !reflect.DeepEqual(got.Assignment, response.Assignment) {
+		t.Fatalf("valid custom backend assignment rejected: artifact=%+v err=%v", got, err)
+	}
+}
+
+func TestExternalBackendRequestMustBeExactCanonicalArtifact(t *testing.T) {
+	request, err := Build(fixture(), config())
+	if err != nil {
+		t.Fatal(err)
+	}
+	raw, err := CanonicalJSON(request)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	_, err = RunExternalJSONForRequestWithLimits(ctx, []string{"definitely-not-an-executable"}, append(raw, '\n'), ExternalJSONLimits{MaxInput: len(raw) + 1, MaxOutput: len(raw)}, request)
+	if err == nil || !strings.Contains(err.Error(), "input does not match requested artifact") {
+		t.Fatalf("non-canonical or mismatched request reached backend: %v", err)
 	}
 }
 

--- a/TreeDB/internal/vectorpartition/vectorpartition_test.go
+++ b/TreeDB/internal/vectorpartition/vectorpartition_test.go
@@ -416,10 +416,13 @@ func TestPartitionWorkCountsAllPassesAtEmptyGraphBoundary(t *testing.T) {
 	// guards against silently accepting an allocation shape above the declared
 	// work cap merely because it has degree zero.
 	const n = 1_000_000
-	if work, overflow := partitionWorkUnits(n, 242, 0); overflow || work > maxPartitionWork {
+	if work, overflow := partitionWorkUnits(n, 238, 0); overflow || work != 249_000_717 || work > maxPartitionWork {
 		t.Fatalf("accepted boundary miscounted: work=%d overflow=%v", work, overflow)
 	}
-	if !partitionWorkExceeded(n, 243, 0) {
+	if work, overflow := partitionWorkUnits(n, 239, 0); overflow || work != 250_000_720 || work <= maxPartitionWork {
+		t.Fatalf("rejected boundary miscounted: work=%d overflow=%v", work, overflow)
+	}
+	if !partitionWorkExceeded(n, 239, 0) {
 		t.Fatal("empty-graph work above cap accepted")
 	}
 }

--- a/TreeDB/internal/vectorpartition/vectorpartition_test.go
+++ b/TreeDB/internal/vectorpartition/vectorpartition_test.go
@@ -1054,6 +1054,26 @@ func TestValidatorRejectsSymmetricPolicyEvenForReciprocalGraph(t *testing.T) {
 		t.Fatal("decode accepted a reciprocal symmetric artifact")
 	}
 }
+
+func TestSymmetricConfigFailsBeforeInputOrBackendWork(t *testing.T) {
+	c := config()
+	c.Symmetric = true
+	if err := ValidateConfig(c); err == nil || err.Error() != "symmetric graph policy is not supported" {
+		t.Fatalf("ValidateConfig error=%v", err)
+	}
+	called := false
+	poison := []Vector{{ID: string([]byte{0xff}), Values: []float64{math.NaN()}}}
+	_, err := BuildWithPartitioner(poison, c, Source{SourceID: "symmetric-preflight"}, identityPartitioner{name: "poison", license: "test", called: &called})
+	if err == nil || err.Error() != "symmetric graph policy is not supported" {
+		t.Fatalf("symmetric build did not fail in config preflight: %v", err)
+	}
+	if called {
+		t.Fatal("symmetric config reached partition backend")
+	}
+	if _, err := Build(fixture(), config()); err != nil {
+		t.Fatalf("directed build regressed: %v", err)
+	}
+}
 func TestReferencePartitionerCoversEveryPartition(t *testing.T) {
 	g := emptyGraph(8)
 	a, err := (ReferencePartitioner{}).Partition(g, 4, 2)

--- a/TreeDB/internal/vectorpartition/vectorpartition_test.go
+++ b/TreeDB/internal/vectorpartition/vectorpartition_test.go
@@ -2,7 +2,11 @@ package vectorpartition
 
 import (
 	"bytes"
+	"context"
+	"encoding/json"
 	"math"
+	"os"
+	"path/filepath"
 	"testing"
 )
 
@@ -87,5 +91,73 @@ func TestValidatorRejectsCorruptBackendOutput(t *testing.T) {
 	a.Graph.Neighbors[0] = append(a.Graph.Neighbors[0], 0)
 	if e := ValidateArtifact(a); e == nil {
 		t.Fatal("self edge accepted")
+	}
+}
+
+func TestStrictDecoderRejectsNonCanonicalAndMetricForgery(t *testing.T) {
+	a, err := Build(fixture(), config())
+	if err != nil {
+		t.Fatal(err)
+	}
+	raw, err := CanonicalJSON(a)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := DecodeArtifact(raw, len(raw)); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := DecodeArtifact(append(raw, '\n'), len(raw)+1); err == nil {
+		t.Fatal("noncanonical whitespace accepted")
+	}
+	a.Metrics.EdgeCut++
+	bad, _ := json.Marshal(a)
+	if _, err := DecodeArtifact(bad, len(bad)); err == nil {
+		t.Fatal("forged metrics accepted")
+	}
+}
+
+func TestGraphPartitionBeatsStableIDHashOnClusteredFixture(t *testing.T) {
+	v := make([]Vector, 24)
+	for i := range v {
+		cluster := i / 12
+		x, y := 0.0, 0.0
+		if cluster == 0 {
+			x = 1
+		} else {
+			y = 1
+		}
+		v[i] = Vector{ID: string(rune('a' + i)), Values: []float64{x, y}}
+	}
+	c := config()
+	c.Partitions = 2
+	c.MaxLeafBucket = 32
+	c.Degree = 4
+	c.MaxEdges = 256
+	a, err := Build(v, c)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if a.Metrics.EdgeCut >= a.Metrics.StableIDHashEdgeCut {
+		t.Fatalf("graph cut=%d hash=%d", a.Metrics.EdgeCut, a.Metrics.StableIDHashEdgeCut)
+	}
+}
+
+func TestExternalBackendCancellationCleansPrivateTemp(t *testing.T) {
+	root := t.TempDir()
+	t.Setenv("TMPDIR", root)
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	_, err := RunExternalJSON(ctx, []string{"sh", "-c", "sleep 1"}, []byte("{}"), 1024)
+	if err == nil {
+		t.Fatal("cancelled backend accepted")
+	}
+	entries, err := os.ReadDir(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, entry := range entries {
+		if entry.IsDir() && filepath.Base(entry.Name()) != "" {
+			t.Fatalf("backend temporary directory leaked: %s", entry.Name())
+		}
 	}
 }

--- a/TreeDB/internal/vectorpartition/vectorpartition_test.go
+++ b/TreeDB/internal/vectorpartition/vectorpartition_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"math"
 	"os"
@@ -484,12 +485,18 @@ func TestGraphPartitionBeatsStableIDHashOnDeterministic10kClusters(t *testing.T)
 
 func TestExternalBackendCancellationCleansPrivateTemp(t *testing.T) {
 	root := t.TempDir()
+	marker := filepath.Join(t.TempDir(), "started")
 	t.Setenv("TMPDIR", root)
+	t.Setenv("TREE_DB_START_MARKER", marker)
+	request, input := externalBackendRequest(t)
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	cancel()
-	_, err := RunExternalJSONForSource(ctx, []string{"sh", "-c", "sleep 1"}, []byte("{}"), 1024, Source{SourceID: "expected", Checksum: strings.Repeat("0", 64), Vectors: 1, Dimensions: 1, Metric: "cosine"})
+	_, err := RunExternalJSONForRequestWithLimits(ctx, []string{"sh", "-c", ": > \"$TREE_DB_START_MARKER\"; sleep 1"}, input, ExternalJSONLimits{MaxInput: len(input), MaxOutput: 1024}, request)
 	if err == nil {
 		t.Fatal("cancelled backend accepted")
+	}
+	if _, err := os.Stat(marker); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("cancelled context started backend: %v", err)
 	}
 	entries, err := os.ReadDir(root)
 	if err != nil {
@@ -503,12 +510,18 @@ func TestExternalBackendCancellationCleansPrivateTemp(t *testing.T) {
 }
 func TestExternalBackendStartedCancellationCleansPrivateTemp(t *testing.T) {
 	root := t.TempDir()
+	marker := filepath.Join(t.TempDir(), "started")
 	t.Setenv("TMPDIR", root)
+	t.Setenv("TREE_DB_START_MARKER", marker)
+	request, input := externalBackendRequest(t)
 	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
 	defer cancel()
-	_, err := RunExternalJSONForSource(ctx, []string{"sh", "-c", "printf '{' > \"$1\"; sleep 1"}, []byte("{}"), 1024, Source{SourceID: "expected", Checksum: strings.Repeat("0", 64), Vectors: 1, Dimensions: 1, Metric: "cosine"})
+	_, err := RunExternalJSONForRequestWithLimits(ctx, []string{"sh", "-c", ": > \"$TREE_DB_START_MARKER\"; printf '{' > \"$1\"; sleep 1"}, input, ExternalJSONLimits{MaxInput: len(input), MaxOutput: 1024}, request)
 	if err == nil {
 		t.Fatal("started backend cancellation accepted")
+	}
+	if _, err := os.Stat(marker); err != nil {
+		t.Fatalf("cancellation test backend did not start: %v", err)
 	}
 	entries, err := os.ReadDir(root)
 	if err != nil {
@@ -520,13 +533,19 @@ func TestExternalBackendStartedCancellationCleansPrivateTemp(t *testing.T) {
 }
 func TestExternalBackendDeadlineKillsPipeHoldingDescendant(t *testing.T) {
 	root := t.TempDir()
+	marker := filepath.Join(t.TempDir(), "started")
 	t.Setenv("TMPDIR", root)
+	t.Setenv("TREE_DB_START_MARKER", marker)
+	request, input := externalBackendRequest(t)
 	ctx, cancel := context.WithTimeout(context.Background(), 75*time.Millisecond)
 	defer cancel()
 	started := time.Now()
-	_, err := RunExternalJSONForSource(ctx, []string{"sh", "-c", "printf '{' > \"$1\"; (sleep 5) & wait"}, []byte("{}"), 1024, Source{SourceID: "expected", Checksum: strings.Repeat("0", 64), Vectors: 1, Dimensions: 1, Metric: "cosine"})
+	_, err := RunExternalJSONForRequestWithLimits(ctx, []string{"sh", "-c", ": > \"$TREE_DB_START_MARKER\"; printf '{' > \"$1\"; (sleep 5) & wait"}, input, ExternalJSONLimits{MaxInput: len(input), MaxOutput: 1024}, request)
 	if err == nil {
 		t.Fatal("pipe-holding descendant accepted")
+	}
+	if _, err := os.Stat(marker); err != nil {
+		t.Fatalf("deadline test backend did not start: %v", err)
 	}
 	if elapsed := time.Since(started); elapsed > 750*time.Millisecond {
 		t.Fatalf("deadline return too slow: %s", elapsed)
@@ -541,16 +560,22 @@ func TestExternalBackendDeadlineKillsPipeHoldingDescendant(t *testing.T) {
 }
 func TestExternalBackendRootExitStillCleansPipeHoldingDescendant(t *testing.T) {
 	root := t.TempDir()
+	marker := filepath.Join(t.TempDir(), "started")
 	t.Setenv("TMPDIR", root)
+	t.Setenv("TREE_DB_START_MARKER", marker)
 	// The shell exits successfully immediately, leaving sleep with the command's
 	// inherited stderr pipe. CommandContext does not invoke Cancel in this case;
 	// post-Wait process-group cleanup must do so.
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
+	request, input := externalBackendRequest(t)
 	started := time.Now()
-	_, err := RunExternalJSONForSource(ctx, []string{"sh", "-c", "printf '{' > \"$1\"; (sleep 5) & exit 0"}, []byte("{}"), 1024, Source{SourceID: "expected", Checksum: strings.Repeat("0", 64), Vectors: 1, Dimensions: 1, Metric: "cosine"})
+	_, err := RunExternalJSONForRequestWithLimits(ctx, []string{"sh", "-c", ": > \"$TREE_DB_START_MARKER\"; printf '{' > \"$1\"; (sleep 5) & exit 0"}, input, ExternalJSONLimits{MaxInput: len(input), MaxOutput: 1024}, request)
 	if err == nil {
 		t.Fatal("root-exited pipe-holding descendant accepted")
+	}
+	if _, err := os.Stat(marker); err != nil {
+		t.Fatalf("root-exit test backend did not start: %v", err)
 	}
 	if elapsed := time.Since(started); elapsed > 750*time.Millisecond {
 		t.Fatalf("root-exited descendant return too slow: %s", elapsed)
@@ -564,9 +589,28 @@ func TestExternalBackendRootExitStillCleansPipeHoldingDescendant(t *testing.T) {
 	}
 }
 func TestExternalBackendRequiresDeadline(t *testing.T) {
-	if _, err := RunExternalJSON(context.Background(), []string{"true"}, []byte("{}"), 1024); err == nil {
+	marker := filepath.Join(t.TempDir(), "started")
+	t.Setenv("TREE_DB_START_MARKER", marker)
+	request, input := externalBackendRequest(t)
+	if _, err := RunExternalJSONForRequestWithLimits(context.Background(), []string{"sh", "-c", ": > \"$TREE_DB_START_MARKER\""}, input, ExternalJSONLimits{MaxInput: len(input), MaxOutput: 1024}, request); err == nil || !strings.Contains(err.Error(), "requires context deadline") {
 		t.Fatal("deadline-less backend accepted")
 	}
+	if _, err := os.Stat(marker); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("deadline-less request started backend: %v", err)
+	}
+}
+
+func externalBackendRequest(t *testing.T) (Artifact, []byte) {
+	t.Helper()
+	request, err := Build(fixture(), config())
+	if err != nil {
+		t.Fatal(err)
+	}
+	input, err := CanonicalJSON(request)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return request, input
 }
 
 func TestExternalBackendSeparatesInputAndOutputCaps(t *testing.T) {
@@ -673,6 +717,15 @@ func TestExternalBackendRejectsUnboundExpectedSourceBeforeExecution(t *testing.T
 		if _, err := RunExternalJSONForSource(ctx, []string{"definitely-not-an-executable"}, []byte("{}"), 1024, source); err == nil || !strings.Contains(err.Error(), "invalid expected source binding") {
 			t.Fatalf("unbound expected source reached backend: source=%+v err=%v", source, err)
 		}
+	}
+	request, input := externalBackendRequest(t)
+	marker := filepath.Join(t.TempDir(), "started")
+	t.Setenv("TREE_DB_START_MARKER", marker)
+	if _, err := RunExternalJSONForSourceWithLimits(ctx, []string{"sh", "-c", ": > \"$TREE_DB_START_MARKER\""}, input, ExternalJSONLimits{MaxInput: len(input), MaxOutput: 1024}, request.Source); err == nil || !strings.Contains(err.Error(), "requires requested artifact binding") {
+		t.Fatalf("source-only backend did not fail closed: %v", err)
+	}
+	if _, err := os.Stat(marker); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("source-only adapter started backend: %v", err)
 	}
 }
 

--- a/TreeDB/internal/vectorpartition/vectorpartition_test.go
+++ b/TreeDB/internal/vectorpartition/vectorpartition_test.go
@@ -131,6 +131,48 @@ func TestBuildRejectsOverCapBeforeVectorElementValidation(t *testing.T) {
 		t.Fatalf("Build error=%v; count cap must reject before element validation", err)
 	}
 }
+
+func TestBuildAndArtifactRejectInvalidUTF8IDs(t *testing.T) {
+	vectors := fixture()
+	vectors[0].ID = string([]byte{0xff})
+	if _, err := Build(vectors, config()); err == nil {
+		t.Fatal("Build accepted an invalid UTF-8 vector ID")
+	}
+	artifact, err := Build(fixture(), config())
+	if err != nil {
+		t.Fatal(err)
+	}
+	artifact.IDs[0] = string([]byte{0xff})
+	if _, err := CanonicalJSON(artifact); err == nil {
+		t.Fatal("CanonicalJSON accepted an artifact with an invalid UTF-8 ID")
+	}
+	validArtifact, err := Build(fixture(), config())
+	if err != nil {
+		t.Fatal(err)
+	}
+	canonical, err := CanonicalJSON(validArtifact)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := DecodeArtifact(canonical, len(canonical)); err != nil {
+		t.Fatalf("strict decode rejected a valid canonical artifact: %v", err)
+	}
+}
+
+func TestInputShapePreflightCountsTopLevelPivotWork(t *testing.T) {
+	c := DefaultConfig()
+	c.Partitions = 1
+	c.Repetitions = 1
+	c.Pivots = maxPivots
+	c.MaxLeafBucket = 2
+	c.Degree = 1
+	if err := ValidateInputShape(c, 300_000, 64); err != nil {
+		t.Fatalf("pivot-work boundary below cap rejected: %v", err)
+	}
+	if err := ValidateInputShape(c, 310_000, 64); err == nil || !strings.Contains(err.Error(), "scalar-work") {
+		t.Fatalf("pivot-work shape error=%v; expected scalar-work rejection", err)
+	}
+}
 func TestValidatorRejectsCorruptBackendOutput(t *testing.T) {
 	a, e := Build(fixture(), config())
 	if e != nil {

--- a/TreeDB/internal/vectorpartition/vectorpartition_test.go
+++ b/TreeDB/internal/vectorpartition/vectorpartition_test.go
@@ -400,6 +400,55 @@ func TestExternalBackendRequiresDeadline(t *testing.T) {
 	}
 }
 
+func TestExternalBackendSeparatesInputAndOutputCaps(t *testing.T) {
+	a, err := Build(fixture(), config())
+	if err != nil {
+		t.Fatal(err)
+	}
+	raw, err := CanonicalJSON(a)
+	if err != nil {
+		t.Fatal(err)
+	}
+	input := bytes.Repeat([]byte("x"), len(raw)+1)
+	t.Setenv("TREE_DB_TEST_RESPONSE", string(raw))
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	got, err := RunExternalJSONForSourceWithLimits(ctx, []string{"sh", "-c", "printf '%s' \"$TREE_DB_TEST_RESPONSE\" > \"$1\""}, input, ExternalJSONLimits{MaxInput: len(input), MaxOutput: len(raw)}, a.Source)
+	if err != nil {
+		t.Fatalf("larger bounded input with compact response rejected: %v", err)
+	}
+	if !reflect.DeepEqual(got, a) {
+		t.Fatal("external backend response changed")
+	}
+}
+
+func TestExternalBackendRejectsInputCapBeforeExecution(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	_, err := RunExternalJSONForSourceWithLimits(ctx, []string{"definitely-not-an-executable"}, []byte("{}"), ExternalJSONLimits{MaxInput: 1, MaxOutput: 1024}, Source{SourceID: "expected", Checksum: strings.Repeat("0", 64), Vectors: 1, Dimensions: 1, Metric: "cosine"})
+	if err == nil || !strings.Contains(err.Error(), "input exceeds cap") {
+		t.Fatalf("over-input cap reached backend or returned wrong error: %v", err)
+	}
+}
+
+func TestExternalBackendStillRejectsOutputOverflow(t *testing.T) {
+	a, err := Build(fixture(), config())
+	if err != nil {
+		t.Fatal(err)
+	}
+	raw, err := CanonicalJSON(a)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("TREE_DB_TEST_RESPONSE", string(raw))
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	_, err = RunExternalJSONForSourceWithLimits(ctx, []string{"sh", "-c", "printf '%s' \"$TREE_DB_TEST_RESPONSE\" > \"$1\""}, []byte("{}"), ExternalJSONLimits{MaxInput: 2, MaxOutput: len(raw) - 1}, a.Source)
+	if err == nil || !strings.Contains(err.Error(), "output exceeds cap") {
+		t.Fatalf("output overflow accepted or wrong error: %v", err)
+	}
+}
+
 func TestExternalBackendRejectsUnboundExpectedSourceBeforeExecution(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()

--- a/TreeDB/internal/vectorpartition/vectorpartition_test.go
+++ b/TreeDB/internal/vectorpartition/vectorpartition_test.go
@@ -275,6 +275,30 @@ func TestExternalBackendDeadlineKillsPipeHoldingDescendant(t *testing.T) {
 		t.Fatalf("descendant temp cleanup leaked: %v", entries)
 	}
 }
+func TestExternalBackendRootExitStillCleansPipeHoldingDescendant(t *testing.T) {
+	root := t.TempDir()
+	t.Setenv("TMPDIR", root)
+	// The shell exits successfully immediately, leaving sleep with the command's
+	// inherited stderr pipe. CommandContext does not invoke Cancel in this case;
+	// post-Wait process-group cleanup must do so.
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	started := time.Now()
+	_, err := RunExternalJSONForSource(ctx, []string{"sh", "-c", "printf '{' > \"$1\"; (sleep 5) & exit 0"}, []byte("{}"), 1024, Source{SourceID: "expected", Checksum: strings.Repeat("0", 64), Vectors: 1, Dimensions: 1, Metric: "cosine"})
+	if err == nil {
+		t.Fatal("root-exited pipe-holding descendant accepted")
+	}
+	if elapsed := time.Since(started); elapsed > 750*time.Millisecond {
+		t.Fatalf("root-exited descendant return too slow: %s", elapsed)
+	}
+	entries, readErr := os.ReadDir(root)
+	if readErr != nil {
+		t.Fatal(readErr)
+	}
+	if len(entries) != 0 {
+		t.Fatalf("root-exited descendant temp cleanup leaked: %v", entries)
+	}
+}
 func TestExternalBackendRequiresDeadline(t *testing.T) {
 	if _, err := RunExternalJSON(context.Background(), []string{"true"}, []byte("{}"), 1024); err == nil {
 		t.Fatal("deadline-less backend accepted")
@@ -386,17 +410,23 @@ func TestReferencePartitionerRejectsExcessiveWork(t *testing.T) {
 		t.Fatal("unbounded partition work accepted")
 	}
 }
-func TestPartitionWorkAccountsForValidatorAndOrderingPasses(t *testing.T) {
-	// The former estimate charged only parts+d+d*(d+1)+log2(n), which would
-	// accept this shape (249,681,744 units) while omitting validator and ordering
-	// passes. Degree buckets make the new exact loop bound reject it.
-	const n, parts, degree = 234, 16_384, 1_024
-	oldPerNode := int64(parts + degree + degree*(degree+1) + 8)
-	if oldPerNode*int64(n) > maxPartitionWork {
-		t.Fatal("test no longer distinguishes old accounting")
+func TestPartitionWorkCountsAllPassesAtEmptyGraphBoundary(t *testing.T) {
+	// On an empty graph, the capacity boundary is determined entirely by the
+	// full-node initialization, partition scan, and global slice setup. This
+	// guards against silently accepting an allocation shape above the declared
+	// work cap merely because it has degree zero.
+	const n = 1_000_000
+	if work, overflow := partitionWorkUnits(n, 242, 0); overflow || work > maxPartitionWork {
+		t.Fatalf("accepted boundary miscounted: work=%d overflow=%v", work, overflow)
 	}
-	if !partitionWorkExceeded(n, parts, degree) {
-		t.Fatal("validator/order work omitted from cap")
+	if !partitionWorkExceeded(n, 243, 0) {
+		t.Fatal("empty-graph work above cap accepted")
+	}
+}
+func TestReferencePartitionerRejectsVectorBoundBeforeInternalAllocation(t *testing.T) {
+	g := Graph{Neighbors: make([][]int, maxVectors+1)}
+	if _, err := (ReferencePartitioner{}).Partition(g, 1, maxVectors+1); err == nil {
+		t.Fatal("partitioner accepted graph above direct vector bound")
 	}
 }
 func TestLeafNearestTieBreaksByOrdinal(t *testing.T) {

--- a/TreeDB/internal/vectorpartition/vectorpartition_test.go
+++ b/TreeDB/internal/vectorpartition/vectorpartition_test.go
@@ -29,6 +29,14 @@ func config() Config {
 	c.MaxEdges = 128
 	return c
 }
+
+func emptyGraph(nodes int) Graph {
+	g := Graph{Neighbors: make([][]int, nodes)}
+	for i := range g.Neighbors {
+		g.Neighbors[i] = make([]int, 0)
+	}
+	return g
+}
 func TestDenseBallGraphAndPartitionDeterministic(t *testing.T) {
 	a, e := Build(fixture(), config())
 	if e != nil {
@@ -397,6 +405,11 @@ func TestValidatorRejectsCorruptBackendOutput(t *testing.T) {
 		t.Fatal("missing graph node accepted")
 	}
 	a, _ = Build(fixture(), config())
+	a.Graph.Neighbors[0] = nil
+	if e := ValidateArtifact(a); e == nil {
+		t.Fatal("null graph row accepted")
+	}
+	a, _ = Build(fixture(), config())
 	a.IDs[1] = a.IDs[0]
 	if e := ValidateArtifact(a); e == nil {
 		t.Fatal("duplicate ID accepted")
@@ -405,6 +418,68 @@ func TestValidatorRejectsCorruptBackendOutput(t *testing.T) {
 	a.Assignment = []int{0, 0, 0, 0, 0, 0}
 	if e := ValidateArtifact(a); e == nil {
 		t.Fatal("over-cap assignment accepted")
+	}
+}
+
+func TestZeroDegreeGraphRowsAreCanonicalEmptyArrays(t *testing.T) {
+	c := config()
+	c.Partitions, c.MaxVectors, c.MaxEdges = 1, 1, 4
+	isolate, err := Build([]Vector{{ID: "only", Values: []float64{1, 0}}}, c)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(isolate.Graph.Neighbors) != 1 || isolate.Graph.Neighbors[0] == nil || len(isolate.Graph.Neighbors[0]) != 0 {
+		t.Fatalf("isolated build emitted non-canonical graph: %#v", isolate.Graph.Neighbors)
+	}
+
+	a, err := Build(fixture(), config())
+	if err != nil {
+		t.Fatal(err)
+	}
+	for i := range a.Graph.Neighbors {
+		a.Graph.Neighbors[i] = make([]int, 0)
+	}
+	a.Metrics = metrics(a)
+	if err := ValidateArtifact(a); err != nil {
+		t.Fatalf("all-empty graph rejected: %v", err)
+	}
+	raw, err := CanonicalJSON(a)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if bytes.Contains(raw, []byte(`null`)) {
+		t.Fatalf("canonical all-empty graph contains null: %s", raw)
+	}
+	if !bytes.Contains(raw, []byte(`"neighbors":[[],`)) {
+		t.Fatalf("canonical all-empty graph does not use arrays: %s", raw)
+	}
+	roundTrip, err := DecodeArtifact(raw, len(raw))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(roundTrip.Graph, a.Graph) {
+		t.Fatalf("canonical graph round trip changed rows: %#v", roundTrip.Graph.Neighbors)
+	}
+	digest, err := Digest(a)
+	if err != nil {
+		t.Fatal(err)
+	}
+	roundTripDigest, err := Digest(roundTrip)
+	if err != nil || digest != roundTripDigest {
+		t.Fatalf("canonical digest changed after round trip: %q %q %v", digest, roundTripDigest, err)
+	}
+	if _, err := DecodeArtifactForRequest(raw, len(raw), a); err != nil {
+		t.Fatalf("exact request binding rejected canonical empty rows: %v", err)
+	}
+	forged := bytes.Replace(raw, []byte(`"neighbors":[[]`), []byte(`"neighbors":[null`), 1)
+	if bytes.Equal(forged, raw) {
+		t.Fatal("failed to forge null graph row")
+	}
+	if _, err := DecodeArtifact(forged, len(forged)); err == nil || !strings.Contains(err.Error(), "neighbor row must be an array") {
+		t.Fatalf("null graph row was normalized or accepted: %v", err)
+	}
+	if _, err := DecodeArtifactForRequest(forged, len(forged), a); err == nil || !strings.Contains(err.Error(), "neighbor row must be an array") {
+		t.Fatalf("request binding normalized null graph row: %v", err)
 	}
 }
 
@@ -774,7 +849,7 @@ func TestDecodeArtifactForRequestBindsGraphConfigAndIDs(t *testing.T) {
 	})
 	t.Run("graph", func(t *testing.T) {
 		response := request
-		response.Graph.Neighbors = make([][]int, len(request.Graph.Neighbors))
+		response.Graph = emptyGraph(len(request.Graph.Neighbors))
 		assertRejected(t, response)
 	})
 	// Assignment is the intended backend result. A different valid assignment
@@ -907,7 +982,7 @@ func TestBuildWithPartitionerFailsClosedAfterMutatingBackendFailure(t *testing.T
 }
 
 func TestCloneGraphBoundedUsesIndependentExactBacking(t *testing.T) {
-	original := Graph{Neighbors: [][]int{{1, 2}, {0}}}
+	original := Graph{Neighbors: [][]int{{1, 2}, {}, {0}}}
 	clone, err := cloneGraphBounded(original, 3)
 	if err != nil {
 		t.Fatal(err)
@@ -915,6 +990,9 @@ func TestCloneGraphBoundedUsesIndependentExactBacking(t *testing.T) {
 	clone.Neighbors[0][0] = 99
 	if original.Neighbors[0][0] != 1 {
 		t.Fatalf("backend graph clone aliases canonical graph: %v", original)
+	}
+	if clone.Neighbors[1] == nil {
+		t.Fatal("backend graph clone changed an empty row to null")
 	}
 	if _, err := cloneGraphBounded(original, 2); err == nil {
 		t.Fatal("oversized backend graph copy accepted")
@@ -951,7 +1029,7 @@ func TestValidatorRejectsSymmetricPolicyEvenForReciprocalGraph(t *testing.T) {
 	}
 }
 func TestReferencePartitionerCoversEveryPartition(t *testing.T) {
-	g := Graph{Neighbors: make([][]int, 8)}
+	g := emptyGraph(8)
 	a, err := (ReferencePartitioner{}).Partition(g, 4, 2)
 	if err != nil {
 		t.Fatal(err)
@@ -967,7 +1045,7 @@ func TestReferencePartitionerCoversEveryPartition(t *testing.T) {
 	}
 }
 func TestReferencePartitionerRejectsExcessiveWork(t *testing.T) {
-	g := Graph{Neighbors: make([][]int, 16_384)}
+	g := emptyGraph(16_384)
 	if _, err := (ReferencePartitioner{}).Partition(g, 16_384, 2); err == nil {
 		t.Fatal("unbounded partition work accepted")
 	}
@@ -989,7 +1067,7 @@ func TestPartitionWorkCountsAllPassesAtEmptyGraphBoundary(t *testing.T) {
 	}
 }
 func TestReferencePartitionerRejectsVectorBoundBeforeInternalAllocation(t *testing.T) {
-	g := Graph{Neighbors: make([][]int, maxVectors+1)}
+	g := emptyGraph(maxVectors + 1)
 	if _, err := (ReferencePartitioner{}).Partition(g, 1, maxVectors+1); err == nil {
 		t.Fatal("partitioner accepted graph above direct vector bound")
 	}
@@ -1057,7 +1135,7 @@ func TestArtifactRejectsOversizedIDsAndSourceDimensions(t *testing.T) {
 func TestArtifactRejectsAggregateIDByteCap(t *testing.T) {
 	chunk := strings.Repeat("x", maxTotalIDBytes/2+1)
 	c := Config{Metric: "cosine", Repetitions: 1, Pivots: 2, MaxLeafBucket: 2, Degree: 1, Partitions: 2, MaxVectors: 2, MaxEdges: 2}
-	a := Artifact{SchemaVersion: SchemaVersion, Backend: "test", BackendLicense: "test", Source: Source{SourceID: "test", Checksum: strings.Repeat("0", 64), Vectors: 2, Dimensions: 1, Metric: "cosine"}, Config: c, IDs: []string{"a" + chunk, "b" + chunk}, Graph: Graph{Neighbors: make([][]int, 2)}, Assignment: []int{0, 1}}
+	a := Artifact{SchemaVersion: SchemaVersion, Backend: "test", BackendLicense: "test", Source: Source{SourceID: "test", Checksum: strings.Repeat("0", 64), Vectors: 2, Dimensions: 1, Metric: "cosine"}, Config: c, IDs: []string{"a" + chunk, "b" + chunk}, Graph: emptyGraph(2), Assignment: []int{0, 1}}
 	if err := ValidateArtifact(a); err == nil {
 		t.Fatal("aggregate ID cap accepted")
 	}
@@ -1072,7 +1150,7 @@ func TestMetricsHighPartitionCountUsesAssignmentHistogram(t *testing.T) {
 		assignment[i] = i
 	}
 	c := Config{Metric: "cosine", Seed: 1, Repetitions: 1, Pivots: 2, MaxLeafBucket: 2, Degree: 1, Partitions: n, Imbalance: .05, MaxVectors: n, MaxEdges: n}
-	a := Artifact{SchemaVersion: SchemaVersion, Backend: "test", BackendLicense: "test", Source: Source{SourceID: "test", Checksum: strings.Repeat("0", 64), Vectors: n, Dimensions: 1, Metric: "cosine"}, Config: c, IDs: ids, Graph: Graph{Neighbors: make([][]int, n)}, Assignment: assignment}
+	a := Artifact{SchemaVersion: SchemaVersion, Backend: "test", BackendLicense: "test", Source: Source{SourceID: "test", Checksum: strings.Repeat("0", 64), Vectors: n, Dimensions: 1, Metric: "cosine"}, Config: c, IDs: ids, Graph: emptyGraph(n), Assignment: assignment}
 	a.Metrics = metrics(a)
 	if err := ValidateArtifact(a); err != nil {
 		t.Fatal(err)

--- a/TreeDB/internal/vectorpartition/vectorpartition_test.go
+++ b/TreeDB/internal/vectorpartition/vectorpartition_test.go
@@ -416,13 +416,13 @@ func TestPartitionWorkCountsAllPassesAtEmptyGraphBoundary(t *testing.T) {
 	// guards against silently accepting an allocation shape above the declared
 	// work cap merely because it has degree zero.
 	const n = 1_000_000
-	if work, overflow := partitionWorkUnits(n, 238, 0); overflow || work != 249_000_717 || work > maxPartitionWork {
+	if work, overflow := partitionWorkUnits(n, 237, 0); overflow || work != 249_000_716 || work > maxPartitionWork {
 		t.Fatalf("accepted boundary miscounted: work=%d overflow=%v", work, overflow)
 	}
-	if work, overflow := partitionWorkUnits(n, 239, 0); overflow || work != 250_000_720 || work <= maxPartitionWork {
+	if work, overflow := partitionWorkUnits(n, 238, 0); overflow || work != 250_000_719 || work <= maxPartitionWork {
 		t.Fatalf("rejected boundary miscounted: work=%d overflow=%v", work, overflow)
 	}
-	if !partitionWorkExceeded(n, 239, 0) {
+	if !partitionWorkExceeded(n, 238, 0) {
 		t.Fatal("empty-graph work above cap accepted")
 	}
 }

--- a/TreeDB/internal/vectorpartition/vectorpartition_test.go
+++ b/TreeDB/internal/vectorpartition/vectorpartition_test.go
@@ -47,6 +47,17 @@ func TestDenseBallGraphAndPartitionDeterministic(t *testing.T) {
 	if e := ValidateArtifact(a); e != nil {
 		t.Fatal(e)
 	}
+	if got, want := mustDigest(t, a), "9ec528eff2020ba0d6af5a73b069ce9ba2368850270fb7b561a27d45c889e80e"; got != want {
+		t.Fatalf("tiny canonical graph/assignment bytes changed: got %s want %s", got, want)
+	}
+}
+func mustDigest(t *testing.T, a Artifact) string {
+	t.Helper()
+	d, err := Digest(a)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return d
 }
 func TestGraphDegreeAndCapOnDuplicateSkew(t *testing.T) {
 	v := make([]Vector, 12)
@@ -97,7 +108,7 @@ func TestMalformedFailsClosed(t *testing.T) {
 		name string
 		v    []Vector
 		c    Config
-	}{{"empty", nil, config()}, {"duplicate", []Vector{{"a", []float64{1}}, {"a", []float64{1}}}, func() Config { c := config(); c.Partitions = 2; return c }()}, {"nonfinite", []Vector{{"a", []float64{math.NaN()}}, {"b", []float64{1}}}, func() Config { c := config(); c.Partitions = 2; return c }()}}
+	}{{"empty", nil, config()}, {"duplicate", []Vector{{"a", []float64{1}}, {"a", []float64{1}}}, func() Config { c := config(); c.Partitions = 2; return c }()}, {"wrong-dimension", []Vector{{"a", []float64{1}}, {"b", []float64{1, 0}}}, func() Config { c := config(); c.Partitions = 2; return c }()}, {"nonfinite", []Vector{{"a", []float64{math.NaN()}}, {"b", []float64{1}}}, func() Config { c := config(); c.Partitions = 2; return c }()}}
 	for _, x := range cases {
 		if _, e := Build(x.v, x.c); e == nil {
 			t.Fatalf("%s accepted", x.name)
@@ -118,6 +129,21 @@ func TestValidatorRejectsCorruptBackendOutput(t *testing.T) {
 	if e := ValidateArtifact(a); e == nil {
 		t.Fatal("self edge accepted")
 	}
+	a, _ = Build(fixture(), config())
+	a.Graph.Neighbors = a.Graph.Neighbors[:len(a.Graph.Neighbors)-1]
+	if e := ValidateArtifact(a); e == nil {
+		t.Fatal("missing graph node accepted")
+	}
+	a, _ = Build(fixture(), config())
+	a.IDs[1] = a.IDs[0]
+	if e := ValidateArtifact(a); e == nil {
+		t.Fatal("duplicate ID accepted")
+	}
+	a, _ = Build(fixture(), config())
+	a.Assignment = []int{0, 0, 0, 0, 0, 0}
+	if e := ValidateArtifact(a); e == nil {
+		t.Fatal("over-cap assignment accepted")
+	}
 }
 
 func TestStrictDecoderRejectsNonCanonicalAndMetricForgery(t *testing.T) {
@@ -131,6 +157,9 @@ func TestStrictDecoderRejectsNonCanonicalAndMetricForgery(t *testing.T) {
 	}
 	if _, err := DecodeArtifact(raw, len(raw)); err != nil {
 		t.Fatal(err)
+	}
+	if _, err := DecodeArtifact(raw, len(raw)-1); err == nil {
+		t.Fatal("over-max decoder input accepted")
 	}
 	if _, err := DecodeArtifact(append(raw, '\n'), len(raw)+1); err == nil {
 		t.Fatal("noncanonical whitespace accepted")
@@ -167,6 +196,27 @@ func TestGraphPartitionBeatsStableIDHashOnClusteredFixture(t *testing.T) {
 		t.Fatalf("graph cut=%d hash=%d", a.Metrics.EdgeCut, a.Metrics.StableIDHashEdgeCut)
 	}
 }
+func TestGraphPartitionBeatsStableIDHashOnDeterministic10kClusters(t *testing.T) {
+	const n = 10_000
+	v := make([]Vector, n)
+	for i := range v {
+		cluster := i % 16
+		values := make([]float64, 16)
+		values[cluster] = 1
+		values[(cluster+1)%16] = float64(i%17) * 1e-6
+		v[i] = Vector{ID: fmt.Sprintf("cluster-%02d-%04d", cluster, i/16), Values: values}
+	}
+	c := DefaultConfig()
+	c.Partitions, c.Repetitions, c.Pivots, c.MaxLeafBucket, c.Degree = 16, 1, 4, 64, 4
+	c.MaxVectors, c.MaxEdges = n, n*c.Degree
+	a, err := Build(v, c)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if a.Metrics.EdgeCut >= a.Metrics.StableIDHashEdgeCut {
+		t.Fatalf("10k clustered edge cut=%d hash=%d", a.Metrics.EdgeCut, a.Metrics.StableIDHashEdgeCut)
+	}
+}
 
 func TestExternalBackendCancellationCleansPrivateTemp(t *testing.T) {
 	root := t.TempDir()
@@ -185,6 +235,23 @@ func TestExternalBackendCancellationCleansPrivateTemp(t *testing.T) {
 		if entry.IsDir() && filepath.Base(entry.Name()) != "" {
 			t.Fatalf("backend temporary directory leaked: %s", entry.Name())
 		}
+	}
+}
+func TestExternalBackendStartedCancellationCleansPrivateTemp(t *testing.T) {
+	root := t.TempDir()
+	t.Setenv("TMPDIR", root)
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+	_, err := RunExternalJSONForSource(ctx, []string{"sh", "-c", "printf '{' > \"$1\"; sleep 1"}, []byte("{}"), 1024, Source{SourceID: "expected", Checksum: strings.Repeat("0", 64), Vectors: 1, Dimensions: 1, Metric: "cosine"})
+	if err == nil {
+		t.Fatal("started backend cancellation accepted")
+	}
+	entries, err := os.ReadDir(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 0 {
+		t.Fatalf("backend temporary directory leaked after start: %v", entries)
 	}
 }
 func TestExternalBackendRequiresDeadline(t *testing.T) {
@@ -230,6 +297,84 @@ func (badPartitioner) License() string { return "test license" }
 func (badPartitioner) Partition(g Graph, parts, cap int) ([]int, error) {
 	return make([]int, len(g.Neighbors)), nil
 }
+
+type assignmentPartitioner struct{ assignment []int }
+
+func (p assignmentPartitioner) Name() string    { return "assignment-test" }
+func (p assignmentPartitioner) License() string { return "test" }
+func (p assignmentPartitioner) Partition(Graph, int, int) ([]int, error) {
+	return p.assignment, nil
+}
+func TestBuildFailsClosedOnMalformedBackendAssignment(t *testing.T) {
+	for _, assignment := range [][]int{nil, {0}, {0, 1, 0, 1, 0, 1, 0}, {-1, 0, 0, 1, 1, 0}, {2, 0, 0, 1, 1, 0}} {
+		if _, err := BuildWithPartitioner(fixture(), config(), Source{SourceID: "fixture"}, assignmentPartitioner{assignment}); err == nil {
+			t.Fatalf("malformed assignment accepted: %v", assignment)
+		}
+	}
+}
+func TestValidatorEnforcesSymmetricPolicy(t *testing.T) {
+	a, err := Build(fixture(), config())
+	if err != nil {
+		t.Fatal(err)
+	}
+	from, to := -1, -1
+	for i, ns := range a.Graph.Neighbors {
+		if len(ns) > 0 {
+			from, to = i, ns[0]
+			break
+		}
+	}
+	if from < 0 {
+		t.Fatal("fixture graph has no edge")
+	}
+	for i, ns := range a.Graph.Neighbors {
+		if i != to {
+			continue
+		}
+		for at, node := range ns {
+			if node == from {
+				a.Graph.Neighbors[i] = append(ns[:at], ns[at+1:]...)
+				break
+			}
+		}
+	}
+	a.Config.Symmetric = true
+	if err := ValidateArtifact(a); err == nil {
+		t.Fatal("non-reciprocal graph accepted as symmetric")
+	}
+}
+func TestReferencePartitionerCoversEveryPartition(t *testing.T) {
+	g := Graph{Neighbors: make([][]int, 8)}
+	a, err := (ReferencePartitioner{}).Partition(g, 4, 2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	seen := make([]bool, 4)
+	for _, p := range a {
+		seen[p] = true
+	}
+	for p, ok := range seen {
+		if !ok {
+			t.Fatalf("partition %d left empty: %v", p, a)
+		}
+	}
+}
+func TestReferencePartitionerRejectsExcessiveWork(t *testing.T) {
+	g := Graph{Neighbors: make([][]int, 16_384)}
+	if _, err := (ReferencePartitioner{}).Partition(g, 16_384, 2); err == nil {
+		t.Fatal("unbounded partition work accepted")
+	}
+}
+func TestLeafNearestTieBreaksByOrdinal(t *testing.T) {
+	v := []Vector{{"a", []float64{1, 0}}, {"b", []float64{0, 1}}, {"c", []float64{0, -1}}, {"d", []float64{-1, 0}}}
+	got, err := nearest(v, []int{0, 1, 2, 3}, 0, 2, &distanceBudget{remaining: 100})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got[0].i != 1 || got[1].i != 2 {
+		t.Fatalf("ties not ordinal-stable: %+v", got)
+	}
+}
 func TestBuildWithPartitionerValidatesBackendOutputAndSource(t *testing.T) {
 	_, err := BuildWithPartitioner(fixture(), config(), Source{SourceID: "fixture", Checksum: "00"}, badPartitioner{})
 	if err == nil {
@@ -237,6 +382,9 @@ func TestBuildWithPartitionerValidatesBackendOutputAndSource(t *testing.T) {
 	}
 	if _, err := BuildWithPartitioner(fixture(), config(), Source{SourceID: "fixture"}, badPartitioner{}); err == nil {
 		t.Fatal("malicious assignment accepted")
+	}
+	if _, err := BuildWithPartitioner(fixture(), config(), Source{SourceID: "fixture", Metric: "cosine"}, ReferencePartitioner{}); err == nil {
+		t.Fatal("partial source identity accepted")
 	}
 	a, err := Build(fixture(), config())
 	if err != nil {
@@ -275,6 +423,14 @@ func TestArtifactRejectsOversizedIDsAndSourceDimensions(t *testing.T) {
 	a.IDs[0] = strings.Repeat("x", maxIDBytes+1)
 	if err := ValidateArtifact(a); err == nil {
 		t.Fatal("oversized ID accepted")
+	}
+}
+func TestArtifactRejectsAggregateIDByteCap(t *testing.T) {
+	chunk := strings.Repeat("x", maxTotalIDBytes/2+1)
+	c := Config{Metric: "cosine", Repetitions: 1, Pivots: 2, MaxLeafBucket: 2, Degree: 1, Partitions: 2, MaxVectors: 2, MaxEdges: 2}
+	a := Artifact{SchemaVersion: SchemaVersion, Backend: "test", BackendLicense: "test", Source: Source{SourceID: "test", Checksum: strings.Repeat("0", 64), Vectors: 2, Dimensions: 1, Metric: "cosine"}, Config: c, IDs: []string{"a" + chunk, "b" + chunk}, Graph: Graph{Neighbors: make([][]int, 2)}, Assignment: []int{0, 1}}
+	if err := ValidateArtifact(a); err == nil {
+		t.Fatal("aggregate ID cap accepted")
 	}
 }
 

--- a/TreeDB/internal/vectorpartition/vectorpartition_test.go
+++ b/TreeDB/internal/vectorpartition/vectorpartition_test.go
@@ -166,7 +166,10 @@ func TestStrictDecoderRejectsNonCanonicalAndMetricForgery(t *testing.T) {
 		t.Fatal("noncanonical whitespace accepted")
 	}
 	a.Metrics.EdgeCut++
-	bad, _ := json.Marshal(a)
+	bad, err := json.Marshal(a)
+	if err != nil {
+		t.Fatal(err)
+	}
 	if _, err := DecodeArtifact(bad, len(bad)); err == nil {
 		t.Fatal("forged metrics accepted")
 	}

--- a/TreeDB/internal/vectorpartition/vectorpartition_test.go
+++ b/TreeDB/internal/vectorpartition/vectorpartition_test.go
@@ -426,35 +426,27 @@ func TestBuildFailsClosedOnMalformedBackendAssignment(t *testing.T) {
 		}
 	}
 }
-func TestValidatorEnforcesSymmetricPolicy(t *testing.T) {
+func TestValidatorRejectsSymmetricPolicyEvenForReciprocalGraph(t *testing.T) {
 	a, err := Build(fixture(), config())
 	if err != nil {
 		t.Fatal(err)
 	}
-	from, to := -1, -1
-	for i, ns := range a.Graph.Neighbors {
-		if len(ns) > 0 {
-			from, to = i, ns[0]
-			break
-		}
+	a.Graph.Neighbors = [][]int{{1}, {0}, {3}, {2}, {5}, {4}}
+	loads, err := validateAssignment(a.Assignment, len(a.IDs), a.Config)
+	if err != nil {
+		t.Fatal(err)
 	}
-	if from < 0 {
-		t.Fatal("fixture graph has no edge")
-	}
-	for i, ns := range a.Graph.Neighbors {
-		if i != to {
-			continue
-		}
-		for at, node := range ns {
-			if node == from {
-				a.Graph.Neighbors[i] = append(ns[:at], ns[at+1:]...)
-				break
-			}
-		}
-	}
+	a.Metrics = metricsWithLoads(a, loads)
 	a.Config.Symmetric = true
 	if err := ValidateArtifact(a); err == nil {
-		t.Fatal("non-reciprocal graph accepted as symmetric")
+		t.Fatal("reciprocal graph accepted as symmetric")
+	}
+	raw, err := json.Marshal(a)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := DecodeArtifact(raw, len(raw)); err == nil {
+		t.Fatal("decode accepted a reciprocal symmetric artifact")
 	}
 }
 func TestReferencePartitionerCoversEveryPartition(t *testing.T) {

--- a/TreeDB/internal/vectorpartition/vectorpartition_test.go
+++ b/TreeDB/internal/vectorpartition/vectorpartition_test.go
@@ -132,6 +132,79 @@ func TestBuildRejectsOverCapBeforeVectorElementValidation(t *testing.T) {
 	}
 }
 
+func TestBuildPreflightsSelectedShapeBeforeFullVectorScan(t *testing.T) {
+	shapeConfig := func() Config {
+		c := DefaultConfig()
+		c.Repetitions = 1
+		c.Pivots = 2
+		c.MaxLeafBucket = 2
+		c.Degree = 1
+		return c
+	}
+	edge := shapeConfig()
+	edge.Partitions, edge.Degree, edge.MaxEdges = 1, 2, 1
+	pivot := shapeConfig()
+	pivot.Partitions, pivot.Pivots = 1, maxPivots
+	overlap := shapeConfig()
+	overlap.Partitions, overlap.MaxLeafBucket = 1, 65_536
+	partition := shapeConfig()
+	partition.Partitions = 238
+	for _, tc := range []struct {
+		name  string
+		count int
+		dims  int
+		cfg   Config
+		want  string
+	}{
+		{"edge bound", 2, 1, edge, "graph edge bound"},
+		{"pivot scalar work", 310_000, 64, pivot, "scalar-work"},
+		{"dual leaf scalar work", 300_000, 1, overlap, "scalar-work"},
+		{"reference partition work", 1_000_000, 1, partition, "partition work"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			shared := make([]float64, tc.dims)
+			shared[0] = math.NaN()
+			vectors := make([]Vector, tc.count)
+			for i := range vectors {
+				// An element scan would reject this empty ID/non-finite value
+				// instead of the selected deterministic shape bound.
+				vectors[i] = Vector{Values: shared}
+			}
+			_, err := Build(vectors, tc.cfg)
+			if err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("Build error=%v; want preflight %q", err, tc.want)
+			}
+		})
+	}
+}
+
+func TestBuildAppliesReferenceWorkOnlyToReferenceBackend(t *testing.T) {
+	c := DefaultConfig()
+	c.Partitions, c.Repetitions, c.Pivots, c.MaxLeafBucket, c.Degree = 238, 1, 2, 2, 1
+	vectors := make([]Vector, 1_000_000)
+	shared := []float64{math.NaN()}
+	for i := range vectors {
+		vectors[i] = Vector{ID: "valid", Values: shared}
+	}
+	_, err := BuildWithPartitioner(vectors, c, Source{SourceID: "custom"}, assignmentPartitioner{})
+	if err == nil || !strings.Contains(err.Error(), "non-finite vector value") {
+		t.Fatalf("custom backend incorrectly received reference work gate: %v", err)
+	}
+}
+
+func TestBuildChecksLaterDimensionBeforeValues(t *testing.T) {
+	c := config()
+	c.Partitions = 2
+	vectors := []Vector{
+		{ID: "first", Values: []float64{1}},
+		{ID: "second", Values: []float64{math.NaN(), 1}},
+	}
+	_, err := Build(vectors, c)
+	if err == nil || !strings.Contains(err.Error(), "wrong vector dimension") {
+		t.Fatalf("heterogeneous dimension did not fail before scalar scan: %v", err)
+	}
+}
+
 func TestBuildAndArtifactRejectInvalidUTF8IDs(t *testing.T) {
 	vectors := fixture()
 	vectors[0].ID = string([]byte{0xff})

--- a/TreeDB/internal/vectorpartition/vectorpartition_test.go
+++ b/TreeDB/internal/vectorpartition/vectorpartition_test.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 )
 
 func fixture() []Vector {
@@ -145,7 +146,7 @@ func TestGraphPartitionBeatsStableIDHashOnClusteredFixture(t *testing.T) {
 func TestExternalBackendCancellationCleansPrivateTemp(t *testing.T) {
 	root := t.TempDir()
 	t.Setenv("TMPDIR", root)
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	cancel()
 	_, err := RunExternalJSON(ctx, []string{"sh", "-c", "sleep 1"}, []byte("{}"), 1024)
 	if err == nil {
@@ -159,5 +160,46 @@ func TestExternalBackendCancellationCleansPrivateTemp(t *testing.T) {
 		if entry.IsDir() && filepath.Base(entry.Name()) != "" {
 			t.Fatalf("backend temporary directory leaked: %s", entry.Name())
 		}
+	}
+}
+func TestExternalBackendRequiresDeadline(t *testing.T) {
+	if _, err := RunExternalJSON(context.Background(), []string{"true"}, []byte("{}"), 1024); err == nil {
+		t.Fatal("deadline-less backend accepted")
+	}
+}
+
+type badPartitioner struct{}
+
+func (badPartitioner) Name() string { return "bad" }
+func (badPartitioner) Partition(g Graph, parts, cap int) ([]int, error) {
+	return make([]int, len(g.Neighbors)), nil
+}
+func TestBuildWithPartitionerValidatesBackendOutputAndSource(t *testing.T) {
+	_, err := BuildWithPartitioner(fixture(), config(), Source{SourceID: "fixture", Checksum: "00"}, badPartitioner{})
+	if err == nil {
+		t.Fatal("mismatched source accepted")
+	}
+	if _, err := BuildWithPartitioner(fixture(), config(), Source{SourceID: "fixture"}, badPartitioner{}); err == nil {
+		t.Fatal("malicious assignment accepted")
+	}
+	a, err := Build(fixture(), config())
+	if err != nil {
+		t.Fatal(err)
+	}
+	a.Graph.Neighbors[0] = []int{2, 1}
+	if err := ValidateArtifact(a); err == nil {
+		t.Fatal("noncanonical neighbor ordering accepted")
+	}
+}
+func TestBoundedUnionKeepsClosestNotLowestOrdinal(t *testing.T) {
+	s := map[int]float64{}
+	addCandidateBounded(s, 99, .1, 2)
+	addCandidateBounded(s, 1, .9, 2)
+	addCandidateBounded(s, 50, .2, 2)
+	if _, ok := s[1]; ok {
+		t.Fatal("ordinal-only truncation retained distant neighbor")
+	}
+	if _, ok := s[99]; !ok {
+		t.Fatal("closest candidate lost")
 	}
 }

--- a/TreeDB/internal/vectorpartition/vectorpartition_test.go
+++ b/TreeDB/internal/vectorpartition/vectorpartition_test.go
@@ -1,0 +1,91 @@
+package vectorpartition
+
+import (
+	"bytes"
+	"math"
+	"testing"
+)
+
+func fixture() []Vector {
+	return []Vector{{"z", []float64{1, 0}}, {"a", []float64{1, .01}}, {"b", []float64{.99, .02}}, {"c", []float64{0, 1}}, {"d", []float64{.01, 1}}, {"e", []float64{.02, .99}}}
+}
+func config() Config {
+	c := DefaultConfig()
+	c.Partitions = 2
+	c.Pivots = 2
+	c.MaxLeafBucket = 2
+	c.Degree = 2
+	c.Repetitions = 2
+	c.MaxVectors = 64
+	c.MaxEdges = 128
+	return c
+}
+func TestDenseBallGraphAndPartitionDeterministic(t *testing.T) {
+	a, e := Build(fixture(), config())
+	if e != nil {
+		t.Fatal(e)
+	}
+	b, e := Build(fixture(), config())
+	if e != nil {
+		t.Fatal(e)
+	}
+	aj, _ := CanonicalJSON(a)
+	bj, _ := CanonicalJSON(b)
+	if !bytes.Equal(aj, bj) {
+		t.Fatal("artifact bytes differ")
+	}
+	if a.IDs[0] != "a" || a.Metrics.MaxPartitionSize > a.Metrics.Cap {
+		t.Fatalf("artifact=%+v", a)
+	}
+	if e := ValidateArtifact(a); e != nil {
+		t.Fatal(e)
+	}
+}
+func TestGraphDegreeAndCapOnDuplicateSkew(t *testing.T) {
+	v := make([]Vector, 12)
+	for i := range v {
+		v[i] = Vector{ID: string(rune('a' + i)), Values: []float64{1, 0}}
+	}
+	c := config()
+	c.Partitions = 3
+	c.MaxLeafBucket = 2
+	a, e := Build(v, c)
+	if e != nil {
+		t.Fatal(e)
+	}
+	for _, n := range a.Graph.Neighbors {
+		if len(n) > c.Degree {
+			t.Fatal("degree cap")
+		}
+	}
+	if a.Metrics.MaxPartitionSize > a.Metrics.Cap {
+		t.Fatal("partition cap")
+	}
+}
+func TestMalformedFailsClosed(t *testing.T) {
+	cases := []struct {
+		name string
+		v    []Vector
+		c    Config
+	}{{"empty", nil, config()}, {"duplicate", []Vector{{"a", []float64{1}}, {"a", []float64{1}}}, func() Config { c := config(); c.Partitions = 2; return c }()}, {"nonfinite", []Vector{{"a", []float64{math.NaN()}}, {"b", []float64{1}}}, func() Config { c := config(); c.Partitions = 2; return c }()}}
+	for _, x := range cases {
+		if _, e := Build(x.v, x.c); e == nil {
+			t.Fatalf("%s accepted", x.name)
+		}
+	}
+}
+func TestValidatorRejectsCorruptBackendOutput(t *testing.T) {
+	a, e := Build(fixture(), config())
+	if e != nil {
+		t.Fatal(e)
+	}
+	a.Assignment[0] = a.Config.Partitions
+	if e := ValidateArtifact(a); e == nil {
+		t.Fatal("out of range accepted")
+	}
+	a, e = Build(fixture(), config())
+	a.Graph.Neighbors[0] = append(a.Graph.Neighbors[0], 0)
+	if e := ValidateArtifact(a); e == nil {
+		t.Fatal("self edge accepted")
+	}
+}

--- a/TreeDB/vectorpartition/api.go
+++ b/TreeDB/vectorpartition/api.go
@@ -1,0 +1,24 @@
+// Package vectorpartition exposes the offline M2 builder to TreeDB commands.
+// The implementation remains internal; this is not a server/runtime API.
+package vectorpartition
+
+import internal "github.com/snissn/gomap/TreeDB/internal/vectorpartition"
+
+type Vector = internal.Vector
+type Config = internal.Config
+type Graph = internal.Graph
+type Metrics = internal.Metrics
+type Artifact = internal.Artifact
+type Partitioner = internal.Partitioner
+type ReferencePartitioner = internal.ReferencePartitioner
+
+const SchemaVersion = internal.SchemaVersion
+
+func DefaultConfig() Config                        { return internal.DefaultConfig() }
+func Build(v []Vector, c Config) (Artifact, error) { return internal.Build(v, c) }
+func ValidateArtifact(a Artifact) error            { return internal.ValidateArtifact(a) }
+func CanonicalJSON(a Artifact) ([]byte, error)     { return internal.CanonicalJSON(a) }
+func Digest(a Artifact) (string, error)            { return internal.Digest(a) }
+func DecodeArtifact(raw []byte, maxBytes int) (Artifact, error) {
+	return internal.DecodeArtifact(raw, maxBytes)
+}

--- a/TreeDB/vectorpartition/api.go
+++ b/TreeDB/vectorpartition/api.go
@@ -19,7 +19,11 @@ type ReferencePartitioner = internal.ReferencePartitioner
 
 const SchemaVersion = internal.SchemaVersion
 
-func DefaultConfig() Config                        { return internal.DefaultConfig() }
+func DefaultConfig() Config         { return internal.DefaultConfig() }
+func ValidateConfig(c Config) error { return internal.ValidateConfig(c) }
+func ValidateInputShape(c Config, vectors, dimensions int) error {
+	return internal.ValidateInputShape(c, vectors, dimensions)
+}
 func Build(v []Vector, c Config) (Artifact, error) { return internal.Build(v, c) }
 func BuildWithPartitioner(v []Vector, c Config, s Source, p Partitioner) (Artifact, error) {
 	return internal.BuildWithPartitioner(v, c, s, p)

--- a/TreeDB/vectorpartition/api.go
+++ b/TreeDB/vectorpartition/api.go
@@ -36,3 +36,6 @@ func DecodeArtifact(raw []byte, maxBytes int) (Artifact, error) {
 func RunExternalJSON(ctx context.Context, command []string, input []byte, maxOutput int) (Artifact, error) {
 	return internal.RunExternalJSON(ctx, command, input, maxOutput)
 }
+func RunExternalJSONForSource(ctx context.Context, command []string, input []byte, maxOutput int, source Source) (Artifact, error) {
+	return internal.RunExternalJSONForSource(ctx, command, input, maxOutput, source)
+}

--- a/TreeDB/vectorpartition/api.go
+++ b/TreeDB/vectorpartition/api.go
@@ -9,6 +9,7 @@ type Config = internal.Config
 type Graph = internal.Graph
 type Metrics = internal.Metrics
 type Artifact = internal.Artifact
+type Source = internal.Source
 type Partitioner = internal.Partitioner
 type ReferencePartitioner = internal.ReferencePartitioner
 
@@ -16,9 +17,12 @@ const SchemaVersion = internal.SchemaVersion
 
 func DefaultConfig() Config                        { return internal.DefaultConfig() }
 func Build(v []Vector, c Config) (Artifact, error) { return internal.Build(v, c) }
-func ValidateArtifact(a Artifact) error            { return internal.ValidateArtifact(a) }
-func CanonicalJSON(a Artifact) ([]byte, error)     { return internal.CanonicalJSON(a) }
-func Digest(a Artifact) (string, error)            { return internal.Digest(a) }
+func BuildWithPartitioner(v []Vector, c Config, s Source, p Partitioner) (Artifact, error) {
+	return internal.BuildWithPartitioner(v, c, s, p)
+}
+func ValidateArtifact(a Artifact) error        { return internal.ValidateArtifact(a) }
+func CanonicalJSON(a Artifact) ([]byte, error) { return internal.CanonicalJSON(a) }
+func Digest(a Artifact) (string, error)        { return internal.Digest(a) }
 func DecodeArtifact(raw []byte, maxBytes int) (Artifact, error) {
 	return internal.DecodeArtifact(raw, maxBytes)
 }

--- a/TreeDB/vectorpartition/api.go
+++ b/TreeDB/vectorpartition/api.go
@@ -24,6 +24,9 @@ func ValidateConfig(c Config) error { return internal.ValidateConfig(c) }
 func ValidateInputShape(c Config, vectors, dimensions int) error {
 	return internal.ValidateInputShape(c, vectors, dimensions)
 }
+func ValidateReferenceInputShape(c Config, vectors, dimensions int) error {
+	return internal.ValidateReferenceInputShape(c, vectors, dimensions)
+}
 func Build(v []Vector, c Config) (Artifact, error) { return internal.Build(v, c) }
 func BuildWithPartitioner(v []Vector, c Config, s Source, p Partitioner) (Artifact, error) {
 	return internal.BuildWithPartitioner(v, c, s, p)

--- a/TreeDB/vectorpartition/api.go
+++ b/TreeDB/vectorpartition/api.go
@@ -13,6 +13,7 @@ type Graph = internal.Graph
 type Metrics = internal.Metrics
 type Artifact = internal.Artifact
 type Source = internal.Source
+type PhaseMetrics = internal.PhaseMetrics
 type Partitioner = internal.Partitioner
 type ReferencePartitioner = internal.ReferencePartitioner
 
@@ -22,6 +23,9 @@ func DefaultConfig() Config                        { return internal.DefaultConf
 func Build(v []Vector, c Config) (Artifact, error) { return internal.Build(v, c) }
 func BuildWithPartitioner(v []Vector, c Config, s Source, p Partitioner) (Artifact, error) {
 	return internal.BuildWithPartitioner(v, c, s, p)
+}
+func BuildWithPartitionerPhased(v []Vector, c Config, s Source, p Partitioner) (Artifact, PhaseMetrics, error) {
+	return internal.BuildWithPartitionerPhased(v, c, s, p)
 }
 func ValidateArtifact(a Artifact) error        { return internal.ValidateArtifact(a) }
 func CanonicalJSON(a Artifact) ([]byte, error) { return internal.CanonicalJSON(a) }

--- a/TreeDB/vectorpartition/api.go
+++ b/TreeDB/vectorpartition/api.go
@@ -47,6 +47,9 @@ func RunExternalJSON(ctx context.Context, command []string, input []byte, maxOut
 func RunExternalJSONForSource(ctx context.Context, command []string, input []byte, maxOutput int, source Source) (Artifact, error) {
 	return internal.RunExternalJSONForSource(ctx, command, input, maxOutput, source)
 }
+
+// RunExternalJSONForSourceWithLimits fails closed without running a backend.
+// Use RunExternalJSONForRequestWithLimits for a fully bound request.
 func RunExternalJSONForSourceWithLimits(ctx context.Context, command []string, input []byte, limits ExternalJSONLimits, source Source) (Artifact, error) {
 	return internal.RunExternalJSONForSourceWithLimits(ctx, command, input, limits, source)
 }

--- a/TreeDB/vectorpartition/api.go
+++ b/TreeDB/vectorpartition/api.go
@@ -50,3 +50,6 @@ func RunExternalJSONForSource(ctx context.Context, command []string, input []byt
 func RunExternalJSONForSourceWithLimits(ctx context.Context, command []string, input []byte, limits ExternalJSONLimits, source Source) (Artifact, error) {
 	return internal.RunExternalJSONForSourceWithLimits(ctx, command, input, limits, source)
 }
+func RunExternalJSONForRequestWithLimits(ctx context.Context, command []string, input []byte, limits ExternalJSONLimits, request Artifact) (Artifact, error) {
+	return internal.RunExternalJSONForRequestWithLimits(ctx, command, input, limits, request)
+}

--- a/TreeDB/vectorpartition/api.go
+++ b/TreeDB/vectorpartition/api.go
@@ -2,7 +2,10 @@
 // The implementation remains internal; this is not a server/runtime API.
 package vectorpartition
 
-import internal "github.com/snissn/gomap/TreeDB/internal/vectorpartition"
+import (
+	"context"
+	internal "github.com/snissn/gomap/TreeDB/internal/vectorpartition"
+)
 
 type Vector = internal.Vector
 type Config = internal.Config
@@ -25,4 +28,7 @@ func CanonicalJSON(a Artifact) ([]byte, error) { return internal.CanonicalJSON(a
 func Digest(a Artifact) (string, error)        { return internal.Digest(a) }
 func DecodeArtifact(raw []byte, maxBytes int) (Artifact, error) {
 	return internal.DecodeArtifact(raw, maxBytes)
+}
+func RunExternalJSON(ctx context.Context, command []string, input []byte, maxOutput int) (Artifact, error) {
+	return internal.RunExternalJSON(ctx, command, input, maxOutput)
 }

--- a/TreeDB/vectorpartition/api.go
+++ b/TreeDB/vectorpartition/api.go
@@ -16,6 +16,7 @@ type Source = internal.Source
 type PhaseMetrics = internal.PhaseMetrics
 type Partitioner = internal.Partitioner
 type ReferencePartitioner = internal.ReferencePartitioner
+type ExternalJSONLimits = internal.ExternalJSONLimits
 
 const SchemaVersion = internal.SchemaVersion
 
@@ -45,4 +46,7 @@ func RunExternalJSON(ctx context.Context, command []string, input []byte, maxOut
 }
 func RunExternalJSONForSource(ctx context.Context, command []string, input []byte, maxOutput int, source Source) (Artifact, error) {
 	return internal.RunExternalJSONForSource(ctx, command, input, maxOutput, source)
+}
+func RunExternalJSONForSourceWithLimits(ctx context.Context, command []string, input []byte, limits ExternalJSONLimits, source Source) (Artifact, error) {
+	return internal.RunExternalJSONForSourceWithLimits(ctx, command, input, limits, source)
 }

--- a/TreeDB/vectorpartition/api_test.go
+++ b/TreeDB/vectorpartition/api_test.go
@@ -1,0 +1,21 @@
+package vectorpartition
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestValidateReferenceInputShapeMatchesReferencePreflight(t *testing.T) {
+	c := DefaultConfig()
+	c.Partitions = 238
+	c.Repetitions = 1
+	c.Pivots = 2
+	c.MaxLeafBucket = 2
+	c.Degree = 1
+	if err := ValidateInputShape(c, 1_000_000, 1); err != nil {
+		t.Fatalf("generic API preflight unexpectedly rejected reference-only shape: %v", err)
+	}
+	if err := ValidateReferenceInputShape(c, 1_000_000, 1); err == nil || !strings.Contains(err.Error(), "partition work") {
+		t.Fatalf("reference API shape error=%v; expected partition-work rejection", err)
+	}
+}

--- a/cmd/treedb_vector_partition_bench/main.go
+++ b/cmd/treedb_vector_partition_bench/main.go
@@ -76,15 +76,20 @@ type config struct {
 }
 
 type partitionRun struct {
-	SchemaVersion  int                      `json:"schema_version"`
-	ResultKind     string                   `json:"result_kind"`
-	Dataset        fixtureManifest          `json:"dataset"`
-	Artifact       vectorpartition.Artifact `json:"artifact"`
-	BuildNanos     int64                    `json:"build_nanos"`
-	ArtifactSHA256 string                   `json:"artifact_sha256"`
-	BaseSHA        string                   `json:"base_sha"`
-	HeadSHA        string                   `json:"head_sha"`
-	ArtifactPath   string                   `json:"artifact_path"`
+	SchemaVersion  int                     `json:"schema_version"`
+	ResultKind     string                  `json:"result_kind"`
+	Dataset        fixtureManifest         `json:"dataset"`
+	Source         vectorpartition.Source  `json:"source"`
+	Config         vectorpartition.Config  `json:"config"`
+	Metrics        vectorpartition.Metrics `json:"metrics"`
+	BuildNanos     int64                   `json:"build_nanos"`
+	ArtifactSHA256 string                  `json:"artifact_sha256"`
+	BaseSHA        string                  `json:"base_sha"`
+	HeadSHA        string                  `json:"head_sha"`
+	ArtifactPath   string                  `json:"artifact_path"`
+	ArtifactBytes  int64                   `json:"artifact_bytes"`
+	ReportBytes    int64                   `json:"report_bytes"`
+	FinalBytes     int64                   `json:"final_bytes"`
 }
 
 type fixtureManifest struct {
@@ -429,12 +434,26 @@ func runPartitionStage(cfg config, fixture fixtureManifest, vectors [][]float64,
 	if err := os.WriteFile(path, bytes, 0644); err != nil {
 		return err
 	}
-	report := partitionRun{SchemaVersion: 1, ResultKind: "offline_partition_builder", Dataset: fixture, Artifact: artifact, BuildNanos: time.Since(started).Nanoseconds(), ArtifactSHA256: digest, BaseSHA: cfg.baseSHA, HeadSHA: cfg.headSHA, ArtifactPath: path}
+	report := partitionRun{SchemaVersion: 1, ResultKind: "offline_partition_builder", Dataset: fixture, Source: artifact.Source, Config: artifact.Config, Metrics: artifact.Metrics, BuildNanos: time.Since(started).Nanoseconds(), ArtifactSHA256: digest, BaseSHA: cfg.baseSHA, HeadSHA: cfg.headSHA, ArtifactPath: path, ArtifactBytes: int64(len(bytes))}
 	raw, err := json.Marshal(report)
 	if err != nil {
 		return err
 	}
-	if err := os.WriteFile(filepath.Join(cfg.out, "vector_partition_build_"+digest[:12]+"_"+cfg.baseSHA[:12]+"_"+cfg.headSHA[:12]+".json"), append(raw, '\n'), 0644); err != nil {
+	for i := 0; i < 8; i++ {
+		report.ReportBytes = int64(len(raw))
+		report.FinalBytes = report.ArtifactBytes + report.ReportBytes
+		raw, err = json.Marshal(report)
+		if err != nil {
+			return err
+		}
+		if int64(len(raw)) == report.ReportBytes {
+			break
+		}
+	}
+	if report.ReportBytes != int64(len(raw)) {
+		return errors.New("compact partition report byte accounting did not converge")
+	}
+	if err := os.WriteFile(filepath.Join(cfg.out, "vector_partition_build_"+digest[:12]+"_"+cfg.baseSHA[:12]+"_"+cfg.headSHA[:12]+".json"), raw, 0644); err != nil {
 		return err
 	}
 	if cfg.format == "json" {

--- a/cmd/treedb_vector_partition_bench/main.go
+++ b/cmd/treedb_vector_partition_bench/main.go
@@ -276,7 +276,12 @@ func run(args []string, stdout io.Writer) (runErr error) {
 	if err != nil {
 		return err
 	}
-	if err := validateFixtureWithCaps(fixture, cfg.maxVectors, cfg.maxBytes); err != nil {
+	if cfg.stage == "partition" {
+		err = validatePartitionFixtureWithCaps(fixture, cfg.maxVectors, cfg.maxBytes)
+	} else {
+		err = validateFixtureWithCaps(fixture, cfg.maxVectors, cfg.maxBytes)
+	}
+	if err != nil {
 		return err
 	}
 	if cfg.partitions > fixture.Vectors {
@@ -661,7 +666,10 @@ func validateFixture(m fixtureManifest) error {
 	return validateFixtureWithCaps(m, maxVectors, maxFixtureBytes)
 }
 func validateFixtureWithCaps(m fixtureManifest, capVectors int, capBytes int64) error {
-	if m.SchemaVersion != schemaVersion || m.Fixture == "" || m.Generator != fixtureGenerator || m.Arithmetic != fixtureArithmetic || m.Vectors < 1 || m.Vectors > capVectors || m.Queries < 1 || m.Queries > capVectors || m.Dimensions < 1 || m.Dimensions > maxDimensions || m.Metric != "cosine" || len(m.Checksum) != 64 {
+	if err := validateFixtureSyntax(m, capVectors); err != nil {
+		return err
+	}
+	if m.Queries > capVectors {
 		return errors.New("unsupported or malformed fixture manifest")
 	}
 	if int64(m.Vectors)+int64(m.Queries) > int64(capVectors) {
@@ -669,6 +677,26 @@ func validateFixtureWithCaps(m fixtureManifest, capVectors int, capBytes int64) 
 	}
 	if int64(m.Vectors)+int64(m.Queries) > capBytes/(int64(m.Dimensions)*8) {
 		return errors.New("fixture float64 data alone exceeds pre-allocation memory cap")
+	}
+	return nil
+}
+
+// validatePartitionFixtureWithCaps applies only syntax/integrity and vector
+// corpus allocation caps. Partition mode never generates the query/truth
+// stream, so simulation-only query count and byte limits do not apply here.
+func validatePartitionFixtureWithCaps(m fixtureManifest, capVectors int, capBytes int64) error {
+	if err := validateFixtureSyntax(m, capVectors); err != nil {
+		return err
+	}
+	if int64(m.Vectors) > capBytes/(int64(m.Dimensions)*8) {
+		return errors.New("partition vector data exceeds pre-allocation memory cap")
+	}
+	return nil
+}
+
+func validateFixtureSyntax(m fixtureManifest, capVectors int) error {
+	if m.SchemaVersion != schemaVersion || m.Fixture == "" || m.Generator != fixtureGenerator || m.Arithmetic != fixtureArithmetic || m.Vectors < 1 || m.Vectors > capVectors || m.Queries < 1 || m.Dimensions < 1 || m.Dimensions > maxDimensions || m.Metric != "cosine" || len(m.Checksum) != 64 {
+		return errors.New("unsupported or malformed fixture manifest")
 	}
 	_, e := hex.DecodeString(m.Checksum)
 	return e

--- a/cmd/treedb_vector_partition_bench/main.go
+++ b/cmd/treedb_vector_partition_bench/main.go
@@ -289,6 +289,9 @@ func run(args []string, stdout io.Writer) (runErr error) {
 		// The partition builder owns only the frozen vector corpus and its own
 		// graph controls. Simulation probes, overlaps, stages, top-k and memory
 		// planning are intentionally irrelevant here.
+		if err := vectorpartition.ValidateInputShape(cfg.partition, fixture.Vectors, fixture.Dimensions); err != nil {
+			return err
+		}
 		vectors, queries := deterministicFixture(fixture)
 		if fixtureChecksumFromData(vectors, queries) != fixture.Checksum {
 			return errors.New("fixture checksum does not match generated vector/query/truth stream")

--- a/cmd/treedb_vector_partition_bench/main.go
+++ b/cmd/treedb_vector_partition_bench/main.go
@@ -279,14 +279,24 @@ func run(args []string, stdout io.Writer) (runErr error) {
 	if err := validateFixtureWithCaps(fixture, cfg.maxVectors, cfg.maxBytes); err != nil {
 		return err
 	}
-	if cfg.topK > fixture.Vectors {
-		return errors.New("top-k cannot exceed fixture vectors")
-	}
 	if cfg.partitions > fixture.Vectors {
 		return errors.New("partitions cannot exceed fixture vectors")
 	}
 	if cfg.seed != fixture.Seed {
 		return fmt.Errorf("-seed %d does not match fixture seed %d", cfg.seed, fixture.Seed)
+	}
+	if cfg.stage == "partition" {
+		// The partition builder owns only the frozen vector corpus and its own
+		// graph controls. Simulation probes, overlaps, stages, top-k and memory
+		// planning are intentionally irrelevant here.
+		vectors, queries := deterministicFixture(fixture)
+		if fixtureChecksumFromData(vectors, queries) != fixture.Checksum {
+			return errors.New("fixture checksum does not match generated vector/query/truth stream")
+		}
+		return runPartitionStage(cfg, fixture, vectors, stdout)
+	}
+	if cfg.topK > fixture.Vectors {
+		return errors.New("top-k cannot exceed fixture vectors")
 	}
 	if _, err := validateBenchmarkWork(cfg, fixture, maxBenchmarkWorkUnits); err != nil {
 		return err
@@ -301,9 +311,6 @@ func run(args []string, stdout io.Writer) (runErr error) {
 	vectors, queries := deterministicFixture(fixture)
 	if fixtureChecksumFromData(vectors, queries) != fixture.Checksum {
 		return errors.New("fixture checksum does not match generated vector/query/truth stream")
-	}
-	if cfg.stage == "partition" {
-		return runPartitionStage(cfg, fixture, vectors, stdout)
 	}
 	if cfg.stages["treedb_partition_local_hnsw"] {
 		cfg.hnsw, err = newTreeDBPartitionHNSW(vectors, cfg.partitions)

--- a/cmd/treedb_vector_partition_bench/main.go
+++ b/cmd/treedb_vector_partition_bench/main.go
@@ -292,10 +292,11 @@ func run(args []string, stdout io.Writer) (runErr error) {
 		if err := vectorpartition.ValidateReferenceInputShape(cfg.partition, fixture.Vectors, fixture.Dimensions); err != nil {
 			return err
 		}
-		vectors, queries := deterministicFixture(fixture)
-		if fixtureChecksumFromData(vectors, queries) != fixture.Checksum {
-			return errors.New("fixture checksum does not match generated vector/query/truth stream")
-		}
+		// The artifact's Source.Checksum is computed over these generated vectors
+		// by BuildWithPartitioner. The manifest checksum additionally commits the
+		// simulation-only query/truth stream, so verifying it here would recreate
+		// queries and exact truth that this stage deliberately does not own.
+		vectors := deterministicVectors(fixture)
 		return runPartitionStage(cfg, fixture, vectors, stdout)
 	}
 	if cfg.topK > fixture.Vectors {
@@ -952,6 +953,14 @@ func memoryScaleCeil(value, numerator, denominator int64) (int64, error) {
 // deterministicFixture has intentionally visible cluster/boundary pairs and a
 // duplicate pair, so tie ordering remains part of the executable M0 contract.
 func deterministicFixture(m fixtureManifest) ([][]float64, [][]float64) {
+	v := deterministicVectors(m)
+	return v, deterministicQueries(v, m)
+}
+
+// deterministicVectors is the partition-stage corpus generator. It must not
+// inspect m.Queries: partition artifacts bind the vector corpus only, while
+// simulation mode separately generates and verifies queries and exact truth.
+func deterministicVectors(m fixtureManifest) [][]float64 {
 	v := contiguousFloat64Matrix(m.Vectors, m.Dimensions)
 	for i := range v {
 		row := v[i]
@@ -965,11 +974,15 @@ func deterministicFixture(m fixtureManifest) ([][]float64, [][]float64) {
 	if len(v) > 1 {
 		copy(v[1], v[0])
 	}
+	return v
+}
+
+func deterministicQueries(v [][]float64, m fixtureManifest) [][]float64 {
 	q := contiguousFloat64Matrix(m.Queries, m.Dimensions)
 	for i := range q {
 		copy(q[i], v[(i*7919+17)%len(v)])
 	}
-	return v, q
+	return q
 }
 
 func contiguousFloat64Matrix(rows, dimensions int) [][]float64 {

--- a/cmd/treedb_vector_partition_bench/main.go
+++ b/cmd/treedb_vector_partition_bench/main.go
@@ -82,6 +82,9 @@ type partitionRun struct {
 	Artifact       vectorpartition.Artifact `json:"artifact"`
 	BuildNanos     int64                    `json:"build_nanos"`
 	ArtifactSHA256 string                   `json:"artifact_sha256"`
+	BaseSHA        string                   `json:"base_sha"`
+	HeadSHA        string                   `json:"head_sha"`
+	ArtifactPath   string                   `json:"artifact_path"`
 }
 
 type fixtureManifest struct {
@@ -421,16 +424,17 @@ func runPartitionStage(cfg config, fixture fixtureManifest, vectors [][]float64,
 	if err := os.MkdirAll(cfg.out, 0755); err != nil {
 		return err
 	}
-	path := filepath.Join(cfg.out, "vector_partition_artifact_v1.json")
+	name := fmt.Sprintf("vector_partition_%s_%s_%s.json", digest[:12], cfg.baseSHA[:12], cfg.headSHA[:12])
+	path := filepath.Join(cfg.out, name)
 	if err := os.WriteFile(path, bytes, 0644); err != nil {
 		return err
 	}
-	report := partitionRun{SchemaVersion: 1, ResultKind: "offline_partition_builder", Dataset: fixture, Artifact: artifact, BuildNanos: time.Since(started).Nanoseconds(), ArtifactSHA256: digest}
+	report := partitionRun{SchemaVersion: 1, ResultKind: "offline_partition_builder", Dataset: fixture, Artifact: artifact, BuildNanos: time.Since(started).Nanoseconds(), ArtifactSHA256: digest, BaseSHA: cfg.baseSHA, HeadSHA: cfg.headSHA, ArtifactPath: path}
 	raw, err := json.Marshal(report)
 	if err != nil {
 		return err
 	}
-	if err := os.WriteFile(filepath.Join(cfg.out, "vector_partition_build_v1.json"), append(raw, '\n'), 0644); err != nil {
+	if err := os.WriteFile(filepath.Join(cfg.out, "vector_partition_build_"+digest[:12]+"_"+cfg.baseSHA[:12]+"_"+cfg.headSHA[:12]+".json"), append(raw, '\n'), 0644); err != nil {
 		return err
 	}
 	if cfg.format == "json" {

--- a/cmd/treedb_vector_partition_bench/main.go
+++ b/cmd/treedb_vector_partition_bench/main.go
@@ -289,7 +289,7 @@ func run(args []string, stdout io.Writer) (runErr error) {
 		// The partition builder owns only the frozen vector corpus and its own
 		// graph controls. Simulation probes, overlaps, stages, top-k and memory
 		// planning are intentionally irrelevant here.
-		if err := vectorpartition.ValidateInputShape(cfg.partition, fixture.Vectors, fixture.Dimensions); err != nil {
+		if err := vectorpartition.ValidateReferenceInputShape(cfg.partition, fixture.Vectors, fixture.Dimensions); err != nil {
 			return err
 		}
 		vectors, queries := deterministicFixture(fixture)

--- a/cmd/treedb_vector_partition_bench/main.go
+++ b/cmd/treedb_vector_partition_bench/main.go
@@ -406,7 +406,7 @@ func runPartitionStage(cfg config, fixture fixtureManifest, vectors [][]float64,
 		input[i] = vectorpartition.Vector{ID: fmt.Sprintf("doc-%06d", i), Values: values}
 	}
 	started := time.Now()
-	artifact, err := vectorpartition.Build(input, cfg.partition)
+	artifact, err := vectorpartition.BuildWithPartitioner(input, cfg.partition, vectorpartition.Source{SourceID: "m0_fixture:" + fixture.Checksum}, vectorpartition.ReferencePartitioner{})
 	if err != nil {
 		return fmt.Errorf("build validated vector partition artifact: %w", err)
 	}

--- a/cmd/treedb_vector_partition_bench/main.go
+++ b/cmd/treedb_vector_partition_bench/main.go
@@ -409,8 +409,13 @@ func parseConfig(args []string) (config, error) {
 	cfg.partition.Seed = cfg.seed
 	cfg.partition.Partitions = cfg.partitions
 	cfg.partition.MaxVectors = cfg.maxVectors
-	if cfg.partition.MaxEdges > maxVectors*cfg.partition.Degree {
-		cfg.partition.MaxEdges = maxVectors * cfg.partition.Degree
+	// The graph validator reserves the edge budget for every repetition. Keep
+	// that capacity when constraining the default by the configured input cap.
+	// All operands are independently bounded by parse/build validation, but use
+	// int64 so this preflight cannot overflow on narrower integer targets.
+	maxEdgesForInput := int64(cfg.maxVectors) * int64(cfg.partition.Degree) * int64(cfg.partition.Repetitions)
+	if maxEdgesForInput > 0 && maxEdgesForInput < int64(cfg.partition.MaxEdges) {
+		cfg.partition.MaxEdges = int(maxEdgesForInput)
 	}
 	return cfg, nil
 }
@@ -433,10 +438,14 @@ func runPartitionStage(cfg config, fixture fixtureManifest, vectors [][]float64,
 	if err != nil {
 		return err
 	}
+	suffix, err := provenanceSuffix(digest, cfg.baseSHA, cfg.headSHA)
+	if err != nil {
+		return err
+	}
 	if err := os.MkdirAll(cfg.out, 0755); err != nil {
 		return err
 	}
-	name := fmt.Sprintf("vector_partition_%s_%s_%s.json", digest[:12], cfg.baseSHA[:12], cfg.headSHA[:12])
+	name := "vector_partition_" + suffix + ".json"
 	path := filepath.Join(cfg.out, name)
 	if err := os.WriteFile(path, bytes, 0644); err != nil {
 		return err
@@ -460,7 +469,7 @@ func runPartitionStage(cfg config, fixture fixtureManifest, vectors [][]float64,
 	if report.ReportBytes != int64(len(raw)) {
 		return errors.New("compact partition report byte accounting did not converge")
 	}
-	if err := os.WriteFile(filepath.Join(cfg.out, "vector_partition_build_"+digest[:12]+"_"+cfg.baseSHA[:12]+"_"+cfg.headSHA[:12]+".json"), raw, 0644); err != nil {
+	if err := os.WriteFile(filepath.Join(cfg.out, "vector_partition_build_"+suffix+".json"), raw, 0644); err != nil {
 		return err
 	}
 	if cfg.format == "json" {
@@ -469,6 +478,15 @@ func runPartitionStage(cfg config, fixture fixtureManifest, vectors [][]float64,
 	}
 	_, err = fmt.Fprintf(stdout, "partition artifact=%s edges=%d cut=%d cap=%d\n", path, artifact.Metrics.GraphEdges, artifact.Metrics.EdgeCut, artifact.Metrics.Cap)
 	return err
+}
+
+const provenanceSuffixBytes = 12
+
+func provenanceSuffix(digest, baseSHA, headSHA string) (string, error) {
+	if len(digest) < provenanceSuffixBytes || len(baseSHA) < provenanceSuffixBytes || len(headSHA) < provenanceSuffixBytes {
+		return "", errors.New("partition artifact provenance digest/SHA is too short for filename")
+	}
+	return digest[:provenanceSuffixBytes] + "_" + baseSHA[:provenanceSuffixBytes] + "_" + headSHA[:provenanceSuffixBytes], nil
 }
 
 var knownStages = []string{"exact_global_top_k", "partition_oracle", "exact_representative_routing", "approximate_representative_routing", "exact_partition_local", "treedb_partition_local_hnsw", "end_to_end_distributed_simulation"}

--- a/cmd/treedb_vector_partition_bench/main.go
+++ b/cmd/treedb_vector_partition_bench/main.go
@@ -21,10 +21,12 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"time"
 	"unsafe"
 
 	"github.com/snissn/gomap/TreeDB/collections"
 	backenddb "github.com/snissn/gomap/TreeDB/db"
+	"github.com/snissn/gomap/TreeDB/vectorpartition"
 )
 
 const (
@@ -69,6 +71,17 @@ type config struct {
 	headSHA      string
 	hnsw         *treeDBPartitionHNSW
 	memory       benchmarkMemoryPlan
+	stage        string
+	partition    vectorpartition.Config
+}
+
+type partitionRun struct {
+	SchemaVersion  int                      `json:"schema_version"`
+	ResultKind     string                   `json:"result_kind"`
+	Dataset        fixtureManifest          `json:"dataset"`
+	Artifact       vectorpartition.Artifact `json:"artifact"`
+	BuildNanos     int64                    `json:"build_nanos"`
+	ArtifactSHA256 string                   `json:"artifact_sha256"`
 }
 
 type fixtureManifest struct {
@@ -281,6 +294,9 @@ func run(args []string, stdout io.Writer) (runErr error) {
 	if fixtureChecksumFromData(vectors, queries) != fixture.Checksum {
 		return errors.New("fixture checksum does not match generated vector/query/truth stream")
 	}
+	if cfg.stage == "partition" {
+		return runPartitionStage(cfg, fixture, vectors, stdout)
+	}
 	if cfg.stages["treedb_partition_local_hnsw"] {
 		cfg.hnsw, err = newTreeDBPartitionHNSW(vectors, cfg.partitions)
 		if err != nil {
@@ -317,7 +333,7 @@ func run(args []string, stdout io.Writer) (runErr error) {
 }
 
 func parseConfig(args []string) (config, error) {
-	cfg := config{format: "json", topK: 10, recallTarget: .9, seed: 1}
+	cfg := config{format: "json", topK: 10, recallTarget: .9, seed: 1, stage: "simulation", partition: vectorpartition.DefaultConfig()}
 	var probes, overlap string
 	var stages string
 	fs := flag.NewFlagSet("treedb_vector_partition_bench", flag.ContinueOnError)
@@ -330,11 +346,23 @@ func parseConfig(args []string) (config, error) {
 	fs.Int64Var(&cfg.seed, "seed", cfg.seed, "fixture generation seed (must match manifest)")
 	fs.StringVar(&cfg.format, "format", cfg.format, "json or text")
 	fs.StringVar(&cfg.out, "out", "", "artifact directory")
+	fs.StringVar(&cfg.stage, "stage", cfg.stage, "simulation or partition")
+	fs.IntVar(&cfg.partition.Repetitions, "partition-repetitions", cfg.partition.Repetitions, "dense-ball graph sketch repetitions")
+	fs.IntVar(&cfg.partition.Pivots, "partition-pivots", cfg.partition.Pivots, "dense-ball pivots per recursive level")
+	fs.IntVar(&cfg.partition.MaxLeafBucket, "partition-max-leaf-bucket", cfg.partition.MaxLeafBucket, "maximum dense-ball leaf bucket")
+	fs.IntVar(&cfg.partition.Degree, "partition-degree", cfg.partition.Degree, "maximum canonical graph degree")
+	fs.Float64Var(&cfg.partition.Imbalance, "imbalance", cfg.partition.Imbalance, "partition imbalance epsilon")
 	fs.StringVar(&stages, "stages", "all", "comma-separated independently enabled loss stages, or all")
 	fs.IntVar(&cfg.maxVectors, "max-vectors", maxVectors, "maximum combined fixture vector/query count before allocation")
 	fs.Int64Var(&cfg.maxBytes, "max-fixture-bytes", maxFixtureBytes, "maximum modeled peak bytes for benchmark-owned fixture and working material")
 	if err := fs.Parse(args); err != nil {
 		return config{}, err
+	}
+	// The offline M2 builder does not execute M0 probe simulations. Preserve
+	// the simulation requirement while allowing the issue's partition-stage
+	// invocation to omit a meaningless -probes flag.
+	if cfg.stage == "partition" && probes == "" {
+		probes = "1"
 	}
 	var err error
 	if cfg.probes, err = parseInts(probes); err != nil {
@@ -343,7 +371,7 @@ func parseConfig(args []string) (config, error) {
 	if cfg.overlaps, err = parseFloats(overlap); err != nil {
 		return config{}, fmt.Errorf("overlap: %w", err)
 	}
-	if cfg.dataset == "" || cfg.out == "" || cfg.partitions < 1 || cfg.partitions > maxPartitions || cfg.topK < 1 || cfg.maxVectors < 1 || cfg.maxVectors > maxVectors || cfg.maxBytes < 8 || cfg.maxBytes > maxFixtureBytes || cfg.format != "json" && cfg.format != "text" {
+	if cfg.dataset == "" || cfg.out == "" || cfg.partitions < 1 || cfg.partitions > maxPartitions || cfg.topK < 1 || cfg.maxVectors < 1 || cfg.maxVectors > maxVectors || cfg.maxBytes < 8 || cfg.maxBytes > maxFixtureBytes || cfg.format != "json" && cfg.format != "text" || cfg.stage != "simulation" && cfg.stage != "partition" {
 		return config{}, errors.New("dataset, out, positive bounded partitions/top-k, and json|text format are required")
 	}
 	if len(cfg.probes) == 0 || len(cfg.overlaps) == 0 || math.IsNaN(cfg.recallTarget) || math.IsInf(cfg.recallTarget, 0) || cfg.recallTarget < 0 || cfg.recallTarget > 1 {
@@ -363,7 +391,54 @@ func parseConfig(args []string) (config, error) {
 	if len(cfg.stages) == 0 {
 		return config{}, errors.New("stages must name known stages or all")
 	}
+	cfg.partition.Seed = cfg.seed
+	cfg.partition.Partitions = cfg.partitions
+	cfg.partition.MaxVectors = cfg.maxVectors
+	if cfg.partition.MaxEdges > maxVectors*cfg.partition.Degree {
+		cfg.partition.MaxEdges = maxVectors * cfg.partition.Degree
+	}
 	return cfg, nil
+}
+
+func runPartitionStage(cfg config, fixture fixtureManifest, vectors [][]float64, stdout io.Writer) error {
+	input := make([]vectorpartition.Vector, len(vectors))
+	for i, values := range vectors {
+		input[i] = vectorpartition.Vector{ID: fmt.Sprintf("doc-%06d", i), Values: values}
+	}
+	started := time.Now()
+	artifact, err := vectorpartition.Build(input, cfg.partition)
+	if err != nil {
+		return fmt.Errorf("build validated vector partition artifact: %w", err)
+	}
+	bytes, err := vectorpartition.CanonicalJSON(artifact)
+	if err != nil {
+		return err
+	}
+	digest, err := vectorpartition.Digest(artifact)
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(cfg.out, 0755); err != nil {
+		return err
+	}
+	path := filepath.Join(cfg.out, "vector_partition_artifact_v1.json")
+	if err := os.WriteFile(path, bytes, 0644); err != nil {
+		return err
+	}
+	report := partitionRun{SchemaVersion: 1, ResultKind: "offline_partition_builder", Dataset: fixture, Artifact: artifact, BuildNanos: time.Since(started).Nanoseconds(), ArtifactSHA256: digest}
+	raw, err := json.Marshal(report)
+	if err != nil {
+		return err
+	}
+	if err := os.WriteFile(filepath.Join(cfg.out, "vector_partition_build_v1.json"), append(raw, '\n'), 0644); err != nil {
+		return err
+	}
+	if cfg.format == "json" {
+		_, err = fmt.Fprintln(stdout, string(raw))
+		return err
+	}
+	_, err = fmt.Fprintf(stdout, "partition artifact=%s edges=%d cut=%d cap=%d\n", path, artifact.Metrics.GraphEdges, artifact.Metrics.EdgeCut, artifact.Metrics.Cap)
+	return err
 }
 
 var knownStages = []string{"exact_global_top_k", "partition_oracle", "exact_representative_routing", "approximate_representative_routing", "exact_partition_local", "treedb_partition_local_hnsw", "end_to_end_distributed_simulation"}

--- a/cmd/treedb_vector_partition_bench/main_test.go
+++ b/cmd/treedb_vector_partition_bench/main_test.go
@@ -13,6 +13,7 @@ import (
 	"testing"
 
 	"github.com/snissn/gomap/TreeDB/collections"
+	"github.com/snissn/gomap/TreeDB/vectorpartition"
 )
 
 func fixturePath(t *testing.T) string {
@@ -115,8 +116,19 @@ func TestPartitionStageWritesValidatedDeterministicArtifact(t *testing.T) {
 	if err := json.Unmarshal(first.Bytes(), &report); err != nil {
 		t.Fatal(err)
 	}
-	if report.ResultKind != "offline_partition_builder" || report.Artifact.Metrics.MaxPartitionSize > report.Artifact.Metrics.Cap {
+	if report.ResultKind != "offline_partition_builder" || report.Metrics.MaxPartitionSize > report.Metrics.Cap || report.ArtifactBytes <= 0 || report.ReportBytes <= 0 || report.FinalBytes != report.ArtifactBytes+report.ReportBytes {
 		t.Fatalf("report=%+v", report)
+	}
+	raw, err := os.ReadFile(report.ArtifactPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	artifact, err := vectorpartition.DecodeArtifact(raw, len(raw))
+	if err != nil || artifact.Source != report.Source || artifact.Metrics != report.Metrics {
+		t.Fatalf("artifact does not match compact report: artifact=%+v err=%v", artifact, err)
+	}
+	if bytes.Contains(first.Bytes(), []byte("\"assignment\"")) || bytes.Contains(first.Bytes(), []byte("\"neighbors\"")) {
+		t.Fatalf("stdout contains duplicate artifact payload: %s", first.Bytes())
 	}
 	if _, err := os.Stat(report.ArtifactPath); err != nil {
 		t.Fatal(err)

--- a/cmd/treedb_vector_partition_bench/main_test.go
+++ b/cmd/treedb_vector_partition_bench/main_test.go
@@ -118,7 +118,7 @@ func TestPartitionStageWritesValidatedDeterministicArtifact(t *testing.T) {
 	if report.ResultKind != "offline_partition_builder" || report.Artifact.Metrics.MaxPartitionSize > report.Artifact.Metrics.Cap {
 		t.Fatalf("report=%+v", report)
 	}
-	if _, err := os.Stat(filepath.Join(args[3], "vector_partition_artifact_v1.json")); err != nil {
+	if _, err := os.Stat(report.ArtifactPath); err != nil {
 		t.Fatal(err)
 	}
 	var second bytes.Buffer

--- a/cmd/treedb_vector_partition_bench/main_test.go
+++ b/cmd/treedb_vector_partition_bench/main_test.go
@@ -146,6 +146,39 @@ func TestPartitionStageWritesValidatedDeterministicArtifact(t *testing.T) {
 		t.Fatalf("digest changed: %s %s", report.ArtifactSHA256, again.ArtifactSHA256)
 	}
 }
+
+func TestPartitionStageEdgeClampPreservesRepetitionCapacity(t *testing.T) {
+	cfg, err := parseConfig([]string{"-dataset", fixturePath(t), "-out", t.TempDir(), "-partitions", "16", "-probes", "1", "-stage", "partition", "-partition-repetitions", "4", "-partition-degree", "16"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got, want := cfg.partition.MaxEdges, 64_000_000; got != want {
+		t.Fatalf("MaxEdges=%d want %d; repetition capacity was lost", got, want)
+	}
+	capacity := cfg.partition.MaxEdges / cfg.partition.Repetitions / cfg.partition.Degree
+	if capacity < 250_001 {
+		t.Fatalf("large valid partition shape capacity=%d want at least 250001", capacity)
+	}
+	if int64(maxVectors+1)*int64(cfg.partition.Degree) <= int64(cfg.partition.MaxEdges)/int64(cfg.partition.Repetitions) {
+		t.Fatalf("true over-cap shape accepted by edge budget: capacity=%d", capacity)
+	}
+}
+
+func TestPartitionProvenanceSuffixPreservesFilenameAndRejectsShortInputs(t *testing.T) {
+	digest := strings.Repeat("d", 64)
+	base := strings.Repeat("a", 40)
+	head := strings.Repeat("b", 40)
+	got, err := provenanceSuffix(digest, base, head)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if want := strings.Repeat("d", 12) + "_" + strings.Repeat("a", 12) + "_" + strings.Repeat("b", 12); got != want {
+		t.Fatalf("suffix=%q want %q", got, want)
+	}
+	if _, err := provenanceSuffix("short", base, head); err == nil {
+		t.Fatal("short digest accepted")
+	}
+}
 func TestCheckedIn10kFixtureGraphCutBeatsStableHash(t *testing.T) {
 	args := []string{"-dataset", fixturePath(t), "-out", t.TempDir(), "-partitions", "16", "-probes", "1", "-stage", "partition", "-partition-repetitions", "4", "-partition-pivots", "8", "-partition-max-leaf-bucket", "128", "-partition-degree", "16"}
 	var stdout bytes.Buffer
@@ -156,7 +189,7 @@ func TestCheckedIn10kFixtureGraphCutBeatsStableHash(t *testing.T) {
 	if err := json.Unmarshal(stdout.Bytes(), &report); err != nil {
 		t.Fatal(err)
 	}
-	if report.Dataset.Checksum != "2413ef7c2f65a4b5ce8ecc3846f473fd85d337a87511538f962af7cdf6aec291" || report.Source.Checksum != "6515025f540b955d453de99cf13f1efc002fd91135b2745b722c19e8d736e386" || report.ArtifactSHA256 != "32a5b5cf2dc13f800040661c88d5602322478276e197433a95eaa1fe1effad98" || report.Metrics.EdgeCut != 5184 || report.Metrics.StableIDHashEdgeCut != 149877 {
+	if report.Dataset.Checksum != "2413ef7c2f65a4b5ce8ecc3846f473fd85d337a87511538f962af7cdf6aec291" || report.Source.Checksum != "6515025f540b955d453de99cf13f1efc002fd91135b2745b722c19e8d736e386" || report.ArtifactSHA256 != "9af8ddca00b42caa04f06f69dcc5991532193a3e95642d723cddaff664a04a11" || report.Metrics.EdgeCut != 5184 || report.Metrics.StableIDHashEdgeCut != 149877 {
 		t.Fatalf("frozen 10k regression changed: report=%+v", report)
 	}
 }

--- a/cmd/treedb_vector_partition_bench/main_test.go
+++ b/cmd/treedb_vector_partition_bench/main_test.go
@@ -104,6 +104,37 @@ func TestFixtureArithmeticUsesExplicitFMA(t *testing.T) {
 	}
 }
 
+func TestPartitionStageWritesValidatedDeterministicArtifact(t *testing.T) {
+	dataset := writeFixtureForTest(t, 16, 2, 4)
+	args := []string{"-dataset", dataset, "-out", t.TempDir(), "-partitions", "4", "-probes", "1", "-stage", "partition", "-partition-repetitions", "1", "-partition-pivots", "2", "-partition-max-leaf-bucket", "4", "-partition-degree", "2"}
+	var first bytes.Buffer
+	if err := runWithHermeticProvenance(t, args, &first); err != nil {
+		t.Fatal(err)
+	}
+	var report partitionRun
+	if err := json.Unmarshal(first.Bytes(), &report); err != nil {
+		t.Fatal(err)
+	}
+	if report.ResultKind != "offline_partition_builder" || report.Artifact.Metrics.MaxPartitionSize > report.Artifact.Metrics.Cap {
+		t.Fatalf("report=%+v", report)
+	}
+	if _, err := os.Stat(filepath.Join(args[3], "vector_partition_artifact_v1.json")); err != nil {
+		t.Fatal(err)
+	}
+	var second bytes.Buffer
+	args[3] = t.TempDir()
+	if err := runWithHermeticProvenance(t, args, &second); err != nil {
+		t.Fatal(err)
+	}
+	var again partitionRun
+	if err := json.Unmarshal(second.Bytes(), &again); err != nil {
+		t.Fatal(err)
+	}
+	if report.ArtifactSHA256 != again.ArtifactSHA256 {
+		t.Fatalf("digest changed: %s %s", report.ArtifactSHA256, again.ArtifactSHA256)
+	}
+}
+
 func TestFixtureTruthDeterministicAndChecksumStable(t *testing.T) {
 	m, err := loadFixture(fixturePath(t))
 	if err != nil {

--- a/cmd/treedb_vector_partition_bench/main_test.go
+++ b/cmd/treedb_vector_partition_bench/main_test.go
@@ -261,6 +261,42 @@ func TestPartitionStageIgnoresLargeSimulationOnlyQueryStream(t *testing.T) {
 	}
 }
 
+func TestPartitionFixtureValidationUsesVectorOnlyCaps(t *testing.T) {
+	base := fixtureManifest{
+		SchemaVersion: schemaVersion,
+		Fixture:       "partition-vector-boundary",
+		Generator:     fixtureGenerator,
+		Arithmetic:    fixtureArithmetic,
+		Vectors:       maxVectors,
+		Queries:       1,
+		Dimensions:    1,
+		Metric:        "cosine",
+		Checksum:      strings.Repeat("0", 64),
+	}
+	if err := validatePartitionFixtureWithCaps(base, maxVectors, maxFixtureBytes); err != nil {
+		t.Fatalf("max vector corpus plus required query rejected in partition mode: %v", err)
+	}
+	queryHeavy := base
+	queryHeavy.Queries = maxVectors * 4
+	if err := validatePartitionFixtureWithCaps(queryHeavy, maxVectors, maxFixtureBytes); err != nil {
+		t.Fatalf("irrelevant query count affected partition mode: %v", err)
+	}
+	if err := validateFixtureWithCaps(queryHeavy, maxVectors, maxFixtureBytes); err == nil {
+		t.Fatal("simulation accepted query-heavy fixture")
+	}
+	overCount := base
+	overCount.Vectors++
+	if err := validatePartitionFixtureWithCaps(overCount, maxVectors, maxFixtureBytes); err == nil {
+		t.Fatal("partition mode accepted over-count vector corpus")
+	}
+	overBytes := base
+	overBytes.Vectors = 2
+	overBytes.Dimensions = 2
+	if err := validatePartitionFixtureWithCaps(overBytes, maxVectors, 8); err == nil {
+		t.Fatal("partition mode accepted over-byte vector corpus")
+	}
+}
+
 func TestFixtureTruthDeterministicAndChecksumStable(t *testing.T) {
 	m, err := loadFixture(fixturePath(t))
 	if err != nil {

--- a/cmd/treedb_vector_partition_bench/main_test.go
+++ b/cmd/treedb_vector_partition_bench/main_test.go
@@ -156,8 +156,19 @@ func TestCheckedIn10kFixtureGraphCutBeatsStableHash(t *testing.T) {
 	if err := json.Unmarshal(stdout.Bytes(), &report); err != nil {
 		t.Fatal(err)
 	}
-	if report.Dataset.Checksum == "" || report.Metrics.EdgeCut >= report.Metrics.StableIDHashEdgeCut {
-		t.Fatalf("checked-in 10k graph cut=%d hash=%d checksum=%s", report.Metrics.EdgeCut, report.Metrics.StableIDHashEdgeCut, report.Dataset.Checksum)
+	if report.Dataset.Checksum != "2413ef7c2f65a4b5ce8ecc3846f473fd85d337a87511538f962af7cdf6aec291" || report.Source.Checksum != "6515025f540b955d453de99cf13f1efc002fd91135b2745b722c19e8d736e386" || report.ArtifactSHA256 != "32a5b5cf2dc13f800040661c88d5602322478276e197433a95eaa1fe1effad98" || report.Metrics.EdgeCut != 5184 || report.Metrics.StableIDHashEdgeCut != 149877 {
+		t.Fatalf("frozen 10k regression changed: report=%+v", report)
+	}
+}
+func TestPartitionStageSkipsSimulationOnlyValidation(t *testing.T) {
+	args := []string{"-dataset", fixturePath(t), "-out", t.TempDir(), "-partitions", "16", "-probes", "16", "-overlap", "1", "-top-k", "10001", "-stages", "treedb_partition_local_hnsw", "-stage", "partition", "-partition-repetitions", "1", "-partition-pivots", "2", "-partition-max-leaf-bucket", "64", "-partition-degree", "4"}
+	var stdout bytes.Buffer
+	if err := runWithHermeticProvenance(t, args, &stdout); err != nil {
+		t.Fatal(err)
+	}
+	var report partitionRun
+	if err := json.Unmarshal(stdout.Bytes(), &report); err != nil || report.ArtifactPath == "" {
+		t.Fatalf("partition artifact missing: report=%+v err=%v", report, err)
 	}
 }
 

--- a/cmd/treedb_vector_partition_bench/main_test.go
+++ b/cmd/treedb_vector_partition_bench/main_test.go
@@ -205,6 +205,62 @@ func TestPartitionStageSkipsSimulationOnlyValidation(t *testing.T) {
 	}
 }
 
+func TestPartitionStageIgnoresLargeSimulationOnlyQueryStream(t *testing.T) {
+	const vectors = 20_000
+	m := fixtureManifest{
+		SchemaVersion: schemaVersion,
+		Fixture:       "partition-only-large-query-stream",
+		Generator:     fixtureGenerator,
+		Arithmetic:    fixtureArithmetic,
+		Vectors:       vectors,
+		Queries:       maxVectors - vectors,
+		Dimensions:    1,
+		Metric:        "cosine",
+		Seed:          1,
+		Checksum:      strings.Repeat("0", 64),
+	}
+	dataset := t.TempDir()
+	raw, err := json.Marshal(m)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dataset, "fixture_manifest.json"), raw, 0644); err != nil {
+		t.Fatal(err)
+	}
+	args := []string{"-dataset", dataset, "-out", t.TempDir(), "-partitions", "4", "-probes", "1", "-stage", "partition", "-partition-repetitions", "1", "-partition-pivots", "2", "-partition-max-leaf-bucket", "2", "-partition-degree", "1"}
+	var first bytes.Buffer
+	if err := runWithHermeticProvenance(t, args, &first); err != nil {
+		t.Fatalf("partition stage charged simulation-only queries: %v", err)
+	}
+	var report partitionRun
+	if err := json.Unmarshal(first.Bytes(), &report); err != nil {
+		t.Fatal(err)
+	}
+	artifactRaw, err := os.ReadFile(report.ArtifactPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	artifact, err := vectorpartition.DecodeArtifact(artifactRaw, len(artifactRaw))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if artifact.Source != report.Source || artifact.Source.Vectors != vectors || artifact.Source.Dimensions != 1 {
+		t.Fatalf("partition artifact lost vector-corpus identity: %+v", artifact.Source)
+	}
+	args[3] = t.TempDir()
+	var second bytes.Buffer
+	if err := runWithHermeticProvenance(t, args, &second); err != nil {
+		t.Fatal(err)
+	}
+	var again partitionRun
+	if err := json.Unmarshal(second.Bytes(), &again); err != nil {
+		t.Fatal(err)
+	}
+	if report.ArtifactSHA256 != again.ArtifactSHA256 || report.Source != again.Source {
+		t.Fatalf("partition-only output changed with irrelevant query stream: first=%+v second=%+v", report, again)
+	}
+}
+
 func TestFixtureTruthDeterministicAndChecksumStable(t *testing.T) {
 	m, err := loadFixture(fixturePath(t))
 	if err != nil {

--- a/cmd/treedb_vector_partition_bench/main_test.go
+++ b/cmd/treedb_vector_partition_bench/main_test.go
@@ -146,6 +146,20 @@ func TestPartitionStageWritesValidatedDeterministicArtifact(t *testing.T) {
 		t.Fatalf("digest changed: %s %s", report.ArtifactSHA256, again.ArtifactSHA256)
 	}
 }
+func TestCheckedIn10kFixtureGraphCutBeatsStableHash(t *testing.T) {
+	args := []string{"-dataset", fixturePath(t), "-out", t.TempDir(), "-partitions", "16", "-probes", "1", "-stage", "partition", "-partition-repetitions", "4", "-partition-pivots", "8", "-partition-max-leaf-bucket", "128", "-partition-degree", "16"}
+	var stdout bytes.Buffer
+	if err := runWithHermeticProvenance(t, args, &stdout); err != nil {
+		t.Fatal(err)
+	}
+	var report partitionRun
+	if err := json.Unmarshal(stdout.Bytes(), &report); err != nil {
+		t.Fatal(err)
+	}
+	if report.Dataset.Checksum == "" || report.Metrics.EdgeCut >= report.Metrics.StableIDHashEdgeCut {
+		t.Fatalf("checked-in 10k graph cut=%d hash=%d checksum=%s", report.Metrics.EdgeCut, report.Metrics.StableIDHashEdgeCut, report.Dataset.Checksum)
+	}
+}
 
 func TestFixtureTruthDeterministicAndChecksumStable(t *testing.T) {
 	m, err := loadFixture(fixturePath(t))

--- a/cmd/treedb_vector_partition_build/accounting_linux.go
+++ b/cmd/treedb_vector_partition_build/accounting_linux.go
@@ -1,0 +1,29 @@
+//go:build linux
+
+package main
+
+import (
+	"fmt"
+	"os"
+	"runtime"
+	"strings"
+)
+
+// peakRSS reads Linux VmHWM, whose unit is kB. Other platforms explicitly
+// report this measurement as unavailable instead of fabricating a zero.
+func peakRSS() (int64, bool) {
+	runtime.GC()
+	b, err := os.ReadFile("/proc/self/status")
+	if err != nil {
+		return 0, false
+	}
+	for _, line := range strings.Split(string(b), "\n") {
+		if strings.HasPrefix(line, "VmHWM:") {
+			var kb int64
+			if _, err := fmt.Sscanf(line, "VmHWM: %d kB", &kb); err == nil {
+				return kb * 1024, true
+			}
+		}
+	}
+	return 0, false
+}

--- a/cmd/treedb_vector_partition_build/accounting_other.go
+++ b/cmd/treedb_vector_partition_build/accounting_other.go
@@ -1,0 +1,7 @@
+//go:build !unix
+
+package main
+
+// CPU accounting is intentionally unavailable rather than represented as a
+// measured zero on platforms without the Unix getrusage contract.
+func cpuNanos() (int64, bool) { return 0, false }

--- a/cmd/treedb_vector_partition_build/accounting_other_rss.go
+++ b/cmd/treedb_vector_partition_build/accounting_other_rss.go
@@ -1,0 +1,6 @@
+//go:build !linux
+
+package main
+
+// Peak RSS is unavailable outside the Linux /proc VmHWM contract.
+func peakRSS() (int64, bool) { return 0, false }

--- a/cmd/treedb_vector_partition_build/accounting_unix.go
+++ b/cmd/treedb_vector_partition_build/accounting_unix.go
@@ -11,5 +11,10 @@ func cpuNanos() (int64, bool) {
 	if syscall.Getrusage(syscall.RUSAGE_SELF, &r) != nil {
 		return 0, false
 	}
-	return (r.Utime.Sec+r.Stime.Sec)*1e9 + (r.Utime.Usec+r.Stime.Usec)*1e3, true
+	// Timeval fields do not have a uniform integer width across Unix targets.
+	// Convert each field before arithmetic so this also compiles on Darwin,
+	// NetBSD, and AIX.
+	seconds := int64(r.Utime.Sec) + int64(r.Stime.Sec)
+	micros := int64(r.Utime.Usec) + int64(r.Stime.Usec)
+	return seconds*1e9 + micros*1e3, true
 }

--- a/cmd/treedb_vector_partition_build/accounting_unix.go
+++ b/cmd/treedb_vector_partition_build/accounting_unix.go
@@ -1,0 +1,15 @@
+//go:build unix
+
+package main
+
+import "syscall"
+
+// cpuNanos reports process user+system CPU time only where getrusage is
+// available and succeeds; callers must retain the availability bit in reports.
+func cpuNanos() (int64, bool) {
+	var r syscall.Rusage
+	if syscall.Getrusage(syscall.RUSAGE_SELF, &r) != nil {
+		return 0, false
+	}
+	return (r.Utime.Sec+r.Stime.Sec)*1e9 + (r.Utime.Usec+r.Stime.Usec)*1e3, true
+}

--- a/cmd/treedb_vector_partition_build/main.go
+++ b/cmd/treedb_vector_partition_build/main.go
@@ -133,7 +133,7 @@ func run(args []string) error {
 	cfg.Degree = degree
 	cfg.Imbalance = imbalance
 	const graphRecallSamples = 64
-	if err := vectorpartition.ValidateInputShape(cfg, m.Docs, m.Dimensions); err != nil {
+	if err := vectorpartition.ValidateReferenceInputShape(cfg, m.Docs, m.Dimensions); err != nil {
 		return err
 	}
 	if err := validateQualityWork(m.Docs, min(m.Queries, maxQueries), m.Dimensions, min(graphRecallSamples, m.Docs)); err != nil {

--- a/cmd/treedb_vector_partition_build/main.go
+++ b/cmd/treedb_vector_partition_build/main.go
@@ -341,7 +341,7 @@ func loadCorpus(dir string, m manifest) ([]vectorpartition.Vector, [][]float64, 
 	return vs, qs, nil
 }
 func safeCorpusName(name string) bool {
-	return name != "" && !filepath.IsAbs(name) && filepath.Base(name) == name && !strings.Contains(name, "\\")
+	return name != "" && name != "." && name != ".." && !filepath.IsAbs(name) && filepath.Base(name) == name && !strings.Contains(name, "\\")
 }
 func readF32(path string, fi fileInfo, rows, dims int) ([]float32, error) {
 	want, ok := checkedByteCount(rows, dims)

--- a/cmd/treedb_vector_partition_build/main.go
+++ b/cmd/treedb_vector_partition_build/main.go
@@ -55,23 +55,31 @@ type manifest struct {
 	Files               map[string]fileInfo `json:"files"`
 }
 type report struct {
-	SchemaVersion             int                      `json:"schema_version"`
-	ResultKind                string                   `json:"result_kind"`
-	Dataset                   manifest                 `json:"dataset"`
-	Artifact                  vectorpartition.Artifact `json:"artifact"`
-	BuildWallNanos            int64                    `json:"build_wall_nanos"`
-	BuildCPUNanos             int64                    `json:"build_cpu_nanos"`
-	PeakRSSBytes              int64                    `json:"peak_rss_bytes"`
-	TemporaryBytes            int64                    `json:"temporary_bytes"`
-	FinalBytes                int64                    `json:"final_bytes"`
-	BytesPerVector            float64                  `json:"bytes_per_vector"`
-	Balance                   float64                  `json:"balance"`
-	GraphNeighborRecall       float64                  `json:"graph_neighbor_recall_sample"`
-	GraphNeighborSamples      int                      `json:"graph_neighbor_samples"`
-	PartitionOracleRecallAt10 float64                  `json:"partition_oracle_recall_at_10"`
-	StableHashRecallAt10      float64                  `json:"stable_hash_recall_at_10"`
-	Probes                    int                      `json:"probes"`
-	ArtifactSHA256            string                   `json:"artifact_sha256"`
+	SchemaVersion             int                     `json:"schema_version"`
+	ResultKind                string                  `json:"result_kind"`
+	Dataset                   manifest                `json:"dataset"`
+	Source                    vectorpartition.Source  `json:"source"`
+	Config                    vectorpartition.Config  `json:"config"`
+	Metrics                   vectorpartition.Metrics `json:"metrics"`
+	ArtifactPath              string                  `json:"artifact_path"`
+	BuildWallNanos            int64                   `json:"build_wall_nanos"`
+	BuildCPUNanos             int64                   `json:"build_cpu_nanos"`
+	GraphBuildNanos           int64                   `json:"graph_build_nanos"`
+	BackendPartitionNanos     int64                   `json:"backend_partition_nanos"`
+	ValidationNanos           int64                   `json:"validation_nanos"`
+	PeakRSSBytes              int64                   `json:"peak_rss_bytes"`
+	TemporaryBytes            int64                   `json:"temporary_bytes"`
+	ArtifactBytes             int64                   `json:"artifact_bytes"`
+	ReportBytes               int64                   `json:"report_bytes"`
+	FinalBytes                int64                   `json:"final_bytes"`
+	BytesPerVector            float64                 `json:"bytes_per_vector"`
+	Balance                   float64                 `json:"balance"`
+	GraphNeighborRecall       float64                 `json:"graph_neighbor_recall_sample"`
+	GraphNeighborSamples      int                     `json:"graph_neighbor_samples"`
+	PartitionOracleRecallAt10 float64                 `json:"partition_oracle_recall_at_10"`
+	StableHashRecallAt10      float64                 `json:"stable_hash_recall_at_10"`
+	Probes                    int                     `json:"probes"`
+	ArtifactSHA256            string                  `json:"artifact_sha256"`
 }
 
 func main() {
@@ -116,7 +124,7 @@ func run(args []string) error {
 	cfg.Imbalance = imbalance
 	start := time.Now()
 	cpuStart := cpuNanos()
-	art, err := vectorpartition.BuildWithPartitioner(vs, cfg, vectorpartition.Source{SourceID: "exporter_manifest:" + manifestDigest(m)}, vectorpartition.ReferencePartitioner{})
+	art, phases, err := vectorpartition.BuildWithPartitionerPhased(vs, cfg, vectorpartition.Source{SourceID: "exporter_manifest:" + manifestDigest(m)}, vectorpartition.ReferencePartitioner{})
 	if err != nil {
 		return err
 	}
@@ -129,7 +137,8 @@ func run(args []string) error {
 	if err != nil {
 		return err
 	}
-	gr := graphRecall(vs, art, 16)
+	const graphRecallSamples = 64
+	gr := graphRecall(vs, art, min(graphRecallSamples, len(vs)))
 	pr, hr := oracleRecall(vs, qs, art, probes, 10)
 	if pr <= hr {
 		return fmt.Errorf("quality gate failed: partition oracle recall@10 %.4f <= stable hash %.4f at probes=%d", pr, hr, probes)
@@ -145,15 +154,26 @@ func run(args []string) error {
 	st, _ := os.Stat(path)
 	cap := art.Metrics.Cap
 	bal := float64(art.Metrics.MaxPartitionSize) * float64(partitions) / float64(len(vs))
-	r := report{1, "offline_partition_builder_exporter_v1", m, art, wall, cpuNanos() - cpuStart, peakRSS(), 0, st.Size(), float64(st.Size()) / float64(len(vs)), bal, gr, min(16, len(vs)), pr, hr, probes, digest}
+	r := report{SchemaVersion: 1, ResultKind: "offline_partition_builder_exporter_v1", Dataset: m, Source: art.Source, Config: art.Config, Metrics: art.Metrics, ArtifactPath: path, BuildWallNanos: wall, BuildCPUNanos: cpuNanos() - cpuStart, GraphBuildNanos: phases.GraphBuildNanos, BackendPartitionNanos: phases.BackendPartitionNanos, ValidationNanos: phases.ValidationNanos, PeakRSSBytes: peakRSS(), TemporaryBytes: 0, ArtifactBytes: st.Size(), BytesPerVector: float64(st.Size()) / float64(len(vs)), Balance: bal, GraphNeighborRecall: gr, GraphNeighborSamples: min(graphRecallSamples, len(vs)), PartitionOracleRecallAt10: pr, StableHashRecallAt10: hr, Probes: probes, ArtifactSHA256: digest}
 	rr, err := json.Marshal(r)
 	if err != nil {
 		return err
 	}
-	if err = os.WriteFile(filepath.Join(out, "vector_partition_report_"+digest[:16]+".json"), rr, 0644); err != nil {
+	reportPath := filepath.Join(out, "vector_partition_report_"+digest[:16]+".json")
+	// Account for the report itself without embedding the artifact or writing a
+	// second giant JSON stream. A bounded fixed-point pass stabilizes FinalBytes.
+	for i := 0; i < 2; i++ {
+		r.ReportBytes = int64(len(rr))
+		r.FinalBytes = r.ArtifactBytes + r.ReportBytes
+		rr, err = json.Marshal(r)
+		if err != nil {
+			return err
+		}
+	}
+	if err = os.WriteFile(reportPath, rr, 0644); err != nil {
 		return err
 	}
-	fmt.Println(string(rr))
+	fmt.Printf("partition artifact=%s report=%s digest=%s final_bytes=%d oracle_recall_at_10=%.4f hash_recall_at_10=%.4f\n", path, reportPath, digest, r.FinalBytes, pr, hr)
 	_ = cap
 	return nil
 }
@@ -282,22 +302,24 @@ func graphRecall(v []vectorpartition.Vector, a vectorpartition.Artifact, n int) 
 	}
 	return sum / float64(n)
 }
+
+// oracleRecall intentionally has no centroid/router step: it uses the global
+// exact top-k truth to select the partitions holding most truth neighbors,
+// with stable partition-ID ties. That isolates M2 assignment quality from M4.
 func oracleRecall(v []vectorpartition.Vector, qs [][]float64, a vectorpartition.Artifact, probes, k int) (float64, float64) {
 	if len(qs) == 0 {
 		return 0, 0
 	}
-	pcent := centroids(v, a.Assignment, a.Config.Partitions)
 	hassign := make([]int, len(v))
 	for i, x := range v {
 		s := sha256.Sum256([]byte(x.ID))
 		hassign[i] = int(binary.BigEndian.Uint64(s[:8]) % uint64(a.Config.Partitions))
 	}
-	hcent := centroids(v, hassign, a.Config.Partitions)
 	var pr, hr float64
 	for _, q := range qs {
 		truth := nearest(v, q, k, func(int) bool { return true })
-		p := topParts(pcent, q, probes)
-		h := topParts(hcent, q, probes)
+		p := oracleParts(truth, a.Assignment, a.Config.Partitions, probes)
+		h := oracleParts(truth, hassign, a.Config.Partitions, probes)
 		pr += recall(truth, nearest(v, q, k, func(i int) bool {
 			for _, x := range p {
 				if a.Assignment[i] == x {
@@ -316,6 +338,20 @@ func oracleRecall(v []vectorpartition.Vector, qs [][]float64, a vectorpartition.
 		}))
 	}
 	return pr / float64(len(qs)), hr / float64(len(qs))
+}
+func oracleParts(truth, assignment []int, partitions, probes int) []int {
+	counts := make([]int, partitions)
+	for _, i := range truth {
+		counts[assignment[i]]++
+	}
+	order := make([]int, partitions)
+	for i := range order {
+		order[i] = i
+	}
+	sort.Slice(order, func(i, j int) bool {
+		return counts[order[i]] > counts[order[j]] || counts[order[i]] == counts[order[j]] && order[i] < order[j]
+	})
+	return order[:probes]
 }
 func centroids(v []vectorpartition.Vector, a []int, p int) [][]float64 {
 	o := make([][]float64, p)

--- a/cmd/treedb_vector_partition_build/main.go
+++ b/cmd/treedb_vector_partition_build/main.go
@@ -1,0 +1,395 @@
+// treedb_vector_partition_build consumes the repository-owned exporter corpus
+// format and produces a bounded offline M2 artifact/report. It has no server,
+// collection, Raft, or runtime-FFI dependency.
+package main
+
+import (
+	"crypto/sha256"
+	"encoding/binary"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"math"
+	"os"
+	"path/filepath"
+	"runtime"
+	"sort"
+	"strings"
+	"syscall"
+	"time"
+
+	"github.com/snissn/gomap/TreeDB/vectorpartition"
+)
+
+const maxManifest = 1 << 20
+const maxCorpusBytes int64 = 4 << 30
+const maxQueries = 128
+
+type fileInfo struct {
+	Bytes  int64  `json:"bytes"`
+	SHA256 string `json:"sha256"`
+}
+type manifest struct {
+	Version             int                 `json:"version"`
+	Generator           string              `json:"generator"`
+	CreatedAt           string              `json:"created_at"`
+	Docs                int                 `json:"docs"`
+	Dimensions          int                 `json:"dimensions"`
+	Queries             int                 `json:"queries"`
+	TopK                int                 `json:"top_k"`
+	Metric              string              `json:"metric"`
+	Normalized          bool                `json:"normalized"`
+	DocumentIDPattern   string              `json:"document_id_pattern"`
+	GroupModulo         int                 `json:"group_modulo"`
+	DocumentVectorsFile string              `json:"document_vectors_file"`
+	QueryVectorsFile    string              `json:"query_vectors_file"`
+	DocumentsJSONLFile  string              `json:"documents_jsonl_file"`
+	QueriesJSONLFile    string              `json:"queries_jsonl_file"`
+	FloatFormat         string              `json:"float_format"`
+	ExactTruthFile      string              `json:"exact_truth_file"`
+	ExactTruthKind      string              `json:"exact_truth_kind"`
+	ExactTruthQueries   int                 `json:"exact_truth_queries"`
+	Files               map[string]fileInfo `json:"files"`
+}
+type report struct {
+	SchemaVersion             int                      `json:"schema_version"`
+	ResultKind                string                   `json:"result_kind"`
+	Dataset                   manifest                 `json:"dataset"`
+	Artifact                  vectorpartition.Artifact `json:"artifact"`
+	BuildWallNanos            int64                    `json:"build_wall_nanos"`
+	BuildCPUNanos             int64                    `json:"build_cpu_nanos"`
+	PeakRSSBytes              int64                    `json:"peak_rss_bytes"`
+	TemporaryBytes            int64                    `json:"temporary_bytes"`
+	FinalBytes                int64                    `json:"final_bytes"`
+	BytesPerVector            float64                  `json:"bytes_per_vector"`
+	Balance                   float64                  `json:"balance"`
+	GraphNeighborRecall       float64                  `json:"graph_neighbor_recall_sample"`
+	GraphNeighborSamples      int                      `json:"graph_neighbor_samples"`
+	PartitionOracleRecallAt10 float64                  `json:"partition_oracle_recall_at_10"`
+	StableHashRecallAt10      float64                  `json:"stable_hash_recall_at_10"`
+	Probes                    int                      `json:"probes"`
+	ArtifactSHA256            string                   `json:"artifact_sha256"`
+}
+
+func main() {
+	if err := run(os.Args[1:]); err != nil {
+		fmt.Fprintln(os.Stderr, "treedb-vector-partition-build:", err)
+		os.Exit(1)
+	}
+}
+func run(args []string) error {
+	var dataset, out string
+	var partitions, probes, reps, pivots, leaf, degree int
+	var imbalance float64
+	var seed int64
+	fs := flag.NewFlagSet("treedb_vector_partition_build", flag.ContinueOnError)
+	fs.StringVar(&dataset, "dataset", "", "exporter dataset directory")
+	fs.StringVar(&out, "out", "", "artifact output directory")
+	fs.IntVar(&partitions, "partitions", 16, "partition count")
+	fs.IntVar(&probes, "probes", 2, "fixed routing probe budget")
+	fs.Int64Var(&seed, "seed", 1, "graph seed")
+	fs.IntVar(&reps, "repetitions", 4, "graph repetitions")
+	fs.IntVar(&pivots, "pivots", 8, "pivots")
+	fs.IntVar(&leaf, "max-leaf-bucket", 128, "leaf cap")
+	fs.IntVar(&degree, "degree", 16, "degree cap")
+	fs.Float64Var(&imbalance, "imbalance", .05, "imbalance epsilon")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	if dataset == "" || out == "" || probes < 1 || probes > partitions {
+		return errors.New("dataset/out and probes within partitions required")
+	}
+	m, vs, qs, err := load(dataset)
+	if err != nil {
+		return err
+	}
+	cfg := vectorpartition.DefaultConfig()
+	cfg.Partitions = partitions
+	cfg.Seed = seed
+	cfg.Repetitions = reps
+	cfg.Pivots = pivots
+	cfg.MaxLeafBucket = leaf
+	cfg.Degree = degree
+	cfg.Imbalance = imbalance
+	start := time.Now()
+	cpuStart := cpuNanos()
+	art, err := vectorpartition.BuildWithPartitioner(vs, cfg, vectorpartition.Source{SourceID: "exporter_manifest:" + manifestDigest(m)}, vectorpartition.ReferencePartitioner{})
+	if err != nil {
+		return err
+	}
+	wall := time.Since(start).Nanoseconds()
+	digest, err := vectorpartition.Digest(art)
+	if err != nil {
+		return err
+	}
+	raw, err := vectorpartition.CanonicalJSON(art)
+	if err != nil {
+		return err
+	}
+	gr := graphRecall(vs, art, 16)
+	pr, hr := oracleRecall(vs, qs, art, probes, 10)
+	if pr <= hr {
+		return fmt.Errorf("quality gate failed: partition oracle recall@10 %.4f <= stable hash %.4f at probes=%d", pr, hr, probes)
+	}
+	if err := os.MkdirAll(out, 0755); err != nil {
+		return err
+	}
+	name := "vector_partition_" + digest[:16] + ".json"
+	path := filepath.Join(out, name)
+	if err := os.WriteFile(path, raw, 0644); err != nil {
+		return err
+	}
+	st, _ := os.Stat(path)
+	cap := art.Metrics.Cap
+	bal := float64(art.Metrics.MaxPartitionSize) * float64(partitions) / float64(len(vs))
+	r := report{1, "offline_partition_builder_exporter_v1", m, art, wall, cpuNanos() - cpuStart, peakRSS(), 0, st.Size(), float64(st.Size()) / float64(len(vs)), bal, gr, min(16, len(vs)), pr, hr, probes, digest}
+	rr, err := json.Marshal(r)
+	if err != nil {
+		return err
+	}
+	if err = os.WriteFile(filepath.Join(out, "vector_partition_report_"+digest[:16]+".json"), rr, 0644); err != nil {
+		return err
+	}
+	fmt.Println(string(rr))
+	_ = cap
+	return nil
+}
+func load(dir string) (manifest, []vectorpartition.Vector, [][]float64, error) {
+	raw, e := os.ReadFile(filepath.Join(dir, "manifest.json"))
+	if e != nil {
+		return manifest{}, nil, nil, e
+	}
+	if len(raw) > maxManifest {
+		return manifest{}, nil, nil, errors.New("manifest too large")
+	}
+	var m manifest
+	d := json.NewDecoder(strings.NewReader(string(raw)))
+	d.DisallowUnknownFields()
+	if e = d.Decode(&m); e != nil {
+		return m, nil, nil, e
+	}
+	if m.Version != 1 || m.Generator != "treedb_vector_synthetic_v1" || m.Docs < 1 || m.Docs > 1_000_000 || m.Dimensions < 1 || m.Dimensions > 4096 || m.Metric != "cosine" || m.FloatFormat != "float32_le_row_major" || m.DocumentIDPattern != "doc-%06d" {
+		return m, nil, nil, errors.New("unsupported exporter manifest")
+	}
+	docs, e := readF32(filepath.Join(dir, m.DocumentVectorsFile), m.Files[m.DocumentVectorsFile], m.Docs, m.Dimensions)
+	if e != nil {
+		return m, nil, nil, e
+	}
+	vs := make([]vectorpartition.Vector, m.Docs)
+	for i := range vs {
+		row := make([]float64, m.Dimensions)
+		for j := range row {
+			row[j] = float64(docs[i*m.Dimensions+j])
+		}
+		vs[i] = vectorpartition.Vector{ID: fmt.Sprintf("doc-%06d", i), Values: row}
+	}
+	qcount := min(m.Queries, maxQueries)
+	qs := [][]float64{}
+	if qcount > 0 {
+		q, e := readF32(filepath.Join(dir, m.QueryVectorsFile), m.Files[m.QueryVectorsFile], m.Queries, m.Dimensions)
+		if e != nil {
+			return m, nil, nil, e
+		}
+		for i := 0; i < qcount; i++ {
+			row := make([]float64, m.Dimensions)
+			for j := range row {
+				row[j] = float64(q[i*m.Dimensions+j])
+			}
+			qs = append(qs, row)
+		}
+	}
+	return m, vs, qs, nil
+}
+func readF32(path string, fi fileInfo, rows, dims int) ([]float32, error) {
+	want := int64(rows) * int64(dims) * 4
+	if want < 1 || want > maxCorpusBytes || fi.Bytes != want || len(fi.SHA256) != 64 {
+		return nil, errors.New("invalid corpus file bounds")
+	}
+	f, e := os.Open(path)
+	if e != nil {
+		return nil, e
+	}
+	defer f.Close()
+	h := sha256.New()
+	r := io.TeeReader(io.LimitReader(f, want+1), h)
+	b, e := io.ReadAll(r)
+	if e != nil || int64(len(b)) != want {
+		return nil, errors.New("corpus truncated or oversized")
+	}
+	if hex.EncodeToString(h.Sum(nil)) != fi.SHA256 {
+		return nil, errors.New("corpus checksum mismatch")
+	}
+	a := make([]float32, rows*dims)
+	for i := range a {
+		a[i] = math.Float32frombits(binary.LittleEndian.Uint32(b[4*i:]))
+	}
+	return a, nil
+}
+func manifestDigest(m manifest) string {
+	b, _ := json.Marshal(m)
+	s := sha256.Sum256(b)
+	return hex.EncodeToString(s[:])
+}
+func dot(a, b []float64) float64 {
+	var x float64
+	for i := range a {
+		x = math.FMA(a[i], b[i], x)
+	}
+	return x
+}
+func nearest(v []vectorpartition.Vector, q []float64, k int, include func(int) bool) []int {
+	type c struct {
+		i int
+		d float64
+	}
+	a := make([]c, 0)
+	for i, x := range v {
+		if include(i) {
+			a = append(a, c{i, 1 - dot(x.Values, q)})
+		}
+	}
+	sort.Slice(a, func(i, j int) bool { return a[i].d < a[j].d || a[i].d == a[j].d && a[i].i < a[j].i })
+	if len(a) > k {
+		a = a[:k]
+	}
+	o := make([]int, len(a))
+	for i := range a {
+		o[i] = a[i].i
+	}
+	return o
+}
+func graphRecall(v []vectorpartition.Vector, a vectorpartition.Artifact, n int) float64 {
+	if n == 0 {
+		return 0
+	}
+	sum := 0.0
+	for i := 0; i < n; i++ {
+		want := nearest(v, v[i].Values, min(10, len(v)-1), func(j int) bool { return j != i })
+		seen := map[int]bool{}
+		for _, j := range a.Graph.Neighbors[i] {
+			seen[j] = true
+		}
+		hit := 0
+		for _, j := range want {
+			if seen[j] {
+				hit++
+			}
+		}
+		sum += float64(hit) / float64(len(want))
+	}
+	return sum / float64(n)
+}
+func oracleRecall(v []vectorpartition.Vector, qs [][]float64, a vectorpartition.Artifact, probes, k int) (float64, float64) {
+	if len(qs) == 0 {
+		return 0, 0
+	}
+	pcent := centroids(v, a.Assignment, a.Config.Partitions)
+	hassign := make([]int, len(v))
+	for i, x := range v {
+		s := sha256.Sum256([]byte(x.ID))
+		hassign[i] = int(binary.BigEndian.Uint64(s[:8]) % uint64(a.Config.Partitions))
+	}
+	hcent := centroids(v, hassign, a.Config.Partitions)
+	var pr, hr float64
+	for _, q := range qs {
+		truth := nearest(v, q, k, func(int) bool { return true })
+		p := topParts(pcent, q, probes)
+		h := topParts(hcent, q, probes)
+		pr += recall(truth, nearest(v, q, k, func(i int) bool {
+			for _, x := range p {
+				if a.Assignment[i] == x {
+					return true
+				}
+			}
+			return false
+		}))
+		hr += recall(truth, nearest(v, q, k, func(i int) bool {
+			for _, x := range h {
+				if hassign[i] == x {
+					return true
+				}
+			}
+			return false
+		}))
+	}
+	return pr / float64(len(qs)), hr / float64(len(qs))
+}
+func centroids(v []vectorpartition.Vector, a []int, p int) [][]float64 {
+	o := make([][]float64, p)
+	n := make([]int, p)
+	for i, x := range v {
+		if o[a[i]] == nil {
+			o[a[i]] = make([]float64, len(x.Values))
+		}
+		for d := range x.Values {
+			o[a[i]][d] += x.Values[d]
+		}
+		n[a[i]]++
+	}
+	for i := range o {
+		for d := range o[i] {
+			o[i][d] /= float64(n[i])
+		}
+	}
+	return o
+}
+func topParts(c [][]float64, q []float64, k int) []int {
+	type x struct {
+		i int
+		d float64
+	}
+	a := make([]x, len(c))
+	for i := range c {
+		a[i] = x{i, 1 - dot(c[i], q)}
+	}
+	sort.Slice(a, func(i, j int) bool { return a[i].d < a[j].d })
+	o := make([]int, k)
+	for i := range o {
+		o[i] = a[i].i
+	}
+	return o
+}
+func recall(a, b []int) float64 {
+	s := map[int]bool{}
+	for _, x := range b {
+		s[x] = true
+	}
+	n := 0
+	for _, x := range a {
+		if s[x] {
+			n++
+		}
+	}
+	return float64(n) / float64(len(a))
+}
+func peakRSS() int64 {
+	runtime.GC()
+	b, e := os.ReadFile("/proc/self/status")
+	if e != nil {
+		return 0
+	}
+	for _, l := range strings.Split(string(b), "\n") {
+		if strings.HasPrefix(l, "VmHWM:") {
+			var kb int64
+			fmt.Sscanf(l, "VmHWM: %d kB", &kb)
+			return kb * 1024
+		}
+	}
+	return 0
+}
+func cpuNanos() int64 {
+	var r syscall.Rusage
+	if syscall.Getrusage(syscall.RUSAGE_SELF, &r) != nil {
+		return 0
+	}
+	return (r.Utime.Sec+r.Stime.Sec)*1e9 + (r.Utime.Usec+r.Stime.Usec)*1e3
+}
+func min(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}

--- a/cmd/treedb_vector_partition_build/main.go
+++ b/cmd/treedb_vector_partition_build/main.go
@@ -294,6 +294,11 @@ func loadManifest(dir string) (manifest, error) {
 	if !ok || !qok {
 		return m, errors.New("manifest corpus file entry missing")
 	}
+	for _, name := range []string{m.DocumentVectorsFile, m.QueryVectorsFile} {
+		if !canonicalSHA256(m.Files[name].SHA256) {
+			return m, errors.New("invalid corpus checksum")
+		}
+	}
 	return m, nil
 }
 
@@ -340,7 +345,7 @@ func safeCorpusName(name string) bool {
 }
 func readF32(path string, fi fileInfo, rows, dims int) ([]float32, error) {
 	want, ok := checkedByteCount(rows, dims)
-	if !ok || want > maxCorpusBytes || fi.Bytes != want || len(fi.SHA256) != 64 || strings.ToLower(fi.SHA256) != fi.SHA256 {
+	if !ok || want > maxCorpusBytes || fi.Bytes != want || !canonicalSHA256(fi.SHA256) {
 		return nil, errors.New("invalid corpus file bounds")
 	}
 	f, e := os.Open(path)
@@ -363,6 +368,15 @@ func readF32(path string, fi fileInfo, rows, dims int) ([]float32, error) {
 	}
 	return a, nil
 }
+
+// canonicalSHA256 accepts only the lower-case, fixed-width hex form used by
+// exporter manifests. Decode and re-encode so length/casing checks cannot
+// admit malformed non-hex metadata before corpus I/O.
+func canonicalSHA256(s string) bool {
+	decoded, err := hex.DecodeString(s)
+	return err == nil && len(decoded) == sha256.Size && hex.EncodeToString(decoded) == s
+}
+
 func checkedByteCount(rows, dims int) (int64, bool) {
 	if rows < 1 || dims < 1 || int64(rows) > math.MaxInt64/int64(dims) || int64(rows)*int64(dims) > math.MaxInt64/4 {
 		return 0, false

--- a/cmd/treedb_vector_partition_build/main.go
+++ b/cmd/treedb_vector_partition_build/main.go
@@ -184,7 +184,6 @@ func run(args []string) error {
 	if err != nil {
 		return err
 	}
-	cap := art.Metrics.Cap
 	bal := float64(art.Metrics.MaxPartitionSize) * float64(partitions) / float64(len(vs))
 	peakRSSBytes, peakRSSAvailable := peakRSS()
 	var peakRSSValue *int64
@@ -238,7 +237,6 @@ func run(args []string) error {
 		return errors.New("report byte accounting mismatch")
 	}
 	fmt.Printf("partition artifact=%s report=%s digest=%s final_bytes=%d oracle_recall_at_10=%.4f hash_recall_at_10=%.4f\n", path, reportPath, digest, r.FinalBytes, pr, hr)
-	_ = cap
 	return nil
 }
 

--- a/cmd/treedb_vector_partition_build/main.go
+++ b/cmd/treedb_vector_partition_build/main.go
@@ -120,12 +120,10 @@ func run(args []string) error {
 	if dataset == "" || out == "" || probes < 1 || probes > partitions {
 		return errors.New("dataset/out and probes within partitions required")
 	}
-	loadStart := time.Now()
-	m, vs, qs, err := load(dataset)
+	m, err := loadManifest(dataset)
 	if err != nil {
 		return err
 	}
-	loadWall := time.Since(loadStart).Nanoseconds()
 	cfg := vectorpartition.DefaultConfig()
 	cfg.Partitions = partitions
 	cfg.Seed = seed
@@ -135,9 +133,18 @@ func run(args []string) error {
 	cfg.Degree = degree
 	cfg.Imbalance = imbalance
 	const graphRecallSamples = 64
-	if err := validateQualityWork(len(vs), len(qs), m.Dimensions, min(graphRecallSamples, len(vs))); err != nil {
+	if err := vectorpartition.ValidateInputShape(cfg, m.Docs, m.Dimensions); err != nil {
 		return err
 	}
+	if err := validateQualityWork(m.Docs, min(m.Queries, maxQueries), m.Dimensions, min(graphRecallSamples, m.Docs)); err != nil {
+		return err
+	}
+	loadStart := time.Now()
+	vs, qs, err := loadCorpus(dataset, m)
+	if err != nil {
+		return err
+	}
+	loadWall := time.Since(loadStart).Nanoseconds()
 	start := time.Now()
 	cpuStart, buildCPUAvailable := cpuNanos()
 	art, phases, err := vectorpartition.BuildWithPartitionerPhased(vs, cfg, vectorpartition.Source{SourceID: "exporter_manifest:" + manifestDigest(m)}, vectorpartition.ReferencePartitioner{})
@@ -245,45 +252,60 @@ func passesOracleQualityGate(oracle, stableHash float64, probes, partitions int)
 	return oracle > stableHash
 }
 func load(dir string) (manifest, []vectorpartition.Vector, [][]float64, error) {
+	m, err := loadManifest(dir)
+	if err != nil {
+		return m, nil, nil, err
+	}
+	vs, qs, err := loadCorpus(dir, m)
+	return m, vs, qs, err
+}
+
+func loadManifest(dir string) (manifest, error) {
 	f, e := os.Open(filepath.Join(dir, "manifest.json"))
 	if e != nil {
-		return manifest{}, nil, nil, e
+		return manifest{}, e
 	}
 	defer f.Close()
 	raw, e := io.ReadAll(io.LimitReader(f, maxManifest+1))
 	if e != nil {
-		return manifest{}, nil, nil, e
+		return manifest{}, e
 	}
 	if len(raw) > maxManifest {
-		return manifest{}, nil, nil, errors.New("manifest too large")
+		return manifest{}, errors.New("manifest too large")
 	}
 	var m manifest
 	d := json.NewDecoder(strings.NewReader(string(raw)))
 	d.DisallowUnknownFields()
 	if e = d.Decode(&m); e != nil {
-		return m, nil, nil, e
+		return m, e
 	}
 	var extra any
 	if e = d.Decode(&extra); e != io.EOF {
-		return m, nil, nil, errors.New("manifest has trailing JSON")
+		return m, errors.New("manifest has trailing JSON")
 	}
 	if m.Version != 1 || m.Generator != "treedb_vector_synthetic_v1" || m.Docs < 1 || m.Docs > 1_000_000 || m.Dimensions < 1 || m.Dimensions > 4096 || m.Queries < 1 || m.Queries > 1_000_000 || m.TopK < 1 || m.TopK > 1024 || m.GroupModulo < 1 || m.ExactTruthQueries < 0 || m.ExactTruthQueries > m.Queries || m.Metric != "cosine" || !m.Normalized || m.FloatFormat != "float32_le_row_major" || m.DocumentIDPattern != "doc-%06d" || !safeCorpusName(m.DocumentVectorsFile) || !safeCorpusName(m.QueryVectorsFile) || m.DocumentVectorsFile == m.QueryVectorsFile {
-		return m, nil, nil, errors.New("unsupported exporter manifest")
+		return m, errors.New("unsupported exporter manifest")
 	}
 	if m.Files == nil {
-		return m, nil, nil, errors.New("manifest files missing")
+		return m, errors.New("manifest files missing")
 	}
-	df, ok := m.Files[m.DocumentVectorsFile]
-	qf, qok := m.Files[m.QueryVectorsFile]
+	_, ok := m.Files[m.DocumentVectorsFile]
+	_, qok := m.Files[m.QueryVectorsFile]
 	if !ok || !qok {
-		return m, nil, nil, errors.New("manifest corpus file entry missing")
+		return m, errors.New("manifest corpus file entry missing")
 	}
+	return m, nil
+}
+
+func loadCorpus(dir string, m manifest) ([]vectorpartition.Vector, [][]float64, error) {
+	df := m.Files[m.DocumentVectorsFile]
+	qf := m.Files[m.QueryVectorsFile]
 	docs, e := readF32(filepath.Join(dir, m.DocumentVectorsFile), df, m.Docs, m.Dimensions)
 	if e != nil {
-		return m, nil, nil, e
+		return nil, nil, e
 	}
 	if err := validateNormalized(docs, m.Docs, m.Dimensions); err != nil {
-		return m, nil, nil, err
+		return nil, nil, err
 	}
 	vs := make([]vectorpartition.Vector, m.Docs)
 	for i := range vs {
@@ -298,10 +320,10 @@ func load(dir string) (manifest, []vectorpartition.Vector, [][]float64, error) {
 	if qcount > 0 {
 		q, e := readF32(filepath.Join(dir, m.QueryVectorsFile), qf, m.Queries, m.Dimensions)
 		if e != nil {
-			return m, nil, nil, e
+			return nil, nil, e
 		}
 		if err := validateNormalized(q, m.Queries, m.Dimensions); err != nil {
-			return m, nil, nil, err
+			return nil, nil, err
 		}
 		for i := 0; i < qcount; i++ {
 			row := make([]float64, m.Dimensions)
@@ -311,7 +333,7 @@ func load(dir string) (manifest, []vectorpartition.Vector, [][]float64, error) {
 			qs = append(qs, row)
 		}
 	}
-	return m, vs, qs, nil
+	return vs, qs, nil
 }
 func safeCorpusName(name string) bool {
 	return name != "" && !filepath.IsAbs(name) && filepath.Base(name) == name && !strings.Contains(name, "\\")

--- a/cmd/treedb_vector_partition_build/main.go
+++ b/cmd/treedb_vector_partition_build/main.go
@@ -4,6 +4,7 @@
 package main
 
 import (
+	"container/heap"
 	"crypto/sha256"
 	"encoding/binary"
 	"encoding/hex"
@@ -62,11 +63,14 @@ type report struct {
 	Config                    vectorpartition.Config  `json:"config"`
 	Metrics                   vectorpartition.Metrics `json:"metrics"`
 	ArtifactPath              string                  `json:"artifact_path"`
+	LoadWallNanos             int64                   `json:"load_wall_nanos"`
 	BuildWallNanos            int64                   `json:"build_wall_nanos"`
 	BuildCPUNanos             int64                   `json:"build_cpu_nanos"`
 	GraphBuildNanos           int64                   `json:"graph_build_nanos"`
 	BackendPartitionNanos     int64                   `json:"backend_partition_nanos"`
 	ValidationNanos           int64                   `json:"validation_nanos"`
+	QualityWallNanos          int64                   `json:"quality_wall_nanos"`
+	TotalCommandWallNanos     int64                   `json:"total_command_wall_nanos"`
 	PeakRSSBytes              int64                   `json:"peak_rss_bytes"`
 	TemporaryBytes            int64                   `json:"temporary_bytes"`
 	ArtifactBytes             int64                   `json:"artifact_bytes"`
@@ -89,6 +93,7 @@ func main() {
 	}
 }
 func run(args []string) error {
+	commandStart := time.Now()
 	var dataset, out string
 	var partitions, probes, reps, pivots, leaf, degree int
 	var imbalance float64
@@ -110,10 +115,12 @@ func run(args []string) error {
 	if dataset == "" || out == "" || probes < 1 || probes > partitions {
 		return errors.New("dataset/out and probes within partitions required")
 	}
+	loadStart := time.Now()
 	m, vs, qs, err := load(dataset)
 	if err != nil {
 		return err
 	}
+	loadWall := time.Since(loadStart).Nanoseconds()
 	cfg := vectorpartition.DefaultConfig()
 	cfg.Partitions = partitions
 	cfg.Seed = seed
@@ -137,12 +144,14 @@ func run(args []string) error {
 	if err != nil {
 		return err
 	}
+	qualityStart := time.Now()
 	const graphRecallSamples = 64
 	gr := graphRecall(vs, art, min(graphRecallSamples, len(vs)))
 	pr, hr := oracleRecall(vs, qs, art, probes, 10)
 	if pr <= hr {
 		return fmt.Errorf("quality gate failed: partition oracle recall@10 %.4f <= stable hash %.4f at probes=%d", pr, hr, probes)
 	}
+	qualityWall := time.Since(qualityStart).Nanoseconds()
 	if err := os.MkdirAll(out, 0755); err != nil {
 		return err
 	}
@@ -154,7 +163,7 @@ func run(args []string) error {
 	st, _ := os.Stat(path)
 	cap := art.Metrics.Cap
 	bal := float64(art.Metrics.MaxPartitionSize) * float64(partitions) / float64(len(vs))
-	r := report{SchemaVersion: 1, ResultKind: "offline_partition_builder_exporter_v1", Dataset: m, Source: art.Source, Config: art.Config, Metrics: art.Metrics, ArtifactPath: path, BuildWallNanos: wall, BuildCPUNanos: cpuNanos() - cpuStart, GraphBuildNanos: phases.GraphBuildNanos, BackendPartitionNanos: phases.BackendPartitionNanos, ValidationNanos: phases.ValidationNanos, PeakRSSBytes: peakRSS(), TemporaryBytes: 0, ArtifactBytes: st.Size(), BytesPerVector: float64(st.Size()) / float64(len(vs)), Balance: bal, GraphNeighborRecall: gr, GraphNeighborSamples: min(graphRecallSamples, len(vs)), PartitionOracleRecallAt10: pr, StableHashRecallAt10: hr, Probes: probes, ArtifactSHA256: digest}
+	r := report{SchemaVersion: 1, ResultKind: "offline_partition_builder_exporter_v1", Dataset: m, Source: art.Source, Config: art.Config, Metrics: art.Metrics, ArtifactPath: path, LoadWallNanos: loadWall, BuildWallNanos: wall, BuildCPUNanos: cpuNanos() - cpuStart, GraphBuildNanos: phases.GraphBuildNanos, BackendPartitionNanos: phases.BackendPartitionNanos, ValidationNanos: phases.ValidationNanos, QualityWallNanos: qualityWall, PeakRSSBytes: peakRSS(), TemporaryBytes: 0, ArtifactBytes: st.Size(), BytesPerVector: float64(st.Size()) / float64(len(vs)), Balance: bal, GraphNeighborRecall: gr, GraphNeighborSamples: min(graphRecallSamples, len(vs)), PartitionOracleRecallAt10: pr, StableHashRecallAt10: hr, Probes: probes, ArtifactSHA256: digest}
 	rr, err := json.Marshal(r)
 	if err != nil {
 		return err
@@ -162,23 +171,44 @@ func run(args []string) error {
 	reportPath := filepath.Join(out, "vector_partition_report_"+digest[:16]+".json")
 	// Account for the report itself without embedding the artifact or writing a
 	// second giant JSON stream. A bounded fixed-point pass stabilizes FinalBytes.
-	for i := 0; i < 2; i++ {
+	converged := false
+	for i := 0; i < 8; i++ {
+		r.TotalCommandWallNanos = time.Since(commandStart).Nanoseconds()
 		r.ReportBytes = int64(len(rr))
 		r.FinalBytes = r.ArtifactBytes + r.ReportBytes
 		rr, err = json.Marshal(r)
 		if err != nil {
 			return err
 		}
+		if int64(len(rr)) == r.ReportBytes {
+			converged = true
+			break
+		}
+	}
+	if !converged {
+		return errors.New("report byte accounting did not converge")
 	}
 	if err = os.WriteFile(reportPath, rr, 0644); err != nil {
 		return err
+	}
+	actual, err := os.Stat(reportPath)
+	if err != nil {
+		return err
+	}
+	if actual.Size() != r.ReportBytes || r.FinalBytes != r.ArtifactBytes+actual.Size() {
+		return errors.New("report byte accounting mismatch")
 	}
 	fmt.Printf("partition artifact=%s report=%s digest=%s final_bytes=%d oracle_recall_at_10=%.4f hash_recall_at_10=%.4f\n", path, reportPath, digest, r.FinalBytes, pr, hr)
 	_ = cap
 	return nil
 }
 func load(dir string) (manifest, []vectorpartition.Vector, [][]float64, error) {
-	raw, e := os.ReadFile(filepath.Join(dir, "manifest.json"))
+	f, e := os.Open(filepath.Join(dir, "manifest.json"))
+	if e != nil {
+		return manifest{}, nil, nil, e
+	}
+	defer f.Close()
+	raw, e := io.ReadAll(io.LimitReader(f, maxManifest+1))
 	if e != nil {
 		return manifest{}, nil, nil, e
 	}
@@ -191,10 +221,22 @@ func load(dir string) (manifest, []vectorpartition.Vector, [][]float64, error) {
 	if e = d.Decode(&m); e != nil {
 		return m, nil, nil, e
 	}
-	if m.Version != 1 || m.Generator != "treedb_vector_synthetic_v1" || m.Docs < 1 || m.Docs > 1_000_000 || m.Dimensions < 1 || m.Dimensions > 4096 || m.Metric != "cosine" || m.FloatFormat != "float32_le_row_major" || m.DocumentIDPattern != "doc-%06d" {
+	var extra any
+	if e = d.Decode(&extra); e != io.EOF {
+		return m, nil, nil, errors.New("manifest has trailing JSON")
+	}
+	if m.Version != 1 || m.Generator != "treedb_vector_synthetic_v1" || m.Docs < 1 || m.Docs > 1_000_000 || m.Dimensions < 1 || m.Dimensions > 4096 || m.Metric != "cosine" || !m.Normalized || m.FloatFormat != "float32_le_row_major" || m.DocumentIDPattern != "doc-%06d" || !safeCorpusName(m.DocumentVectorsFile) || !safeCorpusName(m.QueryVectorsFile) {
 		return m, nil, nil, errors.New("unsupported exporter manifest")
 	}
-	docs, e := readF32(filepath.Join(dir, m.DocumentVectorsFile), m.Files[m.DocumentVectorsFile], m.Docs, m.Dimensions)
+	if m.Files == nil {
+		return m, nil, nil, errors.New("manifest files missing")
+	}
+	df, ok := m.Files[m.DocumentVectorsFile]
+	qf, qok := m.Files[m.QueryVectorsFile]
+	if !ok || !qok {
+		return m, nil, nil, errors.New("manifest corpus file entry missing")
+	}
+	docs, e := readF32(filepath.Join(dir, m.DocumentVectorsFile), df, m.Docs, m.Dimensions)
 	if e != nil {
 		return m, nil, nil, e
 	}
@@ -209,7 +251,7 @@ func load(dir string) (manifest, []vectorpartition.Vector, [][]float64, error) {
 	qcount := min(m.Queries, maxQueries)
 	qs := [][]float64{}
 	if qcount > 0 {
-		q, e := readF32(filepath.Join(dir, m.QueryVectorsFile), m.Files[m.QueryVectorsFile], m.Queries, m.Dimensions)
+		q, e := readF32(filepath.Join(dir, m.QueryVectorsFile), qf, m.Queries, m.Dimensions)
 		if e != nil {
 			return m, nil, nil, e
 		}
@@ -223,9 +265,12 @@ func load(dir string) (manifest, []vectorpartition.Vector, [][]float64, error) {
 	}
 	return m, vs, qs, nil
 }
+func safeCorpusName(name string) bool {
+	return name != "" && !filepath.IsAbs(name) && filepath.Base(name) == name && !strings.Contains(name, "\\")
+}
 func readF32(path string, fi fileInfo, rows, dims int) ([]float32, error) {
 	want := int64(rows) * int64(dims) * 4
-	if want < 1 || want > maxCorpusBytes || fi.Bytes != want || len(fi.SHA256) != 64 {
+	if want < 1 || want > maxCorpusBytes || fi.Bytes != want || len(fi.SHA256) != 64 || strings.ToLower(fi.SHA256) != fi.SHA256 {
 		return nil, errors.New("invalid corpus file bounds")
 	}
 	f, e := os.Open(path)
@@ -261,26 +306,38 @@ func dot(a, b []float64) float64 {
 	return x
 }
 func nearest(v []vectorpartition.Vector, q []float64, k int, include func(int) bool) []int {
-	type c struct {
-		i int
-		d float64
-	}
-	a := make([]c, 0)
+	a := make(candidateMaxHeap, 0, k)
 	for i, x := range v {
 		if include(i) {
-			a = append(a, c{i, 1 - dot(x.Values, q)})
+			c := candidate{i, 1 - dot(x.Values, q)}
+			if len(a) < k {
+				heap.Push(&a, c)
+			} else if candidateLess(c, a[0]) {
+				a[0] = c
+				heap.Fix(&a, 0)
+			}
 		}
 	}
-	sort.Slice(a, func(i, j int) bool { return a[i].d < a[j].d || a[i].d == a[j].d && a[i].i < a[j].i })
-	if len(a) > k {
-		a = a[:k]
-	}
+	sort.Slice(a, func(i, j int) bool { return candidateLess(a[i], a[j]) })
 	o := make([]int, len(a))
 	for i := range a {
 		o[i] = a[i].i
 	}
 	return o
 }
+
+type candidate struct {
+	i int
+	d float64
+}
+type candidateMaxHeap []candidate
+
+func (h candidateMaxHeap) Len() int           { return len(h) }
+func (h candidateMaxHeap) Less(i, j int) bool { return candidateLess(h[j], h[i]) }
+func (h candidateMaxHeap) Swap(i, j int)      { h[i], h[j] = h[j], h[i] }
+func (h *candidateMaxHeap) Push(x any)        { *h = append(*h, x.(candidate)) }
+func (h *candidateMaxHeap) Pop() any          { o := *h; x := o[len(o)-1]; *h = o[:len(o)-1]; return x }
+func candidateLess(a, b candidate) bool       { return a.d < b.d || a.d == b.d && a.i < b.i }
 func graphRecall(v []vectorpartition.Vector, a vectorpartition.Artifact, n int) float64 {
 	if n == 0 {
 		return 0

--- a/cmd/treedb_vector_partition_build/main.go
+++ b/cmd/treedb_vector_partition_build/main.go
@@ -161,7 +161,7 @@ func run(args []string) error {
 	qualityStart := time.Now()
 	gr := graphRecall(vs, art, min(graphRecallSamples, len(vs)))
 	pr, hr := oracleRecall(vs, qs, art, probes, 10)
-	if pr <= hr {
+	if !passesOracleQualityGate(pr, hr, probes, partitions) {
 		return fmt.Errorf("quality gate failed: partition oracle recall@10 %.4f <= stable hash %.4f at probes=%d", pr, hr, probes)
 	}
 	qualityWall := time.Since(qualityStart).Nanoseconds()
@@ -233,6 +233,16 @@ func run(args []string) error {
 	fmt.Printf("partition artifact=%s report=%s digest=%s final_bytes=%d oracle_recall_at_10=%.4f hash_recall_at_10=%.4f\n", path, reportPath, digest, r.FinalBytes, pr, hr)
 	_ = cap
 	return nil
+}
+
+// passesOracleQualityGate requires a strict improvement for partial routing.
+// At full coverage both routes inspect every partition, so equality is the
+// expected parity result rather than a quality failure.
+func passesOracleQualityGate(oracle, stableHash float64, probes, partitions int) bool {
+	if probes == partitions {
+		return oracle >= stableHash
+	}
+	return oracle > stableHash
 }
 func load(dir string) (manifest, []vectorpartition.Vector, [][]float64, error) {
 	f, e := os.Open(filepath.Join(dir, "manifest.json"))
@@ -423,8 +433,12 @@ func graphRecall(v []vectorpartition.Vector, a vectorpartition.Artifact, n int) 
 		return 0
 	}
 	sum := 0.0
+	valid := 0
 	for i := 0; i < n; i++ {
 		want := nearest(v, v[i].Values, min(10, len(v)-1), func(j int) bool { return j != i })
+		if len(want) == 0 {
+			continue
+		}
 		seen := map[int]bool{}
 		for _, j := range a.Graph.Neighbors[i] {
 			seen[j] = true
@@ -436,8 +450,12 @@ func graphRecall(v []vectorpartition.Vector, a vectorpartition.Artifact, n int) 
 			}
 		}
 		sum += float64(hit) / float64(len(want))
+		valid++
 	}
-	return sum / float64(n)
+	if valid == 0 {
+		return 0
+	}
+	return sum / float64(valid)
 }
 
 // oracleRecall intentionally has no centroid/router step: it uses the global

--- a/cmd/treedb_vector_partition_build/main.go
+++ b/cmd/treedb_vector_partition_build/main.go
@@ -28,6 +28,8 @@ import (
 const maxManifest = 1 << 20
 const maxCorpusBytes int64 = 4 << 30
 const maxQueries = 128
+const maxQualityWork int64 = 10_000_000_000 // scalar dot-product dimensions
+const normalizedTolerance = 1e-3
 
 type fileInfo struct {
 	Bytes  int64  `json:"bytes"`
@@ -71,6 +73,7 @@ type report struct {
 	ValidationNanos           int64                   `json:"validation_nanos"`
 	QualityWallNanos          int64                   `json:"quality_wall_nanos"`
 	TotalCommandWallNanos     int64                   `json:"total_command_wall_nanos"`
+	TotalCommandCPUNanos      int64                   `json:"total_command_cpu_nanos"`
 	PeakRSSBytes              int64                   `json:"peak_rss_bytes"`
 	TemporaryBytes            int64                   `json:"temporary_bytes"`
 	ArtifactBytes             int64                   `json:"artifact_bytes"`
@@ -94,6 +97,7 @@ func main() {
 }
 func run(args []string) error {
 	commandStart := time.Now()
+	commandCPUStart := cpuNanos()
 	var dataset, out string
 	var partitions, probes, reps, pivots, leaf, degree int
 	var imbalance float64
@@ -129,6 +133,10 @@ func run(args []string) error {
 	cfg.MaxLeafBucket = leaf
 	cfg.Degree = degree
 	cfg.Imbalance = imbalance
+	const graphRecallSamples = 64
+	if err := validateQualityWork(len(vs), len(qs), m.Dimensions, min(graphRecallSamples, len(vs))); err != nil {
+		return err
+	}
 	start := time.Now()
 	cpuStart := cpuNanos()
 	art, phases, err := vectorpartition.BuildWithPartitionerPhased(vs, cfg, vectorpartition.Source{SourceID: "exporter_manifest:" + manifestDigest(m)}, vectorpartition.ReferencePartitioner{})
@@ -136,6 +144,7 @@ func run(args []string) error {
 		return err
 	}
 	wall := time.Since(start).Nanoseconds()
+	buildCPU := cpuNanos() - cpuStart
 	digest, err := vectorpartition.Digest(art)
 	if err != nil {
 		return err
@@ -145,7 +154,6 @@ func run(args []string) error {
 		return err
 	}
 	qualityStart := time.Now()
-	const graphRecallSamples = 64
 	gr := graphRecall(vs, art, min(graphRecallSamples, len(vs)))
 	pr, hr := oracleRecall(vs, qs, art, probes, 10)
 	if pr <= hr {
@@ -160,10 +168,13 @@ func run(args []string) error {
 	if err := os.WriteFile(path, raw, 0644); err != nil {
 		return err
 	}
-	st, _ := os.Stat(path)
+	st, err := os.Stat(path)
+	if err != nil {
+		return err
+	}
 	cap := art.Metrics.Cap
 	bal := float64(art.Metrics.MaxPartitionSize) * float64(partitions) / float64(len(vs))
-	r := report{SchemaVersion: 1, ResultKind: "offline_partition_builder_exporter_v1", Dataset: m, Source: art.Source, Config: art.Config, Metrics: art.Metrics, ArtifactPath: path, LoadWallNanos: loadWall, BuildWallNanos: wall, BuildCPUNanos: cpuNanos() - cpuStart, GraphBuildNanos: phases.GraphBuildNanos, BackendPartitionNanos: phases.BackendPartitionNanos, ValidationNanos: phases.ValidationNanos, QualityWallNanos: qualityWall, PeakRSSBytes: peakRSS(), TemporaryBytes: 0, ArtifactBytes: st.Size(), BytesPerVector: float64(st.Size()) / float64(len(vs)), Balance: bal, GraphNeighborRecall: gr, GraphNeighborSamples: min(graphRecallSamples, len(vs)), PartitionOracleRecallAt10: pr, StableHashRecallAt10: hr, Probes: probes, ArtifactSHA256: digest}
+	r := report{SchemaVersion: 1, ResultKind: "offline_partition_builder_exporter_v1", Dataset: m, Source: art.Source, Config: art.Config, Metrics: art.Metrics, ArtifactPath: path, LoadWallNanos: loadWall, BuildWallNanos: wall, BuildCPUNanos: buildCPU, GraphBuildNanos: phases.GraphBuildNanos, BackendPartitionNanos: phases.BackendPartitionNanos, ValidationNanos: phases.ValidationNanos, QualityWallNanos: qualityWall, PeakRSSBytes: peakRSS(), TemporaryBytes: 0, ArtifactBytes: st.Size(), BytesPerVector: float64(st.Size()) / float64(len(vs)), Balance: bal, GraphNeighborRecall: gr, GraphNeighborSamples: min(graphRecallSamples, len(vs)), PartitionOracleRecallAt10: pr, StableHashRecallAt10: hr, Probes: probes, ArtifactSHA256: digest}
 	rr, err := json.Marshal(r)
 	if err != nil {
 		return err
@@ -174,6 +185,7 @@ func run(args []string) error {
 	converged := false
 	for i := 0; i < 8; i++ {
 		r.TotalCommandWallNanos = time.Since(commandStart).Nanoseconds()
+		r.TotalCommandCPUNanos = cpuNanos() - commandCPUStart
 		r.ReportBytes = int64(len(rr))
 		r.FinalBytes = r.ArtifactBytes + r.ReportBytes
 		rr, err = json.Marshal(r)
@@ -225,7 +237,7 @@ func load(dir string) (manifest, []vectorpartition.Vector, [][]float64, error) {
 	if e = d.Decode(&extra); e != io.EOF {
 		return m, nil, nil, errors.New("manifest has trailing JSON")
 	}
-	if m.Version != 1 || m.Generator != "treedb_vector_synthetic_v1" || m.Docs < 1 || m.Docs > 1_000_000 || m.Dimensions < 1 || m.Dimensions > 4096 || m.Metric != "cosine" || !m.Normalized || m.FloatFormat != "float32_le_row_major" || m.DocumentIDPattern != "doc-%06d" || !safeCorpusName(m.DocumentVectorsFile) || !safeCorpusName(m.QueryVectorsFile) {
+	if m.Version != 1 || m.Generator != "treedb_vector_synthetic_v1" || m.Docs < 1 || m.Docs > 1_000_000 || m.Dimensions < 1 || m.Dimensions > 4096 || m.Queries < 1 || m.Queries > 1_000_000 || m.TopK < 1 || m.TopK > 1024 || m.GroupModulo < 1 || m.ExactTruthQueries < 0 || m.ExactTruthQueries > m.Queries || m.Metric != "cosine" || !m.Normalized || m.FloatFormat != "float32_le_row_major" || m.DocumentIDPattern != "doc-%06d" || !safeCorpusName(m.DocumentVectorsFile) || !safeCorpusName(m.QueryVectorsFile) || m.DocumentVectorsFile == m.QueryVectorsFile {
 		return m, nil, nil, errors.New("unsupported exporter manifest")
 	}
 	if m.Files == nil {
@@ -239,6 +251,9 @@ func load(dir string) (manifest, []vectorpartition.Vector, [][]float64, error) {
 	docs, e := readF32(filepath.Join(dir, m.DocumentVectorsFile), df, m.Docs, m.Dimensions)
 	if e != nil {
 		return m, nil, nil, e
+	}
+	if err := validateNormalized(docs, m.Docs, m.Dimensions); err != nil {
+		return m, nil, nil, err
 	}
 	vs := make([]vectorpartition.Vector, m.Docs)
 	for i := range vs {
@@ -255,6 +270,9 @@ func load(dir string) (manifest, []vectorpartition.Vector, [][]float64, error) {
 		if e != nil {
 			return m, nil, nil, e
 		}
+		if err := validateNormalized(q, m.Queries, m.Dimensions); err != nil {
+			return m, nil, nil, err
+		}
 		for i := 0; i < qcount; i++ {
 			row := make([]float64, m.Dimensions)
 			for j := range row {
@@ -269,8 +287,8 @@ func safeCorpusName(name string) bool {
 	return name != "" && !filepath.IsAbs(name) && filepath.Base(name) == name && !strings.Contains(name, "\\")
 }
 func readF32(path string, fi fileInfo, rows, dims int) ([]float32, error) {
-	want := int64(rows) * int64(dims) * 4
-	if want < 1 || want > maxCorpusBytes || fi.Bytes != want || len(fi.SHA256) != 64 || strings.ToLower(fi.SHA256) != fi.SHA256 {
+	want, ok := checkedByteCount(rows, dims)
+	if !ok || want > maxCorpusBytes || fi.Bytes != want || len(fi.SHA256) != 64 || strings.ToLower(fi.SHA256) != fi.SHA256 {
 		return nil, errors.New("invalid corpus file bounds")
 	}
 	f, e := os.Open(path)
@@ -292,6 +310,48 @@ func readF32(path string, fi fileInfo, rows, dims int) ([]float32, error) {
 		a[i] = math.Float32frombits(binary.LittleEndian.Uint32(b[4*i:]))
 	}
 	return a, nil
+}
+func checkedByteCount(rows, dims int) (int64, bool) {
+	if rows < 1 || dims < 1 || int64(rows) > math.MaxInt64/int64(dims) || int64(rows)*int64(dims) > math.MaxInt64/4 {
+		return 0, false
+	}
+	return int64(rows) * int64(dims) * 4, true
+}
+func validateNormalized(values []float32, rows, dims int) error {
+	if len(values) != rows*dims {
+		return errors.New("corpus shape mismatch")
+	}
+	for row := 0; row < rows; row++ {
+		var norm float64
+		for _, value := range values[row*dims : (row+1)*dims] {
+			if math.IsNaN(float64(value)) || math.IsInf(float64(value), 0) {
+				return errors.New("corpus contains non-finite vector")
+			}
+			norm = math.FMA(float64(value), float64(value), norm)
+		}
+		if math.Abs(math.Sqrt(norm)-1) > normalizedTolerance {
+			return errors.New("corpus vector is not unit-normalized")
+		}
+	}
+	return nil
+}
+func validateQualityWork(docs, queries, dims, samples int) error {
+	// graph recall scans one corpus per sample; each oracle query performs the
+	// global truth scan plus graph and hash selected-partition scans.
+	if exceedsProduct(maxQualityWork, int64(docs), int64(dims), int64(samples+3*queries)) {
+		return errors.New("quality scalar-work bound exceeded")
+	}
+	return nil
+}
+func exceedsProduct(limit int64, values ...int64) bool {
+	p := int64(1)
+	for _, value := range values {
+		if value < 0 || value != 0 && p > limit/value {
+			return true
+		}
+		p *= value
+	}
+	return p > limit
 }
 func manifestDigest(m manifest) string {
 	b, _ := json.Marshal(m)
@@ -409,41 +469,6 @@ func oracleParts(truth, assignment []int, partitions, probes int) []int {
 		return counts[order[i]] > counts[order[j]] || counts[order[i]] == counts[order[j]] && order[i] < order[j]
 	})
 	return order[:probes]
-}
-func centroids(v []vectorpartition.Vector, a []int, p int) [][]float64 {
-	o := make([][]float64, p)
-	n := make([]int, p)
-	for i, x := range v {
-		if o[a[i]] == nil {
-			o[a[i]] = make([]float64, len(x.Values))
-		}
-		for d := range x.Values {
-			o[a[i]][d] += x.Values[d]
-		}
-		n[a[i]]++
-	}
-	for i := range o {
-		for d := range o[i] {
-			o[i][d] /= float64(n[i])
-		}
-	}
-	return o
-}
-func topParts(c [][]float64, q []float64, k int) []int {
-	type x struct {
-		i int
-		d float64
-	}
-	a := make([]x, len(c))
-	for i := range c {
-		a[i] = x{i, 1 - dot(c[i], q)}
-	}
-	sort.Slice(a, func(i, j int) bool { return a[i].d < a[j].d })
-	o := make([]int, k)
-	for i := range o {
-		o[i] = a[i].i
-	}
-	return o
 }
 func recall(a, b []int) float64 {
 	s := map[int]bool{}

--- a/cmd/treedb_vector_partition_build/main.go
+++ b/cmd/treedb_vector_partition_build/main.go
@@ -321,12 +321,9 @@ func loadCorpus(dir string, m manifest) ([]vectorpartition.Vector, [][]float64, 
 	qcount := min(m.Queries, maxQueries)
 	qs := [][]float64{}
 	if qcount > 0 {
-		q, e := readF32(filepath.Join(dir, m.QueryVectorsFile), qf, m.Queries, m.Dimensions)
+		q, e := readQueryF32(filepath.Join(dir, m.QueryVectorsFile), qf, m.Queries, m.Dimensions, qcount)
 		if e != nil {
 			return nil, nil, e
-		}
-		if err := validateNormalized(q, m.Queries, m.Dimensions); err != nil {
-			return nil, nil, err
 		}
 		for i := 0; i < qcount; i++ {
 			row := make([]float64, m.Dimensions)
@@ -367,6 +364,48 @@ func readF32(path string, fi fileInfo, rows, dims int) ([]float32, error) {
 	return a, nil
 }
 
+// readQueryF32 verifies every declared query row while retaining only the
+// bounded quality prefix. Its fixed row buffer prevents query-file allocation
+// from scaling with m.Queries.
+func readQueryF32(path string, fi fileInfo, rows, dims, retainRows int) ([]float32, error) {
+	want, ok := checkedByteCount(rows, dims)
+	if !ok || want > maxCorpusBytes || fi.Bytes != want || !canonicalSHA256(fi.SHA256) || retainRows < 0 || retainRows > rows {
+		return nil, errors.New("invalid corpus file bounds")
+	}
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+	h := sha256.New()
+	r := io.TeeReader(io.LimitReader(f, want+1), h)
+	rowBytes := make([]byte, dims*4)
+	row := make([]float32, dims)
+	retained := make([]float32, retainRows*dims)
+	for i := 0; i < rows; i++ {
+		if _, err := io.ReadFull(r, rowBytes); err != nil {
+			return nil, errors.New("corpus truncated or oversized")
+		}
+		for j := range row {
+			row[j] = math.Float32frombits(binary.LittleEndian.Uint32(rowBytes[4*j:]))
+		}
+		if err := validateNormalizedRow(row); err != nil {
+			return nil, err
+		}
+		if i < retainRows {
+			copy(retained[i*dims:(i+1)*dims], row)
+		}
+	}
+	var extra [1]byte
+	if n, err := r.Read(extra[:]); err != io.EOF || n != 0 {
+		return nil, errors.New("corpus truncated or oversized")
+	}
+	if hex.EncodeToString(h.Sum(nil)) != fi.SHA256 {
+		return nil, errors.New("corpus checksum mismatch")
+	}
+	return retained, nil
+}
+
 // canonicalSHA256 accepts only the lower-case, fixed-width hex form used by
 // exporter manifests. Decode and re-encode so length/casing checks cannot
 // admit malformed non-hex metadata before corpus I/O.
@@ -386,16 +425,23 @@ func validateNormalized(values []float32, rows, dims int) error {
 		return errors.New("corpus shape mismatch")
 	}
 	for row := 0; row < rows; row++ {
-		var norm float64
-		for _, value := range values[row*dims : (row+1)*dims] {
-			if math.IsNaN(float64(value)) || math.IsInf(float64(value), 0) {
-				return errors.New("corpus contains non-finite vector")
-			}
-			norm = math.FMA(float64(value), float64(value), norm)
+		if err := validateNormalizedRow(values[row*dims : (row+1)*dims]); err != nil {
+			return err
 		}
-		if math.Abs(math.Sqrt(norm)-1) > normalizedTolerance {
-			return errors.New("corpus vector is not unit-normalized")
+	}
+	return nil
+}
+
+func validateNormalizedRow(row []float32) error {
+	var norm float64
+	for _, value := range row {
+		if math.IsNaN(float64(value)) || math.IsInf(float64(value), 0) {
+			return errors.New("corpus contains non-finite vector")
 		}
+		norm = math.FMA(float64(value), float64(value), norm)
+	}
+	if math.Abs(math.Sqrt(norm)-1) > normalizedTolerance {
+		return errors.New("corpus vector is not unit-normalized")
 	}
 	return nil
 }

--- a/cmd/treedb_vector_partition_build/main.go
+++ b/cmd/treedb_vector_partition_build/main.go
@@ -16,10 +16,8 @@ import (
 	"math"
 	"os"
 	"path/filepath"
-	"runtime"
 	"sort"
 	"strings"
-	"syscall"
 	"time"
 
 	"github.com/snissn/gomap/TreeDB/vectorpartition"
@@ -67,14 +65,17 @@ type report struct {
 	ArtifactPath              string                  `json:"artifact_path"`
 	LoadWallNanos             int64                   `json:"load_wall_nanos"`
 	BuildWallNanos            int64                   `json:"build_wall_nanos"`
-	BuildCPUNanos             int64                   `json:"build_cpu_nanos"`
+	BuildCPUNanos             *int64                  `json:"build_cpu_nanos,omitempty"`
+	BuildCPUAvailable         bool                    `json:"build_cpu_available"`
 	GraphBuildNanos           int64                   `json:"graph_build_nanos"`
 	BackendPartitionNanos     int64                   `json:"backend_partition_nanos"`
 	ValidationNanos           int64                   `json:"validation_nanos"`
 	QualityWallNanos          int64                   `json:"quality_wall_nanos"`
 	TotalCommandWallNanos     int64                   `json:"total_command_wall_nanos"`
-	TotalCommandCPUNanos      int64                   `json:"total_command_cpu_nanos"`
-	PeakRSSBytes              int64                   `json:"peak_rss_bytes"`
+	TotalCommandCPUNanos      *int64                  `json:"total_command_cpu_nanos,omitempty"`
+	TotalCommandCPUAvailable  bool                    `json:"total_command_cpu_available"`
+	PeakRSSBytes              *int64                  `json:"peak_rss_bytes,omitempty"`
+	PeakRSSAvailable          bool                    `json:"peak_rss_available"`
 	TemporaryBytes            int64                   `json:"temporary_bytes"`
 	ArtifactBytes             int64                   `json:"artifact_bytes"`
 	ReportBytes               int64                   `json:"report_bytes"`
@@ -97,7 +98,7 @@ func main() {
 }
 func run(args []string) error {
 	commandStart := time.Now()
-	commandCPUStart := cpuNanos()
+	commandCPUStart, commandCPUAvailable := cpuNanos()
 	var dataset, out string
 	var partitions, probes, reps, pivots, leaf, degree int
 	var imbalance float64
@@ -138,13 +139,17 @@ func run(args []string) error {
 		return err
 	}
 	start := time.Now()
-	cpuStart := cpuNanos()
+	cpuStart, buildCPUAvailable := cpuNanos()
 	art, phases, err := vectorpartition.BuildWithPartitionerPhased(vs, cfg, vectorpartition.Source{SourceID: "exporter_manifest:" + manifestDigest(m)}, vectorpartition.ReferencePartitioner{})
 	if err != nil {
 		return err
 	}
 	wall := time.Since(start).Nanoseconds()
-	buildCPU := cpuNanos() - cpuStart
+	var buildCPU *int64
+	if cpuEnd, ok := cpuNanos(); buildCPUAvailable && ok {
+		v := cpuEnd - cpuStart
+		buildCPU = &v
+	}
 	digest, err := vectorpartition.Digest(art)
 	if err != nil {
 		return err
@@ -174,7 +179,12 @@ func run(args []string) error {
 	}
 	cap := art.Metrics.Cap
 	bal := float64(art.Metrics.MaxPartitionSize) * float64(partitions) / float64(len(vs))
-	r := report{SchemaVersion: 1, ResultKind: "offline_partition_builder_exporter_v1", Dataset: m, Source: art.Source, Config: art.Config, Metrics: art.Metrics, ArtifactPath: path, LoadWallNanos: loadWall, BuildWallNanos: wall, BuildCPUNanos: buildCPU, GraphBuildNanos: phases.GraphBuildNanos, BackendPartitionNanos: phases.BackendPartitionNanos, ValidationNanos: phases.ValidationNanos, QualityWallNanos: qualityWall, PeakRSSBytes: peakRSS(), TemporaryBytes: 0, ArtifactBytes: st.Size(), BytesPerVector: float64(st.Size()) / float64(len(vs)), Balance: bal, GraphNeighborRecall: gr, GraphNeighborSamples: min(graphRecallSamples, len(vs)), PartitionOracleRecallAt10: pr, StableHashRecallAt10: hr, Probes: probes, ArtifactSHA256: digest}
+	peakRSSBytes, peakRSSAvailable := peakRSS()
+	var peakRSSValue *int64
+	if peakRSSAvailable {
+		peakRSSValue = &peakRSSBytes
+	}
+	r := report{SchemaVersion: 1, ResultKind: "offline_partition_builder_exporter_v1", Dataset: m, Source: art.Source, Config: art.Config, Metrics: art.Metrics, ArtifactPath: path, LoadWallNanos: loadWall, BuildWallNanos: wall, BuildCPUNanos: buildCPU, BuildCPUAvailable: buildCPU != nil, GraphBuildNanos: phases.GraphBuildNanos, BackendPartitionNanos: phases.BackendPartitionNanos, ValidationNanos: phases.ValidationNanos, QualityWallNanos: qualityWall, PeakRSSBytes: peakRSSValue, PeakRSSAvailable: peakRSSAvailable, TemporaryBytes: 0, ArtifactBytes: st.Size(), BytesPerVector: float64(st.Size()) / float64(len(vs)), Balance: bal, GraphNeighborRecall: gr, GraphNeighborSamples: min(graphRecallSamples, len(vs)), PartitionOracleRecallAt10: pr, StableHashRecallAt10: hr, Probes: probes, ArtifactSHA256: digest}
 	rr, err := json.Marshal(r)
 	if err != nil {
 		return err
@@ -185,7 +195,17 @@ func run(args []string) error {
 	converged := false
 	for i := 0; i < 8; i++ {
 		r.TotalCommandWallNanos = time.Since(commandStart).Nanoseconds()
-		r.TotalCommandCPUNanos = cpuNanos() - commandCPUStart
+		if commandCPUAvailable {
+			if cpuEnd, ok := cpuNanos(); ok {
+				v := cpuEnd - commandCPUStart
+				r.TotalCommandCPUNanos = &v
+				r.TotalCommandCPUAvailable = true
+			} else {
+				commandCPUAvailable = false
+				r.TotalCommandCPUNanos = nil
+				r.TotalCommandCPUAvailable = false
+			}
+		}
 		r.ReportBytes = int64(len(rr))
 		r.FinalBytes = r.ArtifactBytes + r.ReportBytes
 		rr, err = json.Marshal(r)
@@ -482,28 +502,6 @@ func recall(a, b []int) float64 {
 		}
 	}
 	return float64(n) / float64(len(a))
-}
-func peakRSS() int64 {
-	runtime.GC()
-	b, e := os.ReadFile("/proc/self/status")
-	if e != nil {
-		return 0
-	}
-	for _, l := range strings.Split(string(b), "\n") {
-		if strings.HasPrefix(l, "VmHWM:") {
-			var kb int64
-			fmt.Sscanf(l, "VmHWM: %d kB", &kb)
-			return kb * 1024
-		}
-	}
-	return 0
-}
-func cpuNanos() int64 {
-	var r syscall.Rusage
-	if syscall.Getrusage(syscall.RUSAGE_SELF, &r) != nil {
-		return 0
-	}
-	return (r.Utime.Sec+r.Stime.Sec)*1e9 + (r.Utime.Usec+r.Stime.Usec)*1e3
 }
 func min(a, b int) int {
 	if a < b {

--- a/cmd/treedb_vector_partition_build/main_test.go
+++ b/cmd/treedb_vector_partition_build/main_test.go
@@ -1,6 +1,12 @@
 package main
 
-import "testing"
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
 
 func TestOraclePartsUsesTruthMembershipNotCentroids(t *testing.T) {
 	// A centroid route could prefer partition 0 for a query near its mean. The
@@ -9,5 +15,69 @@ func TestOraclePartsUsesTruthMembershipNotCentroids(t *testing.T) {
 	got := oracleParts([]int{0, 1, 2}, assignment, 2, 1)
 	if len(got) != 1 || got[0] != 1 {
 		t.Fatalf("oracle=%v want truth partition 1", got)
+	}
+}
+func TestCorpusPathAndChecksumGuards(t *testing.T) {
+	for _, p := range []string{"../x", "/tmp/x", "a/b", "a\\b", ""} {
+		if safeCorpusName(p) {
+			t.Fatalf("unsafe path accepted %q", p)
+		}
+	}
+	if !safeCorpusName("documents.f32") {
+		t.Fatal("safe name rejected")
+	}
+	if _, err := readF32("missing", fileInfo{Bytes: 4, SHA256: strings.Repeat("A", 64)}, 1, 1); err == nil {
+		t.Fatal("uppercase checksum accepted")
+	}
+}
+
+func TestLoadFailsClosedOnMalformedManifestAndCorpusMetadata(t *testing.T) {
+	base := manifest{Version: 1, Generator: "treedb_vector_synthetic_v1", Docs: 1, Dimensions: 1, Queries: 0, Metric: "cosine", Normalized: true, DocumentIDPattern: "doc-%06d", DocumentVectorsFile: "documents.f32", QueryVectorsFile: "queries.f32", FloatFormat: "float32_le_row_major", Files: map[string]fileInfo{"documents.f32": {Bytes: 4, SHA256: strings.Repeat("0", 64)}, "queries.f32": {Bytes: 4, SHA256: strings.Repeat("0", 64)}}}
+	write := func(t *testing.T, m manifest, suffix string) string {
+		t.Helper()
+		dir := t.TempDir()
+		raw, err := json.Marshal(m)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(dir, "manifest.json"), append(raw, suffix...), 0600); err != nil {
+			t.Fatal(err)
+		}
+		return dir
+	}
+	if _, _, _, err := load(write(t, base, " {}")); err == nil {
+		t.Fatal("trailing manifest JSON accepted")
+	}
+	badPath := base
+	badPath.DocumentVectorsFile = "../documents.f32"
+	if _, _, _, err := load(write(t, badPath, "")); err == nil {
+		t.Fatal("path traversal accepted")
+	}
+	notNormalized := base
+	notNormalized.Normalized = false
+	if _, _, _, err := load(write(t, notNormalized, "")); err == nil {
+		t.Fatal("unnormalized corpus accepted")
+	}
+	missing := base
+	missing.Files = map[string]fileInfo{}
+	if _, _, _, err := load(write(t, missing, "")); err == nil {
+		t.Fatal("missing corpus metadata accepted")
+	}
+	truncated := write(t, base, "")
+	if err := os.WriteFile(filepath.Join(truncated, "documents.f32"), []byte{0, 0}, 0600); err != nil {
+		t.Fatal(err)
+	}
+	if _, _, _, err := load(truncated); err == nil {
+		t.Fatal("truncated corpus accepted")
+	}
+}
+
+func TestLoadRejectsOversizedManifestBeforeDecode(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "manifest.json"), []byte(strings.Repeat("x", maxManifest+1)), 0600); err != nil {
+		t.Fatal(err)
+	}
+	if _, _, _, err := load(dir); err == nil {
+		t.Fatal("oversized manifest accepted")
 	}
 }

--- a/cmd/treedb_vector_partition_build/main_test.go
+++ b/cmd/treedb_vector_partition_build/main_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"encoding/json"
+	"math"
 	"os"
 	"path/filepath"
 	"strings"
@@ -32,7 +33,7 @@ func TestCorpusPathAndChecksumGuards(t *testing.T) {
 }
 
 func TestLoadFailsClosedOnMalformedManifestAndCorpusMetadata(t *testing.T) {
-	base := manifest{Version: 1, Generator: "treedb_vector_synthetic_v1", Docs: 1, Dimensions: 1, Queries: 0, Metric: "cosine", Normalized: true, DocumentIDPattern: "doc-%06d", DocumentVectorsFile: "documents.f32", QueryVectorsFile: "queries.f32", FloatFormat: "float32_le_row_major", Files: map[string]fileInfo{"documents.f32": {Bytes: 4, SHA256: strings.Repeat("0", 64)}, "queries.f32": {Bytes: 4, SHA256: strings.Repeat("0", 64)}}}
+	base := manifest{Version: 1, Generator: "treedb_vector_synthetic_v1", Docs: 1, Dimensions: 1, Queries: 1, TopK: 10, GroupModulo: 1, Metric: "cosine", Normalized: true, DocumentIDPattern: "doc-%06d", DocumentVectorsFile: "documents.f32", QueryVectorsFile: "queries.f32", FloatFormat: "float32_le_row_major", Files: map[string]fileInfo{"documents.f32": {Bytes: 4, SHA256: strings.Repeat("0", 64)}, "queries.f32": {Bytes: 4, SHA256: strings.Repeat("0", 64)}}}
 	write := func(t *testing.T, m manifest, suffix string) string {
 		t.Helper()
 		dir := t.TempDir()
@@ -63,12 +64,40 @@ func TestLoadFailsClosedOnMalformedManifestAndCorpusMetadata(t *testing.T) {
 	if _, _, _, err := load(write(t, missing, "")); err == nil {
 		t.Fatal("missing corpus metadata accepted")
 	}
+	duplicate := base
+	duplicate.QueryVectorsFile = duplicate.DocumentVectorsFile
+	if _, _, _, err := load(write(t, duplicate, "")); err == nil {
+		t.Fatal("shared document/query corpus accepted")
+	}
+	badQueries := base
+	badQueries.Queries = 0
+	if _, _, _, err := load(write(t, badQueries, "")); err == nil {
+		t.Fatal("zero query count accepted")
+	}
 	truncated := write(t, base, "")
 	if err := os.WriteFile(filepath.Join(truncated, "documents.f32"), []byte{0, 0}, 0600); err != nil {
 		t.Fatal(err)
 	}
 	if _, _, _, err := load(truncated); err == nil {
 		t.Fatal("truncated corpus accepted")
+	}
+}
+
+func TestCorpusNormalizationAndOverflowGuards(t *testing.T) {
+	if err := validateNormalized([]float32{2}, 1, 1); err == nil {
+		t.Fatal("non-unit vector accepted")
+	}
+	if err := validateNormalized([]float32{float32(math.NaN())}, 1, 1); err == nil {
+		t.Fatal("non-finite vector accepted")
+	}
+	if err := validateNormalized([]float32{1}, 1, 1); err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := checkedByteCount(math.MaxInt, 2); ok {
+		t.Fatal("overflowing corpus byte count accepted")
+	}
+	if err := validateQualityWork(1_000_000, maxQueries, 4096, 64); err == nil {
+		t.Fatal("unbounded quality work accepted")
 	}
 }
 

--- a/cmd/treedb_vector_partition_build/main_test.go
+++ b/cmd/treedb_vector_partition_build/main_test.go
@@ -1,7 +1,9 @@
 package main
 
 import (
+	"crypto/sha256"
 	"encoding/json"
+	"fmt"
 	"math"
 	"os"
 	"path/filepath"
@@ -129,5 +131,65 @@ func TestReportMarksUnavailableAccountingWithoutMeasuredZero(t *testing.T) {
 		if got, ok := fields[name].(bool); !ok || got {
 			t.Fatalf("unavailable accounting not explicit for %s: %s", name, raw)
 		}
+	}
+}
+
+func TestOracleQualityGateAllowsFullProbeParityOnly(t *testing.T) {
+	for _, tc := range []struct {
+		name               string
+		oracle, stableHash float64
+		probes, partitions int
+		want               bool
+	}{
+		{name: "one partition parity", oracle: 1, stableHash: 1, probes: 1, partitions: 1, want: true},
+		{name: "full probe parity", oracle: 1, stableHash: 1, probes: 4, partitions: 4, want: true},
+		{name: "partial probe equality rejected", oracle: .8, stableHash: .8, probes: 1, partitions: 4, want: false},
+		{name: "partial probe improvement accepted", oracle: .9, stableHash: .8, probes: 1, partitions: 4, want: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := passesOracleQualityGate(tc.oracle, tc.stableHash, tc.probes, tc.partitions); got != tc.want {
+				t.Fatalf("passesOracleQualityGate(%v, %v, %d, %d)=%v want %v", tc.oracle, tc.stableHash, tc.probes, tc.partitions, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestSingleDocumentBuildWritesFiniteReport(t *testing.T) {
+	dataset, out := t.TempDir(), t.TempDir()
+	unit := []byte{0, 0, 128, 63}
+	digest := sha256.Sum256(unit)
+	for _, name := range []string{"documents.f32", "queries.f32"} {
+		if err := os.WriteFile(filepath.Join(dataset, name), unit, 0600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	m := manifest{Version: 1, Generator: "treedb_vector_synthetic_v1", Docs: 1, Dimensions: 1, Queries: 1, TopK: 1, GroupModulo: 1, Metric: "cosine", Normalized: true, DocumentIDPattern: "doc-%06d", DocumentVectorsFile: "documents.f32", QueryVectorsFile: "queries.f32", FloatFormat: "float32_le_row_major", Files: map[string]fileInfo{"documents.f32": {Bytes: 4, SHA256: fmt.Sprintf("%x", digest)}, "queries.f32": {Bytes: 4, SHA256: fmt.Sprintf("%x", digest)}}}
+	raw, err := json.Marshal(m)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dataset, "manifest.json"), raw, 0600); err != nil {
+		t.Fatal(err)
+	}
+	if err := run([]string{"-dataset", dataset, "-out", out, "-partitions", "1", "-probes", "1", "-repetitions", "1", "-pivots", "2", "-max-leaf-bucket", "2", "-degree", "1"}); err != nil {
+		t.Fatal(err)
+	}
+	reports, err := filepath.Glob(filepath.Join(out, "vector_partition_report_*.json"))
+	if err != nil || len(reports) != 1 {
+		t.Fatalf("reports=%v err=%v", reports, err)
+	}
+	reportRaw, err := os.ReadFile(reports[0])
+	if err != nil {
+		t.Fatal(err)
+	}
+	var got report
+	if err := json.Unmarshal(reportRaw, &got); err != nil {
+		t.Fatal(err)
+	}
+	if got.GraphNeighborRecall != 0 || math.IsNaN(got.GraphNeighborRecall) || math.IsInf(got.GraphNeighborRecall, 0) {
+		t.Fatalf("single-document graph recall=%v", got.GraphNeighborRecall)
+	}
+	if _, err := os.Stat(got.ArtifactPath); err != nil {
+		t.Fatalf("artifact was not retained with report: %v", err)
 	}
 }

--- a/cmd/treedb_vector_partition_build/main_test.go
+++ b/cmd/treedb_vector_partition_build/main_test.go
@@ -216,6 +216,7 @@ func TestRunPreflightsManifestShapeAndConfigBeforeCorpusIO(t *testing.T) {
 		want string
 	}{
 		{name: "over-cap shape", docs: 1_000_000, dims: 4096, want: "configured graph scalar-work bound exceeded before allocation"},
+		{name: "pivot work before missing corpus", docs: 310_000, dims: 64, args: []string{"-partitions", "1", "-probes", "1", "-repetitions", "1", "-pivots", "1024", "-max-leaf-bucket", "2", "-degree", "1"}, want: "configured graph scalar-work bound exceeded before allocation"},
 		{name: "invalid requested config", docs: 1, dims: 1, args: []string{"-partitions", "1", "-probes", "1", "-repetitions", "33"}, want: "invalid vector partition configuration"},
 	} {
 		t.Run(tc.name, func(t *testing.T) {

--- a/cmd/treedb_vector_partition_build/main_test.go
+++ b/cmd/treedb_vector_partition_build/main_test.go
@@ -1,0 +1,13 @@
+package main
+
+import "testing"
+
+func TestOraclePartsUsesTruthMembershipNotCentroids(t *testing.T) {
+	// A centroid route could prefer partition 0 for a query near its mean. The
+	// oracle must instead choose the partition containing the exact truth IDs.
+	assignment := []int{1, 1, 0, 0}
+	got := oracleParts([]int{0, 1, 2}, assignment, 2, 1)
+	if len(got) != 1 || got[0] != 1 {
+		t.Fatalf("oracle=%v want truth partition 1", got)
+	}
+}

--- a/cmd/treedb_vector_partition_build/main_test.go
+++ b/cmd/treedb_vector_partition_build/main_test.go
@@ -193,3 +193,39 @@ func TestSingleDocumentBuildWritesFiniteReport(t *testing.T) {
 		t.Fatalf("artifact was not retained with report: %v", err)
 	}
 }
+
+func TestRunPreflightsManifestShapeAndConfigBeforeCorpusIO(t *testing.T) {
+	writeManifestOnly := func(t *testing.T, docs, dimensions int) string {
+		t.Helper()
+		dataset := t.TempDir()
+		m := manifest{Version: 1, Generator: "treedb_vector_synthetic_v1", Docs: docs, Dimensions: dimensions, Queries: 1, TopK: 1, GroupModulo: 1, Metric: "cosine", Normalized: true, DocumentIDPattern: "doc-%06d", DocumentVectorsFile: "missing-documents.f32", QueryVectorsFile: "missing-queries.f32", FloatFormat: "float32_le_row_major", Files: map[string]fileInfo{"missing-documents.f32": {Bytes: 4, SHA256: strings.Repeat("0", 64)}, "missing-queries.f32": {Bytes: 4, SHA256: strings.Repeat("0", 64)}}}
+		raw, err := json.Marshal(m)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(dataset, "manifest.json"), raw, 0600); err != nil {
+			t.Fatal(err)
+		}
+		return dataset
+	}
+	for _, tc := range []struct {
+		name string
+		docs int
+		dims int
+		args []string
+		want string
+	}{
+		{name: "over-cap shape", docs: 1_000_000, dims: 4096, want: "configured graph scalar-work bound exceeded before allocation"},
+		{name: "invalid requested config", docs: 1, dims: 1, args: []string{"-partitions", "1", "-probes", "1", "-repetitions", "33"}, want: "invalid vector partition configuration"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			dataset := writeManifestOnly(t, tc.docs, tc.dims)
+			args := []string{"-dataset", dataset, "-out", t.TempDir()}
+			args = append(args, tc.args...)
+			err := run(args)
+			if err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("run error=%v want %q before missing corpus I/O", err, tc.want)
+			}
+		})
+	}
+}

--- a/cmd/treedb_vector_partition_build/main_test.go
+++ b/cmd/treedb_vector_partition_build/main_test.go
@@ -217,6 +217,8 @@ func TestRunPreflightsManifestShapeAndConfigBeforeCorpusIO(t *testing.T) {
 	}{
 		{name: "over-cap shape", docs: 1_000_000, dims: 4096, want: "configured graph scalar-work bound exceeded before allocation"},
 		{name: "pivot work before missing corpus", docs: 310_000, dims: 64, args: []string{"-partitions", "1", "-probes", "1", "-repetitions", "1", "-pivots", "1024", "-max-leaf-bucket", "2", "-degree", "1"}, want: "configured graph scalar-work bound exceeded before allocation"},
+		{name: "reference partition work before missing corpus", docs: 1_000_000, dims: 1, args: []string{"-partitions", "238", "-probes", "1", "-repetitions", "1", "-pivots", "2", "-max-leaf-bucket", "2", "-degree", "1"}, want: "partition work bound exceeded before allocation"},
+		{name: "top-level overlap before missing corpus", docs: 300_000, dims: 1, args: []string{"-partitions", "1", "-probes", "1", "-repetitions", "1", "-pivots", "2", "-max-leaf-bucket", "65536", "-degree", "1"}, want: "configured graph scalar-work bound exceeded before allocation"},
 		{name: "invalid requested config", docs: 1, dims: 1, args: []string{"-partitions", "1", "-probes", "1", "-repetitions", "33"}, want: "invalid vector partition configuration"},
 	} {
 		t.Run(tc.name, func(t *testing.T) {

--- a/cmd/treedb_vector_partition_build/main_test.go
+++ b/cmd/treedb_vector_partition_build/main_test.go
@@ -110,3 +110,24 @@ func TestLoadRejectsOversizedManifestBeforeDecode(t *testing.T) {
 		t.Fatal("oversized manifest accepted")
 	}
 }
+
+func TestReportMarksUnavailableAccountingWithoutMeasuredZero(t *testing.T) {
+	raw, err := json.Marshal(report{BuildCPUAvailable: false, TotalCommandCPUAvailable: false, PeakRSSAvailable: false})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var fields map[string]any
+	if err := json.Unmarshal(raw, &fields); err != nil {
+		t.Fatal(err)
+	}
+	for _, name := range []string{"build_cpu_nanos", "total_command_cpu_nanos", "peak_rss_bytes"} {
+		if _, ok := fields[name]; ok {
+			t.Fatalf("unavailable accounting emitted fabricated %s: %s", name, raw)
+		}
+	}
+	for _, name := range []string{"build_cpu_available", "total_command_cpu_available", "peak_rss_available"} {
+		if got, ok := fields[name].(bool); !ok || got {
+			t.Fatalf("unavailable accounting not explicit for %s: %s", name, raw)
+		}
+	}
+}

--- a/cmd/treedb_vector_partition_build/main_test.go
+++ b/cmd/treedb_vector_partition_build/main_test.go
@@ -209,20 +209,44 @@ func TestRunPreflightsManifestShapeAndConfigBeforeCorpusIO(t *testing.T) {
 		return dataset
 	}
 	for _, tc := range []struct {
-		name string
-		docs int
-		dims int
-		args []string
-		want string
+		name        string
+		docs        int
+		dims        int
+		args        []string
+		documentSHA string
+		want        string
 	}{
 		{name: "over-cap shape", docs: 1_000_000, dims: 4096, want: "configured graph scalar-work bound exceeded before allocation"},
 		{name: "pivot work before missing corpus", docs: 310_000, dims: 64, args: []string{"-partitions", "1", "-probes", "1", "-repetitions", "1", "-pivots", "1024", "-max-leaf-bucket", "2", "-degree", "1"}, want: "configured graph scalar-work bound exceeded before allocation"},
 		{name: "reference partition work before missing corpus", docs: 1_000_000, dims: 1, args: []string{"-partitions", "238", "-probes", "1", "-repetitions", "1", "-pivots", "2", "-max-leaf-bucket", "2", "-degree", "1"}, want: "partition work bound exceeded before allocation"},
 		{name: "top-level overlap before missing corpus", docs: 300_000, dims: 1, args: []string{"-partitions", "1", "-probes", "1", "-repetitions", "1", "-pivots", "2", "-max-leaf-bucket", "65536", "-degree", "1"}, want: "configured graph scalar-work bound exceeded before allocation"},
+		{name: "non-hex checksum before missing corpus", docs: 1, dims: 1, documentSHA: strings.Repeat("z", 64), want: "invalid corpus checksum"},
+		{name: "uppercase checksum before missing corpus", docs: 1, dims: 1, documentSHA: strings.Repeat("A", 64), want: "invalid corpus checksum"},
 		{name: "invalid requested config", docs: 1, dims: 1, args: []string{"-partitions", "1", "-probes", "1", "-repetitions", "33"}, want: "invalid vector partition configuration"},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			dataset := writeManifestOnly(t, tc.docs, tc.dims)
+			if tc.documentSHA != "" {
+				path := filepath.Join(dataset, "manifest.json")
+				raw, err := os.ReadFile(path)
+				if err != nil {
+					t.Fatal(err)
+				}
+				var m manifest
+				if err := json.Unmarshal(raw, &m); err != nil {
+					t.Fatal(err)
+				}
+				fi := m.Files[m.DocumentVectorsFile]
+				fi.SHA256 = tc.documentSHA
+				m.Files[m.DocumentVectorsFile] = fi
+				raw, err = json.Marshal(m)
+				if err != nil {
+					t.Fatal(err)
+				}
+				if err := os.WriteFile(path, raw, 0600); err != nil {
+					t.Fatal(err)
+				}
+			}
 			args := []string{"-dataset", dataset, "-out", t.TempDir()}
 			args = append(args, tc.args...)
 			err := run(args)

--- a/cmd/treedb_vector_partition_build/main_test.go
+++ b/cmd/treedb_vector_partition_build/main_test.go
@@ -21,7 +21,9 @@ func TestOraclePartsUsesTruthMembershipNotCentroids(t *testing.T) {
 	}
 }
 func TestCorpusPathAndChecksumGuards(t *testing.T) {
-	for _, p := range []string{"../x", "/tmp/x", "a/b", "a\\b", ""} {
+	// Dot names alias the dataset directory/current parent rather than a corpus
+	// file; reject them alongside traversal and separator forms before joining.
+	for _, p := range []string{".", "..", "../x", "/tmp/x", "a/b", "a\\b", ""} {
 		if safeCorpusName(p) {
 			t.Fatalf("unsafe path accepted %q", p)
 		}

--- a/cmd/treedb_vector_partition_build/main_test.go
+++ b/cmd/treedb_vector_partition_build/main_test.go
@@ -1,15 +1,34 @@
 package main
 
 import (
+	"bytes"
 	"crypto/sha256"
+	"encoding/binary"
 	"encoding/json"
 	"fmt"
 	"math"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 )
+
+func writeQueryCorpus(t *testing.T, payload []byte) (string, fileInfo) {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "queries.f32")
+	if err := os.WriteFile(path, payload, 0600); err != nil {
+		t.Fatal(err)
+	}
+	digest := sha256.Sum256(payload)
+	return path, fileInfo{Bytes: int64(len(payload)), SHA256: fmt.Sprintf("%x", digest)}
+}
+
+func unitQueryPayload(rows int) []byte {
+	row := make([]byte, 4)
+	binary.LittleEndian.PutUint32(row, math.Float32bits(1))
+	return bytes.Repeat(row, rows)
+}
 
 func TestOraclePartsUsesTruthMembershipNotCentroids(t *testing.T) {
 	// A centroid route could prefer partition 0 for a query near its mean. The
@@ -103,6 +122,70 @@ func TestCorpusNormalizationAndOverflowGuards(t *testing.T) {
 	if err := validateQualityWork(1_000_000, maxQueries, 4096, 64); err == nil {
 		t.Fatal("unbounded quality work accepted")
 	}
+}
+
+func TestReadQueryF32StreamsAndValidatesUnusedTail(t *testing.T) {
+	rows := maxQueries + 2
+	payload := unitQueryPayload(rows)
+	path, fi := writeQueryCorpus(t, payload)
+	got, err := readQueryF32(path, fi, rows, 1, maxQueries)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != maxQueries || got[0] != 1 || got[len(got)-1] != 1 {
+		t.Fatalf("retained query prefix=%v", got)
+	}
+	for _, tc := range []struct {
+		name   string
+		mutate func([]byte)
+		want   string
+	}{
+		{name: "non-finite tail", mutate: func(b []byte) { binary.LittleEndian.PutUint32(b[(rows-1)*4:], math.Float32bits(float32(math.NaN()))) }, want: "corpus contains non-finite vector"},
+		{name: "non-normalized tail", mutate: func(b []byte) { binary.LittleEndian.PutUint32(b[(rows-1)*4:], math.Float32bits(2)) }, want: "corpus vector is not unit-normalized"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			bad := append([]byte(nil), payload...)
+			tc.mutate(bad)
+			badPath, badFI := writeQueryCorpus(t, bad)
+			if _, err := readQueryF32(badPath, badFI, rows, 1, maxQueries); err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("unused tail corruption error=%v want %q", err, tc.want)
+			}
+		})
+	}
+	truncatedPath, _ := writeQueryCorpus(t, payload[:len(payload)-1])
+	if _, err := readQueryF32(truncatedPath, fi, rows, 1, maxQueries); err == nil || !strings.Contains(err.Error(), "truncated or oversized") {
+		t.Fatalf("truncated query corpus error=%v", err)
+	}
+	trailingPath, _ := writeQueryCorpus(t, append(append([]byte(nil), payload...), 0))
+	if _, err := readQueryF32(trailingPath, fi, rows, 1, maxQueries); err == nil || !strings.Contains(err.Error(), "truncated or oversized") {
+		t.Fatalf("trailing query corpus error=%v", err)
+	}
+	badChecksum := fi
+	badChecksum.SHA256 = strings.Repeat("0", sha256.Size*2)
+	if _, err := readQueryF32(path, badChecksum, rows, 1, maxQueries); err == nil || !strings.Contains(err.Error(), "checksum mismatch") {
+		t.Fatalf("checksum mismatch error=%v", err)
+	}
+}
+
+func TestReadQueryF32RetainedMemoryIsIndependentOfDeclaredRows(t *testing.T) {
+	const rows = 262_144 // 1 MiB on disk; eager decoding allocated per row.
+	payload := unitQueryPayload(rows)
+	path, fi := writeQueryCorpus(t, payload)
+	runtime.GC()
+	var before, after runtime.MemStats
+	runtime.ReadMemStats(&before)
+	got, err := readQueryF32(path, fi, rows, 1, maxQueries)
+	runtime.ReadMemStats(&after)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != maxQueries {
+		t.Fatalf("retained queries=%d want %d", len(got), maxQueries)
+	}
+	if allocated := after.TotalAlloc - before.TotalAlloc; allocated > 256<<10 {
+		t.Fatalf("query validation allocated %d bytes; must not scale with %d declared rows", allocated, rows)
+	}
+	runtime.KeepAlive(got)
 }
 
 func TestLoadRejectsOversizedManifestBeforeDecode(t *testing.T) {


### PR DESCRIPTION
## Objective

Implement the bounded deterministic offline M2 vector graph and balanced-partition artifact builder required by #3908.

Closes #3911.

## Context

M0 froze the cross-layer contract in #3918. M2 supplies the clean-room rough graph, backend-neutral balanced assignment seam, strict artifact validation, and reproducible resource/quality evidence needed independently by M3 #3912 and M4 #3913.

## Non-goals

- No TreeDB serving path, collection mutation, Raft integration, placement, router, RPC, overlap, HNSW partition asset, or catalog cutover.
- No runtime FFI or selected third-party partitioner.
- No claim that offline resource and quality evidence is production query performance.

## Design

- Canonically sort unique stable vector IDs and build the seeded bounded projection-tree rough graph.
- v1 emits and accepts only the directed policy with symmetric=false.
- Partition through the deterministic repository-owned greedy reference backend under ceil((1+imbalance)*vectors/partitions), exact coverage, stable ordering, and a conservative work cap.
- Independently validate source binding, graph ordinals/degree/self/duplicates, assignment, capacity, metrics, canonical JSON, and digest.
- Bound vectors, edges, repetitions, dimensions, work, partitions, external output, and allocations before use.
- Isolate non-reference in-process backends with a bounded deep graph clone.
- Run optional external backends in a private temporary directory with context cancellation, bounded output, and scoped Unix process-group cleanup.
- Report Unix CPU and Linux VmHWM RSS only when available; unsupported values are omitted with availability=false.
- Allow quality equality only when probes cover every partition; partial-probe evidence must strictly improve over stable hash.

## Scope

- Includes TreeDB/internal/vectorpartition, TreeDB/vectorpartition, cmd/treedb_vector_partition_build, the partition stage in cmd/treedb_vector_partition_bench, M2 specs, tests, and compact evidence.
- Excludes TreeDB collections/DB/Raft/search runtime and all M3-M8 implementation.

## Correctness

Exact final-head validation:

- GOWORK=off go test ./TreeDB/internal/vectorpartition ./TreeDB/vectorpartition ./cmd/treedb_vector_partition_build ./cmd/treedb_vector_partition_bench -count=1
- GOWORK=off go test -race ./TreeDB/internal/vectorpartition ./cmd/treedb_vector_partition_build ./cmd/treedb_vector_partition_bench -count=1
- GOWORK=off go vet ./TreeDB/internal/vectorpartition ./TreeDB/vectorpartition ./cmd/treedb_vector_partition_build ./cmd/treedb_vector_partition_bench
- GOOS=windows GOARCH=amd64 CGO_ENABLED=0 GOWORK=off go test -c for all four scoped packages/commands.
- CGO_ENABLED=0 builder cross-compiles for aix/ppc64, darwin/amd64, darwin/arm64, dragonfly/amd64, freebsd/amd64, illumos/amd64, linux/amd64, netbsd/amd64, openbsd/amd64, and solaris/amd64.
- gofmt and git diff --check are clean.

Regressions cover deterministic ties/duplicates, empty/over-cap input, work boundaries, strict decode corruption, reciprocal symmetric rejection, external timeout/output/process cleanup, zombie handling, graph mutation isolation, backend error/malformed assignment, OS accounting, repetition-aware edge capacity, full-probe parity, partial-probe strictness, one-document finite reporting, and provenance filename bounds.

## Performance

The durable ledger is TreeDB/docs/spec/artifacts/vector-partition-m2-evidence-v1.json; exact reproduction commands and claim boundaries are in TreeDB/docs/spec/vector-partition-m2.md.

| Corpus | Build / total wall | Peak RSS | Artifact B/vector | Partition oracle / stable hash recall@10 |
| --- | ---: | ---: | ---: | ---: |
| 10k x 64 | 3.400s / 3.524s | 34.5 MB | 95.59 | 0.863 / 0.413 |
| 100k x 16 | 4.184s / 4.693s | 102.9 MB | 64.62 | 1.000 / 0.588 |
| 1M x 16 | 20.667s / 23.977s | 1.245 GB | 44.67 | 1.000 / 0.700 |

These exporter runs remain bound to implementation commit 58db38e173093126e5b1ef3c92d79e160d63b0cf after normally merging origin/main 3e225cb99. Later correctness fixes do not claim refreshed scale measurements. Retained artifact hashes are c270226154a4e741..., 627778e026d17732..., and f76fba39db8a51fb....

The conservative 250M work cap accepts the 1M degree-zero 237-part boundary at 249,000,716 units and rejects 238 parts at 250,000,719. The partition-stage 10k regression digest changed only because its config now preserves the correct default 64M r4/d16 edge budget; graph metrics are unchanged.

## Rollout / Toggle Plan

- Default: offline and opt-in; no TreeDB runtime path invokes M2.
- Disable: do not run the partition commands or configure an external backend.
- On-disk/API disclosure: new pre-alpha offline artifact/report formats; no migration scaffold.

## Follow-ups

- #3912 consumes the disjoint artifact for bounded overlap and partition-local HNSW assets.
- #3913 consumes it for the multi-representative router.
- Backend selection remains a separately evidenced decision.

## Column Graph Native Workstream (#1646, if applicable)

### Copied/Adapted From Old Stack

- Copied: none.
- Adapted: existing repository vector fixture/export and bounded command patterns only.
- Oracle/comparator only: stable-hash and exact partition-oracle baselines.
- Quarantined/not copied: unlicensed gp-ann code and all runtime serving integration.

### Path Identity

- Native reader: not applicable; this is an offline artifact builder.
- Decoded comparator: strict canonical artifact decode/validate.
- Legacy/native vector index: no runtime vector-index path changed.
- Unsupported/fail-closed: symmetric policy, malformed identity/graph/assignment, over-cap work/output, and non-finite input.

### Base And Dependency State

- Base branch: main.
- Base commit: current origin/main dc383529612a5a81be8d499bfcd7b09f1b7873e5 was merged normally.
- Base PR/head: #3920 at integration time.
- M0 dependency: #3909 merged through PR #3918.
- Current head: 51d88e65197aca94b25ad65375ef460bec2b0ec1 (with origin/main dc383529612a5a81be8d499bfcd7b09f1b7873e5 retained as ancestor).
- #1621/#1634 assumptions and missing column-store primitives: not applicable.
- Parent review fixes propagated: all current M0 vocabulary/identity boundaries retained.

### Evidence

- Tests: targeted packages, race, vet, Windows, ten-family Unix cross-compile, formatting, and review regressions.
- Benchmarks: deterministic 10k/100k/1M exporter builds plus partition work boundaries.
- Status/fallback proof: offline adapter failure and cleanup outcomes only; no runtime status claim.
- Performance attribution: graph construction, assignment, validation, and offline quality oracle only.
- Local regressions found/fixed: work-accounting/bucket allocation, backend isolation, platform accounting, edge clamp, full-probe parity, and finite degenerate recall.

### Test Plan Start

- Milestone tasks targeted: deterministic graph/assignment, strict artifact/source identity, backend seam, resource caps, and scale quality evidence.
- Tests planned: canonical fixtures, malformed decode, cap boundaries, external failure cleanup, and reproducibility.
- Existing tests preserved: M0 fixture/oracle and benchmark artifact contracts.
- #1646 test-list changes: not applicable.

### Performance Plan Start

- Metrics: build wall/CPU, phase time, RSS, temp/final bytes, bytes/vector, balance/cut, graph recall, partition-oracle and stable-hash recall.
- Baseline: stable hash at identical probe budget; exact global truth for the partition oracle.
- Boundary: offline builder and quality work only.
- Excluded: TreeDB server, Raft/RPC, overlap, router, local HNSW, document fetch.

### Test Plan Close

- Review-added cases: strict symmetric rejection, bounded stdout/stderr, partition-stage-only validation, zombie-aware cleanup, backend graph isolation, exact-capacity buckets, OS accounting, repetition-aware edges, full-probe parity, one-document finite report, provenance suffix, corpus-I-O preflight, and direct vector-count preflight, UTF-8 identity rejection, pivot-work preflight, reference partition-work preflight, and top-level overlap work, strict manifest SHA preflight, and independent external request/response caps, and direct Build shape-before-content preflight, canonical UTF-8 identity validation, and escaped external request-cap accounting, and query-free partition-only fixture generation, exact external request-artifact binding, vector-only partition fixture-cap boundaries, executable external process/deadline cleanup coverage, and canonical empty graph-row encoding, strict corpus dot-name rejection, specific vector-ID failure diagnostics, bounded streaming validation of declared query tails, and symmetric-policy config preflight.
- All actionable Codex/CodeRabbit threads on predecessor heads have fix/test evidence.
- Residual gap: none; exact-head local validation, independent audit, GitHub CI, Codex, and CodeRabbit are complete.

### Performance Plan Close

- Exact reproduction commands and hashes are committed in the spec/ledger.
- Absolute scale evidence is reported because this is a new M2 format.
- The failed lower-budget 100k shape remains disclosed rather than substituted.
- Later correctness fixes do not relabel old scale numbers as final-head measurements.

### AI Review Loop

- Independent review rejected 4840e7f2; its follow-up findings were corrected on 25efbecf, 6e972b23, 0affe76fe, 68962f4f, c50d9c4b, 767d140f, and 2208cb35d, 6dc99d130, and 747ab1427 and 1c442faec and 8a140222c and f186cad34 and d84f56895 and 89725494 and 085cc3203 and 8b797758 and e695118f and 2faf6a33 and 51d88e65.
- Exact-head independent audit accepted 51d88e65197aca94b25ad65375ef460bec2b0ec1 and authorized resolution of all five deliberate review threads.
- Exact-head Codex completed clean: https://github.com/snissn/gomap/pull/3922#issuecomment-5021947519.
- Exact-head CodeRabbit completed clean, all review threads are resolved, and every required GitHub Actions job is green.

---

## Optimization PR Checklist (TreeDB)

### Scope
- [x] Single objective and explicit include/exclude boundaries.
- [x] No runtime feature reintroduction.

### Safety / Correctness
- [x] Caps precede count-derived allocations.
- [x] Strict formats/checksums/digests fail closed.
- [x] Concurrency/process cleanup boundary is explicit.

### Tests
- [x] Deterministic regressions cover review-found failures.
- [x] Targeted tests, race, vet, Windows, Unix matrix, formatting, and diff checks pass.
- [x] Repository-wide and platform-sharded coverage passed in latest-head CI.

### Benchmarks / Measurements
- [x] Relevant scale/quality/resource evidence is committed.
- [x] Evidence scope and non-production attribution are explicit.

### Docs
- [x] New pre-alpha formats/config/bounds are documented.
- [x] No migration compatibility is promised.

### Rollout / Toggle Plan
- [x] Offline behavior is disabled by default at runtime.
- [x] Disable path and observability limits are explicit.

### Final gates
- [x] Latest-head GitHub CI complete.
- [x] Mature latest-head AI review complete.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added offline vector partitioning to build deterministic, validated graph artifacts.
  * Added a public vector-partitioning API for building, validating, encoding, decoding, and digesting artifacts.
  * Added a partition stage to the benchmark command with configurable graph and partition settings.
  * Added a standalone builder that produces artifacts, reports, provenance hashes, and recall metrics.

* **Bug Fixes**
  * Improved external process cleanup during cancellation, timeout, and failure scenarios.
  * Added platform-aware CPU and memory reporting when measurements are unavailable.

* **Documentation**
  * Added the Vector Partitioning M2 specification and reproducibility evidence manifest.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
