### PR TITLE
perf(treedb): fast-path relaxed singleton MVCC writes

### DIFF
--- a/TreeDB/mvcc/commit_group_test.go
+++ b/TreeDB/mvcc/commit_group_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"os/exec"
 	"strconv"
+	"sync/atomic"
 	"testing"
 
 	treedb "github.com/snissn/gomap/TreeDB"
@@ -126,6 +127,95 @@ func TestCommitGroupAtUsesOneWritePerMode(t *testing.T) {
 	}
 }
 
+func TestCommitGroupAtRoutesSingletonToPointWriter(t *testing.T) {
+	for _, tc := range []struct {
+		name      string
+		mode      CommitMode
+		wantSet   int64
+		wantBatch int64
+	}{
+		{name: "relaxed", mode: CommitRelaxed, wantSet: 1},
+		{name: "durable", mode: CommitDurable, wantBatch: 1},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			db := openTestDB(t, t.TempDir(), treedb.DurabilityWALOnRelaxed)
+			defer db.Close()
+			spy := &pointRouteSpyDB{DB: db}
+			store := newStore(spy)
+			if err := store.CommitAt(7, []Mutation{{Key: []byte("key"), Value: []byte("value")}}, tc.mode); err != nil {
+				t.Fatalf("CommitAt: %v", err)
+			}
+			if got := spy.setCalls.Load(); got != tc.wantSet {
+				t.Fatalf("Set calls=%d want %d", got, tc.wantSet)
+			}
+			if got := spy.setSyncCalls.Load(); got != 0 {
+				t.Fatalf("SetSync calls=%d want 0", got)
+			}
+			if got := spy.batchCalls.Load(); got != tc.wantBatch {
+				t.Fatalf("batch creations=%d want %d", got, tc.wantBatch)
+			}
+			requireResult(t, store, []byte("key"), 7, Present, 7, []byte("value"))
+		})
+	}
+}
+
+func TestCommitGroupAtSingletonPointWriterFailureIsStorageError(t *testing.T) {
+	db := openTestDB(t, t.TempDir(), treedb.DurabilityDurable)
+	defer db.Close()
+	injected := errors.New("injected point failure")
+	spy := &pointRouteSpyDB{DB: db, pointErr: injected}
+	err := newStore(spy).CommitAt(8, []Mutation{{Key: []byte("key"), Delete: true}}, CommitRelaxed)
+	if !errors.Is(err, ErrStorage) || !errors.Is(err, injected) {
+		t.Fatalf("CommitAt error=%v want ErrStorage and injected error", err)
+	}
+	if got := spy.setCalls.Load(); got != 1 {
+		t.Fatalf("Set calls=%d want 1", got)
+	}
+	if got := spy.batchCalls.Load(); got != 0 {
+		t.Fatalf("batch creations=%d want 0", got)
+	}
+}
+
+func TestCommitGroupAtCommandWALSingletonUsesPointFrame(t *testing.T) {
+	opts := treedb.OptionsFor(treedb.ProfileCommandWALRelaxed, t.TempDir())
+	opts.DisableSideStores = true
+	opts.BackgroundCheckpointInterval = -1
+	db, err := treedb.Open(opts)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer db.Close()
+	store := New(db)
+
+	before := db.Stats()
+	if err := store.CommitAt(9, []Mutation{{Key: []byte("single"), Value: []byte("value")}}, CommitRelaxed); err != nil {
+		t.Fatalf("singleton CommitAt: %v", err)
+	}
+	afterPoint := db.Stats()
+	requireMVCCStatDelta(t, before, afterPoint, "treedb.command_wal.append.count_total", 1)
+	requireMVCCStatDelta(t, before, afterPoint, "treedb.command_wal.append.point.count_total", 1)
+	requireMVCCStatDelta(t, before, afterPoint, "treedb.command_wal.append.payload.count_total", 0)
+	requireMVCCStatDelta(t, before, afterPoint, "treedb.command_wal.flush.count_total", 1)
+	requireMVCCStatDelta(t, before, afterPoint, "treedb.command_wal.write.syscalls_total", 1)
+	requireMVCCStatDelta(t, before, afterPoint, "treedb.command_wal.file_sync.calls_total", 0)
+	requireMVCCStatDelta(t, before, afterPoint, "treedb.public.batch.write.calls_total", 0)
+
+	if err := store.CommitAt(10, []Mutation{
+		{Key: []byte("multi-a"), Value: []byte("A")},
+		{Key: []byte("multi-b"), Delete: true},
+	}, CommitRelaxed); err != nil {
+		t.Fatalf("multi CommitAt: %v", err)
+	}
+	afterBatch := db.Stats()
+	requireMVCCStatDelta(t, afterPoint, afterBatch, "treedb.command_wal.append.count_total", 1)
+	requireMVCCStatDelta(t, afterPoint, afterBatch, "treedb.command_wal.append.point.count_total", 0)
+	requireMVCCStatDelta(t, afterPoint, afterBatch, "treedb.command_wal.append.payload.count_total", 1)
+	requireMVCCStatDelta(t, afterPoint, afterBatch, "treedb.command_wal.flush.count_total", 1)
+	requireMVCCStatDelta(t, afterPoint, afterBatch, "treedb.command_wal.write.syscalls_total", 1)
+	requireMVCCStatDelta(t, afterPoint, afterBatch, "treedb.command_wal.file_sync.calls_total", 0)
+	requireMVCCStatDelta(t, afterPoint, afterBatch, "treedb.public.batch.write.calls_total", 1)
+}
+
 func TestCommitGroupAtEmptyGroupsAreNoOp(t *testing.T) {
 	db := openTestDB(t, t.TempDir(), treedb.DurabilityDurable)
 	defer db.Close()
@@ -221,3 +311,50 @@ func mvccTestStat(t *testing.T, db *treedb.DB, name string) uint64 {
 	}
 	return value
 }
+
+func requireMVCCStatDelta(t *testing.T, before, after map[string]string, name string, want uint64) {
+	t.Helper()
+	parse := func(stats map[string]string) uint64 {
+		value, err := strconv.ParseUint(stats[name], 10, 64)
+		if err != nil {
+			t.Fatalf("parse %s=%q: %v", name, stats[name], err)
+		}
+		return value
+	}
+	start, finish := parse(before), parse(after)
+	if finish < start || finish-start != want {
+		t.Fatalf("%s delta=%d want %d (before=%d after=%d)", name, finish-start, want, start, finish)
+	}
+}
+
+type pointRouteSpyDB struct {
+	*treedb.DB
+	pointErr     error
+	setCalls     atomic.Int64
+	setSyncCalls atomic.Int64
+	batchCalls   atomic.Int64
+}
+
+func (db *pointRouteSpyDB) Set(key, value []byte) error {
+	db.setCalls.Add(1)
+	if db.pointErr != nil {
+		return db.pointErr
+	}
+	return db.DB.Set(key, value)
+}
+
+func (db *pointRouteSpyDB) SetSync(key, value []byte) error {
+	db.setSyncCalls.Add(1)
+	if db.pointErr != nil {
+		return db.pointErr
+	}
+	return db.DB.SetSync(key, value)
+}
+
+func (db *pointRouteSpyDB) NewBatchWithSize(size int) treedb.Batch {
+	db.batchCalls.Add(1)
+	return db.DB.NewBatchWithSize(size)
+}
+
+var _ treeDB = (*pointRouteSpyDB)(nil)
+var _ pointWriter = (*pointRouteSpyDB)(nil)

--- a/TreeDB/mvcc/mvcc.go
+++ b/TreeDB/mvcc/mvcc.go
@@ -84,6 +84,13 @@ type treeDB interface {
 	NewBatchWithSize(size int) treedb.Batch
 }
 
+// pointWriter is an optional optimization implemented by the public TreeDB
+// handle. Keeping it separate from treeDB preserves the narrow test and
+// maintenance adapters that intentionally support only the batch contract.
+type pointWriter interface {
+	Set(key, value []byte) error
+}
+
 type pointSuccessorDB interface {
 	SeekGE(start, end []byte) (key, value []byte, found bool, err error)
 }
@@ -137,9 +144,11 @@ func (s *Store) CommitAt(timestamp uint64, mutations []Mutation, mode CommitMode
 	return s.CommitGroupAt([]CommitGroup{{Timestamp: timestamp, Mutations: mutations}}, mode)
 }
 
-// CommitGroupAt validates and atomically publishes timestamped mutation groups
-// through exactly one TreeDB Batch.Write or Batch.WriteSync call. Every group
-// is validated before a batch is created: timestamps must be non-zero and
+// CommitGroupAt validates and atomically publishes timestamped mutation groups.
+// A single relaxed physical record uses TreeDB's equivalent point-write path
+// when the handle supports it; durable and larger publications use exactly one
+// TreeDB Batch.Write or Batch.WriteSync call. Every group is validated before
+// storage is accessed: timestamps must be non-zero and
 // above the discard floor, keys must fit the MVCC codec, and no physical MVCC
 // key may occur twice. Thus the same logical key at distinct timestamps is
 // allowed, while duplicate logical keys at the same timestamp are rejected
@@ -218,6 +227,14 @@ func (s *Store) CommitGroupAt(groups []CommitGroup, mode CommitMode) error {
 	for _, entry := range staged {
 		if entry.timestamp <= floor {
 			return fmt.Errorf("%w: group index %d timestamp %d is not above floor %d", ErrVersionBelowDiscardFloor, entry.group, entry.timestamp, floor)
+		}
+	}
+	if mode == CommitRelaxed && len(staged) == 1 {
+		if writer, ok := s.db.(pointWriter); ok {
+			if err := writer.Set(staged[0].physical, staged[0].record); err != nil {
+				return storageError("commit point", err)
+			}
+			return nil
 		}
 	}
 

--- a/TreeDB/mvcc/mvcc_bench_test.go
+++ b/TreeDB/mvcc/mvcc_bench_test.go
@@ -2,6 +2,7 @@ package mvcc
 
 import (
 	"fmt"
+	"strconv"
 	"testing"
 
 	treedb "github.com/snissn/gomap/TreeDB"
@@ -81,6 +82,83 @@ func BenchmarkCommitAt(b *testing.B) {
 	}
 }
 
+// BenchmarkCommitAtCommandWALRelaxedSingleton exercises the production-shaped
+// cached command-WAL path used by Dgraph. BenchmarkCommitAt deliberately uses
+// the no-WAL profile and is a useful MVCC-front-end control, but it does not
+// expose the asynchronous canonical-flush/root-publication work that dominates
+// the live relaxed profile.
+func BenchmarkCommitAtCommandWALRelaxedSingleton(b *testing.B) {
+	opts := treedb.OptionsFor(treedb.ProfileCommandWALRelaxed, b.TempDir())
+	opts.DisableSideStores = true
+	opts.BackgroundCheckpointInterval = -1
+	// Keep the reproduction bounded while forcing several background flushes in
+	// a short benchmark. One shard makes source/flush accounting deterministic;
+	// the live Dgraph gate retains its production defaults.
+	opts.FlushThreshold = 64 << 10
+	opts.MemtableShards = 1
+	db, err := treedb.Open(opts)
+	if err != nil {
+		b.Fatalf("Open: %v", err)
+	}
+	b.Cleanup(func() { _ = db.Close() })
+	store := New(db)
+	logicalKeys := [][]byte{
+		[]byte("dgraph-posting-0"),
+		[]byte("dgraph-posting-1"),
+		[]byte("dgraph-posting-2"),
+		[]byte("dgraph-posting-3"),
+	}
+	value := make([]byte, 512)
+	before := db.Stats()
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		mutation := []Mutation{{Key: logicalKeys[i%len(logicalKeys)], Value: value}}
+		if err := store.CommitAt(uint64(i+1), mutation, CommitRelaxed); err != nil {
+			b.Fatalf("CommitAt(%d): %v", i+1, err)
+		}
+	}
+	b.StopTimer()
+	if err := db.Checkpoint(); err != nil {
+		b.Fatalf("Checkpoint: %v", err)
+	}
+	after := db.Stats()
+	commandAppends := benchmarkStatDelta(b, before, after, "treedb.command_wal.append.count_total")
+	pointAppends := benchmarkStatDelta(b, before, after, "treedb.command_wal.append.point.count_total")
+	payloadAppends := benchmarkStatDelta(b, before, after, "treedb.command_wal.append.payload.count_total")
+	backendWrites := benchmarkStatDelta(b, before, after, "treedb.cache.flush_apply.batches_total")
+	units := benchmarkStatDelta(b, before, after, "treedb.cache.flush_apply.units_total")
+	entries := benchmarkStatDelta(b, before, after, "treedb.cache.flush_apply.entries_total")
+	b.ReportMetric(commandAppends/float64(b.N), "command_wal_appends/op")
+	b.ReportMetric(pointAppends/float64(b.N), "point_appends/op")
+	b.ReportMetric(payloadAppends/float64(b.N), "payload_appends/op")
+	b.ReportMetric(backendWrites/float64(b.N), "backend_writes/op")
+	if backendWrites > 0 {
+		b.ReportMetric(units/backendWrites, "memtables/backend_write")
+		b.ReportMetric(entries/backendWrites, "entries/backend_write")
+	}
+}
+
+func benchmarkStatDelta(b *testing.B, before, after map[string]string, key string) float64 {
+	b.Helper()
+	parse := func(stats map[string]string) uint64 {
+		value, ok := stats[key]
+		if !ok {
+			b.Fatalf("missing stat %q", key)
+		}
+		parsed, err := strconv.ParseUint(value, 10, 64)
+		if err != nil {
+			b.Fatalf("parse stat %q=%q: %v", key, value, err)
+		}
+		return parsed
+	}
+	start, finish := parse(before), parse(after)
+	if finish < start {
+		b.Fatalf("stat %q regressed from %d to %d", key, start, finish)
+	}
+	return float64(finish - start)
+}
+
 // BenchmarkCommitGroupAtDgraphShape models the c4 external-MVCC publication
 // wedge: four independently timestamped caller commits, each with a small
 // mutation batch. The grouped row must issue one public TreeDB batch write per
@@ -123,7 +201,8 @@ func BenchmarkCommitGroupAtDgraphShape(b *testing.B) {
 				}
 			}
 			b.StopTimer()
-			b.ReportMetric(float64(countingDB.writes)/float64(b.N), "public_batch_writes/publication")
+			b.ReportMetric(float64(countingDB.pointWrites+countingDB.batchWrites)/float64(b.N), "public_writes/publication")
+			b.ReportMetric(float64(countingDB.batchWrites)/float64(b.N), "public_batch_writes/publication")
 		})
 	}
 }
@@ -132,11 +211,22 @@ func BenchmarkCommitGroupAtDgraphShape(b *testing.B) {
 // rather than relying on optional runtime statistics in a benchmark profile.
 type benchmarkBatchCounterDB struct {
 	*treedb.DB
-	writes uint64
+	pointWrites uint64
+	batchWrites uint64
 }
 
 func (db *benchmarkBatchCounterDB) NewBatchWithSize(size int) treedb.Batch {
 	return &benchmarkBatchCounter{Batch: db.DB.NewBatchWithSize(size), db: db}
+}
+
+func (db *benchmarkBatchCounterDB) Set(key, value []byte) error {
+	db.pointWrites++
+	return db.DB.Set(key, value)
+}
+
+func (db *benchmarkBatchCounterDB) SetSync(key, value []byte) error {
+	db.pointWrites++
+	return db.DB.SetSync(key, value)
 }
 
 type benchmarkBatchCounter struct {
@@ -145,12 +235,12 @@ type benchmarkBatchCounter struct {
 }
 
 func (b *benchmarkBatchCounter) Write() error {
-	b.db.writes++
+	b.db.batchWrites++
 	return b.Batch.Write()
 }
 
 func (b *benchmarkBatchCounter) WriteSync() error {
-	b.db.writes++
+	b.db.batchWrites++
 	return b.Batch.WriteSync()
 }
 


### PR DESCRIPTION
Advances #3952 without closing it. The local singleton wedge is fixed, but the terminal restricted-Dgraph gate still misses its durability-matched Badger target and now has a narrower residual.

## What changed

- Route exactly one fully validated `CommitRelaxed` MVCC record through TreeDB's existing point `Set` path.
- Preserve the batch path for `CommitDurable`, multi-record commits, and narrow internal test/maintenance adapters that do not implement the optional point interface.
- Add routing, failure, visibility, and real command-WAL counter tests.
- Add a production-shaped singleton benchmark and make the grouped control report point and batch publications separately.

## Contract audit

This does not alter MVCC encoding, on-disk layout, command-WAL format, recovery bytes, root/freelist/value-log bytes, or acknowledgement classes. The point path is an existing public TreeDB path with the same prepared-revision ordering. The counter test proves one relaxed singleton still causes exactly:

- one command-WAL append;
- one WAL flush;
- one WAL write syscall;
- zero command-WAL fsyncs.

Only the frame construction route changes from one batch payload to one point frame. Durable singleton commits deliberately retain `Batch.WriteSync` after a point-`SetSync` experiment failed the durable-neutrality performance gate.

## Correctness evidence

- `go test ./TreeDB/mvcc -count=1`
- `go test -race ./TreeDB/mvcc -count=1`
- `go test ./TreeDB ./TreeDB/caching ./TreeDB/db -count=1`
- Focused singleton route/counter/error tests pass.
- Existing grouped, crash/reopen, snapshot, pruning, caching, flush, checkpoint, backend, and power-loss-heavy package suites pass.

## Deterministic performance evidence

Matched predecessor `092f41cc0a9359b3c947106ea82cc4e9a728b2e7` versus this branch, five samples:

- closeout `CommitAt/wal_on_relaxed/batch=1`: median 6.05 us -> 3.38 us (about -44%); 14 -> 9 allocs/op; about 4.99 KiB -> 0.93 KiB/op;
- production-shaped command-WAL singleton: about 29.4-30.5 us and 98 allocs/op -> median 6.32 us and 10 allocs/op;
- canonical flush remains amortized at about 0.00075-0.00077 backend writes/op, roughly 1.3k entries/backend write;
- grouped `CommitGroupAt_x4` remains one batch publication and is neutral within run noise;
- durable `CommitAt/batch=1` retains the predecessor batch route and allocation count.

## Live Dgraph disposition

Unchanged Dgraph `cc51080c7c4b110f3b43410955abe781be5cc42b`, local replacement to this exact branch, frozen 500-node / 100-warmup / 100,000-op / concurrency-4 relaxed workload:

- valid runs: 4,539.10, 4,606.74, 5,012.35 ops/s;
- median: 4,606.74 ops/s;
- median p50/p95/p99: 0.721/1.636/2.342 ms;
- restart/schema/posting/unsupported-feature validation passed in every valid run;
- zero command-WAL and value-log fsyncs.

Against the frozen durability-matched Badger median of 6,112 ops/s, TreeDB remains about -24.63%, so #3952 must remain open with one exclusive successor. Two additional runs rejected by the harness for load1 > 9 were not counted.

The exact candidate CPU profile leaves canonical flush at 13.59% cumulative, backend batch write at 13.33%, final commit at 10.81%, queued root publication at 8.95%, point reads at 4.44%, root preparation at 3.05%, and freelist mutation at 3.38%. The MVCC singleton batch-construction path is no longer a top residual.
