### PR TITLE
feat(treedb): materialize bounded value-log RIDs in command WAL

### DIFF
--- a/TreeDB/caching/batch_ptr_value_arena_test.go
+++ b/TreeDB/caching/batch_ptr_value_arena_test.go
@@ -198,6 +198,19 @@ func TestBatchPtrValueArena_RecycledAfterMaterializedCommandWALAppend(t *testing
 	if count := countBatchArenaLeaseChunks(db, db.mutableShards[0].mem); count != 1 {
 		t.Fatalf("expected only the main batch arena lease after materialized command WAL append; got %d chunks", count)
 	}
+	for i := 0; i < 256; i++ {
+		b.Reset()
+		iterKey := []byte(fmt.Sprintf("materialized-command-wal-%03d", i))
+		iterVal := bytes.Repeat([]byte{byte(i)}, 64)
+		if err := b.Set(iterKey, iterVal); err != nil {
+			t.Fatalf("set reuse %d: %v", i, err)
+		}
+		if err := b.WriteAfterCommandWALAppend(true, func() error {
+			return b.Replay(func(batch.Entry) error { return nil })
+		}); err != nil {
+			t.Fatalf("write reuse %d: %v", i, err)
+		}
+	}
 
 	got, err := db.Get(key)
 	if err != nil {

--- a/TreeDB/caching/batch_ptr_value_arena_test.go
+++ b/TreeDB/caching/batch_ptr_value_arena_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/snissn/gomap/TreeDB/batch"
 	"github.com/snissn/gomap/TreeDB/internal/memtable"
 )
 
@@ -130,6 +131,72 @@ func TestBatchPtrValueArena_RecycledWhenPointersAssigned(t *testing.T) {
 	}
 	if count := countBatchArenaLeaseChunks(db, db.mutableShards[0].mem); count != 1 {
 		t.Fatalf("expected only the main batch arena lease to remain; got %d chunks", count)
+	}
+
+	got, err := db.Get(key)
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if !bytes.Equal(got, val) {
+		t.Fatalf("value corrupted: got=%x want=%x", got, val)
+	}
+}
+
+func TestBatchPtrValueArena_RecycledAfterMaterializedCommandWALAppend(t *testing.T) {
+	dir := t.TempDir()
+	db, err := Open(dir, NewMockBackend(), Options{
+		ExternalCommandWAL:       true,
+		MemtableMode:             "btree",
+		MemtableShards:           1,
+		FlushThreshold:           1 << 20,
+		ValueLogPointerThreshold: 32,
+		ForceValueLogPointers:    true,
+	})
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer db.Close()
+
+	key := []byte("materialized-command-wal")
+	val := bytes.Repeat([]byte{0x44}, 64)
+
+	b := db.NewBatchWithSize(1)
+	defer b.Close()
+	if err := b.Set(key, val); err != nil {
+		t.Fatalf("set: %v", err)
+	}
+	if got := len(b.ptrValueIdxs); got != 1 {
+		t.Fatalf("expected exactly one pointer-value entry after Set, got %d", got)
+	}
+	if len(b.ptrCopyArenaChunks) == 0 && b.ptrCopyBytes == 0 {
+		t.Fatal("expected pointer-value arena path to allocate copy storage after Set")
+	}
+
+	if err := b.WriteAfterCommandWALAppend(true, func() error {
+		if !b.commandWALMaterializedRID {
+			t.Fatal("expected command WAL materialized-RID mode before append")
+		}
+		return b.Replay(func(entry batch.Entry) error {
+			if !entry.IsPtr || entry.ValuePtr.FileID == 0 || entry.ValuePtr.Length == 0 {
+				t.Fatalf("command WAL replay entry lacks materialized pointer: %+v", entry)
+			}
+			if !bytes.Equal(entry.Value, val) {
+				t.Fatalf("command WAL replay value=%x, want %x", entry.Value, val)
+			}
+			return nil
+		})
+	}); err != nil {
+		t.Fatalf("write after command WAL append: %v", err)
+	}
+
+	if len(b.ptrValueIdxs) != 0 {
+		t.Fatalf("expected pointer entry indices to be cleared after write, got %d", len(b.ptrValueIdxs))
+	}
+	if len(b.ptrCopyArenaChunks) != 0 {
+		t.Fatalf("expected ptr copy arena chunks to drain after write, got %d", len(b.ptrCopyArenaChunks))
+	}
+	if count := countBatchArenaLeaseChunks(db, db.mutableShards[0].mem); count != 1 {
+		t.Fatalf("expected only the main batch arena lease after materialized command WAL append; got %d chunks", count)
 	}
 
 	got, err := db.Get(key)

--- a/TreeDB/caching/db.go
+++ b/TreeDB/caching/db.go
@@ -77,6 +77,17 @@ var ErrBatchDeleteRangeTooLarge = errors.New("cachingdb: batch DeleteRange mater
 var errWALClosed = errors.New("cachingdb: wal writer closed")
 var errWALUnavailable = errors.New("cachingdb: wal unavailable")
 
+const (
+	commandWALMaterializedRIDMaxValueBytes  = 64 << 10
+	commandWALMaterializedRIDMaxBatchBytes  = 1 << 20
+	commandWALMaterializedRIDMaxOps         = 256
+	commandWALDefaultMaxSegmentBytes        = 64 << 20
+	commandWALMaterializedRIDFrameReserve   = 256
+	commandWALMaterializedRIDOpOverhead     = 17 + 8
+	commandWALMaterializedRIDVLogReserve    = 1 << 20
+	commandWALMaterializedRIDVLogOpOverhead = 64
+)
+
 var iteratorDebugEnabled atomic.Bool
 
 var valueLogEligiblePool sync.Pool                  // stores []int
@@ -10665,6 +10676,22 @@ func (b *Batch) OrderedEntries() []batch.Entry {
 		return nil
 	}
 	return b.entries
+}
+
+// ExternalCommandWALRequiresEntryScan reports whether cached preflight placed
+// any operation in the value log. The public command-WAL wrapper must then
+// encode the post-placement entries instead of its prebuilt inline payload so
+// the frame records either SetRID or SetMaterializedRID explicitly.
+func (b *Batch) ExternalCommandWALRequiresEntryScan() bool {
+	if b == nil || b.db == nil || !b.db.externalCommandWAL {
+		return false
+	}
+	for i := range b.entries {
+		if b.entries[i].Type == batch.OpPut && b.entries[i].IsPtr {
+			return true
+		}
+	}
+	return false
 }
 
 func assignLegacyPointEntryRevisions(entries []batch.Entry, revision page.EntryRevision) page.EntryRevision {
@@ -33332,6 +33359,7 @@ type Batch struct {
 	entryRevision                page.EntryRevision
 	commandWALAppend             func() error
 	commandWALPreparedRevision   bool
+	commandWALMaterializedRID    bool
 	valueCopyShard               *memShard
 	appendOnlyDirectValueCopier  func([]byte) []byte
 
@@ -34430,6 +34458,7 @@ func (b *Batch) Reset() {
 	b.maxEntries = 0
 	b.commandWALAppend = nil
 	b.commandWALPreparedRevision = false
+	b.commandWALMaterializedRID = false
 	b.valueCopyShard = nil
 	b.commandWALCompactReplay = false
 	b.commandWALCompactRanges = nil
@@ -36113,6 +36142,7 @@ func (b *Batch) writeRegularLocked(syncWrite bool, unlockWriteMu func()) error {
 	needRotate := false
 	needSyncBarrier := false
 	commandWALAppended := false
+	b.commandWALMaterializedRID = false
 	var retainStableViewValueMems []memtable.Table
 	var stableViewValueLeaseBytes int64
 	stableViewValueLeaseFinalized := false
@@ -36298,11 +36328,12 @@ func (b *Batch) writeRegularLocked(syncWrite bool, unlockWriteMu func()) error {
 	valueLogEnabled := b.db.valueLogEnabled()
 
 	var (
-		eligibleIdxs       []int
-		eligibleCountTotal int
-		allowPointers      bool
-		eligibleCount      int
-		multiLanePointers  bool
+		eligibleIdxs                  []int
+		eligibleCountTotal            int
+		allowPointers                 bool
+		eligibleCount                 int
+		multiLanePointers             bool
+		materializeCommandWALPointers bool
 	)
 	if !allDeletes {
 		eligibleIdxs = b.eligibleIdxs
@@ -36331,6 +36362,8 @@ func (b *Batch) writeRegularLocked(syncWrite bool, unlockWriteMu func()) error {
 			allowPointers = false
 		}
 		eligibleCount = len(eligibleIdxs)
+		materializeCommandWALPointers = allowPointers &&
+			b.commandWALCanMaterializeValueLogPointers(eligibleIdxs)
 		if debugPtr && eligibleCountTotal > 0 {
 			b.db.debugPtrEligible.Add(int64(eligibleCountTotal))
 			if !valueLogEnabled {
@@ -36340,6 +36373,7 @@ func (b *Batch) writeRegularLocked(syncWrite bool, unlockWriteMu func()) error {
 			}
 		}
 		multiLanePointers = allowPointers &&
+			!materializeCommandWALPointers &&
 			b.db.disableJournal &&
 			// journalDurabilityFlush is still an unsynced fast-path write. We widen
 			// multi-lane pointer batching to include it so unsynced importer batches
@@ -36355,20 +36389,31 @@ func (b *Batch) writeRegularLocked(syncWrite bool, unlockWriteMu func()) error {
 	)
 	needLaneForPointers := !allDeletes && !multiLanePointers && allowPointers
 	needLaneForJournal := !b.db.disableJournal
+	reserveLane := durability == journalDurabilitySync || materializeCommandWALPointers
 	if needLaneForPointers || needLaneForJournal {
-		l, err := b.db.pickLane(durability == journalDurabilitySync, -1)
+		l, err := b.db.pickLane(reserveLane, -1)
 		if err != nil {
 			unlockWriteMu()
 			return err
 		}
 		lane = l
-		if durability == journalDurabilitySync {
+		if reserveLane {
 			defer b.db.releaseLaneSync(lane)
 		}
 		if !b.db.disableJournal && allowPointers {
 			rids = make([]uint64, len(b.entries))
 		}
 	}
+	if materializeCommandWALPointers {
+		materializeCommandWALPointers = b.commandWALMaterializedRIDFitsCurrentValueLogSegment(lane, eligibleIdxs)
+		if materializeCommandWALPointers {
+			// The command frame carries both the reserved RID and the value
+			// bytes, so the value-log append is recoverable without becoming a
+			// stable dependency before the command-WAL acknowledgement.
+			durability = journalDurabilityNone
+		}
+	}
+	b.commandWALMaterializedRID = materializeCommandWALPointers
 
 	if !allDeletes && allowPointers && eligibleCount > 0 {
 		if multiLanePointers {
@@ -36472,7 +36517,7 @@ func (b *Batch) writeRegularLocked(syncWrite bool, unlockWriteMu func()) error {
 					op := &b.entries[idx]
 					op.ValuePtr = lb.ptrs[i]
 					op.IsPtr = true
-					if b.db.memtableValueLogPointers {
+					if b.db.memtableValueLogPointers && !materializeCommandWALPointers {
 						op.Value = nil
 					}
 				}
@@ -36556,7 +36601,7 @@ func (b *Batch) writeRegularLocked(syncWrite bool, unlockWriteMu func()) error {
 					op := &b.entries[idx]
 					op.ValuePtr = ptr
 					op.IsPtr = true
-					if b.db.memtableValueLogPointers {
+					if b.db.memtableValueLogPointers && !materializeCommandWALPointers {
 						op.Value = nil
 					}
 					used++
@@ -36973,6 +37018,79 @@ func (b *Batch) writeRegularLocked(syncWrite bool, unlockWriteMu func()) error {
 	b.db.maybeAssistFlush()
 	b.Reset()
 	return nil
+}
+
+func (b *Batch) commandWALCanMaterializeValueLogPointers(eligibleIdxs []int) bool {
+	if b == nil || b.db == nil || b.commandWALAppend == nil || !b.db.externalCommandWAL ||
+		len(eligibleIdxs) == 0 || len(eligibleIdxs) > commandWALMaterializedRIDMaxOps {
+		return false
+	}
+	capBytes := b.db.walMaxSegmentBytes
+	if capBytes <= 0 {
+		capBytes = commandWALDefaultMaxSegmentBytes
+	}
+	if capBytes > commandWALMaterializedRIDMaxBatchBytes {
+		capBytes = commandWALMaterializedRIDMaxBatchBytes
+	}
+	estimated := int64(commandWALMaterializedRIDFrameReserve)
+	for i, idx := range eligibleIdxs {
+		if idx < 0 || idx >= len(b.entries) {
+			return false
+		}
+		if i > 0 && idx <= eligibleIdxs[i-1] {
+			return false
+		}
+		if len(b.entries[idx].Value) == 0 || len(b.entries[idx].Value) > commandWALMaterializedRIDMaxValueBytes {
+			return false
+		}
+	}
+	eligibleCursor := 0
+	for i := range b.entries {
+		entry := &b.entries[i]
+		delta := int64(commandWALMaterializedRIDOpOverhead) + int64(len(entry.Key))
+		if entry.Type == batch.OpPut {
+			delta += int64(len(entry.Value))
+			if eligibleCursor < len(eligibleIdxs) && eligibleIdxs[eligibleCursor] == i {
+				eligibleCursor++
+			}
+		} else if entry.Type == batch.OpDeleteRange {
+			delta += int64(len(entry.Value))
+		}
+		if delta > capBytes-estimated {
+			return false
+		}
+		estimated += delta
+	}
+	return eligibleCursor == len(eligibleIdxs) && estimated <= capBytes
+}
+
+func (b *Batch) commandWALMaterializedRIDFitsCurrentValueLogSegment(l *lane, eligibleIdxs []int) bool {
+	if b == nil || b.db == nil || l == nil || len(eligibleIdxs) == 0 {
+		return false
+	}
+	maxBytes := b.db.valueLogMaxSegmentBytesForLane(l)
+	if maxBytes <= 0 {
+		return true
+	}
+	estimated := int64(commandWALMaterializedRIDVLogReserve)
+	for _, idx := range eligibleIdxs {
+		if idx < 0 || idx >= len(b.entries) {
+			return false
+		}
+		entry := &b.entries[idx]
+		delta := int64(commandWALMaterializedRIDVLogOpOverhead) + int64(len(entry.Key)) + int64(len(entry.Value))
+		if delta > maxBytes-estimated {
+			return false
+		}
+		estimated += delta
+	}
+	l.vlogMu.Lock()
+	defer l.vlogMu.Unlock()
+	if l.vlog == nil {
+		return true
+	}
+	size := l.vlog.Size()
+	return size <= maxBytes-estimated
 }
 
 type logSegmentInfo struct {
@@ -37493,6 +37611,7 @@ func (b *Batch) Close() error {
 	b.commandWALCompactReplay = false
 	b.commandWALCompactRanges = nil
 	b.commandWALCompactPointStart = 0
+	b.commandWALMaterializedRID = false
 	return nil
 }
 
@@ -37521,6 +37640,9 @@ func (b *Batch) Replay(fn func(batch.Entry) error) error {
 			pointStart = len(b.entries)
 		}
 		for _, entry := range b.entries[pointStart:] {
+			if entry.IsPtr && !b.commandWALMaterializedRID {
+				entry.Value = nil
+			}
 			if err := fn(entry); err != nil {
 				return err
 			}
@@ -37529,6 +37651,9 @@ func (b *Batch) Replay(fn func(batch.Entry) error) error {
 	}
 
 	for _, entry := range b.entries {
+		if entry.IsPtr && !b.commandWALMaterializedRID {
+			entry.Value = nil
+		}
 		if err := fn(entry); err != nil {
 			return err
 		}

--- a/TreeDB/caching/db.go
+++ b/TreeDB/caching/db.go
@@ -78,11 +78,11 @@ var errWALClosed = errors.New("cachingdb: wal writer closed")
 var errWALUnavailable = errors.New("cachingdb: wal unavailable")
 
 const (
-	commandWALMaterializedRIDMaxValueBytes  = 64 << 10
-	commandWALMaterializedRIDMaxBatchBytes  = 1 << 20
-	commandWALMaterializedRIDMaxOps         = 256
+	commandWALMaterializedRIDMaxValueBytes  = backenddb.RawKVCommandWALMaterializedRIDMaxValueBytes
+	commandWALMaterializedRIDMaxBatchBytes  = backenddb.RawKVCommandWALMaterializedRIDMaxFrameBytes
+	commandWALMaterializedRIDMaxOps         = backenddb.RawKVCommandWALMaterializedRIDMaxOperations
 	commandWALDefaultMaxSegmentBytes        = 64 << 20
-	commandWALMaterializedRIDFrameReserve   = 256
+	commandWALMaterializedRIDFrameReserve   = backenddb.RawKVCommandWALMaterializedRIDFrameReserve
 	commandWALMaterializedRIDOpOverhead     = 17 + 8
 	commandWALMaterializedRIDVLogReserve    = 1 << 20
 	commandWALMaterializedRIDVLogOpOverhead = 64

--- a/TreeDB/caching/db.go
+++ b/TreeDB/caching/db.go
@@ -36960,6 +36960,13 @@ func (b *Batch) writeRegularLocked(syncWrite bool, unlockWriteMu func()) error {
 				unlockWriteMu()
 				return fmt.Errorf("cachingdb: ptr value entry index %d out of range", idx)
 			}
+			// Materialized command-WAL pointers retain their values through the
+			// append callback so SetMaterializedRID can serialize them. After the
+			// callback succeeds, pointer-in-memtable publication stores only the
+			// pointer metadata and does not borrow those value bytes.
+			if b.commandWALMaterializedRID && b.db.memtableValueLogPointers && b.entries[idx].IsPtr {
+				continue
+			}
 			if b.entries[idx].Value == nil {
 				continue
 			}

--- a/TreeDB/caching/db.go
+++ b/TreeDB/caching/db.go
@@ -36668,11 +36668,30 @@ func (b *Batch) writeRegularLocked(syncWrite bool, unlockWriteMu func()) error {
 	}
 
 	if b.commandWALAppend != nil {
+		if b.commandWALMaterializedRID && b.db.memtableValueLogPointers {
+			for _, idx := range b.ptrValueIdxs {
+				if idx < 0 || idx >= len(b.entries) {
+					unlockWriteMu()
+					return fmt.Errorf("cachingdb: ptr value entry index %d out of range", idx)
+				}
+			}
+		}
 		if err := b.commandWALAppend(); err != nil {
 			unlockWriteMu()
 			return err
 		}
 		commandWALAppended = true
+		if b.commandWALMaterializedRID && b.db.memtableValueLogPointers {
+			// SetMaterializedRID needs the value through the callback above. The
+			// pointer-in-memtable representation needs only ValuePtr, so clear the
+			// serialization copy before any sorted/steal publication path can take
+			// ownership of it.
+			for _, idx := range b.ptrValueIdxs {
+				if b.entries[idx].IsPtr {
+					b.entries[idx].Value = nil
+				}
+			}
+		}
 	}
 
 	if !allDeletes {
@@ -36959,13 +36978,6 @@ func (b *Batch) writeRegularLocked(syncWrite bool, unlockWriteMu func()) error {
 			if idx < 0 || idx >= len(b.entries) || idx >= len(shardIdxs) {
 				unlockWriteMu()
 				return fmt.Errorf("cachingdb: ptr value entry index %d out of range", idx)
-			}
-			// Materialized command-WAL pointers retain their values through the
-			// append callback so SetMaterializedRID can serialize them. After the
-			// callback succeeds, pointer-in-memtable publication stores only the
-			// pointer metadata and does not borrow those value bytes.
-			if b.commandWALMaterializedRID && b.db.memtableValueLogPointers && b.entries[idx].IsPtr {
-				continue
 			}
 			if b.entries[idx].Value == nil {
 				continue

--- a/TreeDB/caching/db.go
+++ b/TreeDB/caching/db.go
@@ -12232,10 +12232,9 @@ func Open(dir string, backend BackendDB, opts Options) (*DB, error) {
 	segments, _ := listNonEmptySplitLogSegments(walDir, valueLogDir, leafLogDir)
 	reserveLeafLogLane := opts.IndexOuterLeavesInValueLog
 	// Cached value-log RIDs remain globally unique across reopen/rewrite cycles.
-	// RID allocation is monotonic, so each non-leaf lane's latest non-empty
-	// value-log segment contains that lane's high-watermark. Leaf-log append lanes
-	// share one encoded lane across multiple physical writers, so their RID seed
-	// scans every non-empty reserved leaf-log segment.
+	// Scan every non-empty segment: exact-RID command-WAL recovery may append an
+	// older missing RID into a newer segment, so the physical tail is no longer
+	// guaranteed to carry the allocator high-watermark.
 	maxExistingRID, err := maxValueLogRIDFromSegments(segments)
 	if err != nil {
 		return nil, err
@@ -37023,7 +37022,7 @@ func (b *Batch) writeRegularLocked(syncWrite bool, unlockWriteMu func()) error {
 
 func (b *Batch) commandWALCanMaterializeValueLogPointers(eligibleIdxs []int) bool {
 	if b == nil || b.db == nil || b.commandWALAppend == nil || !b.db.externalCommandWAL ||
-		len(eligibleIdxs) == 0 || len(eligibleIdxs) > commandWALMaterializedRIDMaxOps {
+		len(eligibleIdxs) == 0 || len(b.entries) == 0 || len(b.entries) > commandWALMaterializedRIDMaxOps {
 		return false
 	}
 	capBytes := b.db.walMaxSegmentBytes
@@ -37191,7 +37190,7 @@ func listNonEmptySplitLogSegments(walDir, valueLogDir, leafLogDir string) (segme
 
 func maxValueLogRIDFromSegments(segments []logSegmentInfo) (uint64, error) {
 	var maxRID uint64
-	for _, seg := range ridSeedValueLogSegments(segments) {
+	for _, seg := range segments {
 		if !seg.valueLog || seg.size <= 0 || seg.lane < 0 || seg.seq < 0 {
 			continue
 		}
@@ -37226,32 +37225,6 @@ func maxValueLogRIDFromSegments(segments []logSegmentInfo) (uint64, error) {
 		}
 	}
 	return maxRID, nil
-}
-
-func ridSeedValueLogSegments(segments []logSegmentInfo) []logSegmentInfo {
-	if len(segments) == 0 {
-		return nil
-	}
-	out := make([]logSegmentInfo, 0, len(segments))
-	for _, seg := range segments {
-		if !seg.valueLog || seg.size <= 0 || seg.lane < 0 || seg.seq < 0 {
-			continue
-		}
-		if seg.lane == leafLogLaneID {
-			out = append(out, seg)
-		}
-	}
-	out = append(out, tailValueLogSegmentsByLaneExcept(segments, leafLogLaneID)...)
-	sort.Slice(out, func(i, j int) bool {
-		if out[i].lane != out[j].lane {
-			return out[i].lane < out[j].lane
-		}
-		if out[i].seq != out[j].seq {
-			return out[i].seq < out[j].seq
-		}
-		return out[i].path < out[j].path
-	})
-	return out
 }
 
 func tailValueLogSegmentsByLane(segments []logSegmentInfo) []logSegmentInfo {

--- a/TreeDB/caching/db.go
+++ b/TreeDB/caching/db.go
@@ -36362,7 +36362,8 @@ func (b *Batch) writeRegularLocked(syncWrite bool, unlockWriteMu func()) error {
 			allowPointers = false
 		}
 		eligibleCount = len(eligibleIdxs)
-		materializeCommandWALPointers = allowPointers &&
+		materializeCommandWALPointers = durability == journalDurabilitySync &&
+			allowPointers &&
 			b.commandWALCanMaterializeValueLogPointers(eligibleIdxs)
 		if debugPtr && eligibleCountTotal > 0 {
 			b.db.debugPtrEligible.Add(int64(eligibleCountTotal))

--- a/TreeDB/caching/vlog_segment_scan_test.go
+++ b/TreeDB/caching/vlog_segment_scan_test.go
@@ -8,19 +8,16 @@ import (
 	"github.com/snissn/gomap/TreeDB/internal/valuelog"
 )
 
-func TestMaxValueLogRIDFromSegmentsScansLatestSegmentPerLane(t *testing.T) {
+func TestMaxValueLogRIDFromSegmentsScansAllSegments(t *testing.T) {
 	t.Parallel()
 
 	dir := t.TempDir()
-	oldCorruptPath := filepath.Join(dir, valueLogName(0, 1))
-	if err := os.WriteFile(oldCorruptPath, []byte{0x01}, 0o644); err != nil {
-		t.Fatalf("WriteFile: %v", err)
-	}
+	lane0Older := writeRIDValueLogSegment(t, dir, 0, 1, 200)
 	lane0Tail := writeRIDValueLogSegment(t, dir, 0, 2, 22)
 	lane1Tail := writeRIDValueLogSegment(t, dir, 1, 1, 33)
 
 	segments := []logSegmentInfo{
-		{path: oldCorruptPath, size: 1, seq: 1, lane: 0, valueLog: true},
+		{path: lane0Older, size: fileSize(t, lane0Older), seq: 1, lane: 0, valueLog: true},
 		{path: lane0Tail, size: fileSize(t, lane0Tail), seq: 2, lane: 0, valueLog: true},
 		{path: lane1Tail, size: fileSize(t, lane1Tail), seq: 1, lane: 1, valueLog: true},
 		{path: filepath.Join(dir, commitLogName(9, 9)), size: 128, seq: 9, lane: 9, valueLog: false},
@@ -30,8 +27,8 @@ func TestMaxValueLogRIDFromSegmentsScansLatestSegmentPerLane(t *testing.T) {
 	if err != nil {
 		t.Fatalf("maxValueLogRIDFromSegments: %v", err)
 	}
-	if maxRID != 33 {
-		t.Fatalf("maxRID=%d want 33", maxRID)
+	if maxRID != 200 {
+		t.Fatalf("maxRID=%d want 200 from older exact-RID segment", maxRID)
 	}
 }
 

--- a/TreeDB/command_wal_durable_prefix_test.go
+++ b/TreeDB/command_wal_durable_prefix_test.go
@@ -256,7 +256,9 @@ func TestPublicCommandWALRelaxedPointerDebtStatsCloseOnSetSync(t *testing.T) {
 	defer func() { _ = db.Close() }()
 
 	b := db.NewBatch()
-	if err := b.Set([]byte("relaxed-pointer"), bytes.Repeat([]byte("r"), 4096)); err != nil {
+	// Keep this above the bounded materialized-RID value limit so the test
+	// continues to exercise #3920's external dependency-debt path.
+	if err := b.Set([]byte("relaxed-pointer"), bytes.Repeat([]byte("r"), 65<<10)); err != nil {
 		_ = b.Close()
 		t.Fatalf("relaxed pointer batch Set: %v", err)
 	}
@@ -313,7 +315,9 @@ func TestPublicCommandWALRelaxedPointerDebtEmitsExactDependencySyncCuts(t *testi
 	defer restore()
 
 	b := db.NewBatch()
-	if err := b.Set([]byte("relaxed-pointer"), bytes.Repeat([]byte("r"), 4096)); err != nil {
+	// Keep this above the bounded materialized-RID value limit so the test
+	// continues to exercise #3920's external dependency-sync path.
+	if err := b.Set([]byte("relaxed-pointer"), bytes.Repeat([]byte("r"), 65<<10)); err != nil {
 		_ = b.Close()
 		t.Fatalf("relaxed pointer batch Set: %v", err)
 	}
@@ -389,7 +393,9 @@ func TestPublicCommandWALRelaxedPointerDependencySyncCutsRetainDebtForRetry(t *t
 			defer func() { _ = db.Close() }()
 
 			b := db.NewBatch()
-			if err := b.Set([]byte("relaxed-pointer"), bytes.Repeat([]byte("r"), 4096)); err != nil {
+			// Keep this above the bounded materialized-RID value limit so the test
+			// continues to exercise #3920's external dependency retry path.
+			if err := b.Set([]byte("relaxed-pointer"), bytes.Repeat([]byte("r"), 65<<10)); err != nil {
 				_ = b.Close()
 				t.Fatalf("batch Set relaxed pointer: %v", err)
 			}

--- a/TreeDB/command_wal_group_commit_test.go
+++ b/TreeDB/command_wal_group_commit_test.go
@@ -1142,7 +1142,9 @@ func TestPublicCommandWALGroupCommitCoversRotationAndExternalValueDependencies(t
 		go func(i int) {
 			b := db.NewBatch()
 			defer b.Close()
-			if err := b.Set([]byte(fmt.Sprintf("external/%d", i)), bytes.Repeat([]byte{byte('a' + i)}, 4096)); err != nil {
+			// Stay above the bounded materialized-RID value limit so this test
+			// continues to cover grouped external dependency fences.
+			if err := b.Set([]byte(fmt.Sprintf("external/%d", i)), bytes.Repeat([]byte{byte('a' + i)}, 65<<10)); err != nil {
 				errs <- err
 				return
 			}

--- a/TreeDB/command_wal_public_cached.go
+++ b/TreeDB/command_wal_public_cached.go
@@ -501,6 +501,10 @@ type commandWALPublicRevisionAssigner interface {
 	AssignExternalCommandWALPointRevisions() page.EntryRevision
 }
 
+type commandWALPublicEntryScanSelector interface {
+	ExternalCommandWALRequiresEntryScan() bool
+}
+
 type commandWALPublicInnerSetViewValidated interface {
 	SetViewValidated(key, value []byte) error
 }
@@ -1359,7 +1363,11 @@ func (b *commandWALPublicBatch) appendCommandWAL(sync bool) error {
 	if b == nil || b.inner == nil {
 		return ErrClosed
 	}
-	if !b.payloadBypass && b.payload.Count() == b.opCount && b.payload.Count() > 0 {
+	entryScanRequired := false
+	if selector, ok := b.inner.(commandWALPublicEntryScanSelector); ok {
+		entryScanRequired = selector.ExternalCommandWALRequiresEntryScan()
+	}
+	if !entryScanRequired && !b.payloadBypass && b.payload.Count() == b.opCount && b.payload.Count() > 0 {
 		return b.db.appendPublicRawKVCommandPayloadPrepared(func() ([]byte, error) {
 			if err := b.assignCommandWALPointRevisions(); err != nil {
 				return nil, err
@@ -1377,7 +1385,11 @@ func (b *commandWALPublicBatch) appendCommandWALMeasured(sync bool) (db.CommandW
 	if b == nil || b.inner == nil || b.db == nil {
 		return timing, ErrClosed
 	}
-	if !b.payloadBypass && b.payload.Count() == b.opCount && b.payload.Count() > 0 {
+	entryScanRequired := false
+	if selector, ok := b.inner.(commandWALPublicEntryScanSelector); ok {
+		entryScanRequired = selector.ExternalCommandWALRequiresEntryScan()
+	}
+	if !entryScanRequired && !b.payloadBypass && b.payload.Count() == b.opCount && b.payload.Count() > 0 {
 		var preparation time.Duration
 		timing, err := b.db.appendPublicRawKVCommandPayloadPreparedMeasured(func() ([]byte, error) {
 			preparationStart := time.Now()

--- a/TreeDB/command_wal_public_cached.go
+++ b/TreeDB/command_wal_public_cached.go
@@ -18,6 +18,16 @@ func (tdb *DB) commandWALOrdinaryWriteRequiresSync() bool {
 	return tdb != nil && tdb.commandWALCached && tdb.resolvedProfile == ProfileCommandWALDurable
 }
 
+func publicRawKVCommandWALAppendMode(durable, appendSync bool) db.RawKVCommandWALAppendMode {
+	if appendSync {
+		return db.RawKVCommandWALAppendDurable
+	}
+	if durable {
+		return db.RawKVCommandWALAppendDurablePrefixParticipant
+	}
+	return db.RawKVCommandWALAppendRelaxed
+}
+
 func (tdb *DB) appendPublicRawKVPointCommand(op commitlog.RawKVOp, key, value []byte, assignRevision func() page.EntryRevision, sync bool, publication *publicCommandWALPublication) error {
 	if tdb == nil || !tdb.commandWALCached {
 		return nil
@@ -138,7 +148,7 @@ func (tdb *DB) appendPublicRawKVCommandEntries(entries []batch.Entry, sync bool,
 		return ErrClosed
 	}
 	result, err := tdb.appendAndRegisterPublicCommandWAL(len(entries)*64, nil, sync, nil, nil, nil, func(appendSync bool) (uint64, error) {
-		return tdb.backend.AppendRawKVCommandWALOrderedEntries(entries, appendSync)
+		return tdb.backend.AppendRawKVCommandWALOrderedEntriesWithMode(entries, publicRawKVCommandWALAppendMode(sync, appendSync))
 	})
 	if publication != nil {
 		*publication = result
@@ -154,7 +164,7 @@ func (tdb *DB) appendPublicRawKVCommandEntryScan(scanEntries func(func(batch.Ent
 		return ErrClosed
 	}
 	result, err := tdb.appendAndRegisterPublicCommandWAL(opHint*64, nil, sync, nil, nil, nil, func(appendSync bool) (uint64, error) {
-		return tdb.backend.AppendRawKVCommandWALOrderedEntryScanWithHint(scanEntries, opHint, appendSync)
+		return tdb.backend.AppendRawKVCommandWALOrderedEntryScanWithHintAndMode(scanEntries, opHint, publicRawKVCommandWALAppendMode(sync, appendSync))
 	})
 	if publication != nil {
 		*publication = result
@@ -174,7 +184,7 @@ func (tdb *DB) appendPublicRawKVCommandEntryScanMeasured(scanEntries func(func(b
 	result, err := tdb.appendAndRegisterPublicCommandWAL(opHint*64, nil, sync, &timing.PostAppendPendingLSNBookkeeping, &timing.GroupCommitWait, &timing.GroupCommitWaitObserved, func(appendSync bool) (uint64, error) {
 		var appendErr error
 		var lsn uint64
-		lsn, timing, appendErr = tdb.backend.AppendRawKVCommandWALOrderedEntryScanWithHintMeasured(scanEntries, opHint, appendSync)
+		lsn, timing, appendErr = tdb.backend.AppendRawKVCommandWALOrderedEntryScanWithHintAndModeMeasured(scanEntries, opHint, publicRawKVCommandWALAppendMode(sync, appendSync))
 		return lsn, appendErr
 	})
 	if publication != nil {
@@ -192,7 +202,7 @@ func (tdb *DB) appendPublicRawKVCommandEntryScanPrepared(prepare func() error, s
 		return ErrClosed
 	}
 	result, err := tdb.appendAndRegisterPublicCommandWAL(opHint*64, nil, sync, nil, nil, nil, func(appendSync bool) (uint64, error) {
-		return tdb.backend.AppendRawKVCommandWALOrderedEntryScanWithHintPrepared(prepare, scanEntries, opHint, appendSync)
+		return tdb.backend.AppendRawKVCommandWALOrderedEntryScanWithHintPreparedAndMode(prepare, scanEntries, opHint, publicRawKVCommandWALAppendMode(sync, appendSync))
 	})
 	if publicationTicket != nil {
 		*publicationTicket = result.ticket
@@ -212,7 +222,7 @@ func (tdb *DB) appendPublicRawKVCommandEntryScanPreparedMeasured(prepare func() 
 	result, err := tdb.appendAndRegisterPublicCommandWAL(opHint*64, nil, sync, &timing.PostAppendPendingLSNBookkeeping, &timing.GroupCommitWait, &timing.GroupCommitWaitObserved, func(appendSync bool) (uint64, error) {
 		var appendErr error
 		var lsn uint64
-		lsn, timing, appendErr = tdb.backend.AppendRawKVCommandWALOrderedEntryScanWithHintPreparedMeasured(prepare, scanEntries, opHint, appendSync)
+		lsn, timing, appendErr = tdb.backend.AppendRawKVCommandWALOrderedEntryScanWithHintPreparedAndModeMeasured(prepare, scanEntries, opHint, publicRawKVCommandWALAppendMode(sync, appendSync))
 		return lsn, appendErr
 	})
 	if publicationTicket != nil {

--- a/TreeDB/command_wal_public_test.go
+++ b/TreeDB/command_wal_public_test.go
@@ -19,6 +19,7 @@ import (
 	backenddb "github.com/snissn/gomap/TreeDB/db"
 	"github.com/snissn/gomap/TreeDB/internal/commitlog"
 	"github.com/snissn/gomap/TreeDB/internal/durabilitycut"
+	"github.com/snissn/gomap/TreeDB/internal/valuelog"
 	"github.com/snissn/gomap/TreeDB/page"
 )
 
@@ -1042,6 +1043,180 @@ func TestPublicCommandWALMaterializedRIDRequiresStrictDurableWrite(t *testing.T)
 			}
 		})
 	}
+}
+
+func TestPublicCommandWALMaterializedRIDTotalOperationBoundFallsBackAtomically(t *testing.T) {
+	for _, tc := range []struct {
+		name       string
+		totalOps   int
+		wantFormat commitlog.PayloadFormat
+		wantFirst  commitlog.RawKVOp
+	}{
+		{name: "at-bound", totalOps: 256, wantFormat: commitlog.PayloadFormatRawKVBatchV2, wantFirst: commitlog.RawKVOpSetMaterializedRID},
+		{name: "over-bound", totalOps: 257, wantFormat: commitlog.PayloadFormatRawKVBatchV1, wantFirst: commitlog.RawKVOpSetRID},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			opts := commandWALDurabilityProofOptions(t.TempDir())
+			opts.ValueLog.PointerThreshold = 1024
+			opts.ValueLog.ForcePointers = false
+			db, err := Open(opts)
+			if err != nil {
+				t.Fatalf("Open command WAL: %v", err)
+			}
+			defer func() { _ = db.Close() }()
+
+			b := db.NewBatchWithSize(tc.totalOps)
+			if err := b.Set([]byte("pointer"), bytes.Repeat([]byte("p"), 4096)); err != nil {
+				_ = b.Close()
+				t.Fatalf("batch pointer Set: %v", err)
+			}
+			for i := 1; i < tc.totalOps; i++ {
+				if err := b.Set([]byte(fmt.Sprintf("inline-%03d", i)), []byte("i")); err != nil {
+					_ = b.Close()
+					t.Fatalf("batch inline Set %d: %v", i, err)
+				}
+			}
+			if err := b.WriteSync(); err != nil {
+				_ = b.Close()
+				t.Fatalf("batch WriteSync: %v", err)
+			}
+			if err := b.Close(); err != nil {
+				t.Fatalf("batch Close: %v", err)
+			}
+
+			r, err := commitlog.NewReader(filepath.Join(backenddb.WALDirPath(opts.Dir), "commit-l0-000001.log"))
+			if err != nil {
+				t.Fatalf("NewReader operation bound: %v", err)
+			}
+			defer r.Close()
+			env, err := r.ReadCommandFrame()
+			if err != nil {
+				t.Fatalf("ReadCommandFrame operation bound: %v", err)
+			}
+			if env.PayloadFormat != tc.wantFormat {
+				t.Fatalf("operation-bound payload format=%d, want %d", env.PayloadFormat, tc.wantFormat)
+			}
+			ops, err := commitlog.DecodeRawKVBatchPayload(env.Payload)
+			if err != nil {
+				t.Fatalf("DecodeRawKVBatchPayload operation bound: %v", err)
+			}
+			if len(ops) != tc.totalOps {
+				t.Fatalf("operation-bound ops len=%d, want %d", len(ops), tc.totalOps)
+			}
+			if ops[0].Op != tc.wantFirst {
+				t.Fatalf("operation-bound first op=%+v, want op %d", ops[0], tc.wantFirst)
+			}
+			for i := 1; i < len(ops); i++ {
+				if ops[i].Op != commitlog.RawKVOpSet {
+					t.Fatalf("operation-bound op[%d]=%+v, want inline Set", i, ops[i])
+				}
+			}
+		})
+	}
+}
+
+func TestPublicCommandWALMaterializedRIDRecoveryPreservesCachedAllocatorHighWater(t *testing.T) {
+	dir := t.TempDir()
+	opts := commandWALDurabilityProofOptions(dir)
+	opts.ValueLog.PointerThreshold = 1
+	opts.ValueLog.ForcePointers = true
+
+	bootstrap, err := Open(opts)
+	if err != nil {
+		t.Fatalf("Open bootstrap command WAL: %v", err)
+	}
+	if err := bootstrap.Close(); err != nil {
+		t.Fatalf("Close bootstrap command WAL: %v", err)
+	}
+
+	fileID, err := valuelog.EncodeFileID(0, 1)
+	if err != nil {
+		t.Fatalf("EncodeFileID: %v", err)
+	}
+	valuePath := filepath.Join(backenddb.ValueLogDirPath(dir), "value-l0-000001.log")
+	valueWriter, err := valuelog.NewWriter(valuePath, fileID)
+	if err != nil {
+		t.Fatalf("NewWriter existing high RID: %v", err)
+	}
+	if _, err := valueWriter.Append(0, nil, 200, []byte("existing-high-water")); err != nil {
+		_ = valueWriter.Close()
+		t.Fatalf("Append existing high RID: %v", err)
+	}
+	if err := valueWriter.Sync(); err != nil {
+		_ = valueWriter.Close()
+		t.Fatalf("Sync existing high RID: %v", err)
+	}
+	if err := valueWriter.Close(); err != nil {
+		t.Fatalf("Close existing high RID: %v", err)
+	}
+
+	payload, err := commitlog.EncodeRawKVBatchPayload([]commitlog.RawKVOperation{{
+		Op:    commitlog.RawKVOpSetMaterializedRID,
+		Key:   []byte("recovered"),
+		Value: []byte("materialized-older-rid"),
+		RID:   42,
+	}})
+	if err != nil {
+		t.Fatalf("EncodeRawKVBatchPayload: %v", err)
+	}
+	commandPath := filepath.Join(backenddb.WALDirPath(dir), "commit-l0-000001.log")
+	commandWriter, err := commitlog.NewWriter(commandPath)
+	if err != nil {
+		t.Fatalf("NewWriter materialized command: %v", err)
+	}
+	if err := commandWriter.AppendCommand(commitlog.CommandEnvelope{
+		Version:         commitlog.CommandFrameVersionV2,
+		DurabilityClass: commitlog.CommandDurabilityDurable,
+		LSN:             1,
+		Kind:            commitlog.CommandKindRawKVBatch,
+		Scope:           commitlog.CommandScopeRawKV,
+		PayloadFormat:   commitlog.PayloadFormatRawKVBatchV2,
+		Payload:         payload,
+	}); err != nil {
+		_ = commandWriter.Close()
+		t.Fatalf("AppendCommand materialized command: %v", err)
+	}
+	if err := commandWriter.Sync(); err != nil {
+		_ = commandWriter.Close()
+		t.Fatalf("Sync materialized command: %v", err)
+	}
+	if err := commandWriter.Close(); err != nil {
+		t.Fatalf("Close materialized command: %v", err)
+	}
+
+	recovered, err := Open(opts)
+	if err != nil {
+		t.Fatalf("Open materialized recovery: %v", err)
+	}
+	requireRawKVValue(t, recovered, []byte("recovered"), []byte("materialized-older-rid"))
+	startRID, err := recovered.cached.ReserveValueLogRIDs(1)
+	if err != nil {
+		_ = recovered.Close()
+		t.Fatalf("ReserveValueLogRIDs after materialized recovery: %v", err)
+	}
+	if startRID <= 200 {
+		_ = recovered.Close()
+		t.Fatalf("cached allocator start RID=%d, want a RID above the all-segment high-water 200", startRID)
+	}
+	if err := recovered.SetSync([]byte("foreground"), bytes.Repeat([]byte("f"), 4096)); err != nil {
+		_ = recovered.Close()
+		t.Fatalf("foreground pointer SetSync: %v", err)
+	}
+	if err := recovered.Checkpoint(); err != nil {
+		_ = recovered.Close()
+		t.Fatalf("Checkpoint after foreground pointer: %v", err)
+	}
+	if err := recovered.Close(); err != nil {
+		t.Fatalf("Close after foreground pointer: %v", err)
+	}
+
+	reopened, err := Open(opts)
+	if err != nil {
+		t.Fatalf("Reopen after foreground pointer: %v", err)
+	}
+	defer reopened.Close()
+	requireRawKVValue(t, reopened, []byte("recovered"), []byte("materialized-older-rid"))
+	requireRawKVValue(t, reopened, []byte("foreground"), bytes.Repeat([]byte("f"), 4096))
 }
 
 func TestPublicCommandWALStateShapedDurabilityLedger(t *testing.T) {

--- a/TreeDB/command_wal_public_test.go
+++ b/TreeDB/command_wal_public_test.go
@@ -906,9 +906,10 @@ func TestPublicCommandWALBatchWriteSyncExternalRefOrderingPhaseStats(t *testing.
 	defer func() { _ = db.Close() }()
 	db.commandWALGroupCommit.testBeforeSync = func(int) {}
 	before := db.Stats()
+	value := bytes.Repeat([]byte("v"), 4096)
 
 	b := db.NewBatch()
-	if err := b.Set([]byte("external-ref"), bytes.Repeat([]byte("v"), 2048)); err != nil {
+	if err := b.Set([]byte("external-ref"), value); err != nil {
 		_ = b.Close()
 		t.Fatalf("batch Set: %v", err)
 	}
@@ -923,18 +924,57 @@ func TestPublicCommandWALBatchWriteSyncExternalRefOrderingPhaseStats(t *testing.
 	stats := db.Stats()
 	prefix := "treedb.public.batch.write_sync.phase."
 	if got := statMapUint64(t, stats, prefix+"command_external_ref_ordering.calls_total"); got != 1 {
-		t.Fatalf("phase external-ref ordering calls=%d, want 1 (stats=%#v)", got, stats)
+		t.Fatalf("phase external-ref planning calls=%d, want 1 observed no-op planning phase (stats=%#v)", got, stats)
 	}
 	requirePublicStatDelta(t, before, stats, "treedb.command_wal.sync.count_total", 1)
 	// The mutation frame and the durable-prefix barrier are distinct WAL
 	// writes, but the group still owns exactly one shared file sync.
 	requirePublicStatDelta(t, before, stats, "treedb.command_wal.write.syscalls_total", 2)
 	requirePublicStatDelta(t, before, stats, "treedb.command_wal.file_sync.calls_total", 1)
-	requirePublicStatDelta(t, before, stats, "treedb.cache.value_log.sync.calls_total", 1)
-	requirePublicStatDelta(t, before, stats, "treedb.cache.value_log.sync.materialization.calls_total", 1)
+	requirePublicStatDelta(t, before, stats, "treedb.cache.value_log.sync.calls_total", 0)
+	requirePublicStatDelta(t, before, stats, "treedb.cache.value_log.sync.materialization.calls_total", 0)
 	requirePublicStatDelta(t, before, stats, "treedb.cache.value_log.sync.external_ref.calls_total", 0)
-	requirePublicStatDelta(t, before, stats, "treedb.cache.value_log.file_sync.calls_total", 1)
+	requirePublicStatDelta(t, before, stats, "treedb.cache.value_log.file_sync.calls_total", 0)
 	requirePublicBatchWriteSyncPhasePartitions(t, stats)
+
+	r, err := commitlog.NewReader(filepath.Join(backenddb.WALDirPath(opts.Dir), "commit-l0-000001.log"))
+	if err != nil {
+		t.Fatalf("NewReader materialized command frame: %v", err)
+	}
+	env, err := r.ReadCommandFrame()
+	if err != nil {
+		_ = r.Close()
+		t.Fatalf("ReadCommandFrame materialized command frame: %v", err)
+	}
+	if env.PayloadFormat != commitlog.PayloadFormatRawKVBatchV2 {
+		_ = r.Close()
+		t.Fatalf("payload format=%d, want RawKVBatchV2", env.PayloadFormat)
+	}
+	ops, err := commitlog.DecodeRawKVBatchPayload(env.Payload)
+	if err != nil {
+		_ = r.Close()
+		t.Fatalf("DecodeRawKVBatchPayload materialized command frame: %v", err)
+	}
+	if len(ops) != 1 || ops[0].Op != commitlog.RawKVOpSetMaterializedRID || ops[0].RID == 0 ||
+		string(ops[0].Key) != "external-ref" || !bytes.Equal(ops[0].Value, value) {
+		_ = r.Close()
+		t.Fatalf("materialized command ops=%+v", ops)
+	}
+	if err := r.Close(); err != nil {
+		t.Fatalf("Close materialized command reader: %v", err)
+	}
+	if err := db.Checkpoint(); err != nil {
+		t.Fatalf("Checkpoint materialized command: %v", err)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatalf("Close materialized command DB: %v", err)
+	}
+	reopen, err := Open(opts)
+	if err != nil {
+		t.Fatalf("Reopen materialized command DB: %v", err)
+	}
+	defer reopen.Close()
+	requireRawKVValue(t, reopen, []byte("external-ref"), value)
 }
 
 func TestPublicCommandWALStateShapedDurabilityLedger(t *testing.T) {
@@ -3698,7 +3738,7 @@ func benchmarkPublicCommandWALDurableShape(b *testing.B, forcedPointers bool, sh
 
 	value := []byte("public-command-wal-value")
 	if forcedPointers {
-		value = bytes.Repeat([]byte("p"), 2048)
+		value = bytes.Repeat([]byte("p"), 4096)
 	}
 	before := db.Stats()
 	latencyCapacity := b.N
@@ -3826,9 +3866,6 @@ func publicCommandWALDurableShapeExpectedCounters(shape string, forcedPointers b
 	case "dirty_batch":
 		appendCalls, syncCalls, writeSyscalls, fileSyncCalls = 1, 1, 1, 1
 		batchWriteSyncCalls = 1
-		if forcedPointers {
-			valueLogMaterializationSyncs = 1
-		}
 	case "write_then_dirty_write_sync":
 		appendCalls, flushCalls, syncCalls, writeSyscalls, fileSyncCalls = 2, 1, 1, 2, 1
 		batchWriteCalls, batchWriteSyncCalls = 1, 1
@@ -3841,11 +3878,6 @@ func publicCommandWALDurableShapeExpectedCounters(shape string, forcedPointers b
 	case "state_point_point_sync_batch_sync":
 		appendCalls, flushCalls, syncCalls, writeSyscalls, fileSyncCalls = 3, 1, 2, 3, 2
 		batchWriteSyncCalls = 1
-		if forcedPointers {
-			// Public point commands remain inline command-WAL inputs. The batch
-			// materialization is the state-shaped external-value boundary.
-			valueLogMaterializationSyncs = 1
-		}
 	}
 	if durability == DurabilityDurable {
 		switch shape {
@@ -3853,14 +3885,8 @@ func publicCommandWALDurableShapeExpectedCounters(shape string, forcedPointers b
 			appendCalls, flushCalls, writeSyscalls, barrierSyncCalls = 1, 0, 1, 0
 		case "write_then_dirty_write_sync":
 			appendCalls, flushCalls, syncCalls, writeSyscalls, fileSyncCalls, barrierSyncCalls = 2, 0, 2, 2, 2, 0
-			if forcedPointers {
-				valueLogMaterializationSyncs = 2
-			}
 		case "empty_write_sync_after_write":
 			appendCalls, flushCalls, syncCalls, writeSyscalls, fileSyncCalls = 1, 0, 2, 1, 2
-			if forcedPointers {
-				valueLogMaterializationSyncs = 1
-			}
 		case "state_point_point_sync_batch_sync":
 			appendCalls, flushCalls, syncCalls, writeSyscalls, fileSyncCalls, barrierSyncCalls = 3, 0, 3, 3, 3, 0
 		}
@@ -4707,6 +4733,7 @@ func reportCommandWALBenchmarkDeltas(b *testing.B, before, after map[string]stri
 		"treedb.cache.value_log.file_sync.ns_total",
 		"treedb.cache.value_log.file_sync.rotated_segment.calls_total",
 		"treedb.cache.value_log.file_sync.rotated_segment.ns_total",
+		"treedb.cache.vlog_io.bytes",
 		"treedb.public.batch.write_sync.phase.wall.ns_total",
 		"treedb.public.batch.write_sync.phase.checkpoint_gate.ns_total",
 		"treedb.public.batch.write_sync.phase.preflight_materialization.ns_total",
@@ -5131,6 +5158,44 @@ func TestPublicCommandWALBatchValueLogPointersStayBelowFrameCap(t *testing.T) {
 	if frames := publicCommandWALFrameCount(t, db); frames != 1 {
 		_ = db.Close()
 		t.Fatalf("command_wal.frames=%d, want one directly synced mutation", frames)
+	}
+	r, err := commitlog.NewReader(filepath.Join(backenddb.WALDirPath(dir), "commit-l0-000001.log"))
+	if err != nil {
+		_ = db.Close()
+		t.Fatalf("NewReader fallback command frame: %v", err)
+	}
+	env, err := r.ReadCommandFrame()
+	if err != nil {
+		_ = r.Close()
+		_ = db.Close()
+		t.Fatalf("ReadCommandFrame fallback command frame: %v", err)
+	}
+	if env.PayloadFormat != commitlog.PayloadFormatRawKVBatchV1 {
+		_ = r.Close()
+		_ = db.Close()
+		t.Fatalf("fallback payload format=%d, want RawKVBatchV1", env.PayloadFormat)
+	}
+	ops, err := commitlog.DecodeRawKVBatchPayload(env.Payload)
+	if err != nil {
+		_ = r.Close()
+		_ = db.Close()
+		t.Fatalf("DecodeRawKVBatchPayload fallback command frame: %v", err)
+	}
+	for i := range ops {
+		if ops[i].Op != commitlog.RawKVOpSetRID || ops[i].RID == 0 || ops[i].Value != nil {
+			_ = r.Close()
+			_ = db.Close()
+			t.Fatalf("fallback command op[%d]=%+v, want SetRID", i, ops[i])
+		}
+	}
+	if len(ops) != len(values) {
+		_ = r.Close()
+		_ = db.Close()
+		t.Fatalf("fallback command op count=%d, want %d", len(ops), len(values))
+	}
+	if err := r.Close(); err != nil {
+		_ = db.Close()
+		t.Fatalf("Close fallback command reader: %v", err)
 	}
 	for key, value := range values {
 		requireRawKVValue(t, db, []byte(key), value)

--- a/TreeDB/command_wal_public_test.go
+++ b/TreeDB/command_wal_public_test.go
@@ -977,6 +977,73 @@ func TestPublicCommandWALBatchWriteSyncExternalRefOrderingPhaseStats(t *testing.
 	requireRawKVValue(t, reopen, []byte("external-ref"), value)
 }
 
+func TestPublicCommandWALMaterializedRIDRequiresStrictDurableWrite(t *testing.T) {
+	tests := []struct {
+		name    string
+		relaxed bool
+		write   func(Batch) error
+	}{
+		{
+			name:    "relaxed-ordinary-write",
+			relaxed: true,
+			write:   func(b Batch) error { return b.Write() },
+		},
+		{
+			name:    "relaxed-write-sync",
+			relaxed: true,
+			write:   func(b Batch) error { return b.WriteSync() },
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			opts := commandWALDurabilityProofOptions(t.TempDir())
+			if tc.relaxed {
+				ApplyProfile(&opts, ProfileCommandWALRelaxed)
+			}
+			opts.ValueLog.PointerThreshold = 1
+			opts.ValueLog.ForcePointers = true
+			db, err := Open(opts)
+			if err != nil {
+				t.Fatalf("Open command WAL: %v", err)
+			}
+			defer func() { _ = db.Close() }()
+
+			b := db.NewBatch()
+			if err := b.Set([]byte("external-ref"), bytes.Repeat([]byte("v"), 4096)); err != nil {
+				_ = b.Close()
+				t.Fatalf("batch Set: %v", err)
+			}
+			if err := tc.write(b); err != nil {
+				_ = b.Close()
+				t.Fatalf("batch write: %v", err)
+			}
+			if err := b.Close(); err != nil {
+				t.Fatalf("batch Close: %v", err)
+			}
+
+			r, err := commitlog.NewReader(filepath.Join(backenddb.WALDirPath(opts.Dir), "commit-l0-000001.log"))
+			if err != nil {
+				t.Fatalf("NewReader command frame: %v", err)
+			}
+			defer r.Close()
+			env, err := r.ReadCommandFrame()
+			if err != nil {
+				t.Fatalf("ReadCommandFrame: %v", err)
+			}
+			if env.PayloadFormat != commitlog.PayloadFormatRawKVBatchV1 {
+				t.Fatalf("payload format=%d, want RawKVBatchV1 outside strict durable writes", env.PayloadFormat)
+			}
+			ops, err := commitlog.DecodeRawKVBatchPayload(env.Payload)
+			if err != nil {
+				t.Fatalf("DecodeRawKVBatchPayload: %v", err)
+			}
+			if len(ops) != 1 || ops[0].Op != commitlog.RawKVOpSetRID {
+				t.Fatalf("command ops=%+v, want one SetRID dependency", ops)
+			}
+		})
+	}
+}
+
 func TestPublicCommandWALStateShapedDurabilityLedger(t *testing.T) {
 	opts := commandWALDurabilityProofOptions(t.TempDir())
 	ApplyProfile(&opts, ProfileCommandWALRelaxed)

--- a/TreeDB/db/batch.go
+++ b/TreeDB/db/batch.go
@@ -322,7 +322,7 @@ func (b *Batch) write(sync bool) error {
 			return err
 		}
 		var err error
-		intent, err = b.db.prepareRawKVCommandWALIntent(b)
+		intent, err = b.db.prepareRawKVCommandWALIntent(b, sync)
 		if err != nil {
 			return err
 		}
@@ -845,7 +845,7 @@ func (b *Batch) writeConditional(sync bool, conditional *ConditionalTxn) error {
 		if err := b.db.runCommandWALRawPublishBarriers(); err != nil {
 			return err
 		}
-		intent, err = b.db.prepareRawKVCommandWALIntent(b)
+		intent, err = b.db.prepareRawKVCommandWALIntent(b, sync)
 		if err != nil {
 			return err
 		}

--- a/TreeDB/db/command_wal_raw.go
+++ b/TreeDB/db/command_wal_raw.go
@@ -1326,11 +1326,12 @@ func (db *DB) newRawKVCommandWALIntentFromEntryScanWithHint(scanEntries func(fun
 	materializedRefs := false
 	materializedEligible := true
 	operations := 0
-	planScan := db.rawKVCommandWALOperationScannerFromEntryScan(func(emit func(batchpkg.Entry) error) error {
+	planScan := commitlog.RawKVBatchOperationScanner(func(emit func(commitlog.RawKVOperation) error) error {
 		if scanEntries == nil {
 			return nil
 		}
 		return scanEntries(func(entry batchpkg.Entry) error {
+			materializeEntry := materialize
 			if materialize {
 				operations++
 				if operations > RawKVCommandWALMaterializedRIDMaxOperations {
@@ -1342,13 +1343,22 @@ func (db *DB) newRawKVCommandWALIntentFromEntryScanWithHint(scanEntries func(fun
 						materializedEligible = false
 					}
 				}
+				materializeEntry = materializedEligible
 			}
 			if entry.Type != batchpkg.OpDeleteRange && entry.Revision > maxEntryRevision {
 				maxEntryRevision = entry.Revision
 			}
-			return emit(entry)
+			validateRetainedValue := !materialize || materializeEntry
+			op, ok, err := db.rawKVCommandWALOperationFromEntry(entry, &ridCache, &externalRefs, &externalRefFileIDs, opHint, materializeEntry, validateRetainedValue)
+			if err != nil {
+				return err
+			}
+			if !ok {
+				return nil
+			}
+			return emit(op)
 		})
-	}, &ridCache, &externalRefs, &externalRefFileIDs, opHint, materialize, true)
+	})
 	plan, err := commitlog.PlanRawKVBatchPayloadScan(planScan)
 	if err != nil {
 		return nil, err

--- a/TreeDB/db/command_wal_raw.go
+++ b/TreeDB/db/command_wal_raw.go
@@ -2630,6 +2630,10 @@ func applyRawKVCommandWALFrame(db *DB, env commitlog.CommandEnvelope, ridMap map
 			if ok {
 				got, producedThisFrame := materializedThisFrame[entry.RID]
 				if !producedThisFrame {
+					// Registration binds this exact existing segment to the synchronous
+					// root-publication closure below. That closure syncs it after the
+					// provisional in-memory LSN assignment but before the publication
+					// seal, index, and durable meta make the LSN/root tuple stable.
 					if err := db.registerReplayValueLogPointer(ptr); err != nil {
 						return err
 					}

--- a/TreeDB/db/command_wal_raw.go
+++ b/TreeDB/db/command_wal_raw.go
@@ -49,6 +49,47 @@ type commandWALBatchIntent struct {
 const rawKVCommandWALRIDInlineCacheEntries = 4
 const rawKVCommandWALRIDMaxPooledOverflowEntries = 4 * 1024
 
+// Bounded RawKVBatchV2 materialization limits. The cached public preflight and
+// backend command encoder both enforce these values so callers cannot select a
+// dependency-free materialized-RID frame merely by retaining entry.Value.
+const (
+	RawKVCommandWALMaterializedRIDMaxValueBytes = 64 << 10
+	RawKVCommandWALMaterializedRIDMaxFrameBytes = 1 << 20
+	RawKVCommandWALMaterializedRIDMaxOperations = 256
+	RawKVCommandWALMaterializedRIDFrameReserve  = 256
+)
+
+// RawKVCommandWALAppendMode declares the durability boundary that will cover a
+// raw-KV command frame. It is intentionally separate from whether this append
+// performs the sync: grouped durable writes append participant frames first and
+// acknowledge them only after a later durable-prefix barrier.
+type RawKVCommandWALAppendMode uint8
+
+const (
+	// RawKVCommandWALAppendRelaxed flushes without a power-loss durability
+	// boundary and always retains the external SetRID dependency contract.
+	RawKVCommandWALAppendRelaxed RawKVCommandWALAppendMode = iota
+	// RawKVCommandWALAppendDurable syncs this frame directly and may select the
+	// bounded, self-contained SetMaterializedRID representation.
+	RawKVCommandWALAppendDurable
+	// RawKVCommandWALAppendDurablePrefixParticipant appends without syncing this
+	// frame. The caller must not acknowledge it until a later durable-prefix
+	// barrier has synced the frame. It may select bounded SetMaterializedRID.
+	RawKVCommandWALAppendDurablePrefixParticipant
+)
+
+func (mode RawKVCommandWALAppendMode) valid() bool {
+	return mode <= RawKVCommandWALAppendDurablePrefixParticipant
+}
+
+func (mode RawKVCommandWALAppendMode) sync() bool {
+	return mode == RawKVCommandWALAppendDurable
+}
+
+func (mode RawKVCommandWALAppendMode) allowsMaterializedRID() bool {
+	return mode == RawKVCommandWALAppendDurable || mode == RawKVCommandWALAppendDurablePrefixParticipant
+}
+
 type rawKVCommandWALRIDCacheEntry struct {
 	ptr page.ValuePtr
 	rid uint64
@@ -968,7 +1009,7 @@ func NewCommandWALCoverageIntent(appliedLSN uint64, covered CommandWALLSNRange) 
 	}}, nil
 }
 
-func (db *DB) prepareRawKVCommandWALIntent(b *Batch) (*commandWALBatchIntent, error) {
+func (db *DB) prepareRawKVCommandWALIntent(b *Batch, sync bool) (*commandWALBatchIntent, error) {
 	if db == nil || !db.commandWAL {
 		return nil, nil
 	}
@@ -987,14 +1028,17 @@ func (db *DB) prepareRawKVCommandWALIntent(b *Batch) (*commandWALBatchIntent, er
 	if len(entries) == 0 {
 		return nil, nil
 	}
-	return db.newRawKVCommandWALIntentFromEntries(entries)
+	return db.newRawKVCommandWALIntentFromEntries(entries, sync)
 }
 
 // NewRawKVCommandWALIntentFromOrderedEntries builds a public raw-KV command
 // intent from entries that are already in the caller's required application
 // order. Unlike prepareRawKVCommandWALIntent, this does not sort or compact
 // point ops; public cached batches rely on replay order to preserve mixed
-// set/delete/range-delete semantics.
+// set/delete/range-delete semantics. Because a reusable intent does not declare
+// its eventual durability boundary, this constructor conservatively encodes
+// pointer entries as SetRID. One-shot append APIs with an explicit append mode
+// own bounded SetMaterializedRID selection.
 func (db *DB) NewRawKVCommandWALIntentFromOrderedEntries(entries []batchpkg.Entry) (*CommandWALIntent, error) {
 	if db == nil || !db.commandWAL {
 		return nil, nil
@@ -1005,7 +1049,7 @@ func (db *DB) NewRawKVCommandWALIntentFromOrderedEntries(entries []batchpkg.Entr
 	if len(entries) == 0 {
 		return nil, nil
 	}
-	intent, err := db.newRawKVCommandWALPayloadIntentFromEntries(entries)
+	intent, err := db.newRawKVCommandWALPayloadIntentFromEntries(entries, false)
 	if intent == nil || err != nil {
 		return nil, err
 	}
@@ -1017,8 +1061,23 @@ func (db *DB) NewRawKVCommandWALIntentFromOrderedEntries(entries []batchpkg.Entr
 // caller must keep entries and their key/value buffers immutable until this
 // method returns.
 func (db *DB) AppendRawKVCommandWALOrderedEntries(entries []batchpkg.Entry, sync bool) (uint64, error) {
+	mode := RawKVCommandWALAppendRelaxed
+	if sync {
+		mode = RawKVCommandWALAppendDurable
+	}
+	return db.AppendRawKVCommandWALOrderedEntriesWithMode(entries, mode)
+}
+
+// AppendRawKVCommandWALOrderedEntriesWithMode is the durability-explicit form
+// of AppendRawKVCommandWALOrderedEntries. A durable-prefix participant is
+// appended relaxed and is safe to acknowledge only after its caller establishes
+// a covering durable-prefix barrier.
+func (db *DB) AppendRawKVCommandWALOrderedEntriesWithMode(entries []batchpkg.Entry, mode RawKVCommandWALAppendMode) (uint64, error) {
 	if db == nil || !db.commandWAL {
 		return 0, nil
+	}
+	if !mode.valid() {
+		return 0, fmt.Errorf("%w: invalid raw kv command wal append mode %d", ErrCommandWALUnsupported, mode)
 	}
 	if db.durability == DurabilityWALOffRelaxed {
 		return 0, fmt.Errorf("%w: WAL-off durability is incompatible with command WAL", ErrCommandWALUnsupported)
@@ -1026,13 +1085,13 @@ func (db *DB) AppendRawKVCommandWALOrderedEntries(entries []batchpkg.Entry, sync
 	if len(entries) == 0 {
 		return 0, nil
 	}
-	intent, err := db.newRawKVCommandWALIntentFromEntries(entries)
+	intent, err := db.newRawKVCommandWALIntentFromEntries(entries, mode.allowsMaterializedRID())
 	if intent == nil || err != nil {
 		return 0, err
 	}
 	publicIntent := &CommandWALIntent{inner: *intent}
 	defer releaseUnassignedCommandWALIntent(&publicIntent.inner)
-	return db.AppendCommandWALIntent(publicIntent, sync)
+	return db.AppendCommandWALIntent(publicIntent, mode.sync())
 }
 
 // AppendRawKVCommandWALOrderedEntryScan appends a raw-KV command frame by
@@ -1048,8 +1107,21 @@ func (db *DB) AppendRawKVCommandWALOrderedEntryScan(scanEntries func(func(batchp
 // like AppendRawKVCommandWALOrderedEntryScan, using opHint only to pre-size
 // transient planning caches.
 func (db *DB) AppendRawKVCommandWALOrderedEntryScanWithHint(scanEntries func(func(batchpkg.Entry) error) error, opHint int, sync bool) (uint64, error) {
+	mode := RawKVCommandWALAppendRelaxed
+	if sync {
+		mode = RawKVCommandWALAppendDurable
+	}
+	return db.AppendRawKVCommandWALOrderedEntryScanWithHintAndMode(scanEntries, opHint, mode)
+}
+
+// AppendRawKVCommandWALOrderedEntryScanWithHintAndMode is the
+// durability-explicit ordered-scan append variant.
+func (db *DB) AppendRawKVCommandWALOrderedEntryScanWithHintAndMode(scanEntries func(func(batchpkg.Entry) error) error, opHint int, mode RawKVCommandWALAppendMode) (uint64, error) {
 	if db == nil || !db.commandWAL {
 		return 0, nil
+	}
+	if !mode.valid() {
+		return 0, fmt.Errorf("%w: invalid raw kv command wal append mode %d", ErrCommandWALUnsupported, mode)
 	}
 	if db.durability == DurabilityWALOffRelaxed {
 		return 0, fmt.Errorf("%w: WAL-off durability is incompatible with command WAL", ErrCommandWALUnsupported)
@@ -1057,13 +1129,13 @@ func (db *DB) AppendRawKVCommandWALOrderedEntryScanWithHint(scanEntries func(fun
 	if scanEntries == nil {
 		return 0, nil
 	}
-	intent, err := db.newRawKVCommandWALIntentFromEntryScanWithHint(scanEntries, opHint)
+	intent, err := db.newRawKVCommandWALIntentFromEntryScanWithHint(scanEntries, opHint, mode.allowsMaterializedRID())
 	if intent == nil || err != nil {
 		return 0, err
 	}
 	publicIntent := &CommandWALIntent{inner: *intent}
 	defer releaseUnassignedCommandWALIntent(&publicIntent.inner)
-	return db.AppendCommandWALIntent(publicIntent, sync)
+	return db.AppendCommandWALIntent(publicIntent, mode.sync())
 }
 
 // AppendRawKVCommandWALOrderedEntryScanWithHintMeasured is the opt-in
@@ -1071,9 +1143,22 @@ func (db *DB) AppendRawKVCommandWALOrderedEntryScanWithHint(scanEntries func(fun
 // partitions intent planning, publish serialization/barriers, append,
 // flush/sync, and post-append bookkeeping without changing their ordering.
 func (db *DB) AppendRawKVCommandWALOrderedEntryScanWithHintMeasured(scanEntries func(func(batchpkg.Entry) error) error, opHint int, sync bool) (uint64, CommandWALRequestTiming, error) {
+	mode := RawKVCommandWALAppendRelaxed
+	if sync {
+		mode = RawKVCommandWALAppendDurable
+	}
+	return db.AppendRawKVCommandWALOrderedEntryScanWithHintAndModeMeasured(scanEntries, opHint, mode)
+}
+
+// AppendRawKVCommandWALOrderedEntryScanWithHintAndModeMeasured is the
+// durability-explicit diagnostic ordered-scan append variant.
+func (db *DB) AppendRawKVCommandWALOrderedEntryScanWithHintAndModeMeasured(scanEntries func(func(batchpkg.Entry) error) error, opHint int, mode RawKVCommandWALAppendMode) (uint64, CommandWALRequestTiming, error) {
 	var timing CommandWALRequestTiming
 	if db == nil || !db.commandWAL {
 		return 0, timing, nil
+	}
+	if !mode.valid() {
+		return 0, timing, fmt.Errorf("%w: invalid raw kv command wal append mode %d", ErrCommandWALUnsupported, mode)
 	}
 	if db.readOnly {
 		return 0, timing, ErrReadOnly
@@ -1086,7 +1171,7 @@ func (db *DB) AppendRawKVCommandWALOrderedEntryScanWithHintMeasured(scanEntries 
 	}
 	planningStart := time.Now()
 	timing.BackendIntentPlanningSerializationObserved = true
-	intent, err := db.newRawKVCommandWALIntentFromEntryScanWithHint(scanEntries, opHint)
+	intent, err := db.newRawKVCommandWALIntentFromEntryScanWithHint(scanEntries, opHint, mode.allowsMaterializedRID())
 	timing.BackendIntentPlanningSerialization += time.Since(planningStart)
 	if intent == nil || err != nil {
 		return 0, timing, err
@@ -1100,7 +1185,7 @@ func (db *DB) AppendRawKVCommandWALOrderedEntryScanWithHintMeasured(scanEntries 
 		return 0, timing, err
 	}
 	defer unlockCommandWALPublish()
-	lsn, err := db.appendCommandWALIntentWithTiming(intent, sync, &timing)
+	lsn, err := db.appendCommandWALIntentWithTiming(intent, mode.sync(), &timing)
 	return lsn, timing, err
 }
 
@@ -1108,20 +1193,44 @@ func (db *DB) AppendRawKVCommandWALOrderedEntryScanWithHintMeasured(scanEntries 
 // metadata while holding the barrier-aware publish lock, then plans and appends
 // the ordered entry scan under that same serialization boundary.
 func (db *DB) AppendRawKVCommandWALOrderedEntryScanWithHintPrepared(prepare func() error, scanEntries func(func(batchpkg.Entry) error) error, opHint int, sync bool) (uint64, error) {
-	lsn, _, err := db.appendRawKVCommandWALOrderedEntryScanWithHintPrepared(prepare, scanEntries, opHint, sync, false)
+	mode := RawKVCommandWALAppendRelaxed
+	if sync {
+		mode = RawKVCommandWALAppendDurable
+	}
+	lsn, _, err := db.appendRawKVCommandWALOrderedEntryScanWithHintPrepared(prepare, scanEntries, opHint, mode, false)
+	return lsn, err
+}
+
+// AppendRawKVCommandWALOrderedEntryScanWithHintPreparedAndMode is the
+// durability-explicit prepared ordered-scan append variant.
+func (db *DB) AppendRawKVCommandWALOrderedEntryScanWithHintPreparedAndMode(prepare func() error, scanEntries func(func(batchpkg.Entry) error) error, opHint int, mode RawKVCommandWALAppendMode) (uint64, error) {
+	lsn, _, err := db.appendRawKVCommandWALOrderedEntryScanWithHintPrepared(prepare, scanEntries, opHint, mode, false)
 	return lsn, err
 }
 
 // AppendRawKVCommandWALOrderedEntryScanWithHintPreparedMeasured is the
 // diagnostic counterpart to the prepared ordered-entry scan append.
 func (db *DB) AppendRawKVCommandWALOrderedEntryScanWithHintPreparedMeasured(prepare func() error, scanEntries func(func(batchpkg.Entry) error) error, opHint int, sync bool) (uint64, CommandWALRequestTiming, error) {
-	return db.appendRawKVCommandWALOrderedEntryScanWithHintPrepared(prepare, scanEntries, opHint, sync, true)
+	mode := RawKVCommandWALAppendRelaxed
+	if sync {
+		mode = RawKVCommandWALAppendDurable
+	}
+	return db.appendRawKVCommandWALOrderedEntryScanWithHintPrepared(prepare, scanEntries, opHint, mode, true)
 }
 
-func (db *DB) appendRawKVCommandWALOrderedEntryScanWithHintPrepared(prepare func() error, scanEntries func(func(batchpkg.Entry) error) error, opHint int, sync bool, measured bool) (uint64, CommandWALRequestTiming, error) {
+// AppendRawKVCommandWALOrderedEntryScanWithHintPreparedAndModeMeasured is the
+// durability-explicit diagnostic prepared ordered-scan append variant.
+func (db *DB) AppendRawKVCommandWALOrderedEntryScanWithHintPreparedAndModeMeasured(prepare func() error, scanEntries func(func(batchpkg.Entry) error) error, opHint int, mode RawKVCommandWALAppendMode) (uint64, CommandWALRequestTiming, error) {
+	return db.appendRawKVCommandWALOrderedEntryScanWithHintPrepared(prepare, scanEntries, opHint, mode, true)
+}
+
+func (db *DB) appendRawKVCommandWALOrderedEntryScanWithHintPrepared(prepare func() error, scanEntries func(func(batchpkg.Entry) error) error, opHint int, mode RawKVCommandWALAppendMode, measured bool) (uint64, CommandWALRequestTiming, error) {
 	var timing CommandWALRequestTiming
 	if db == nil || !db.commandWAL {
 		return 0, timing, nil
+	}
+	if !mode.valid() {
+		return 0, timing, fmt.Errorf("%w: invalid raw kv command wal append mode %d", ErrCommandWALUnsupported, mode)
 	}
 	if db.readOnly {
 		return 0, timing, ErrReadOnly
@@ -1168,7 +1277,7 @@ func (db *DB) appendRawKVCommandWALOrderedEntryScanWithHintPrepared(prepare func
 		}
 		return 0, timing, err
 	}
-	intent, err := db.newRawKVCommandWALIntentFromEntryScanWithHint(scanEntries, opHint)
+	intent, err := db.newRawKVCommandWALIntentFromEntryScanWithHint(scanEntries, opHint, mode.allowsMaterializedRID())
 	if measured {
 		timing.BackendIntentPlanningSerialization += time.Since(planningStart)
 	}
@@ -1176,7 +1285,7 @@ func (db *DB) appendRawKVCommandWALOrderedEntryScanWithHintPrepared(prepare func
 		return 0, timing, err
 	}
 	defer releaseUnassignedCommandWALIntent(intent)
-	lsn, err := db.appendCommandWALIntentWithTiming(intent, sync, func() *CommandWALRequestTiming {
+	lsn, err := db.appendCommandWALIntentWithTiming(intent, mode.sync(), func() *CommandWALRequestTiming {
 		if measured {
 			return &timing
 		}
@@ -1185,7 +1294,7 @@ func (db *DB) appendRawKVCommandWALOrderedEntryScanWithHintPrepared(prepare func
 	return lsn, timing, err
 }
 
-func (db *DB) newRawKVCommandWALIntentFromEntries(entries []batchpkg.Entry) (*commandWALBatchIntent, error) {
+func (db *DB) newRawKVCommandWALIntentFromEntries(entries []batchpkg.Entry, allowMaterializedRID bool) (*commandWALBatchIntent, error) {
 	if len(entries) == 0 {
 		return nil, nil
 	}
@@ -1196,43 +1305,70 @@ func (db *DB) newRawKVCommandWALIntentFromEntries(entries []batchpkg.Entry) (*co
 			}
 		}
 		return nil
-	}, len(entries))
+	}, len(entries), allowMaterializedRID)
 }
 
-func (db *DB) newRawKVCommandWALIntentFromEntryScan(scanEntries func(func(batchpkg.Entry) error) error) (*commandWALBatchIntent, error) {
-	return db.newRawKVCommandWALIntentFromEntryScanWithHint(scanEntries, 0)
+func (db *DB) newRawKVCommandWALIntentFromEntryScan(scanEntries func(func(batchpkg.Entry) error) error, allowMaterializedRID bool) (*commandWALBatchIntent, error) {
+	return db.newRawKVCommandWALIntentFromEntryScanWithHint(scanEntries, 0, allowMaterializedRID)
 }
 
-func (db *DB) newRawKVCommandWALIntentFromEntryScanWithHint(scanEntries func(func(batchpkg.Entry) error) error, opHint int) (*commandWALBatchIntent, error) {
+func (db *DB) newRawKVCommandWALIntentFromEntryScanWithHint(scanEntries func(func(batchpkg.Entry) error) error, opHint int, allowMaterializedRID bool) (_ *commandWALBatchIntent, err error) {
+	materialize := allowMaterializedRID
 	externalRefs := false
-	materializedRefs := false
 	var ridCache *rawKVCommandWALRIDCache
 	var externalRefFileIDs []uint32
 	maxEntryRevision := page.LegacyEntryRevision
+	defer func() {
+		if err != nil && ridCache != nil {
+			ridCache.release()
+		}
+	}()
+	materializedRefs := false
+	materializedEligible := true
+	operations := 0
 	planScan := db.rawKVCommandWALOperationScannerFromEntryScan(func(emit func(batchpkg.Entry) error) error {
 		if scanEntries == nil {
 			return nil
 		}
 		return scanEntries(func(entry batchpkg.Entry) error {
+			if materialize {
+				operations++
+				if operations > RawKVCommandWALMaterializedRIDMaxOperations {
+					materializedEligible = false
+				}
+				if entry.Type == batchpkg.OpPut && entry.IsPtr && entry.Value != nil {
+					materializedRefs = true
+					if len(entry.Value) == 0 || len(entry.Value) > RawKVCommandWALMaterializedRIDMaxValueBytes {
+						materializedEligible = false
+					}
+				}
+			}
 			if entry.Type != batchpkg.OpDeleteRange && entry.Revision > maxEntryRevision {
 				maxEntryRevision = entry.Revision
 			}
-			if entry.Type == batchpkg.OpPut && entry.IsPtr && entry.Value != nil {
-				materializedRefs = true
-			}
 			return emit(entry)
 		})
-	}, &ridCache, &externalRefs, &externalRefFileIDs, opHint)
+	}, &ridCache, &externalRefs, &externalRefFileIDs, opHint, materialize)
 	plan, err := commitlog.PlanRawKVBatchPayloadScan(planScan)
 	if err != nil {
 		return nil, err
 	}
+	if materialize && (!materializedRefs || !materializedEligible || !db.rawKVCommandWALMaterializedRIDPlanFits(plan)) {
+		materialize = false
+		externalRefs = false
+		externalRefFileIDs = externalRefFileIDs[:0]
+		fallbackScan := db.rawKVCommandWALOperationScannerFromEntryScan(scanEntries, &ridCache, &externalRefs, &externalRefFileIDs, opHint, false)
+		plan, err = commitlog.PlanRawKVBatchPayloadScan(fallbackScan)
+		if err != nil {
+			return nil, err
+		}
+	}
 	if plan.Count == 0 {
 		return nil, nil
 	}
-	writeScan := db.rawKVCommandWALOperationScannerFromEntryScan(scanEntries, &ridCache, nil, nil, opHint)
+	writeScan := db.rawKVCommandWALOperationScannerFromEntryScan(scanEntries, &ridCache, nil, nil, opHint, materialize)
 	payloadFormat := commitlog.PayloadFormatRawKVBatchV1
-	if materializedRefs {
+	if materialize {
 		payloadFormat = commitlog.PayloadFormatRawKVBatchV2
 	}
 	return &commandWALBatchIntent{
@@ -1249,47 +1385,34 @@ func (db *DB) newRawKVCommandWALIntentFromEntryScanWithHint(scanEntries func(fun
 	}, nil
 }
 
-func (db *DB) newRawKVCommandWALPayloadIntentFromEntries(entries []batchpkg.Entry) (*commandWALBatchIntent, error) {
-	externalRefs := false
-	var ridCache *rawKVCommandWALRIDCache
-	scan := db.rawKVCommandWALOperationScannerWithHint(entries, &ridCache, &externalRefs, len(entries))
-	plan, err := commitlog.PlanRawKVBatchPayloadScan(scan)
+func (db *DB) newRawKVCommandWALPayloadIntentFromEntries(entries []batchpkg.Entry, allowMaterializedRID bool) (*commandWALBatchIntent, error) {
+	intent, err := db.newRawKVCommandWALIntentFromEntries(entries, allowMaterializedRID)
+	if err != nil || intent == nil {
+		return intent, err
+	}
+	payload, err := commitlog.EncodeRawKVBatchPayloadPlanned(intent.rawKVPlan, intent.rawKVScan)
 	if err != nil {
-		return nil, err
-	}
-	if plan.Count == 0 {
-		return nil, nil
-	}
-	var payload []byte
-	if plan.EntryRevisions {
-		payload, err = commitlog.EncodeRawKVBatchPayloadPlanned(plan, scan)
-	} else {
-		payload, err = commitlog.EncodeRawKVBatchPayloadScanWithHint(scan, plan.Count, 0)
-	}
-	if err != nil {
-		return nil, err
-	}
-	var externalRefFileIDs []uint32
-	if externalRefs {
-		externalRefFileIDs = rawKVCommandWALExternalRefFileIDs(entries)
-	}
-	payloadFormat := commitlog.PayloadFormatRawKVBatchV1
-	for i := range entries {
-		if entries[i].Type == batchpkg.OpPut && entries[i].IsPtr && entries[i].Value != nil {
-			payloadFormat = commitlog.PayloadFormatRawKVBatchV2
-			break
+		if intent.rawKVRIDCache != nil {
+			intent.rawKVRIDCache.release()
 		}
+		return nil, err
 	}
-	return &commandWALBatchIntent{
-		kind:               commitlog.CommandKindRawKVBatch,
-		scope:              commitlog.CommandScopeRawKV,
-		payloadFormat:      payloadFormat,
-		payload:            payload,
-		rawKVRIDCache:      ridCache,
-		externalRefs:       externalRefs,
-		externalRefFileIDs: externalRefFileIDs,
-		maxEntryRevision:   maxEntryRevisionFromEntries(entries),
-	}, nil
+	intent.payload = payload
+	intent.rawKVScan = nil
+	intent.rawKVDirect = false
+	return intent, nil
+}
+
+func (db *DB) rawKVCommandWALMaterializedRIDPlanFits(plan commitlog.RawKVBatchPayloadPlan) bool {
+	if plan.Count <= 0 || plan.Count > RawKVCommandWALMaterializedRIDMaxOperations {
+		return false
+	}
+	maxFrame := int64(RawKVCommandWALMaterializedRIDMaxFrameBytes)
+	if db != nil && db.walMaxSegmentBytes > 0 && db.walMaxSegmentBytes < maxFrame {
+		maxFrame = db.walMaxSegmentBytes
+	}
+	maxPayload := maxFrame - RawKVCommandWALMaterializedRIDFrameReserve
+	return maxPayload >= 0 && plan.PayloadLen >= 0 && int64(plan.PayloadLen) <= maxPayload
 }
 
 func stableExternalRIDSegmentDigest(fileID uint32) [sha256.Size]byte {
@@ -1458,10 +1581,10 @@ func maxEntryRevisionFromCommandWALPayload(kind commitlog.CommandKind, scope com
 }
 
 func (db *DB) rawKVCommandWALOperationScanner(entries []batchpkg.Entry, ridCache **rawKVCommandWALRIDCache, externalRefs *bool) commitlog.RawKVBatchOperationScanner {
-	return db.rawKVCommandWALOperationScannerWithHint(entries, ridCache, externalRefs, len(entries))
+	return db.rawKVCommandWALOperationScannerWithHint(entries, ridCache, externalRefs, len(entries), false)
 }
 
-func (db *DB) rawKVCommandWALOperationScannerWithHint(entries []batchpkg.Entry, ridCache **rawKVCommandWALRIDCache, externalRefs *bool, opHint int) commitlog.RawKVBatchOperationScanner {
+func (db *DB) rawKVCommandWALOperationScannerWithHint(entries []batchpkg.Entry, ridCache **rawKVCommandWALRIDCache, externalRefs *bool, opHint int, materialize bool) commitlog.RawKVBatchOperationScanner {
 	return db.rawKVCommandWALOperationScannerFromEntryScan(func(emit func(batchpkg.Entry) error) error {
 		for i := range entries {
 			if err := emit(entries[i]); err != nil {
@@ -1469,16 +1592,16 @@ func (db *DB) rawKVCommandWALOperationScannerWithHint(entries []batchpkg.Entry, 
 			}
 		}
 		return nil
-	}, ridCache, externalRefs, nil, opHint)
+	}, ridCache, externalRefs, nil, opHint, materialize)
 }
 
-func (db *DB) rawKVCommandWALOperationScannerFromEntryScan(scanEntries func(func(batchpkg.Entry) error) error, ridCache **rawKVCommandWALRIDCache, externalRefs *bool, externalRefFileIDs *[]uint32, opHint int) commitlog.RawKVBatchOperationScanner {
+func (db *DB) rawKVCommandWALOperationScannerFromEntryScan(scanEntries func(func(batchpkg.Entry) error) error, ridCache **rawKVCommandWALRIDCache, externalRefs *bool, externalRefFileIDs *[]uint32, opHint int, materialize bool) commitlog.RawKVBatchOperationScanner {
 	return func(emit func(commitlog.RawKVOperation) error) error {
 		if scanEntries == nil {
 			return nil
 		}
 		return scanEntries(func(entry batchpkg.Entry) error {
-			op, ok, err := db.rawKVCommandWALOperationFromEntry(entry, ridCache, externalRefs, externalRefFileIDs, opHint)
+			op, ok, err := db.rawKVCommandWALOperationFromEntry(entry, ridCache, externalRefs, externalRefFileIDs, opHint, materialize)
 			if err != nil {
 				return err
 			}
@@ -1490,7 +1613,7 @@ func (db *DB) rawKVCommandWALOperationScannerFromEntryScan(scanEntries func(func
 	}
 }
 
-func (db *DB) rawKVCommandWALOperationFromEntry(entry batchpkg.Entry, ridCache **rawKVCommandWALRIDCache, externalRefs *bool, externalRefFileIDs *[]uint32, opHint int) (commitlog.RawKVOperation, bool, error) {
+func (db *DB) rawKVCommandWALOperationFromEntry(entry batchpkg.Entry, ridCache **rawKVCommandWALRIDCache, externalRefs *bool, externalRefFileIDs *[]uint32, opHint int, materializePointers bool) (commitlog.RawKVOperation, bool, error) {
 	switch entry.Type {
 	case batchpkg.OpDeleteRange:
 		if batchpkg.IsDeleteRangeNoop(entry.Key, entry.Value) {
@@ -1501,7 +1624,8 @@ func (db *DB) rawKVCommandWALOperationFromEntry(entry batchpkg.Entry, ridCache *
 		return commitlog.RawKVOperation{Op: commitlog.RawKVOpDelete, Key: entry.Key, Revision: uint64(entry.Revision)}, true, nil
 	case batchpkg.OpPut:
 		if entry.IsPtr {
-			materialized := entry.Value != nil
+			hasRetainedValue := entry.Value != nil
+			materialized := materializePointers && hasRetainedValue
 			if ridCache == nil {
 				return commitlog.RawKVOperation{}, false, fmt.Errorf("treedb: command wal raw kv rid cache unavailable")
 			}
@@ -1512,7 +1636,7 @@ func (db *DB) rawKVCommandWALOperationFromEntry(entry batchpkg.Entry, ridCache *
 			if err != nil {
 				return commitlog.RawKVOperation{}, false, err
 			}
-			if materialized {
+			if hasRetainedValue {
 				persisted, err := db.valueLogManager.Read(entry.ValuePtr)
 				if isCommandWALRIDLookupVisibilityError(err) {
 					if flushErr := db.flushCommandWALExternalRefs([]uint32{entry.ValuePtr.FileID}); flushErr != nil {
@@ -1526,6 +1650,8 @@ func (db *DB) rawKVCommandWALOperationFromEntry(entry batchpkg.Entry, ridCache *
 				if !bytes.Equal(persisted, entry.Value) {
 					return commitlog.RawKVOperation{}, false, fmt.Errorf("%w: rid=%d", ErrCommandWALConflictingValueLogRID, rid)
 				}
+			}
+			if materialized {
 				return commitlog.RawKVOperation{
 					Op:       commitlog.RawKVOpSetMaterializedRID,
 					Key:      entry.Key,

--- a/TreeDB/db/command_wal_raw.go
+++ b/TreeDB/db/command_wal_raw.go
@@ -1,6 +1,7 @@
 package db
 
 import (
+	"bytes"
 	"crypto/sha256"
 	"encoding/binary"
 	"errors"
@@ -227,6 +228,7 @@ func (timing *CommandWALPublishTiming) Add(other CommandWALPublishTiming) {
 }
 
 var ErrCommandWALMissingValueLogRID = errors.New("treedb: command wal missing value-log rid")
+var ErrCommandWALConflictingValueLogRID = errors.New("treedb: command wal conflicting value-log rid")
 
 // AssignedLSN returns the command LSN already assigned to this intent. Replay
 // intents use this to finalize durable command coverage without appending a
@@ -1203,6 +1205,7 @@ func (db *DB) newRawKVCommandWALIntentFromEntryScan(scanEntries func(func(batchp
 
 func (db *DB) newRawKVCommandWALIntentFromEntryScanWithHint(scanEntries func(func(batchpkg.Entry) error) error, opHint int) (*commandWALBatchIntent, error) {
 	externalRefs := false
+	materializedRefs := false
 	var ridCache *rawKVCommandWALRIDCache
 	var externalRefFileIDs []uint32
 	maxEntryRevision := page.LegacyEntryRevision
@@ -1213,6 +1216,9 @@ func (db *DB) newRawKVCommandWALIntentFromEntryScanWithHint(scanEntries func(fun
 		return scanEntries(func(entry batchpkg.Entry) error {
 			if entry.Type != batchpkg.OpDeleteRange && entry.Revision > maxEntryRevision {
 				maxEntryRevision = entry.Revision
+			}
+			if entry.Type == batchpkg.OpPut && entry.IsPtr && entry.Value != nil {
+				materializedRefs = true
 			}
 			return emit(entry)
 		})
@@ -1225,10 +1231,14 @@ func (db *DB) newRawKVCommandWALIntentFromEntryScanWithHint(scanEntries func(fun
 		return nil, nil
 	}
 	writeScan := db.rawKVCommandWALOperationScannerFromEntryScan(scanEntries, &ridCache, nil, nil, opHint)
+	payloadFormat := commitlog.PayloadFormatRawKVBatchV1
+	if materializedRefs {
+		payloadFormat = commitlog.PayloadFormatRawKVBatchV2
+	}
 	return &commandWALBatchIntent{
 		kind:               commitlog.CommandKindRawKVBatch,
 		scope:              commitlog.CommandScopeRawKV,
-		payloadFormat:      commitlog.PayloadFormatRawKVBatchV1,
+		payloadFormat:      payloadFormat,
 		rawKVScan:          writeScan,
 		rawKVPlan:          plan,
 		rawKVRIDCache:      ridCache,
@@ -1263,10 +1273,17 @@ func (db *DB) newRawKVCommandWALPayloadIntentFromEntries(entries []batchpkg.Entr
 	if externalRefs {
 		externalRefFileIDs = rawKVCommandWALExternalRefFileIDs(entries)
 	}
+	payloadFormat := commitlog.PayloadFormatRawKVBatchV1
+	for i := range entries {
+		if entries[i].Type == batchpkg.OpPut && entries[i].IsPtr && entries[i].Value != nil {
+			payloadFormat = commitlog.PayloadFormatRawKVBatchV2
+			break
+		}
+	}
 	return &commandWALBatchIntent{
 		kind:               commitlog.CommandKindRawKVBatch,
 		scope:              commitlog.CommandScopeRawKV,
-		payloadFormat:      commitlog.PayloadFormatRawKVBatchV1,
+		payloadFormat:      payloadFormat,
 		payload:            payload,
 		rawKVRIDCache:      ridCache,
 		externalRefs:       externalRefs,
@@ -1309,6 +1326,32 @@ func (db *DB) captureCommandWALExternalDependencies(intent *commandWALBatchInten
 	entries := intent.rawKVRIDCache.snapshot()
 	if len(entries) == 0 {
 		return nil, fmt.Errorf("%w: command WAL external-RID payload has an empty producer closure", rootpublication.ErrUnresolvedResource)
+	}
+	if intent.payloadFormat == commitlog.PayloadFormatRawKVBatchV2 {
+		// A V2 intent may also cache self-contained materialized RIDs. Keep
+		// those out of the external dependency closure. V1 is all-SetRID here,
+		// so retaining its lower-allocation snapshot path avoids regressing the
+		// conservative fallback.
+		operations, err := commitlog.DecodeRawKVBatchPayload(intent.payload)
+		if err != nil {
+			return nil, err
+		}
+		requiredRIDs := make(map[uint64]struct{}, fence.Count)
+		for i := range operations {
+			if operations[i].Op == commitlog.RawKVOpSetRID {
+				requiredRIDs[operations[i].RID] = struct{}{}
+			}
+		}
+		filtered := entries[:0]
+		for i := range entries {
+			if _, ok := requiredRIDs[entries[i].rid]; ok {
+				filtered = append(filtered, entries[i])
+			}
+		}
+		entries = filtered
+		if len(entries) == 0 {
+			return nil, fmt.Errorf("%w: command WAL external-RID payload has no matching producer closure", rootpublication.ErrUnresolvedResource)
+		}
 	}
 	fileIDs := make([]uint32, 0)
 	for _, entry := range entries {
@@ -1393,7 +1436,8 @@ func maxEntryRevisionFromEntries(entries []batchpkg.Entry) page.EntryRevision {
 }
 
 func maxEntryRevisionFromCommandWALPayload(kind commitlog.CommandKind, scope commitlog.CommandScope, payloadFormat commitlog.PayloadFormat, payload []byte) (page.EntryRevision, error) {
-	if kind != commitlog.CommandKindRawKVBatch || scope != commitlog.CommandScopeRawKV || payloadFormat != commitlog.PayloadFormatRawKVBatchV1 {
+	if kind != commitlog.CommandKindRawKVBatch || scope != commitlog.CommandScopeRawKV ||
+		(payloadFormat != commitlog.PayloadFormatRawKVBatchV1 && payloadFormat != commitlog.PayloadFormatRawKVBatchV2) {
 		return page.LegacyEntryRevision, nil
 	}
 	maxRevision := page.LegacyEntryRevision
@@ -1457,12 +1501,7 @@ func (db *DB) rawKVCommandWALOperationFromEntry(entry batchpkg.Entry, ridCache *
 		return commitlog.RawKVOperation{Op: commitlog.RawKVOpDelete, Key: entry.Key, Revision: uint64(entry.Revision)}, true, nil
 	case batchpkg.OpPut:
 		if entry.IsPtr {
-			if externalRefs != nil {
-				*externalRefs = true
-			}
-			if externalRefFileIDs != nil {
-				appendRawKVCommandWALExternalRefFileID(externalRefFileIDs, entry.ValuePtr.FileID)
-			}
+			materialized := entry.Value != nil
 			if ridCache == nil {
 				return commitlog.RawKVOperation{}, false, fmt.Errorf("treedb: command wal raw kv rid cache unavailable")
 			}
@@ -1472,6 +1511,34 @@ func (db *DB) rawKVCommandWALOperationFromEntry(entry batchpkg.Entry, ridCache *
 			rid, err := db.lookupCommandWALValueLogRID(entry.ValuePtr, *ridCache)
 			if err != nil {
 				return commitlog.RawKVOperation{}, false, err
+			}
+			if materialized {
+				persisted, err := db.valueLogManager.Read(entry.ValuePtr)
+				if isCommandWALRIDLookupVisibilityError(err) {
+					if flushErr := db.flushCommandWALExternalRefs([]uint32{entry.ValuePtr.FileID}); flushErr != nil {
+						return commitlog.RawKVOperation{}, false, flushErr
+					}
+					persisted, err = db.valueLogManager.Read(entry.ValuePtr)
+				}
+				if err != nil {
+					return commitlog.RawKVOperation{}, false, err
+				}
+				if !bytes.Equal(persisted, entry.Value) {
+					return commitlog.RawKVOperation{}, false, fmt.Errorf("%w: rid=%d", ErrCommandWALConflictingValueLogRID, rid)
+				}
+				return commitlog.RawKVOperation{
+					Op:       commitlog.RawKVOpSetMaterializedRID,
+					Key:      entry.Key,
+					Value:    entry.Value,
+					RID:      rid,
+					Revision: uint64(entry.Revision),
+				}, true, nil
+			}
+			if externalRefs != nil {
+				*externalRefs = true
+			}
+			if externalRefFileIDs != nil {
+				appendRawKVCommandWALExternalRefFileID(externalRefFileIDs, entry.ValuePtr.FileID)
 			}
 			return commitlog.RawKVOperation{Op: commitlog.RawKVOpSetRID, Key: entry.Key, RID: rid, Revision: uint64(entry.Revision)}, true, nil
 		}
@@ -1492,7 +1559,7 @@ func rawKVCommandWALExternalRefFileIDs(entries []batchpkg.Entry) []uint32 {
 	var ids []uint32
 	for i := range entries {
 		entry := entries[i]
-		if entry.Type != batchpkg.OpPut || !entry.IsPtr || entry.ValuePtr.FileID == 0 {
+		if entry.Type != batchpkg.OpPut || !entry.IsPtr || entry.Value != nil || entry.ValuePtr.FileID == 0 {
 			continue
 		}
 		appendRawKVCommandWALExternalRefFileID(&ids, entry.ValuePtr.FileID)
@@ -1708,8 +1775,8 @@ func (db *DB) AppendRawKVSingleCommandWAL(op commitlog.RawKVOperation, sync bool
 		return 0, err
 	}
 	defer unlockCommandWALPublish()
-	if op.Op == commitlog.RawKVOpSetRID {
-		return 0, fmt.Errorf("%w: public single-op command WAL cannot carry external refs", ErrCommandWALUnsupported)
+	if op.Op == commitlog.RawKVOpSetRID || op.Op == commitlog.RawKVOpSetMaterializedRID {
+		return 0, fmt.Errorf("%w: public single-op command WAL cannot carry RID-bearing operations", ErrCommandWALUnsupported)
 	}
 	if db.closing.Load() {
 		return 0, ErrClosed
@@ -1759,6 +1826,9 @@ func (db *DB) AppendRawKVPointCommandWALTrustedWithPreparedRevision(op commitlog
 	if db.durability == DurabilityWALOffRelaxed {
 		return 0, fmt.Errorf("%w: WAL-off durability is incompatible with command WAL", ErrCommandWALUnsupported)
 	}
+	if op == commitlog.RawKVOpSetMaterializedRID {
+		return 0, fmt.Errorf("%w: point command WAL cannot carry a materialized RID", ErrCommandWALUnsupported)
+	}
 	if assignRevision == nil {
 		return 0, fmt.Errorf("%w: missing command wal revision allocator", ErrCommandWALRejected)
 	}
@@ -1799,6 +1869,9 @@ func (db *DB) appendRawKVPointCommandWALTrustedWithRevision(op commitlog.RawKVOp
 	}
 	if db.durability == DurabilityWALOffRelaxed {
 		return 0, fmt.Errorf("%w: WAL-off durability is incompatible with command WAL", ErrCommandWALUnsupported)
+	}
+	if op == commitlog.RawKVOpSetMaterializedRID {
+		return 0, fmt.Errorf("%w: point command WAL cannot carry a materialized RID", ErrCommandWALUnsupported)
 	}
 	unlockCommandWALPublish, err := db.LockCommandWALPublishWithBarriers()
 	if err != nil {
@@ -2305,7 +2378,8 @@ func applyRawKVCommandWALFrame(db *DB, env commitlog.CommandEnvelope, ridMap map
 	if db == nil {
 		return fmt.Errorf("treedb: command wal recovery missing db")
 	}
-	if env.Kind != commitlog.CommandKindRawKVBatch || env.Scope != commitlog.CommandScopeRawKV || env.PayloadFormat != commitlog.PayloadFormatRawKVBatchV1 {
+	if env.Kind != commitlog.CommandKindRawKVBatch || env.Scope != commitlog.CommandScopeRawKV ||
+		(env.PayloadFormat != commitlog.PayloadFormatRawKVBatchV1 && env.PayloadFormat != commitlog.PayloadFormatRawKVBatchV2) {
 		return commitlog.ErrCommandWALUnsupportedKind
 	}
 	ops, err := commitlog.DecodeRawKVBatchPayload(env.Payload)
@@ -2326,6 +2400,7 @@ func applyRawKVCommandWALFrame(db *DB, env commitlog.CommandEnvelope, ridMap map
 	}
 	b := db.NewBatch().(*Batch)
 	defer func() { _ = b.Close() }()
+	var materializedThisFrame map[uint64][]byte
 	for i := range ops {
 		entry := ops[i]
 		revision := page.EntryRevision(entry.Revision)
@@ -2388,6 +2463,57 @@ func applyRawKVCommandWALFrame(db *DB, env commitlog.CommandEnvelope, ridMap map
 			}
 			if err := db.registerReplayValueLogPointer(ptr); err != nil {
 				return err
+			}
+			if err := b.SetPointerWithRevision(entry.Key, ptr, revision); err != nil {
+				return err
+			}
+		case commitlog.RawKVOpSetMaterializedRID:
+			if env.PayloadFormat != commitlog.PayloadFormatRawKVBatchV2 {
+				return commitlog.ErrCorrupt
+			}
+			if inlineAppender == nil || ridMap == nil {
+				if ensureReplayLogSupport == nil {
+					return fmt.Errorf("treedb: command wal replay log support unavailable")
+				}
+				var err error
+				ridMap, inlineAppender, err = ensureReplayLogSupport()
+				if err != nil {
+					return err
+				}
+			}
+			if inlineAppender == nil || ridMap == nil {
+				return fmt.Errorf("treedb: command wal missing replay value-log appender")
+			}
+			ptr, ok := ridMap[entry.RID]
+			if ok {
+				got, producedThisFrame := materializedThisFrame[entry.RID]
+				if !producedThisFrame {
+					if err := db.registerReplayValueLogPointer(ptr); err != nil {
+						return err
+					}
+					var err error
+					got, err = db.valueLogManager.Read(ptr)
+					if err != nil {
+						return err
+					}
+				}
+				if !bytes.Equal(got, entry.Value) {
+					return errors.Join(
+						commitlog.ErrCorrupt,
+						fmt.Errorf("%w: rid=%d", ErrCommandWALConflictingValueLogRID, entry.RID),
+					)
+				}
+			} else {
+				var err error
+				ptr, err = inlineAppender.appendExactRID(entry.RID, entry.Value)
+				if err != nil {
+					return err
+				}
+				ridMap[entry.RID] = ptr
+				if materializedThisFrame == nil {
+					materializedThisFrame = make(map[uint64][]byte)
+				}
+				materializedThisFrame[entry.RID] = entry.Value
 			}
 			if err := b.SetPointerWithRevision(entry.Key, ptr, revision); err != nil {
 				return err

--- a/TreeDB/db/command_wal_raw.go
+++ b/TreeDB/db/command_wal_raw.go
@@ -1348,16 +1348,20 @@ func (db *DB) newRawKVCommandWALIntentFromEntryScanWithHint(scanEntries func(fun
 			}
 			return emit(entry)
 		})
-	}, &ridCache, &externalRefs, &externalRefFileIDs, opHint, materialize)
+	}, &ridCache, &externalRefs, &externalRefFileIDs, opHint, materialize, true)
 	plan, err := commitlog.PlanRawKVBatchPayloadScan(planScan)
 	if err != nil {
 		return nil, err
 	}
-	if materialize && (!materializedRefs || !materializedEligible || !db.rawKVCommandWALMaterializedRIDPlanFits(plan)) {
+	if materialize && !materializedRefs {
+		// The optimistic scan already produced the exact V1 plan: without a
+		// retained pointer value, materialization changes no operation.
+		materialize = false
+	} else if materialize && (!materializedEligible || !db.rawKVCommandWALMaterializedRIDPlanFits(plan)) {
 		materialize = false
 		externalRefs = false
 		externalRefFileIDs = externalRefFileIDs[:0]
-		fallbackScan := db.rawKVCommandWALOperationScannerFromEntryScan(scanEntries, &ridCache, &externalRefs, &externalRefFileIDs, opHint, false)
+		fallbackScan := db.rawKVCommandWALOperationScannerFromEntryScan(scanEntries, &ridCache, &externalRefs, &externalRefFileIDs, opHint, false, false)
 		plan, err = commitlog.PlanRawKVBatchPayloadScan(fallbackScan)
 		if err != nil {
 			return nil, err
@@ -1366,7 +1370,9 @@ func (db *DB) newRawKVCommandWALIntentFromEntryScanWithHint(scanEntries func(fun
 	if plan.Count == 0 {
 		return nil, nil
 	}
-	writeScan := db.rawKVCommandWALOperationScannerFromEntryScan(scanEntries, &ridCache, nil, nil, opHint, materialize)
+	// The successful planning scan already validated every retained pointer
+	// value while the caller-owned entry buffers were immutable.
+	writeScan := db.rawKVCommandWALOperationScannerFromEntryScan(scanEntries, &ridCache, nil, nil, opHint, materialize, false)
 	payloadFormat := commitlog.PayloadFormatRawKVBatchV1
 	if materialize {
 		payloadFormat = commitlog.PayloadFormatRawKVBatchV2
@@ -1592,16 +1598,16 @@ func (db *DB) rawKVCommandWALOperationScannerWithHint(entries []batchpkg.Entry, 
 			}
 		}
 		return nil
-	}, ridCache, externalRefs, nil, opHint, materialize)
+	}, ridCache, externalRefs, nil, opHint, materialize, true)
 }
 
-func (db *DB) rawKVCommandWALOperationScannerFromEntryScan(scanEntries func(func(batchpkg.Entry) error) error, ridCache **rawKVCommandWALRIDCache, externalRefs *bool, externalRefFileIDs *[]uint32, opHint int, materialize bool) commitlog.RawKVBatchOperationScanner {
+func (db *DB) rawKVCommandWALOperationScannerFromEntryScan(scanEntries func(func(batchpkg.Entry) error) error, ridCache **rawKVCommandWALRIDCache, externalRefs *bool, externalRefFileIDs *[]uint32, opHint int, materialize, validateRetainedValues bool) commitlog.RawKVBatchOperationScanner {
 	return func(emit func(commitlog.RawKVOperation) error) error {
 		if scanEntries == nil {
 			return nil
 		}
 		return scanEntries(func(entry batchpkg.Entry) error {
-			op, ok, err := db.rawKVCommandWALOperationFromEntry(entry, ridCache, externalRefs, externalRefFileIDs, opHint, materialize)
+			op, ok, err := db.rawKVCommandWALOperationFromEntry(entry, ridCache, externalRefs, externalRefFileIDs, opHint, materialize, validateRetainedValues)
 			if err != nil {
 				return err
 			}
@@ -1613,7 +1619,7 @@ func (db *DB) rawKVCommandWALOperationScannerFromEntryScan(scanEntries func(func
 	}
 }
 
-func (db *DB) rawKVCommandWALOperationFromEntry(entry batchpkg.Entry, ridCache **rawKVCommandWALRIDCache, externalRefs *bool, externalRefFileIDs *[]uint32, opHint int, materializePointers bool) (commitlog.RawKVOperation, bool, error) {
+func (db *DB) rawKVCommandWALOperationFromEntry(entry batchpkg.Entry, ridCache **rawKVCommandWALRIDCache, externalRefs *bool, externalRefFileIDs *[]uint32, opHint int, materializePointers, validateRetainedValues bool) (commitlog.RawKVOperation, bool, error) {
 	switch entry.Type {
 	case batchpkg.OpDeleteRange:
 		if batchpkg.IsDeleteRangeNoop(entry.Key, entry.Value) {
@@ -1636,7 +1642,7 @@ func (db *DB) rawKVCommandWALOperationFromEntry(entry batchpkg.Entry, ridCache *
 			if err != nil {
 				return commitlog.RawKVOperation{}, false, err
 			}
-			if hasRetainedValue {
+			if hasRetainedValue && validateRetainedValues {
 				persisted, err := db.valueLogManager.Read(entry.ValuePtr)
 				if isCommandWALRIDLookupVisibilityError(err) {
 					if flushErr := db.flushCommandWALExternalRefs([]uint32{entry.ValuePtr.FileID}); flushErr != nil {

--- a/TreeDB/db/command_wal_raw_test.go
+++ b/TreeDB/db/command_wal_raw_test.go
@@ -24,6 +24,46 @@ func TestSyncCommandWALDependenciesThroughNoDebtIsAllocationFree(t *testing.T) {
 	}
 }
 
+func TestRawKVPointCommandWALRejectsMaterializedRIDBeforeRevisionAllocation(t *testing.T) {
+	d, err := Open(Options{
+		Dir:                    t.TempDir(),
+		CommandWAL:             true,
+		DisableBackgroundPrune: true,
+	})
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer func() { _ = d.Close() }()
+
+	assigned := false
+	_, err = d.AppendRawKVPointCommandWALTrustedWithPreparedRevision(
+		commitlog.RawKVOpSetMaterializedRID,
+		[]byte("key"),
+		[]byte("value"),
+		func() page.EntryRevision {
+			assigned = true
+			return page.EntryRevision(1)
+		},
+		false,
+	)
+	if !errors.Is(err, ErrCommandWALUnsupported) {
+		t.Fatalf("prepared materialized RID error=%v, want %v", err, ErrCommandWALUnsupported)
+	}
+	if assigned {
+		t.Fatal("materialized RID rejection consumed a prepared revision")
+	}
+
+	if _, err := d.AppendRawKVPointCommandWALTrustedWithRevision(
+		commitlog.RawKVOpSetMaterializedRID,
+		[]byte("key"),
+		[]byte("value"),
+		page.EntryRevision(1),
+		false,
+	); !errors.Is(err, ErrCommandWALUnsupported) {
+		t.Fatalf("revision materialized RID error=%v, want %v", err, ErrCommandWALUnsupported)
+	}
+}
+
 type commandWALCountingValueLogAppender struct {
 	inner   ValueLogAppender
 	flushes int
@@ -710,6 +750,70 @@ func TestRawKVCommandWALPreAppendFailureRetainsReusableDependenciesForRetry(t *t
 	}
 }
 
+func TestRawKVCommandWALMixedMaterializedAndSetRIDPreservesExternalDependency(t *testing.T) {
+	d, external := openCommandWALPointerDependencyTestDB(t)
+	defer func() { _ = d.Close() }()
+
+	conflicting := external
+	conflicting.Value = []byte("wrong-materialization")
+	if _, err := d.NewRawKVCommandWALIntentFromOrderedEntries([]batchpkg.Entry{conflicting}); !errors.Is(err, ErrCommandWALConflictingValueLogRID) {
+		t.Fatalf("conflicting live materialization error=%v, want %v", err, ErrCommandWALConflictingValueLogRID)
+	}
+
+	materializedValue := bytes.Repeat([]byte("materialized-command-value|"), 16)
+	materializedPtrs, err := d.AppendValueLogValues([][]byte{materializedValue})
+	if err != nil {
+		t.Fatalf("AppendValueLogValues materialized: %v", err)
+	}
+	if len(materializedPtrs) != 1 {
+		t.Fatalf("AppendValueLogValues materialized returned %d pointers, want 1", len(materializedPtrs))
+	}
+	path, fileID, ok := d.currentValueLogAppender().CurrentValueLogSegment()
+	if !ok || path == "" || fileID != materializedPtrs[0].FileID {
+		t.Fatalf("CurrentValueLogSegment materialized=(%q,%d,%t), pointer file_id=%d", path, fileID, ok, materializedPtrs[0].FileID)
+	}
+	if err := d.RegisterValueLogSegment(path, fileID); err != nil {
+		t.Fatalf("RegisterValueLogSegment materialized: %v", err)
+	}
+
+	materialized := external
+	materialized.Key = []byte("materialized")
+	materialized.Value = materializedValue
+	materialized.ValuePtr = materializedPtrs[0]
+	intent, err := d.NewRawKVCommandWALIntentFromOrderedEntries([]batchpkg.Entry{materialized, external})
+	if err != nil {
+		t.Fatalf("NewRawKVCommandWALIntentFromOrderedEntries: %v", err)
+	}
+	if intent == nil || intent.inner.payloadFormat != commitlog.PayloadFormatRawKVBatchV2 || !intent.inner.externalRefs {
+		t.Fatalf("mixed intent=%+v, want RawKVBatchV2 with external refs", intent)
+	}
+	lsn, err := d.AppendCommandWALIntent(intent, true)
+	if err != nil {
+		t.Fatalf("AppendCommandWALIntent mixed materialized/SetRID: %v", err)
+	}
+	if lsn == 0 {
+		t.Fatal("AppendCommandWALIntent mixed materialized/SetRID lsn=0")
+	}
+	if intent.inner.dependencyResources != nil {
+		t.Fatal("mixed materialized/SetRID dependency resources retained after durable append")
+	}
+	ops, err := commitlog.DecodeRawKVBatchPayload(intent.inner.payload)
+	if err != nil {
+		t.Fatalf("DecodeRawKVBatchPayload mixed materialized/SetRID: %v", err)
+	}
+	if len(ops) != 2 || ops[0].Op != commitlog.RawKVOpSetMaterializedRID || ops[1].Op != commitlog.RawKVOpSetRID ||
+		ops[0].RID == 0 || ops[1].RID == 0 || ops[0].RID == ops[1].RID {
+		t.Fatalf("mixed materialized/SetRID ops=%+v", ops)
+	}
+	fence, err := commitlog.ExternalRefFenceV1FromRawKVPayload(intent.inner.payload)
+	if err != nil {
+		t.Fatalf("ExternalRefFenceV1FromRawKVPayload: %v", err)
+	}
+	if fence.Count != 1 {
+		t.Fatalf("mixed materialized/SetRID fence count=%d, want only SetRID dependency", fence.Count)
+	}
+}
+
 func openCommandWALPointerDependencyTestDB(t *testing.T) (*DB, batchpkg.Entry) {
 	t.Helper()
 	d, err := Open(Options{
@@ -749,7 +853,7 @@ func openCommandWALPointerDependencyTestDB(t *testing.T) (*DB, batchpkg.Entry) {
 
 func rawKVOpTypeForTest(op commitlog.RawKVOp) batchpkg.OpType {
 	switch op {
-	case commitlog.RawKVOpSet, commitlog.RawKVOpSetRID:
+	case commitlog.RawKVOpSet, commitlog.RawKVOpSetRID, commitlog.RawKVOpSetMaterializedRID:
 		return batchpkg.OpPut
 	case commitlog.RawKVOpDelete:
 		return batchpkg.OpDelete

--- a/TreeDB/db/command_wal_raw_test.go
+++ b/TreeDB/db/command_wal_raw_test.go
@@ -956,6 +956,30 @@ func TestRawKVCommandWALMaterializedRIDSelectionRequiresDurableModeAndBounds(t *
 		}
 	})
 
+	t.Run("operation-count-cap-stops-materialization-validation", func(t *testing.T) {
+		d, err := Open(Options{Dir: t.TempDir(), CommandWAL: true, Durability: DurabilityWALOnRelaxed, DisableBackgroundPrune: true})
+		if err != nil {
+			t.Fatalf("Open: %v", err)
+		}
+		defer func() { _ = d.Close() }()
+		pointer := appendCommandWALPointerEntry(t, d, []byte("pointer-000"), materializedValue)
+		entries := make([]batchpkg.Entry, RawKVCommandWALMaterializedRIDMaxOperations+1)
+		for i := range entries {
+			entries[i] = pointer
+			entries[i].Key = []byte(fmt.Sprintf("pointer-%03d", i))
+		}
+		entries[len(entries)-1].Value = []byte("conflicting-retained-value-after-cap")
+
+		intent, err := d.newRawKVCommandWALIntentFromEntries(entries, true)
+		if err != nil {
+			t.Fatalf("newRawKVCommandWALIntentFromEntries after cap: %v", err)
+		}
+		defer releaseUnassignedCommandWALIntent(intent)
+		if intent.payloadFormat != commitlog.PayloadFormatRawKVBatchV1 || !intent.externalRefs {
+			t.Fatalf("257-op capped intent format=%d external=%t, want V1 external", intent.payloadFormat, intent.externalRefs)
+		}
+	})
+
 	t.Run("frame-over-bound", func(t *testing.T) {
 		d, err := Open(Options{Dir: t.TempDir(), CommandWAL: true, Durability: DurabilityWALOnRelaxed, DisableBackgroundPrune: true})
 		if err != nil {

--- a/TreeDB/db/command_wal_raw_test.go
+++ b/TreeDB/db/command_wal_raw_test.go
@@ -819,6 +819,29 @@ func TestRawKVCommandWALMixedMaterializedAndSetRIDPreservesExternalDependency(t 
 func TestRawKVCommandWALMaterializedRIDSelectionRequiresDurableModeAndBounds(t *testing.T) {
 	materializedValue := bytes.Repeat([]byte("materialized-mode-value|"), 16)
 
+	t.Run("inline-only-reuses-first-plan", func(t *testing.T) {
+		d, err := Open(Options{Dir: t.TempDir(), CommandWAL: true, Durability: DurabilityWALOnRelaxed, DisableBackgroundPrune: true})
+		if err != nil {
+			t.Fatalf("Open: %v", err)
+		}
+		defer func() { _ = d.Close() }()
+		scans := 0
+		intent, err := d.newRawKVCommandWALIntentFromEntryScanWithHint(func(emit func(batchpkg.Entry) error) error {
+			scans++
+			return emit(batchpkg.Entry{Type: batchpkg.OpPut, Key: []byte("inline"), Value: []byte("value")})
+		}, 1, true)
+		if err != nil {
+			t.Fatalf("newRawKVCommandWALIntentFromEntryScanWithHint: %v", err)
+		}
+		defer releaseUnassignedCommandWALIntent(intent)
+		if scans != 1 {
+			t.Fatalf("planning scans=%d, want 1 for an already-correct inline V1 plan", scans)
+		}
+		if intent == nil || intent.payloadFormat != commitlog.PayloadFormatRawKVBatchV1 || intent.externalRefs {
+			t.Fatalf("inline intent=%+v, want dependency-free RawKVBatchV1", intent)
+		}
+	})
+
 	t.Run("reusable-intent-falls-back", func(t *testing.T) {
 		d, external := openCommandWALPointerDependencyTestDB(t)
 		defer func() { _ = d.Close() }()

--- a/TreeDB/db/command_wal_raw_test.go
+++ b/TreeDB/db/command_wal_raw_test.go
@@ -3,6 +3,7 @@ package db
 import (
 	"bytes"
 	"errors"
+	"fmt"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -387,7 +388,7 @@ func TestRawKVCommandWALIntentUsesDirectEntries(t *testing.T) {
 		_ = d.Close()
 		t.Fatalf("DeleteRange: %v", err)
 	}
-	intent, err := d.prepareRawKVCommandWALIntent(b)
+	intent, err := d.prepareRawKVCommandWALIntent(b, false)
 	if err != nil {
 		_ = b.Close()
 		_ = d.Close()
@@ -756,7 +757,7 @@ func TestRawKVCommandWALMixedMaterializedAndSetRIDPreservesExternalDependency(t 
 
 	conflicting := external
 	conflicting.Value = []byte("wrong-materialization")
-	if _, err := d.NewRawKVCommandWALIntentFromOrderedEntries([]batchpkg.Entry{conflicting}); !errors.Is(err, ErrCommandWALConflictingValueLogRID) {
+	if _, err := d.AppendRawKVCommandWALOrderedEntriesWithMode([]batchpkg.Entry{conflicting}, RawKVCommandWALAppendDurable); !errors.Is(err, ErrCommandWALConflictingValueLogRID) {
 		t.Fatalf("conflicting live materialization error=%v, want %v", err, ErrCommandWALConflictingValueLogRID)
 	}
 
@@ -780,10 +781,11 @@ func TestRawKVCommandWALMixedMaterializedAndSetRIDPreservesExternalDependency(t 
 	materialized.Key = []byte("materialized")
 	materialized.Value = materializedValue
 	materialized.ValuePtr = materializedPtrs[0]
-	intent, err := d.NewRawKVCommandWALIntentFromOrderedEntries([]batchpkg.Entry{materialized, external})
+	inner, err := d.newRawKVCommandWALPayloadIntentFromEntries([]batchpkg.Entry{materialized, external}, true)
 	if err != nil {
-		t.Fatalf("NewRawKVCommandWALIntentFromOrderedEntries: %v", err)
+		t.Fatalf("newRawKVCommandWALPayloadIntentFromEntries: %v", err)
 	}
+	intent := &CommandWALIntent{inner: *inner}
 	if intent == nil || intent.inner.payloadFormat != commitlog.PayloadFormatRawKVBatchV2 || !intent.inner.externalRefs {
 		t.Fatalf("mixed intent=%+v, want RawKVBatchV2 with external refs", intent)
 	}
@@ -814,6 +816,186 @@ func TestRawKVCommandWALMixedMaterializedAndSetRIDPreservesExternalDependency(t 
 	}
 }
 
+func TestRawKVCommandWALMaterializedRIDSelectionRequiresDurableModeAndBounds(t *testing.T) {
+	materializedValue := bytes.Repeat([]byte("materialized-mode-value|"), 16)
+
+	t.Run("reusable-intent-falls-back", func(t *testing.T) {
+		d, external := openCommandWALPointerDependencyTestDB(t)
+		defer func() { _ = d.Close() }()
+		external.Value = bytes.Repeat([]byte("command-wal-dependency|"), 16)
+		intent, err := d.NewRawKVCommandWALIntentFromOrderedEntries([]batchpkg.Entry{external})
+		if err != nil {
+			t.Fatalf("NewRawKVCommandWALIntentFromOrderedEntries: %v", err)
+		}
+		if intent == nil || intent.inner.payloadFormat != commitlog.PayloadFormatRawKVBatchV1 || !intent.inner.externalRefs {
+			t.Fatalf("reusable intent=%+v, want dependency-bearing RawKVBatchV1", intent)
+		}
+		ops, err := commitlog.DecodeRawKVBatchPayload(intent.inner.payload)
+		if err != nil {
+			t.Fatalf("DecodeRawKVBatchPayload: %v", err)
+		}
+		if len(ops) != 1 || ops[0].Op != commitlog.RawKVOpSetRID {
+			t.Fatalf("reusable intent ops=%+v, want SetRID", ops)
+		}
+	})
+
+	for _, tc := range []struct {
+		name       string
+		mode       RawKVCommandWALAppendMode
+		legacyAPI  bool
+		wantFormat commitlog.PayloadFormat
+		wantOp     commitlog.RawKVOp
+		wantClass  commitlog.CommandDurabilityClass
+	}{
+		{name: "relaxed", mode: RawKVCommandWALAppendRelaxed, legacyAPI: true, wantFormat: commitlog.PayloadFormatRawKVBatchV1, wantOp: commitlog.RawKVOpSetRID, wantClass: commitlog.CommandDurabilityRelaxed},
+		{name: "direct-durable", mode: RawKVCommandWALAppendDurable, legacyAPI: true, wantFormat: commitlog.PayloadFormatRawKVBatchV2, wantOp: commitlog.RawKVOpSetMaterializedRID, wantClass: commitlog.CommandDurabilityDurable},
+		{name: "durable-prefix-participant", mode: RawKVCommandWALAppendDurablePrefixParticipant, wantFormat: commitlog.PayloadFormatRawKVBatchV2, wantOp: commitlog.RawKVOpSetMaterializedRID, wantClass: commitlog.CommandDurabilityRelaxed},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			d, external := openCommandWALPointerDependencyTestDB(t)
+			external.Value = bytes.Repeat([]byte("command-wal-dependency|"), 16)
+			var err error
+			if tc.legacyAPI {
+				_, err = d.AppendRawKVCommandWALOrderedEntries([]batchpkg.Entry{external}, tc.mode == RawKVCommandWALAppendDurable)
+			} else {
+				_, err = d.AppendRawKVCommandWALOrderedEntriesWithMode([]batchpkg.Entry{external}, tc.mode)
+			}
+			if err != nil {
+				_ = d.Close()
+				t.Fatalf("AppendRawKVCommandWALOrderedEntriesWithMode: %v", err)
+			}
+			env := readFirstRawKVCommandWALEnvelope(t, d)
+			if env.PayloadFormat != tc.wantFormat || env.DurabilityClass != tc.wantClass {
+				_ = d.Close()
+				t.Fatalf("envelope format=%d class=%d, want format=%d class=%d", env.PayloadFormat, env.DurabilityClass, tc.wantFormat, tc.wantClass)
+			}
+			ops, err := commitlog.DecodeRawKVBatchPayload(env.Payload)
+			if err != nil {
+				_ = d.Close()
+				t.Fatalf("DecodeRawKVBatchPayload: %v", err)
+			}
+			if len(ops) != 1 || ops[0].Op != tc.wantOp {
+				_ = d.Close()
+				t.Fatalf("ops=%+v, want one %d", ops, tc.wantOp)
+			}
+			if err := d.Close(); err != nil {
+				t.Fatalf("Close: %v", err)
+			}
+		})
+	}
+
+	t.Run("value-over-bound", func(t *testing.T) {
+		d, err := Open(Options{Dir: t.TempDir(), CommandWAL: true, Durability: DurabilityWALOnRelaxed, DisableBackgroundPrune: true})
+		if err != nil {
+			t.Fatalf("Open: %v", err)
+		}
+		defer func() { _ = d.Close() }()
+		entry := appendCommandWALPointerEntry(t, d, []byte("oversize"), bytes.Repeat([]byte("x"), RawKVCommandWALMaterializedRIDMaxValueBytes+1))
+		intent, err := d.newRawKVCommandWALIntentFromEntries([]batchpkg.Entry{entry}, true)
+		if err != nil {
+			t.Fatalf("newRawKVCommandWALIntentFromEntries: %v", err)
+		}
+		defer releaseUnassignedCommandWALIntent(intent)
+		if intent.payloadFormat != commitlog.PayloadFormatRawKVBatchV1 || !intent.externalRefs {
+			t.Fatalf("oversize intent format=%d external=%t, want V1 external", intent.payloadFormat, intent.externalRefs)
+		}
+	})
+
+	t.Run("operation-count-over-bound", func(t *testing.T) {
+		d, err := Open(Options{Dir: t.TempDir(), CommandWAL: true, Durability: DurabilityWALOnRelaxed, DisableBackgroundPrune: true})
+		if err != nil {
+			t.Fatalf("Open: %v", err)
+		}
+		defer func() { _ = d.Close() }()
+		entries := make([]batchpkg.Entry, 0, RawKVCommandWALMaterializedRIDMaxOperations+1)
+		entries = append(entries, appendCommandWALPointerEntry(t, d, []byte("materialized"), materializedValue))
+		for i := 1; i < RawKVCommandWALMaterializedRIDMaxOperations; i++ {
+			entries = append(entries, batchpkg.Entry{Type: batchpkg.OpDelete, Key: []byte(fmt.Sprintf("delete-%03d", i))})
+		}
+		intent, err := d.newRawKVCommandWALIntentFromEntries(entries, true)
+		if err != nil {
+			t.Fatalf("newRawKVCommandWALIntentFromEntries: %v", err)
+		}
+		if intent.payloadFormat != commitlog.PayloadFormatRawKVBatchV2 || intent.externalRefs {
+			releaseUnassignedCommandWALIntent(intent)
+			t.Fatalf("256-op intent format=%d external=%t, want self-contained V2", intent.payloadFormat, intent.externalRefs)
+		}
+		releaseUnassignedCommandWALIntent(intent)
+
+		entries = append(entries, batchpkg.Entry{Type: batchpkg.OpDelete, Key: []byte("delete-256")})
+		intent, err = d.newRawKVCommandWALIntentFromEntries(entries, true)
+		if err != nil {
+			t.Fatalf("newRawKVCommandWALIntentFromEntries over bound: %v", err)
+		}
+		defer releaseUnassignedCommandWALIntent(intent)
+		if intent.payloadFormat != commitlog.PayloadFormatRawKVBatchV1 || !intent.externalRefs {
+			t.Fatalf("257-op intent format=%d external=%t, want V1 external", intent.payloadFormat, intent.externalRefs)
+		}
+	})
+
+	t.Run("frame-over-bound", func(t *testing.T) {
+		d, err := Open(Options{Dir: t.TempDir(), CommandWAL: true, Durability: DurabilityWALOnRelaxed, DisableBackgroundPrune: true})
+		if err != nil {
+			t.Fatalf("Open: %v", err)
+		}
+		defer func() { _ = d.Close() }()
+		entries := []batchpkg.Entry{appendCommandWALPointerEntry(t, d, []byte("materialized"), materializedValue)}
+		for i := 0; i < 16; i++ {
+			entries = append(entries, batchpkg.Entry{Type: batchpkg.OpPut, Key: []byte(fmt.Sprintf("inline-%02d", i)), Value: bytes.Repeat([]byte{byte(i + 1)}, 64<<10)})
+		}
+		intent, err := d.newRawKVCommandWALIntentFromEntries(entries, true)
+		if err != nil {
+			t.Fatalf("newRawKVCommandWALIntentFromEntries: %v", err)
+		}
+		defer releaseUnassignedCommandWALIntent(intent)
+		if intent.rawKVPlan.PayloadLen <= RawKVCommandWALMaterializedRIDMaxFrameBytes-RawKVCommandWALMaterializedRIDFrameReserve {
+			t.Fatalf("fallback payload len=%d, want over materialized frame bound", intent.rawKVPlan.PayloadLen)
+		}
+		if intent.payloadFormat != commitlog.PayloadFormatRawKVBatchV1 || !intent.externalRefs {
+			t.Fatalf("oversize-frame intent format=%d external=%t, want V1 external", intent.payloadFormat, intent.externalRefs)
+		}
+	})
+}
+
+func readFirstRawKVCommandWALEnvelope(t *testing.T, d *DB) commitlog.CommandEnvelope {
+	t.Helper()
+	if d == nil || d.commandJournal == nil {
+		t.Fatal("missing command journal")
+	}
+	if err := d.commandJournal.FlushObserved(false); err != nil {
+		t.Fatalf("FlushObserved: %v", err)
+	}
+	r, err := commitlog.NewReader(filepath.Join(WALDirPath(d.dir), "commit-l0-000001.log"))
+	if err != nil {
+		t.Fatalf("NewReader: %v", err)
+	}
+	defer r.Close()
+	env, err := r.ReadCommandFrame()
+	if err != nil {
+		t.Fatalf("ReadCommandFrame: %v", err)
+	}
+	return env
+}
+
+func appendCommandWALPointerEntry(t *testing.T, d *DB, key, value []byte) batchpkg.Entry {
+	t.Helper()
+	ptrs, err := d.AppendValueLogValues([][]byte{value})
+	if err != nil {
+		t.Fatalf("AppendValueLogValues: %v", err)
+	}
+	if len(ptrs) != 1 {
+		t.Fatalf("AppendValueLogValues returned %d pointers, want 1", len(ptrs))
+	}
+	path, fileID, ok := d.currentValueLogAppender().CurrentValueLogSegment()
+	if !ok || path == "" || fileID != ptrs[0].FileID {
+		t.Fatalf("CurrentValueLogSegment=(%q,%d,%t), pointer file_id=%d", path, fileID, ok, ptrs[0].FileID)
+	}
+	if err := d.RegisterValueLogSegment(path, fileID); err != nil {
+		t.Fatalf("RegisterValueLogSegment: %v", err)
+	}
+	return batchpkg.Entry{Type: batchpkg.OpPut, Key: key, Value: value, IsPtr: true, ValuePtr: ptrs[0]}
+}
+
 func openCommandWALPointerDependencyTestDB(t *testing.T) (*DB, batchpkg.Entry) {
 	t.Helper()
 	d, err := Open(Options{
@@ -825,30 +1007,9 @@ func openCommandWALPointerDependencyTestDB(t *testing.T) (*DB, batchpkg.Entry) {
 	if err != nil {
 		t.Fatalf("Open: %v", err)
 	}
-	ptrs, err := d.AppendValueLogValues([][]byte{bytes.Repeat([]byte("command-wal-dependency|"), 16)})
-	if err != nil {
-		_ = d.Close()
-		t.Fatalf("AppendValueLogValues: %v", err)
-	}
-	if len(ptrs) != 1 {
-		_ = d.Close()
-		t.Fatalf("AppendValueLogValues returned %d pointers, want 1", len(ptrs))
-	}
-	path, fileID, ok := d.currentValueLogAppender().CurrentValueLogSegment()
-	if !ok || path == "" || fileID != ptrs[0].FileID {
-		_ = d.Close()
-		t.Fatalf("CurrentValueLogSegment=(%q,%d,%t), pointer file_id=%d", path, fileID, ok, ptrs[0].FileID)
-	}
-	if err := d.RegisterValueLogSegment(path, fileID); err != nil {
-		_ = d.Close()
-		t.Fatalf("RegisterValueLogSegment: %v", err)
-	}
-	return d, batchpkg.Entry{
-		Type:     batchpkg.OpPut,
-		Key:      []byte("pointer-dependency"),
-		IsPtr:    true,
-		ValuePtr: ptrs[0],
-	}
+	entry := appendCommandWALPointerEntry(t, d, []byte("pointer-dependency"), bytes.Repeat([]byte("command-wal-dependency|"), 16))
+	entry.Value = nil
+	return d, entry
 }
 
 func rawKVOpTypeForTest(op commitlog.RawKVOp) batchpkg.OpType {

--- a/TreeDB/db/command_wal_recovery_test.go
+++ b/TreeDB/db/command_wal_recovery_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/snissn/gomap/TreeDB/internal/commitlog"
 	"github.com/snissn/gomap/TreeDB/internal/durabilitycut"
 	"github.com/snissn/gomap/TreeDB/internal/rootpublication"
+	"github.com/snissn/gomap/TreeDB/internal/valuelog"
 	"github.com/snissn/gomap/TreeDB/page"
 )
 
@@ -1702,6 +1703,288 @@ func TestCommandWALRIDFencePreservedForRawKVBatch(t *testing.T) {
 	}
 }
 
+func TestCommandWALMaterializedRIDRecoveryCreatesExactRIDAndSurvivesCheckpointReopen(t *testing.T) {
+	dir := t.TempDir()
+	enableCommandWALFormat(t, dir)
+	bootstrap := openCommandWALDB(t, dir)
+	if err := bootstrap.Close(); err != nil {
+		t.Fatalf("Close bootstrap db: %v", err)
+	}
+	writeCommandWALRawKVFrameWithFormat(t, dir, 1, 1, commitlog.PayloadFormatRawKVBatchV2, []commitlog.RawKVOperation{{
+		Op: commitlog.RawKVOpSetMaterializedRID, Key: []byte("k"), RID: 42, Value: []byte("materialized"),
+	}})
+
+	_, err := Open(Options{Dir: dir, testCommandWALRecoveryFailAfterLSN: 1})
+	if !errors.Is(err, errTestFinalizeCommitFailpoint) {
+		t.Fatalf("Open after materialized RID replay error=%v, want post-publication failpoint", err)
+	}
+
+	reopen := openCommandWALDB(t, dir)
+	assertDBValue(t, reopen, "k", "materialized")
+	if err := reopen.Checkpoint(); err != nil {
+		_ = reopen.Close()
+		t.Fatalf("Checkpoint materialized RID replay: %v", err)
+	}
+	if err := reopen.Close(); err != nil {
+		t.Fatalf("Close materialized RID replay: %v", err)
+	}
+
+	segments, err := listSegmentsInDir(ValueLogDirPath(dir))
+	if err != nil {
+		t.Fatalf("list value-log segments: %v", err)
+	}
+	ridMap, err := scanValueLogSegments(segments, nil)
+	if err != nil {
+		t.Fatalf("scanValueLogSegments: %v", err)
+	}
+	if len(ridMap) != 1 {
+		t.Fatalf("materialized recovery RID count=%d, want exactly 1 after replay retry", len(ridMap))
+	}
+	sourcePtr, ok := ridMap[42]
+	if !ok {
+		t.Fatalf("materialized recovery did not preserve exact RID 42: %+v", ridMap)
+	}
+
+	final := openCommandWALDB(t, dir)
+	assertDBValue(t, final, "k", "materialized")
+	if got := final.State().AppliedCommandLSN; got != 1 {
+		_ = final.Close()
+		t.Fatalf("AppliedCommandLSN=%d, want 1", got)
+	}
+	appender, ok := final.currentValueLogAppender().(*replayInlineAppender)
+	if !ok {
+		_ = final.Close()
+		t.Fatalf("value-log appender type=%T, want replayInlineAppender", final.currentValueLogAppender())
+	}
+	appender.mu.Lock()
+	nextRID := appender.nextRID
+	appender.mu.Unlock()
+	if nextRID <= 42 {
+		_ = final.Close()
+		t.Fatalf("next value-log RID=%d, want allocator advanced past recovered RID 42", nextRID)
+	}
+	rewriteStats, err := final.ValueLogRewriteOnline(context.Background(), ValueLogRewriteOnlineOptions{
+		SourceFileIDs: []uint32{sourcePtr.FileID},
+		BatchSize:     1,
+	})
+	if err != nil {
+		_ = final.Close()
+		t.Fatalf("ValueLogRewriteOnline after materialized RID recovery: %v", err)
+	}
+	if rewriteStats.RecordsCopied != 1 {
+		_ = final.Close()
+		t.Fatalf("materialized RID rewrite records copied=%d, want 1 (stats=%+v)", rewriteStats.RecordsCopied, rewriteStats)
+	}
+	if _, err := final.ValueLogGC(context.Background(), ValueLogGCOptions{}); err != nil {
+		_ = final.Close()
+		t.Fatalf("ValueLogGC after materialized RID recovery: %v", err)
+	}
+	assertDBValue(t, final, "k", "materialized")
+	if err := final.Close(); err != nil {
+		t.Fatalf("Close after materialized RID rewrite/GC: %v", err)
+	}
+
+	afterGC := openCommandWALDB(t, dir)
+	defer afterGC.Close()
+	assertDBValue(t, afterGC, "k", "materialized")
+}
+
+func TestCommandWALMaterializedRIDRecoveryReusesMatchingRID(t *testing.T) {
+	dir := t.TempDir()
+	enableCommandWALFormat(t, dir)
+	bootstrap := openCommandWALDB(t, dir)
+	if err := bootstrap.Close(); err != nil {
+		t.Fatalf("Close bootstrap db: %v", err)
+	}
+	writeValueLogRID(t, dir, 42, []byte("materialized"))
+	writeCommandWALRawKVFrameWithFormat(t, dir, 1, 1, commitlog.PayloadFormatRawKVBatchV2, []commitlog.RawKVOperation{{
+		Op: commitlog.RawKVOpSetMaterializedRID, Key: []byte("k"), RID: 42, Value: []byte("materialized"),
+	}})
+
+	reopen := openCommandWALDB(t, dir)
+	defer reopen.Close()
+	assertDBValue(t, reopen, "k", "materialized")
+
+	segments, err := listSegmentsInDir(ValueLogDirPath(dir))
+	if err != nil {
+		t.Fatalf("list value-log segments: %v", err)
+	}
+	ridMap, err := scanValueLogSegments(segments, nil)
+	if err != nil {
+		t.Fatalf("scanValueLogSegments: %v", err)
+	}
+	if len(ridMap) != 1 {
+		t.Fatalf("matching materialized recovery RID count=%d, want no duplicate", len(ridMap))
+	}
+}
+
+func TestCommandWALMaterializedRIDRecoveryDuplicateRIDWithinFrame(t *testing.T) {
+	t.Run("matching", func(t *testing.T) {
+		dir := t.TempDir()
+		enableCommandWALFormat(t, dir)
+		bootstrap := openCommandWALDB(t, dir)
+		if err := bootstrap.Close(); err != nil {
+			t.Fatalf("Close bootstrap db: %v", err)
+		}
+		writeCommandWALRawKVFrameWithFormat(t, dir, 1, 1, commitlog.PayloadFormatRawKVBatchV2, []commitlog.RawKVOperation{
+			{Op: commitlog.RawKVOpSetMaterializedRID, Key: []byte("a"), RID: 42, Value: []byte("materialized")},
+			{Op: commitlog.RawKVOpSetMaterializedRID, Key: []byte("b"), RID: 42, Value: []byte("materialized")},
+		})
+
+		reopen := openCommandWALDB(t, dir)
+		defer reopen.Close()
+		assertDBValue(t, reopen, "a", "materialized")
+		assertDBValue(t, reopen, "b", "materialized")
+		segments, err := listSegmentsInDir(ValueLogDirPath(dir))
+		if err != nil {
+			t.Fatalf("list value-log segments: %v", err)
+		}
+		ridMap, err := scanValueLogSegments(segments, nil)
+		if err != nil {
+			t.Fatalf("scanValueLogSegments: %v", err)
+		}
+		if len(ridMap) != 1 {
+			t.Fatalf("matching duplicate RID count=%d, want one physical record", len(ridMap))
+		}
+	})
+
+	t.Run("conflicting", func(t *testing.T) {
+		dir := t.TempDir()
+		enableCommandWALFormat(t, dir)
+		bootstrap := openCommandWALDB(t, dir)
+		if err := bootstrap.Close(); err != nil {
+			t.Fatalf("Close bootstrap db: %v", err)
+		}
+		writeCommandWALRawKVFrameWithFormat(t, dir, 1, 1, commitlog.PayloadFormatRawKVBatchV2, []commitlog.RawKVOperation{
+			{Op: commitlog.RawKVOpSetMaterializedRID, Key: []byte("a"), RID: 42, Value: []byte("first")},
+			{Op: commitlog.RawKVOpSetMaterializedRID, Key: []byte("b"), RID: 42, Value: []byte("second")},
+		})
+
+		_, err := Open(Options{Dir: dir})
+		if !errors.Is(err, ErrCommandWALConflictingValueLogRID) || !errors.Is(err, commitlog.ErrCorrupt) {
+			t.Fatalf("Open conflicting duplicate RID error=%v, want conflict plus corruption", err)
+		}
+	})
+}
+
+func TestCommandWALMaterializedRIDRecoveryRejectsConflictingRID(t *testing.T) {
+	dir := t.TempDir()
+	enableCommandWALFormat(t, dir)
+	bootstrap := openCommandWALDB(t, dir)
+	if err := bootstrap.Close(); err != nil {
+		t.Fatalf("Close bootstrap db: %v", err)
+	}
+	writeValueLogRID(t, dir, 42, []byte("other"))
+	writeCommandWALRawKVFrameWithFormat(t, dir, 1, 1, commitlog.PayloadFormatRawKVBatchV2, []commitlog.RawKVOperation{{
+		Op: commitlog.RawKVOpSetMaterializedRID, Key: []byte("k"), RID: 42, Value: []byte("materialized"),
+	}})
+
+	_, err := Open(Options{Dir: dir})
+	if !errors.Is(err, ErrCommandWALConflictingValueLogRID) {
+		t.Fatalf("Open conflicting materialized RID error=%v, want %v", err, ErrCommandWALConflictingValueLogRID)
+	}
+	if !errors.Is(err, commitlog.ErrCorrupt) {
+		t.Fatalf("Open conflicting materialized RID error=%v, want corruption classification", err)
+	}
+}
+
+func TestCommandWALMaterializedRIDRecoveryReplacesTruncatedTail(t *testing.T) {
+	dir := t.TempDir()
+	enableCommandWALFormat(t, dir)
+	bootstrap := openCommandWALDB(t, dir)
+	if err := bootstrap.Close(); err != nil {
+		t.Fatalf("Close bootstrap db: %v", err)
+	}
+	writeValueLogRID(t, dir, 42, []byte("partial-materialization"))
+	valueLogPath := filepath.Join(ValueLogDirPath(dir), "value-l0-000001.log")
+	info, err := os.Stat(valueLogPath)
+	if err != nil {
+		t.Fatalf("Stat value-log segment: %v", err)
+	}
+	if err := os.Truncate(valueLogPath, info.Size()-4); err != nil {
+		t.Fatalf("Truncate value-log tail: %v", err)
+	}
+	writeCommandWALRawKVFrameWithFormat(t, dir, 1, 1, commitlog.PayloadFormatRawKVBatchV2, []commitlog.RawKVOperation{{
+		Op: commitlog.RawKVOpSetMaterializedRID, Key: []byte("k"), RID: 42, Value: []byte("materialized"),
+	}})
+
+	reopen := openCommandWALDB(t, dir)
+	defer reopen.Close()
+	assertDBValue(t, reopen, "k", "materialized")
+}
+
+func TestCommandWALMaterializedRIDRecoveryRejectsChecksumMismatch(t *testing.T) {
+	dir := t.TempDir()
+	enableCommandWALFormat(t, dir)
+	bootstrap := openCommandWALDB(t, dir)
+	if err := bootstrap.Close(); err != nil {
+		t.Fatalf("Close bootstrap db: %v", err)
+	}
+	writeValueLogRID(t, dir, 42, []byte("materialized"))
+	valueLogPath := filepath.Join(ValueLogDirPath(dir), "value-l0-000001.log")
+	f, err := os.OpenFile(valueLogPath, os.O_RDWR, 0)
+	if err != nil {
+		t.Fatalf("OpenFile value-log segment: %v", err)
+	}
+	info, err := f.Stat()
+	if err != nil {
+		_ = f.Close()
+		t.Fatalf("Stat value-log segment: %v", err)
+	}
+	var last [1]byte
+	if _, err := f.ReadAt(last[:], info.Size()-1); err != nil {
+		_ = f.Close()
+		t.Fatalf("ReadAt value-log tail: %v", err)
+	}
+	last[0] ^= 0xff
+	if _, err := f.WriteAt(last[:], info.Size()-1); err != nil {
+		_ = f.Close()
+		t.Fatalf("WriteAt value-log tail: %v", err)
+	}
+	if err := f.Close(); err != nil {
+		t.Fatalf("Close corrupted value-log segment: %v", err)
+	}
+	writeCommandWALRawKVFrameWithFormat(t, dir, 1, 1, commitlog.PayloadFormatRawKVBatchV2, []commitlog.RawKVOperation{{
+		Op: commitlog.RawKVOpSetMaterializedRID, Key: []byte("k"), RID: 42, Value: []byte("materialized"),
+	}})
+
+	if _, err := Open(Options{Dir: dir}); !errors.Is(err, valuelog.ErrCorrupt) {
+		t.Fatalf("Open checksum-mismatched materialized RID error=%v, want %v", err, valuelog.ErrCorrupt)
+	}
+}
+
+func TestCommandWALMaterializedRIDRecoveryMixedV1V2AndDelete(t *testing.T) {
+	dir := t.TempDir()
+	enableCommandWALFormat(t, dir)
+	bootstrap := openCommandWALDB(t, dir)
+	if err := bootstrap.Close(); err != nil {
+		t.Fatalf("Close bootstrap db: %v", err)
+	}
+	writeCommandWALRawKVFrame(t, dir, 1, 1, []commitlog.RawKVOperation{
+		{Op: commitlog.RawKVOpSet, Key: []byte("pointer"), Value: []byte("old")},
+		{Op: commitlog.RawKVOpSet, Key: []byte("legacy"), Value: []byte("v1")},
+	})
+	writeCommandWALRawKVFrameWithFormat(t, dir, 2, 2, commitlog.PayloadFormatRawKVBatchV2, []commitlog.RawKVOperation{
+		{Op: commitlog.RawKVOpSetMaterializedRID, Key: []byte("pointer"), RID: 42, Value: []byte("v2")},
+		{Op: commitlog.RawKVOpSetMaterializedRID, Key: []byte("doomed"), RID: 43, Value: []byte("gone")},
+		{Op: commitlog.RawKVOpDelete, Key: []byte("doomed")},
+		{Op: commitlog.RawKVOpDelete, Key: []byte("legacy")},
+	})
+
+	reopen := openCommandWALDB(t, dir)
+	defer reopen.Close()
+	assertDBValue(t, reopen, "pointer", "v2")
+	if has, err := reopen.Has([]byte("legacy")); err != nil || has {
+		t.Fatalf("Has(legacy)=(%t,%v), want false,nil after mixed V1/V2 delete", has, err)
+	}
+	if has, err := reopen.Has([]byte("doomed")); err != nil || has {
+		t.Fatalf("Has(doomed)=(%t,%v), want false,nil after materialized V2 delete", has, err)
+	}
+	if got := reopen.State().AppliedCommandLSN; got != 2 {
+		t.Fatalf("AppliedCommandLSN=%d, want 2", got)
+	}
+}
+
 func TestCommandWALRelaxedRIDReplaySyncsDependenciesBeforeRootPublication(t *testing.T) {
 	dir := t.TempDir()
 	enableCommandWALFormat(t, dir)
@@ -2197,6 +2480,11 @@ func writeCommandWALRawKVFrame(t testing.TB, dir string, segmentSeq uint64, lsn 
 	writeCommandWALRawKVFrameWithDurability(t, dir, segmentSeq, lsn, commitlog.CommandDurabilityDurable, ops)
 }
 
+func writeCommandWALRawKVFrameWithFormat(t testing.TB, dir string, segmentSeq uint64, lsn uint64, format commitlog.PayloadFormat, ops []commitlog.RawKVOperation) {
+	t.Helper()
+	writeCommandWALRawKVFrameForLaneWithDurabilityAndFormat(t, dir, 0, segmentSeq, lsn, commitlog.CommandDurabilityDurable, format, ops)
+}
+
 func writeCommandWALRawKVFrameWithDurability(t testing.TB, dir string, segmentSeq uint64, lsn uint64, durability commitlog.CommandDurabilityClass, ops []commitlog.RawKVOperation) {
 	t.Helper()
 	writeCommandWALRawKVFrameForLaneWithDurability(t, dir, 0, segmentSeq, lsn, durability, ops)
@@ -2208,6 +2496,11 @@ func writeCommandWALRawKVFrameForLane(t testing.TB, dir string, lane int, segmen
 }
 
 func writeCommandWALRawKVFrameForLaneWithDurability(t testing.TB, dir string, lane int, segmentSeq uint64, lsn uint64, durability commitlog.CommandDurabilityClass, ops []commitlog.RawKVOperation) {
+	t.Helper()
+	writeCommandWALRawKVFrameForLaneWithDurabilityAndFormat(t, dir, lane, segmentSeq, lsn, durability, commitlog.PayloadFormatRawKVBatchV1, ops)
+}
+
+func writeCommandWALRawKVFrameForLaneWithDurabilityAndFormat(t testing.TB, dir string, lane int, segmentSeq uint64, lsn uint64, durability commitlog.CommandDurabilityClass, format commitlog.PayloadFormat, ops []commitlog.RawKVOperation) {
 	t.Helper()
 	walDir := WALDirPath(dir)
 	if err := os.MkdirAll(walDir, 0o755); err != nil {
@@ -2228,7 +2521,7 @@ func writeCommandWALRawKVFrameForLaneWithDurability(t testing.TB, dir string, la
 		LSN:             lsn,
 		Kind:            commitlog.CommandKindRawKVBatch,
 		Scope:           commitlog.CommandScopeRawKV,
-		PayloadFormat:   commitlog.PayloadFormatRawKVBatchV1,
+		PayloadFormat:   format,
 		Payload:         payload,
 	}); err != nil {
 		_ = w.Close()

--- a/TreeDB/db/command_wal_recovery_test.go
+++ b/TreeDB/db/command_wal_recovery_test.go
@@ -1818,6 +1818,38 @@ func TestCommandWALMaterializedRIDRecoveryReusesMatchingRID(t *testing.T) {
 	}
 }
 
+func TestCommandWALMaterializedRIDRecoveryPreservesExistingRIDHighWaterAcrossReopen(t *testing.T) {
+	dir := t.TempDir()
+	enableCommandWALFormat(t, dir)
+	bootstrap := openCommandWALDB(t, dir)
+	if err := bootstrap.Close(); err != nil {
+		t.Fatalf("Close bootstrap db: %v", err)
+	}
+	writeValueLogRID(t, dir, 200, []byte("existing-high-water"))
+	writeCommandWALRawKVFrameWithFormat(t, dir, 1, 1, commitlog.PayloadFormatRawKVBatchV2, []commitlog.RawKVOperation{{
+		Op: commitlog.RawKVOpSetMaterializedRID, Key: []byte("recovered"), RID: 42, Value: []byte("materialized-older-rid"),
+	}})
+
+	recovered := openCommandWALDB(t, dir)
+	assertDBValue(t, recovered, "recovered", "materialized-older-rid")
+	if err := recovered.Close(); err != nil {
+		t.Fatalf("Close recovered db: %v", err)
+	}
+
+	reopened := openCommandWALDB(t, dir)
+	defer reopened.Close()
+	appender, ok := reopened.currentValueLogAppender().(*replayInlineAppender)
+	if !ok {
+		t.Fatalf("value-log appender type=%T, want replayInlineAppender", reopened.currentValueLogAppender())
+	}
+	appender.mu.Lock()
+	nextRID := appender.nextRID
+	appender.mu.Unlock()
+	if nextRID != 201 {
+		t.Fatalf("next value-log RID=%d, want 201 after exact-RID recovery below existing high-water", nextRID)
+	}
+}
+
 func TestCommandWALMaterializedRIDRecoveryDuplicateRIDWithinFrame(t *testing.T) {
 	t.Run("matching", func(t *testing.T) {
 		dir := t.TempDir()

--- a/TreeDB/db/command_wal_recovery_test.go
+++ b/TreeDB/db/command_wal_recovery_test.go
@@ -1878,6 +1878,99 @@ func TestCommandWALMaterializedRIDRecoveryReusesMatchingRID(t *testing.T) {
 	}
 }
 
+func TestCommandWALMaterializedRIDRecoverySyncsReusedRIDBeforeDurableRootPublication(t *testing.T) {
+	dir := t.TempDir()
+	enableCommandWALFormat(t, dir)
+	bootstrap := openCommandWALDB(t, dir)
+	if err := bootstrap.Close(); err != nil {
+		t.Fatalf("Close bootstrap db: %v", err)
+	}
+	ptr := writeValueLogRID(t, dir, 42, []byte("materialized"))
+	writeCommandWALRawKVFrameWithFormat(t, dir, 1, 1, commitlog.PayloadFormatRawKVBatchV2, []commitlog.RawKVOperation{{
+		Op: commitlog.RawKVOpSetMaterializedRID, Key: []byte("k"), RID: 42, Value: []byte("materialized"),
+	}})
+	valueLogPath := valuelog.SegmentPath(ValueLogDirPath(dir), ptr.FileID)
+	containsValueLogPath := func(event durabilitycut.Event) bool {
+		if event.Path == valueLogPath {
+			return true
+		}
+		for _, path := range event.Paths {
+			if path == valueLogPath {
+				return true
+			}
+		}
+		return false
+	}
+
+	var events []durabilitycut.Event
+	restore := durabilitycut.Install(func(event durabilitycut.Event) error {
+		events = append(events, event)
+		return nil
+	})
+	reopen := openCommandWALDB(t, dir)
+	restore()
+	defer reopen.Close()
+	assertDBValue(t, reopen, "k", "materialized")
+
+	beforeSync, afterSync, applied, beforeSeal := -1, -1, -1, -1
+	for i, event := range events {
+		switch {
+		case event.Resource == durabilitycut.ResourceAuxiliary && event.Point == durabilitycut.BeforeDependencyFileSync && containsValueLogPath(event):
+			beforeSync = i
+		case event.Resource == durabilitycut.ResourceAuxiliary && event.Point == durabilitycut.AfterDependencyFileSync && containsValueLogPath(event):
+			afterSync = i
+		case event.Resource == durabilitycut.ResourceMeta && event.Point == durabilitycut.AfterAppliedLSNAdvance && event.LSN == 1:
+			applied = i
+		case event.Resource == durabilitycut.ResourceSeal && event.Point == durabilitycut.BeforePublicationSealWrite:
+			beforeSeal = i
+		}
+	}
+	if applied < 0 || beforeSync <= applied || afterSync <= beforeSync || beforeSeal <= afterSync {
+		t.Fatalf("reused RID sync must precede durable root publication: applied=%d before=%d after=%d seal=%d path=%q events=%#v", applied, beforeSync, afterSync, beforeSeal, valueLogPath, events)
+	}
+}
+
+func TestCommandWALMaterializedRIDRecoveryReusedRIDSyncFailureFailsClosed(t *testing.T) {
+	dir := t.TempDir()
+	enableCommandWALFormat(t, dir)
+	bootstrap := openCommandWALDB(t, dir)
+	if err := bootstrap.Close(); err != nil {
+		t.Fatalf("Close bootstrap db: %v", err)
+	}
+	ptr := writeValueLogRID(t, dir, 42, []byte("materialized"))
+	writeCommandWALRawKVFrameWithFormat(t, dir, 1, 1, commitlog.PayloadFormatRawKVBatchV2, []commitlog.RawKVOperation{{
+		Op: commitlog.RawKVOpSetMaterializedRID, Key: []byte("k"), RID: 42, Value: []byte("materialized"),
+	}})
+	valueLogPath := valuelog.SegmentPath(ValueLogDirPath(dir), ptr.FileID)
+	wantErr := errors.New("injected reused RID sync failure")
+	restore := durabilitycut.Install(func(event durabilitycut.Event) error {
+		if event.Resource != durabilitycut.ResourceAuxiliary || event.Point != durabilitycut.BeforeDependencyFileSync {
+			return nil
+		}
+		if event.Path == valueLogPath {
+			return wantErr
+		}
+		for _, path := range event.Paths {
+			if path == valueLogPath {
+				return wantErr
+			}
+		}
+		return nil
+	})
+	_, err := Open(Options{Dir: dir})
+	restore()
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("Open reused RID sync error=%v, want %v", err, wantErr)
+	}
+
+	reopen := openCommandWALDB(t, dir)
+	defer reopen.Close()
+	assertDBValue(t, reopen, "k", "materialized")
+	if got := reopen.State().AppliedCommandLSN; got != 1 {
+		t.Fatalf("AppliedCommandLSN=%d, want 1 after successful retry", got)
+	}
+}
+
 func TestCommandWALMaterializedRIDRecoveryPreservesExistingRIDHighWaterAcrossReopen(t *testing.T) {
 	dir := t.TempDir()
 	enableCommandWALFormat(t, dir)

--- a/TreeDB/db/command_wal_recovery_test.go
+++ b/TreeDB/db/command_wal_recovery_test.go
@@ -415,6 +415,66 @@ func TestCommandWALRawSetReplayRePointersWhenThresholdDrops(t *testing.T) {
 	}
 }
 
+func TestCommandWALReplayAllocatesAbovePendingMaterializedRIDs(t *testing.T) {
+	dir := t.TempDir()
+	enableCommandWALFormat(t, dir)
+	bootstrap := openCommandWALDB(t, dir)
+	if err := bootstrap.Close(); err != nil {
+		t.Fatalf("Close bootstrap db: %v", err)
+	}
+
+	legacyValue := strings.Repeat("legacy-externalized-", 8)
+	writeCommandWALRawKVFrame(t, dir, 1, 1, []commitlog.RawKVOperation{{
+		Op: commitlog.RawKVOpSet, Key: []byte("legacy"), Value: []byte(legacyValue),
+	}})
+	writeCommandWALRawKVFrameWithFormat(t, dir, 2, 2, commitlog.PayloadFormatRawKVBatchV2, []commitlog.RawKVOperation{{
+		Op: commitlog.RawKVOpSetMaterializedRID, Key: []byte("materialized"), RID: 1, Value: []byte("exact-rid-one"),
+	}})
+
+	recovered, err := Open(Options{
+		Dir: dir,
+		ValueLog: ValueLogOptions{
+			PointerThreshold: 1,
+		},
+	})
+	if err != nil {
+		t.Fatalf("Open mixed V1/V2 recovery: %v", err)
+	}
+	assertDBValue(t, recovered, "legacy", legacyValue)
+	assertDBValue(t, recovered, "materialized", "exact-rid-one")
+	if err := recovered.Close(); err != nil {
+		t.Fatalf("Close mixed V1/V2 recovery: %v", err)
+	}
+
+	reopened, err := Open(Options{
+		Dir: dir,
+		ValueLog: ValueLogOptions{
+			PointerThreshold: 1,
+		},
+	})
+	if err != nil {
+		t.Fatalf("Reopen mixed V1/V2 recovery: %v", err)
+	}
+	defer reopened.Close()
+	assertDBValue(t, reopened, "legacy", legacyValue)
+	assertDBValue(t, reopened, "materialized", "exact-rid-one")
+
+	segments, err := listSegmentsInDir(ValueLogDirPath(dir))
+	if err != nil {
+		t.Fatalf("list value-log segments: %v", err)
+	}
+	ridMap, err := scanValueLogSegments(segments, nil)
+	if err != nil {
+		t.Fatalf("scan value-log segments: %v", err)
+	}
+	if len(ridMap) != 2 {
+		t.Fatalf("recovered RID count=%d, want exact RID plus replay allocation", len(ridMap))
+	}
+	if _, ok := ridMap[1]; !ok {
+		t.Fatalf("pending materialized RID 1 missing after replay: %+v", ridMap)
+	}
+}
+
 func TestCommandWALRawSetNeedsReplayValueLogMatchesBatchSet(t *testing.T) {
 	db, err := Open(Options{
 		Dir: t.TempDir(),

--- a/TreeDB/db/wal_recovery.go
+++ b/TreeDB/db/wal_recovery.go
@@ -1,6 +1,7 @@
 package db
 
 import (
+	"encoding/binary"
 	"errors"
 	"fmt"
 	"io"
@@ -356,6 +357,10 @@ func replayCommandWALIntoBackend(db *DB, segments []logSegment, maxSegmentBytes 
 	if len(frames) == 0 {
 		return nil
 	}
+	pendingMaterializedRIDHighWater, err := commandWALReplayPendingMaterializedRIDHighWater(frames, applied)
+	if err != nil {
+		return err
+	}
 	replayDependencies, err := captureCommandWALReplayRelaxedDependencies(db, frames, classification.DurableFrontier, ridMap)
 	if err != nil {
 		return err
@@ -412,6 +417,14 @@ func replayCommandWALIntoBackend(db *DB, segments []logSegment, maxSegmentBytes 
 		inlineAppender, err = newReplayInlineAppender(db, segments, ridMap)
 		if err != nil {
 			return nil, nil, err
+		}
+		if pendingMaterializedRIDHighWater >= inlineAppender.nextRID {
+			if pendingMaterializedRIDHighWater == ^uint64(0) {
+				_ = inlineAppender.close()
+				inlineAppender = nil
+				return nil, nil, fmt.Errorf("value-log rid space exhausted")
+			}
+			inlineAppender.nextRID = pendingMaterializedRIDHighWater + 1
 		}
 		db.SetValueLogAppender(inlineAppender)
 		valueLogAppenderInstalled = true
@@ -653,6 +666,28 @@ func commandWALReplayFramesNeedLogSupport(db *DB, frames []commandWALReplayFrame
 		return hasUnappliedRawKVBatch, nil
 	}
 	return false, nil
+}
+
+func commandWALReplayPendingMaterializedRIDHighWater(frames []commandWALReplayFrame, applied uint64) (uint64, error) {
+	var highWater uint64
+	for _, frame := range frames {
+		if frame.env.LSN <= applied || frame.env.Kind != commitlog.CommandKindRawKVBatch {
+			continue
+		}
+		if err := commitlog.ScanRawKVBatchPayload(frame.env.Payload, func(op commitlog.RawKVOp, _, value []byte) error {
+			if op != commitlog.RawKVOpSetMaterializedRID {
+				return nil
+			}
+			rid := binary.LittleEndian.Uint64(value[:8])
+			if rid > highWater {
+				highWater = rid
+			}
+			return nil
+		}); err != nil {
+			return 0, err
+		}
+	}
+	return highWater, nil
 }
 
 func commandWALRawSetNeedsReplayValueLog(db *DB, key, value []byte) bool {

--- a/TreeDB/db/wal_recovery.go
+++ b/TreeDB/db/wal_recovery.go
@@ -1005,51 +1005,12 @@ func newReplayInlineAppenderWithNextRID(db *DB, segments []logSegment, nextRID u
 
 func nextReplayAppenderRIDStart(segments []logSegment) (uint64, error) {
 	// RIDs are allocated from one monotonically increasing namespace. The appender
-	// only needs the high-water mark, so scan the latest value-log segment in each
-	// lane instead of rebuilding a full RID->pointer map from every segment.
-	latest := latestValueLogSegmentsByLane(segments)
-	if len(latest) == 0 {
-		return 1, nil
-	}
-	maxRID := uint64(0)
-	for i := range latest {
-		seg := &latest[i]
-		segMaxRID, err := scanValueLogFileMaxRID(&valuelog.File{ID: seg.fileID, Path: seg.path})
-		if err != nil {
-			if errors.Is(err, os.ErrNotExist) {
-				continue
-			}
-			return 0, err
-		}
-		if segMaxRID > maxRID {
-			maxRID = segMaxRID
-		}
-	}
-	if maxRID == ^uint64(0) {
-		return 0, fmt.Errorf("value-log rid space exhausted")
-	}
-	return maxRID + 1, nil
-}
-
-func latestValueLogSegmentsByLane(segments []logSegment) []logSegment {
-	latestByLane := make(map[int]logSegment)
-	for _, seg := range segments {
-		if !seg.valueLog {
-			continue
-		}
-		cur, ok := latestByLane[seg.lane]
-		if !ok || seg.seq > cur.seq {
-			latestByLane[seg.lane] = seg
-		}
-	}
-	latest := make([]logSegment, 0, len(latestByLane))
-	for _, seg := range latestByLane {
-		latest = append(latest, seg)
-	}
-	sort.Slice(latest, func(i, j int) bool {
-		return latest[i].lane < latest[j].lane
-	})
-	return latest
+	// only needs the high-water mark, so scan every value-log segment without
+	// rebuilding a full RID->pointer map. Recovery may append a missing exact RID
+	// below the current high-water into the newest lane-0 segment; consulting only
+	// the latest segment per lane after that repair would let allocation move
+	// backwards and reuse an existing RID on the following open.
+	return nextRewriteRIDStart(segments)
 }
 
 func (a *replayInlineAppender) append(value []byte) (page.ValuePtr, error) {

--- a/TreeDB/db/wal_recovery.go
+++ b/TreeDB/db/wal_recovery.go
@@ -635,7 +635,8 @@ func commandWALReplayFramesNeedLogSupport(db *DB, frames []commandWALReplayFrame
 		hasUnappliedRawKVBatch = true
 		needsLogSupport := false
 		if err := commitlog.ScanRawKVBatchPayload(frame.env.Payload, func(op commitlog.RawKVOp, key, value []byte) error {
-			if op == commitlog.RawKVOpSet && commandWALRawSetNeedsReplayValueLog(db, key, value) {
+			if op == commitlog.RawKVOpSetMaterializedRID ||
+				(op == commitlog.RawKVOpSet && commandWALRawSetNeedsReplayValueLog(db, key, value)) {
 				needsLogSupport = true
 			}
 			return nil
@@ -1074,6 +1075,35 @@ func (a *replayInlineAppender) appendLocked(value []byte) (page.ValuePtr, error)
 	}
 	if err := a.registerProducedPointerLocked(ptr); err != nil {
 		return page.ValuePtr{}, err
+	}
+	a.dirty = true
+	return ptr, nil
+}
+
+func (a *replayInlineAppender) appendExactRID(rid uint64, value []byte) (page.ValuePtr, error) {
+	if a == nil {
+		return page.ValuePtr{}, fmt.Errorf("commitlog: replay value-log appender unavailable")
+	}
+	if rid == 0 {
+		return page.ValuePtr{}, fmt.Errorf("value-log rid must be non-zero")
+	}
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	if a.writer == nil {
+		return page.ValuePtr{}, fmt.Errorf("commitlog: replay value-log appender unavailable")
+	}
+	if rid >= a.nextRID && rid == ^uint64(0) {
+		return page.ValuePtr{}, fmt.Errorf("value-log rid space exhausted")
+	}
+	ptr, err := a.writer.appendValue(rid, value)
+	if err != nil {
+		return page.ValuePtr{}, err
+	}
+	if err := a.registerProducedPointerLocked(ptr); err != nil {
+		return page.ValuePtr{}, err
+	}
+	if rid >= a.nextRID {
+		a.nextRID = rid + 1
 	}
 	a.dirty = true
 	return ptr, nil

--- a/TreeDB/db/wal_recovery_test.go
+++ b/TreeDB/db/wal_recovery_test.go
@@ -14,23 +14,12 @@ import (
 	"github.com/snissn/gomap/TreeDB/page"
 )
 
-func TestNextReplayAppenderRIDStartScansLatestValueLogSegmentPerLane(t *testing.T) {
+func TestNextReplayAppenderRIDStartPreservesRIDHighWaterAcrossAllSegments(t *testing.T) {
 	dir := t.TempDir()
-	older := writeRIDStartValueLogSegment(t, dir, 2, 1, 10)
-	latest := writeRIDStartValueLogSegment(t, dir, 2, 2, 200)
+	older := writeRIDStartValueLogSegment(t, dir, 2, 1, 200)
+	latest := writeRIDStartValueLogSegment(t, dir, 2, 2, 42)
 	leafLatest := writeRIDStartValueLogSegment(t, dir, rewriteLeafLogLaneID, 1, 150)
 	ignoredCommit := logSegment{lane: 2, seq: 99, path: filepath.Join(dir, "commit.log")}
-
-	gotLatest := latestValueLogSegmentsByLane([]logSegment{older, latest, leafLatest, ignoredCommit})
-	if len(gotLatest) != 2 {
-		t.Fatalf("latest segments len=%d want 2", len(gotLatest))
-	}
-	if gotLatest[0].lane != 2 || gotLatest[0].seq != 2 {
-		t.Fatalf("lane 2 latest=%+v want seq 2", gotLatest[0])
-	}
-	if gotLatest[1].lane != int(rewriteLeafLogLaneID) || gotLatest[1].seq != 1 {
-		t.Fatalf("leaf lane latest=%+v want seq 1", gotLatest[1])
-	}
 
 	next, err := nextReplayAppenderRIDStart([]logSegment{older, latest, leafLatest, ignoredCommit})
 	if err != nil {

--- a/TreeDB/docs/spec/command-wal-durable-write-contract.md
+++ b/TreeDB/docs/spec/command-wal-durable-write-contract.md
@@ -58,7 +58,7 @@ creation/rotation concern, not a per-operation durability barrier.
 
 ### Bounded materialized pointer-backed dirty `WriteSync`
 
-When a batch has at most 256 pointer-eligible operations, every eligible value
+When a batch has at most 256 total operations, every eligible value
 is at most 64 KiB, the conservative full command-frame estimate is at most
 1 MiB and below the configured command segment cap, and a capped active
 value-log segment has enough conservatively reserved space to avoid rotation:

--- a/TreeDB/docs/spec/command-wal-durable-write-contract.md
+++ b/TreeDB/docs/spec/command-wal-durable-write-contract.md
@@ -83,6 +83,16 @@ syncs any newly appended value-log bytes before publishing roots and
 `AppliedCommandLSN`, so a replay crash can safely retry without allocating a
 different RID or duplicating a logical record.
 
+The backend encoder independently enforces the same 64 KiB value, 1 MiB frame,
+and 256 total-operation bounds. Retaining `entry.Value` beside a pointer is not
+by itself permission to emit `SetMaterializedRID`. One-shot raw entry APIs must
+declare one of three append modes: relaxed, directly durable, or a grouped
+durable-prefix participant. Relaxed mode always emits the V1 `SetRID` fallback.
+A prefix participant may emit bounded V2 while appending an individually
+relaxed frame, but its caller must not acknowledge the mutation until a later
+durable-prefix barrier covers that frame. Reusable entry intents, whose eventual
+boundary is unknown, conservatively remain V1.
+
 ### `SetRID` fallback
 
 If any materialized value or the estimated frame exceeds the bounds above, or

--- a/TreeDB/docs/spec/command-wal-durable-write-contract.md
+++ b/TreeDB/docs/spec/command-wal-durable-write-contract.md
@@ -1,8 +1,8 @@
 # Command-WAL Durable Write Contract
 
-Status: current behavior and measurement contract for issue #3657 (M3
-candidate). The candidate preserves this contract but does not meet the issue's
-latency exit gate.
+Status: current behavior and measurement contract, including the bounded
+RID-plus-bytes materialization path from issue #3731 and the conservative
+`SetRID` fallback.
 
 This document defines the durability boundary used by cached public raw-KV
 operations in `ProfileCommandWALDurable`. It distinguishes a logical public
@@ -14,8 +14,9 @@ weaker durability mode.
 
 For `SetSync`, `DeleteSync`, and a dirty `Batch.WriteSync`, a nil return means:
 
-1. any value-log records referenced by the command frame have passed a file
-   sync boundary;
+1. any external value-log records referenced by the command frame have passed a
+   file sync boundary, while any materialized RID operation carries the exact
+   RID and logical bytes needed to recreate that record;
 2. the complete typed command-WAL frame has been written and the command-WAL
    file has passed a later file sync boundary; and
 3. the mutation has been published to the cached memtable before the call
@@ -55,53 +56,49 @@ There is one logical command-WAL sync and one actual command-WAL file-sync hook
 for this operation when no segment rotation occurs. Directory sync is a segment
 creation/rotation concern, not a per-operation durability barrier.
 
-### Pointer-backed dirty `WriteSync`
+### Bounded materialized pointer-backed dirty `WriteSync`
+
+When a batch has at most 256 pointer-eligible operations, every eligible value
+is at most 64 KiB, the conservative full command-frame estimate is at most
+1 MiB and below the configured command segment cap, and a capped active
+value-log segment has enough conservatively reserved space to avoid rotation:
 
 ```text
 public Batch.WriteSync
-  -> append external records to the selected persistent value-log lane
-  -> value-log materialization Sync
-  -> retain that lane's durable-write reservation
+  -> append records to the selected persistent value-log lane without fsync
   -> acquire the command publish/barrier ordering lock
   -> validate/read each pointer RID
-  -> verify the active lane still has the certified file, sequence, and size
-  -> reuse the materialization Sync for that unchanged active segment
-  -> encode RID references and append one RawKVBatch command frame
+  -> encode each RID plus its exact logical bytes in RawKVBatchV2
+  -> append one RawKVBatch command frame
   -> flush command writer buffers
   -> command-WAL file Sync
   -> publish pointers to cached memtables and reset the batch
   -> return nil
 ```
 
-For an unchanged active segment, current code therefore performs one actual
-value-log file-sync hook for a forced-pointer dirty `WriteSync`, attributed to
-`materialization`; the logical `external_ref` sync and its duplicate physical
-file sync are coalesced. The successful materialization sync records a
-certificate containing the active file ID, lane sequence, and writer size while
-holding `vlogMu`. The durable batch retains `lane.syncing` until
-external-reference ordering. Reuse requires that reservation plus an exact
-file/sequence/size match under the same lock. The value log is append-only, so
-the certificate covers every referenced byte in that unchanged file at or
-below the recorded boundary. Pointer validation and RID lookup complete before
-external-reference ordering can append or sync a command frame. The later
-command-WAL sync remains mandatory.
+This path has one durable barrier: the command-WAL file sync. Recovery scans the
+value log by RID. A missing RID is appended under the encoded exact RID; a
+matching RID is reused; a present RID with different bytes fails closed. Replay
+syncs any newly appended value-log bytes before publishing roots and
+`AppliedCommandLSN`, so a replay crash can safely retry without allocating a
+different RID or duplicating a logical record.
 
-Every uncertainty falls back to the original external-reference sync: writer
-growth, rotation, reservation release, missing active writer, a failed
-materialization sync, or a referenced file different from the certified active
-file. Malformed or unreadable pointers fail before command-WAL durability.
+### `SetRID` fallback
 
-When a command frame references a rotated, non-current value-log segment, the
-current implementation first flushes and, unless its own active reference is
-certified, syncs the referenced lane's active writer, then opens and syncs each
-distinct referenced old segment directly.
-Each operation is a logical `external_ref` observation. The active-writer call
-records its lane-lock wait; the direct old-segment call has zero lock wait and
-records the direct request time. Failure to open an old segment is a logical error
-without a physical file-sync attempt. A reached direct sync hook is both a
-logical observation and a physical rotated-segment attempt. This is measured
-ordering, not a required sync count, and it makes segment rotation an explicit
-exclusion in any M3 coalescing proof.
+If any materialized value or the estimated frame exceeds the bounds above, or
+the append could cross a configured value-log segment boundary, the whole batch
+retains the external-reference path:
+
+```text
+append value-log records -> sync exact producer closure -> encode SetRID
+-> sync command WAL -> publish pointers
+```
+
+The fallback keeps `ExternalRefFenceV1`, exact stable dependency handles,
+rotation/old-segment handling, pending-debt barriers, and GC/rewrite protection.
+A mixed V2 payload may contain both operations: only `SetRID` contributes to the
+external RID fence and producer closure. Malformed or unreadable pointers fail
+before command-WAL durability.
 
 ### `Write` followed by `WriteSync`
 
@@ -206,7 +203,7 @@ The verification matrix requires all of the following:
   counts; and
 - observer state remains race-safe.
 
-## M3 result and remaining ownership
+## Historical M3 result and #3731 boundary
 
 M3 removes the only redundancy proven by M2: the second value-log sync in the
 unchanged active-segment pointer path. Deterministic counters and Linux syscall
@@ -214,11 +211,9 @@ tracing show one value-log sync rather than two, while rotation, writer growth,
 missing-writer, released-reservation, and error fallbacks retain conservative
 ordering. Crash/reopen, race, and full repository tests pass.
 
-The identical focused benchmark does not demonstrate the required latency
-improvement: the canonical alternating comparison is statistically
-inconclusive and has a +3.0% geomean. The remaining power-loss-durable floor is
-one value-log materialization sync followed by one command-WAL sync. Therefore
-this candidate is a partial mechanism result and a no-go for #3657's latency
-gate, not completion of that issue. Command-WAL sync removal, async
-acknowledgement, relaxed durability, and per-write backend checkpointing remain
-outside the optimization boundary.
+That candidate left one value-log materialization sync followed by one
+command-WAL sync. #3731 removes the first sync only for the bounded,
+format-explicit materialized-RID path above. Oversized or uncertain batches
+continue to use `SetRID`; command-WAL sync removal, async acknowledgement,
+relaxed durability, and per-write backend checkpointing remain outside the
+optimization boundary.

--- a/TreeDB/docs/spec/recovery.md
+++ b/TreeDB/docs/spec/recovery.md
@@ -252,6 +252,12 @@ records are synced before roots plus `AppliedLSN`; a crash after that append can
 retry by matching and reusing the same RID. Legacy `SetRID` remains a lookup-only
 operation with its external dependency fence.
 
+Exact-RID repair can place a lower RID in a newer physical segment. Backend
+replay and the public cached allocator therefore derive their RID high-water by
+scanning every non-empty persistent value-log segment, not only each lane's
+physical tail. Foreground allocation after recovery must remain above that
+all-segment high-water.
+
 For target versioned raw-KV entries, the replay executor assigns the same
 revision contract as live apply from the persisted raw-KV revision domain.
 Command-WAL replay uses the accepted command LSN as the mutation revision only

--- a/TreeDB/docs/spec/recovery.md
+++ b/TreeDB/docs/spec/recovery.md
@@ -244,6 +244,14 @@ replay must observe either the old root plus old `AppliedLSN`, or the new root
 plus advanced `AppliedLSN`; it must not observe command effects without the
 matching `AppliedLSN` or `AppliedLSN` without command effects.
 
+`RawKVBatchV2` adds `SetMaterializedRID(RID, value)`. Recovery reuses an
+existing RID only when its decoded value bytes match exactly. If the RID is
+absent, recovery appends `value` under that exact RID and advances the allocator
+past it. Conflicting bytes fail with a hard corruption error. Newly appended
+records are synced before roots plus `AppliedLSN`; a crash after that append can
+retry by matching and reusing the same RID. Legacy `SetRID` remains a lookup-only
+operation with its external dependency fence.
+
 For target versioned raw-KV entries, the replay executor assigns the same
 revision contract as live apply from the persisted raw-KV revision domain.
 Command-WAL replay uses the accepted command LSN as the mutation revision only

--- a/TreeDB/docs/spec/storage-format.md
+++ b/TreeDB/docs/spec/storage-format.md
@@ -2145,7 +2145,13 @@ whose RID and bytes both match or appends the bytes under that exact RID before
 publishing the pointer. A present RID with different bytes is corruption.
 Materialized RID operations are self-contained and do not enter the external
 RID fence; `SetRID` operations in the same V2 payload retain the normal fence
-and stable dependency closure.
+and stable dependency closure. Live encoding selects V2 only through an
+explicit directly durable or durable-prefix-participant append mode and only
+within the shared 64 KiB/value, 1 MiB/frame, and 256-operation bounds. An
+ordinary relaxed append and a reusable intent with no declared final durability
+boundary use V1 even if pointer entries retain logical value bytes. A grouped
+participant's envelope remains individually relaxed; its later durable-prefix
+barrier is the acknowledgement boundary that stabilizes the preceding frame.
 
 A `RawKVBatch` command frame is one atomic command: one frame, one `LSN`, and
 all contained operations decode as one batch. Delete operations require

--- a/TreeDB/docs/spec/storage-format.md
+++ b/TreeDB/docs/spec/storage-format.md
@@ -2076,9 +2076,10 @@ through an obsolete rotation token. A failure before a durable frame append
 retains the debt for retry; a failure after append or during the final WAL sync
 is commit-ambiguous and poisons the open handle with `ErrRecoveryRequired`.
 
-Every V2 `RawKVBatch` frame containing at least one `SetRID` operation has
-exactly one `ExternalRefFenceV1` precondition. Frames without `SetRID` have no
-RID fence. Its payload is:
+Every V2 command envelope containing a `RawKVBatch` payload with at least one
+`SetRID` operation has exactly one `ExternalRefFenceV1` precondition. Frames
+without `SetRID` have no RID fence, including `RawKVBatchV2` frames whose
+pointer operations are all `SetMaterializedRID`. Its payload is:
 
 ```text
 u32 UniqueRIDCount
@@ -2099,7 +2100,7 @@ Current command kinds:
 
 | Value | Kind | Scope | Payload format | Status |
 |---:|---|---|---|---|
-| 1 | `RawKVBatch` | raw KV | `RawKVBatchV1` | typed raw key/value command batch |
+| 1 | `RawKVBatch` | raw KV | `RawKVBatchV1` or `RawKVBatchV2` | typed raw key/value command batch |
 | 100 | `CollectionInsertBatchByID` | collection | `CollectionInsertBatchByIDV1` | deterministic collection insert/upsert-by-id batch |
 | 101 | `CollectionDeleteBatchByID` | collection | `CollectionDeleteBatchByIDV1` | deterministic collection delete-by-id batch |
 | 102 | `CollectionUpdateBatchByID` | collection | `CollectionUpdateBatchByIDV1` | deterministic collection update/replace-by-id batch |
@@ -2119,8 +2120,9 @@ Current payload format IDs:
 | 6 | `CatalogCreateCollectionV1` |
 | 7 | `CollectionRebuildVectorIndexV1` |
 | 8 | `DurablePrefixBarrierV1` |
+| 9 | `RawKVBatchV2` |
 
-`RawKVBatchV1` payload:
+`RawKVBatchV1` and `RawKVBatchV2` share this payload framing:
 
 ```text
 u16 Version        // 1
@@ -2128,12 +2130,22 @@ u32 OpCount
 Op[OpCount]
 
 Op:
-u8  Op             // 1=set, 2=delete, 3=set-by-value-log-RID, 4=delete-range
+u8  Op             // 1=set, 2=delete, 3=set-by-value-log-RID, 4=delete-range,
+                   // 5=set-by-materialized-value-log-RID (V2 only)
 u32 KeyLen          // for delete-range: StartLen, or 0xffffffff for nil/unbounded
 u32 ValueLen        // for delete-range: EndLen, or 0xffffffff for nil/unbounded
 bytes Key[KeyLen]   // omitted when delete-range StartLen is 0xffffffff
 bytes Value[ValueLen] // omitted when delete-range EndLen is 0xffffffff
 ```
+
+`SetMaterializedRID` encodes `ValueLen >= 8`, followed by a non-zero
+little-endian `u64 RID` and the exact logical value bytes. `RawKVBatchV1`
+rejects this operation. `RawKVBatchV2` recovery either reuses an existing record
+whose RID and bytes both match or appends the bytes under that exact RID before
+publishing the pointer. A present RID with different bytes is corruption.
+Materialized RID operations are self-contained and do not enter the external
+RID fence; `SetRID` operations in the same V2 payload retain the normal fence
+and stable dependency closure.
 
 A `RawKVBatch` command frame is one atomic command: one frame, one `LSN`, and
 all contained operations decode as one batch. Delete operations require

--- a/TreeDB/docs/spec/value-log-lifecycle.md
+++ b/TreeDB/docs/spec/value-log-lifecycle.md
@@ -75,6 +75,14 @@ truncating, rewriting, or moving value-log bytes. The first implementation must
 skip value-log records protected only by command WAL rather than patching WAL
 records in place.
 
+A `RawKVBatchV2` `SetMaterializedRID` is not an external-ref retention root:
+the complete command frame contains the exact RID and value bytes needed to
+recreate a missing record. Before apply it is protected by retaining the command
+frame itself; after apply, the recreated or reused pointer participates in the
+ordinary published-root and cached-memtable reachability rules. `SetRID` entries,
+including those sharing the same V2 frame, retain the external-ref protections
+above.
+
 Command-WAL-only protection may be released only after the command frame is covered by a
 durable `AppliedLSN`, the root descriptors containing the refs are durable, and
 the value-log reachability tracker has incorporated those published roots or a

--- a/TreeDB/docs/spec/verification.md
+++ b/TreeDB/docs/spec/verification.md
@@ -942,6 +942,12 @@ PR3 implementation evidence:
 - Raw KV `SetRID` command entries preserve the existing value-log RID fence by
   requiring the referenced RID to be present in scanned value-log segments
   before recovery can publish the command.
+- `RawKVBatchV2` materialized-RID entries carry exact RID plus value bytes.
+  Codec tests reject them under V1; recovery tests prove exact creation,
+  crash/retry reuse, matching existing-RID reuse, conflict failure, and
+  checkpoint/reopen readability. Bounded forced-pointer `Batch.WriteSync`
+  proves one command-WAL file sync and zero value-log file syncs, while the
+  frame-cap case proves the `SetRID` fallback and its dependency fence.
 - Pointer-backed raw KV command writes resolve the source RID directly from
   value-log pointer metadata instead of scanning whole value-log segments.
 - Inline-only raw KV replay does not depend on value-log RID scanning. Recovery

--- a/TreeDB/docs/spec/verification.md
+++ b/TreeDB/docs/spec/verification.md
@@ -945,9 +945,12 @@ PR3 implementation evidence:
 - `RawKVBatchV2` materialized-RID entries carry exact RID plus value bytes.
   Codec tests reject them under V1; recovery tests prove exact creation,
   crash/retry reuse, matching existing-RID reuse, conflict failure, and
-  checkpoint/reopen readability. Bounded forced-pointer `Batch.WriteSync`
+  checkpoint/reopen readability. Public reopen tests also prove that a lower
+  exact RID repaired into a newer segment cannot lower the cached foreground
+  allocator below an older segment's high-water. Bounded forced-pointer `Batch.WriteSync`
   proves one command-WAL file sync and zero value-log file syncs, while the
-  frame-cap case proves the `SetRID` fallback and its dependency fence.
+  frame-cap and 257-total-operation cases prove whole-batch `SetRID` fallback
+  and its dependency fence; the 256-operation boundary remains eligible.
 - Pointer-backed raw KV command writes resolve the source RID directly from
   value-log pointer metadata instead of scanning whole value-log segments.
 - Inline-only raw KV replay does not depend on value-log RID scanning. Recovery

--- a/TreeDB/internal/commitlog/command_frame.go
+++ b/TreeDB/internal/commitlog/command_frame.go
@@ -2139,6 +2139,13 @@ func validateCommandEnvelopeIdentity(env CommandEnvelope) error {
 			(env.PayloadFormat != PayloadFormatRawKVBatchV1 && env.PayloadFormat != PayloadFormatRawKVBatchV2) {
 			return ErrCorrupt
 		}
+		// RawKVBatchV2 is coupled to the V2 frame's persisted durability
+		// class and external-reference fence. Never allow a legacy V1 frame
+		// (including a zero-version caller that defaults to V1) to carry the
+		// V2 payload identity and bypass those checks.
+		if env.PayloadFormat == PayloadFormatRawKVBatchV2 && env.Version != CommandFrameVersionV2 {
+			return ErrCommandWALUnsupportedVersion
+		}
 	case CommandKindCollectionInsertBatchByID:
 		if env.Scope != CommandScopeCollection || env.PayloadFormat != PayloadFormatCollectionInsertBatchByIDV1 {
 			return ErrCorrupt

--- a/TreeDB/internal/commitlog/command_frame.go
+++ b/TreeDB/internal/commitlog/command_frame.go
@@ -103,6 +103,7 @@ const (
 	PayloadFormatCatalogCreateCollectionV1      PayloadFormat = 6
 	PayloadFormatCollectionRebuildVectorIndexV1 PayloadFormat = 7
 	PayloadFormatDurablePrefixBarrierV1         PayloadFormat = 8
+	PayloadFormatRawKVBatchV2                   PayloadFormat = 9
 )
 
 // RawKVOp is a deterministic raw key/value mutation inside a RawKVBatch
@@ -115,6 +116,7 @@ const (
 	RawKVOpDelete
 	RawKVOpSetRID
 	RawKVOpDeleteRange
+	RawKVOpSetMaterializedRID
 )
 
 // RawKVOperation represents a single operation in a RawKVBatch command frame.
@@ -127,10 +129,13 @@ const (
 //   - RawKVOpDeleteRange: Key is the start bound and Value is the exclusive
 //     end bound. Nil bounds are unbounded and are encoded with a sentinel
 //     length; bounded empty/reversed ranges are invalid in command frames.
+//   - RawKVOpSetMaterializedRID: Key and Value are the raw bytes and RID is
+//     non-zero. Recovery must preserve that logical RID, reusing a matching
+//     value-log record or materializing Value under that exact RID.
 //
 // Revision is optional per-entry metadata. Zero is the legacy/no-revision
-// value. Revision is valid on point Set/Delete/SetRID operations; range deletes
-// do not carry per-item revision metadata.
+// value. Revision is valid on point Set/Delete/SetRID/SetMaterializedRID
+// operations; range deletes do not carry per-item revision metadata.
 type RawKVOperation struct {
 	Op       RawKVOp
 	Key      []byte
@@ -145,8 +150,9 @@ type RawKVOperation struct {
 // a canonical payload slice.
 type RawKVBatchOperationScanner func(func(RawKVOperation) error) error
 
-// RawKVBatchPayloadPlan is the exact RawKVBatchV1 payload shape for a replayable
-// operation source.
+// RawKVBatchPayloadPlan is the exact shared RawKVBatchV1/V2 payload shape for a
+// replayable operation source. The enclosing payload-format ID gates V2-only
+// operations.
 type RawKVBatchPayloadPlan struct {
 	Count          int
 	PayloadLen     int
@@ -736,6 +742,8 @@ func (b *RawKVBatchPayloadBuilder) Append(op RawKVOperation) (keyView, valueView
 	valueLen := len(op.Value)
 	if op.Op == RawKVOpSetRID {
 		valueLen = 8
+	} else if op.Op == RawKVOpSetMaterializedRID {
+		valueLen += 8
 	}
 	if commandFrameIntExceedsUint32(len(op.Key)) || commandFrameIntExceedsUint32(valueLen) {
 		return nil, nil, ErrRecordTooLarge
@@ -745,6 +753,11 @@ func (b *RawKVBatchPayloadBuilder) Append(op RawKVOperation) (keyView, valueView
 	if op.Op == RawKVOpSetRID {
 		binary.LittleEndian.PutUint64(ridBuf[:], op.RID)
 		value = ridBuf[:]
+	} else if op.Op == RawKVOpSetMaterializedRID {
+		materialized := make([]byte, 8+len(op.Value))
+		binary.LittleEndian.PutUint64(materialized[:8], op.RID)
+		copy(materialized[8:], op.Value)
+		value = materialized
 	}
 	return b.appendValidatedWithRevision(op.Op, op.Key, value, op.Revision)
 }
@@ -1750,6 +1763,9 @@ func encodeRawKVSingleCommandFrameTo(dst []byte, lsn, baseAppliedLSN uint64, op 
 	if err := validateRawKVOperation(&op); err != nil {
 		return nil, err
 	}
+	if op.Op == RawKVOpSetMaterializedRID {
+		return nil, ErrCommandWALUnsupportedVersion
+	}
 	if op.Op == RawKVOpDeleteRange {
 		payload, err := EncodeRawKVSingleOperationPayload(op)
 		if err != nil {
@@ -2119,7 +2135,8 @@ func validateCommandEnvelopeIdentity(env CommandEnvelope) error {
 	}
 	switch env.Kind {
 	case CommandKindRawKVBatch:
-		if env.Scope != CommandScopeRawKV || env.PayloadFormat != PayloadFormatRawKVBatchV1 {
+		if env.Scope != CommandScopeRawKV ||
+			(env.PayloadFormat != PayloadFormatRawKVBatchV1 && env.PayloadFormat != PayloadFormatRawKVBatchV2) {
 			return ErrCorrupt
 		}
 	case CommandKindCollectionInsertBatchByID:
@@ -2151,7 +2168,7 @@ func validateCommandEnvelopeIdentity(env CommandEnvelope) error {
 func validateCommandEnvelopePayload(env CommandEnvelope) error {
 	switch env.Kind {
 	case CommandKindRawKVBatch:
-		return validateRawKVBatchPayload(env.Payload)
+		return validateRawKVBatchPayloadForFormat(env.PayloadFormat, env.Payload)
 	case CommandKindCollectionInsertBatchByID:
 		_, err := DecodeCollectionInsertBatchByIDPayload(env.Payload)
 		return err
@@ -2245,6 +2262,11 @@ func rawKVOperationPayloadLens(op *RawKVOperation) (keyBytes, valueBytes int, er
 	valueBytes = len(op.Value)
 	if op.Op == RawKVOpSetRID {
 		valueBytes = 8
+	} else if op.Op == RawKVOpSetMaterializedRID {
+		if len(op.Value) > int(^uint(0)>>1)-8 {
+			return 0, 0, ErrRecordTooLarge
+		}
+		valueBytes = 8 + len(op.Value)
 	} else if op.Op == RawKVOpDeleteRange {
 		_, startBytes, err := rawKVRangeBoundEncodedLen(op.Key)
 		if err != nil {
@@ -2399,6 +2421,8 @@ func writeRawKVOperationPayloadTo(dst []byte, op RawKVOperation, entryRevisions 
 	valueLen := uint32(len(op.Value))
 	if op.Op == RawKVOpSetRID {
 		valueLen = 8
+	} else if op.Op == RawKVOpSetMaterializedRID {
+		valueLen = uint32(valueBytes)
 	} else if op.Op == RawKVOpDeleteRange {
 		keyLen, _, err = rawKVRangeBoundEncodedLen(op.Key)
 		if err != nil {
@@ -2432,6 +2456,14 @@ func writeRawKVOperationPayloadTo(dst []byte, op RawKVOperation, entryRevisions 
 		}
 		binary.LittleEndian.PutUint64(dst[off:off+8], op.RID)
 		off += 8
+	case RawKVOpSetMaterializedRID:
+		if off > len(dst) || len(dst)-off < 8 {
+			return 0, ErrCorrupt
+		}
+		binary.LittleEndian.PutUint64(dst[off:off+8], op.RID)
+		off += 8
+		copy(dst[off:], op.Value)
+		off += len(op.Value)
 	default:
 		if len(op.Value) > 0 {
 			copy(dst[off:], op.Value)
@@ -2461,6 +2493,8 @@ func writeRawKVOperationPayloadPiecesWithRevisionFlag(op RawKVOperation, entryRe
 		binary.LittleEndian.PutUint64(ridBuf[:], op.RID)
 		value = ridBuf[:]
 		valueLen = uint32(len(value))
+	} else if op.Op == RawKVOpSetMaterializedRID {
+		valueLen = uint32(valueBytes)
 	} else if op.Op == RawKVOpDeleteRange {
 		keyLen, _, err = rawKVRangeBoundEncodedLen(key)
 		if err != nil {
@@ -2484,6 +2518,12 @@ func writeRawKVOperationPayloadPiecesWithRevisionFlag(op RawKVOperation, entryRe
 	}
 	if len(key) > 0 {
 		if err := write(key); err != nil {
+			return 0, err
+		}
+	}
+	if op.Op == RawKVOpSetMaterializedRID {
+		binary.LittleEndian.PutUint64(ridBuf[:], op.RID)
+		if err := write(ridBuf[:]); err != nil {
 			return 0, err
 		}
 	}
@@ -2576,6 +2616,9 @@ func DecodeRawKVBatchPayload(payload []byte) ([]RawKVOperation, error) {
 		entry := RawKVOperation{Op: op, Key: cloneBytesPreserveEmpty(key), Revision: revision}
 		if op == RawKVOpSetRID {
 			entry.RID = binary.LittleEndian.Uint64(value)
+		} else if op == RawKVOpSetMaterializedRID {
+			entry.RID = binary.LittleEndian.Uint64(value[:8])
+			entry.Value = cloneBytesPreserveEmpty(value[8:])
 		} else {
 			entry.Value = cloneBytesPreserveEmpty(value)
 		}
@@ -2591,10 +2634,27 @@ func validateRawKVBatchPayload(payload []byte) error {
 	return ScanRawKVBatchPayload(payload, nil)
 }
 
+func validateRawKVBatchPayloadForFormat(format PayloadFormat, payload []byte) error {
+	switch format {
+	case PayloadFormatRawKVBatchV1:
+		return ScanRawKVBatchPayload(payload, func(op RawKVOp, _, _ []byte) error {
+			if op == RawKVOpSetMaterializedRID {
+				return ErrCorrupt
+			}
+			return nil
+		})
+	case PayloadFormatRawKVBatchV2:
+		return ScanRawKVBatchPayload(payload, nil)
+	default:
+		return ErrCorrupt
+	}
+}
+
 // ScanRawKVBatchPayload validates payload and visits each op with slices that
 // reference payload. For RawKVOpSetRID, value is exactly the 8-byte
-// little-endian RID payload. Use DecodeRawKVBatchPayload when callers need
-// owned copies or typed RID fields.
+// little-endian RID payload. For RawKVOpSetMaterializedRID, value is the
+// 8-byte little-endian RID followed by the materialization bytes. Use
+// DecodeRawKVBatchPayload when callers need owned copies or typed RID fields.
 func ScanRawKVBatchPayload(payload []byte, visit func(op RawKVOp, key, value []byte) error) error {
 	if visit == nil {
 		return ScanRawKVBatchPayloadWithRevision(payload, nil)
@@ -2699,10 +2759,10 @@ func ScanRawKVBatchPayloadWithRevision(payload []byte, visit func(op RawKVOp, ke
 		if !valueNil {
 			value = payload[off : off+int(valueBytes)]
 		}
-		if op == RawKVOpSetRID {
-			// validateRawKVOperationShape already enforces valueLen == 8 for
-			// RawKVOpSetRID, so len(value) == 8 is guaranteed here. Only
-			// check for the zero-RID sentinel, which is always invalid.
+		if op == RawKVOpSetRID || op == RawKVOpSetMaterializedRID {
+			// validateRawKVOperationShape enforces valueLen == 8 for SetRID and
+			// valueLen >= 8 for SetMaterializedRID, so the RID prefix is present.
+			// Only check for the zero-RID sentinel, which is always invalid.
 			if binary.LittleEndian.Uint64(value) == 0 {
 				return ErrCorrupt
 			}
@@ -2795,6 +2855,14 @@ func validateRawKVOperation(op *RawKVOperation) error {
 			return ErrCorrupt
 		}
 		valueLen = 8
+	} else if op.Op == RawKVOpSetMaterializedRID {
+		if op.RID == 0 || op.Value == nil {
+			return ErrCorrupt
+		}
+		if len(op.Value) > int(^uint(0)>>1)-8 {
+			return ErrRecordTooLarge
+		}
+		valueLen = 8 + len(op.Value)
 	}
 	if commandFrameIntExceedsUint32(valueLen) {
 		return ErrRecordTooLarge
@@ -2816,6 +2884,11 @@ func validateRawKVOperationShape(op RawKVOp, key []byte, valueLen int) error {
 		return nil
 	case RawKVOpSetRID:
 		if key == nil || valueLen != 8 {
+			return ErrCorrupt
+		}
+		return nil
+	case RawKVOpSetMaterializedRID:
+		if key == nil || valueLen < 8 {
 			return ErrCorrupt
 		}
 		return nil

--- a/TreeDB/internal/commitlog/command_frame_test.go
+++ b/TreeDB/internal/commitlog/command_frame_test.go
@@ -2013,6 +2013,104 @@ func TestCommandWALRawKVBatchRevisionRoundTrip(t *testing.T) {
 	}
 }
 
+func TestCommandWALRawKVBatchMaterializedRIDV2RoundTripAndFormatGate(t *testing.T) {
+	value := []byte("persistent-value")
+	payload, err := EncodeRawKVBatchPayload([]RawKVOperation{{
+		Op:       RawKVOpSetMaterializedRID,
+		Key:      []byte("materialized"),
+		Value:    value,
+		RID:      42,
+		Revision: 13,
+	}})
+	if err != nil {
+		t.Fatalf("EncodeRawKVBatchPayload materialized RID: %v", err)
+	}
+
+	if _, err := EncodeCommandFrameV2(CommandEnvelope{
+		Version:         CommandFrameVersionV2,
+		DurabilityClass: CommandDurabilityDurable,
+		LSN:             1,
+		Kind:            CommandKindRawKVBatch,
+		Scope:           CommandScopeRawKV,
+		PayloadFormat:   PayloadFormatRawKVBatchV1,
+		Payload:         payload,
+	}); !errors.Is(err, ErrCorrupt) {
+		t.Fatalf("V1 materialized RID error=%v, want ErrCorrupt", err)
+	}
+	directPath := filepath.Join(t.TempDir(), "commit-l0-000001.log")
+	direct, err := NewWriter(directPath)
+	if err != nil {
+		t.Fatalf("NewWriter direct materialized RID: %v", err)
+	}
+	if err := direct.AppendRawKVSingleCommandDirect(1, 0, RawKVOperation{
+		Op: RawKVOpSetMaterializedRID, Key: []byte("materialized"), Value: value, RID: 42,
+	}); !errors.Is(err, ErrCommandWALUnsupportedVersion) {
+		_ = direct.Close()
+		t.Fatalf("direct single materialized RID error=%v, want ErrCommandWALUnsupportedVersion", err)
+	}
+	if err := direct.Close(); err != nil {
+		t.Fatalf("Close direct materialized RID writer: %v", err)
+	}
+
+	frame, err := EncodeCommandFrameV2(CommandEnvelope{
+		Version:         CommandFrameVersionV2,
+		DurabilityClass: CommandDurabilityDurable,
+		LSN:             1,
+		Kind:            CommandKindRawKVBatch,
+		Scope:           CommandScopeRawKV,
+		PayloadFormat:   PayloadFormatRawKVBatchV2,
+		Payload:         payload,
+	})
+	if err != nil {
+		t.Fatalf("EncodeCommandFrameV2 materialized RID: %v", err)
+	}
+	env, err := DecodeCommandFrameV2(frame)
+	if err != nil {
+		t.Fatalf("DecodeCommandFrameV2 materialized RID: %v", err)
+	}
+	ops, err := DecodeRawKVBatchPayload(env.Payload)
+	if err != nil {
+		t.Fatalf("DecodeRawKVBatchPayload materialized RID: %v", err)
+	}
+	if len(ops) != 1 || ops[0].Op != RawKVOpSetMaterializedRID ||
+		string(ops[0].Key) != "materialized" || !bytes.Equal(ops[0].Value, value) ||
+		ops[0].RID != 42 || ops[0].Revision != 13 {
+		t.Fatalf("decoded materialized RID ops=%+v", ops)
+	}
+	fence, err := ExternalRefFenceV1FromRawKVPayload(env.Payload)
+	if err != nil {
+		t.Fatalf("ExternalRefFenceV1FromRawKVPayload: %v", err)
+	}
+	if fence.Count != 0 {
+		t.Fatalf("materialized RID external fence count=%d, want 0", fence.Count)
+	}
+	corrupt := append([]byte(nil), frame...)
+	// Raw frame bytes do not carry their segment CRC; Reader verifies that
+	// outer checksum. Corrupt the materialized RID prefix here so the strict
+	// frame decoder still exercises its V2 payload-shape fail-closed path.
+	ridOffset := commandFrameHeaderSize + rawKVBatchHeaderSize + rawKVOpRevisionHeaderSize + len("materialized")
+	clear(corrupt[ridOffset : ridOffset+8])
+	if _, err := DecodeCommandFrameV2(corrupt); !errors.Is(err, ErrCorrupt) {
+		t.Fatalf("zero-RID V2 materialized frame error=%v, want ErrCorrupt", err)
+	}
+	if _, err := DecodeCommandFrameV2(frame[:len(frame)-1]); !errors.Is(err, ErrCorrupt) {
+		t.Fatalf("truncated V2 materialized frame error=%v, want ErrCorrupt", err)
+	}
+
+	for name, op := range map[string]RawKVOperation{
+		"zero-rid":   {Op: RawKVOpSetMaterializedRID, Key: []byte("k"), Value: value},
+		"nil-value":  {Op: RawKVOpSetMaterializedRID, Key: []byte("k"), RID: 42},
+		"nil-key":    {Op: RawKVOpSetMaterializedRID, Value: value, RID: 42},
+		"unknown-op": {Op: RawKVOp(0xff), Key: []byte("k"), Value: value, RID: 42},
+	} {
+		t.Run(name, func(t *testing.T) {
+			if _, err := EncodeRawKVBatchPayload([]RawKVOperation{op}); !errors.Is(err, ErrCorrupt) {
+				t.Fatalf("EncodeRawKVBatchPayload error=%v, want ErrCorrupt", err)
+			}
+		})
+	}
+}
+
 func TestCommandWALFeatureGateRejectsLegacyRawPayload(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "commit-l0-000001.log")
 	w, err := NewWriter(path)

--- a/TreeDB/internal/commitlog/command_frame_test.go
+++ b/TreeDB/internal/commitlog/command_frame_test.go
@@ -2025,6 +2025,52 @@ func TestCommandWALRawKVBatchMaterializedRIDV2RoundTripAndFormatGate(t *testing.
 	if err != nil {
 		t.Fatalf("EncodeRawKVBatchPayload materialized RID: %v", err)
 	}
+	legacyV2Envelope := CommandEnvelope{
+		LSN:           1,
+		Kind:          CommandKindRawKVBatch,
+		Scope:         CommandScopeRawKV,
+		PayloadFormat: PayloadFormatRawKVBatchV2,
+		Payload:       payload,
+	}
+	if _, err := EncodeCommandFrame(legacyV2Envelope); !errors.Is(err, ErrCommandWALUnsupportedVersion) {
+		t.Fatalf("legacy frame with V2 payload error=%v, want ErrCommandWALUnsupportedVersion", err)
+	}
+
+	legacyPath := filepath.Join(t.TempDir(), "commit-l0-000001.log")
+	legacy, err := NewWriter(legacyPath)
+	if err != nil {
+		t.Fatalf("NewWriter legacy V2 payload: %v", err)
+	}
+	if err := legacy.AppendCommand(legacyV2Envelope); !errors.Is(err, ErrCommandWALUnsupportedVersion) {
+		_ = legacy.Close()
+		t.Fatalf("AppendCommand legacy V2 payload error=%v, want ErrCommandWALUnsupportedVersion", err)
+	}
+	if err := legacy.AppendCommand(CommandEnvelope{
+		LSN:           2,
+		Kind:          CommandKindRawKVBatch,
+		Scope:         CommandScopeRawKV,
+		PayloadFormat: PayloadFormatRawKVBatchV1,
+	}); err != nil {
+		_ = legacy.Close()
+		t.Fatalf("AppendCommand valid V1 after rejected V2 payload: %v", err)
+	}
+	if err := legacy.Close(); err != nil {
+		t.Fatalf("Close legacy V2 payload writer: %v", err)
+	}
+
+	legacyFrame, err := EncodeCommandFrame(CommandEnvelope{
+		LSN:           3,
+		Kind:          CommandKindRawKVBatch,
+		Scope:         CommandScopeRawKV,
+		PayloadFormat: PayloadFormatRawKVBatchV1,
+	})
+	if err != nil {
+		t.Fatalf("EncodeCommandFrame legacy fixture: %v", err)
+	}
+	binary.LittleEndian.PutUint16(legacyFrame[52:54], uint16(PayloadFormatRawKVBatchV2))
+	if _, err := DecodeCommandFrame(legacyFrame); !errors.Is(err, ErrCommandWALUnsupportedVersion) {
+		t.Fatalf("DecodeCommandFrame legacy V2 payload error=%v, want ErrCommandWALUnsupportedVersion", err)
+	}
 
 	if _, err := EncodeCommandFrameV2(CommandEnvelope{
 		Version:         CommandFrameVersionV2,

--- a/TreeDB/internal/commitlog/journal_owner.go
+++ b/TreeDB/internal/commitlog/journal_owner.go
@@ -1295,6 +1295,9 @@ func (j *CommandJournal) appendRawKVSingleCommandLocked(baseAppliedLSN uint64, o
 	if err := validateRawKVOperation(&op); err != nil {
 		return 0, err
 	}
+	if op.Op == RawKVOpSetMaterializedRID {
+		return 0, ErrCommandWALUnsupportedVersion
+	}
 	valueLen := len(op.Value)
 	if op.Op == RawKVOpSetRID {
 		valueLen = 8

--- a/TreeDB/internal/commitlog/writer.go
+++ b/TreeDB/internal/commitlog/writer.go
@@ -1075,6 +1075,9 @@ func (w *Writer) AppendCommandV2(env CommandEnvelope) error {
 }
 
 func (w *Writer) AppendRawKVSingleCommandDirect(lsn, baseAppliedLSN uint64, op RawKVOperation) error {
+	if op.Op == RawKVOpSetMaterializedRID {
+		return ErrCommandWALUnsupportedVersion
+	}
 	valueLen := len(op.Value)
 	if op.Op == RawKVOpSetRID {
 		valueLen = 8

--- a/TreeDB/power_loss_oracle_test.go
+++ b/TreeDB/power_loss_oracle_test.go
@@ -1119,7 +1119,9 @@ func TestPowerLossOracleCounterexampleRelaxedCommandFrameMissingRID(t *testing.T
 		return nil
 	})
 	b := db.NewBatch()
-	if err := b.Set([]byte("rid/missing"), bytes.Repeat([]byte("r"), 4096)); err != nil {
+	// Stay above the bounded materialized-RID value limit: this witness owns
+	// the absent external-RID suffix contract, not V2 self-contained replay.
+	if err := b.Set([]byte("rid/missing"), bytes.Repeat([]byte("r"), 65<<10)); err != nil {
 		t.Fatal(err)
 	}
 	err = b.Write()
@@ -1787,7 +1789,8 @@ func buildPowerLossCommandFrames(model *powerlossoracle.Model, root string, obse
 			ChecksumValid: checksumValid,
 			Applied:       observedFrame.LSN <= openedAppliedLSN,
 		}
-		if checksumValid && envelope.Kind == commitlog.CommandKindRawKVBatch && envelope.Scope == commitlog.CommandScopeRawKV && envelope.PayloadFormat == commitlog.PayloadFormatRawKVBatchV1 {
+		if checksumValid && envelope.Kind == commitlog.CommandKindRawKVBatch && envelope.Scope == commitlog.CommandScopeRawKV &&
+			(envelope.PayloadFormat == commitlog.PayloadFormatRawKVBatchV1 || envelope.PayloadFormat == commitlog.PayloadFormatRawKVBatchV2) {
 			operations, err := commitlog.DecodeRawKVBatchPayload(envelope.Payload)
 			if err != nil {
 				return nil, fmt.Errorf("decode stable command-WAL LSN %d dependencies: %w", observedFrame.LSN, err)

--- a/benchmarks/dgraph_durability/README.md
+++ b/benchmarks/dgraph_durability/README.md
@@ -66,7 +66,11 @@ value-log sync, checkpoint, iterator rotation/source, and queue metrics where
 the public `Stats` map exposes them. `command_wal_group_commits/sync`,
 `command_wal_group_syncs/ack`, and `command_wal_group_size_max` are derived
 from production coordinator counters; they are not inferred from benchmark
-concurrency.
+concurrency. The same rows also report command-WAL and value-log bytes written
+per acknowledged commit, pre/post-checkpoint logical file bytes, and untimed
+checkpoint, close, and verified reopen latency. These lifecycle measurements
+run after the acknowledgement timer and therefore do not change `ns/op` or
+the acknowledgement percentiles.
 
 The MVCC package has a separately named write/read-alternating row:
 

--- a/benchmarks/dgraph_durability/benchmark_test.go
+++ b/benchmarks/dgraph_durability/benchmark_test.go
@@ -4,7 +4,9 @@ import (
 	"bytes"
 	"encoding/binary"
 	"fmt"
+	"io/fs"
 	"math"
+	"path/filepath"
 	"runtime"
 	"sort"
 	"strings"
@@ -352,6 +354,10 @@ func benchmarkConcurrentAcknowledgement(b *testing.B, profile benchmarkProfile, 
 	reportLatencyPercentiles(b, profile.class, latencies)
 	reportStoreCounters(b, before, store.stats(), b.N, 0)
 	b.ReportMetric(float64(concurrency), "workers")
+	if tree, ok := store.(*treeDBStore); ok {
+		reportTreeDBLifecycleAndStorage(b, tree, uint64(benchmarkWarmupCommits+b.N), mutations[0].key, b.N)
+		return
+	}
 	if err := store.close(); err != nil {
 		b.Fatalf("close: %v", err)
 	}
@@ -486,6 +492,8 @@ type treeDBStore struct {
 	db      *treedb.DB
 	mvcc    *mvcc.Store
 	mode    mvcc.CommitMode
+	profile treedb.Profile
+	dir     string
 	scratch []mvcc.Mutation
 }
 
@@ -506,7 +514,7 @@ func openTreeDB(tb testing.TB, dir string, profile treedb.Profile, mode mvcc.Com
 	if err != nil {
 		tb.Fatalf("open TreeDB profile=%s: %v", profile, err)
 	}
-	return &treeDBStore{db: db, mvcc: mvcc.New(db), mode: mode}
+	return &treeDBStore{db: db, mvcc: mvcc.New(db), mode: mode, profile: profile, dir: dir}
 }
 
 func (s *treeDBStore) commitAt(timestamp uint64, mutations []mutation) error {
@@ -539,6 +547,87 @@ func (s *treeDBStore) getAt(key []byte, timestamp uint64) ([]byte, bool, error) 
 func (s *treeDBStore) stats() map[string]string { return s.db.Stats() }
 func (s *treeDBStore) close() error             { return s.db.Close() }
 
+type treeDBStorageBytes struct {
+	total      uint64
+	commandWAL uint64
+	valueLog   uint64
+}
+
+func reportTreeDBLifecycleAndStorage(b *testing.B, store *treeDBStore, timestamp uint64, key []byte, writeCommits int) {
+	b.Helper()
+	before := measureTreeDBStorageBytes(b, store.dir)
+	reportTreeDBStorageBytes(b, "pre_checkpoint", before, writeCommits)
+
+	started := time.Now()
+	if err := store.db.Checkpoint(); err != nil {
+		b.Fatalf("checkpoint: %v", err)
+	}
+	b.ReportMetric(float64(time.Since(started).Nanoseconds()), "checkpoint_ns")
+	after := measureTreeDBStorageBytes(b, store.dir)
+	reportTreeDBStorageBytes(b, "post_checkpoint", after, writeCommits)
+
+	started = time.Now()
+	if err := store.close(); err != nil {
+		b.Fatalf("close: %v", err)
+	}
+	b.ReportMetric(float64(time.Since(started).Nanoseconds()), "close_ns")
+
+	opts := treedb.OptionsFor(store.profile, store.dir)
+	started = time.Now()
+	reopened, err := treedb.Open(opts)
+	if err != nil {
+		b.Fatalf("reopen: %v", err)
+	}
+	b.ReportMetric(float64(time.Since(started).Nanoseconds()), "reopen_ns")
+	result, err := mvcc.New(reopened).GetAt(key, timestamp)
+	if err != nil || result.State != mvcc.Present {
+		_ = reopened.Close()
+		b.Fatalf("reopen GetAt state=%d err=%v", result.State, err)
+	}
+	if err := reopened.Close(); err != nil {
+		b.Fatalf("reopened close: %v", err)
+	}
+}
+
+func measureTreeDBStorageBytes(b *testing.B, root string) treeDBStorageBytes {
+	b.Helper()
+	var measured treeDBStorageBytes
+	err := filepath.WalkDir(root, func(path string, entry fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if entry.IsDir() {
+			return nil
+		}
+		info, err := entry.Info()
+		if err != nil {
+			return err
+		}
+		size := uint64(info.Size())
+		measured.total += size
+		name := filepath.Base(path)
+		switch {
+		case strings.HasPrefix(name, "commit-l"):
+			measured.commandWAL += size
+		case strings.HasPrefix(name, "value-l"):
+			measured.valueLog += size
+		}
+		return nil
+	})
+	if err != nil {
+		b.Fatalf("measure TreeDB storage: %v", err)
+	}
+	return measured
+}
+
+func reportTreeDBStorageBytes(b *testing.B, phase string, measured treeDBStorageBytes, writeCommits int) {
+	b.Helper()
+	denominator := float64(max(writeCommits, 1))
+	b.ReportMetric(float64(measured.total)/denominator, phase+"_storage_B/write_commit")
+	b.ReportMetric(float64(measured.commandWAL)/denominator, phase+"_command_wal_B/write_commit")
+	b.ReportMetric(float64(measured.valueLog)/denominator, phase+"_value_log_B/write_commit")
+}
+
 type storeCounterMetric struct {
 	key         string
 	name        string
@@ -546,6 +635,7 @@ type storeCounterMetric struct {
 }
 
 var storeCounterMetrics = []storeCounterMetric{
+	{key: "treedb.command_wal.write.bytes_total", name: "command_wal_write_B/write_commit", denominator: "writes"},
 	{key: "treedb.command_wal.sync.count_total", name: "command_wal_syncs/write_commit", denominator: "writes"},
 	{key: "treedb.command_wal.flush.count_total", name: "command_wal_flushes/write_commit", denominator: "writes"},
 	{key: "treedb.command_wal.file_sync.calls_total", name: "command_wal_file_syncs/write_commit", denominator: "writes"},
@@ -557,6 +647,8 @@ var storeCounterMetrics = []storeCounterMetric{
 	{key: "treedb.cache.value_log.sync.calls_total", name: "value_log_syncs/write_commit", denominator: "writes"},
 	{key: "treedb.cache.value_log.file_sync.calls_total", name: "value_log_file_syncs/write_commit", denominator: "writes"},
 	{key: "treedb.cache.value_log.directory_sync.calls_total", name: "value_log_directory_syncs/write_commit", denominator: "writes"},
+	{key: "treedb.cache.vlog_writev.bytes", name: "value_log_writev_B/write_commit", denominator: "writes"},
+	{key: "treedb.cache.vlog_write.bytes", name: "value_log_write_B/write_commit", denominator: "writes"},
 	{key: "treedb.cache.checkpoint.runs", name: "checkpoints/write_commit", denominator: "writes"},
 	{key: "treedb.publish.ordered_root_delta_group.calls_total", name: "root_publications/write_commit", denominator: "writes"},
 	{key: "treedb.cache.write.wait_for_checkpoint.count_total", name: "checkpoint_caller_waits/write_commit", denominator: "writes"},

--- a/benchmarks/dgraph_durability/benchmark_test.go
+++ b/benchmarks/dgraph_durability/benchmark_test.go
@@ -355,7 +355,8 @@ func benchmarkConcurrentAcknowledgement(b *testing.B, profile benchmarkProfile, 
 	reportStoreCounters(b, before, store.stats(), b.N, 0)
 	b.ReportMetric(float64(concurrency), "workers")
 	if tree, ok := store.(*treeDBStore); ok {
-		reportTreeDBLifecycleAndStorage(b, tree, uint64(benchmarkWarmupCommits+b.N), mutations[0].key, b.N)
+		totalWriteCommits := benchmarkWarmupCommits + b.N
+		reportTreeDBLifecycleAndStorage(b, tree, uint64(totalWriteCommits), mutations[0].key, totalWriteCommits)
 		return
 	}
 	if err := store.close(); err != nil {


### PR DESCRIPTION
Closes #3731

Parent: #3726
Depends on merged #3729 and #3718.

## Outcome

TreeDB's strict durable command-WAL path can now acknowledge bounded externalized values after one foreground stable barrier. A new RawKVBatchV2 operation carries the reserved persistent value-log RID and its bytes in the command WAL. Recovery either reuses an identical existing RID or materializes the bytes under that exact RID before publishing the pointer; mismatches and corrupt mixed formats fail closed.

The persistent value log remains authoritative storage after apply/replay. This does not turn it into an ephemeral WAL.

## Selected policy and bounds

- Materialize only strict durable writes. Relaxed ordinary and relaxed explicit-sync writes retain the V1 pointer-dependency path.
- Bound eligibility to 64 KiB per value, 1 MiB per command frame, and 256 operations.
- Fall back atomically for the whole batch when any value, frame, operation-count, or segment-fit bound is exceeded.
- Preserve V1 fallback across value-log rotation and oversized values.
- Treat a matching existing RID as idempotent replay; reject conflicting RID contents and corrupt V1/V2 combinations.
- Keep the pre-alpha format break explicit in the storage, durability, recovery, value-log lifecycle, and verification specs.

Dependency-frontier grouping was not selected for this issue: merged #3729 already amortizes command-WAL syncs across concurrent acknowledgements, while the serial 4 KiB row still paid the referenced value-log barrier. The bounded self-contained frame removes that remaining foreground dependency without weakening #3718's fallback contract.

## Correctness coverage

- crash after acknowledgement but before value-log stability, followed by exact-RID materialization and reopen;
- idempotent recovery and conflict/corruption rejection;
- all-segment backend and cached-foreground RID high-water preservation after lower exact-RID recovery;
- mixed V1/V2 format gates and torn/checksum-corrupt frames;
- overwrite/delete, all-version iteration, pruning, GC/rewrite, checkpoint, close, and reopen;
- value-log rotation, segment-fit rejection, oversize, batch-byte, and 256/257 total-operation fallback boundaries;
- strict durable activation and relaxed V1 non-activation;
- zero retained dependency debt on the selected path.

## Performance evidence

Measured predecessor `3e225cb992f0ccc6b2a0f7022c00414d8c783715`; product-measurement candidate `00c1c42490edfcafe8015f84ce7a75109ef4c13a`; review-fix candidates `a1dca751689ad09cf35fc840f19f32ed88fbd218`, `0278d22a8623a2e2a7b3bb96e81bd477b49ac42c`, `c8933b196b7639a6e8590667120497a262fdb1b3`, `cb9f971cc103f24033483c1a2947ed059398c216`, and `abbb3bfe5294a3134d9003cc80a7d5c82b8ec1da`; measured review-fix candidate `abbb3bfe5294a3134d9003cc80a7d5c82b8ec1da` after merging orthogonal main change `dc383529612a5a81be8d499bfcd7b09f1b7873e5` (#3925). Linux 6.8/ext4 on `/mnt/fast4tb`, Go 1.26.3, i5-11400F. Raw outputs and CPU/syscall artifacts are retained under `/mnt/fast4tb/bench-results/gomap-3731-f6beb2222`.

| Dgraph-shaped TreeDB row | Base | Candidate | Delta |
| --- | ---: | ---: | ---: |
| concurrent durable c1, batch 1, 4 KiB, ns/op (10 combined reps) | 14.295 ms | 6.048 ms | -57.7% |
| concurrent durable c8, batch 1, 4 KiB, ns/op | 8.060 ms | 2.424 ms | -69.9% |
| c1 p50 acknowledgement | 14.855 ms | 5.900 ms | -60.3% |
| c8 p95 acknowledgement | 218.35 ms | 44.45 ms | -79.7% |
| strict commit-only batch 1, 4 KiB, ns/op (10 reps) | 10.636 ms | 6.628 ms | -37.7% |
| strict commit-only batch 16, 4 KiB, ns/op | 12.108 ms | 6.639 ms | -45.2% |
| command-WAL syncs / serial commit | 1.0 | 1.0 | unchanged |
| value-log syncs / selected commit | 1.0 | 0.0 | -100% |
| command-WAL bytes / 4 KiB commit | 211 B | 4,260 B | bounded inline copy |
| value-log bytes / 4 KiB commit | 495 B | 495 B | unchanged persistent placement |

The measured costs are explicit:

- corrected pre/post-checkpoint logical fixture storage rises 10.8% for the 4 KiB target (the denominator includes all 16 warmup plus 100 timed commits);
- checkpoint work rises directionally because it scans/retains larger active command frames (about +27% geomean in the broad five-rep durable matrix; absolute target deltas varied by run);
- reopen geomean was flat in the broad guardrail matrix, though individual target runs were noisy;
- Go allocation bytes rise with the bounded in-WAL copy (4 KiB batch-1 about +93%), while allocation count falls about 68%; batch-16 amplification remains bounded by the 1 MiB frame cap.

After review, exact head was rebuilt and rerun against a baseline binary carrying only the same lifecycle instrumentation and corrected storage denominator. The c8 4 KiB row improved from 10.181 ms to 2.088 ms per commit (-79.5%, 10 reps); reopen improved from 8.837 ms to 7.405 ms (-16.2%); checkpoint was statistically unchanged. The c1 row improved from 10.421 ms to 5.548 ms (-46.8%, 5 reps), with no reopen regression. Corrected pre-checkpoint storage is 37.44 KiB versus 41.49 KiB per stored commit (+10.8%). This also exercises the backend review fix that scans all persistent value-log segments for the RID high-water after exact-RID recovery. Exact-head public tests additionally prove the cached foreground allocator stays above that high-water through a subsequent pointer write, checkpoint, close, and reopen.

These are bounded pre-alpha storage/recovery tradeoffs, not retained dependency debt. Oversized inputs remain on V1.

The first relaxed matrix exposed an unintended 16x4 KiB regression because V2 was being selected where no stable barrier was promised. The final change gates V2 on strict durability. The rerun has statistically unchanged latency across all eight relaxed rows, identical WAL bytes/sync counts, and identical allocation counts. Larger reverse-order 128 B runs likewise show no material regression.

CPU profiles are sparse because the workload is I/O-bound, but they agree with the counters: flat syscall samples fall from 110 ms to 20 ms and value-log append/flush work disappears from the foreground profile. Direct-binary `strace -f -c` shows lifecycle fsync calls falling from 477 to 217 for the 100x row; detailed `-yy` traces show per-commit referenced value-log file fsyncs disappear while the command-WAL fsync remains. Open/checkpoint/close namespace and index calls are included in those syscall totals, so the production counters above are the authoritative per-commit accounting.


The final backend-enforcement and plan-reuse repairs were benchmarked directly against `c8933b196b7639a6e8590667120497a262fdb1b3` using identical exact-SHA binaries and 100-commit, ten-repetition 4 KiB c1/c8 samples. Latency was statistically unchanged (c1 7.132 ms versus 7.406 ms, p=0.280; c8 2.899 ms versus 3.046 ms, p=0.280); the directional geomean delta was +4.47% inside broad run variance. WAL/value-log bytes and sync semantics were unchanged. Validating retained values once and reusing the already-correct V1 plan reduced allocation bytes by 17.72% and allocation count by 5.33%. Raw outputs are `review4_baseline.txt`, `review8_candidate.txt`, and `review8_benchstat.txt` in the retained artifact directory.

## Validation

- `GOWORK=off go test ./TreeDB/internal/commitlog -count=1`
- `GOWORK=off go test ./TreeDB/db -count=1`
- `GOWORK=off go test ./TreeDB/caching -count=1`
- `GOWORK=off go test ./TreeDB -count=1`
- focused materialized-RID recovery, public, corruption, fallback, rewrite/GC, and exact-RID tests
- targeted race tests at count 3, including the final strict/relaxed activation and older-RID high-water reopen tests
- `GOWORK=off go vet ./TreeDB/internal/commitlog ./TreeDB/db ./TreeDB/caching ./TreeDB ./benchmarks/dgraph_durability`
- benchmark package tests and durable/relaxed/commit-only guardrail matrices
- `git diff --check`

CI and latest-head Codex and CodeRabbit review remain required before merge.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added bounded “materialized RID” command-WAL handling for eligible value-log pointers to improve durable write efficiency.
  * Introduced RawKV batch payload format V2 with `SetMaterializedRID` to preserve exact RID + value bytes and ensure consistent recovery.
  * Added command-WAL append modes for relaxed, durable, and durable-prefix writes.

* **Bug Fixes**
  * Improved command-WAL recovery for materialized RIDs (reuse vs append, conflict detection, checkpoint reopen survival, tail replacement, and allocator high-water preservation), with safe atomic fallback when bounds are exceeded.

* **Documentation**
  * Updated durability/recovery/storage-format/lifecycle/verification specs to reflect the new V2 behavior and durable return boundary rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Latest-head review repairs

Current exact candidate: `e8c6b02e68610fc2924e5293e42fe8f398dfc29c`, including current main `95df3639492525838d675ee2026f754c0548e04c` (#3922). Two latest-head review findings were reproduced before repair:

- mixed V1 replay allocation followed by a pending exact RID produced `valuelog: duplicate rid 1` on the former head; recovery now reserves above every unapplied materialized-RID high-water before ordinary replay allocation;
- a conflicting retained value at operation 257 formerly failed during materialized validation instead of taking the bounded V1 fallback; planning now stops materialization validation when eligibility is lost and retains whole-batch atomic fallback.

Both regression tests, their focused race suite, and `go test ./TreeDB/db -count=1` (320.535s) pass on the exact candidate. Latest-head CI, Codex review, and CodeRabbit review remain merge gates.

The final exact-head review follow-up proved that reused materialized RIDs already cross an exact stable-resource file barrier before the publication seal/index/meta become durable. A forced barrier failure aborts recovery and leaves the frame retryable. `e8c6b02e68610fc2924e5293e42fe8f398dfc29c` adds that explicit ordering/fail-closed witness and documents the existing seam; no production ordering changed.


The final arena-ownership review finding was reproduced before repair: materialized pointer values remained available through command-WAL serialization as required, but pointer-in-memtable publication unnecessarily retained their copy arena. `e8c6b02e68610fc2924e5293e42fe8f398dfc29c` releases that arena after the successful callback because the memtable stores only pointer metadata. The red-before regression, focused suite, race test, full `TreeDB/caching` package (70.333s), and `git diff --check` pass.



The sorted-steal ownership follow-up was also reproduced before repair: recycling the released pointer arena changed the original 0x44 value to 0xff bytes. `e8c6b02e68610fc2924e5293e42fe8f398dfc29c` keeps values through command-WAL serialization, clears them before every pointer-in-memtable publication path, and then releases the arena. The 256-reuse corruption regression, focused suite, race test, full `TreeDB/caching` package (70.100s), and `git diff --check` pass.
