### PR TITLE
test(treedb): bind stale-build recovery state

### DIFF
--- a/TreeDB/db/power_loss_certification_stale_build_test.go
+++ b/TreeDB/db/power_loss_certification_stale_build_test.go
@@ -202,6 +202,7 @@ func TestPowerLossCertificationStaleBuildBasePublicReopen(t *testing.T) {
 	if result.Rejected || recovered == nil {
 		t.Fatalf("public Open rejected stale-build stable image: %v", result.Err)
 	}
+	assertStaleBuildRecoveryStats(t, result)
 	value, err := recovered.Get([]byte("stale-build/public-baseline"))
 	if err != nil || string(value) != "stable" {
 		t.Fatalf("recovered public baseline=%q err=%v want stable", value, err)
@@ -211,6 +212,37 @@ func TestPowerLossCertificationStaleBuildBasePublicReopen(t *testing.T) {
 	}
 	assertStableStaleBuildSystemValues(t, model, opts)
 	t.Logf("recovered rejected-stale counterexample at commit %d", result.CommitSeq)
+}
+
+func assertStaleBuildRecoveryStats(t *testing.T, result powerlossreopen.Result) {
+	t.Helper()
+	if result.CommitSeq != 4 || result.AppliedLSN != 0 {
+		t.Fatalf("recovered horizon=(commit=%d applied_lsn=%d), want (commit=4 applied_lsn=0)", result.CommitSeq, result.AppliedLSN)
+	}
+	want := []struct {
+		key   string
+		value string
+	}{
+		{key: "treedb.profile.resolved", value: "no_wal_fast"},
+		{key: "treedb.applied_command_lsn", value: "0"},
+		{key: "treedb.command_wal.durable_wal_lsn", value: "0"},
+		{key: "treedb.durable_root.selected_slot", value: "1"},
+		{key: "treedb.durable_root.commit_seq", value: "4"},
+		{key: "treedb.durable_root.slot0.commit_seq", value: "3"},
+		{key: "treedb.durable_root.slot1.commit_seq", value: "4"},
+		{key: "treedb.durable_root.freelist.generation", value: "8"},
+		{key: "treedb.durable_root.manifest.entries", value: "1"},
+		{key: "treedb.durable_root.durable_seq", value: "4"},
+	}
+	for _, item := range want {
+		got, ok := result.Stats[item.key]
+		if !ok {
+			t.Fatalf("recovery stats missing %q", item.key)
+		}
+		if got != item.value {
+			t.Fatalf("recovery stats[%q]=%q, want %q", item.key, got, item.value)
+		}
+	}
 }
 
 func mustFrozenStaleBuildDelta(t *testing.T, key, value string) memtable.Table {

--- a/TreeDB/testdata/power_loss_witness_contracts.json
+++ b/TreeDB/testdata/power_loss_witness_contracts.json
@@ -1244,13 +1244,13 @@
       "expected_outcome": "accepted:new-root",
       "expected_typed_error": "none",
       "state": {
-        "root_meta_generation": "selected_slot=0 commit_seq=4 slot0=4 slot1=2",
-        "freelist_generation": "generation=7",
+        "root_meta_generation": "selected_slot=1 commit_seq=4 slot0=3 slot1=4",
+        "freelist_generation": "generation=8",
         "external_resource_ids_frontiers": "stable_image_tree_artifact=stable_image_tree.json manifest_entries=1",
         "namespace_generations": "stable_image_tree_artifact=stable_image_tree.json",
         "wal_lineage": "profile=no_wal_fast applied_lsn=0",
-        "durable_lsn": "durable_wal_lsn=0 durable_root_seq=3",
-        "cleanup_maintenance_pins": "slot0_commit_seq=4 slot1_commit_seq=2"
+        "durable_lsn": "durable_wal_lsn=0 durable_root_seq=4",
+        "cleanup_maintenance_pins": "slot0_commit_seq=3 slot1_commit_seq=4"
       },
       "counterexample_id": "stale-build-base-root-publication",
       "seed": 12505447533306515078,


### PR DESCRIPTION
Closes #3937
Parent: #3684

## Outcome

Binds the `retained-stale-build-base-retry` witness to the deterministic exact physical recovery state produced after #3934 scoped the terminal trace behind the predecessor checkpoint. This repairs the frozen certificate contract without changing production recovery or durability behavior.

The failed exact candidate `1c6cbd22b26c90b149a6c35fbf521344d22b6521` remains unpublished and is not reused.

## Changes

- assert the public-reopen witness commit/applied horizon and all certificate-relevant recovery stats in ordinary CI;
- update only the matching frozen root-slot, freelist, durable-root, and cleanup-pin fields;
- preserve exact physical comparison and all behavioral assertions for predecessor survival, stale-successor rejection, accepted retry survival, and the single terminal meta-sync selector.

## Evidence

- exact failed-candidate mismatch reproduced before this patch;
- 12/12 independent exact-selector diagnostics produced the corrected state;
- `GOWORK=off go test ./TreeDB/db -run ^TestPowerLossCertificationStaleBuildBasePublicReopen$ -count=20`;
- `GOWORK=off go test -race ./TreeDB/db -run ^TestPowerLossCertificationStaleBuildBasePublicReopen$ -count=10`;
- `GOWORK=off go test ./TreeDB/internal/powerlosscert ./TreeDB/internal/powerlossoracle -count=1`;
- `GOWORK=off go vet ./TreeDB/db ./TreeDB/internal/powerlosscert ./TreeDB/internal/powerlossoracle`;
- contract JSON parses and the updated fields match the asserted state.

## Claim boundary

This is evidence-only test and contract maintenance. It does not change TreeDB write, checkpoint, recovery, or slot-selection behavior. #3684 remains the sole terminal certificate owner and must rerun from the eventual immutable merge SHA with a fresh output path.

## Performance

No production code is modified, so product throughput gates are not applicable.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved recovery validation after power-loss scenarios.
  * Updated expected recovery state to reflect corrected durable root, slot selection, freelist, and cleanup metadata.
  * Confirmed recovered data and stale-build acceptance/rejection behavior remain consistent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->