### PR TITLE
test(treedb): model fresh layout crash namespaces

### DIFF
--- a/TreeDB/db/layout.go
+++ b/TreeDB/db/layout.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"syscall"
 
+	"github.com/snissn/gomap/TreeDB/internal/durabilitycut"
 	"github.com/snissn/gomap/TreeDB/internal/rootpublication"
 )
 
@@ -357,12 +358,18 @@ func syncStorageLayoutDirRequired(dir string) error {
 	if dir == "" {
 		return fmt.Errorf("treedb: empty storage layout namespace")
 	}
+	if err := durabilitycut.EmitPath(durabilitycut.BeforeNewFileDirectorySync, durabilitycut.ResourceAuxiliary, dir, dir); err != nil {
+		return errors.Join(err, ErrRecoveryRequired)
+	}
 	if runtime.GOOS == "windows" {
-		return fmt.Errorf("%w: generic parent-directory sync is unavailable on windows", ErrNamespacePersistenceUnsupported)
+		return errors.Join(
+			fmt.Errorf("%w: generic parent-directory sync is unavailable on windows", ErrNamespacePersistenceUnsupported),
+			ErrRecoveryRequired,
+		)
 	}
 	file, err := os.Open(dir)
 	if err != nil {
-		return err
+		return errors.Join(err, ErrRecoveryRequired)
 	}
 	defer func() { _ = file.Close() }()
 	if err := file.Sync(); err != nil {
@@ -372,9 +379,15 @@ func syncStorageLayoutDirRequired(dir string) error {
 			errors.Is(err, syscall.ENOTSUP) ||
 			errors.Is(err, syscall.ENOSYS) ||
 			strings.Contains(lowerErr, "not supported") {
-			return fmt.Errorf("%w: sync directory %q: %v", ErrNamespacePersistenceUnsupported, dir, err)
+			return errors.Join(
+				fmt.Errorf("%w: sync directory %q: %v", ErrNamespacePersistenceUnsupported, dir, err),
+				ErrRecoveryRequired,
+			)
 		}
-		return err
+		return errors.Join(err, ErrRecoveryRequired)
+	}
+	if err := durabilitycut.EmitPath(durabilitycut.AfterNewFileDirectorySync, durabilitycut.ResourceAuxiliary, dir, dir); err != nil {
+		return errors.Join(err, ErrRecoveryRequired)
 	}
 	return nil
 }

--- a/TreeDB/db/layout.go
+++ b/TreeDB/db/layout.go
@@ -354,6 +354,15 @@ func storageLayoutPathDepth(path string) int {
 
 var syncStorageLayoutDir = syncStorageLayoutDirRequired
 
+var syncStorageLayoutDirHandle = func(dir string) error {
+	file, err := os.Open(dir)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = file.Close() }()
+	return file.Sync()
+}
+
 func syncStorageLayoutDirRequired(dir string) error {
 	if dir == "" {
 		return fmt.Errorf("treedb: empty storage layout namespace")
@@ -367,12 +376,7 @@ func syncStorageLayoutDirRequired(dir string) error {
 			ErrRecoveryRequired,
 		)
 	}
-	file, err := os.Open(dir)
-	if err != nil {
-		return errors.Join(err, ErrRecoveryRequired)
-	}
-	defer func() { _ = file.Close() }()
-	if err := file.Sync(); err != nil {
+	if err := syncStorageLayoutDirHandle(dir); err != nil {
 		lowerErr := strings.ToLower(err.Error())
 		if errors.Is(err, syscall.EINVAL) ||
 			errors.Is(err, syscall.EPERM) ||

--- a/TreeDB/db/layout_test.go
+++ b/TreeDB/db/layout_test.go
@@ -7,6 +7,8 @@ import (
 	"reflect"
 	"runtime"
 	"testing"
+
+	"github.com/snissn/gomap/TreeDB/internal/durabilitycut"
 )
 
 func TestLayoutPaths_DefaultSplitDirs(t *testing.T) {
@@ -115,6 +117,54 @@ func TestEnsureStorageLayoutDirsSyncsRootForColumnAssetsM12A(t *testing.T) {
 		}
 	}
 	t.Fatalf("new storage layout dirs did not sync DB root %q; synced=%v", dir, synced)
+}
+
+func TestSyncStorageLayoutDirRequiredEmitsModeledNamespaceBarrier(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("generic parent-directory sync is unsupported on Windows")
+	}
+	dir := t.TempDir()
+	var events []durabilitycut.Event
+	restore := durabilitycut.Install(func(event durabilitycut.Event) error {
+		events = append(events, event)
+		return nil
+	})
+	defer restore()
+
+	if err := syncStorageLayoutDirRequired(dir); err != nil {
+		t.Fatalf("syncStorageLayoutDirRequired: %v", err)
+	}
+	if len(events) != 2 {
+		t.Fatalf("namespace barrier events=%v, want before and after", events)
+	}
+	for i, want := range []durabilitycut.Point{
+		durabilitycut.BeforeNewFileDirectorySync,
+		durabilitycut.AfterNewFileDirectorySync,
+	} {
+		if events[i].Point != want || events[i].Resource != durabilitycut.ResourceAuxiliary || events[i].Path != dir {
+			t.Fatalf("namespace barrier event[%d]=%+v, want point=%s resource=%s path=%q", i, events[i], want, durabilitycut.ResourceAuxiliary, dir)
+		}
+	}
+}
+
+func TestSyncStorageLayoutDirRequiredFailsClosedAfterModeledBarrier(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("generic parent-directory sync is unsupported on Windows")
+	}
+	dir := t.TempDir()
+	wantErr := errors.New("injected post-directory-sync cut")
+	restore := durabilitycut.Install(func(event durabilitycut.Event) error {
+		if event.Point == durabilitycut.AfterNewFileDirectorySync {
+			return wantErr
+		}
+		return nil
+	})
+	defer restore()
+
+	err := syncStorageLayoutDirRequired(dir)
+	if !errors.Is(err, wantErr) || !errors.Is(err, ErrRecoveryRequired) {
+		t.Fatalf("syncStorageLayoutDirRequired error=%v, want injected error joined with ErrRecoveryRequired", err)
+	}
 }
 
 func TestEnsureStorageLayoutDirsSyncsFreshNamespaceBottomUp(t *testing.T) {

--- a/TreeDB/db/layout_test.go
+++ b/TreeDB/db/layout_test.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"reflect"
 	"runtime"
+	"syscall"
 	"testing"
 
 	"github.com/snissn/gomap/TreeDB/internal/durabilitycut"
@@ -164,6 +165,31 @@ func TestSyncStorageLayoutDirRequiredFailsClosedAfterModeledBarrier(t *testing.T
 	err := syncStorageLayoutDirRequired(dir)
 	if !errors.Is(err, wantErr) || !errors.Is(err, ErrRecoveryRequired) {
 		t.Fatalf("syncStorageLayoutDirRequired error=%v, want injected error joined with ErrRecoveryRequired", err)
+	}
+}
+
+func TestSyncStorageLayoutDirRequiredClassifiesUnsupportedSync(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("generic parent-directory sync is unsupported on Windows")
+	}
+	dir := t.TempDir()
+	previous := syncStorageLayoutDirHandle
+	syncStorageLayoutDirHandle = func(string) error { return syscall.EINVAL }
+	t.Cleanup(func() { syncStorageLayoutDirHandle = previous })
+
+	var events []durabilitycut.Event
+	restore := durabilitycut.Install(func(event durabilitycut.Event) error {
+		events = append(events, event)
+		return nil
+	})
+	defer restore()
+
+	err := syncStorageLayoutDirRequired(dir)
+	if !errors.Is(err, ErrNamespacePersistenceUnsupported) || !errors.Is(err, ErrRecoveryRequired) {
+		t.Fatalf("syncStorageLayoutDirRequired error=%v, want unsupported and recovery-required", err)
+	}
+	if len(events) != 1 || events[0].Point != durabilitycut.BeforeNewFileDirectorySync {
+		t.Fatalf("namespace barrier events=%v, want only before-sync", events)
 	}
 }
 

--- a/TreeDB/docs/spec/power-loss-certification-3684.md
+++ b/TreeDB/docs/spec/power-loss-certification-3684.md
@@ -94,7 +94,14 @@ The evidence directory must be empty. Capture writes:
 - `recovery_trace.json` from the normal public open path, bound to the SHA-256
   of `stable_image_tree.json` and the model's stable fingerprint; and
 - `metrics.json` with image sizes, file counts, trace count, and stable-image
-  fingerprint.
+fingerprint.
+
+The directory-bound contract uses run-plan and witness-contract schema v3,
+child-manifest schema v2, and recovery-trace schema v2. The plan freezes the
+expected slash-separated recovery directory; the child manifest retains that
+expectation, and the trace must identify the same canonical `recovery-input`
+root or descendant. These version bumps are intentional because strict readers
+of the preceding schemas do not accept the new fields or child-root semantics.
 
 Every modeled witness registers those five JSON files and
 `command_log.json` at their canonical names directly below its declared
@@ -122,7 +129,7 @@ not evidence.
 
 ## Exact-SHA runner
 
-`TreeDB/cmd/power_loss_certify` consumes a strict risk inventory and version-2
+`TreeDB/cmd/power_loss_certify` consumes a strict risk inventory and version-3
 run plan. The plan freezes `refs/remotes/origin/main`, its exact repository SHA,
 PR provenance, replay selector, profile, reopen mode, expected outcome, typed
 error, complete expected recovery state, per-case timeout, captured-output

--- a/TreeDB/internal/powerlosscert/bundle.go
+++ b/TreeDB/internal/powerlosscert/bundle.go
@@ -17,7 +17,7 @@ import (
 const (
 	operationTraceSchemaVersion = "treedb-power-loss-operation-trace/v1"
 	imageTreeSchemaVersion      = "treedb-power-loss-image-tree/v1"
-	recoveryTraceSchemaVersion  = "treedb-power-loss-recovery-trace/v1"
+	recoveryTraceSchemaVersion  = "treedb-power-loss-recovery-trace/v2"
 	metricsSchemaVersion        = "treedb-power-loss-metrics/v1"
 	commandLogSchemaVersion     = "treedb-power-loss-command-log/v1"
 )

--- a/TreeDB/internal/powerlosscert/bundle.go
+++ b/TreeDB/internal/powerlosscert/bundle.go
@@ -577,7 +577,14 @@ func verifyRecoveryTrace(root, evidenceDir, manifestID string, witness Witness, 
 	if err := decodeStrict(data, &recovery); err != nil {
 		return recoveryTraceArtifact{}, fmt.Errorf("%s decode: %w", prefix, err)
 	}
-	if recovery.SchemaVersion != recoveryTraceSchemaVersion || recovery.PublicAPI != "treedb.Open" || recovery.Dir != "recovery-input" || recovery.PreOpenSnapshotDir != "recovery-preopen" {
+	expectedRecoveryDir, err := normalizeRecoveryDir(witness.ExpectedRecoveryDir)
+	if err != nil {
+		return recoveryTraceArtifact{}, fmt.Errorf("%s: %w", prefix, err)
+	}
+	if actualRecoveryDir, normalizeErr := normalizeRecoveryDir(recovery.Dir); recovery.Dir == "" || normalizeErr != nil || actualRecoveryDir != expectedRecoveryDir {
+		return recoveryTraceArtifact{}, fmt.Errorf("%s dir=%q does not match expected recovery directory %q", prefix, recovery.Dir, expectedRecoveryDir)
+	}
+	if recovery.SchemaVersion != recoveryTraceSchemaVersion || recovery.PublicAPI != "treedb.Open" || recovery.PreOpenSnapshotDir != "recovery-preopen" {
 		return recoveryTraceArtifact{}, fmt.Errorf("%s has invalid schema, public_api, dir, or pre_open_snapshot_dir", prefix)
 	}
 	if recovery.InputTreeSHA256 != stableArtifact.SHA256 || recovery.StableFingerprint != metrics.StableFingerprint {

--- a/TreeDB/internal/powerlosscert/bundle_test.go
+++ b/TreeDB/internal/powerlosscert/bundle_test.go
@@ -111,6 +111,37 @@ func TestVerifyArtifactsChecksContentAndRejectsEscapes(t *testing.T) {
 	}
 }
 
+func TestVerifyArtifactsAcceptsFrozenChildRecoveryDirectory(t *testing.T) {
+	root := t.TempDir()
+	manifest := testChildManifest("fresh-layout")
+	manifest.Witnesses[0].ExpectedRecoveryDir = "recovery-input/db"
+	for index := range manifest.TestBinaries {
+		manifest.TestBinaries[index] = writeArtifactFixture(t, root, manifest.TestBinaries[index].Kind, manifest.TestBinaries[index].Path, "binary")
+	}
+	writeModeledEvidenceFixture(t, root, &manifest, "after-meta-write")
+	if err := VerifyArtifacts(root, []ChildManifest{manifest}); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestVerifyArtifactsRejectsRecoveryDirectorySubstitution(t *testing.T) {
+	for _, dir := range []string{"", "recovery-input", "../db", "/recovery-input/db", `recovery-input\db`} {
+		t.Run(strings.NewReplacer("/", "-", `\`, "-").Replace(dir), func(t *testing.T) {
+			root := t.TempDir()
+			manifest := testChildManifest("fresh-layout")
+			manifest.Witnesses[0].ExpectedRecoveryDir = "recovery-input/db"
+			for index := range manifest.TestBinaries {
+				manifest.TestBinaries[index] = writeArtifactFixture(t, root, manifest.TestBinaries[index].Kind, manifest.TestBinaries[index].Path, "binary")
+			}
+			writeModeledEvidenceFixture(t, root, &manifest, "after-meta-write")
+			rewriteArtifactJSONField(t, root, &manifest.Witnesses[0], ArtifactKindRecoveryTrace, "dir", dir)
+			if err := VerifyArtifacts(root, []ChildManifest{manifest}); err == nil || !strings.Contains(err.Error(), "expected recovery directory") {
+				t.Fatalf("VerifyArtifacts dir=%q error=%v", dir, err)
+			}
+		})
+	}
+}
+
 func TestVerifyArtifactsRejectsOperationTraceThatDoesNotMatchWitness(t *testing.T) {
 	root := t.TempDir()
 	manifest := testChildManifest("witness-a")
@@ -457,6 +488,19 @@ func writeModeledEvidenceFixture(t *testing.T, root string, manifest *ChildManif
 	t.Helper()
 	witness := &manifest.Witnesses[0]
 	evidenceDir := filepath.Join(root, filepath.FromSlash(witness.Command.Env["TREEDB_POWERLOSS_EVIDENCE_DIR"]))
+	recoveryDir, err := normalizeRecoveryDir(witness.ExpectedRecoveryDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	imageFile := "index.db"
+	var imageDirectories []string
+	if child := strings.TrimPrefix(recoveryDir, defaultRecoveryDir+"/"); child != recoveryDir {
+		imageFile = filepath.Join(filepath.FromSlash(child), "index.db")
+		parts := strings.Split(child, "/")
+		for index := range parts {
+			imageDirectories = append(imageDirectories, strings.Join(parts[:index+1], "/"))
+		}
+	}
 	stableContents := []byte("stable")
 	dirtyContents := []byte("dirty")
 	for _, image := range []struct {
@@ -471,7 +515,11 @@ func writeModeledEvidenceFixture(t *testing.T, root string, manifest *ChildManif
 		if err := os.MkdirAll(filepath.Join(evidenceDir, image.dir), 0o700); err != nil {
 			t.Fatal(err)
 		}
-		if err := os.WriteFile(filepath.Join(evidenceDir, image.dir, "index.db"), image.contents, 0o600); err != nil {
+		imagePath := filepath.Join(evidenceDir, image.dir, imageFile)
+		if err := os.MkdirAll(filepath.Dir(imagePath), 0o700); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(imagePath, image.contents, 0o600); err != nil {
 			t.Fatal(err)
 		}
 	}
@@ -480,13 +528,15 @@ func writeModeledEvidenceFixture(t *testing.T, root string, manifest *ChildManif
 	stableTree := imageTreeArtifact{
 		SchemaVersion: imageTreeSchemaVersion,
 		Kind:          "stable-image",
-		Files:         []imageTreeFileArtifact{{Path: "index.db", Bytes: int64(len(stableContents)), SHA256: fmt.Sprintf("%x", stableDigest)}},
+		Directories:   imageDirectories,
+		Files:         []imageTreeFileArtifact{{Path: filepath.ToSlash(imageFile), Bytes: int64(len(stableContents)), SHA256: fmt.Sprintf("%x", stableDigest)}},
 		TotalBytes:    int64(len(stableContents)),
 	}
 	dirtyTree := imageTreeArtifact{
 		SchemaVersion: imageTreeSchemaVersion,
 		Kind:          "dirty-image",
-		Files:         []imageTreeFileArtifact{{Path: "index.db", Bytes: int64(len(dirtyContents)), SHA256: fmt.Sprintf("%x", dirtyDigest)}},
+		Directories:   imageDirectories,
+		Files:         []imageTreeFileArtifact{{Path: filepath.ToSlash(imageFile), Bytes: int64(len(dirtyContents)), SHA256: fmt.Sprintf("%x", dirtyDigest)}},
 		TotalBytes:    int64(len(dirtyContents)),
 	}
 	stableFingerprint := strings.Repeat("a", 64)
@@ -515,7 +565,7 @@ func writeModeledEvidenceFixture(t *testing.T, root string, manifest *ChildManif
 	recovery := recoveryTraceArtifact{
 		SchemaVersion:      recoveryTraceSchemaVersion,
 		PublicAPI:          "treedb.Open",
-		Dir:                "recovery-input",
+		Dir:                recoveryDir,
 		PreOpenSnapshotDir: "recovery-preopen",
 		InputTreeSHA256:    stableArtifact.SHA256,
 		StableFingerprint:  stableFingerprint,

--- a/TreeDB/internal/powerlosscert/contracts.go
+++ b/TreeDB/internal/powerlosscert/contracts.go
@@ -5,7 +5,7 @@ import (
 	"reflect"
 )
 
-const WitnessContractsSchemaVersion = "treedb-power-loss-witness-contracts/v2"
+const WitnessContractsSchemaVersion = "treedb-power-loss-witness-contracts/v3"
 
 // WitnessContracts is the committed binding between the certification issue,
 // required graph PRs, replay selectors, and the risk dimensions they are

--- a/TreeDB/internal/powerlosscert/contracts_test.go
+++ b/TreeDB/internal/powerlosscert/contracts_test.go
@@ -19,6 +19,16 @@ func TestValidateWitnessContractsRejectsCoverageRelabeling(t *testing.T) {
 	}
 }
 
+func TestValidateWitnessContractsRejectsRecoveryDirectorySubstitution(t *testing.T) {
+	plan := testRunPlan()
+	plan.Cases[0].ExpectedRecovery.Dir = "recovery-input/db"
+	contracts := testWitnessContracts(plan)
+	plan.Cases[0].ExpectedRecovery.Dir = defaultRecoveryDir
+	if err := ValidateWitnessContracts(plan, contracts); err == nil || !strings.Contains(err.Error(), "not identical") {
+		t.Fatalf("recovery directory substitution error=%v", err)
+	}
+}
+
 func TestValidateWitnessContractsRejectsIssueOrPullRequestSubstitution(t *testing.T) {
 	base := testRunPlan()
 	contracts := testWitnessContracts(base)

--- a/TreeDB/internal/powerlosscert/manifest.go
+++ b/TreeDB/internal/powerlosscert/manifest.go
@@ -133,6 +133,7 @@ type Witness struct {
 	ExpectedOutcome        string       `json:"expected_outcome"`
 	ActualOutcome          string       `json:"actual_outcome"`
 	TypedError             string       `json:"typed_error"`
+	ExpectedRecoveryDir    string       `json:"expected_recovery_dir,omitempty"`
 	State                  WitnessState `json:"state"`
 	CounterexampleID       string       `json:"counterexample_id,omitempty"`
 	NegativeControlID      string       `json:"negative_control_id,omitempty"`
@@ -447,6 +448,9 @@ func validateWitness(prefix string, witness Witness, binaries map[string]bool) e
 		return fmt.Errorf("%s has incomplete recovery-state metadata", prefix)
 	}
 	if witness.EvidenceTier == EvidenceTierModeledCrash {
+		if _, err := normalizeRecoveryDir(witness.ExpectedRecoveryDir); err != nil {
+			return fmt.Errorf("%s: %w", prefix, err)
+		}
 		if witness.Seed == 0 {
 			return fmt.Errorf("%s has zero seed", prefix)
 		}

--- a/TreeDB/internal/powerlosscert/manifest.go
+++ b/TreeDB/internal/powerlosscert/manifest.go
@@ -13,7 +13,7 @@ import (
 )
 
 const (
-	ChildManifestSchemaVersion  = "treedb-power-loss-child/v1"
+	ChildManifestSchemaVersion  = "treedb-power-loss-child/v2"
 	RiskInventorySchemaVersion  = "treedb-power-loss-risk-inventory/v1"
 	CoverageReportSchemaVersion = "treedb-power-loss-coverage/v1"
 	SelectionPlanSchemaVersion  = "treedb-power-loss-selection/v1"

--- a/TreeDB/internal/powerlosscert/manifest_test.go
+++ b/TreeDB/internal/powerlosscert/manifest_test.go
@@ -25,7 +25,7 @@ func TestCommittedRiskInventoryIsValid(t *testing.T) {
 }
 
 func TestParseChildManifestRejectsUnknownFields(t *testing.T) {
-	data := []byte(`{"schema_version":"treedb-power-loss-child/v1","unexpected":true}`)
+	data := []byte(`{"schema_version":"treedb-power-loss-child/v2","unexpected":true}`)
 	if _, err := ParseChildManifest(data); err == nil || !strings.Contains(err.Error(), "unknown field") {
 		t.Fatalf("ParseChildManifest error=%v, want unknown-field rejection", err)
 	}

--- a/TreeDB/internal/powerlosscert/manifest_test.go
+++ b/TreeDB/internal/powerlosscert/manifest_test.go
@@ -124,6 +124,23 @@ func TestValidateBundleRequiresModeledReopenMode(t *testing.T) {
 	}
 }
 
+func TestValidateBundleRecoveryDirectoryContract(t *testing.T) {
+	for _, dir := range []string{"", "recovery-input", "recovery-input/db"} {
+		manifest := testChildManifest("witness-a")
+		manifest.Witnesses[0].ExpectedRecoveryDir = dir
+		if err := ValidateBundle(testRepositorySHA, testRiskInventory(), []ChildManifest{manifest}); err != nil {
+			t.Fatalf("ValidateBundle dir=%q: %v", dir, err)
+		}
+	}
+	for _, dir := range []string{"/recovery-input/db", "../db", "recovery-input/../db", "recovery-input//db", `recovery-input\db`, "other/db"} {
+		manifest := testChildManifest("witness-a")
+		manifest.Witnesses[0].ExpectedRecoveryDir = dir
+		if err := ValidateBundle(testRepositorySHA, testRiskInventory(), []ChildManifest{manifest}); err == nil || !strings.Contains(err.Error(), "recovery directory") {
+			t.Fatalf("ValidateBundle dir=%q error=%v", dir, err)
+		}
+	}
+}
+
 func TestValidateChildManifestScopesCutMetadataToModeledCrashes(t *testing.T) {
 	manifest := testChildManifest("witness-a")
 	for _, tier := range []EvidenceTier{EvidenceTierCleanProcess, EvidenceTierBlockDevice} {

--- a/TreeDB/internal/powerlosscert/runner.go
+++ b/TreeDB/internal/powerlosscert/runner.go
@@ -475,7 +475,7 @@ func prospectiveSquashMergeTreeFallback(repoRoot string, gitEnvironment []string
 	}
 	defer func() { _ = os.RemoveAll(privateRoot) }()
 	checkout := filepath.Join(privateRoot, "checkout")
-	if _, err := commandOutputWithEnvironment("", gitEnvironment, gitBinary, "clone", "--no-checkout", "--no-hardlinks", "--", repoRoot, checkout); err != nil {
+	if _, err := commandOutputWithEnvironment("", gitEnvironment, gitBinary, "clone", "--no-checkout", "--shared", "--", repoRoot, checkout); err != nil {
 		return "", fmt.Errorf("clone isolated merge-tree checkout: %w", err)
 	}
 	if _, err := commandOutputWithEnvironment(checkout, gitEnvironment, gitBinary, "checkout", "--detach", parent); err != nil {

--- a/TreeDB/internal/powerlosscert/runner.go
+++ b/TreeDB/internal/powerlosscert/runner.go
@@ -914,8 +914,12 @@ func validateExecutedRecovery(runCase RunCase, trace operationTraceArtifact, rec
 		return fmt.Errorf("%s recovery read_only=%t want=%t", prefix, recovery.ReadOnly, wantReadOnly)
 	}
 	want := runCase.ExpectedRecovery
-	if recovery.Rejected != want.Rejected || recovery.ErrorType != want.ErrorType || recovery.CommitSeq != want.CommitSeq || recovery.AppliedLSN != want.AppliedLSN {
-		return fmt.Errorf("%s recovery=(rejected=%t error_type=%q commit=%d applied=%d) want=(rejected=%t error_type=%q commit=%d applied=%d)", prefix, recovery.Rejected, recovery.ErrorType, recovery.CommitSeq, recovery.AppliedLSN, want.Rejected, want.ErrorType, want.CommitSeq, want.AppliedLSN)
+	wantDir, err := normalizeRecoveryDir(want.Dir)
+	if err != nil {
+		return fmt.Errorf("%s: %w", prefix, err)
+	}
+	if recovery.Dir != wantDir || recovery.Rejected != want.Rejected || recovery.ErrorType != want.ErrorType || recovery.CommitSeq != want.CommitSeq || recovery.AppliedLSN != want.AppliedLSN {
+		return fmt.Errorf("%s recovery=(dir=%q rejected=%t error_type=%q commit=%d applied=%d) want=(dir=%q rejected=%t error_type=%q commit=%d applied=%d)", prefix, recovery.Dir, recovery.Rejected, recovery.ErrorType, recovery.CommitSeq, recovery.AppliedLSN, wantDir, want.Rejected, want.ErrorType, want.CommitSeq, want.AppliedLSN)
 	}
 	if recovery.Rejected && recovery.Error == "" {
 		return fmt.Errorf("%s rejected recovery has no error text", prefix)
@@ -988,6 +992,10 @@ func buildChildManifest(plan RunPlan, outputRoot string, binaries map[string]Art
 		if err != nil {
 			return ChildManifest{}, err
 		}
+		expectedRecoveryDir, err := normalizeRecoveryDir(runCase.ExpectedRecovery.Dir)
+		if err != nil {
+			return ChildManifest{}, fmt.Errorf("powerlosscert: case %q: %w", runCase.ID, err)
+		}
 		witness := Witness{
 			ID:                     runCase.ID,
 			EvidenceTier:           EvidenceTierModeledCrash,
@@ -1002,6 +1010,7 @@ func buildChildManifest(plan RunPlan, outputRoot string, binaries map[string]Art
 			ExpectedOutcome:        runCase.ExpectedOutcome,
 			ActualOutcome:          runCase.ExpectedOutcome,
 			TypedError:             runCase.ExpectedTypedError,
+			ExpectedRecoveryDir:    expectedRecoveryDir,
 			State:                  observedWitnessState(result.recovery),
 			CounterexampleID:       runCase.CounterexampleID,
 			NegativeControlID:      runCase.NegativeControlID,

--- a/TreeDB/internal/powerlosscert/runner.go
+++ b/TreeDB/internal/powerlosscert/runner.go
@@ -437,7 +437,7 @@ func requirePullRequestProvenance(repoRoot, repositorySHA string, pullRequests [
 				if len(parents) != 2 {
 					return fmt.Errorf("%s head_sha=%s is not a non-first merge parent and does not produce the exact squash merge tree for merge_sha=%s", prefix, pr.HeadSHA, pr.MergeSHA)
 				}
-				prospectiveTree, err := commandOutputWithEnvironment(repoRoot, gitEnvironment, gitBinary, "merge-tree", "--write-tree", parents[1], pr.HeadSHA)
+				prospectiveTree, err := prospectiveSquashMergeTree(repoRoot, gitEnvironment, gitBinary, parents[1], pr.HeadSHA)
 				if err != nil {
 					return fmt.Errorf("%s compute exact squash merge tree from head_sha=%s: %w", prefix, pr.HeadSHA, err)
 				}
@@ -450,6 +450,53 @@ func requirePullRequestProvenance(repoRoot, repositorySHA string, pullRequests [
 		previousMergeSHA = pr.MergeSHA
 	}
 	return nil
+}
+
+// prospectiveSquashMergeTree computes the tree produced by applying head to
+// parent without committing it. Git 2.38 added merge-tree --write-tree; older
+// trusted system Git versions use an isolated clone so certification keeps the
+// same exact-tree provenance gate without mutating the candidate repository.
+func prospectiveSquashMergeTree(repoRoot string, gitEnvironment []string, gitBinary, parent, head string) (string, error) {
+	prospectiveTree, fastErr := commandOutputWithEnvironment(repoRoot, gitEnvironment, gitBinary, "merge-tree", "--write-tree", parent, head)
+	if fastErr == nil {
+		return prospectiveTree, nil
+	}
+	prospectiveTree, err := prospectiveSquashMergeTreeFallback(repoRoot, gitEnvironment, gitBinary, parent, head)
+	if err != nil {
+		return "", fmt.Errorf("fast merge-tree failed (%v); isolated fallback failed: %w", fastErr, err)
+	}
+	return prospectiveTree, nil
+}
+
+func prospectiveSquashMergeTreeFallback(repoRoot string, gitEnvironment []string, gitBinary, parent, head string) (string, error) {
+	privateRoot, err := os.MkdirTemp("", "treedb-power-loss-cert-merge-tree-*")
+	if err != nil {
+		return "", fmt.Errorf("create isolated merge-tree checkout: %w", err)
+	}
+	defer func() { _ = os.RemoveAll(privateRoot) }()
+	checkout := filepath.Join(privateRoot, "checkout")
+	if _, err := commandOutputWithEnvironment("", gitEnvironment, gitBinary, "clone", "--no-checkout", "--no-hardlinks", "--", repoRoot, checkout); err != nil {
+		return "", fmt.Errorf("clone isolated merge-tree checkout: %w", err)
+	}
+	if _, err := commandOutputWithEnvironment(checkout, gitEnvironment, gitBinary, "checkout", "--detach", parent); err != nil {
+		return "", fmt.Errorf("checkout merge parent %s: %w", parent, err)
+	}
+	if _, err := commandOutputWithEnvironment(
+		checkout,
+		gitEnvironment,
+		gitBinary,
+		"-c", "user.name=TreeDB power-loss certification",
+		"-c", "user.email=powerlosscert@example.invalid",
+		"-c", "commit.gpgSign=false",
+		"merge", "--no-commit", "--no-ff", head,
+	); err != nil {
+		return "", fmt.Errorf("merge head %s: %w", head, err)
+	}
+	prospectiveTree, err := commandOutputWithEnvironment(checkout, gitEnvironment, gitBinary, "write-tree")
+	if err != nil {
+		return "", fmt.Errorf("write isolated prospective tree: %w", err)
+	}
+	return prospectiveTree, nil
 }
 
 func requireEmptyOutputRoot(root string) error {

--- a/TreeDB/internal/powerlosscert/runner_test.go
+++ b/TreeDB/internal/powerlosscert/runner_test.go
@@ -238,6 +238,68 @@ func TestRequirePullRequestProvenanceBindsClaimsToCertifiedGraph(t *testing.T) {
 	}
 }
 
+func TestProspectiveSquashMergeTreeFallbackMatchesCommittedTree(t *testing.T) {
+	repo := t.TempDir()
+	runGit := func(args ...string) string {
+		t.Helper()
+		cmd := exec.Command("git", args...)
+		cmd.Dir = repo
+		output, err := cmd.CombinedOutput()
+		if err != nil {
+			t.Fatalf("git %s: %v\n%s", strings.Join(args, " "), err, output)
+		}
+		return strings.TrimSpace(string(output))
+	}
+	writeSource := func(contents string) {
+		t.Helper()
+		if err := os.WriteFile(filepath.Join(repo, "tracked.go"), []byte(contents), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	runGit("init", "-b", "main")
+	runGit("config", "user.email", "powerlosscert@example.invalid")
+	runGit("config", "user.name", "powerlosscert test")
+	writeSource("package fixture\n")
+	runGit("add", "tracked.go")
+	runGit("commit", "-m", "base")
+	baseSHA := runGit("rev-parse", "HEAD")
+	runGit("checkout", "-b", "feature")
+	writeSource("package fixture\n\nconst Feature = true\n")
+	runGit("add", "tracked.go")
+	runGit("commit", "-m", "feature head")
+	headSHA := runGit("rev-parse", "HEAD")
+	runGit("checkout", "main")
+	if err := os.WriteFile(filepath.Join(repo, "main_only.go"), []byte("package fixture\n\nconst MainOnly = true\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	runGit("add", "main_only.go")
+	runGit("commit", "-m", "advance main before squash")
+	parentSHA := runGit("rev-parse", "HEAD")
+	runGit("merge", "--squash", "feature")
+	runGit("commit", "-m", "Feature (#42)")
+	wantTree := runGit("rev-parse", "HEAD^{tree}")
+
+	gitBinary, err := resolveGitBinary()
+	if err != nil {
+		t.Fatal(err)
+	}
+	gotTree, err := prospectiveSquashMergeTreeFallback(repo, certificationGitEnvironment(), gitBinary, parentSHA, headSHA)
+	if err != nil {
+		t.Fatalf("prospectiveSquashMergeTreeFallback: %v", err)
+	}
+	if strings.TrimSpace(gotTree) != wantTree {
+		t.Fatalf("fallback tree=%q, want committed squash tree %q", strings.TrimSpace(gotTree), wantTree)
+	}
+	unrelatedTree, err := prospectiveSquashMergeTreeFallback(repo, certificationGitEnvironment(), gitBinary, parentSHA, baseSHA)
+	if err != nil {
+		t.Fatalf("prospectiveSquashMergeTreeFallback(unrelated): %v", err)
+	}
+	if strings.TrimSpace(unrelatedTree) == wantTree {
+		t.Fatalf("unrelated head unexpectedly produced certified tree %q", wantTree)
+	}
+}
+
 func TestCertificationExecutableResolutionIgnoresInheritedPATH(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("shell executable shadow fixture is Unix-specific")

--- a/TreeDB/internal/powerlosscert/runner_test.go
+++ b/TreeDB/internal/powerlosscert/runner_test.go
@@ -598,7 +598,7 @@ func TestValidateExecutedRecoveryMatchesFrozenExpectation(t *testing.T) {
 		ObservedEventCount: 3,
 	}
 	recovery := recoveryTraceArtifact{
-		ReadOnly: true, CommitSeq: 11, AppliedLSN: 7,
+		Dir: defaultRecoveryDir, ReadOnly: true, CommitSeq: 11, AppliedLSN: 7,
 		Stats: map[string]string{
 			"treedb.profile.resolved":                 "command_wal_durable",
 			"treedb.commit_seq":                       "11",
@@ -636,9 +636,70 @@ func TestValidateExecutedRecoveryRejectsPostHocOutcomeChange(t *testing.T) {
 		DeclaredCutPoint:   runCase.CutPoint,
 		ObservedEventCount: 1,
 	}
-	recovery := recoveryTraceArtifact{Rejected: false}
+	recovery := recoveryTraceArtifact{Dir: defaultRecoveryDir, Rejected: false}
 	err := validateExecutedRecovery(runCase, trace, recovery)
-	if err == nil || !strings.Contains(err.Error(), "want=(rejected=true") {
+	if err == nil || !strings.Contains(err.Error(), "rejected=true") {
 		t.Fatalf("validateExecutedRecovery error=%v", err)
+	}
+}
+
+func TestValidateExecutedRecoveryRequiresFrozenChildDirectory(t *testing.T) {
+	runCase := RunCase{
+		ID: "fresh-composite-layout", Profile: "command_wal_durable", Seed: 3684,
+		CutID: "cut/layout/after-directory-sync/000", CutPoint: "after-directory-sync", VariantID: "variant/fresh",
+		ReopenMode: powerLossReopenModeReadOnly, ExpectedRecovery: RecoveryExpectation{Dir: "recovery-input/db"},
+	}
+	trace := operationTraceArtifact{
+		CutID: runCase.CutID, VariantID: runCase.VariantID, Seed: "3684",
+		DeclaredCutPoint: runCase.CutPoint, ObservedEventCount: 1,
+	}
+	recovery := recoveryTraceArtifact{
+		Dir: "recovery-input/db", ReadOnly: true,
+		Stats: map[string]string{
+			"treedb.profile.resolved": "command_wal_durable", "treedb.commit_seq": "0",
+			"treedb.applied_command_lsn": "0", "treedb.durable_root.selected_slot": "0",
+			"treedb.durable_root.commit_seq": "0", "treedb.durable_root.durable_seq": "0",
+			"treedb.durable_root.freelist.generation": "0", "treedb.durable_root.manifest.entries": "0",
+			"treedb.durable_root.slot0.commit_seq": "0", "treedb.durable_root.slot1.commit_seq": "0",
+			"treedb.command_wal.durable_wal_lsn": "0",
+		},
+	}
+	runCase.State = observedWitnessState(recovery)
+	if err := validateExecutedRecovery(runCase, trace, recovery); err != nil {
+		t.Fatal(err)
+	}
+	recovery.Dir = defaultRecoveryDir
+	if err := validateExecutedRecovery(runCase, trace, recovery); err == nil || !strings.Contains(err.Error(), `dir="recovery-input"`) {
+		t.Fatalf("validateExecutedRecovery mismatched dir error=%v", err)
+	}
+}
+
+func TestBuildChildManifestFreezesNormalizedRecoveryDirectory(t *testing.T) {
+	for _, expected := range []struct {
+		name string
+		dir  string
+		want string
+	}{{name: "legacy-default", want: defaultRecoveryDir}, {name: "child", dir: "recovery-input/db", want: "recovery-input/db"}} {
+		t.Run(expected.name, func(t *testing.T) {
+			root := t.TempDir()
+			plan := testRunPlan()
+			plan.Cases[0].ExpectedRecovery.Dir = expected.dir
+			for _, name := range modeledArtifactNames {
+				path := filepath.Join(root, "evidence", plan.Cases[0].ID, name)
+				if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+					t.Fatal(err)
+				}
+				if err := os.WriteFile(path, []byte(name), 0o600); err != nil {
+					t.Fatal(err)
+				}
+			}
+			manifest, err := buildChildManifest(plan, root, nil, []executedCase{{runCase: plan.Cases[0]}}, strings.Repeat("f", 64))
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got := manifest.Witnesses[0].ExpectedRecoveryDir; got != expected.want {
+				t.Fatalf("ExpectedRecoveryDir=%q want=%q", got, expected.want)
+			}
+		})
 	}
 }

--- a/TreeDB/internal/powerlosscert/runplan.go
+++ b/TreeDB/internal/powerlosscert/runplan.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 )
 
-const RunPlanSchemaVersion = "treedb-power-loss-run-plan/v2"
+const RunPlanSchemaVersion = "treedb-power-loss-run-plan/v3"
 
 const CertifiedRepositoryRef = "refs/remotes/origin/main"
 
@@ -32,7 +32,7 @@ const defaultRecoveryDir = "recovery-input"
 
 // normalizeRecoveryDir validates the logical, slash-separated path recorded in
 // portable certification artifacts. An omitted path preserves the legacy
-// public-open root used by v1 child manifests and v2 run plans.
+// public-open root used by pre-directory-contract plans.
 func normalizeRecoveryDir(dir string) (string, error) {
 	if dir == "" {
 		return defaultRecoveryDir, nil

--- a/TreeDB/internal/powerlosscert/runplan.go
+++ b/TreeDB/internal/powerlosscert/runplan.go
@@ -2,6 +2,7 @@ package powerlosscert
 
 import (
 	"fmt"
+	"path"
 	"path/filepath"
 	"regexp"
 	"strings"
@@ -24,6 +25,23 @@ type RecoveryExpectation struct {
 	ErrorType  string `json:"error_type"`
 	CommitSeq  uint64 `json:"commit_seq"`
 	AppliedLSN uint64 `json:"applied_lsn"`
+	Dir        string `json:"dir,omitempty"`
+}
+
+const defaultRecoveryDir = "recovery-input"
+
+// normalizeRecoveryDir validates the logical, slash-separated path recorded in
+// portable certification artifacts. An omitted path preserves the legacy
+// public-open root used by v1 child manifests and v2 run plans.
+func normalizeRecoveryDir(dir string) (string, error) {
+	if dir == "" {
+		return defaultRecoveryDir, nil
+	}
+	if strings.Contains(dir, `\`) || path.IsAbs(dir) || path.Clean(dir) != dir ||
+		(dir != defaultRecoveryDir && !strings.HasPrefix(dir, defaultRecoveryDir+"/")) {
+		return "", fmt.Errorf("unsafe or non-canonical recovery directory %q", dir)
+	}
+	return dir, nil
 }
 
 // RunCase is the immutable semantic contract for one exact replay. Runtime
@@ -181,6 +199,10 @@ func validateRunCase(inventory RiskInventory, runCase RunCase) error {
 	if runCase.ReopenMode != powerLossReopenModeReadWrite && runCase.ReopenMode != powerLossReopenModeReadOnly {
 		return fmt.Errorf("%s has invalid reopen mode %q", prefix, runCase.ReopenMode)
 	}
+	expectedRecoveryDir, err := normalizeRecoveryDir(runCase.ExpectedRecovery.Dir)
+	if err != nil {
+		return fmt.Errorf("%s: %w", prefix, err)
+	}
 	class := modeledOutcomeClass(runCase.ExpectedOutcome)
 	if runCase.ExpectedRecovery.Rejected {
 		if class != "rejected" || runCase.ExpectedTypedError == "" || runCase.ExpectedTypedError == "none" || runCase.ExpectedRecovery.ErrorType != runCase.ExpectedTypedError {
@@ -219,6 +241,7 @@ func validateRunCase(inventory RiskInventory, runCase RunCase) error {
 		ExpectedOutcome:        runCase.ExpectedOutcome,
 		ActualOutcome:          runCase.ExpectedOutcome,
 		TypedError:             runCase.ExpectedTypedError,
+		ExpectedRecoveryDir:    expectedRecoveryDir,
 		State:                  runCase.State,
 		CounterexampleID:       runCase.CounterexampleID,
 		NegativeControlID:      runCase.NegativeControlID,

--- a/TreeDB/internal/powerlosscert/runplan_test.go
+++ b/TreeDB/internal/powerlosscert/runplan_test.go
@@ -6,7 +6,7 @@ import (
 )
 
 func TestParseRunPlanRejectsUnknownFields(t *testing.T) {
-	if _, err := ParseRunPlan([]byte(`{"schema_version":"treedb-power-loss-run-plan/v2","unknown":true}`)); err == nil || !strings.Contains(err.Error(), "unknown field") {
+	if _, err := ParseRunPlan([]byte(`{"schema_version":"treedb-power-loss-run-plan/v3","unknown":true}`)); err == nil || !strings.Contains(err.Error(), "unknown field") {
 		t.Fatalf("ParseRunPlan unknown-field error=%v", err)
 	}
 }

--- a/TreeDB/internal/powerlosscert/runplan_test.go
+++ b/TreeDB/internal/powerlosscert/runplan_test.go
@@ -18,6 +18,27 @@ func TestValidateRunPlanAcceptsFrozenExpectedRecovery(t *testing.T) {
 	}
 }
 
+func TestValidateRunPlanRecoveryDirectoryContract(t *testing.T) {
+	for _, dir := range []string{"", "recovery-input", "recovery-input/db"} {
+		t.Run("accept-"+strings.ReplaceAll(dir, "/", "-"), func(t *testing.T) {
+			plan := testRunPlan()
+			plan.Cases[0].ExpectedRecovery.Dir = dir
+			if err := ValidateRunPlan(testRiskInventory(), plan); err != nil {
+				t.Fatalf("ValidateRunPlan dir=%q: %v", dir, err)
+			}
+		})
+	}
+	for _, dir := range []string{"/recovery-input/db", "../db", "recovery-input/../db", "recovery-input//db", `recovery-input\db`, "other/db"} {
+		t.Run("reject-"+strings.NewReplacer("/", "-", `\`, "-").Replace(dir), func(t *testing.T) {
+			plan := testRunPlan()
+			plan.Cases[0].ExpectedRecovery.Dir = dir
+			if err := ValidateRunPlan(testRiskInventory(), plan); err == nil || !strings.Contains(err.Error(), "recovery directory") {
+				t.Fatalf("ValidateRunPlan dir=%q error=%v", dir, err)
+			}
+		})
+	}
+}
+
 func TestValidateRunPlanRejectsIncompleteFrozenRiskCoverage(t *testing.T) {
 	plan := testRunPlan()
 	plan.Cases[0].CounterexampleID = ""

--- a/TreeDB/internal/powerlossoracle/model.go
+++ b/TreeDB/internal/powerlossoracle/model.go
@@ -244,6 +244,9 @@ func (m *Model) PathStable(root, path string) (bool, error) {
 	if !volatileOK || !stableOK || volatileID != stableID {
 		return false, nil
 	}
+	if !stableDirReachable(m.stableDirs, cleanInternal(pathpkg.Dir(rel))) {
+		return false, nil
+	}
 	node := m.inodes[volatileID]
 	return node != nil && bytes.Equal(node.volatile, node.stable), nil
 }
@@ -650,11 +653,6 @@ func (m *Model) SyncDir(dir string) error {
 	if _, ok := m.volatileDirs[dir]; !ok {
 		return fmt.Errorf("powerlossoracle: sync missing directory %q", dir)
 	}
-	if dir != "." {
-		if _, ok := m.stableDirs[dir]; !ok {
-			return fmt.Errorf("powerlossoracle: sync unreachable directory %q before parent directory entry", dir)
-		}
-	}
 	for path := range m.stable {
 		if cleanInternal(pathpkg.Dir(path)) == dir {
 			delete(m.stable, path)
@@ -701,13 +699,16 @@ func (m *Model) SyncDir(dir string) error {
 
 // Crash discards every volatile byte and namespace mutation.
 func (m *Model) Crash() {
-	m.volatile = make(map[string]uint64, len(m.stable))
-	for path, id := range m.stable {
+	reachableDirs, reachableFiles := reachableNamespace(m.stableDirs, m.stable)
+	m.stableDirs = reachableDirs
+	m.stable = reachableFiles
+	m.volatile = make(map[string]uint64, len(reachableFiles))
+	for path, id := range reachableFiles {
 		m.volatile[path] = id
 		m.inodes[id].volatile = clone(m.inodes[id].stable)
 	}
-	m.volatileDirs = make(map[string]rootpublication.StableIdentity, len(m.stableDirs))
-	for dir, identity := range m.stableDirs {
+	m.volatileDirs = make(map[string]rootpublication.StableIdentity, len(reachableDirs))
+	for dir, identity := range reachableDirs {
 		m.volatileDirs[dir] = identity
 	}
 	m.trace = append(m.trace, "crash")
@@ -729,6 +730,9 @@ func (m *Model) MaterializeVolatile(root string) error {
 func (m *Model) materialize(root string, dirs map[string]rootpublication.StableIdentity, files map[string]uint64, bytesFor func(*inode) []byte, label string) error {
 	if err := os.MkdirAll(root, 0o755); err != nil {
 		return err
+	}
+	if label == "stable" {
+		dirs, files = reachableNamespace(dirs, files)
 	}
 	dirPaths := keys(dirs)
 	sort.Slice(dirPaths, func(i, j int) bool {
@@ -780,13 +784,14 @@ func (m *Model) InstallStableIdentityOverrides(root string) (func(), error) {
 	if err != nil {
 		return nil, err
 	}
-	overrides := make(map[string]rootpublication.StableIdentity, len(m.stable)+len(m.stableDirs))
-	for dir, identity := range m.stableDirs {
+	reachableDirs, reachableFiles := reachableNamespace(m.stableDirs, m.stable)
+	overrides := make(map[string]rootpublication.StableIdentity, len(reachableFiles)+len(reachableDirs))
+	for dir, identity := range reachableDirs {
 		if validStableIdentity(identity) {
 			overrides[filepath.Join(root, filepath.FromSlash(dir))] = physicalStableIdentity(identity)
 		}
 	}
-	for path, id := range m.stable {
+	for path, id := range reachableFiles {
 		identity := m.inodes[id].stableIdentity
 		if validStableIdentity(identity) {
 			overrides[filepath.Join(root, filepath.FromSlash(path))] = physicalStableIdentity(identity)
@@ -797,8 +802,9 @@ func (m *Model) InstallStableIdentityOverrides(root string) (func(), error) {
 
 // StablePaths returns stable regular-file paths in deterministic order.
 func (m *Model) StablePaths() []string {
-	paths := make([]string, 0, len(m.stable))
-	for path := range m.stable {
+	_, reachableFiles := reachableNamespace(m.stableDirs, m.stable)
+	paths := make([]string, 0, len(reachableFiles))
+	for path := range reachableFiles {
 		paths = append(paths, path)
 	}
 	sort.Strings(paths)
@@ -813,6 +819,52 @@ func (m *Model) VolatilePaths() []string {
 	}
 	sort.Strings(paths)
 	return paths
+}
+
+// reachableNamespace projects per-directory durable contents onto the names
+// reachable from the materialized root. A child directory can be synced before
+// its own parent entry; its durable contents become reachable only if a later
+// ancestor sync persists the chain.
+func reachableNamespace(dirs map[string]rootpublication.StableIdentity, files map[string]uint64) (map[string]rootpublication.StableIdentity, map[string]uint64) {
+	reachableDirs := make(map[string]rootpublication.StableIdentity, len(dirs))
+	if identity, ok := dirs["."]; ok {
+		reachableDirs["."] = identity
+	}
+	dirPaths := keys(dirs)
+	sort.Slice(dirPaths, func(i, j int) bool {
+		di, dj := strings.Count(dirPaths[i], "/"), strings.Count(dirPaths[j], "/")
+		if di == dj {
+			return dirPaths[i] < dirPaths[j]
+		}
+		return di < dj
+	})
+	for _, dir := range dirPaths {
+		if dir == "." {
+			continue
+		}
+		if _, ok := reachableDirs[cleanInternal(pathpkg.Dir(dir))]; ok {
+			reachableDirs[dir] = dirs[dir]
+		}
+	}
+	reachableFiles := make(map[string]uint64, len(files))
+	for path, id := range files {
+		if _, ok := reachableDirs[cleanInternal(pathpkg.Dir(path))]; ok {
+			reachableFiles[path] = id
+		}
+	}
+	return reachableDirs, reachableFiles
+}
+
+func stableDirReachable(dirs map[string]rootpublication.StableIdentity, dir string) bool {
+	for {
+		if _, ok := dirs[dir]; !ok {
+			return false
+		}
+		if dir == "." {
+			return true
+		}
+		dir = cleanInternal(pathpkg.Dir(dir))
+	}
 }
 
 // Trace returns the deterministic operation trace used in failure diagnostics.

--- a/TreeDB/internal/powerlossoracle/model.go
+++ b/TreeDB/internal/powerlossoracle/model.go
@@ -664,9 +664,14 @@ func (m *Model) SyncDir(dir string) error {
 		}
 	}
 	removedTrees := make([]string, 0)
-	for child := range m.stableDirs {
+	for child, stableIdentity := range m.stableDirs {
 		if child != "." && cleanInternal(pathpkg.Dir(child)) == dir {
-			if _, stillVisible := m.volatileDirs[child]; !stillVisible {
+			volatileIdentity, stillVisible := m.volatileDirs[child]
+			replaced := stillVisible &&
+				validStableIdentity(stableIdentity) &&
+				validStableIdentity(volatileIdentity) &&
+				!rootpublication.SamePhysicalIdentity(stableIdentity, volatileIdentity)
+			if !stillVisible || replaced {
 				removedTrees = append(removedTrees, child)
 			}
 			delete(m.stableDirs, child)
@@ -887,13 +892,17 @@ func (m *Model) UseObservedTrace(observed *Model) error {
 // and bytes at a cut without materializing them.
 func (m *Model) StableFingerprint() string {
 	h := sha256.New()
-	dirs := keys(m.stableDirs)
+	reachableDirs, reachableFiles := reachableNamespace(m.stableDirs, m.stable)
+	dirs := keys(reachableDirs)
 	sort.Strings(dirs)
 	for _, dir := range dirs {
-		_, _ = fmt.Fprintf(h, "d:%s\x00", dir)
+		identity := physicalStableIdentity(reachableDirs[dir])
+		_, _ = fmt.Fprintf(h, "d:%s:%s:%d:%x\x00", dir, identity.Platform, identity.VolumeID, identity.ObjectID)
 	}
-	for _, path := range m.StablePaths() {
-		id := m.stable[path]
+	paths := keys(reachableFiles)
+	sort.Strings(paths)
+	for _, path := range paths {
+		id := reachableFiles[path]
 		_, _ = fmt.Fprintf(h, "f:%s:%d:", path, id)
 		_, _ = h.Write(m.inodes[id].stable)
 		_, _ = h.Write([]byte{0})

--- a/TreeDB/internal/powerlossoracle/model.go
+++ b/TreeDB/internal/powerlossoracle/model.go
@@ -5,6 +5,7 @@ package powerlossoracle
 import (
 	"bytes"
 	"crypto/sha256"
+	"encoding/binary"
 	"errors"
 	"fmt"
 	"io/fs"
@@ -85,6 +86,7 @@ type ByteRange struct{ Offset, Length int64 }
 // sync followed by rename and directory sync has realistic semantics.
 type Model struct {
 	nextID           uint64
+	nextDirID        uint64
 	inodes           map[uint64]*inode
 	volatile         map[string]uint64
 	stable           map[string]uint64
@@ -175,12 +177,14 @@ func capture(root string, excludeLockFiles bool, excluded []string) (*Model, err
 }
 
 func newModel() *Model {
+	rootIdentity := syntheticDirectoryIdentity(1)
 	return &Model{
+		nextDirID:    1,
 		inodes:       make(map[uint64]*inode),
 		volatile:     make(map[string]uint64),
 		stable:       make(map[string]uint64),
-		volatileDirs: map[string]rootpublication.StableIdentity{".": {}},
-		stableDirs:   map[string]rootpublication.StableIdentity{".": {}},
+		volatileDirs: map[string]rootpublication.StableIdentity{".": rootIdentity},
+		stableDirs:   map[string]rootpublication.StableIdentity{".": rootIdentity},
 	}
 }
 
@@ -202,6 +206,7 @@ func (m *Model) allocateWithIdentity(volatile, stable []byte, identity rootpubli
 func (m *Model) Clone() *Model {
 	out := newModel()
 	out.nextID = m.nextID
+	out.nextDirID = m.nextDirID
 	out.excludeLockFiles = m.excludeLockFiles
 	for id, node := range m.inodes {
 		out.inodes[id] = &inode{
@@ -913,12 +918,19 @@ func (m *Model) StableFingerprint() string {
 func (m *Model) ensureVolatileParents(path string) {
 	for dir := cleanInternal(pathpkg.Dir(path)); ; dir = cleanInternal(pathpkg.Dir(dir)) {
 		if _, exists := m.volatileDirs[dir]; !exists {
-			m.volatileDirs[dir] = rootpublication.StableIdentity{}
+			m.nextDirID++
+			m.volatileDirs[dir] = syntheticDirectoryIdentity(m.nextDirID)
 		}
 		if dir == "." {
 			return
 		}
 	}
+}
+
+func syntheticDirectoryIdentity(id uint64) rootpublication.StableIdentity {
+	var objectID [16]byte
+	binary.BigEndian.PutUint64(objectID[8:], id)
+	return rootpublication.StableIdentity{Platform: "powerlossoracle", ObjectID: objectID}
 }
 
 func captureStableIdentity(path string) (rootpublication.StableIdentity, error) {

--- a/TreeDB/internal/powerlossoracle/model_test.go
+++ b/TreeDB/internal/powerlossoracle/model_test.go
@@ -354,7 +354,7 @@ func TestMaterializeVolatileWritesProcessVisibleImage(t *testing.T) {
 	}
 }
 
-func TestNestedCreateRequiresStableAncestorChain(t *testing.T) {
+func TestNestedCreateBecomesReachableOnlyAfterStableAncestorChain(t *testing.T) {
 	model := newModel()
 	if err := model.Create("a/b/value", []byte("stable")); err != nil {
 		t.Fatal(err)
@@ -362,10 +362,17 @@ func TestNestedCreateRequiresStableAncestorChain(t *testing.T) {
 	if err := model.SyncFile("a/b/value"); err != nil {
 		t.Fatal(err)
 	}
-	if err := model.SyncDir("a/b"); err == nil {
-		t.Fatal("SyncDir(a/b) succeeded before parent entries were stable")
+	if err := model.SyncDir("a/b"); err != nil {
+		t.Fatalf("SyncDir(a/b): %v", err)
 	}
-	for _, dir := range []string{".", "a", "a/b"} {
+	unreachable := t.TempDir()
+	if err := model.MaterializeStable(unreachable); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(filepath.Join(unreachable, "a")); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("unreachable stable child materialized before ancestor sync: %v", err)
+	}
+	for _, dir := range []string{".", "a"} {
 		if err := model.SyncDir(dir); err != nil {
 			t.Fatalf("SyncDir(%q): %v", dir, err)
 		}

--- a/TreeDB/internal/powerlossoracle/model_test.go
+++ b/TreeDB/internal/powerlossoracle/model_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/snissn/gomap/TreeDB/internal/durabilitycut"
+	"github.com/snissn/gomap/TreeDB/internal/rootpublication"
 )
 
 func TestCaptureOmitsProcessLocalLock(t *testing.T) {
@@ -384,6 +385,71 @@ func TestNestedCreateBecomesReachableOnlyAfterStableAncestorChain(t *testing.T) 
 	got, err := os.ReadFile(filepath.Join(crashDir, "a", "b", "value"))
 	if err != nil || string(got) != "stable" {
 		t.Fatalf("nested stable value=%q err=%v", got, err)
+	}
+}
+
+func TestStableFingerprintExcludesUnreachableDurableSubtree(t *testing.T) {
+	model := newModel()
+	want := model.StableFingerprint()
+	if err := model.Create("a/b/value", []byte("stable")); err != nil {
+		t.Fatal(err)
+	}
+	if err := model.SyncFile("a/b/value"); err != nil {
+		t.Fatal(err)
+	}
+	if err := model.SyncDir("a/b"); err != nil {
+		t.Fatal(err)
+	}
+	if err := model.SyncDir("a"); err != nil {
+		t.Fatal(err)
+	}
+	if got := model.StableFingerprint(); got != want {
+		t.Fatalf("unreachable durable subtree changed stable fingerprint: got=%s want=%s", got, want)
+	}
+	model.Crash()
+	if got := model.StableFingerprint(); got != want {
+		t.Fatalf("crash projection changed stable fingerprint: got=%s want=%s", got, want)
+	}
+}
+
+func TestSyncDirReplacementPrunesOldDurableSubtree(t *testing.T) {
+	root := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(root, "dir", "old"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "dir", "old", "value"), []byte("old"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	model, err := Capture(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	oldIdentity := model.stableDirs["dir"]
+	if err := os.RemoveAll(filepath.Join(root, "dir")); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Mkdir(filepath.Join(root, "dir"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := model.Overlay(root); err != nil {
+		t.Fatal(err)
+	}
+	newIdentity := model.volatileDirs["dir"]
+	if !validStableIdentity(oldIdentity) || !validStableIdentity(newIdentity) || rootpublication.SamePhysicalIdentity(oldIdentity, newIdentity) {
+		t.Skip("filesystem does not expose distinct stable directory identities")
+	}
+	if err := model.SyncDir("."); err != nil {
+		t.Fatal(err)
+	}
+	crashDir := t.TempDir()
+	if err := model.MaterializeStable(crashDir); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(filepath.Join(crashDir, "dir", "old", "value")); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("replacement retained old durable subtree: %v", err)
+	}
+	if info, err := os.Stat(filepath.Join(crashDir, "dir")); err != nil || !info.IsDir() {
+		t.Fatalf("replacement directory missing from stable image: info=%v err=%v", info, err)
 	}
 }
 

--- a/TreeDB/internal/powerlossoracle/model_test.go
+++ b/TreeDB/internal/powerlossoracle/model_test.go
@@ -453,6 +453,45 @@ func TestSyncDirReplacementPrunesOldDurableSubtree(t *testing.T) {
 	}
 }
 
+func TestSyncDirSyntheticReplacementPrunesOldDurableSubtree(t *testing.T) {
+	model := newModel()
+	if err := model.Create("dir/old/value", []byte("old")); err != nil {
+		t.Fatal(err)
+	}
+	if err := model.SyncFile("dir/old/value"); err != nil {
+		t.Fatal(err)
+	}
+	for _, dir := range []string{"dir/old", "dir", "."} {
+		if err := model.SyncDir(dir); err != nil {
+			t.Fatal(err)
+		}
+	}
+	oldIdentity := model.stableDirs["dir"]
+	if err := model.Unlink("dir"); err != nil {
+		t.Fatal(err)
+	}
+	if err := model.Create("dir/new/value", []byte("new")); err != nil {
+		t.Fatal(err)
+	}
+	newIdentity := model.volatileDirs["dir"]
+	if !validStableIdentity(oldIdentity) || !validStableIdentity(newIdentity) || rootpublication.SamePhysicalIdentity(oldIdentity, newIdentity) {
+		t.Fatalf("synthetic directory replacement identities old=%+v new=%+v", oldIdentity, newIdentity)
+	}
+	if err := model.SyncDir("."); err != nil {
+		t.Fatal(err)
+	}
+	crashDir := t.TempDir()
+	if err := model.MaterializeStable(crashDir); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(filepath.Join(crashDir, "dir", "old", "value")); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("synthetic replacement retained old durable subtree: %v", err)
+	}
+	if info, err := os.Stat(filepath.Join(crashDir, "dir")); err != nil || !info.IsDir() {
+		t.Fatalf("synthetic replacement directory missing from stable image: info=%v err=%v", info, err)
+	}
+}
+
 func TestRenameOverwritePreservesInodeUntilDestinationDirectorySync(t *testing.T) {
 	model := newModel()
 	for path, value := range map[string]string{"dir/source": "source", "dir/destination": "destination"} {

--- a/TreeDB/internal/powerlossreopen/reopen.go
+++ b/TreeDB/internal/powerlossreopen/reopen.go
@@ -86,10 +86,12 @@ func stableRelative(model *powerlossoracle.Model, relativeDir string, opts treed
 			AppliedLSN         uint64            `json:"applied_lsn"`
 			Stats              map[string]string `json:"stats"`
 		}{
-			SchemaVersion:      "treedb-power-loss-recovery-trace/v1",
-			PublicAPI:          "treedb.Open",
-			Dir:                filepath.ToSlash(filepath.Join("recovery-input", relativeDir)),
-			PreOpenSnapshotDir: filepath.ToSlash(filepath.Join("recovery-preopen", relativeDir)),
+			SchemaVersion: "treedb-power-loss-recovery-trace/v1",
+			PublicAPI:     "treedb.Open",
+			Dir:           filepath.ToSlash(filepath.Join("recovery-input", relativeDir)),
+			// The immutable snapshot and its tree hash cover the whole modeled
+			// parent. Dir may name an absent child within that parent.
+			PreOpenSnapshotDir: "recovery-preopen",
 			InputTreeSHA256:    evidence.StableImageTreeSHA256(),
 			StableFingerprint:  evidence.StableFingerprint(),
 			ReadOnly:           result.ReadOnly,

--- a/TreeDB/internal/powerlossreopen/reopen.go
+++ b/TreeDB/internal/powerlossreopen/reopen.go
@@ -196,7 +196,7 @@ func openAt(materializationRoot, dir string, model *powerlossoracle.Model, opts 
 }
 
 func cleanRelativeDir(relativeDir string) (string, error) {
-	if relativeDir == "" || filepath.IsAbs(relativeDir) {
+	if relativeDir == "" || filepath.IsAbs(relativeDir) || filepath.VolumeName(relativeDir) != "" {
 		return "", fmt.Errorf("powerlossreopen: child directory %q must be a non-empty relative path", relativeDir)
 	}
 	clean := filepath.Clean(relativeDir)

--- a/TreeDB/internal/powerlossreopen/reopen.go
+++ b/TreeDB/internal/powerlossreopen/reopen.go
@@ -86,7 +86,7 @@ func stableRelative(model *powerlossoracle.Model, relativeDir string, opts treed
 			AppliedLSN         uint64            `json:"applied_lsn"`
 			Stats              map[string]string `json:"stats"`
 		}{
-			SchemaVersion: "treedb-power-loss-recovery-trace/v1",
+			SchemaVersion: "treedb-power-loss-recovery-trace/v2",
 			PublicAPI:     "treedb.Open",
 			Dir:           filepath.ToSlash(filepath.Join("recovery-input", relativeDir)),
 			// The immutable snapshot and its tree hash cover the whole modeled

--- a/TreeDB/internal/powerlossreopen/reopen.go
+++ b/TreeDB/internal/powerlossreopen/reopen.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path/filepath"
 	"strconv"
+	"strings"
 
 	treedb "github.com/snissn/gomap/TreeDB"
 	"github.com/snissn/gomap/TreeDB/internal/powerlossoracle"
@@ -43,12 +44,30 @@ var recoveryStatKeys = []string{
 // modeled identity scope and removes the materialized image whether Open
 // accepts or rejects it.
 func Stable(model *powerlossoracle.Model, opts treedb.Options, readOnly bool) (Result, *treedb.DB, func() error, error) {
+	return stableRelative(model, ".", opts, readOnly)
+}
+
+// StableChild materializes the model's stable parent image and reopens a
+// relative child through the normal public TreeDB API. This is required for a
+// fresh database root whose directory entry itself is part of the modeled
+// namespace rather than an already-existing materialization root.
+func StableChild(model *powerlossoracle.Model, relativeDir string, opts treedb.Options, readOnly bool) (Result, *treedb.DB, func() error, error) {
+	relativeDir, err := cleanRelativeDir(relativeDir)
+	if err != nil {
+		return Result{}, nil, nil, err
+	}
+	return stableRelative(model, relativeDir, opts, readOnly)
+}
+
+func stableRelative(model *powerlossoracle.Model, relativeDir string, opts treedb.Options, readOnly bool) (Result, *treedb.DB, func() error, error) {
 	evidence, err := powerlossoracle.BeginEvidenceFromEnv(model, readOnly)
 	if err != nil {
 		return Result{}, nil, nil, err
 	}
 	if evidence != nil {
-		result, db, closeFn, err := openAt(evidence.RecoveryInputDir(), model, opts, readOnly, false)
+		materializationRoot := evidence.RecoveryInputDir()
+		openDir := filepath.Join(materializationRoot, relativeDir)
+		result, db, closeFn, err := openAt(materializationRoot, openDir, model, opts, readOnly, false)
 		if err != nil {
 			return Result{}, nil, nil, err
 		}
@@ -69,8 +88,8 @@ func Stable(model *powerlossoracle.Model, opts treedb.Options, readOnly bool) (R
 		}{
 			SchemaVersion:      "treedb-power-loss-recovery-trace/v1",
 			PublicAPI:          "treedb.Open",
-			Dir:                "recovery-input",
-			PreOpenSnapshotDir: "recovery-preopen",
+			Dir:                filepath.ToSlash(filepath.Join("recovery-input", relativeDir)),
+			PreOpenSnapshotDir: filepath.ToSlash(filepath.Join("recovery-preopen", relativeDir)),
 			InputTreeSHA256:    evidence.StableImageTreeSHA256(),
 			StableFingerprint:  evidence.StableFingerprint(),
 			ReadOnly:           result.ReadOnly,
@@ -93,7 +112,7 @@ func Stable(model *powerlossoracle.Model, opts treedb.Options, readOnly bool) (R
 	if err != nil {
 		return Result{}, nil, nil, err
 	}
-	return stableAt(dir, model, opts, readOnly, true)
+	return stableRelativeAt(dir, relativeDir, model, opts, readOnly, true)
 }
 
 // StableAt materializes the stable-only crash image at a caller-owned path and
@@ -103,27 +122,40 @@ func StableAt(dir string, model *powerlossoracle.Model, opts treedb.Options, rea
 	if err := requireEmptyDestination(dir); err != nil {
 		return Result{}, nil, nil, err
 	}
-	return stableAt(dir, model, opts, readOnly, false)
+	return stableRelativeAt(dir, ".", model, opts, readOnly, false)
 }
 
-func stableAt(dir string, model *powerlossoracle.Model, opts treedb.Options, readOnly, removeOnClose bool) (Result, *treedb.DB, func() error, error) {
-	if err := model.MaterializeStable(dir); err != nil {
+// StableChildAt is StableChild with a caller-owned materialization root. The
+// close callback preserves root for inspection.
+func StableChildAt(root, relativeDir string, model *powerlossoracle.Model, opts treedb.Options, readOnly bool) (Result, *treedb.DB, func() error, error) {
+	if err := requireEmptyDestination(root); err != nil {
+		return Result{}, nil, nil, err
+	}
+	relativeDir, err := cleanRelativeDir(relativeDir)
+	if err != nil {
+		return Result{}, nil, nil, err
+	}
+	return stableRelativeAt(root, relativeDir, model, opts, readOnly, false)
+}
+
+func stableRelativeAt(root, relativeDir string, model *powerlossoracle.Model, opts treedb.Options, readOnly, removeOnClose bool) (Result, *treedb.DB, func() error, error) {
+	if err := model.MaterializeStable(root); err != nil {
 		if removeOnClose {
-			_ = os.RemoveAll(dir)
+			_ = os.RemoveAll(root)
 		}
 		return Result{}, nil, nil, err
 	}
-	return openAt(dir, model, opts, readOnly, removeOnClose)
+	return openAt(root, filepath.Join(root, relativeDir), model, opts, readOnly, removeOnClose)
 }
 
-func openAt(dir string, model *powerlossoracle.Model, opts treedb.Options, readOnly, removeOnClose bool) (Result, *treedb.DB, func() error, error) {
+func openAt(materializationRoot, dir string, model *powerlossoracle.Model, opts treedb.Options, readOnly, removeOnClose bool) (Result, *treedb.DB, func() error, error) {
 	cleanup := func() error {
 		if removeOnClose {
-			return os.RemoveAll(dir)
+			return os.RemoveAll(materializationRoot)
 		}
 		return nil
 	}
-	releaseIdentities, err := model.InstallStableIdentityOverrides(dir)
+	releaseIdentities, err := model.InstallStableIdentityOverrides(materializationRoot)
 	if err != nil {
 		_ = cleanup()
 		return Result{}, nil, nil, err
@@ -159,6 +191,17 @@ func openAt(dir string, model *powerlossoracle.Model, opts treedb.Options, readO
 		return result, nil, nil, fmt.Errorf("powerlossreopen: public Open returned nil DB and nil error")
 	}
 	return result, db, closeFn, nil
+}
+
+func cleanRelativeDir(relativeDir string) (string, error) {
+	if relativeDir == "" || filepath.IsAbs(relativeDir) {
+		return "", fmt.Errorf("powerlossreopen: child directory %q must be a non-empty relative path", relativeDir)
+	}
+	clean := filepath.Clean(relativeDir)
+	if clean == ".." || strings.HasPrefix(clean, ".."+string(filepath.Separator)) {
+		return "", fmt.Errorf("powerlossreopen: child directory %q escapes the materialized root", relativeDir)
+	}
+	return clean, nil
 }
 
 func requireEmptyDestination(dir string) error {

--- a/TreeDB/internal/powerlossreopen/reopen_test.go
+++ b/TreeDB/internal/powerlossreopen/reopen_test.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -97,6 +98,11 @@ func TestStableChildAtReopensModeledRelativeDatabaseRoot(t *testing.T) {
 
 	if _, _, _, err := powerlossreopen.StableChildAt(filepath.Join(canonicalTempDir(t), "escape-parent"), "../db", model, opts, true); err == nil || !strings.Contains(err.Error(), "escapes") {
 		t.Fatalf("StableChildAt traversal error=%v", err)
+	}
+	if runtime.GOOS == "windows" {
+		if _, _, _, err := powerlossreopen.StableChildAt(filepath.Join(canonicalTempDir(t), "volume-parent"), `C:db`, model, opts, true); err == nil || !strings.Contains(err.Error(), "relative path") {
+			t.Fatalf("StableChildAt volume-qualified error=%v", err)
+		}
 	}
 }
 

--- a/TreeDB/internal/powerlossreopen/reopen_test.go
+++ b/TreeDB/internal/powerlossreopen/reopen_test.go
@@ -100,6 +100,59 @@ func TestStableChildAtReopensModeledRelativeDatabaseRoot(t *testing.T) {
 	}
 }
 
+func TestStableChildCapturesParentEvidenceForAbsentDatabaseRoot(t *testing.T) {
+	sourceRoot := t.TempDir()
+	model, err := powerlossoracle.Capture(sourceRoot)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := model.Observe(sourceRoot, durabilitycut.Event{
+		Point:    durabilitycut.AfterNewFileDirectorySync,
+		Resource: durabilitycut.ResourceAuxiliary,
+		Path:     sourceRoot,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	opts := treedb.OptionsFor(treedb.ProfileNoWALFast, filepath.Join(sourceRoot, "db"))
+	opts.DisableSideStores = true
+	opts.DisableBackgroundPrune = true
+	evidenceDir := filepath.Join(canonicalTempDir(t), "relative-evidence")
+	t.Setenv(powerlossoracle.EnvEvidenceDir, evidenceDir)
+	t.Setenv(powerlossoracle.EnvEvidenceCutPoint, string(durabilitycut.AfterNewFileDirectorySync))
+	t.Setenv(powerlossoracle.EnvEvidenceReopenMode, powerlossoracle.EvidenceReopenReadWrite)
+	t.Setenv(powerlossoracle.EnvReplayCut, "cut/fresh-layout/after-new-file-directory-sync/000")
+	t.Setenv(powerlossoracle.EnvReplayVariant, "fresh-layout")
+	t.Setenv(powerlossoracle.EnvReplaySeed, "1")
+
+	result, reopened, closeFn, err := powerlossreopen.StableChild(model, "db", opts, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Dir != filepath.Join(evidenceDir, "recovery-input", "db") || result.Rejected || reopened == nil {
+		t.Fatalf("StableChild evidence result=%+v reopened=%v", result, reopened)
+	}
+	if err := closeFn(); err != nil {
+		t.Fatal(err)
+	}
+	recoveryData, err := os.ReadFile(filepath.Join(evidenceDir, "recovery_trace.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var recovery struct {
+		Dir                string `json:"dir"`
+		PreOpenSnapshotDir string `json:"pre_open_snapshot_dir"`
+	}
+	if err := json.Unmarshal(recoveryData, &recovery); err != nil {
+		t.Fatal(err)
+	}
+	if recovery.Dir != "recovery-input/db" || recovery.PreOpenSnapshotDir != "recovery-preopen" {
+		t.Fatalf("relative recovery evidence=%+v", recovery)
+	}
+	if _, err := os.Stat(filepath.Join(evidenceDir, "recovery-preopen", "db")); !os.IsNotExist(err) {
+		t.Fatalf("pre-open snapshot unexpectedly contains absent database root: %v", err)
+	}
+}
+
 func TestStableCapturesEvidenceWhenRequested(t *testing.T) {
 	source := t.TempDir()
 	opts := treedb.OptionsFor(treedb.ProfileNoWALFast, source)

--- a/TreeDB/internal/powerlossreopen/reopen_test.go
+++ b/TreeDB/internal/powerlossreopen/reopen_test.go
@@ -55,6 +55,51 @@ func TestStableAtPreservesCallerOwnedCrashImage(t *testing.T) {
 	}
 }
 
+func TestStableChildAtReopensModeledRelativeDatabaseRoot(t *testing.T) {
+	sourceRoot := t.TempDir()
+	sourceDB := filepath.Join(sourceRoot, "db")
+	opts := treedb.OptionsFor(treedb.ProfileNoWALFast, sourceDB)
+	opts.DisableSideStores = true
+	opts.DisableBackgroundPrune = true
+	db, err := treedb.Open(opts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := db.SetSync([]byte("stable-child"), []byte("value")); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatal(err)
+	}
+	model, err := powerlossoracle.Capture(sourceRoot)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	destinationRoot := filepath.Join(canonicalTempDir(t), "relative-parent")
+	result, reopened, closeFn, err := powerlossreopen.StableChildAt(destinationRoot, "db", model, opts, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Dir != filepath.Join(destinationRoot, "db") || result.Rejected || reopened == nil {
+		t.Fatalf("StableChildAt result=%+v reopened=%v", result, reopened)
+	}
+	got, err := reopened.Get([]byte("stable-child"))
+	if err != nil || !bytes.Equal(got, []byte("value")) {
+		t.Fatalf("Get stable-child=%q err=%v", got, err)
+	}
+	if err := closeFn(); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(destinationRoot); err != nil {
+		t.Fatalf("caller-owned parent image removed: %v", err)
+	}
+
+	if _, _, _, err := powerlossreopen.StableChildAt(filepath.Join(canonicalTempDir(t), "escape-parent"), "../db", model, opts, true); err == nil || !strings.Contains(err.Error(), "escapes") {
+		t.Fatalf("StableChildAt traversal error=%v", err)
+	}
+}
+
 func TestStableCapturesEvidenceWhenRequested(t *testing.T) {
 	source := t.TempDir()
 	opts := treedb.OptionsFor(treedb.ProfileNoWALFast, source)

--- a/TreeDB/internal/powerlossreopen/reopen_test.go
+++ b/TreeDB/internal/powerlossreopen/reopen_test.go
@@ -62,6 +62,7 @@ func TestStableChildAtReopensModeledRelativeDatabaseRoot(t *testing.T) {
 	opts := treedb.OptionsFor(treedb.ProfileNoWALFast, sourceDB)
 	opts.DisableSideStores = true
 	opts.DisableBackgroundPrune = true
+	opts.ValueLog.PointerThreshold = 1
 	db, err := treedb.Open(opts)
 	if err != nil {
 		t.Fatal(err)

--- a/TreeDB/power_loss_certification_layout_test.go
+++ b/TreeDB/power_loss_certification_layout_test.go
@@ -1,0 +1,225 @@
+package treedb_test
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	treedb "github.com/snissn/gomap/TreeDB"
+	"github.com/snissn/gomap/TreeDB/internal/durabilitycut"
+	"github.com/snissn/gomap/TreeDB/internal/powerlossoracle"
+	"github.com/snissn/gomap/TreeDB/internal/powerlossreopen"
+)
+
+type freshLayoutNamespaceCase struct {
+	variantID         string
+	disableSideStores bool
+	partial           bool
+	point             durabilitycut.Point
+	path              func(parent, database string) string
+}
+
+func TestPowerLossCertificationFreshCompositeBeforeOuterParentSync(t *testing.T) {
+	testPowerLossCertificationFreshLayout(t, freshLayoutNamespaceCase{
+		variantID: "fresh-layout-composite-before-outer-parent-sync",
+		point:     durabilitycut.BeforeNewFileDirectorySync,
+		path:      func(parent, _ string) string { return parent },
+	})
+}
+
+func TestPowerLossCertificationFreshCompositeAfterRootSync(t *testing.T) {
+	testPowerLossCertificationFreshLayout(t, freshLayoutNamespaceCase{
+		variantID: "fresh-layout-composite-after-root-sync",
+		point:     durabilitycut.AfterNewFileDirectorySync,
+		path:      func(_, database string) string { return database },
+	})
+}
+
+func TestPowerLossCertificationFreshCompositeAfterOuterParentSync(t *testing.T) {
+	testPowerLossCertificationFreshLayout(t, freshLayoutNamespaceCase{
+		variantID: "fresh-layout-composite-after-outer-parent-sync",
+		point:     durabilitycut.AfterNewFileDirectorySync,
+		path:      func(parent, _ string) string { return parent },
+	})
+}
+
+func TestPowerLossCertificationFreshCompositeAfterMainDBParentSync(t *testing.T) {
+	testPowerLossCertificationFreshLayout(t, freshLayoutNamespaceCase{
+		variantID: "fresh-layout-composite-after-maindb-parent-sync",
+		point:     durabilitycut.AfterNewFileDirectorySync,
+		path:      func(_, database string) string { return filepath.Join(database, "maindb") },
+	})
+}
+
+func TestPowerLossCertificationPartialCompositeAfterOuterParentSync(t *testing.T) {
+	testPowerLossCertificationFreshLayout(t, freshLayoutNamespaceCase{
+		variantID: "partial-layout-composite-after-outer-parent-sync",
+		partial:   true,
+		point:     durabilitycut.AfterNewFileDirectorySync,
+		path:      func(parent, _ string) string { return parent },
+	})
+}
+
+func TestPowerLossCertificationFreshFlatBeforeOuterParentSync(t *testing.T) {
+	testPowerLossCertificationFreshLayout(t, freshLayoutNamespaceCase{
+		variantID:         "fresh-layout-flat-before-outer-parent-sync",
+		disableSideStores: true,
+		point:             durabilitycut.BeforeNewFileDirectorySync,
+		path:              func(parent, _ string) string { return parent },
+	})
+}
+
+func TestPowerLossCertificationFreshFlatAfterOuterParentSync(t *testing.T) {
+	testPowerLossCertificationFreshLayout(t, freshLayoutNamespaceCase{
+		variantID:         "fresh-layout-flat-after-outer-parent-sync",
+		disableSideStores: true,
+		point:             durabilitycut.AfterNewFileDirectorySync,
+		path:              func(parent, _ string) string { return parent },
+	})
+}
+
+func testPowerLossCertificationFreshLayout(t *testing.T, testCase freshLayoutNamespaceCase) {
+	t.Helper()
+	if runtime.GOOS == "windows" {
+		t.Skip("modeled generic parent-directory barriers are unavailable on Windows")
+	}
+	selector, err := powerlossoracle.ReplaySelectorFromEnv()
+	if err != nil {
+		t.Fatal(err)
+	}
+	wantCutID := fmt.Sprintf("cut/%s/%s/000", testCase.variantID, testCase.point)
+	if selector != (powerlossoracle.ReplaySelector{}) {
+		if selector.CutID != wantCutID || selector.VariantID != testCase.variantID || selector.Seed != powerLossOracleSeed {
+			t.Fatalf("replay selector=(%q,%q,%d) want=(%q,%q,%d)", selector.CutID, selector.VariantID, selector.Seed, wantCutID, testCase.variantID, powerLossOracleSeed)
+		}
+	}
+
+	parent := t.TempDir()
+	databaseDir := filepath.Join(parent, "db")
+	model, err := powerlossoracle.Capture(parent)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if testCase.partial {
+		if err := os.MkdirAll(filepath.Join(databaseDir, "maindb"), 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	opts := treedb.OptionsFor(treedb.ProfileCommandWALDurable, databaseDir)
+	opts.DisableSideStores = testCase.disableSideStores
+	opts.DisableBackgroundPrune = true
+	opts.BackgroundCheckpointInterval = -1
+
+	cutErr := errors.New("power-loss-certification: fresh-layout namespace cut")
+	wantPath := filepath.Clean(testCase.path(parent, databaseDir))
+	cutTriggered := false
+	restore := durabilitycut.Install(func(event durabilitycut.Event) error {
+		if event.Path != "" && !pathWithinRoot(parent, event.Path) {
+			// Writable open conservatively repairs ancestors above the modeled
+			// parent. That parent was captured as the stable oracle root, so its
+			// own ancestor barriers are outside this crash image.
+			return nil
+		}
+		if err := model.Observe(parent, event); err != nil {
+			return err
+		}
+		if !cutTriggered && event.Resource == durabilitycut.ResourceAuxiliary && event.Point == testCase.point && filepath.Clean(event.Path) == wantPath {
+			cutTriggered = true
+			return cutErr
+		}
+		return nil
+	})
+	database, openErr := treedb.Open(opts)
+	restore()
+	if database != nil {
+		_ = database.Close()
+	}
+	if !cutTriggered || !errors.Is(openErr, cutErr) {
+		t.Fatalf("fresh-layout Open error=%v cutTriggered=%t want injected cut at %s %q", openErr, cutTriggered, testCase.point, wantPath)
+	}
+
+	readOnly := os.Getenv(powerlossoracle.EnvEvidenceReopenMode) == powerlossoracle.EvidenceReopenReadOnly
+	if readOnly {
+		// These cuts intentionally precede initialization proof. A stable image
+		// may contain no database root or only an empty/partial layout, so normal
+		// recovery is the writable public Open path.
+		t.Skip("fresh-layout initialization cuts require read-write public reopen")
+	}
+	result, reopened, closeReopened, err := powerlossreopen.StableChild(model, "db", opts, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Rejected || reopened == nil {
+		t.Fatalf("public Open rejected modeled fresh-layout image: %+v", result)
+	}
+	if err := reopened.SetSync([]byte("fresh-layout/recovered"), []byte(testCase.variantID)); err != nil {
+		_ = closeReopened()
+		t.Fatalf("recovered database is not durably writable: %v", err)
+	}
+	if got, err := reopened.Get([]byte("fresh-layout/recovered")); err != nil || string(got) != testCase.variantID {
+		_ = closeReopened()
+		t.Fatalf("recovered value=%q err=%v want=%q", got, err, testCase.variantID)
+	}
+	if err := closeReopened(); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func pathWithinRoot(root, path string) bool {
+	relative, err := filepath.Rel(root, path)
+	if err != nil {
+		return false
+	}
+	return relative != ".." && !strings.HasPrefix(relative, ".."+string(filepath.Separator))
+}
+
+func TestPowerLossCertificationProvenLayoutDoesNotRewriteNamespace(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("generic parent-directory barrier control is Unix-specific")
+	}
+	parent := t.TempDir()
+	databaseDir := filepath.Join(parent, "db")
+	opts := treedb.OptionsFor(treedb.ProfileCommandWALDurable, databaseDir)
+	opts.DisableBackgroundPrune = true
+	opts.BackgroundCheckpointInterval = -1
+	database, err := treedb.Open(opts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := database.SetSync([]byte("proven-layout"), []byte("stable")); err != nil {
+		t.Fatal(err)
+	}
+	if err := database.Close(); err != nil {
+		t.Fatal(err)
+	}
+	model, err := powerlossoracle.Capture(parent)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var layoutBarriers int
+	restore := durabilitycut.Install(func(event durabilitycut.Event) error {
+		if err := model.Observe(parent, event); err != nil {
+			return err
+		}
+		if event.Resource == durabilitycut.ResourceAuxiliary && (event.Point == durabilitycut.BeforeNewFileDirectorySync || event.Point == durabilitycut.AfterNewFileDirectorySync) {
+			layoutBarriers++
+		}
+		return nil
+	})
+	reopened, err := treedb.Open(opts)
+	if err == nil {
+		err = reopened.Close()
+	}
+	restore()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if layoutBarriers != 0 {
+		t.Fatalf("proven steady-state layout emitted %d creation barriers, want no rewrite", layoutBarriers)
+	}
+}

--- a/TreeDB/power_loss_certification_layout_test.go
+++ b/TreeDB/power_loss_certification_layout_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"reflect"
 	"runtime"
 	"strings"
 	"testing"
@@ -21,46 +22,70 @@ type freshLayoutNamespaceCase struct {
 	partial           bool
 	point             durabilitycut.Point
 	path              func(parent, database string) string
+	wantStableDirs    []string
 }
 
 func TestPowerLossCertificationFreshCompositeBeforeOuterParentSync(t *testing.T) {
 	testPowerLossCertificationFreshLayout(t, freshLayoutNamespaceCase{
-		variantID: "fresh-layout-composite-before-outer-parent-sync",
-		point:     durabilitycut.BeforeNewFileDirectorySync,
-		path:      func(parent, _ string) string { return parent },
+		variantID:      "fresh-layout-composite-before-outer-parent-sync",
+		point:          durabilitycut.BeforeNewFileDirectorySync,
+		path:           func(parent, _ string) string { return parent },
+		wantStableDirs: []string{"."},
+	})
+}
+
+func TestPowerLossCertificationFreshCompositeBeforeRootSync(t *testing.T) {
+	testPowerLossCertificationFreshLayout(t, freshLayoutNamespaceCase{
+		variantID:      "fresh-layout-composite-before-root-sync",
+		point:          durabilitycut.BeforeNewFileDirectorySync,
+		path:           func(_, database string) string { return database },
+		wantStableDirs: []string{"."},
 	})
 }
 
 func TestPowerLossCertificationFreshCompositeAfterRootSync(t *testing.T) {
 	testPowerLossCertificationFreshLayout(t, freshLayoutNamespaceCase{
-		variantID: "fresh-layout-composite-after-root-sync",
-		point:     durabilitycut.AfterNewFileDirectorySync,
-		path:      func(_, database string) string { return database },
+		variantID:      "fresh-layout-composite-after-root-sync",
+		point:          durabilitycut.AfterNewFileDirectorySync,
+		path:           func(_, database string) string { return database },
+		wantStableDirs: []string{"."},
 	})
 }
 
 func TestPowerLossCertificationFreshCompositeAfterOuterParentSync(t *testing.T) {
 	testPowerLossCertificationFreshLayout(t, freshLayoutNamespaceCase{
-		variantID: "fresh-layout-composite-after-outer-parent-sync",
-		point:     durabilitycut.AfterNewFileDirectorySync,
-		path:      func(parent, _ string) string { return parent },
+		variantID:      "fresh-layout-composite-after-outer-parent-sync",
+		point:          durabilitycut.AfterNewFileDirectorySync,
+		path:           func(parent, _ string) string { return parent },
+		wantStableDirs: []string{".", "db", "db/dictdb", "db/maindb"},
+	})
+}
+
+func TestPowerLossCertificationFreshCompositeBeforeMainDBParentSync(t *testing.T) {
+	testPowerLossCertificationFreshLayout(t, freshLayoutNamespaceCase{
+		variantID:      "fresh-layout-composite-before-maindb-parent-sync",
+		point:          durabilitycut.BeforeNewFileDirectorySync,
+		path:           func(_, database string) string { return filepath.Join(database, "maindb") },
+		wantStableDirs: []string{".", "db", "db/dictdb", "db/dictdb/column_assets", "db/dictdb/leaf_vlog", "db/dictdb/value_vlog", "db/dictdb/wal", "db/maindb"},
 	})
 }
 
 func TestPowerLossCertificationFreshCompositeAfterMainDBParentSync(t *testing.T) {
 	testPowerLossCertificationFreshLayout(t, freshLayoutNamespaceCase{
-		variantID: "fresh-layout-composite-after-maindb-parent-sync",
-		point:     durabilitycut.AfterNewFileDirectorySync,
-		path:      func(_, database string) string { return filepath.Join(database, "maindb") },
+		variantID:      "fresh-layout-composite-after-maindb-parent-sync",
+		point:          durabilitycut.AfterNewFileDirectorySync,
+		path:           func(_, database string) string { return filepath.Join(database, "maindb") },
+		wantStableDirs: []string{".", "db", "db/dictdb", "db/dictdb/column_assets", "db/dictdb/leaf_vlog", "db/dictdb/value_vlog", "db/dictdb/wal", "db/maindb", "db/maindb/column_assets", "db/maindb/leaf_vlog", "db/maindb/value_vlog", "db/maindb/wal"},
 	})
 }
 
 func TestPowerLossCertificationPartialCompositeAfterOuterParentSync(t *testing.T) {
 	testPowerLossCertificationFreshLayout(t, freshLayoutNamespaceCase{
-		variantID: "partial-layout-composite-after-outer-parent-sync",
-		partial:   true,
-		point:     durabilitycut.AfterNewFileDirectorySync,
-		path:      func(parent, _ string) string { return parent },
+		variantID:      "partial-layout-composite-after-outer-parent-sync",
+		partial:        true,
+		point:          durabilitycut.AfterNewFileDirectorySync,
+		path:           func(parent, _ string) string { return parent },
+		wantStableDirs: []string{".", "db", "db/dictdb", "db/maindb"},
 	})
 }
 
@@ -70,6 +95,7 @@ func TestPowerLossCertificationFreshFlatBeforeOuterParentSync(t *testing.T) {
 		disableSideStores: true,
 		point:             durabilitycut.BeforeNewFileDirectorySync,
 		path:              func(parent, _ string) string { return parent },
+		wantStableDirs:    []string{"."},
 	})
 }
 
@@ -79,6 +105,7 @@ func TestPowerLossCertificationFreshFlatAfterOuterParentSync(t *testing.T) {
 		disableSideStores: true,
 		point:             durabilitycut.AfterNewFileDirectorySync,
 		path:              func(parent, _ string) string { return parent },
+		wantStableDirs:    []string{".", "db"},
 	})
 }
 
@@ -141,6 +168,15 @@ func testPowerLossCertificationFreshLayout(t *testing.T, testCase freshLayoutNam
 	if !cutTriggered || !errors.Is(openErr, cutErr) {
 		t.Fatalf("fresh-layout Open error=%v cutTriggered=%t want injected cut at %s %q", openErr, cutTriggered, testCase.point, wantPath)
 	}
+	stableImage := t.TempDir()
+	if err := model.MaterializeStable(stableImage); err != nil {
+		t.Fatal(err)
+	}
+	if got, err := relativeDirectories(stableImage); err != nil {
+		t.Fatal(err)
+	} else if !reflect.DeepEqual(got, testCase.wantStableDirs) {
+		t.Fatalf("stable namespace directories=%v want=%v", got, testCase.wantStableDirs)
+	}
 
 	readOnly := os.Getenv(powerlossoracle.EnvEvidenceReopenMode) == powerlossoracle.EvidenceReopenReadOnly
 	if readOnly {
@@ -167,6 +203,25 @@ func testPowerLossCertificationFreshLayout(t *testing.T, testCase freshLayoutNam
 	if err := closeReopened(); err != nil {
 		t.Fatal(err)
 	}
+}
+
+func relativeDirectories(root string) ([]string, error) {
+	var dirs []string
+	err := filepath.WalkDir(root, func(path string, entry os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if !entry.IsDir() {
+			return nil
+		}
+		relative, err := filepath.Rel(root, path)
+		if err != nil {
+			return err
+		}
+		dirs = append(dirs, filepath.ToSlash(relative))
+		return nil
+	})
+	return dirs, err
 }
 
 func pathWithinRoot(root, path string) bool {

--- a/TreeDB/power_loss_certification_layout_test.go
+++ b/TreeDB/power_loss_certification_layout_test.go
@@ -22,6 +22,7 @@ type freshLayoutNamespaceCase struct {
 	partial           bool
 	point             durabilitycut.Point
 	path              func(parent, database string) string
+	wantOccurrence    int
 	wantStableDirs    []string
 }
 
@@ -30,6 +31,7 @@ func TestPowerLossCertificationFreshCompositeBeforeOuterParentSync(t *testing.T)
 		variantID:      "fresh-layout-composite-before-outer-parent-sync",
 		point:          durabilitycut.BeforeNewFileDirectorySync,
 		path:           func(parent, _ string) string { return parent },
+		wantOccurrence: 1,
 		wantStableDirs: []string{"."},
 	})
 }
@@ -39,6 +41,7 @@ func TestPowerLossCertificationFreshCompositeBeforeRootSync(t *testing.T) {
 		variantID:      "fresh-layout-composite-before-root-sync",
 		point:          durabilitycut.BeforeNewFileDirectorySync,
 		path:           func(_, database string) string { return database },
+		wantOccurrence: 0,
 		wantStableDirs: []string{"."},
 	})
 }
@@ -48,6 +51,7 @@ func TestPowerLossCertificationFreshCompositeAfterRootSync(t *testing.T) {
 		variantID:      "fresh-layout-composite-after-root-sync",
 		point:          durabilitycut.AfterNewFileDirectorySync,
 		path:           func(_, database string) string { return database },
+		wantOccurrence: 0,
 		wantStableDirs: []string{"."},
 	})
 }
@@ -57,6 +61,7 @@ func TestPowerLossCertificationFreshCompositeAfterOuterParentSync(t *testing.T) 
 		variantID:      "fresh-layout-composite-after-outer-parent-sync",
 		point:          durabilitycut.AfterNewFileDirectorySync,
 		path:           func(parent, _ string) string { return parent },
+		wantOccurrence: 1,
 		wantStableDirs: []string{".", "db", "db/dictdb", "db/maindb"},
 	})
 }
@@ -66,6 +71,7 @@ func TestPowerLossCertificationFreshCompositeBeforeMainDBParentSync(t *testing.T
 		variantID:      "fresh-layout-composite-before-maindb-parent-sync",
 		point:          durabilitycut.BeforeNewFileDirectorySync,
 		path:           func(_, database string) string { return filepath.Join(database, "maindb") },
+		wantOccurrence: 5,
 		wantStableDirs: []string{".", "db", "db/dictdb", "db/dictdb/column_assets", "db/dictdb/leaf_vlog", "db/dictdb/value_vlog", "db/dictdb/wal", "db/maindb"},
 	})
 }
@@ -75,6 +81,7 @@ func TestPowerLossCertificationFreshCompositeAfterMainDBParentSync(t *testing.T)
 		variantID:      "fresh-layout-composite-after-maindb-parent-sync",
 		point:          durabilitycut.AfterNewFileDirectorySync,
 		path:           func(_, database string) string { return filepath.Join(database, "maindb") },
+		wantOccurrence: 5,
 		wantStableDirs: []string{".", "db", "db/dictdb", "db/dictdb/column_assets", "db/dictdb/leaf_vlog", "db/dictdb/value_vlog", "db/dictdb/wal", "db/maindb", "db/maindb/column_assets", "db/maindb/leaf_vlog", "db/maindb/value_vlog", "db/maindb/wal"},
 	})
 }
@@ -85,6 +92,7 @@ func TestPowerLossCertificationPartialCompositeAfterOuterParentSync(t *testing.T
 		partial:        true,
 		point:          durabilitycut.AfterNewFileDirectorySync,
 		path:           func(parent, _ string) string { return parent },
+		wantOccurrence: 1,
 		wantStableDirs: []string{".", "db", "db/dictdb", "db/maindb"},
 	})
 }
@@ -95,6 +103,7 @@ func TestPowerLossCertificationFreshFlatBeforeOuterParentSync(t *testing.T) {
 		disableSideStores: true,
 		point:             durabilitycut.BeforeNewFileDirectorySync,
 		path:              func(parent, _ string) string { return parent },
+		wantOccurrence:    0,
 		wantStableDirs:    []string{"."},
 	})
 }
@@ -105,6 +114,7 @@ func TestPowerLossCertificationFreshFlatAfterOuterParentSync(t *testing.T) {
 		disableSideStores: true,
 		point:             durabilitycut.AfterNewFileDirectorySync,
 		path:              func(parent, _ string) string { return parent },
+		wantOccurrence:    0,
 		wantStableDirs:    []string{".", "db"},
 	})
 }
@@ -118,13 +128,6 @@ func testPowerLossCertificationFreshLayout(t *testing.T, testCase freshLayoutNam
 	if err != nil {
 		t.Fatal(err)
 	}
-	wantCutID := fmt.Sprintf("cut/%s/%s/000", testCase.variantID, testCase.point)
-	if selector != (powerlossoracle.ReplaySelector{}) {
-		if selector.CutID != wantCutID || selector.VariantID != testCase.variantID || selector.Seed != powerLossOracleSeed {
-			t.Fatalf("replay selector=(%q,%q,%d) want=(%q,%q,%d)", selector.CutID, selector.VariantID, selector.Seed, wantCutID, testCase.variantID, powerLossOracleSeed)
-		}
-	}
-
 	parent := t.TempDir()
 	databaseDir := filepath.Join(parent, "db")
 	model, err := powerlossoracle.Capture(parent)
@@ -144,6 +147,8 @@ func testPowerLossCertificationFreshLayout(t *testing.T, testCase freshLayoutNam
 	cutErr := errors.New("power-loss-certification: fresh-layout namespace cut")
 	wantPath := filepath.Clean(testCase.path(parent, databaseDir))
 	cutTriggered := false
+	pointOccurrence := 0
+	targetOccurrence := -1
 	restore := durabilitycut.Install(func(event durabilitycut.Event) error {
 		if event.Path != "" && !pathWithinRoot(parent, event.Path) {
 			// Writable open conservatively repairs ancestors above the modeled
@@ -154,8 +159,14 @@ func testPowerLossCertificationFreshLayout(t *testing.T, testCase freshLayoutNam
 		if err := model.Observe(parent, event); err != nil {
 			return err
 		}
+		occurrence := -1
+		if event.Point == testCase.point {
+			occurrence = pointOccurrence
+			pointOccurrence++
+		}
 		if !cutTriggered && event.Resource == durabilitycut.ResourceAuxiliary && event.Point == testCase.point && filepath.Clean(event.Path) == wantPath {
 			cutTriggered = true
+			targetOccurrence = occurrence
 			return cutErr
 		}
 		return nil
@@ -165,8 +176,18 @@ func testPowerLossCertificationFreshLayout(t *testing.T, testCase freshLayoutNam
 	if database != nil {
 		_ = database.Close()
 	}
-	if !cutTriggered || !errors.Is(openErr, cutErr) {
+	if !cutTriggered || targetOccurrence < 0 || !errors.Is(openErr, cutErr) {
 		t.Fatalf("fresh-layout Open error=%v cutTriggered=%t want injected cut at %s %q", openErr, cutTriggered, testCase.point, wantPath)
+	}
+	if targetOccurrence != testCase.wantOccurrence {
+		t.Fatalf("fresh-layout target occurrence=%d want frozen address occurrence=%d", targetOccurrence, testCase.wantOccurrence)
+	}
+	wantCutID := fmt.Sprintf("cut/%s/%s/%03d", testCase.variantID, testCase.point, targetOccurrence)
+	t.Logf("fresh-layout evidence address=%s", wantCutID)
+	if selector != (powerlossoracle.ReplaySelector{}) {
+		if selector.CutID != wantCutID || selector.VariantID != testCase.variantID || selector.Seed != powerLossOracleSeed {
+			t.Fatalf("replay selector=(%q,%q,%d) want=(%q,%q,%d)", selector.CutID, selector.VariantID, selector.Seed, wantCutID, testCase.variantID, powerLossOracleSeed)
+		}
 	}
 	stableImage := t.TempDir()
 	if err := model.MaterializeStable(stableImage); err != nil {

--- a/TreeDB/testdata/power_loss_witness_contracts.json
+++ b/TreeDB/testdata/power_loss_witness_contracts.json
@@ -1,5 +1,5 @@
 {
-  "schema_version": "treedb-power-loss-witness-contracts/v2",
+  "schema_version": "treedb-power-loss-witness-contracts/v3",
   "issue": 3684,
   "required_pull_requests": [
     3706,


### PR DESCRIPTION
Progresses #3684.

## Outcome

Adds the first terminal-certificate slice after #3926: modeled namespace persistence for fresh and unproven public TreeDB layouts, fail-closed production directory-sync classification, parent-root recovery evidence, and a Git 2.34-compatible exact-tree provenance fallback.

## Changes

- models per-directory durable namespace contents, reachable crash projection, directory identities, and delete/recreate subtree replacement;
- emits before/after layout directory-sync cuts through the production path and classifies unsupported persistence as both typed unsupported and recovery-required;
- materializes a parent crash image and reopens the relative public database root without allowing path escape or Windows volume-qualified paths;
- freezes the expected recovery directory in the run plan and retained witness, defaulting omitted root expectations to `recovery-input` while requiring child-root evidence to match `recovery-input/db` exactly;
- versions the strict directory-bound formats as run-plan/contracts v3, child-manifest v2, and recovery-trace v2 so older strict readers cannot misinterpret new fields or child-root semantics;
- covers absent composite and flat roots, an unproven partial composite layout, pre-existing/proven no-rewrite control, outer/root/nested before and after cuts, retry through writable public Open, and injected/unsupported sync failures;
- freezes actual evidence addresses at `/000`, `/001`, and `/005`, and asserts the exact reachable directory set before writable recovery;
- preserves exact PR provenance checks on older Git by computing the synthetic merge tree in an isolated shared-object temporary clone;
- forces a value-log pointer through the relative stable-child reopen regression.

## Validation

Exact head: `cc03d1bc170a6957d62a7395f475b55b083ac979`

- `go test ./TreeDB -count=1` — pass on predecessor `10274b332`, 365.562s; the exact-head schema-only delta has focused producer/verifier coverage;
- `go test ./TreeDB/db -count=1` — pass on code-equivalent `227acb7f1`, 513.810s; no `TreeDB/db` change followed;
- `go test ./TreeDB/internal/powerlosscert -count=1` — pass;
- `go test ./TreeDB/internal/powerlossreopen -count=1` — pass;
- `go test -race ./TreeDB/internal/powerlosscert -count=1` — pass;
- `go test -race ./TreeDB/internal/powerlossreopen -count=1` — pass;
- `go vet ./TreeDB/internal/powerlosscert ./TreeDB/internal/powerlossreopen` — pass;
- Windows/amd64 cross-compilation for the certificate verifier and recovery producer — pass;
- focused oracle, reopen, certificate-runner, layout, and all nine public layout witnesses — pass;
- all nine witnesses also pass in retained-evidence mode at their frozen addresses;
- `git diff --check` — pass;
- independent review found the recovery-directory wiring correct and raised one P2 strict-schema versioning issue; that issue is fixed in `cc03d1bc1`, and exact-head re-review is requested.

The exact-head MVCC raw-path gate passes all five rows. Its fsync-dominated tiny `WriteSync` row measures a -0.59% paired delta (`234299` base vs `234233` candidate ns/op), 17 allocs/op on both sides, and slightly fewer candidate bytes/op. This resolves the previous head's isolated +37.18% observation as measurement noise; the PR changes no timed write path because its production observer calls surround one-time layout-directory synchronization before the benchmark resets its timer.

## Claim boundary

This PR establishes modeled fresh-layout namespace witnesses and supporting harness correctness. It does not close #3684, replace the terminal resource/group/stale-build matrix, publish a new exact-SHA release, or claim block-device evidence. The terminal follow-up remains responsible for behavioral resource coverage, grouped acknowledgements, the #3865 counterexample, sealed evidence, and the new superseding release. The historical release already carries the required scope erratum and its assets remain immutable.
