### PR TITLE
fix(treedb): stabilize authoritative resource replay

### DIFF
--- a/TreeDB/caching/db.go
+++ b/TreeDB/caching/db.go
@@ -8860,7 +8860,7 @@ type DB struct {
 	valueLogDictMetricsPauseBytes  int
 
 	valueLogDictTrainerMu      sync.RWMutex
-	valueLogDictApplyMu        sync.RWMutex
+	valueLogDictApplyMu        sync.Mutex
 	valueLogDictTrainer        *compression.Trainer
 	valueLogDictTrainerByClass [vlogDictClassCount]*compression.Trainer
 	valueLogDictKickCh         chan struct{}

--- a/TreeDB/caching/vlog_dict.go
+++ b/TreeDB/caching/vlog_dict.go
@@ -1020,8 +1020,13 @@ func (db *DB) applyValueLogDictProfileForClass(class vlogDictClass) {
 	if db == nil {
 		return
 	}
-	db.valueLogDictApplyMu.RLock()
-	defer db.valueLogDictApplyMu.RUnlock()
+	// Profile application is a check-then-publish transaction: the applied hash
+	// is checked before the dictionary and current marker are persisted, then the
+	// hash is advanced only after publication succeeds. Serialize callers so the
+	// trainer callback and periodic publisher cannot both observe the old hash
+	// and persist the same accepted profile twice.
+	db.valueLogDictApplyMu.Lock()
+	defer db.valueLogDictApplyMu.Unlock()
 	if db.closing.Load() {
 		return
 	}

--- a/TreeDB/caching/vlog_dict_k_update_test.go
+++ b/TreeDB/caching/vlog_dict_k_update_test.go
@@ -3,6 +3,7 @@ package caching
 import (
 	"context"
 	"errors"
+	"sync"
 	"testing"
 	"time"
 
@@ -26,6 +27,81 @@ type classWriterOnlyDictStoreForClassPublishTest struct {
 type classReadWriteDictStoreForClassPublishTest struct {
 	*legacyDictStoreForClassPublishTest
 	classCurrent map[string]uint64
+}
+
+type blockingDictStoreForConcurrentPublishTest struct {
+	mu            sync.Mutex
+	nextID        uint64
+	currentID     uint64
+	dicts         map[uint64][]byte
+	putCalls      int
+	inPut         int
+	concurrentPut bool
+	firstEntered  chan struct{}
+	secondEntered chan struct{}
+	releaseFirst  chan struct{}
+}
+
+func newBlockingDictStoreForConcurrentPublishTest() *blockingDictStoreForConcurrentPublishTest {
+	return &blockingDictStoreForConcurrentPublishTest{
+		dicts:         make(map[uint64][]byte),
+		firstEntered:  make(chan struct{}),
+		secondEntered: make(chan struct{}),
+		releaseFirst:  make(chan struct{}),
+	}
+}
+
+func (s *blockingDictStoreForConcurrentPublishTest) GetCurrent(context.Context) (uint64, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.currentID, nil
+}
+
+func (s *blockingDictStoreForConcurrentPublishTest) GetDictBytes(_ context.Context, dictID uint64) ([]byte, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return append([]byte(nil), s.dicts[dictID]...), nil
+}
+
+func (s *blockingDictStoreForConcurrentPublishTest) PutDictBytes(_ context.Context, dict []byte) (uint64, error) {
+	s.mu.Lock()
+	s.putCalls++
+	call := s.putCalls
+	s.inPut++
+	if s.inPut > 1 {
+		s.concurrentPut = true
+	}
+	if call == 1 {
+		close(s.firstEntered)
+	} else if call == 2 {
+		close(s.secondEntered)
+	}
+	s.mu.Unlock()
+
+	if call == 1 {
+		<-s.releaseFirst
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.inPut--
+	s.nextID++
+	id := s.nextID
+	s.dicts[id] = append([]byte(nil), dict...)
+	return id, nil
+}
+
+func (s *blockingDictStoreForConcurrentPublishTest) SetCurrent(_ context.Context, dictID uint64) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.currentID = dictID
+	return nil
+}
+
+func (s *blockingDictStoreForConcurrentPublishTest) snapshot() (putCalls int, concurrent bool, currentID uint64) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.putCalls, s.concurrentPut, s.currentID
 }
 
 func (s *legacyDictStoreForClassPublishTest) GetCurrent(context.Context) (uint64, error) {
@@ -157,6 +233,65 @@ func TestApplyValueLogDictProfileUpdatesKForSameDict(t *testing.T) {
 	}
 	if curK := int(db.valueLogDictCurrentK.Load()); curK != 16 {
 		t.Fatalf("expected currentK=16, got %d", curK)
+	}
+}
+
+func TestApplyValueLogDictProfileForClass_SerializesConcurrentPublishers(t *testing.T) {
+	tr := &compression.Trainer{}
+	dictBytes := []byte("concurrent-publish-dictionary")
+	dictHash := xxhash.Sum64(dictBytes)
+	tr.AcceptProfile(&compression.ActiveProfile{
+		DictHash:     dictHash,
+		DictBytes:    len(dictBytes),
+		Dict:         dictBytes,
+		K:            8,
+		PayloadRatio: 0.6,
+		TotalRatio:   0.6,
+		Timestamp:    time.Now(),
+	})
+
+	store := newBlockingDictStoreForConcurrentPublishTest()
+	database := &DB{dictStore: store}
+	database.valueLogDictTrainerByClass[vlogDictClassSingleValue] = tr
+
+	var publishers sync.WaitGroup
+	publishers.Add(2)
+	go func() {
+		defer publishers.Done()
+		database.applyValueLogDictProfileForClass(vlogDictClassSingleValue)
+	}()
+	select {
+	case <-store.firstEntered:
+	case <-time.After(5 * time.Second):
+		t.Fatal("first dictionary publisher did not enter the store")
+	}
+
+	go func() {
+		defer publishers.Done()
+		database.applyValueLogDictProfileForClass(vlogDictClassSingleValue)
+	}()
+	select {
+	case <-store.secondEntered:
+		close(store.releaseFirst)
+		publishers.Wait()
+		t.Fatal("second publisher entered before the first completed")
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	close(store.releaseFirst)
+	publishers.Wait()
+	putCalls, concurrent, currentID := store.snapshot()
+	if putCalls != 1 {
+		t.Fatalf("dictionary PutDictBytes calls=%d want 1", putCalls)
+	}
+	if concurrent {
+		t.Fatal("dictionary store observed concurrent PutDictBytes calls")
+	}
+	if currentID != 1 {
+		t.Fatalf("current dictionary id=%d want 1", currentID)
+	}
+	if got := database.valueLogDictLastAppliedDictHashByClass[vlogDictClassSingleValue].Load(); got != dictHash {
+		t.Fatalf("last applied dictionary hash=%x want %x", got, dictHash)
 	}
 }
 

--- a/TreeDB/docs/spec/power-loss-certification-3684.md
+++ b/TreeDB/docs/spec/power-loss-certification-3684.md
@@ -82,7 +82,9 @@ TREEDB_POWERLOSS_REOPEN_MODE=read-write|read-only
 
 The evidence directory must be empty. Capture writes:
 
-- `operation_trace.json` with the declared cut and actual observed event count;
+- `operation_trace.json` with the declared cut, replay variant, optional
+  replay-window contract, scoped observed event count, and complete retained
+  operation trace;
 - immutable `stable-image/` and `dirty-image/` trees plus deterministic tree
   manifests that bind the complete directory namespace (including empty
   directories) and every regular file;
@@ -96,12 +98,17 @@ The evidence directory must be empty. Capture writes:
 - `metrics.json` with image sizes, file counts, trace count, and stable-image
 fingerprint.
 
-The directory-bound contract uses run-plan and witness-contract schema v3,
-child-manifest schema v2, and recovery-trace schema v2. The plan freezes the
-expected slash-separated recovery directory; the child manifest retains that
-expectation, and the trace must identify the same canonical `recovery-input`
-root or descendant. These version bumps are intentional because strict readers
-of the preceding schemas do not accept the new fields or child-root semantics.
+The current contract uses run-plan and witness-contract schema v4,
+child-manifest schema v3, operation-trace schema v2, and recovery-trace schema
+v2. The plan freezes the expected slash-separated recovery directory; the
+child manifest retains that expectation, and the recovery trace must identify
+the same canonical `recovery-input` root or descendant. A windowed case also
+freezes one replay window equal to its replay variant. Capture and retained
+verification require exactly one matching marker followed by the selected cut;
+missing, duplicate, mismatched, late, or undeclared markers fail closed while
+the full pre-window trace remains retained. These version bumps are intentional
+because strict readers of the preceding schemas do not accept the new fields,
+child-root semantics, state comparison, or window-relative cut addressing.
 
 Every modeled witness registers those five JSON files and
 `command_log.json` at their canonical names directly below its declared
@@ -129,12 +136,13 @@ not evidence.
 
 ## Exact-SHA runner
 
-`TreeDB/cmd/power_loss_certify` consumes a strict risk inventory and version-3
+`TreeDB/cmd/power_loss_certify` consumes a strict risk inventory and version-4
 run plan. The plan freezes `refs/remotes/origin/main`, its exact repository SHA,
-PR provenance, replay selector, profile, reopen mode, expected outcome, typed
-error, complete expected recovery state, per-case timeout, captured-output
-limit, per-case evidence limit, and whole-bundle byte limit before any case
-runs. Before checking out evidence, the runner proves that the frozen cases
+PR provenance, replay selector and optional replay window, profile, reopen
+mode, expected outcome, typed error, state-comparison rule, complete expected
+recovery state, per-case timeout, captured-output limit, per-case evidence
+limit, and whole-bundle byte limit before any case runs. Before checking out
+evidence, the runner proves that the frozen cases
 match the committed witness contracts and cover every inventory value, retained
 counterexample, negative control, and required interaction. It then refuses a
 different current-main ref or HEAD, tracked or untracked worktree changes, and

--- a/TreeDB/internal/powerlosscert/bundle.go
+++ b/TreeDB/internal/powerlosscert/bundle.go
@@ -402,6 +402,9 @@ func verifyOperationTrace(root, manifestID string, witness Witness, traceArtifac
 	if trace.ReplayWindow != witness.ReplayWindow {
 		return operationTraceArtifact{}, fmt.Errorf("%s replay_window=%q want=%q", prefix, trace.ReplayWindow, witness.ReplayWindow)
 	}
+	if trace.ReplayWindow != "" && trace.ReplayWindow != trace.VariantID {
+		return operationTraceArtifact{}, fmt.Errorf("%s replay_window=%q does not match variant_id=%q", prefix, trace.ReplayWindow, trace.VariantID)
+	}
 	matchingEvents, err := replayWindowCutCount(trace.Events, witness.CutPoint, trace.ReplayWindow)
 	if err != nil {
 		return operationTraceArtifact{}, fmt.Errorf("%s: %w", prefix, err)

--- a/TreeDB/internal/powerlosscert/bundle.go
+++ b/TreeDB/internal/powerlosscert/bundle.go
@@ -398,13 +398,7 @@ func verifyOperationTrace(root, manifestID string, witness Witness, traceArtifac
 	if trace.VariantID == "" {
 		return operationTraceArtifact{}, fmt.Errorf("%s has empty variant_id", prefix)
 	}
-	matchingEvents := 0
-	cutPrefix := "cut:" + witness.CutPoint + ":"
-	for _, event := range trace.Events {
-		if strings.HasPrefix(event, cutPrefix) {
-			matchingEvents++
-		}
-	}
+	matchingEvents := replayWindowCutCount(trace.Events, witness.CutPoint, trace.VariantID)
 	if trace.ObservedEventCount != matchingEvents || trace.ObservedEventCount != witness.ObservedEventCount {
 		return operationTraceArtifact{}, fmt.Errorf("%s observed_event_count=%d matching_events=%d witness=%d", prefix, trace.ObservedEventCount, matchingEvents, witness.ObservedEventCount)
 	}
@@ -426,6 +420,22 @@ func verifyOperationTrace(root, manifestID string, witness Witness, traceArtifac
 		return operationTraceArtifact{}, fmt.Errorf("%s command env TREEDB_POWERLOSS_EVIDENCE_DIR is empty", prefix)
 	}
 	return trace, nil
+}
+
+func replayWindowCutCount(events []string, cutPoint, variantID string) int {
+	cutPrefix := "cut:" + cutPoint + ":"
+	windowMarker := "replay-window:" + variantID
+	matching := 0
+	for _, event := range events {
+		if event == windowMarker {
+			matching = 0
+			continue
+		}
+		if strings.HasPrefix(event, cutPrefix) {
+			matching++
+		}
+	}
+	return matching
 }
 
 func verifyImageTree(root, evidenceDir, manifestID, witnessID string, artifact Artifact, kind string) (imageTreeArtifact, error) {
@@ -600,7 +610,11 @@ func verifyRecoveryTrace(root, evidenceDir, manifestID string, witness Witness, 
 	if err := validateRecoveryStats(recovery, witness.Command.Env[powerLossProfileEnv]); err != nil {
 		return recoveryTraceArtifact{}, fmt.Errorf("%s: %w", prefix, err)
 	}
-	if got := observedWitnessState(recovery); got != witness.State {
+	got, err := observedWitnessStateForComparison(recovery, witness.StateComparison)
+	if err != nil {
+		return recoveryTraceArtifact{}, fmt.Errorf("%s: %w", prefix, err)
+	}
+	if got != witness.State {
 		return recoveryTraceArtifact{}, fmt.Errorf("%s observed state=%+v does not match manifest state=%+v", prefix, got, witness.State)
 	}
 	recoveryDir := filepath.Join(root, filepath.FromSlash(evidenceDir), recovery.Dir)

--- a/TreeDB/internal/powerlosscert/bundle.go
+++ b/TreeDB/internal/powerlosscert/bundle.go
@@ -15,7 +15,7 @@ import (
 )
 
 const (
-	operationTraceSchemaVersion = "treedb-power-loss-operation-trace/v1"
+	operationTraceSchemaVersion = "treedb-power-loss-operation-trace/v2"
 	imageTreeSchemaVersion      = "treedb-power-loss-image-tree/v1"
 	recoveryTraceSchemaVersion  = "treedb-power-loss-recovery-trace/v2"
 	metricsSchemaVersion        = "treedb-power-loss-metrics/v1"
@@ -28,6 +28,7 @@ type operationTraceArtifact struct {
 	VariantID          string   `json:"variant_id"`
 	Seed               string   `json:"seed"`
 	DeclaredCutPoint   string   `json:"declared_cut_point"`
+	ReplayWindow       string   `json:"replay_window,omitempty"`
 	ObservedEventCount int      `json:"observed_event_count"`
 	Events             []string `json:"events"`
 }
@@ -398,7 +399,13 @@ func verifyOperationTrace(root, manifestID string, witness Witness, traceArtifac
 	if trace.VariantID == "" {
 		return operationTraceArtifact{}, fmt.Errorf("%s has empty variant_id", prefix)
 	}
-	matchingEvents := replayWindowCutCount(trace.Events, witness.CutPoint, trace.VariantID)
+	if trace.ReplayWindow != witness.ReplayWindow {
+		return operationTraceArtifact{}, fmt.Errorf("%s replay_window=%q want=%q", prefix, trace.ReplayWindow, witness.ReplayWindow)
+	}
+	matchingEvents, err := replayWindowCutCount(trace.Events, witness.CutPoint, trace.ReplayWindow)
+	if err != nil {
+		return operationTraceArtifact{}, fmt.Errorf("%s: %w", prefix, err)
+	}
 	if trace.ObservedEventCount != matchingEvents || trace.ObservedEventCount != witness.ObservedEventCount {
 		return operationTraceArtifact{}, fmt.Errorf("%s observed_event_count=%d matching_events=%d witness=%d", prefix, trace.ObservedEventCount, matchingEvents, witness.ObservedEventCount)
 	}
@@ -411,6 +418,11 @@ func verifyOperationTrace(root, manifestID string, witness Witness, traceArtifac
 		"TREEDB_POWERLOSS_SEED":             wantSeed,
 		"TREEDB_POWERLOSS_EXPECT_CUT_POINT": witness.CutPoint,
 	}
+	if witness.ReplayWindow != "" {
+		wantEnv[powerLossReplayWindowEnv] = witness.ReplayWindow
+	} else if got := witness.Command.Env[powerLossReplayWindowEnv]; got != "" {
+		return operationTraceArtifact{}, fmt.Errorf("%s command env %s=%q want empty", prefix, powerLossReplayWindowEnv, got)
+	}
 	for name, want := range wantEnv {
 		if got := witness.Command.Env[name]; got != want {
 			return operationTraceArtifact{}, fmt.Errorf("%s command env %s=%q want=%q", prefix, name, got, want)
@@ -422,20 +434,38 @@ func verifyOperationTrace(root, manifestID string, witness Witness, traceArtifac
 	return trace, nil
 }
 
-func replayWindowCutCount(events []string, cutPoint, variantID string) int {
+func replayWindowCutCount(events []string, cutPoint, replayWindow string) (int, error) {
 	cutPrefix := "cut:" + cutPoint + ":"
-	windowMarker := "replay-window:" + variantID
+	windowMarker := "replay-window:" + replayWindow
 	matching := 0
+	markerCount := 0
+	inWindow := replayWindow == ""
 	for _, event := range events {
-		if event == windowMarker {
-			matching = 0
+		if strings.HasPrefix(event, "replay-window:") {
+			if replayWindow == "" {
+				return 0, fmt.Errorf("operation trace contains replay-window marker without a declared replay window")
+			}
+			if event != windowMarker {
+				return 0, fmt.Errorf("operation trace replay-window marker %q does not match declared replay window %q", event, replayWindow)
+			}
+			markerCount++
+			if markerCount > 1 {
+				return 0, fmt.Errorf("operation trace requires exactly one replay-window marker %q; found %d", windowMarker, markerCount)
+			}
+			inWindow = true
 			continue
 		}
-		if strings.HasPrefix(event, cutPrefix) {
+		if inWindow && strings.HasPrefix(event, cutPrefix) {
 			matching++
 		}
 	}
-	return matching
+	if replayWindow != "" && markerCount != 1 {
+		return 0, fmt.Errorf("operation trace requires exactly one replay-window marker %q; found %d", windowMarker, markerCount)
+	}
+	if replayWindow != "" && matching == 0 {
+		return 0, fmt.Errorf("operation trace replay-window marker %q does not precede a matching cut %q", windowMarker, cutPoint)
+	}
+	return matching, nil
 }
 
 func verifyImageTree(root, evidenceDir, manifestID, witnessID string, artifact Artifact, kind string) (imageTreeArtifact, error) {

--- a/TreeDB/internal/powerlosscert/bundle_test.go
+++ b/TreeDB/internal/powerlosscert/bundle_test.go
@@ -326,6 +326,27 @@ func TestVerifyArtifactsRejectsInvalidDeclaredReplayWindow(t *testing.T) {
 			}
 		})
 	}
+
+	t.Run("trace-variant-mismatch", func(t *testing.T) {
+		root := t.TempDir()
+		manifest := testChildManifest("witness-a")
+		witness := &manifest.Witnesses[0]
+		witness.ReplayWindow = "variant-a"
+		witness.Command.Env[powerLossReplayWindowEnv] = witness.ReplayWindow
+		witness.CutID = "cut/checkpoint-generation-2/after-meta-write/000"
+		witness.CutOccurrence = 0
+		witness.ObservedEventCount = 1
+		witness.Command.Env["TREEDB_POWERLOSS_CUT_ID"] = witness.CutID
+		for index := range manifest.TestBinaries {
+			manifest.TestBinaries[index] = writeArtifactFixture(t, root, manifest.TestBinaries[index].Kind, manifest.TestBinaries[index].Path, "binary")
+		}
+		writeModeledEvidenceFixture(t, root, &manifest, "after-meta-write")
+		rewriteArtifactJSONField(t, root, witness, ArtifactKindOperationTrace, "variant_id", "variant-b")
+
+		if err := VerifyArtifacts(root, []ChildManifest{manifest}); err == nil || !strings.Contains(err.Error(), "does not match variant_id") {
+			t.Fatalf("VerifyArtifacts trace-variant mismatch error=%v", err)
+		}
+	})
 }
 
 func TestVerifyArtifactsRejectsImageBytesThatDoNotMatchTree(t *testing.T) {

--- a/TreeDB/internal/powerlosscert/bundle_test.go
+++ b/TreeDB/internal/powerlosscert/bundle_test.go
@@ -214,6 +214,21 @@ func TestVerifyArtifactsRequiresTraceToEndAtDeclaredCutOccurrence(t *testing.T) 
 	}
 }
 
+func TestReplayWindowCutCountRetainsPrefixButScopesAddress(t *testing.T) {
+	events := []string{
+		"cut:after-meta-write:meta",
+		"cut:after-meta-write:meta",
+		"replay-window:variant-a",
+		"cut:after-meta-write:meta",
+	}
+	if got := replayWindowCutCount(events, "after-meta-write", "variant-a"); got != 1 {
+		t.Fatalf("windowed matching events=%d want 1", got)
+	}
+	if got := replayWindowCutCount(events, "after-meta-write", "variant-b"); got != 3 {
+		t.Fatalf("legacy full-trace matching events=%d want 3", got)
+	}
+}
+
 func TestVerifyArtifactsRejectsModeledEvidenceReuseAcrossWitnesses(t *testing.T) {
 	root := t.TempDir()
 	manifest := testChildManifest("witness-a")

--- a/TreeDB/internal/powerlosscert/bundle_test.go
+++ b/TreeDB/internal/powerlosscert/bundle_test.go
@@ -221,11 +221,26 @@ func TestReplayWindowCutCountRetainsPrefixButScopesAddress(t *testing.T) {
 		"replay-window:variant-a",
 		"cut:after-meta-write:meta",
 	}
-	if got := replayWindowCutCount(events, "after-meta-write", "variant-a"); got != 1 {
-		t.Fatalf("windowed matching events=%d want 1", got)
+	if got, err := replayWindowCutCount(events, "after-meta-write", "variant-a"); err != nil || got != 1 {
+		t.Fatalf("windowed matching events=%d error=%v want 1", got, err)
 	}
-	if got := replayWindowCutCount(events, "after-meta-write", "variant-b"); got != 3 {
-		t.Fatalf("legacy full-trace matching events=%d want 3", got)
+	for _, test := range []struct {
+		name   string
+		events []string
+		window string
+		want   string
+	}{
+		{name: "missing", events: []string{"cut:after-meta-write:meta"}, window: "variant-a", want: "exactly one"},
+		{name: "duplicate", events: []string{"replay-window:variant-a", "replay-window:variant-a", "cut:after-meta-write:meta"}, window: "variant-a", want: "exactly one"},
+		{name: "misordered", events: []string{"cut:after-meta-write:meta", "replay-window:variant-a"}, window: "variant-a", want: "does not precede"},
+		{name: "wrong-marker", events: []string{"replay-window:variant-b", "cut:after-meta-write:meta"}, window: "variant-a", want: "does not match"},
+		{name: "undeclared", events: events, want: "without a declared"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			if _, err := replayWindowCutCount(test.events, "after-meta-write", test.window); err == nil || !strings.Contains(err.Error(), test.want) {
+				t.Fatalf("replayWindowCutCount error=%v want substring %q", err, test.want)
+			}
+		})
 	}
 }
 
@@ -255,6 +270,7 @@ func TestVerifyArtifactsRejectsMalformedOrUnboundModeledArtifacts(t *testing.T) 
 		want  string
 	}{
 		{name: "stable tree schema", kind: ArtifactKindStableImageTree, field: "schema_version", value: "wrong/v1", want: "stable image tree"},
+		{name: "operation trace schema", kind: ArtifactKindOperationTrace, field: "schema_version", value: "treedb-power-loss-operation-trace/v1", want: "operation trace"},
 		{name: "stable tree directory escape", kind: ArtifactKindStableImageTree, field: "directories", value: []string{"../escape"}, want: "unsafe or non-canonical"},
 		{name: "dirty tree totals", kind: ArtifactKindDirtyImageTree, field: "total_bytes", value: 999, want: "dirty image tree"},
 		{name: "metrics cross reference", kind: ArtifactKindMetrics, field: "trace_events", value: 999, want: "does not match"},
@@ -273,6 +289,39 @@ func TestVerifyArtifactsRejectsMalformedOrUnboundModeledArtifacts(t *testing.T) 
 
 			err := VerifyArtifacts(root, []ChildManifest{manifest})
 			if err == nil || !strings.Contains(err.Error(), test.want) {
+				t.Fatalf("VerifyArtifacts error=%v want substring %q", err, test.want)
+			}
+		})
+	}
+}
+
+func TestVerifyArtifactsRejectsInvalidDeclaredReplayWindow(t *testing.T) {
+	for _, test := range []struct {
+		name   string
+		events []string
+		want   string
+	}{
+		{name: "missing-marker", events: []string{"cut:after-meta-write:meta:meta.db:0"}, want: "exactly one replay-window marker"},
+		{name: "duplicate-marker", events: []string{"replay-window:variant-a", "replay-window:variant-a", "cut:after-meta-write:meta:meta.db:0"}, want: "exactly one replay-window marker"},
+		{name: "marker-after-last-cut", events: []string{"cut:after-meta-write:meta:meta.db:0", "replay-window:variant-a"}, want: "does not precede a matching cut"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			root := t.TempDir()
+			manifest := testChildManifest("witness-a")
+			witness := &manifest.Witnesses[0]
+			witness.ReplayWindow = "variant-a"
+			witness.Command.Env[powerLossReplayWindowEnv] = witness.ReplayWindow
+			witness.CutID = "cut/checkpoint-generation-2/after-meta-write/000"
+			witness.CutOccurrence = 0
+			witness.ObservedEventCount = 1
+			witness.Command.Env["TREEDB_POWERLOSS_CUT_ID"] = witness.CutID
+			for index := range manifest.TestBinaries {
+				manifest.TestBinaries[index] = writeArtifactFixture(t, root, manifest.TestBinaries[index].Kind, manifest.TestBinaries[index].Path, "binary")
+			}
+			writeModeledEvidenceFixture(t, root, &manifest, "after-meta-write")
+			rewriteArtifactJSONField(t, root, witness, ArtifactKindOperationTrace, "events", test.events)
+
+			if err := VerifyArtifacts(root, []ChildManifest{manifest}); err == nil || !strings.Contains(err.Error(), test.want) {
 				t.Fatalf("VerifyArtifacts error=%v want substring %q", err, test.want)
 			}
 		})
@@ -674,18 +723,24 @@ func mustJSON(t *testing.T, value any) string {
 
 func testOperationTraceJSON(t *testing.T, witness Witness, cutPoint string) string {
 	t.Helper()
-	events := make([]string, witness.ObservedEventCount)
-	for index := range events {
-		events[index] = "cut:" + cutPoint + ":meta:meta.db:0"
+	events := make([]string, 0, witness.ObservedEventCount+1)
+	if witness.ReplayWindow != "" {
+		events = append(events, "replay-window:"+witness.ReplayWindow)
+	}
+	for range witness.ObservedEventCount {
+		events = append(events, "cut:"+cutPoint+":meta:meta.db:0")
 	}
 	trace := map[string]any{
-		"schema_version":       "treedb-power-loss-operation-trace/v1",
+		"schema_version":       operationTraceSchemaVersion,
 		"cut_id":               witness.CutID,
 		"variant_id":           witness.Command.Env["TREEDB_POWERLOSS_VARIANT_ID"],
 		"seed":                 fmt.Sprint(witness.Seed),
 		"declared_cut_point":   cutPoint,
 		"observed_event_count": witness.ObservedEventCount,
 		"events":               events,
+	}
+	if witness.ReplayWindow != "" {
+		trace["replay_window"] = witness.ReplayWindow
 	}
 	data, err := json.Marshal(trace)
 	if err != nil {

--- a/TreeDB/internal/powerlosscert/contracts.go
+++ b/TreeDB/internal/powerlosscert/contracts.go
@@ -5,7 +5,7 @@ import (
 	"reflect"
 )
 
-const WitnessContractsSchemaVersion = "treedb-power-loss-witness-contracts/v3"
+const WitnessContractsSchemaVersion = "treedb-power-loss-witness-contracts/v4"
 
 // WitnessContracts is the committed binding between the certification issue,
 // required graph PRs, replay selectors, and the risk dimensions they are

--- a/TreeDB/internal/powerlosscert/contracts_test.go
+++ b/TreeDB/internal/powerlosscert/contracts_test.go
@@ -19,6 +19,15 @@ func TestValidateWitnessContractsRejectsCoverageRelabeling(t *testing.T) {
 	}
 }
 
+func TestValidateWitnessContractsRejectsPriorSchema(t *testing.T) {
+	plan := testRunPlan()
+	contracts := testWitnessContracts(plan)
+	contracts.SchemaVersion = "treedb-power-loss-witness-contracts/v3"
+	if err := ValidateWitnessContracts(plan, contracts); err == nil || !strings.Contains(err.Error(), "schema_version") {
+		t.Fatalf("ValidateWitnessContracts prior schema error=%v", err)
+	}
+}
+
 func TestValidateWitnessContractsRejectsRecoveryDirectorySubstitution(t *testing.T) {
 	plan := testRunPlan()
 	plan.Cases[0].ExpectedRecovery.Dir = "recovery-input/db"

--- a/TreeDB/internal/powerlosscert/manifest.go
+++ b/TreeDB/internal/powerlosscert/manifest.go
@@ -456,6 +456,9 @@ func validateWitness(prefix string, witness Witness, binaries map[string]bool) e
 	if got := witness.Command.Env[powerLossReplayWindowEnv]; got != witness.ReplayWindow {
 		return fmt.Errorf("%s command env %s=%q does not match replay window %q", prefix, powerLossReplayWindowEnv, got, witness.ReplayWindow)
 	}
+	if witness.ReplayWindow != "" && witness.Command.Env["TREEDB_POWERLOSS_VARIANT_ID"] != witness.ReplayWindow {
+		return fmt.Errorf("%s replay window %q does not match command variant %q", prefix, witness.ReplayWindow, witness.Command.Env["TREEDB_POWERLOSS_VARIANT_ID"])
+	}
 	if witness.EvidenceTier == EvidenceTierModeledCrash {
 		if _, err := normalizeRecoveryDir(witness.ExpectedRecoveryDir); err != nil {
 			return fmt.Errorf("%s: %w", prefix, err)

--- a/TreeDB/internal/powerlosscert/manifest.go
+++ b/TreeDB/internal/powerlosscert/manifest.go
@@ -13,7 +13,7 @@ import (
 )
 
 const (
-	ChildManifestSchemaVersion  = "treedb-power-loss-child/v2"
+	ChildManifestSchemaVersion  = "treedb-power-loss-child/v3"
 	RiskInventorySchemaVersion  = "treedb-power-loss-risk-inventory/v1"
 	CoverageReportSchemaVersion = "treedb-power-loss-coverage/v1"
 	SelectionPlanSchemaVersion  = "treedb-power-loss-selection/v1"
@@ -27,6 +27,7 @@ const (
 
 const (
 	powerLossReopenModeEnv       = "TREEDB_POWERLOSS_REOPEN_MODE"
+	powerLossReplayWindowEnv     = "TREEDB_POWERLOSS_REPLAY_WINDOW"
 	powerLossReopenModeReadWrite = "read-write"
 	powerLossReopenModeReadOnly  = "read-only"
 	powerLossProfileEnv          = "TREEDB_POWERLOSS_PROFILE"
@@ -136,6 +137,7 @@ type Witness struct {
 	ExpectedRecoveryDir    string       `json:"expected_recovery_dir,omitempty"`
 	State                  WitnessState `json:"state"`
 	StateComparison        string       `json:"state_comparison,omitempty"`
+	ReplayWindow           string       `json:"replay_window,omitempty"`
 	CounterexampleID       string       `json:"counterexample_id,omitempty"`
 	NegativeControlID      string       `json:"negative_control_id,omitempty"`
 	Seed                   uint64       `json:"seed"`
@@ -450,6 +452,9 @@ func validateWitness(prefix string, witness Witness, binaries map[string]bool) e
 	}
 	if witness.StateComparison != stateComparisonExact && witness.StateComparison != stateComparisonLogicalHorizon {
 		return fmt.Errorf("%s has invalid state comparison %q", prefix, witness.StateComparison)
+	}
+	if got := witness.Command.Env[powerLossReplayWindowEnv]; got != witness.ReplayWindow {
+		return fmt.Errorf("%s command env %s=%q does not match replay window %q", prefix, powerLossReplayWindowEnv, got, witness.ReplayWindow)
 	}
 	if witness.EvidenceTier == EvidenceTierModeledCrash {
 		if _, err := normalizeRecoveryDir(witness.ExpectedRecoveryDir); err != nil {

--- a/TreeDB/internal/powerlosscert/manifest.go
+++ b/TreeDB/internal/powerlosscert/manifest.go
@@ -135,6 +135,7 @@ type Witness struct {
 	TypedError             string       `json:"typed_error"`
 	ExpectedRecoveryDir    string       `json:"expected_recovery_dir,omitempty"`
 	State                  WitnessState `json:"state"`
+	StateComparison        string       `json:"state_comparison,omitempty"`
 	CounterexampleID       string       `json:"counterexample_id,omitempty"`
 	NegativeControlID      string       `json:"negative_control_id,omitempty"`
 	Seed                   uint64       `json:"seed"`
@@ -446,6 +447,9 @@ func validateWitness(prefix string, witness Witness, binaries map[string]bool) e
 	state := witness.State
 	if state.RootMetaGeneration == "" || state.FreelistGeneration == "" || state.ExternalFrontiers == "" || state.NamespaceGeneration == "" || state.WALLineage == "" || state.DurableLSN == "" || state.CleanupPins == "" {
 		return fmt.Errorf("%s has incomplete recovery-state metadata", prefix)
+	}
+	if witness.StateComparison != stateComparisonExact && witness.StateComparison != stateComparisonLogicalHorizon {
+		return fmt.Errorf("%s has invalid state comparison %q", prefix, witness.StateComparison)
 	}
 	if witness.EvidenceTier == EvidenceTierModeledCrash {
 		if _, err := normalizeRecoveryDir(witness.ExpectedRecoveryDir); err != nil {

--- a/TreeDB/internal/powerlosscert/manifest_test.go
+++ b/TreeDB/internal/powerlosscert/manifest_test.go
@@ -56,6 +56,16 @@ func TestValidateBundleRejectsPriorChildManifestSchema(t *testing.T) {
 	}
 }
 
+func TestValidateBundleBindsReplayWindowToCommandVariant(t *testing.T) {
+	manifest := testChildManifest("witness-a")
+	witness := &manifest.Witnesses[0]
+	witness.ReplayWindow = "variant-b"
+	witness.Command.Env[powerLossReplayWindowEnv] = witness.ReplayWindow
+	if err := ValidateBundle(testRepositorySHA, testRiskInventory(), []ChildManifest{manifest}); err == nil || !strings.Contains(err.Error(), "does not match command variant") {
+		t.Fatalf("ValidateBundle replay-window variant binding error=%v", err)
+	}
+}
+
 func TestValidateBundleRejectsModeledEvidenceReuseAcrossWitnesses(t *testing.T) {
 	manifest := testChildManifest("witness-a")
 	reused := manifest.Witnesses[0]

--- a/TreeDB/internal/powerlosscert/manifest_test.go
+++ b/TreeDB/internal/powerlosscert/manifest_test.go
@@ -25,7 +25,7 @@ func TestCommittedRiskInventoryIsValid(t *testing.T) {
 }
 
 func TestParseChildManifestRejectsUnknownFields(t *testing.T) {
-	data := []byte(`{"schema_version":"treedb-power-loss-child/v2","unexpected":true}`)
+	data := []byte(`{"schema_version":"treedb-power-loss-child/v3","unexpected":true}`)
 	if _, err := ParseChildManifest(data); err == nil || !strings.Contains(err.Error(), "unknown field") {
 		t.Fatalf("ParseChildManifest error=%v, want unknown-field rejection", err)
 	}
@@ -45,6 +45,14 @@ func TestValidateBundleRejectsStaleSHAAndDuplicateWitnessIDs(t *testing.T) {
 	duplicate.Issue = 3675
 	if err := ValidateBundle(testRepositorySHA, inventory, []ChildManifest{manifest, duplicate}); err == nil || !strings.Contains(err.Error(), "duplicate witness id") {
 		t.Fatalf("ValidateBundle duplicate error=%v", err)
+	}
+}
+
+func TestValidateBundleRejectsPriorChildManifestSchema(t *testing.T) {
+	manifest := testChildManifest("witness-a")
+	manifest.SchemaVersion = "treedb-power-loss-child/v2"
+	if err := ValidateBundle(testRepositorySHA, testRiskInventory(), []ChildManifest{manifest}); err == nil || !strings.Contains(err.Error(), "schema_version") {
+		t.Fatalf("ValidateBundle prior child schema error=%v", err)
 	}
 }
 

--- a/TreeDB/internal/powerlosscert/runner.go
+++ b/TreeDB/internal/powerlosscert/runner.go
@@ -930,7 +930,11 @@ func validateExecutedRecovery(runCase RunCase, trace operationTraceArtifact, rec
 	if err := validateRecoveryStats(recovery, runCase.Profile); err != nil {
 		return fmt.Errorf("%s: %w", prefix, err)
 	}
-	if got := observedWitnessState(recovery); got != runCase.State {
+	got, err := observedWitnessStateForComparison(recovery, runCase.StateComparison)
+	if err != nil {
+		return fmt.Errorf("%s: %w", prefix, err)
+	}
+	if got != runCase.State {
 		return fmt.Errorf("%s observed recovery state=%+v want frozen state=%+v", prefix, got, runCase.State)
 	}
 	return nil
@@ -960,6 +964,48 @@ func observedWitnessState(recovery recoveryTraceArtifact) WitnessState {
 		CleanupPins: fmt.Sprintf("slot0_commit_seq=%s slot1_commit_seq=%s",
 			stat("treedb.durable_root.slot0.commit_seq"), stat("treedb.durable_root.slot1.commit_seq")),
 	}
+}
+
+func observedWitnessStateForComparison(recovery recoveryTraceArtifact, comparison string) (WitnessState, error) {
+	if comparison == stateComparisonExact {
+		return observedWitnessState(recovery), nil
+	}
+	if comparison != stateComparisonLogicalHorizon {
+		return WitnessState{}, fmt.Errorf("invalid state comparison %q", comparison)
+	}
+	if recovery.Rejected {
+		return WitnessState{}, fmt.Errorf("logical-horizon state comparison requires accepted recovery")
+	}
+	stat := func(key string) string { return recovery.Stats[key] }
+	selectedSlot := stat("treedb.durable_root.selected_slot")
+	selectedCommit := stat("treedb.durable_root.commit_seq")
+	var fallbackCommit string
+	switch selectedSlot {
+	case "0":
+		fallbackCommit = stat("treedb.durable_root.slot1.commit_seq")
+	case "1":
+		fallbackCommit = stat("treedb.durable_root.slot0.commit_seq")
+	default:
+		return WitnessState{}, fmt.Errorf("logical-horizon state has invalid selected slot %q", selectedSlot)
+	}
+	if selectedCommit == "" || fallbackCommit == "" {
+		return WitnessState{}, fmt.Errorf("logical-horizon state is missing selected or fallback commit sequence")
+	}
+	freelistGeneration, err := strconv.ParseUint(stat("treedb.durable_root.freelist.generation"), 10, 64)
+	if err != nil || freelistGeneration == 0 {
+		return WitnessState{}, fmt.Errorf("logical-horizon state has invalid freelist generation %q", stat("treedb.durable_root.freelist.generation"))
+	}
+	return WitnessState{
+		RootMetaGeneration: fmt.Sprintf("selected_commit_seq=%s fallback_commit_seq=%s", selectedCommit, fallbackCommit),
+		FreelistGeneration: "generation=persisted",
+		ExternalFrontiers: fmt.Sprintf("stable_image_tree_artifact=stable_image_tree.json manifest_entries=%s",
+			stat("treedb.durable_root.manifest.entries")),
+		NamespaceGeneration: "stable_image_tree_artifact=stable_image_tree.json",
+		WALLineage:          fmt.Sprintf("profile=%s applied_lsn=%s", stat("treedb.profile.resolved"), stat("treedb.applied_command_lsn")),
+		DurableLSN: fmt.Sprintf("durable_wal_lsn=%s durable_root_commit_seq=%s",
+			stat("treedb.command_wal.durable_wal_lsn"), selectedCommit),
+		CleanupPins: fmt.Sprintf("selected_commit_seq=%s fallback_commit_seq=%s", selectedCommit, fallbackCommit),
+	}, nil
 }
 
 func buildChildManifest(plan RunPlan, outputRoot string, binaries map[string]Artifact, executed []executedCase, performanceSHA string) (ChildManifest, error) {
@@ -996,6 +1042,10 @@ func buildChildManifest(plan RunPlan, outputRoot string, binaries map[string]Art
 		if err != nil {
 			return ChildManifest{}, fmt.Errorf("powerlosscert: case %q: %w", runCase.ID, err)
 		}
+		state, err := observedWitnessStateForComparison(result.recovery, runCase.StateComparison)
+		if err != nil {
+			return ChildManifest{}, fmt.Errorf("powerlosscert: case %q: %w", runCase.ID, err)
+		}
 		witness := Witness{
 			ID:                     runCase.ID,
 			EvidenceTier:           EvidenceTierModeledCrash,
@@ -1011,7 +1061,8 @@ func buildChildManifest(plan RunPlan, outputRoot string, binaries map[string]Art
 			ActualOutcome:          runCase.ExpectedOutcome,
 			TypedError:             runCase.ExpectedTypedError,
 			ExpectedRecoveryDir:    expectedRecoveryDir,
-			State:                  observedWitnessState(result.recovery),
+			State:                  state,
+			StateComparison:        runCase.StateComparison,
 			CounterexampleID:       runCase.CounterexampleID,
 			NegativeControlID:      runCase.NegativeControlID,
 			Seed:                   runCase.Seed,

--- a/TreeDB/internal/powerlosscert/runner.go
+++ b/TreeDB/internal/powerlosscert/runner.go
@@ -979,17 +979,27 @@ func observedWitnessStateForComparison(recovery recoveryTraceArtifact, compariso
 	stat := func(key string) string { return recovery.Stats[key] }
 	selectedSlot := stat("treedb.durable_root.selected_slot")
 	selectedCommit := stat("treedb.durable_root.commit_seq")
-	var fallbackCommit string
+	var selectedSlotCommit, fallbackCommit string
 	switch selectedSlot {
 	case "0":
+		selectedSlotCommit = stat("treedb.durable_root.slot0.commit_seq")
 		fallbackCommit = stat("treedb.durable_root.slot1.commit_seq")
 	case "1":
+		selectedSlotCommit = stat("treedb.durable_root.slot1.commit_seq")
 		fallbackCommit = stat("treedb.durable_root.slot0.commit_seq")
 	default:
 		return WitnessState{}, fmt.Errorf("logical-horizon state has invalid selected slot %q", selectedSlot)
 	}
 	if selectedCommit == "" || fallbackCommit == "" {
 		return WitnessState{}, fmt.Errorf("logical-horizon state is missing selected or fallback commit sequence")
+	}
+	if selectedSlotCommit != selectedCommit {
+		return WitnessState{}, fmt.Errorf("logical-horizon state selected slot commit=%q does not match durable root commit=%q", selectedSlotCommit, selectedCommit)
+	}
+	selectedCommitNumber, selectedErr := strconv.ParseUint(selectedCommit, 10, 64)
+	fallbackCommitNumber, fallbackErr := strconv.ParseUint(fallbackCommit, 10, 64)
+	if selectedErr != nil || fallbackErr != nil || selectedCommitNumber <= fallbackCommitNumber {
+		return WitnessState{}, fmt.Errorf("logical-horizon state has invalid selected/fallback commits %q/%q", selectedCommit, fallbackCommit)
 	}
 	freelistGeneration, err := strconv.ParseUint(stat("treedb.durable_root.freelist.generation"), 10, 64)
 	if err != nil || freelistGeneration == 0 {

--- a/TreeDB/internal/powerlosscert/runner.go
+++ b/TreeDB/internal/powerlosscert/runner.go
@@ -721,6 +721,9 @@ func executeRunCase(outputRoot string, plan RunPlan, runCase RunCase, binary Art
 		"TREEDB_POWERLOSS_REOPEN_MODE":      runCase.ReopenMode,
 		powerLossProfileEnv:                 runCase.Profile,
 	}
+	if runCase.ReplayWindow != "" {
+		env[powerLossReplayWindowEnv] = runCase.ReplayWindow
+	}
 	ledgerPath := filepath.Join(outputRoot, "inputs", "power_loss_counterexamples.json")
 	if _, err := os.Stat(ledgerPath); err == nil {
 		env["TREEDB_POWERLOSS_COUNTEREXAMPLE_LEDGER"] = "inputs/power_loss_counterexamples.json"
@@ -899,7 +902,7 @@ func environmentList(values map[string]string) []string {
 
 func validateExecutedRecovery(runCase RunCase, trace operationTraceArtifact, recovery recoveryTraceArtifact) error {
 	prefix := fmt.Sprintf("powerlosscert: case %q", runCase.ID)
-	if trace.CutID != runCase.CutID || trace.VariantID != runCase.VariantID || trace.Seed != strconv.FormatUint(runCase.Seed, 10) || trace.DeclaredCutPoint != runCase.CutPoint {
+	if trace.CutID != runCase.CutID || trace.VariantID != runCase.VariantID || trace.Seed != strconv.FormatUint(runCase.Seed, 10) || trace.DeclaredCutPoint != runCase.CutPoint || trace.ReplayWindow != runCase.ReplayWindow {
 		return fmt.Errorf("%s operation trace does not match the frozen replay selector", prefix)
 	}
 	_, occurrence, err := parseCutAddress(runCase.CutID)
@@ -1073,6 +1076,7 @@ func buildChildManifest(plan RunPlan, outputRoot string, binaries map[string]Art
 			ExpectedRecoveryDir:    expectedRecoveryDir,
 			State:                  state,
 			StateComparison:        runCase.StateComparison,
+			ReplayWindow:           runCase.ReplayWindow,
 			CounterexampleID:       runCase.CounterexampleID,
 			NegativeControlID:      runCase.NegativeControlID,
 			Seed:                   runCase.Seed,

--- a/TreeDB/internal/powerlosscert/runner_test.go
+++ b/TreeDB/internal/powerlosscert/runner_test.go
@@ -619,6 +619,37 @@ func TestValidateExecutedRecoveryMatchesFrozenExpectation(t *testing.T) {
 	}
 }
 
+func TestObservedWitnessStateLogicalHorizonIgnoresSlotParityAndGenerationCounters(t *testing.T) {
+	recovery := func(selectedSlot, slot0, slot1, generation, durableSeq string) recoveryTraceArtifact {
+		return recoveryTraceArtifact{Stats: map[string]string{
+			"treedb.profile.resolved":                 "command_wal_durable",
+			"treedb.applied_command_lsn":              "19",
+			"treedb.durable_root.selected_slot":       selectedSlot,
+			"treedb.durable_root.commit_seq":          "13",
+			"treedb.durable_root.durable_seq":         durableSeq,
+			"treedb.durable_root.freelist.generation": generation,
+			"treedb.durable_root.manifest.entries":    "9",
+			"treedb.durable_root.slot0.commit_seq":    slot0,
+			"treedb.durable_root.slot1.commit_seq":    slot1,
+			"treedb.command_wal.durable_wal_lsn":      "0",
+		}}
+	}
+	first, err := observedWitnessStateForComparison(recovery("1", "12", "13", "23", "10"), stateComparisonLogicalHorizon)
+	if err != nil {
+		t.Fatal(err)
+	}
+	second, err := observedWitnessStateForComparison(recovery("0", "13", "12", "24", "11"), stateComparisonLogicalHorizon)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if first != second {
+		t.Fatalf("logical states differ across equivalent slot/generation layouts:\nfirst=%+v\nsecond=%+v", first, second)
+	}
+	if first.RootMetaGeneration != "selected_commit_seq=13 fallback_commit_seq=12" || first.FreelistGeneration != "generation=persisted" || first.DurableLSN != "durable_wal_lsn=0 durable_root_commit_seq=13" {
+		t.Fatalf("unexpected logical state: %+v", first)
+	}
+}
+
 func TestValidateExecutedRecoveryRejectsPostHocOutcomeChange(t *testing.T) {
 	runCase := RunCase{
 		ID:               "rejected-read-write",

--- a/TreeDB/internal/powerlosscert/runplan.go
+++ b/TreeDB/internal/powerlosscert/runplan.go
@@ -62,6 +62,7 @@ type RunCase struct {
 	ExpectedOutcome        string              `json:"expected_outcome"`
 	ExpectedTypedError     string              `json:"expected_typed_error"`
 	State                  WitnessState        `json:"state"`
+	StateComparison        string              `json:"state_comparison,omitempty"`
 	CounterexampleID       string              `json:"counterexample_id,omitempty"`
 	NegativeControlID      string              `json:"negative_control_id,omitempty"`
 	Seed                   uint64              `json:"seed"`
@@ -72,6 +73,11 @@ type RunCase struct {
 	ExpectedRecovery       RecoveryExpectation `json:"expected_recovery"`
 	ClaimBoundary          string              `json:"claim_boundary"`
 }
+
+const (
+	stateComparisonExact          = ""
+	stateComparisonLogicalHorizon = "logical_horizon"
+)
 
 // RunPlan freezes repository provenance and the exact modeled cases before
 // execution. PullRequests includes every implementation/review merge whose
@@ -199,6 +205,9 @@ func validateRunCase(inventory RiskInventory, runCase RunCase) error {
 	if runCase.ReopenMode != powerLossReopenModeReadWrite && runCase.ReopenMode != powerLossReopenModeReadOnly {
 		return fmt.Errorf("%s has invalid reopen mode %q", prefix, runCase.ReopenMode)
 	}
+	if runCase.StateComparison != stateComparisonExact && runCase.StateComparison != stateComparisonLogicalHorizon {
+		return fmt.Errorf("%s has invalid state comparison %q", prefix, runCase.StateComparison)
+	}
 	expectedRecoveryDir, err := normalizeRecoveryDir(runCase.ExpectedRecovery.Dir)
 	if err != nil {
 		return fmt.Errorf("%s: %w", prefix, err)
@@ -243,6 +252,7 @@ func validateRunCase(inventory RiskInventory, runCase RunCase) error {
 		TypedError:             runCase.ExpectedTypedError,
 		ExpectedRecoveryDir:    expectedRecoveryDir,
 		State:                  runCase.State,
+		StateComparison:        runCase.StateComparison,
 		CounterexampleID:       runCase.CounterexampleID,
 		NegativeControlID:      runCase.NegativeControlID,
 		Seed:                   runCase.Seed,

--- a/TreeDB/internal/powerlosscert/runplan.go
+++ b/TreeDB/internal/powerlosscert/runplan.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 )
 
-const RunPlanSchemaVersion = "treedb-power-loss-run-plan/v3"
+const RunPlanSchemaVersion = "treedb-power-loss-run-plan/v4"
 
 const CertifiedRepositoryRef = "refs/remotes/origin/main"
 
@@ -70,6 +70,7 @@ type RunCase struct {
 	VariantID              string              `json:"variant_id"`
 	CutPoint               string              `json:"cut_point"`
 	ReopenMode             string              `json:"reopen_mode"`
+	ReplayWindow           string              `json:"replay_window,omitempty"`
 	ExpectedRecovery       RecoveryExpectation `json:"expected_recovery"`
 	ClaimBoundary          string              `json:"claim_boundary"`
 }
@@ -205,6 +206,9 @@ func validateRunCase(inventory RiskInventory, runCase RunCase) error {
 	if runCase.ReopenMode != powerLossReopenModeReadWrite && runCase.ReopenMode != powerLossReopenModeReadOnly {
 		return fmt.Errorf("%s has invalid reopen mode %q", prefix, runCase.ReopenMode)
 	}
+	if runCase.ReplayWindow != "" && runCase.ReplayWindow != runCase.VariantID {
+		return fmt.Errorf("%s replay window=%q does not match variant id=%q", prefix, runCase.ReplayWindow, runCase.VariantID)
+	}
 	if runCase.StateComparison != stateComparisonExact && runCase.StateComparison != stateComparisonLogicalHorizon {
 		return fmt.Errorf("%s has invalid state comparison %q", prefix, runCase.StateComparison)
 	}
@@ -236,6 +240,9 @@ func validateRunCase(inventory RiskInventory, runCase RunCase) error {
 		powerLossReopenModeEnv:              runCase.ReopenMode,
 		powerLossProfileEnv:                 runCase.Profile,
 	}
+	if runCase.ReplayWindow != "" {
+		env[powerLossReplayWindowEnv] = runCase.ReplayWindow
+	}
 	witness := Witness{
 		ID:                     runCase.ID,
 		EvidenceTier:           EvidenceTierModeledCrash,
@@ -253,6 +260,7 @@ func validateRunCase(inventory RiskInventory, runCase RunCase) error {
 		ExpectedRecoveryDir:    expectedRecoveryDir,
 		State:                  runCase.State,
 		StateComparison:        runCase.StateComparison,
+		ReplayWindow:           runCase.ReplayWindow,
 		CounterexampleID:       runCase.CounterexampleID,
 		NegativeControlID:      runCase.NegativeControlID,
 		Seed:                   runCase.Seed,

--- a/TreeDB/internal/powerlosscert/runplan_test.go
+++ b/TreeDB/internal/powerlosscert/runplan_test.go
@@ -6,7 +6,7 @@ import (
 )
 
 func TestParseRunPlanRejectsUnknownFields(t *testing.T) {
-	if _, err := ParseRunPlan([]byte(`{"schema_version":"treedb-power-loss-run-plan/v3","unknown":true}`)); err == nil || !strings.Contains(err.Error(), "unknown field") {
+	if _, err := ParseRunPlan([]byte(`{"schema_version":"treedb-power-loss-run-plan/v4","unknown":true}`)); err == nil || !strings.Contains(err.Error(), "unknown field") {
 		t.Fatalf("ParseRunPlan unknown-field error=%v", err)
 	}
 }
@@ -15,6 +15,20 @@ func TestValidateRunPlanAcceptsFrozenExpectedRecovery(t *testing.T) {
 	plan := testRunPlan()
 	if err := ValidateRunPlan(testRiskInventory(), plan); err != nil {
 		t.Fatal(err)
+	}
+}
+
+func TestValidateRunPlanRejectsPriorSchemaAndMismatchedReplayWindow(t *testing.T) {
+	plan := testRunPlan()
+	plan.SchemaVersion = "treedb-power-loss-run-plan/v3"
+	if err := ValidateRunPlan(testRiskInventory(), plan); err == nil || !strings.Contains(err.Error(), "schema_version") {
+		t.Fatalf("ValidateRunPlan prior schema error=%v", err)
+	}
+
+	plan = testRunPlan()
+	plan.Cases[0].ReplayWindow = "another-variant"
+	if err := ValidateRunPlan(testRiskInventory(), plan); err == nil || !strings.Contains(err.Error(), "does not match variant id") {
+		t.Fatalf("ValidateRunPlan mismatched replay window error=%v", err)
 	}
 }
 

--- a/TreeDB/internal/powerlossoracle/evidence.go
+++ b/TreeDB/internal/powerlossoracle/evidence.go
@@ -132,13 +132,7 @@ func BeginEvidenceFromEnv(model *Model, readOnly bool) (*EvidenceSession, error)
 		return nil, err
 	}
 	trace := portableEvidenceTrace(model.Trace())
-	cutPrefix := "cut:" + request.CutPoint + ":"
-	observed := 0
-	for _, event := range trace {
-		if strings.HasPrefix(event, cutPrefix) {
-			observed++
-		}
-	}
+	observed := replayWindowCutCount(trace, request.CutPoint, request.Selector.VariantID)
 	if observed == 0 {
 		return nil, errorsf("declared cut point %q was not observed", request.CutPoint)
 	}
@@ -212,6 +206,22 @@ func BeginEvidenceFromEnv(model *Model, readOnly bool) (*EvidenceSession, error)
 		stableTreeSHA256:   stableTreeSHA256,
 		stableFingerprint:  model.StableFingerprint(),
 	}, nil
+}
+
+func replayWindowCutCount(trace []string, cutPoint, variantID string) int {
+	cutPrefix := "cut:" + cutPoint + ":"
+	windowMarker := replayWindowMarker(variantID)
+	observed := 0
+	for _, event := range trace {
+		if event == windowMarker {
+			observed = 0
+			continue
+		}
+		if strings.HasPrefix(event, cutPrefix) {
+			observed++
+		}
+	}
+	return observed
 }
 
 func portableEvidenceTrace(trace []string) []string {

--- a/TreeDB/internal/powerlossoracle/evidence.go
+++ b/TreeDB/internal/powerlossoracle/evidence.go
@@ -15,20 +15,22 @@ import (
 )
 
 const (
-	EnvEvidenceDir        = "TREEDB_POWERLOSS_EVIDENCE_DIR"
-	EnvEvidenceCutPoint   = "TREEDB_POWERLOSS_EXPECT_CUT_POINT"
-	EnvEvidenceReopenMode = "TREEDB_POWERLOSS_REOPEN_MODE"
+	EnvEvidenceDir          = "TREEDB_POWERLOSS_EVIDENCE_DIR"
+	EnvEvidenceCutPoint     = "TREEDB_POWERLOSS_EXPECT_CUT_POINT"
+	EnvEvidenceReopenMode   = "TREEDB_POWERLOSS_REOPEN_MODE"
+	EnvEvidenceReplayWindow = "TREEDB_POWERLOSS_REPLAY_WINDOW"
 
 	EvidenceReopenReadWrite = "read-write"
 	EvidenceReopenReadOnly  = "read-only"
 )
 
 type EvidenceRequest struct {
-	Root       string
-	CutPoint   string
-	Selector   ReplaySelector
-	Occurrence int
-	ReopenMode string
+	Root         string
+	CutPoint     string
+	Selector     ReplaySelector
+	Occurrence   int
+	ReopenMode   string
+	ReplayWindow string
 }
 
 func (request EvidenceRequest) Enabled() bool {
@@ -53,6 +55,7 @@ type evidenceTrace struct {
 	VariantID          string   `json:"variant_id"`
 	Seed               string   `json:"seed"`
 	DeclaredCutPoint   string   `json:"declared_cut_point"`
+	ReplayWindow       string   `json:"replay_window,omitempty"`
 	ObservedEventCount int      `json:"observed_event_count"`
 	Events             []string `json:"events"`
 }
@@ -85,7 +88,8 @@ func EvidenceRequestFromEnv() (EvidenceRequest, error) {
 	root := os.Getenv(EnvEvidenceDir)
 	cutPoint := os.Getenv(EnvEvidenceCutPoint)
 	reopenMode := os.Getenv(EnvEvidenceReopenMode)
-	if root == "" && cutPoint == "" && reopenMode == "" {
+	replayWindow := os.Getenv(EnvEvidenceReplayWindow)
+	if root == "" && cutPoint == "" && reopenMode == "" && replayWindow == "" {
 		return EvidenceRequest{}, nil
 	}
 	if root == "" || cutPoint == "" || reopenMode == "" {
@@ -108,12 +112,16 @@ func EvidenceRequestFromEnv() (EvidenceRequest, error) {
 	if replayCutPoint != cutPoint {
 		return EvidenceRequest{}, errorsf("replay cut point %q does not match declared cut point %q", replayCutPoint, cutPoint)
 	}
+	if replayWindow != "" && replayWindow != selector.VariantID {
+		return EvidenceRequest{}, errorsf("evidence replay window %q does not match replay variant %q", replayWindow, selector.VariantID)
+	}
 	return EvidenceRequest{
-		Root:       root,
-		CutPoint:   cutPoint,
-		Selector:   selector,
-		Occurrence: replayOccurrence,
-		ReopenMode: reopenMode,
+		Root:         root,
+		CutPoint:     cutPoint,
+		Selector:     selector,
+		Occurrence:   replayOccurrence,
+		ReopenMode:   reopenMode,
+		ReplayWindow: replayWindow,
 	}, nil
 }
 
@@ -132,7 +140,10 @@ func BeginEvidenceFromEnv(model *Model, readOnly bool) (*EvidenceSession, error)
 		return nil, err
 	}
 	trace := portableEvidenceTrace(model.Trace())
-	observed := replayWindowCutCount(trace, request.CutPoint, request.Selector.VariantID)
+	observed, err := replayWindowCutCount(trace, request.CutPoint, request.ReplayWindow)
+	if err != nil {
+		return nil, err
+	}
 	if observed == 0 {
 		return nil, errorsf("declared cut point %q was not observed", request.CutPoint)
 	}
@@ -167,11 +178,12 @@ func BeginEvidenceFromEnv(model *Model, readOnly bool) (*EvidenceSession, error)
 		return nil, err
 	}
 	if err := writeEvidenceJSON(filepath.Join(request.Root, "operation_trace.json"), evidenceTrace{
-		SchemaVersion:      "treedb-power-loss-operation-trace/v1",
+		SchemaVersion:      "treedb-power-loss-operation-trace/v2",
 		CutID:              request.Selector.CutID,
 		VariantID:          request.Selector.VariantID,
 		Seed:               strconv.FormatUint(request.Selector.Seed, 10),
 		DeclaredCutPoint:   request.CutPoint,
+		ReplayWindow:       request.ReplayWindow,
 		ObservedEventCount: observed,
 		Events:             trace,
 	}); err != nil {
@@ -208,20 +220,38 @@ func BeginEvidenceFromEnv(model *Model, readOnly bool) (*EvidenceSession, error)
 	}, nil
 }
 
-func replayWindowCutCount(trace []string, cutPoint, variantID string) int {
+func replayWindowCutCount(trace []string, cutPoint, replayWindow string) (int, error) {
 	cutPrefix := "cut:" + cutPoint + ":"
-	windowMarker := replayWindowMarker(variantID)
+	windowMarker := replayWindowMarker(replayWindow)
 	observed := 0
+	markerCount := 0
+	inWindow := replayWindow == ""
 	for _, event := range trace {
-		if event == windowMarker {
-			observed = 0
+		if strings.HasPrefix(event, "replay-window:") {
+			if replayWindow == "" {
+				return 0, errorsf("operation trace contains replay-window marker without a declared replay window")
+			}
+			if event != windowMarker {
+				return 0, errorsf("operation trace replay-window marker %q does not match declared replay window %q", event, replayWindow)
+			}
+			markerCount++
+			if markerCount > 1 {
+				return 0, errorsf("operation trace requires exactly one replay-window marker %q; found %d", windowMarker, markerCount)
+			}
+			inWindow = true
 			continue
 		}
-		if strings.HasPrefix(event, cutPrefix) {
+		if inWindow && strings.HasPrefix(event, cutPrefix) {
 			observed++
 		}
 	}
-	return observed
+	if replayWindow != "" && markerCount != 1 {
+		return 0, errorsf("operation trace requires exactly one replay-window marker %q; found %d", windowMarker, markerCount)
+	}
+	if replayWindow != "" && observed == 0 {
+		return 0, errorsf("operation trace replay-window marker %q does not precede a matching cut %q", windowMarker, cutPoint)
+	}
+	return observed, nil
 }
 
 func portableEvidenceTrace(trace []string) []string {

--- a/TreeDB/internal/powerlossoracle/evidence_test.go
+++ b/TreeDB/internal/powerlossoracle/evidence_test.go
@@ -165,6 +165,20 @@ func TestEvidenceRequestFromEnvRequiresValidReopenMode(t *testing.T) {
 	}
 }
 
+func TestEvidenceRequestFromEnvRejectsReplayWindowVariantMismatch(t *testing.T) {
+	t.Setenv(EnvEvidenceDir, filepath.Join(canonicalTempDir(t), "evidence"))
+	t.Setenv(EnvEvidenceCutPoint, string(durabilitycut.AfterMetaWrite))
+	t.Setenv(EnvEvidenceReopenMode, EvidenceReopenReadOnly)
+	t.Setenv(EnvReplayCut, "cut/checkpoint-generation-2/after-meta-write/000")
+	t.Setenv(EnvReplayVariant, "variant-a")
+	t.Setenv(EnvReplaySeed, "1")
+	t.Setenv(EnvEvidenceReplayWindow, "variant-b")
+
+	if _, err := EvidenceRequestFromEnv(); err == nil || !strings.Contains(err.Error(), "does not match replay variant") {
+		t.Fatalf("EvidenceRequestFromEnv replay-window mismatch error=%v", err)
+	}
+}
+
 func TestBeginEvidenceFromEnvRejectsReopenModeMismatchBeforeCapture(t *testing.T) {
 	source := t.TempDir()
 	if err := os.WriteFile(filepath.Join(source, "index.db"), []byte("old"), 0o600); err != nil {
@@ -247,6 +261,7 @@ func TestBeginEvidenceFromEnvScopesOccurrenceAfterReplayWindowAndRetainsPrefix(t
 	t.Setenv(EnvReplayCut, "cut/checkpoint-generation-2/after-meta-write/000")
 	t.Setenv(EnvReplayVariant, "variant-a")
 	t.Setenv(EnvReplaySeed, "1")
+	t.Setenv(EnvEvidenceReplayWindow, "variant-a")
 
 	session, err := BeginEvidenceFromEnv(model, false)
 	if err != nil {
@@ -263,8 +278,11 @@ func TestBeginEvidenceFromEnvScopesOccurrenceAfterReplayWindowAndRetainsPrefix(t
 	if err := json.Unmarshal(data, &trace); err != nil {
 		t.Fatal(err)
 	}
-	if got := replayWindowCutCount(trace.Events, string(durabilitycut.AfterMetaWrite), "variant-a"); got != 1 {
-		t.Fatalf("window-relative trace cuts=%d want 1", got)
+	if got, err := replayWindowCutCount(trace.Events, string(durabilitycut.AfterMetaWrite), "variant-a"); err != nil || got != 1 {
+		t.Fatalf("window-relative trace cuts=%d error=%v want 1", got, err)
+	}
+	if trace.ReplayWindow != "variant-a" {
+		t.Fatalf("trace replay window=%q want variant-a", trace.ReplayWindow)
 	}
 	allCuts := 0
 	for _, event := range trace.Events {
@@ -275,6 +293,86 @@ func TestBeginEvidenceFromEnvScopesOccurrenceAfterReplayWindowAndRetainsPrefix(t
 	if allCuts != 3 {
 		t.Fatalf("retained full-trace cuts=%d want 3", allCuts)
 	}
+}
+
+func TestBeginEvidenceFromEnvRejectsInvalidReplayWindowTrace(t *testing.T) {
+	newModel := func(t *testing.T) (*Model, string) {
+		t.Helper()
+		source := t.TempDir()
+		if err := os.WriteFile(filepath.Join(source, "index.db"), []byte("old"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		model, err := Capture(source)
+		if err != nil {
+			t.Fatal(err)
+		}
+		return model, source
+	}
+	setEnv := func(t *testing.T) {
+		t.Helper()
+		t.Setenv(EnvEvidenceDir, filepath.Join(canonicalTempDir(t), "evidence"))
+		t.Setenv(EnvEvidenceCutPoint, string(durabilitycut.AfterMetaWrite))
+		t.Setenv(EnvEvidenceReopenMode, EvidenceReopenReadWrite)
+		t.Setenv(EnvReplayCut, "cut/checkpoint-generation-2/after-meta-write/000")
+		t.Setenv(EnvReplayVariant, "variant-a")
+		t.Setenv(EnvReplaySeed, "1")
+		t.Setenv(EnvEvidenceReplayWindow, "variant-a")
+	}
+	observe := func(t *testing.T, model *Model, source string) {
+		t.Helper()
+		if err := model.Observe(source, durabilitycut.Event{Point: durabilitycut.AfterMetaWrite, Resource: durabilitycut.ResourceMeta}); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	t.Run("missing-marker", func(t *testing.T) {
+		model, source := newModel(t)
+		observe(t, model, source)
+		setEnv(t)
+		if _, err := BeginEvidenceFromEnv(model, false); err == nil || !strings.Contains(err.Error(), "exactly one replay-window marker") {
+			t.Fatalf("BeginEvidenceFromEnv missing-marker error=%v", err)
+		}
+	})
+
+	t.Run("duplicate-marker", func(t *testing.T) {
+		model, source := newModel(t)
+		if err := model.BeginReplayWindow("variant-a"); err != nil {
+			t.Fatal(err)
+		}
+		if err := model.BeginReplayWindow("variant-a"); err != nil {
+			t.Fatal(err)
+		}
+		observe(t, model, source)
+		setEnv(t)
+		if _, err := BeginEvidenceFromEnv(model, false); err == nil || !strings.Contains(err.Error(), "exactly one replay-window marker") {
+			t.Fatalf("BeginEvidenceFromEnv duplicate-marker error=%v", err)
+		}
+	})
+
+	t.Run("marker-after-last-cut", func(t *testing.T) {
+		model, source := newModel(t)
+		observe(t, model, source)
+		if err := model.BeginReplayWindow("variant-a"); err != nil {
+			t.Fatal(err)
+		}
+		setEnv(t)
+		if _, err := BeginEvidenceFromEnv(model, false); err == nil || !strings.Contains(err.Error(), "does not precede a matching cut") {
+			t.Fatalf("BeginEvidenceFromEnv misordered-marker error=%v", err)
+		}
+	})
+
+	t.Run("undeclared-marker", func(t *testing.T) {
+		model, source := newModel(t)
+		if err := model.BeginReplayWindow("variant-a"); err != nil {
+			t.Fatal(err)
+		}
+		observe(t, model, source)
+		setEnv(t)
+		t.Setenv(EnvEvidenceReplayWindow, "")
+		if _, err := BeginEvidenceFromEnv(model, false); err == nil || !strings.Contains(err.Error(), "without a declared replay window") {
+			t.Fatalf("BeginEvidenceFromEnv undeclared-marker error=%v", err)
+		}
+	})
 }
 
 func TestBeginEvidenceFromEnvRejectsSymlinkedEvidenceRoot(t *testing.T) {

--- a/TreeDB/internal/powerlossoracle/evidence_test.go
+++ b/TreeDB/internal/powerlossoracle/evidence_test.go
@@ -219,6 +219,64 @@ func TestBeginEvidenceFromEnvRequiresTraceToEndAtReplayOccurrence(t *testing.T) 
 	}
 }
 
+func TestBeginEvidenceFromEnvScopesOccurrenceAfterReplayWindowAndRetainsPrefix(t *testing.T) {
+	source := t.TempDir()
+	if err := os.WriteFile(filepath.Join(source, "index.db"), []byte("old"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	model, err := Capture(source)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for range 2 {
+		if err := model.Observe(source, durabilitycut.Event{Point: durabilitycut.AfterMetaWrite, Resource: durabilitycut.ResourceMeta}); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := model.BeginReplayWindow("variant-a"); err != nil {
+		t.Fatal(err)
+	}
+	if err := model.Observe(source, durabilitycut.Event{Point: durabilitycut.AfterMetaWrite, Resource: durabilitycut.ResourceMeta}); err != nil {
+		t.Fatal(err)
+	}
+
+	evidenceDir := filepath.Join(canonicalTempDir(t), "evidence")
+	t.Setenv(EnvEvidenceDir, evidenceDir)
+	t.Setenv(EnvEvidenceCutPoint, string(durabilitycut.AfterMetaWrite))
+	t.Setenv(EnvEvidenceReopenMode, EvidenceReopenReadWrite)
+	t.Setenv(EnvReplayCut, "cut/checkpoint-generation-2/after-meta-write/000")
+	t.Setenv(EnvReplayVariant, "variant-a")
+	t.Setenv(EnvReplaySeed, "1")
+
+	session, err := BeginEvidenceFromEnv(model, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if session.ObservedEventCount != 1 {
+		t.Fatalf("observed event count=%d want window-relative 1", session.ObservedEventCount)
+	}
+	var trace evidenceTrace
+	data, err := os.ReadFile(filepath.Join(evidenceDir, "operation_trace.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := json.Unmarshal(data, &trace); err != nil {
+		t.Fatal(err)
+	}
+	if got := replayWindowCutCount(trace.Events, string(durabilitycut.AfterMetaWrite), "variant-a"); got != 1 {
+		t.Fatalf("window-relative trace cuts=%d want 1", got)
+	}
+	allCuts := 0
+	for _, event := range trace.Events {
+		if strings.HasPrefix(event, "cut:"+string(durabilitycut.AfterMetaWrite)+":") {
+			allCuts++
+		}
+	}
+	if allCuts != 3 {
+		t.Fatalf("retained full-trace cuts=%d want 3", allCuts)
+	}
+}
+
 func TestBeginEvidenceFromEnvRejectsSymlinkedEvidenceRoot(t *testing.T) {
 	source := t.TempDir()
 	if err := os.WriteFile(filepath.Join(source, "index.db"), []byte("old"), 0o600); err != nil {

--- a/TreeDB/internal/powerlossoracle/model.go
+++ b/TreeDB/internal/powerlossoracle/model.go
@@ -946,6 +946,28 @@ func stableDirReachable(dirs map[string]rootpublication.StableIdentity, dir stri
 // Trace returns the deterministic operation trace used in failure diagnostics.
 func (m *Model) Trace() []string { return append([]string(nil), m.trace...) }
 
+// BeginReplayWindow records a stable address boundary without discarding the
+// persistence trace that precedes it. Tests with asynchronous setup can use a
+// window-relative cut occurrence while retained evidence still shows every
+// resource and namespace event that made the setup durable.
+//
+// Callers must serialize this method with Observe when observations may arrive
+// concurrently, just as they serialize concurrent Observe calls themselves.
+func (m *Model) BeginReplayWindow(variantID string) error {
+	if m == nil {
+		return errorsf("begin replay window on nil model")
+	}
+	if strings.TrimSpace(variantID) == "" || strings.ContainsAny(variantID, "\r\n") {
+		return errorsf("invalid replay window variant %q", variantID)
+	}
+	m.trace = append(m.trace, replayWindowMarker(variantID))
+	return nil
+}
+
+func replayWindowMarker(variantID string) string {
+	return "replay-window:" + variantID
+}
+
 // UseObservedTrace binds an adversarial selective-writeback model to the
 // operation trace captured from the corresponding real production cut. It
 // intentionally changes no namespace or byte state: callers first derive the

--- a/TreeDB/power_loss_certification_resources_test.go
+++ b/TreeDB/power_loss_certification_resources_test.go
@@ -128,11 +128,17 @@ func TestPowerLossCertificationAuthoritativeResourcesPublicReopen(t *testing.T) 
 	witness := prepareAuthoritativeResourceWitness(t, database, dir, backgroundErrors)
 	waitForAuthoritativeResourceObserverQuiescence(t, &observeMu, &observedEvents, backgroundErrors)
 	observeMu.Lock()
+	if err := model.BeginReplayWindow(authoritativeResourcesVariantID); err != nil {
+		observeMu.Unlock()
+		t.Fatal(err)
+	}
+	metaSyncs = 0
 	armed = true
 	observeMu.Unlock()
 	// Publish one deterministic terminal marker after all asynchronous resource
 	// work is quiescent. The selected cut is the marker's real maindb metadata
-	// sync, so the evidence address cannot drift with dictdb scheduling.
+	// sync and its occurrence is relative to the explicit replay window. The
+	// complete pre-window persistence trace remains in the evidence artifact.
 	boundaryKey := []byte("certification/authoritative-resource-boundary")
 	boundaryValue := []byte("stable")
 	if err := database.SetSync(boundaryKey, boundaryValue); err != nil {

--- a/TreeDB/testdata/power_loss_witness_contracts.json
+++ b/TreeDB/testdata/power_loss_witness_contracts.json
@@ -41,7 +41,8 @@
     3927,
     3930,
     3932,
-    3934
+    3934,
+    3936
   ],
   "cases": [
     {
@@ -498,16 +499,17 @@
       "expected_outcome": "accepted:stable-root",
       "expected_typed_error": "none",
       "state": {
-        "root_meta_generation": "selected_slot=1 commit_seq=13 slot0=12 slot1=13",
-        "freelist_generation": "generation=23",
+        "root_meta_generation": "selected_commit_seq=13 fallback_commit_seq=12",
+        "freelist_generation": "generation=persisted",
         "external_resource_ids_frontiers": "stable_image_tree_artifact=stable_image_tree.json manifest_entries=9",
         "namespace_generations": "stable_image_tree_artifact=stable_image_tree.json",
         "wal_lineage": "profile=command_wal_durable applied_lsn=19",
-        "durable_lsn": "durable_wal_lsn=0 durable_root_seq=10",
-        "cleanup_maintenance_pins": "slot0_commit_seq=12 slot1_commit_seq=13"
+        "durable_lsn": "durable_wal_lsn=0 durable_root_commit_seq=13",
+        "cleanup_maintenance_pins": "selected_commit_seq=13 fallback_commit_seq=12"
       },
+      "state_comparison": "logical_horizon",
       "seed": 3674,
-      "cut_id": "cut/public-authoritative-resources-stable-image/after-meta-sync/011",
+      "cut_id": "cut/public-authoritative-resources-stable-image/after-meta-sync/000",
       "variant_id": "public-authoritative-resources-stable-image",
       "cut_point": "after-meta-sync",
       "reopen_mode": "read-only",

--- a/TreeDB/testdata/power_loss_witness_contracts.json
+++ b/TreeDB/testdata/power_loss_witness_contracts.json
@@ -1,5 +1,5 @@
 {
-  "schema_version": "treedb-power-loss-witness-contracts/v3",
+  "schema_version": "treedb-power-loss-witness-contracts/v4",
   "issue": 3684,
   "required_pull_requests": [
     3706,
@@ -513,6 +513,7 @@
       "variant_id": "public-authoritative-resources-stable-image",
       "cut_point": "after-meta-sync",
       "reopen_mode": "read-only",
+      "replay_window": "public-authoritative-resources-stable-image",
       "expected_recovery": {
         "rejected": false,
         "error_type": "",


### PR DESCRIPTION
Closes #3935
Parent: #3684

## Outcome

Stabilizes the authoritative-resource power-loss witness without discarding its resource-creation trace, and fixes the production dictionary publisher race discovered by parallel replay.

## Changes

- serialize dictionary profile application so the trainer callback and periodic loop cannot persist one accepted profile twice;
- add a deterministic concurrent-publisher regression test;
- add an explicit replay-window contract to the frozen run case, child witness, command environment, and operation trace;
- retain every pre-window persistence event while addressing the terminal crash cut relative to exactly one declared marker;
- fail closed in both capture and retained-bundle verification on missing, duplicate, mismatched, late, or undeclared replay-window markers;
- add a logical-horizon state comparison for asynchronous witnesses, binding selected/fallback commits, WAL horizon, manifest/resource authority, and persisted freelist without overfitting slot parity or schedule-dependent generation numbers;
- bump incompatible artifact contracts together: operation trace v2, child manifest v3, run plan v4, and witness contracts v4;
- move the authoritative-resource cut to window-relative occurrence 000.

## Exact-head evidence

Head: `064a6e261e5a2e46636c29bc462207c4c36d9503`

- Parent head `c1a4e6219`: `go test ./TreeDB/internal/powerlossoracle ./TreeDB/internal/powerlosscert ./TreeDB/caching ./TreeDB -count=1` — green (`TreeDB` 398.084s; `caching` 95.866s).
- Parent head `c1a4e6219`: `go vet ./TreeDB/internal/powerlossoracle ./TreeDB/internal/powerlosscert ./TreeDB/caching ./TreeDB` — green.
- Head `1bef20ab0`: `go test ./TreeDB/internal/powerlossoracle ./TreeDB/internal/powerlosscert -count=1` and matching `go vet` — green. That delta directly binds retained replay-window declarations to the replay variant and adds its regression test.
- Exact head `064a6e261`: `go test ./TreeDB/internal/powerlosscert -count=1` and matching `go vet` — green. The exact-head delta updates the canonical certificate specification for the new schema/window contract and adds direct trace-variant mismatch coverage.
- focused oracle/certificate/dictionary tests under `-race`, three repetitions — green.
- one exact-selector authoritative-resource capture — green; operation-trace v2 retained 1,632 events and 12 matching setup-era cuts while declaring one marker and one post-marker cut.
- 8/8 parallel exact-selector captures — green; every run declared one marker and one post-marker cut. Full-trace setup cut totals varied from 13 to 14 as expected, while every recovery selected commit 13, applied LSN 19, and manifest horizon 9.

Parallel artifact root: `/mnt/fast4tb/gomap-3936-strict-window-stress-20260720T205221Z` on the certification host.

## Performance relevance

This is a correctness/certification-safety PR, not a throughput optimization. The exclusive dictionary-apply mutex covers infrequent accepted-profile publication and replaces an `RLock` whose callers mutate the same applied-hash/store state; there are no read-only users. The replay-window and schema work is test/certificate infrastructure. No production request, write, read, checkpoint, or compaction hot loop gains per-operation work.

## Review and merge gates

- Latest-head GitHub CI is running.
- The prior independent review's schema-version and fail-open window findings are fixed at this head.
- Independent exact-head review is complete with no blockers; the final docs/test delta was separately re-reviewed at `064a6e261`.
- GitHub Codex previously reported its code-review usage limit; a latest-head retry will record whether it remains unavailable.
- CodeRabbit is optional and will be retried at the mature latest head; its prior rate-limit response is not treated as a pass.
- The full #3684 exact-candidate bundle will be regenerated only from the merge SHA after this PR passes review/CI and merges.

## Non-goals

- weakening the witness to hide resource-creation persistence events;
- relabeling clean/process evidence as modeled power-loss evidence;
- publishing a terminal certificate from the failed `379c7ca8` candidate;
- claiming live templatedb value-log compression beyond the committed authoritative-resource boundary.
