### PR TITLE
collections: publish column manifest mutation deltas

### DIFF
--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -652,6 +652,8 @@ type CollectionInsertStats struct {
 	ColumnPublishDirectViewSegmentAppendCount          int
 	ColumnPublishRequiredAssetBytes                    int64
 	ColumnPublishManifestBytes                         int64
+	ColumnPublishManifestMutationRecords               int
+	ColumnPublishManifestMutationBytes                 int64
 	UniqueIndexPreflight                               time.Duration
 	TemplateRunBuild                                   time.Duration
 	PrimaryRunBuild                                    time.Duration

--- a/TreeDB/collections/column_manifest_format.go
+++ b/TreeDB/collections/column_manifest_format.go
@@ -46,6 +46,15 @@ type columnManifestRecord struct {
 	value []byte
 }
 
+// columnManifestMutation is one root-local change between two complete logical
+// manifest snapshots. A deleted mutation carries only the removed record key.
+// The complete post-state remains available separately for checksum and
+// correctness validation.
+type columnManifestMutation struct {
+	record  columnManifestRecord
+	deleted bool
+}
+
 type columnManifestSnapshot struct {
 	Collection         string
 	Operation          ColumnPublishOperation
@@ -219,8 +228,108 @@ func encodeColumnManifestForWrite(input ColumnPublishManifestEncodeInput) (Colum
 	return ColumnPublishManifestEncodeResult{
 		Identity:      identity,
 		ManifestBytes: columnManifestRecordsBytes(records),
-		Records:       cloneColumnManifestRecords(records),
+		Records:       records,
 	}, nil
+}
+
+// buildColumnManifestMutationDelta returns the minimal sorted mutation stream
+// that transforms current into next. Both inputs must be strictly sorted by
+// unique key; this is also the ordering required by ordered-root publication.
+func buildColumnManifestMutationDelta(current, next []columnManifestRecord) ([]columnManifestMutation, error) {
+	if err := validateSortedUniqueColumnManifestRecords(current, "current"); err != nil {
+		return nil, err
+	}
+	if err := validateSortedUniqueColumnManifestRecords(next, "next"); err != nil {
+		return nil, err
+	}
+	mutationCapacity := len(current) + len(next)
+	if mutationCapacity > 8 {
+		mutationCapacity = 8
+	}
+	mutations := make([]columnManifestMutation, 0, mutationCapacity)
+	for currentIndex, nextIndex := 0, 0; currentIndex < len(current) || nextIndex < len(next); {
+		if currentIndex == len(current) {
+			mutations = append(mutations, cloneColumnManifestMutation(next[nextIndex], false))
+			nextIndex++
+			continue
+		}
+		if nextIndex == len(next) {
+			mutations = append(mutations, cloneColumnManifestMutation(current[currentIndex], true))
+			currentIndex++
+			continue
+		}
+		switch comparison := bytes.Compare(current[currentIndex].key, next[nextIndex].key); {
+		case comparison < 0:
+			mutations = append(mutations, cloneColumnManifestMutation(current[currentIndex], true))
+			currentIndex++
+		case comparison > 0:
+			mutations = append(mutations, cloneColumnManifestMutation(next[nextIndex], false))
+			nextIndex++
+		default:
+			if !bytes.Equal(current[currentIndex].value, next[nextIndex].value) {
+				mutations = append(mutations, cloneColumnManifestMutation(next[nextIndex], false))
+			}
+			currentIndex++
+			nextIndex++
+		}
+	}
+	return mutations, nil
+}
+
+func validateSortedUniqueColumnManifestRecords(records []columnManifestRecord, name string) error {
+	for i, record := range records {
+		if len(record.key) == 0 {
+			return fmt.Errorf("collections: %s column manifest record[%d] has empty key", name, i)
+		}
+		if i > 0 && bytes.Compare(records[i-1].key, record.key) >= 0 {
+			return fmt.Errorf("collections: %s column manifest records are not strictly sorted at index %d", name, i)
+		}
+	}
+	return nil
+}
+
+func cloneColumnManifestMutation(record columnManifestRecord, deleted bool) columnManifestMutation {
+	mutation := columnManifestMutation{
+		record:  columnManifestRecord{key: bytes.Clone(record.key)},
+		deleted: deleted,
+	}
+	if !deleted {
+		mutation.record.value = bytes.Clone(record.value)
+	}
+	return mutation
+}
+
+func columnManifestMutationsEqual(left, right []columnManifestMutation) bool {
+	if len(left) != len(right) {
+		return false
+	}
+	for i := range left {
+		if left[i].deleted != right[i].deleted ||
+			!bytes.Equal(left[i].record.key, right[i].record.key) ||
+			!bytes.Equal(left[i].record.value, right[i].record.value) {
+			return false
+		}
+	}
+	return true
+}
+
+func columnManifestMutationBytes(mutations []columnManifestMutation) int64 {
+	var total int64
+	for _, mutation := range mutations {
+		total += int64(len(mutation.record.key))
+		if !mutation.deleted {
+			total += int64(len(mutation.record.value))
+		}
+	}
+	return total
+}
+
+func columnManifestRootMutationRecordCount(mutations []columnManifestMutation) int {
+	return 1 + len(mutations) // independently stored manifest identity record
+}
+
+func columnManifestRootMutationBytes(mutations []columnManifestMutation) int64 {
+	return int64(len(columnManifestIdentityRecordKey)+columnManifestIdentityRecordSize) + columnManifestMutationBytes(mutations)
 }
 
 func retainedColumnManifestRecordsForWrite(records []columnManifestRecord, generation uint64, activeVectorIndexesKnown bool, activeVectorIndexes []VectorIndexDefinition) ([]columnManifestRecord, error) {
@@ -969,6 +1078,29 @@ func columnManifestRootRecordIterator(identityRecord [columnManifestIdentityReco
 			key:   bytes.Clone(record.key),
 			value: bytes.Clone(record.value),
 		})
+	}
+	sort.Slice(entries, func(i, j int) bool {
+		return bytes.Compare(entries[i].key, entries[j].key) < 0
+	})
+	return &systemTargetIterator{entries: entries}
+}
+
+func columnManifestRootMutationIterator(identityRecord [columnManifestIdentityRecordSize]byte, mutations []columnManifestMutation) *systemTargetIterator {
+	entries := make([]systemTargetEntry, 0, 1+len(mutations))
+	identityValue := make([]byte, len(identityRecord))
+	copy(identityValue, identityRecord[:])
+	entries = append(entries, systemTargetEntry{
+		key:   newColumnManifestIdentityRecordKey(),
+		value: identityValue,
+	})
+	for _, mutation := range mutations {
+		entry := systemTargetEntry{key: bytes.Clone(mutation.record.key)}
+		if mutation.deleted {
+			entry.flags = node.FlagTombstone
+		} else {
+			entry.value = bytes.Clone(mutation.record.value)
+		}
+		entries = append(entries, entry)
 	}
 	sort.Slice(entries, func(i, j int) bool {
 		return bytes.Compare(entries[i].key, entries[j].key) < 0

--- a/TreeDB/collections/column_manifest_mutation_delta_test.go
+++ b/TreeDB/collections/column_manifest_mutation_delta_test.go
@@ -1,0 +1,326 @@
+package collections
+
+import (
+	"bytes"
+	"fmt"
+	"testing"
+)
+
+func TestColumnManifestMutationDeltaRepeatedPublishScalesWithChanges(t *testing.T) {
+	cfg, err := normalizeColumnStoreConfig("events", testColumnStoreConfig(nil))
+	if err != nil {
+		t.Fatalf("normalizeColumnStoreConfig: %v", err)
+	}
+
+	var (
+		currentIdentity *ColumnManifestIdentity
+		currentRecords  []columnManifestRecord
+		cumulativeBytes int64
+	)
+	const publishes = 32
+	for generation := uint64(1); generation <= publishes; generation++ {
+		asset := testColumnPublishPreparedAssetM10A()
+		asset.Ref.Generation = generation
+		asset.Ref.PartID = generation
+		asset.Ref.FileID = uint32(generation)
+		asset.GenerationID = generation
+		asset.PublishID = generation
+		manifest, err := encodeColumnManifestForWrite(ColumnPublishManifestEncodeInput{
+			Collection:             "events",
+			ColumnStore:            *cfg,
+			Operation:              ColumnPublishOperationInsert,
+			AppliedCommandLSN:      100 + generation,
+			CurrentManifest:        currentIdentity,
+			CurrentManifestRecords: currentRecords,
+			Prepared: ColumnPublishPreparedAssets{
+				Assets:             []ColumnPreparedAsset{asset},
+				RowCount:           10,
+				ColumnPayloadBytes: asset.Bytes,
+			},
+		})
+		if err != nil {
+			t.Fatalf("encode generation %d: %v", generation, err)
+		}
+
+		mutations, err := buildColumnManifestMutationDelta(currentRecords, manifest.Records)
+		if err != nil {
+			t.Fatalf("build mutation generation %d: %v", generation, err)
+		}
+		if got, want := len(mutations), 2; got != want { // changed header + one new asset
+			t.Fatalf("generation %d mutations=%d want %d", generation, got, want)
+		}
+		cumulativeBytes += columnManifestMutationBytes(mutations)
+
+		oracle, err := applyColumnManifestMutationDelta(currentRecords, mutations)
+		if err != nil {
+			t.Fatalf("apply generation %d: %v", generation, err)
+		}
+		if !equalColumnManifestRecords(oracle, manifest.Records) {
+			t.Fatalf("generation %d mutation result differs from full-snapshot oracle", generation)
+		}
+		if got := checksumColumnManifestRecords(ColumnPublishManifestEncodeInput{
+			Collection:        "events",
+			ColumnStore:       *cfg,
+			Operation:         ColumnPublishOperationInsert,
+			AppliedCommandLSN: 100 + generation,
+		}, generation, oracle); got != manifest.Identity.Checksum {
+			t.Fatalf("generation %d checksum=%d want %d", generation, got, manifest.Identity.Checksum)
+		}
+
+		identity := manifest.Identity
+		currentIdentity = &identity
+		currentRecords = manifest.Records
+	}
+
+	lastMutationBytes := columnManifestMutationBytes(mustBuildColumnManifestMutationDelta(t,
+		currentRecords[:len(currentRecords)-1], currentRecords))
+	if cumulativeBytes > int64(publishes)*lastMutationBytes*2 {
+		t.Fatalf("cumulative mutation bytes=%d scale with retained history; per-publish bound=%d", cumulativeBytes, lastMutationBytes)
+	}
+}
+
+func TestColumnManifestMutationDeltaReplacementAndRemoval(t *testing.T) {
+	base := []columnManifestRecord{
+		{key: []byte("a"), value: []byte("one")},
+		{key: []byte("b"), value: []byte("two")},
+		{key: []byte("c"), value: []byte("three")},
+	}
+	next := []columnManifestRecord{
+		{key: []byte("a"), value: []byte("one")},
+		{key: []byte("b"), value: []byte("replacement")},
+		{key: []byte("d"), value: []byte("four")},
+	}
+	mutations := mustBuildColumnManifestMutationDelta(t, base, next)
+	if got, want := len(mutations), 3; got != want {
+		t.Fatalf("mutations=%d want %d", got, want)
+	}
+	if mutations[0].deleted || string(mutations[0].record.key) != "b" || string(mutations[0].record.value) != "replacement" {
+		t.Fatalf("replacement mutation=%+v", mutations[0])
+	}
+	if !mutations[1].deleted || string(mutations[1].record.key) != "c" {
+		t.Fatalf("removal mutation=%+v", mutations[1])
+	}
+	if mutations[2].deleted || string(mutations[2].record.key) != "d" {
+		t.Fatalf("addition mutation=%+v", mutations[2])
+	}
+	got, err := applyColumnManifestMutationDelta(base, mutations)
+	if err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+	if !equalColumnManifestRecords(got, next) {
+		t.Fatalf("applied=%v want=%v", formatColumnManifestRecords(got), formatColumnManifestRecords(next))
+	}
+}
+
+func TestColumnManifestMutationDeltaIteratorPublishesDurableTombstone(t *testing.T) {
+	identity := ColumnManifestIdentity{Generation: 2, Format: columnManifestFormatTCS1, Version: columnManifestIdentityVersion, Checksum: 42}
+	delta := ColumnManifestRootDelta{
+		RootName:       collectionColumnManifestRootName("events"),
+		BaseRootID:     7,
+		StoragePolicy:  RootStorageFast,
+		Identity:       identity,
+		IdentityRecord: encodeColumnManifestIdentityRecordArray(identity),
+		Mutations: []columnManifestMutation{
+			{record: columnManifestRecord{key: []byte("removed")}, deleted: true},
+			{record: columnManifestRecord{key: []byte("replacement"), value: []byte("value")}},
+		},
+		MutationDelta: true,
+	}
+	ordered, err := delta.OrderedRootDeltaPublishInput()
+	if err != nil {
+		t.Fatalf("OrderedRootDeltaPublishInput: %v", err)
+	}
+	defer func() { _ = ordered.Iter.Close() }()
+	var sawDelete, sawReplacement bool
+	for ordered.Iter.Valid() {
+		switch string(ordered.Iter.UnsafeKey()) {
+		case "removed":
+			sawDelete = ordered.Iter.IsDeleted()
+		case "replacement":
+			sawReplacement = !ordered.Iter.IsDeleted() && string(ordered.Iter.UnsafeValue()) == "value"
+		}
+		ordered.Iter.Next()
+	}
+	if !sawDelete || !sawReplacement {
+		t.Fatalf("mutation iterator delete=%t replacement=%t", sawDelete, sawReplacement)
+	}
+}
+
+func TestColumnManifestMutationDeltaProductionRepeatedPublishReopen(t *testing.T) {
+	dir, _ := prepareColumnStoreCommandWALDirM10B(t)
+	d := openCollectionCommandWALDB(t, dir)
+	col := openColumnStoreCollectionM10B(t, d)
+
+	var firstMutationBytes, lastLogicalBytes int64
+	for i := 0; i < 8; i++ {
+		id := fmt.Sprintf("e%d", i)
+		doc := fmt.Sprintf(`{"time_us":%d,"kind":"like","did":"d%d"}`, i+1, i)
+		if _, err := col.InsertBatch([][]byte{[]byte(id)}, [][]byte{[]byte(doc)}); err != nil {
+			t.Fatalf("InsertBatch %d: %v", i, err)
+		}
+		stats := col.LastInsertStats()
+		if stats.ColumnPublishManifestMutationRecords == 0 || stats.ColumnPublishManifestMutationBytes == 0 {
+			t.Fatalf("publish %d missing mutation accounting: %+v", i, stats)
+		}
+		if stats.ColumnPublishManifestMutationRecords > stats.ColumnPublishPreparedAssets+2 {
+			t.Fatalf("publish %d mutation records=%d exceed prepared+header+identity=%d", i, stats.ColumnPublishManifestMutationRecords, stats.ColumnPublishPreparedAssets+2)
+		}
+		if i == 0 {
+			firstMutationBytes = stats.ColumnPublishManifestMutationBytes
+		} else if stats.ColumnPublishManifestMutationBytes > firstMutationBytes*2 {
+			t.Fatalf("publish %d mutation bytes=%d scale with retained history; first=%d", i, stats.ColumnPublishManifestMutationBytes, firstMutationBytes)
+		}
+		if stats.ColumnPublishManifestBytes <= lastLogicalBytes {
+			t.Fatalf("publish %d logical manifest bytes=%d want growth beyond %d", i, stats.ColumnPublishManifestBytes, lastLogicalBytes)
+		}
+		lastLogicalBytes = stats.ColumnPublishManifestBytes
+	}
+	lastLSN := d.State().AppliedCommandLSN
+	assertColumnManifestStateM10B(t, col, 8, lastLSN)
+	if err := d.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	reopenedDB := openCollectionCommandWALDB(t, dir)
+	defer func() { _ = reopenedDB.Close() }()
+	reopened := openColumnStoreCollectionM10B(t, reopenedDB)
+	assertColumnManifestStateM10B(t, reopened, 8, lastLSN)
+	for i := 0; i < 8; i++ {
+		assertCollectionDocument(t, reopened, fmt.Sprintf("e%d", i), fmt.Sprintf(`{"time_us":%d,"kind":"like","did":"d%d"}`, i+1, i))
+	}
+}
+
+func BenchmarkColumnManifestRootDeltaMaterializationScaling(b *testing.B) {
+	current := make([]columnManifestRecord, 1025)
+	current[0] = columnManifestRecord{key: []byte("header"), value: []byte("generation-1")}
+	for i := 1; i < len(current); i++ {
+		current[i] = columnManifestRecord{
+			key:   []byte(fmt.Sprintf("part/%08d", i)),
+			value: bytes.Repeat([]byte{byte(i)}, 128),
+		}
+	}
+	next := cloneColumnManifestRecords(current)
+	next[0].value = []byte("generation-2")
+	for i := 0; i < 5; i++ {
+		next = append(next, columnManifestRecord{
+			key:   []byte(fmt.Sprintf("part/%08d", len(current)+i)),
+			value: bytes.Repeat([]byte{byte(i + 1)}, 128),
+		})
+	}
+	mutations := mustBuildColumnManifestMutationDelta(b, current, next)
+	identity := ColumnManifestIdentity{Generation: 2, Format: columnManifestFormatTCS1, Version: columnManifestIdentityVersion, Checksum: 42}
+	base := ColumnManifestRootDelta{
+		RootName:       collectionColumnManifestRootName("events"),
+		BaseRootID:     7,
+		StoragePolicy:  RootStorageFast,
+		Identity:       identity,
+		IdentityRecord: encodeColumnManifestIdentityRecordArray(identity),
+		Records:        next,
+	}
+	cases := []struct {
+		name  string
+		delta ColumnManifestRootDelta
+	}{
+		{name: "full_snapshot", delta: base},
+		{name: "mutation_delta", delta: func() ColumnManifestRootDelta {
+			delta := base
+			delta.Mutations = mutations
+			delta.MutationDelta = true
+			return delta
+		}()},
+	}
+	b.Run("iterator", func(b *testing.B) {
+		for _, tc := range cases {
+			b.Run(tc.name, func(b *testing.B) {
+				b.ReportAllocs()
+				publishedRecords := columnManifestRootPublishedRecordCount(tc.delta)
+				publishedBytes := columnManifestRootPublishedBytes(tc.delta)
+				b.ReportMetric(float64(publishedRecords), "published_records/op")
+				b.ReportMetric(float64(publishedBytes), "published_B/op")
+				for i := 0; i < b.N; i++ {
+					ordered, err := tc.delta.OrderedRootDeltaPublishInput()
+					if err != nil {
+						b.Fatal(err)
+					}
+					_ = ordered.Iter.Close()
+				}
+			})
+		}
+	})
+	b.Run("batch", func(b *testing.B) {
+		for _, tc := range cases {
+			b.Run(tc.name, func(b *testing.B) {
+				b.ReportAllocs()
+				publishedRecords := columnManifestRootPublishedRecordCount(tc.delta)
+				publishedBytes := columnManifestRootPublishedBytes(tc.delta)
+				b.ReportMetric(float64(publishedRecords), "published_records/op")
+				b.ReportMetric(float64(publishedBytes), "published_B/op")
+				for i := 0; i < b.N; i++ {
+					_, cleanup, err := tc.delta.OrderedRootDeltaBatchPublishInput()
+					if err != nil {
+						b.Fatal(err)
+					}
+					cleanup()
+				}
+			})
+		}
+	})
+}
+
+func mustBuildColumnManifestMutationDelta(t testing.TB, current, next []columnManifestRecord) []columnManifestMutation {
+	t.Helper()
+	mutations, err := buildColumnManifestMutationDelta(current, next)
+	if err != nil {
+		t.Fatalf("buildColumnManifestMutationDelta: %v", err)
+	}
+	return mutations
+}
+
+func applyColumnManifestMutationDelta(current []columnManifestRecord, mutations []columnManifestMutation) ([]columnManifestRecord, error) {
+	if err := validateSortedUniqueColumnManifestRecords(current, "current"); err != nil {
+		return nil, err
+	}
+	byKey := make(map[string]columnManifestRecord, len(current)+len(mutations))
+	for _, record := range current {
+		byKey[string(record.key)] = columnManifestRecord{key: bytes.Clone(record.key), value: bytes.Clone(record.value)}
+	}
+	for i, mutation := range mutations {
+		if len(mutation.record.key) == 0 {
+			return nil, fmt.Errorf("mutation[%d] has empty key", i)
+		}
+		if i > 0 && bytes.Compare(mutations[i-1].record.key, mutation.record.key) >= 0 {
+			return nil, fmt.Errorf("mutations are not strictly sorted at index %d", i)
+		}
+		key := string(mutation.record.key)
+		if mutation.deleted {
+			delete(byKey, key)
+			continue
+		}
+		byKey[key] = columnManifestRecord{key: bytes.Clone(mutation.record.key), value: bytes.Clone(mutation.record.value)}
+	}
+	result := make([]columnManifestRecord, 0, len(byKey))
+	for _, record := range byKey {
+		result = append(result, record)
+	}
+	sortColumnManifestRecords(result)
+	return result, nil
+}
+
+func equalColumnManifestRecords(a, b []columnManifestRecord) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if !bytes.Equal(a[i].key, b[i].key) || !bytes.Equal(a[i].value, b[i].value) {
+			return false
+		}
+	}
+	return true
+}
+
+func formatColumnManifestRecords(records []columnManifestRecord) []string {
+	out := make([]string, len(records))
+	for i, record := range records {
+		out[i] = fmt.Sprintf("%s=%s", record.key, record.value)
+	}
+	return out
+}

--- a/TreeDB/collections/column_physical_asset_test.go
+++ b/TreeDB/collections/column_physical_asset_test.go
@@ -3299,7 +3299,7 @@ func TestColumnManifestBinaryRecordsAndGCEnumerableAssetRefsM12A(t *testing.T) {
 	badDelta.Identity = badIdentity
 	badDelta.IdentityRecord = encodeColumnManifestIdentityRecordArray(badIdentity)
 	badDelta.StoragePolicy = normalized.ManifestRoot.StoragePolicy
-	if err := validateColumnManifestRootDeltaForPlan(badDelta, delta.BaseRootID, *normalized, badIdentity); err == nil || !strings.Contains(err.Error(), "checksum") {
+	if err := validateColumnManifestRootDeltaForPlan(badDelta, nil, delta.BaseRootID, *normalized, badIdentity); err == nil || !strings.Contains(err.Error(), "checksum") {
 		t.Fatalf("validate bad manifest checksum err=%v want checksum failure", err)
 	}
 }

--- a/TreeDB/collections/column_publish_plan.go
+++ b/TreeDB/collections/column_publish_plan.go
@@ -1,6 +1,7 @@
 package collections
 
 import (
+	"bytes"
 	"errors"
 	"fmt"
 	"math"
@@ -254,6 +255,8 @@ type ColumnPublishPlan struct {
 	RowRemainderBytes                      int64
 	ColumnPayloadBytes                     int64
 	ManifestBytes                          int64
+	ManifestMutationRecords                int
+	ManifestMutationBytes                  int64
 	Lifecycle                              ColumnPublishLifecycleSummary
 	StageMetrics                           ColumnPublishStageMetrics
 	stableResources                        *rootpublication.StableResourceSet
@@ -268,7 +271,14 @@ type ColumnManifestRootDelta struct {
 	StoragePolicy  RootStoragePolicy
 	Identity       ColumnManifestIdentity
 	IdentityRecord [columnManifestIdentityRecordSize]byte
-	Records        []columnManifestRecord
+	// Records is the complete logical post-state manifest used for checksum,
+	// durability-closure, and correctness validation.
+	Records []columnManifestRecord
+	// Mutations is the minimal root-local change set from the base manifest to
+	// Records. MutationDelta distinguishes an intentionally empty mutation set
+	// from legacy/custom full-record root deltas.
+	Mutations     []columnManifestMutation
+	MutationDelta bool
 }
 
 // ColumnPublishLifecycleSummary summarizes lifecycle/GC-relevant asset effects
@@ -467,10 +477,10 @@ func BuildColumnPublishPlan(input ColumnPublishPlanInput) (ColumnPublishPlan, er
 		return ColumnPublishPlan{}, fmt.Errorf("collections: column publish root-delta construction failed: %w", err)
 	}
 	metrics.RootDeltaConstruction = time.Since(start)
-	if err := validateColumnManifestRootDeltaForPlan(rootDelta, input.BaseManifestRootID, *cfg, manifest.Identity); err != nil {
+	if err := validateColumnManifestRootDeltaForPlan(rootDelta, input.CurrentManifestRecords, input.BaseManifestRootID, *cfg, manifest.Identity); err != nil {
 		return ColumnPublishPlan{}, fmt.Errorf("collections: invalid column publish root delta: %w", err)
 	}
-	durableResourceRequirements, err := stableColumnManifestDurableRequirements(rootDelta.Records, manifest.Identity.Generation, cfg.AssetManager.Namespace)
+	durableResourceRequirements, err := stableColumnManifestDurableRequirements(manifest.Records, manifest.Identity.Generation, cfg.AssetManager.Namespace)
 	if err != nil {
 		return ColumnPublishPlan{}, fmt.Errorf("collections: derive durable column resource closure: %w", err)
 	}
@@ -501,6 +511,8 @@ func BuildColumnPublishPlan(input ColumnPublishPlanInput) (ColumnPublishPlan, er
 		RowRemainderBytes:                      manifestPrepared.RowRemainderBytes,
 		ColumnPayloadBytes:                     manifestPrepared.ColumnPayloadBytes,
 		ManifestBytes:                          manifest.ManifestBytes,
+		ManifestMutationRecords:                columnManifestRootPublishedRecordCount(rootDelta),
+		ManifestMutationBytes:                  columnManifestRootPublishedBytes(rootDelta),
 		Lifecycle: ColumnPublishLifecycleSummary{
 			PublishedRefs:  closure.RequiredAssets,
 			PublishedBytes: closure.RequiredBytes,
@@ -548,6 +560,20 @@ func (delta ColumnManifestRootDelta) OrderedRootPublishInput() (backenddb.Ordere
 	}, nil
 }
 
+func columnManifestRootPublishedRecordCount(delta ColumnManifestRootDelta) int {
+	if delta.MutationDelta {
+		return columnManifestRootMutationRecordCount(delta.Mutations)
+	}
+	return 1 + len(delta.Records)
+}
+
+func columnManifestRootPublishedBytes(delta ColumnManifestRootDelta) int64 {
+	if delta.MutationDelta {
+		return columnManifestRootMutationBytes(delta.Mutations)
+	}
+	return columnManifestRecordsBytes(delta.Records)
+}
+
 func (delta ColumnManifestRootDelta) OrderedRootDeltaPublishInput() (backenddb.OrderedRootDeltaPublishInput, error) {
 	if delta.RootName == "" {
 		return backenddb.OrderedRootDeltaPublishInput{}, errors.New("collections: column manifest root delta missing root name")
@@ -564,9 +590,15 @@ func (delta ColumnManifestRootDelta) OrderedRootDeltaPublishInput() (backenddb.O
 	if err != nil {
 		return backenddb.OrderedRootDeltaPublishInput{}, err
 	}
+	var iter iterator.UnsafeIterator
+	if delta.MutationDelta {
+		iter = columnManifestRootMutationIterator(delta.IdentityRecord, delta.Mutations)
+	} else {
+		iter = columnManifestRootRecordIterator(delta.IdentityRecord, delta.Records)
+	}
 	return backenddb.OrderedRootDeltaPublishInput{
 		BaseRoot:      delta.BaseRootID,
-		Iter:          columnManifestRootRecordIterator(delta.IdentityRecord, delta.Records),
+		Iter:          iter,
 		StoragePolicy: policy,
 	}, nil
 }
@@ -587,7 +619,12 @@ func (delta ColumnManifestRootDelta) OrderedRootDeltaBatchPublishInput() (backen
 	if err != nil {
 		return backenddb.OrderedRootDeltaBatchPublishInput{}, func() {}, err
 	}
-	iter := columnManifestRootRecordIterator(delta.IdentityRecord, delta.Records)
+	var iter iterator.UnsafeIterator
+	if delta.MutationDelta {
+		iter = columnManifestRootMutationIterator(delta.IdentityRecord, delta.Mutations)
+	} else {
+		iter = columnManifestRootRecordIterator(delta.IdentityRecord, delta.Records)
+	}
 	defer func() { _ = iter.Close() }()
 	deltaBatch, err := backenddb.OrderedRootDeltaBatchFromIterator(iter)
 	if err != nil {
@@ -828,13 +865,19 @@ func buildColumnPublishRootDelta(input ColumnPublishPlanInput, cfg ColumnStoreCo
 	if cfg.ManifestRoot == nil {
 		return ColumnManifestRootDelta{}, errors.New("missing column manifest root descriptor")
 	}
+	mutations, err := buildColumnManifestMutationDelta(input.CurrentManifestRecords, manifest.Records)
+	if err != nil {
+		return ColumnManifestRootDelta{}, err
+	}
 	return ColumnManifestRootDelta{
 		RootName:       cfg.ManifestRoot.Name,
 		BaseRootID:     input.BaseManifestRootID,
 		StoragePolicy:  cfg.ManifestRoot.StoragePolicy,
 		Identity:       manifest.Identity,
 		IdentityRecord: encodeColumnManifestIdentityRecordArray(manifest.Identity),
-		Records:        cloneColumnManifestRecords(manifest.Records),
+		Records:        manifest.Records,
+		Mutations:      mutations,
+		MutationDelta:  true,
 	}, nil
 }
 
@@ -869,7 +912,7 @@ func validateColumnPublishPlanConfig(collection string, cfg *ColumnStoreConfig) 
 	return nil
 }
 
-func validateColumnManifestRootDeltaForPlan(delta ColumnManifestRootDelta, baseRootID uint64, cfg ColumnStoreConfig, identity ColumnManifestIdentity) error {
+func validateColumnManifestRootDeltaForPlan(delta ColumnManifestRootDelta, currentRecords []columnManifestRecord, baseRootID uint64, cfg ColumnStoreConfig, identity ColumnManifestIdentity) error {
 	if cfg.ManifestRoot == nil {
 		return errors.New("missing column manifest root descriptor")
 	}
@@ -914,6 +957,23 @@ func validateColumnManifestRootDeltaForPlan(delta ColumnManifestRootDelta, baseR
 	}, snapshot.Generation, delta.Records)
 	if checksum != identity.Checksum {
 		return fmt.Errorf("manifest records checksum=%d does not match identity checksum=%d", checksum, identity.Checksum)
+	}
+	if delta.MutationDelta {
+		for i, mutation := range delta.Mutations {
+			if len(mutation.record.key) == 0 {
+				return fmt.Errorf("manifest mutation[%d] has empty key", i)
+			}
+			if i > 0 && bytes.Compare(delta.Mutations[i-1].record.key, mutation.record.key) >= 0 {
+				return fmt.Errorf("manifest mutations are not strictly sorted at index %d", i)
+			}
+		}
+		expectedMutations, err := buildColumnManifestMutationDelta(currentRecords, delta.Records)
+		if err != nil {
+			return fmt.Errorf("derive expected manifest mutation delta: %w", err)
+		}
+		if !columnManifestMutationsEqual(expectedMutations, delta.Mutations) {
+			return errors.New("manifest mutation delta does not produce logical post-state")
+		}
 	}
 	return nil
 }

--- a/TreeDB/collections/column_publish_write.go
+++ b/TreeDB/collections/column_publish_write.go
@@ -601,6 +601,8 @@ func recordColumnPublishPlanStats(stats *CollectionInsertStats, plan ColumnPubli
 	stats.ColumnPublishDirectViewSegmentAppendCount += metrics.AssetMetrics.DirectViewSegmentAppendCount
 	stats.ColumnPublishRequiredAssetBytes = saturatingAddNonNegativeInt64(stats.ColumnPublishRequiredAssetBytes, plan.RequiredAssetBytes)
 	stats.ColumnPublishManifestBytes = saturatingAddNonNegativeInt64(stats.ColumnPublishManifestBytes, plan.ManifestBytes)
+	stats.ColumnPublishManifestMutationRecords += plan.ManifestMutationRecords
+	stats.ColumnPublishManifestMutationBytes = saturatingAddNonNegativeInt64(stats.ColumnPublishManifestMutationBytes, plan.ManifestMutationBytes)
 }
 
 func recordColumnPublishRootDeltaMaterialization(stats *CollectionInsertStats, elapsed time.Duration) {

--- a/TreeDB/collections/shape_bench_test.go
+++ b/TreeDB/collections/shape_bench_test.go
@@ -123,6 +123,8 @@ func addCollectionInsertStats(dst *collections.CollectionInsertStats, src collec
 	dst.ColumnPublishDirectViewSegmentAppendCount += src.ColumnPublishDirectViewSegmentAppendCount
 	dst.ColumnPublishRequiredAssetBytes += src.ColumnPublishRequiredAssetBytes
 	dst.ColumnPublishManifestBytes += src.ColumnPublishManifestBytes
+	dst.ColumnPublishManifestMutationRecords += src.ColumnPublishManifestMutationRecords
+	dst.ColumnPublishManifestMutationBytes += src.ColumnPublishManifestMutationBytes
 	dst.UniqueIndexPreflight += src.UniqueIndexPreflight
 	dst.TemplateRunBuild += src.TemplateRunBuild
 	dst.PrimaryRunBuild += src.PrimaryRunBuild
@@ -211,6 +213,12 @@ func benchmarkReportCollectionInsertStats(b *testing.B, docs, batches int, stats
 	}
 	if stats.ColumnPublishManifestBytes > 0 {
 		b.ReportMetric(float64(stats.ColumnPublishManifestBytes)/float64(docs), "column_publish_manifest_bytes/doc")
+	}
+	if stats.ColumnPublishManifestMutationRecords > 0 {
+		b.ReportMetric(float64(stats.ColumnPublishManifestMutationRecords)/float64(batches), "column_publish_manifest_mutation_records/batch")
+	}
+	if stats.ColumnPublishManifestMutationBytes > 0 {
+		b.ReportMetric(float64(stats.ColumnPublishManifestMutationBytes)/float64(batches), "column_publish_manifest_mutation_bytes/batch")
 	}
 	if stats.ColumnPublishAssetAppenderCloseCount > 0 {
 		b.ReportMetric(float64(stats.ColumnPublishAssetAppenderCloseCount)/float64(batches), "column_publish_asset_appender_closes/batch")
@@ -315,6 +323,8 @@ func TestBenchmarkReportCollectionInsertStatsIncludesColumnPublishExtractionM10B
 			ColumnPublishPreparedAssets:                        2,
 			ColumnPublishRequiredAssetBytes:                    2048,
 			ColumnPublishManifestBytes:                         512,
+			ColumnPublishManifestMutationRecords:               7,
+			ColumnPublishManifestMutationBytes:                 256,
 			ColumnPublishSharedSegmentAppendBytes:              1000,
 			ColumnPublishSharedSegmentAppendCount:              3,
 			ColumnPublishSharedSegmentAppenderCloseCount:       1,
@@ -344,6 +354,12 @@ func TestBenchmarkReportCollectionInsertStatsIncludesColumnPublishExtractionM10B
 	}
 	if got := result.Extra["column_publish_manifest_bytes/doc"]; got <= 0 {
 		t.Fatalf("column publish manifest bytes metric=%v want positive", got)
+	}
+	if got := result.Extra["column_publish_manifest_mutation_records/batch"]; got <= 0 {
+		t.Fatalf("column publish manifest mutation records metric=%v want positive", got)
+	}
+	if got := result.Extra["column_publish_manifest_mutation_bytes/batch"]; got <= 0 {
+		t.Fatalf("column publish manifest mutation bytes metric=%v want positive", got)
 	}
 	for _, name := range []string{
 		"column_publish_shared_segment_asset_appends/batch",

--- a/TreeDB/collections/typed_storage_naming_test.go
+++ b/TreeDB/collections/typed_storage_naming_test.go
@@ -358,6 +358,7 @@ var typedStorageLegacyNameAllowlist = []typedStorageLegacyNameAllowlistEntry{
 	{path: "TreeDB/collections/column_int64_query.go", classification: typedStorageLegacyDerived, matchingLines: 2, occurrences: 2},
 	{path: "TreeDB/collections/column_int64_values_asset.go", classification: typedStorageLegacyDerived, matchingLines: 10, occurrences: 10},
 	{path: "TreeDB/collections/column_manifest_format.go", classification: typedStorageLegacyCompatibility, matchingLines: 2, occurrences: 2},
+	{path: "TreeDB/collections/column_manifest_mutation_delta_test.go", classification: typedStorageLegacyCompatibility, matchingLines: 7, occurrences: 8},
 	{path: "TreeDB/collections/column_physical_asset.go", classification: typedStorageLegacyDeferred, matchingLines: 88, occurrences: 132},
 	{path: "TreeDB/collections/column_physical_asset_stable_append.go", classification: typedStorageLegacyCompatibility, matchingLines: 1, occurrences: 1},
 	{path: "TreeDB/collections/column_physical_asset_stable_append_test.go", classification: typedStorageLegacyCompatibility, matchingLines: 3, occurrences: 3},

--- a/cmd/unified_bench/suite_column_store.go
+++ b/cmd/unified_bench/suite_column_store.go
@@ -314,6 +314,8 @@ type columnStoreInsertPhaseMetric struct {
 
 	ColumnPublishRequiredAssetBytes           int64   `json:"column_publish_required_asset_bytes,omitempty"`
 	ColumnPublishManifestBytes                int64   `json:"column_publish_manifest_bytes,omitempty"`
+	ColumnPublishManifestMutationRecords      int     `json:"column_publish_manifest_mutation_records,omitempty"`
+	ColumnPublishManifestMutationBytes        int64   `json:"column_publish_manifest_mutation_bytes,omitempty"`
 	PrimaryRunBuildDurationMS                 float64 `json:"primary_run_build_duration_ms,omitempty"`
 	PrimaryRunBuildNsPerRow                   float64 `json:"primary_run_build_ns_per_row,omitempty"`
 	PublishDurationMS                         float64 `json:"publish_duration_ms,omitempty"`
@@ -1716,6 +1718,8 @@ func columnStoreAddCollectionInsertStats(dst *collections.CollectionInsertStats,
 	dst.ColumnPublishDirectViewSegmentAppendCount += src.ColumnPublishDirectViewSegmentAppendCount
 	dst.ColumnPublishRequiredAssetBytes += src.ColumnPublishRequiredAssetBytes
 	dst.ColumnPublishManifestBytes += src.ColumnPublishManifestBytes
+	dst.ColumnPublishManifestMutationRecords += src.ColumnPublishManifestMutationRecords
+	dst.ColumnPublishManifestMutationBytes += src.ColumnPublishManifestMutationBytes
 	dst.UniqueIndexPreflight += src.UniqueIndexPreflight
 	dst.TemplateRunBuild += src.TemplateRunBuild
 	dst.PrimaryRunBuild += src.PrimaryRunBuild
@@ -1833,6 +1837,8 @@ func columnStoreInsertPhaseMetricFromStats(stats collections.CollectionInsertSta
 		ColumnPublishDirectViewSegmentAppendCount:          stats.ColumnPublishDirectViewSegmentAppendCount,
 		ColumnPublishRequiredAssetBytes:                    stats.ColumnPublishRequiredAssetBytes,
 		ColumnPublishManifestBytes:                         stats.ColumnPublishManifestBytes,
+		ColumnPublishManifestMutationRecords:               stats.ColumnPublishManifestMutationRecords,
+		ColumnPublishManifestMutationBytes:                 stats.ColumnPublishManifestMutationBytes,
 		PrimaryRunBuildDurationMS:                          durationMS(stats.PrimaryRunBuild),
 		PrimaryRunBuildNsPerRow:                            nsPerRow(stats.PrimaryRunBuild, rows),
 		PublishDurationMS:                                  durationMS(stats.Publish),
@@ -4900,7 +4906,9 @@ func renderColumnStoreInsertStatsMarkdown(sb *strings.Builder, stats columnStore
 	sb.WriteString(fmt.Sprintf("- column_publish_direct_view_segment_append_file_sync_count: %d\n", stats.ColumnPublishDirectViewSegmentAppendFileSyncCount))
 	sb.WriteString(fmt.Sprintf("- column_publish_direct_view_segment_append_sync_epoch_count: %d\n", stats.ColumnPublishDirectViewSegmentAppendSyncEpochCount))
 	sb.WriteString(fmt.Sprintf("- column_publish_required_asset_bytes: %d\n", stats.ColumnPublishRequiredAssetBytes))
-	sb.WriteString(fmt.Sprintf("- column_publish_manifest_bytes: %d\n\n", stats.ColumnPublishManifestBytes))
+	sb.WriteString(fmt.Sprintf("- column_publish_manifest_bytes: %d\n", stats.ColumnPublishManifestBytes))
+	sb.WriteString(fmt.Sprintf("- column_publish_manifest_mutation_records: %d\n", stats.ColumnPublishManifestMutationRecords))
+	sb.WriteString(fmt.Sprintf("- column_publish_manifest_mutation_bytes: %d\n\n", stats.ColumnPublishManifestMutationBytes))
 
 	sb.WriteString("| phase | ms | ns/row |\n")
 	sb.WriteString("|---|---:|---:|\n")

--- a/cmd/unified_bench/suite_column_store_test.go
+++ b/cmd/unified_bench/suite_column_store_test.go
@@ -728,7 +728,7 @@ func TestRunColumnStoreSuiteWritesArtifactsAndMetricsM11A(t *testing.T) {
 	if report.InsertStats.ColumnPublishRows != report.Rows {
 		t.Fatalf("column publish rows=%d want %d: %+v", report.InsertStats.ColumnPublishRows, report.Rows, report.InsertStats)
 	}
-	if report.InsertStats.ColumnPublishPreparedAssets == 0 || report.InsertStats.ColumnPublishRequiredAssetBytes == 0 || report.InsertStats.ColumnPublishManifestBytes == 0 {
+	if report.InsertStats.ColumnPublishPreparedAssets == 0 || report.InsertStats.ColumnPublishRequiredAssetBytes == 0 || report.InsertStats.ColumnPublishManifestBytes == 0 || report.InsertStats.ColumnPublishManifestMutationRecords == 0 || report.InsertStats.ColumnPublishManifestMutationBytes == 0 {
 		t.Fatalf("column publish asset counters missing: %+v", report.InsertStats)
 	}
 	if report.InsertStats.ColumnPublishBuildColumnDeltaDurationMS <= 0 || report.InsertStats.ColumnPublishBuildColumnDeltaNsPerRow <= 0 {


### PR DESCRIPTION
Closes #3924

Parent: #3898

## What changed

- publish column-manifest identity plus only new/changed records and durable tombstones;
- retain the complete logical post-state for checksum validation and durable-resource closure;
- expose mutation record/byte counters through collection stats, unified-bench JSON/Markdown, and shape benchmarks;
- remove redundant full-record clones at manifest result/root-delta ownership boundaries.

This does not change WAL/vlog/GC policy, query execution, reconstruction, or broad storage format/pruning.

## Test-first evidence

Red before implementation:

```text
go test ./TreeDB/collections -run '^TestColumnManifestMutationDelta' -count=1
# undefined mutation-delta implementation symbols
```

Green on commit `23bd801c160c11297cd3afe41653989203d4e453`:

```text
go test ./TreeDB/collections ./cmd/unified_bench -count=1
go test -race ./TreeDB/collections -run '^(TestColumnManifestMutationDelta|TestColumnStoreMutationAssetsPublishAndReopenM12C|TestColumnStoreCommandWALReplayPublishesManifestM10B|TestColumnStoreCommandWALReplayInsertPublishesEquivalentManifestM10C|TestColumnStoreCompactPostCompactionWritesAdvanceFromCompactedManifest1953|TestColumnStoreStaleColumnRootPreflightDoesNotAppendCommandWALM10B|TestColumnManifestPublishSystemDeltaFailureLeavesRootsUnpublishedM10A)$' -count=1
go test ./TreeDB/... -run '^$'
```

Coverage includes full-snapshot oracle/checksum parity, replacement, removal/tombstones, repeated publication, reopen, command-WAL replay, compaction-followed-by-write, stale-root rejection, and atomic failure.

## Focused performance

Five-sample benchmark, 1,030 logical manifest records plus identity, six logical mutations plus identity:

| path | full snapshot | mutation delta | allocation change |
|---|---:|---:|---:|
| iterator median | ~82.6 us | ~0.704 us | 213,969 B / 2,067 allocs -> 1,392 B / 19 allocs |
| batch median | ~103.4 us | ~1.17 us | ~221,959 B / 2,068 allocs -> 1,409 B / 20 allocs |
| published volume | 1,031 records / 145,160 B | 7 records / 776 B | 99.5% fewer bytes |

CPU and heap profiles are under `/mnt/fast4tb/gomap_3924_matched_durable_20260719/profiles` on the benchmark host.

## Matched JSONBench evidence

JSONBench `4df524e73e3594fbebe364e7730a989554400aba`, durable `column-store-full-prepared`, `one_shot_end_to_end`, `no_aggregate_metadata`, five independent loads per cell, same hardware and dataset. Candidate is this PR; baseline is gomap `3602379b6af21db374a16ceabd24c8b2f3544ec5`.

| shape | metric | baseline median | candidate median | result |
|---|---|---:|---:|---:|
| 100k | load | 1.421 s | 1.381 s | -2.8% |
| 100k | publish | 0.789 s | 0.751 s | -4.8% |
| 100k | commit | 0.768 s | 0.732 s | -4.7% |
| 100k | root-delta materialization | 31.36 us | 15.39 us | 2.04x faster |
| 1M | load | 11.846 s | 11.855 s | neutral (+0.08%) |
| 1M | publish | 5.588 s | 5.381 s | -3.7% |
| 1M | commit | 5.499 s | 5.282 s | -3.9% |
| 1M | root-delta construction | 1.021 ms | 0.567 ms | 1.80x faster |
| 1M | root-delta materialization | 1.254 ms | 0.183 ms | 6.85x faster |

Primary-index bytes are unchanged at both scales. WAL-excluded durable storage is slightly lower on the candidate (100k: 18,297,013 vs 18,300,545 B; 1M: 156,835,656 vs 157,372,617 B). Raw artifacts are under `/mnt/fast4tb/gomap_3924_matched_durable_20260719`.

The 1M total-load result is neutral because the manifest residual is still small at that scale; commit improves and the targeted materialization bucket clears the 2x gate. The parent #3900 canonical 10M rerun remains the integrated scaling verdict after merge.

## Remaining boundary

Full logical manifest construction/checksum remains O(retained records), including the intentional `CurrentManifestRecords` clone at the manifest-hook ownership boundary. If the merged 10M rerun still attributes the residual there, that is the next narrow wedge; this PR does not weaken hook ownership or the checksum oracle.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Column manifest publishing now records and reports only changed records where possible, reducing retained publish history for repeated updates.
  * Added metrics for manifest mutation record counts and byte sizes in publish and benchmark reports.

* **Reliability**
  * Improved handling of manifest replacements, removals, durable tombstones, and publish/reopen cycles.

* **Testing**
  * Added coverage and benchmarks for mutation-based publishing, validation, scaling, and persistence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->