### PR TITLE
treedb: group external MVCC publications

### DIFF
--- a/TreeDB/caching/db.go
+++ b/TreeDB/caching/db.go
@@ -9035,12 +9035,17 @@ type DB struct {
 	iteratorQueueLenMax                                          atomic.Uint64
 	pointSuccessorCallsTotal                                     atomic.Uint64
 	pointSuccessorHitsTotal                                      atomic.Uint64
+	pointSuccessorMutableHitsTotal                               atomic.Uint64
+	pointSuccessorQueueHitsTotal                                 atomic.Uint64
+	pointSuccessorBackendHitsTotal                               atomic.Uint64
 	pointSuccessorMutableProbesTotal                             atomic.Uint64
 	pointSuccessorQueueProbesTotal                               atomic.Uint64
 	pointSuccessorBackendProbesTotal                             atomic.Uint64
 	pointSuccessorSourcesTotal                                   atomic.Uint64
 	pointSuccessorSourcesMax                                     atomic.Uint64
 	pointSuccessorGeneralMergeIteratorsTotal                     atomic.Uint64
+	pointSuccessorSelectionNsTotal                               atomic.Uint64
+	pointSuccessorMaterializeNsTotal                             atomic.Uint64
 	checkpointTotalNs                                            atomic.Uint64
 	checkpointMaxNs                                              atomic.Uint64
 	checkpointNoopSkips                                          atomic.Uint64
@@ -30341,11 +30346,16 @@ func (db *DB) Stats() map[string]string {
 	stats["treedb.cache.iterator.queue_len_max"] = fmt.Sprintf("%d", db.iteratorQueueLenMax.Load())
 	stats["treedb.cache.point_successor.calls_total"] = fmt.Sprintf("%d", db.pointSuccessorCallsTotal.Load())
 	stats["treedb.cache.point_successor.hits_total"] = fmt.Sprintf("%d", db.pointSuccessorHitsTotal.Load())
+	stats["treedb.cache.point_successor.mutable_hits_total"] = fmt.Sprintf("%d", db.pointSuccessorMutableHitsTotal.Load())
+	stats["treedb.cache.point_successor.queue_hits_total"] = fmt.Sprintf("%d", db.pointSuccessorQueueHitsTotal.Load())
+	stats["treedb.cache.point_successor.backend_hits_total"] = fmt.Sprintf("%d", db.pointSuccessorBackendHitsTotal.Load())
 	stats["treedb.cache.point_successor.mutable_probes_total"] = fmt.Sprintf("%d", db.pointSuccessorMutableProbesTotal.Load())
 	stats["treedb.cache.point_successor.queue_probes_total"] = fmt.Sprintf("%d", db.pointSuccessorQueueProbesTotal.Load())
 	stats["treedb.cache.point_successor.backend_probes_total"] = fmt.Sprintf("%d", db.pointSuccessorBackendProbesTotal.Load())
 	stats["treedb.cache.point_successor.sources_total"] = fmt.Sprintf("%d", db.pointSuccessorSourcesTotal.Load())
 	stats["treedb.cache.point_successor.sources_max"] = fmt.Sprintf("%d", db.pointSuccessorSourcesMax.Load())
+	stats["treedb.cache.point_successor.selection_ns_total"] = fmt.Sprintf("%d", db.pointSuccessorSelectionNsTotal.Load())
+	stats["treedb.cache.point_successor.materialize_ns_total"] = fmt.Sprintf("%d", db.pointSuccessorMaterializeNsTotal.Load())
 	// This metric is an invariant sentinel for SeekGE, not a global iterator
 	// construction counter. It must stay zero because the point-successor path
 	// has no general-merge fallback; any future fallback must increment it at

--- a/TreeDB/caching/db.go
+++ b/TreeDB/caching/db.go
@@ -9057,6 +9057,8 @@ type DB struct {
 	pointSuccessorGeneralMergeIteratorsTotal                     atomic.Uint64
 	pointSuccessorSelectionNsTotal                               atomic.Uint64
 	pointSuccessorMaterializeNsTotal                             atomic.Uint64
+	pointSuccessorSelectionTimingSamplesTotal                    atomic.Uint64
+	pointSuccessorMaterializeTimingSamplesTotal                  atomic.Uint64
 	checkpointTotalNs                                            atomic.Uint64
 	checkpointMaxNs                                              atomic.Uint64
 	checkpointNoopSkips                                          atomic.Uint64
@@ -30367,6 +30369,8 @@ func (db *DB) Stats() map[string]string {
 	stats["treedb.cache.point_successor.sources_max"] = fmt.Sprintf("%d", db.pointSuccessorSourcesMax.Load())
 	stats["treedb.cache.point_successor.selection_ns_total"] = fmt.Sprintf("%d", db.pointSuccessorSelectionNsTotal.Load())
 	stats["treedb.cache.point_successor.materialize_ns_total"] = fmt.Sprintf("%d", db.pointSuccessorMaterializeNsTotal.Load())
+	stats["treedb.cache.point_successor.selection_timing_samples_total"] = fmt.Sprintf("%d", db.pointSuccessorSelectionTimingSamplesTotal.Load())
+	stats["treedb.cache.point_successor.materialize_timing_samples_total"] = fmt.Sprintf("%d", db.pointSuccessorMaterializeTimingSamplesTotal.Load())
 	// This metric is an invariant sentinel for SeekGE, not a global iterator
 	// construction counter. It must stay zero because the point-successor path
 	// has no general-merge fallback; any future fallback must increment it at

--- a/TreeDB/caching/db.go
+++ b/TreeDB/caching/db.go
@@ -90,6 +90,11 @@ const (
 
 var iteratorDebugEnabled atomic.Bool
 
+// pointSuccessorDebugEnabled gates timestamp-based point-read attribution.
+// Counters remain available in production, but wall-clock probes are opt-in so
+// a diagnostic seam never charges every Dgraph point read.
+var pointSuccessorDebugEnabled atomic.Bool
+
 var valueLogEligiblePool sync.Pool                  // stores []int
 var valueLogKeyPool sync.Pool                       // stores [][]byte
 var batchArenaPools [batchArenaClassCount]sync.Pool // stores []byte
@@ -2459,6 +2464,12 @@ const (
 // intended for benchmarking/diagnostics and is disabled by default.
 func SetIteratorDebug(enabled bool) {
 	iteratorDebugEnabled.Store(enabled)
+}
+
+// SetPointSuccessorDebug toggles timestamp attribution for SeekGE. It is for
+// benchmarks and diagnostics only; normal point reads do no clock sampling.
+func SetPointSuccessorDebug(enabled bool) {
+	pointSuccessorDebugEnabled.Store(enabled)
 }
 
 func envBool(name string) bool {

--- a/TreeDB/caching/point_successor.go
+++ b/TreeDB/caching/point_successor.go
@@ -2,6 +2,7 @@ package caching
 
 import (
 	"bytes"
+	"time"
 
 	"github.com/snissn/gomap/TreeDB/batch"
 	backenddb "github.com/snissn/gomap/TreeDB/db"
@@ -19,7 +20,20 @@ type pointSuccessorCandidate struct {
 	revision page.EntryRevision
 	priority int
 	found    bool
+	layer    pointSuccessorLayer
 }
+
+// pointSuccessorLayer identifies the source that supplied a visible result.
+// Keep this separate from priority: priority expresses recency, while layer is
+// attribution for the Dgraph-shaped read/write workload.
+type pointSuccessorLayer uint8
+
+const (
+	pointSuccessorLayerUnknown pointSuccessorLayer = iota
+	pointSuccessorLayerMutable
+	pointSuccessorLayerQueue
+	pointSuccessorLayerPublished
+)
 
 func choosePointSuccessor(best, candidate pointSuccessorCandidate) pointSuccessorCandidate {
 	if !candidate.found {
@@ -164,6 +178,15 @@ func (db *DB) SeekGE(start, end []byte) (key, value []byte, found bool, err erro
 		return nil, nil, false, nil
 	}
 	db.pointSuccessorCallsTotal.Add(1)
+	selectionStarted := time.Now()
+	selectionRecorded := false
+	recordSelection := func() {
+		if !selectionRecorded {
+			db.pointSuccessorSelectionNsTotal.Add(uint64(time.Since(selectionStarted).Nanoseconds()))
+			selectionRecorded = true
+		}
+	}
+	defer recordSelection()
 	db.noteRead()
 
 	db.writeMu.Lock()
@@ -201,9 +224,11 @@ func (db *DB) SeekGE(start, end []byte) (key, value []byte, found bool, err erro
 		initialTarget = db.shardIndex(start)
 		if initialTarget >= 0 && initialTarget < len(mutables) {
 			initialCandidate = seekPointSuccessorTable(mutables[initialTarget], start, end, nil, 0, 0)
+			initialCandidate.layer = pointSuccessorLayerMutable
 			db.pointSuccessorMutableProbesTotal.Add(1)
 			callSources++
 			if initialCandidate.found && bytes.Equal(initialCandidate.key, start) && initialCandidate.flags&node.FlagTombstone == 0 {
+				recordSelection()
 				return db.materializePointSuccessor(initialCandidate)
 			}
 		}
@@ -225,12 +250,14 @@ func (db *DB) SeekGE(start, end []byte) (key, value []byte, found bool, err erro
 				candidate := initialCandidate
 				if target != initialTarget || !bytes.Equal(lower, start) {
 					candidate = seekPointSuccessorTable(mutables[target], lower, end, nil, 0, priority)
+					candidate.layer = pointSuccessorLayerMutable
 					db.pointSuccessorMutableProbesTotal.Add(1)
 					callSources++
 				}
 				best = choosePointSuccessor(best, candidate)
 				priority++
 				if candidate.found && bytes.Equal(candidate.key, lower) && candidate.flags&node.FlagTombstone == 0 {
+					recordSelection()
 					return db.materializePointSuccessor(candidate)
 				}
 			}
@@ -238,20 +265,25 @@ func (db *DB) SeekGE(start, end []byte) (key, value []byte, found bool, err erro
 				if i == target {
 					continue
 				}
-				best = choosePointSuccessor(best, seekPointSuccessorTable(mt, lower, end, nil, 0, priority))
+				candidate := seekPointSuccessorTable(mt, lower, end, nil, 0, priority)
+				candidate.layer = pointSuccessorLayerMutable
+				best = choosePointSuccessor(best, candidate)
 				db.pointSuccessorMutableProbesTotal.Add(1)
 				callSources++
 				priority++
 			}
 		}
 		for i := len(queue) - 1; i >= 0; i-- {
-			best = choosePointSuccessor(best, seekPointSuccessorTable(queue[i], lower, end, spans, i+1, priority))
+			candidate := seekPointSuccessorTable(queue[i], lower, end, spans, i+1, priority)
+			candidate.layer = pointSuccessorLayerQueue
+			best = choosePointSuccessor(best, candidate)
 			db.pointSuccessorQueueProbesTotal.Add(1)
 			callSources++
 			priority++
 		}
 		if disk != nil {
 			candidate, probeErr := seekPointSuccessorIterator(disk, lower, end, spans, priority)
+			candidate.layer = pointSuccessorLayerPublished
 			db.pointSuccessorBackendProbesTotal.Add(1)
 			callSources++
 			if probeErr != nil {
@@ -263,6 +295,7 @@ func (db *DB) SeekGE(start, end []byte) (key, value []byte, found bool, err erro
 			return nil, nil, false, nil
 		}
 		if best.flags&node.FlagTombstone == 0 {
+			recordSelection()
 			return db.materializePointSuccessor(best)
 		}
 		lower = pointSuccessorAfter(best.key)
@@ -271,6 +304,8 @@ func (db *DB) SeekGE(start, end []byte) (key, value []byte, found bool, err erro
 }
 
 func (db *DB) materializePointSuccessor(candidate pointSuccessorCandidate) ([]byte, []byte, bool, error) {
+	materializeStarted := time.Now()
+	defer func() { db.pointSuccessorMaterializeNsTotal.Add(uint64(time.Since(materializeStarted).Nanoseconds())) }()
 	if !candidate.found || candidate.flags&node.FlagTombstone != 0 {
 		return nil, nil, false, nil
 	}
@@ -287,5 +322,13 @@ func (db *DB) materializePointSuccessor(candidate pointSuccessorCandidate) ([]by
 		value = append([]byte(nil), candidate.value...)
 	}
 	db.pointSuccessorHitsTotal.Add(1)
+	switch candidate.layer {
+	case pointSuccessorLayerMutable:
+		db.pointSuccessorMutableHitsTotal.Add(1)
+	case pointSuccessorLayerQueue:
+		db.pointSuccessorQueueHitsTotal.Add(1)
+	case pointSuccessorLayerPublished:
+		db.pointSuccessorBackendHitsTotal.Add(1)
+	}
 	return key, value, true, nil
 }

--- a/TreeDB/caching/point_successor.go
+++ b/TreeDB/caching/point_successor.go
@@ -187,6 +187,7 @@ func (db *DB) SeekGE(start, end []byte) (key, value []byte, found bool, err erro
 	recordSelection := func() {
 		if debugTiming && !selectionRecorded {
 			db.pointSuccessorSelectionNsTotal.Add(uint64(time.Since(selectionStarted).Nanoseconds()))
+			db.pointSuccessorSelectionTimingSamplesTotal.Add(1)
 			selectionRecorded = true
 		}
 	}
@@ -312,7 +313,10 @@ func (db *DB) materializePointSuccessor(candidate pointSuccessorCandidate) ([]by
 	var materializeStarted time.Time
 	if debugTiming {
 		materializeStarted = time.Now()
-		defer func() { db.pointSuccessorMaterializeNsTotal.Add(uint64(time.Since(materializeStarted).Nanoseconds())) }()
+		defer func() {
+			db.pointSuccessorMaterializeNsTotal.Add(uint64(time.Since(materializeStarted).Nanoseconds()))
+			db.pointSuccessorMaterializeTimingSamplesTotal.Add(1)
+		}()
 	}
 	if !candidate.found || candidate.flags&node.FlagTombstone != 0 {
 		return nil, nil, false, nil

--- a/TreeDB/caching/point_successor.go
+++ b/TreeDB/caching/point_successor.go
@@ -178,10 +178,14 @@ func (db *DB) SeekGE(start, end []byte) (key, value []byte, found bool, err erro
 		return nil, nil, false, nil
 	}
 	db.pointSuccessorCallsTotal.Add(1)
-	selectionStarted := time.Now()
+	debugTiming := pointSuccessorDebugEnabled.Load()
+	var selectionStarted time.Time
+	if debugTiming {
+		selectionStarted = time.Now()
+	}
 	selectionRecorded := false
 	recordSelection := func() {
-		if !selectionRecorded {
+		if debugTiming && !selectionRecorded {
 			db.pointSuccessorSelectionNsTotal.Add(uint64(time.Since(selectionStarted).Nanoseconds()))
 			selectionRecorded = true
 		}
@@ -304,8 +308,12 @@ func (db *DB) SeekGE(start, end []byte) (key, value []byte, found bool, err erro
 }
 
 func (db *DB) materializePointSuccessor(candidate pointSuccessorCandidate) ([]byte, []byte, bool, error) {
-	materializeStarted := time.Now()
-	defer func() { db.pointSuccessorMaterializeNsTotal.Add(uint64(time.Since(materializeStarted).Nanoseconds())) }()
+	debugTiming := pointSuccessorDebugEnabled.Load()
+	var materializeStarted time.Time
+	if debugTiming {
+		materializeStarted = time.Now()
+		defer func() { db.pointSuccessorMaterializeNsTotal.Add(uint64(time.Since(materializeStarted).Nanoseconds())) }()
+	}
 	if !candidate.found || candidate.flags&node.FlagTombstone != 0 {
 		return nil, nil, false, nil
 	}

--- a/TreeDB/caching/point_successor_test.go
+++ b/TreeDB/caching/point_successor_test.go
@@ -3,6 +3,7 @@ package caching
 import (
 	"bytes"
 	"errors"
+	"fmt"
 	"strconv"
 	"sync"
 	"testing"
@@ -303,6 +304,134 @@ func TestSeekGE_CompetingVersionsAcrossMutableQueuedAndPublishedSources(t *testi
 		t.Fatalf("Delete mutable: %v", err)
 	}
 	requireSeekGE(t, db, []byte("k"), nil, []byte("z"), []byte("published-z"))
+}
+
+// This is the deterministic mixed read/write attribution seam used by the
+// Dgraph-shaped investigation.  It proves that the counters distinguish the
+// winning source rather than merely counting every source consulted.
+func TestSeekGE_AttributionPartitionsWinningSource(t *testing.T) {
+	parse := func(t *testing.T, stats map[string]string, name string) uint64 {
+		t.Helper()
+		value, err := strconv.ParseUint(stats[name], 10, 64)
+		if err != nil {
+			t.Fatalf("parse %s=%q: %v", name, stats[name], err)
+		}
+		return value
+	}
+	backend := NewMockBackend()
+	backend.Set([]byte("k"), []byte("published"))
+	db := openPointSuccessorTestDB(t, backend)
+
+	before := db.Stats()
+	if err := db.Set([]byte("k"), []byte("queued")); err != nil {
+		t.Fatalf("Set queued: %v", err)
+	}
+	rotatePointSuccessorMemtables(t, db)
+	requireSeekGE(t, db, []byte("k"), nil, []byte("k"), []byte("queued"))
+	if err := db.Set([]byte("k"), []byte("mutable")); err != nil {
+		t.Fatalf("Set mutable: %v", err)
+	}
+	requireSeekGE(t, db, []byte("k"), nil, []byte("k"), []byte("mutable"))
+	if err := db.Delete([]byte("k")); err != nil {
+		t.Fatalf("Delete mutable: %v", err)
+	}
+	// The visible tombstone removes the queued and published versions; the
+	// layer counters must not turn probes into false hits.
+	if key, value, found, err := db.SeekGE([]byte("k"), nil); err != nil || found || key != nil || value != nil {
+		t.Fatalf("SeekGE tombstoned key = key=%q value=%q found=%t err=%v, want not found", key, value, found, err)
+	}
+	after := db.Stats()
+
+	for _, tc := range []struct {
+		name string
+		want uint64
+	}{
+		{"treedb.cache.point_successor.mutable_hits_total", 1},
+		{"treedb.cache.point_successor.queue_hits_total", 1},
+		{"treedb.cache.point_successor.backend_hits_total", 0},
+	} {
+		if got := parse(t, after, tc.name) - parse(t, before, tc.name); got != tc.want {
+			t.Fatalf("%s delta=%d want %d", tc.name, got, tc.want)
+		}
+	}
+	if got := parse(t, after, "treedb.cache.point_successor.selection_ns_total") - parse(t, before, "treedb.cache.point_successor.selection_ns_total"); got == 0 {
+		t.Fatal("point-successor selection timing did not advance")
+	}
+
+	publishedOnlyBackend := NewMockBackend()
+	publishedOnlyBackend.Set([]byte("p"), []byte("published"))
+	publishedOnly := openPointSuccessorTestDB(t, publishedOnlyBackend)
+	publishedBefore := publishedOnly.Stats()
+	requireSeekGE(t, publishedOnly, []byte("p"), nil, []byte("p"), []byte("published"))
+	publishedAfter := publishedOnly.Stats()
+	if got := parse(t, publishedAfter, "treedb.cache.point_successor.backend_hits_total") - parse(t, publishedBefore, "treedb.cache.point_successor.backend_hits_total"); got != 1 {
+		t.Fatalf("backend hit delta=%d want 1", got)
+	}
+}
+
+// BenchmarkSeekGEQueuedFanIn is a deterministic engine-only analogue of the
+// Dgraph mixed workload: an older key remains visible while newer immutable
+// sources contain later keys.  The lookup must inspect every newer source to
+// prove that the old key is the successor.  It intentionally holds flush so
+// the source set is stable for before/after comparisons.
+func BenchmarkSeekGEQueuedFanIn(b *testing.B) {
+	const queuedSources = 32
+	backend := NewMockBackend()
+	db, err := Open(b.TempDir(), backend, Options{
+		FlushThreshold:     1 << 30,
+		MemtableShards:     1,
+		MaxQueuedMemtables: -1,
+		AllowUnsafe:        true,
+	})
+	if err != nil {
+		b.Fatalf("Open: %v", err)
+	}
+	b.Cleanup(func() { _ = db.Close() })
+	db.flushMu.Lock()
+	b.Cleanup(db.flushMu.Unlock)
+	if err := db.Set([]byte("k"), []byte("visible")); err != nil {
+		b.Fatalf("Set visible: %v", err)
+	}
+	rotate := func() {
+		db.mu.Lock()
+		err := db.rotateMemtableLocked(false)
+		db.mu.Unlock()
+		if err != nil {
+			b.Fatalf("rotateMemtableLocked: %v", err)
+		}
+	}
+	rotate()
+	for i := 0; i < queuedSources-1; i++ {
+		key := []byte(fmt.Sprintf("z%03d", i))
+		if err := db.Set(key, []byte("later")); err != nil {
+			b.Fatalf("Set %q: %v", key, err)
+		}
+		rotate()
+	}
+	before := db.Stats()
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		key, value, found, err := db.SeekGE([]byte("k"), nil)
+		if err != nil || !found || !bytes.Equal(key, []byte("k")) || !bytes.Equal(value, []byte("visible")) {
+			b.Fatalf("SeekGE: key=%q value=%q found=%t err=%v", key, value, found, err)
+		}
+	}
+	b.StopTimer()
+	after := db.Stats()
+	reportPointSuccessorBenchCounter(b, before, after, "treedb.cache.point_successor.sources_total", "sources/op")
+	reportPointSuccessorBenchCounter(b, before, after, "treedb.cache.point_successor.queue_probes_total", "queue_probes/op")
+	reportPointSuccessorBenchCounter(b, before, after, "treedb.cache.point_successor.selection_ns_total", "selection_ns/op")
+	reportPointSuccessorBenchCounter(b, before, after, "treedb.cache.point_successor.materialize_ns_total", "materialize_ns/op")
+}
+
+func reportPointSuccessorBenchCounter(b *testing.B, before, after map[string]string, key, name string) {
+	b.Helper()
+	start, startErr := strconv.ParseUint(before[key], 10, 64)
+	end, endErr := strconv.ParseUint(after[key], 10, 64)
+	if startErr == nil && endErr == nil && end >= start && b.N > 0 {
+		b.ReportMetric(float64(end-start)/float64(b.N), name)
+	}
 }
 
 func TestSeekGE_FlushPublicationPreservesAnswer(t *testing.T) {

--- a/TreeDB/caching/point_successor_test.go
+++ b/TreeDB/caching/point_successor_test.go
@@ -310,6 +310,8 @@ func TestSeekGE_CompetingVersionsAcrossMutableQueuedAndPublishedSources(t *testi
 // Dgraph-shaped investigation.  It proves that the counters distinguish the
 // winning source rather than merely counting every source consulted.
 func TestSeekGE_AttributionPartitionsWinningSource(t *testing.T) {
+	SetPointSuccessorDebug(true)
+	t.Cleanup(func() { SetPointSuccessorDebug(false) })
 	parse := func(t *testing.T, stats map[string]string, name string) uint64 {
 		t.Helper()
 		value, err := strconv.ParseUint(stats[name], 10, 64)
@@ -369,12 +371,36 @@ func TestSeekGE_AttributionPartitionsWinningSource(t *testing.T) {
 	}
 }
 
+func TestSeekGE_TimingAttributionIsOptIn(t *testing.T) {
+	SetPointSuccessorDebug(false)
+	backend := NewMockBackend()
+	backend.Set([]byte("k"), []byte("value"))
+	db := openPointSuccessorTestDB(t, backend)
+	before := db.Stats()
+	requireSeekGE(t, db, []byte("k"), nil, []byte("k"), []byte("value"))
+	after := db.Stats()
+
+	for _, name := range []string{
+		"treedb.cache.point_successor.selection_ns_total",
+		"treedb.cache.point_successor.materialize_ns_total",
+	} {
+		if after[name] != before[name] {
+			t.Fatalf("disabled %s changed from %s to %s", name, before[name], after[name])
+		}
+	}
+	if after["treedb.cache.point_successor.backend_hits_total"] == before["treedb.cache.point_successor.backend_hits_total"] {
+		t.Fatal("winning-layer attribution did not remain active with timing disabled")
+	}
+}
+
 // BenchmarkSeekGEQueuedFanIn is a deterministic engine-only analogue of the
 // Dgraph mixed workload: an older key remains visible while newer immutable
 // sources contain later keys.  The lookup must inspect every newer source to
 // prove that the old key is the successor.  It intentionally holds flush so
 // the source set is stable for before/after comparisons.
 func BenchmarkSeekGEQueuedFanIn(b *testing.B) {
+	SetPointSuccessorDebug(true)
+	b.Cleanup(func() { SetPointSuccessorDebug(false) })
 	const queuedSources = 32
 	backend := NewMockBackend()
 	db, err := Open(b.TempDir(), backend, Options{

--- a/TreeDB/caching/point_successor_test.go
+++ b/TreeDB/caching/point_successor_test.go
@@ -356,8 +356,8 @@ func TestSeekGE_AttributionPartitionsWinningSource(t *testing.T) {
 			t.Fatalf("%s delta=%d want %d", tc.name, got, tc.want)
 		}
 	}
-	if got := parse(t, after, "treedb.cache.point_successor.selection_ns_total") - parse(t, before, "treedb.cache.point_successor.selection_ns_total"); got == 0 {
-		t.Fatal("point-successor selection timing did not advance")
+	if got := parse(t, after, "treedb.cache.point_successor.selection_timing_samples_total") - parse(t, before, "treedb.cache.point_successor.selection_timing_samples_total"); got == 0 {
+		t.Fatal("point-successor selection timing was not sampled")
 	}
 
 	publishedOnlyBackend := NewMockBackend()
@@ -383,6 +383,8 @@ func TestSeekGE_TimingAttributionIsOptIn(t *testing.T) {
 	for _, name := range []string{
 		"treedb.cache.point_successor.selection_ns_total",
 		"treedb.cache.point_successor.materialize_ns_total",
+		"treedb.cache.point_successor.selection_timing_samples_total",
+		"treedb.cache.point_successor.materialize_timing_samples_total",
 	} {
 		if after[name] != before[name] {
 			t.Fatalf("disabled %s changed from %s to %s", name, before[name], after[name])

--- a/TreeDB/mvcc/commit_group_test.go
+++ b/TreeDB/mvcc/commit_group_test.go
@@ -1,0 +1,223 @@
+package mvcc
+
+import (
+	"errors"
+	"os"
+	"os/exec"
+	"strconv"
+	"testing"
+
+	treedb "github.com/snissn/gomap/TreeDB"
+)
+
+func TestCommitGroupAtPublishesVersionsAndTombstones(t *testing.T) {
+	db := openTestDB(t, t.TempDir(), treedb.DurabilityDurable)
+	defer db.Close()
+	store := New(db)
+	if err := store.CommitGroupAt([]CommitGroup{
+		{Timestamp: 7, Mutations: []Mutation{{Key: []byte("a"), Value: []byte("A")}, {Key: []byte("gone"), Delete: true}}},
+		{Timestamp: 9, Mutations: []Mutation{{Key: []byte("a"), Value: []byte("new")}, {Key: []byte("b"), Value: []byte("B")}}},
+	}, CommitRelaxed); err != nil {
+		t.Fatalf("CommitGroupAt: %v", err)
+	}
+	requireResult(t, store, []byte("a"), 7, Present, 7, []byte("A"))
+	requireResult(t, store, []byte("a"), 9, Present, 9, []byte("new"))
+	requireResult(t, store, []byte("b"), 9, Present, 9, []byte("B"))
+	requireResult(t, store, []byte("gone"), 9, Tombstone, 7, nil)
+}
+
+func TestCommitGroupAtValidationPrecedesStorageWrite(t *testing.T) {
+	spy := &validationSpyDB{}
+	store := newStore(spy)
+
+	cases := []struct {
+		name   string
+		groups []CommitGroup
+		want   error
+	}{
+		{"zero timestamp", []CommitGroup{{Timestamp: 0}}, ErrZeroTimestamp},
+		{"invalid key", []CommitGroup{{Timestamp: 1, Mutations: []Mutation{{Key: make([]byte, 16<<20)}}}}, ErrInvalidKey},
+		{"same timestamp duplicate", []CommitGroup{{Timestamp: 1, Mutations: []Mutation{{Key: []byte("k")}}}, {Timestamp: 1, Mutations: []Mutation{{Key: []byte("k")}}}}, ErrDuplicateKey},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if err := store.CommitGroupAt(tc.groups, CommitRelaxed); !errors.Is(err, tc.want) {
+				t.Fatalf("CommitGroupAt error=%v want %v", err, tc.want)
+			}
+		})
+	}
+	if got := spy.created.Load(); got != 0 {
+		t.Fatalf("batches created after validation failures = %d, want 0", got)
+	}
+}
+
+func TestCommitValidationOrderAndEmptyGroups(t *testing.T) {
+	store := New(nil)
+	if err := store.CommitAt(0, nil, CommitMode(99)); !errors.Is(err, ErrZeroTimestamp) {
+		t.Fatalf("CommitAt zero timestamp precedence error=%v want ErrZeroTimestamp", err)
+	}
+	if err := store.CommitGroupAt([]CommitGroup{{Timestamp: 0}}, CommitMode(99)); !errors.Is(err, ErrInvalidCommitMode) {
+		t.Fatalf("CommitGroupAt mode precedence error=%v want ErrInvalidCommitMode", err)
+	}
+	if err := store.CommitGroupAt(nil, CommitMode(99)); !errors.Is(err, ErrInvalidCommitMode) {
+		t.Fatalf("empty CommitGroupAt invalid mode error=%v want ErrInvalidCommitMode", err)
+	}
+	if err := store.CommitGroupAt(nil, CommitRelaxed); !errors.Is(err, ErrStorage) {
+		t.Fatalf("nil-store empty CommitGroupAt error=%v want ErrStorage", err)
+	}
+
+	db := openTestDB(t, t.TempDir(), treedb.DurabilityDurable)
+	if err := db.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	if err := New(db).CommitGroupAt([]CommitGroup{{Timestamp: 1}}, CommitDurable); err != nil {
+		t.Fatalf("empty group on closed non-nil store must not access storage: %v", err)
+	}
+}
+
+func TestCommitGroupAtDistinctTimestampsAndDiscardFloor(t *testing.T) {
+	db := openTestDB(t, t.TempDir(), treedb.DurabilityDurable)
+	defer db.Close()
+	store := New(db)
+	if err := store.CommitGroupAt([]CommitGroup{
+		{Timestamp: 3, Mutations: []Mutation{{Key: []byte("same"), Value: []byte("old")}}},
+		{Timestamp: 4, Mutations: []Mutation{{Key: []byte("same"), Value: []byte("new")}}},
+	}, CommitRelaxed); err != nil {
+		t.Fatalf("distinct timestamps: %v", err)
+	}
+	if err := store.AdvanceDiscardFloor(4, CommitRelaxed); err != nil {
+		t.Fatalf("AdvanceDiscardFloor: %v", err)
+	}
+	err := store.CommitGroupAt([]CommitGroup{
+		{Timestamp: 4, Mutations: []Mutation{{Key: []byte("below"), Value: []byte("x")}}},
+		{Timestamp: 5, Mutations: []Mutation{{Key: []byte("above"), Value: []byte("y")}}},
+	}, CommitRelaxed)
+	if !errors.Is(err, ErrVersionBelowDiscardFloor) {
+		t.Fatalf("floor error=%v want ErrVersionBelowDiscardFloor", err)
+	}
+	requireResult(t, store, []byte("below"), 5, Absent, 0, nil)
+	requireResult(t, store, []byte("above"), 5, Absent, 0, nil)
+}
+
+func TestCommitGroupAtUsesOneWritePerMode(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		mode CommitMode
+		stat string
+	}{
+		{"relaxed", CommitRelaxed, "treedb.public.batch.write.calls_total"},
+		{"durable", CommitDurable, "treedb.public.batch.write_sync.calls_total"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			db := openTestDB(t, t.TempDir(), treedb.DurabilityWALOnRelaxed)
+			defer db.Close()
+			before := mvccTestStat(t, db, tc.stat)
+			err := New(db).CommitGroupAt([]CommitGroup{
+				{Timestamp: 1, Mutations: []Mutation{{Key: []byte("a"), Value: []byte("A")}}},
+				{Timestamp: 2, Mutations: []Mutation{{Key: []byte("b"), Value: []byte("B")}}},
+			}, tc.mode)
+			if err != nil {
+				t.Fatalf("CommitGroupAt: %v", err)
+			}
+			if got := mvccTestStat(t, db, tc.stat) - before; got != 1 {
+				t.Fatalf("%s delta=%d want 1", tc.stat, got)
+			}
+		})
+	}
+}
+
+func TestCommitGroupAtEmptyGroupsAreNoOp(t *testing.T) {
+	db := openTestDB(t, t.TempDir(), treedb.DurabilityDurable)
+	defer db.Close()
+	before := mvccTestStat(t, db, "treedb.public.batch.write.calls_total")
+	if err := New(db).CommitGroupAt([]CommitGroup{{Timestamp: 1}, {Timestamp: 2}}, CommitRelaxed); err != nil {
+		t.Fatalf("empty groups: %v", err)
+	}
+	if got := mvccTestStat(t, db, "treedb.public.batch.write.calls_total") - before; got != 0 {
+		t.Fatalf("empty groups write delta=%d want 0", got)
+	}
+}
+
+func TestCommitGroupAtFailureHasNoPartialVisibility(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		db   func(*treedb.DB) treeDB
+	}{
+		{"stage", func(db *treedb.DB) treeDB { return &stageFailureDB{DB: db, failAt: 1, err: errors.New("stage")} }},
+		{"write", func(db *treedb.DB) treeDB { return &writeFailureDB{DB: db, err: errors.New("write")} }},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			db := openTestDB(t, t.TempDir(), treedb.DurabilityDurable)
+			defer db.Close()
+			err := newStore(tc.db(db)).CommitGroupAt([]CommitGroup{
+				{Timestamp: 11, Mutations: []Mutation{{Key: []byte("a"), Value: []byte("A")}}},
+				{Timestamp: 12, Mutations: []Mutation{{Key: []byte("b"), Value: []byte("B")}}},
+			}, CommitRelaxed)
+			if !errors.Is(err, ErrStorage) {
+				t.Fatalf("CommitGroupAt error=%v want ErrStorage", err)
+			}
+			reader := New(db)
+			requireResult(t, reader, []byte("a"), 12, Absent, 0, nil)
+			requireResult(t, reader, []byte("b"), 12, Absent, 0, nil)
+		})
+	}
+}
+
+func TestCommitGroupAtAmbiguousStorageFailureIsWholeGroup(t *testing.T) {
+	dir := t.TempDir()
+	db := openTestDB(t, dir, treedb.DurabilityDurable)
+	injected := errors.New("write after commit")
+	err := newStore(&writeFailureDB{DB: db, afterCommit: true, err: injected}).CommitGroupAt([]CommitGroup{
+		{Timestamp: 11, Mutations: []Mutation{{Key: []byte("a"), Value: []byte("A")}}},
+		{Timestamp: 12, Mutations: []Mutation{{Key: []byte("b"), Value: []byte("B")}}},
+	}, CommitRelaxed)
+	if !errors.Is(err, injected) || !errors.Is(err, ErrStorage) {
+		t.Fatalf("CommitGroupAt error=%v want ambiguous storage error", err)
+	}
+	reader := New(db)
+	requireResult(t, reader, []byte("a"), 12, Present, 11, []byte("A"))
+	requireResult(t, reader, []byte("b"), 12, Present, 12, []byte("B"))
+	if err := db.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	db = openTestDB(t, dir, treedb.DurabilityDurable)
+	defer db.Close()
+	reader = New(db)
+	requireResult(t, reader, []byte("a"), 12, Present, 11, []byte("A"))
+	requireResult(t, reader, []byte("b"), 12, Present, 12, []byte("B"))
+}
+
+func TestCommitGroupAtDurableProcessCrashRecovery(t *testing.T) {
+	const childEnv = "TREEDB_MVCC_GROUP_CRASH_CHILD"
+	if dir := os.Getenv(childEnv); dir != "" {
+		db := openTestDB(t, dir, treedb.DurabilityDurable)
+		if err := New(db).CommitGroupAt([]CommitGroup{
+			{Timestamp: 31, Mutations: []Mutation{{Key: []byte("a"), Value: []byte("A")}}},
+			{Timestamp: 32, Mutations: []Mutation{{Key: []byte("b"), Delete: true}}},
+		}, CommitDurable); err != nil {
+			t.Fatalf("child CommitGroupAt: %v", err)
+		}
+		os.Exit(0) // Deliberately omit Close to exercise WAL recovery after death.
+	}
+
+	dir := t.TempDir()
+	cmd := exec.Command(os.Args[0], "-test.run=^TestCommitGroupAtDurableProcessCrashRecovery$")
+	cmd.Env = append(os.Environ(), childEnv+"="+dir)
+	if output, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("crash child: %v\n%s", err, output)
+	}
+	db := openTestDB(t, dir, treedb.DurabilityDurable)
+	defer db.Close()
+	store := New(db)
+	requireResult(t, store, []byte("a"), 32, Present, 31, []byte("A"))
+	requireResult(t, store, []byte("b"), 32, Tombstone, 32, nil)
+}
+
+func mvccTestStat(t *testing.T, db *treedb.DB, name string) uint64 {
+	t.Helper()
+	value, err := strconv.ParseUint(db.Stats()[name], 10, 64)
+	if err != nil {
+		t.Fatalf("parse %s: %v", name, err)
+	}
+	return value
+}

--- a/TreeDB/mvcc/mvcc.go
+++ b/TreeDB/mvcc/mvcc.go
@@ -36,6 +36,15 @@ type Mutation struct {
 	Delete bool
 }
 
+// CommitGroup is one caller-assigned timestamp and its mutations. CommitGroupAt
+// publishes every non-empty group in its input through one TreeDB batch, so it
+// is useful when an external MVCC coordinator has already formed several
+// commits that must be made visible together.
+type CommitGroup struct {
+	Timestamp uint64
+	Mutations []Mutation
+}
+
 // ReadState identifies the visibility result returned by GetAt.
 type ReadState uint8
 
@@ -120,61 +129,91 @@ func newStore(db treeDB) *Store {
 // A returned storage error can be commit-ambiguous, but visibility is always
 // whole-batch: readers may see all mutations or none, never a prefix.
 func (s *Store) CommitAt(timestamp uint64, mutations []Mutation, mode CommitMode) error {
+	// Preserve the established CommitAt validation precedence for callers that
+	// distinguish the reserved timestamp from a later mode/store failure.
 	if timestamp == 0 {
 		return ErrZeroTimestamp
 	}
+	return s.CommitGroupAt([]CommitGroup{{Timestamp: timestamp, Mutations: mutations}}, mode)
+}
+
+// CommitGroupAt validates and atomically publishes timestamped mutation groups
+// through exactly one TreeDB Batch.Write or Batch.WriteSync call. Every group
+// is validated before a batch is created: timestamps must be non-zero and
+// above the discard floor, keys must fit the MVCC codec, and no physical MVCC
+// key may occur twice. Thus the same logical key at distinct timestamps is
+// allowed, while duplicate logical keys at the same timestamp are rejected
+// even when they arrive in different groups.
+//
+// Empty groups are validated for timestamp and contribute no record. An empty
+// group list (or a list containing only empty groups) is a no-op after Store
+// and mode validation. As with CommitAt, a storage error can be commit
+// ambiguous; group visibility is nevertheless all-or-none, never a prefix.
+func (s *Store) CommitGroupAt(groups []CommitGroup, mode CommitMode) error {
 	if mode != CommitRelaxed && mode != CommitDurable {
 		return ErrInvalidCommitMode
 	}
 	if s == nil || s.db == nil {
 		return storageError("create batch", treedb.ErrClosed)
 	}
-	if len(mutations) == 0 {
+	type stagedMutation struct {
+		physical  []byte
+		record    []byte
+		timestamp uint64
+		group     int
+		key       int
+	}
+	total := 0
+	for groupIndex := range groups {
+		group := &groups[groupIndex]
+		if group.Timestamp == 0 {
+			return fmt.Errorf("%w at group index %d", ErrZeroTimestamp, groupIndex)
+		}
+		total += len(group.Mutations)
+	}
+	if total == 0 {
 		return nil
 	}
-	type stagedMutation struct {
-		physical []byte
-		record   []byte
-	}
-	staged := make([]stagedMutation, len(mutations))
-	var seen map[string]struct{}
-	if len(mutations) > 1 {
-		seen = make(map[string]struct{}, len(mutations))
-	}
-	for i := range mutations {
-		mutation := &mutations[i]
-		physical, err := mvcckey.Encode(mutation.Key, timestamp)
-		if err != nil {
-			return fmt.Errorf("%w at key index %d: %w", ErrInvalidKey, i, err)
-		}
-		if seen != nil {
-			// Encode validates the bounded codec envelope before the caller key is
-			// copied into duplicate-detection state. Reuse physical below so this
-			// validation does not introduce a second encoding pass.
-			identity := string(mutation.Key)
+
+	staged := make([]stagedMutation, 0, total)
+	seen := make(map[string]struct{}, total)
+	for groupIndex := range groups {
+		group := &groups[groupIndex]
+		for keyIndex := range group.Mutations {
+			mutation := &group.Mutations[keyIndex]
+			physical, err := mvcckey.Encode(mutation.Key, group.Timestamp)
+			if err != nil {
+				return fmt.Errorf("%w at group index %d key index %d: %w", ErrInvalidKey, groupIndex, keyIndex, err)
+			}
+			// The physical encoding contains both logical key and timestamp. This
+			// simultaneously catches duplicates within one commit and across
+			// groups, without rejecting distinct versions of the same logical key.
+			identity := string(physical)
 			if _, exists := seen[identity]; exists {
-				return fmt.Errorf("%w: key index %d", ErrDuplicateKey, i)
+				return fmt.Errorf("%w at group index %d key index %d", ErrDuplicateKey, groupIndex, keyIndex)
 			}
 			seen[identity] = struct{}{}
-		}
 
-		staged[i].physical = physical
-		if mutation.Delete {
-			staged[i].record = []byte{recordTombstoneV1}
-			continue
+			entry := stagedMutation{physical: physical, timestamp: group.Timestamp, group: groupIndex, key: keyIndex}
+			if mutation.Delete {
+				entry.record = []byte{recordTombstoneV1}
+			} else {
+				entry.record = make([]byte, 1+len(mutation.Value))
+				entry.record[0] = recordValueV1
+				copy(entry.record[1:], mutation.Value)
+			}
+			staged = append(staged, entry)
 		}
-		record := make([]byte, 1+len(mutation.Value))
-		record[0] = recordValueV1
-		copy(record[1:], mutation.Value)
-		staged[i].record = record
 	}
 	if err := s.lockDiscardFloorRead(); err != nil {
 		return err
 	}
 	defer s.mu.RUnlock()
 	floor := s.discardFloor
-	if timestamp <= floor {
-		return fmt.Errorf("%w: commit timestamp %d is not above floor %d", ErrVersionBelowDiscardFloor, timestamp, floor)
+	for _, entry := range staged {
+		if entry.timestamp <= floor {
+			return fmt.Errorf("%w: group index %d timestamp %d is not above floor %d", ErrVersionBelowDiscardFloor, entry.group, entry.timestamp, floor)
+		}
 	}
 
 	batch := s.db.NewBatchWithSize(len(staged))
@@ -183,7 +222,7 @@ func (s *Store) CommitAt(timestamp uint64, mutations []Mutation, mode CommitMode
 	}
 	for i := range staged {
 		if err := batch.Set(staged[i].physical, staged[i].record); err != nil {
-			stageErr := storageError(fmt.Sprintf("stage key index %d", i), err)
+			stageErr := storageError(fmt.Sprintf("stage group index %d key index %d", staged[i].group, staged[i].key), err)
 			return errors.Join(stageErr, storageError("close batch", batch.Close()))
 		}
 	}

--- a/TreeDB/mvcc/mvcc.go
+++ b/TreeDB/mvcc/mvcc.go
@@ -176,7 +176,10 @@ func (s *Store) CommitGroupAt(groups []CommitGroup, mode CommitMode) error {
 	}
 
 	staged := make([]stagedMutation, 0, total)
-	seen := make(map[string]struct{}, total)
+	var seen map[string]struct{}
+	if total > 1 {
+		seen = make(map[string]struct{}, total)
+	}
 	for groupIndex := range groups {
 		group := &groups[groupIndex]
 		for keyIndex := range group.Mutations {
@@ -188,11 +191,13 @@ func (s *Store) CommitGroupAt(groups []CommitGroup, mode CommitMode) error {
 			// The physical encoding contains both logical key and timestamp. This
 			// simultaneously catches duplicates within one commit and across
 			// groups, without rejecting distinct versions of the same logical key.
-			identity := string(physical)
-			if _, exists := seen[identity]; exists {
-				return fmt.Errorf("%w at group index %d key index %d", ErrDuplicateKey, groupIndex, keyIndex)
+			if seen != nil {
+				identity := string(physical)
+				if _, exists := seen[identity]; exists {
+					return fmt.Errorf("%w at group index %d key index %d", ErrDuplicateKey, groupIndex, keyIndex)
+				}
+				seen[identity] = struct{}{}
 			}
-			seen[identity] = struct{}{}
 
 			entry := stagedMutation{physical: physical, timestamp: group.Timestamp, group: groupIndex, key: keyIndex}
 			if mutation.Delete {

--- a/TreeDB/mvcc/mvcc_bench_test.go
+++ b/TreeDB/mvcc/mvcc_bench_test.go
@@ -81,6 +81,82 @@ func BenchmarkCommitAt(b *testing.B) {
 	}
 }
 
+// BenchmarkCommitGroupAtDgraphShape models the c4 external-MVCC publication
+// wedge: four independently timestamped caller commits, each with a small
+// mutation batch. The grouped row must issue one public TreeDB batch write per
+// four commits, while the baseline preserves the existing CommitAt boundary.
+func BenchmarkCommitGroupAtDgraphShape(b *testing.B) {
+	const commitsPerPublication = 4
+	for _, grouped := range []bool{false, true} {
+		name := "CommitAt_x4"
+		if grouped {
+			name = "CommitGroupAt_x4"
+		}
+		b.Run(name, func(b *testing.B) {
+			db := openBenchDB(b)
+			countingDB := &benchmarkBatchCounterDB{DB: db}
+			store := newStore(countingDB)
+			groups := make([]CommitGroup, commitsPerPublication)
+			for groupIndex := range groups {
+				groups[groupIndex].Mutations = []Mutation{{
+					Key:   []byte(fmt.Sprintf("dgraph-submission-%d", groupIndex)),
+					Value: []byte("posting-list-delta"),
+				}}
+			}
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				firstTimestamp := uint64(i*commitsPerPublication + 1)
+				for groupIndex := range groups {
+					groups[groupIndex].Timestamp = firstTimestamp + uint64(groupIndex)
+				}
+				if grouped {
+					if err := store.CommitGroupAt(groups, CommitRelaxed); err != nil {
+						b.Fatal(err)
+					}
+					continue
+				}
+				for groupIndex := range groups {
+					if err := store.CommitAt(groups[groupIndex].Timestamp, groups[groupIndex].Mutations, CommitRelaxed); err != nil {
+						b.Fatal(err)
+					}
+				}
+			}
+			b.StopTimer()
+			b.ReportMetric(float64(countingDB.writes)/float64(b.N), "public_batch_writes/publication")
+		})
+	}
+}
+
+// benchmarkBatchCounterDB observes calls at TreeDB's public Batch surface,
+// rather than relying on optional runtime statistics in a benchmark profile.
+type benchmarkBatchCounterDB struct {
+	*treedb.DB
+	writes uint64
+}
+
+func (db *benchmarkBatchCounterDB) NewBatchWithSize(size int) treedb.Batch {
+	return &benchmarkBatchCounter{Batch: db.DB.NewBatchWithSize(size), db: db}
+}
+
+type benchmarkBatchCounter struct {
+	treedb.Batch
+	db *benchmarkBatchCounterDB
+}
+
+func (b *benchmarkBatchCounter) Write() error {
+	b.db.writes++
+	return b.Batch.Write()
+}
+
+func (b *benchmarkBatchCounter) WriteSync() error {
+	b.db.writes++
+	return b.Batch.WriteSync()
+}
+
+var _ treeDB = (*benchmarkBatchCounterDB)(nil)
+var _ treedb.Batch = (*benchmarkBatchCounter)(nil)
+
 func BenchmarkGetAt(b *testing.B) {
 	for _, depth := range []int{1, 8, 64} {
 		b.Run(fmt.Sprintf("DirectSeek/%d", depth), func(b *testing.B) {


### PR DESCRIPTION
## Outcome

Adds a public external-MVCC grouped commit boundary that publishes several independently timestamped logical commits through one TreeDB batch. This targets the repeated root-publication wedge measured by #3941 without restoring the rejected queued-source shortcut.

## Changes

- Add mvcc.CommitGroup and Store.CommitGroupAt.
- Prevalidate modes, timestamps, codec keys, duplicate physical versions, and discard-floor rules before creating a batch.
- Allow the same logical key at distinct timestamps while rejecting duplicate key+timestamp versions across groups.
- Preserve the established CommitAt validation order.
- Use exactly one Batch.Write or Batch.WriteSync for a non-empty group.
- Define storage failures as whole-group commit-ambiguous, never prefix-visible.
- Add opt-in point-successor timing and winning-layer attribution with negligible disabled-path overhead.
- Report explicit timing-sample counters so debug attribution is verifiable on coarse-resolution clocks without inventing elapsed nanoseconds.
- Add the deterministic Dgraph-shaped grouped-publication benchmark.

## Evidence

Three 1-second samples, four logical commits per publication:

| Path | Median time | Public writes | Allocations |
| --- | ---: | ---: | ---: |
| CommitAt x4 | 13.98 us | 4.000 | 43 |
| CommitGroupAt x4 | 6.37 us | 1.000 | 20 |

The grouped path is about 2.2x faster at the median and makes 4x fewer public TreeDB writes. An earlier range-skip candidate reduced synthetic sources but regressed the unchanged Dgraph-shaped live row by 5.94%, so it was removed rather than shipped.

Validation on exact head `dd3ab11b484569b0af0470b7931943f1937ff412`:

- go test -count=1 ./TreeDB/mvcc
- go test -race -count=1 ./TreeDB/mvcc
- go test -run '^$' -bench 'BenchmarkCommitAt/MVCC/1$' -benchmem -count=5 ./TreeDB/mvcc (8 allocs/op; no duplicate map/string identity)
- go test -count=1 ./TreeDB/caching ./TreeDB/mvcc
- go test -race -count=1 ./TreeDB/caching -run "^(TestSeekGE_|Test.*PointSuccessor)"
- go test -count=1 ./TreeDB/caching -run "^(TestSeekGE_AttributionPartitionsWinningSource|TestSeekGE_TimingAttributionIsOptIn)$"
- go test -race -count=1 ./TreeDB/caching -run "^(TestSeekGE_AttributionPartitionsWinningSource|TestSeekGE_TimingAttributionIsOptIn)$"

Coverage includes validation ordering, same-version duplicates, distinct versions, tombstones, discard floor, empty groups, one-write counters in both modes, injected stage/write failures, ambiguous-after-write whole-group visibility, durable process-crash reopen, disabled timing overhead, and clock-resolution-safe debug timing attribution.

## Graph

Advances #3941. The issue intentionally remains open until snissn/dgraph#32 consumes this API and passes the unchanged three-repeat relaxed live gate. Blocks snissn/dgraph#32.

The exact merged Gomap candidate must be power-loss recertified before the final Dgraph #29 decision run because this adds a new durable MVCC publication path.
