### PR TITLE
perf(treedb): shard external MVCC versions together

### DIFF
--- a/TreeDB/caching/db.go
+++ b/TreeDB/caching/db.go
@@ -35,6 +35,7 @@ import (
 	"github.com/snissn/gomap/TreeDB/internal/limits"
 	"github.com/snissn/gomap/TreeDB/internal/memtable"
 	"github.com/snissn/gomap/TreeDB/internal/merging"
+	"github.com/snissn/gomap/TreeDB/internal/mvcckey"
 	"github.com/snissn/gomap/TreeDB/internal/outerleaf"
 	"github.com/snissn/gomap/TreeDB/internal/rootpublication"
 	"github.com/snissn/gomap/TreeDB/internal/valuelog"
@@ -7977,6 +7978,9 @@ func (db *DB) advanceValueLogWriterPastObservedSeq(l *lane, observedMaxSeq int) 
 }
 
 func hashKey(key []byte) uint64 {
+	if prefix, ok := mvcckey.VersionAffinityPrefix(key); ok {
+		key = prefix
+	}
 	return xxhash.Sum64(key)
 }
 

--- a/TreeDB/caching/mvcc_shard_affinity_test.go
+++ b/TreeDB/caching/mvcc_shard_affinity_test.go
@@ -134,6 +134,40 @@ func TestSeekGEExactMVCCRangeDoesNotHideMalformedSuffix(t *testing.T) {
 	}
 }
 
+func TestSeekGEExactMVCCRangeDoesNotHideOversizedMalformedSuffix(t *testing.T) {
+	logical := []byte("oversized-malformed-record")
+	lower, err := mvcckey.Encode(logical, 9)
+	if err != nil {
+		t.Fatalf("Encode lower: %v", err)
+	}
+	upper, err := mvcckey.AppendKeyVersionsUpper(nil, logical)
+	if err != nil {
+		t.Fatalf("AppendKeyVersionsUpper: %v", err)
+	}
+	malformed := append(append([]byte(nil), lower...), bytes.Repeat([]byte{0xa5}, mvcckey.MaxEncodedKeySize-len(lower)+1)...)
+	if len(malformed) <= mvcckey.MaxEncodedKeySize {
+		t.Fatalf("malformed length=%d want > %d", len(malformed), mvcckey.MaxEncodedKeySize)
+	}
+	db, err := Open(t.TempDir(), NewMockBackend(), Options{
+		DisableWAL:         true,
+		FlushThreshold:     1 << 30,
+		MemtableShards:     16,
+		MaxQueuedMemtables: -1,
+		AllowUnsafe:        true,
+	})
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	if err := db.Set(malformed, []byte("corrupt")); err != nil {
+		t.Fatalf("Set oversized malformed suffix: %v", err)
+	}
+	key, value, found, err := db.SeekGE(lower, upper)
+	if err != nil || !found || !bytes.Equal(key, malformed) || !bytes.Equal(value, []byte("corrupt")) {
+		t.Fatalf("SeekGE oversized malformed suffix: key_len=%d value=%q found=%t err=%v", len(key), value, found, err)
+	}
+}
+
 func TestSeekGEExactMVCCRangeUsesSameShardImmutablePrecedence(t *testing.T) {
 	logical := []byte("queued-version")
 	version, err := mvcckey.Encode(logical, 20)

--- a/TreeDB/caching/mvcc_shard_affinity_test.go
+++ b/TreeDB/caching/mvcc_shard_affinity_test.go
@@ -1,0 +1,383 @@
+package caching
+
+import (
+	"bytes"
+	"fmt"
+	"strconv"
+	"testing"
+
+	"github.com/cespare/xxhash/v2"
+	"github.com/snissn/gomap/TreeDB/internal/mvcckey"
+)
+
+func TestMVCCPhysicalVersionsShareMutableShard(t *testing.T) {
+	db, err := Open(t.TempDir(), NewMockBackend(), Options{
+		FlushThreshold:     1 << 30,
+		MemtableShards:     16,
+		MaxQueuedMemtables: -1,
+		AllowUnsafe:        true,
+	})
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	logical := []byte{'d', 0, 'g', 'r', 'a', 'p', 'h'}
+	want := -1
+	for _, timestamp := range []uint64{1, 2, 99, ^uint64(0)} {
+		physical, err := mvcckey.Encode(logical, timestamp)
+		if err != nil {
+			t.Fatalf("Encode(%d): %v", timestamp, err)
+		}
+		got := db.shardIndex(physical)
+		if want < 0 {
+			want = got
+		} else if got != want {
+			t.Fatalf("timestamp %d shard=%d want stable shard %d", timestamp, got, want)
+		}
+	}
+	malformedSuffix, err := mvcckey.Encode(logical, 100)
+	if err != nil {
+		t.Fatalf("Encode malformed suffix base: %v", err)
+	}
+	malformedSuffix = append(malformedSuffix, 0)
+	if got := db.shardIndex(malformedSuffix); got != want {
+		t.Fatalf("malformed MVCC suffix shard=%d want logical-key shard %d", got, want)
+	}
+
+	raw := []byte("raw-key-keeps-legacy-hash")
+	wantRaw := int(xxhash.Sum64(raw) & db.mutableShardMask)
+	if got := db.shardIndex(raw); got != wantRaw {
+		t.Fatalf("raw shard=%d want legacy full-key shard %d", got, wantRaw)
+	}
+	logicalShards := make(map[int]struct{})
+	for i := 0; i < 64; i++ {
+		physical, err := mvcckey.Encode([]byte(fmt.Sprintf("logical-%03d", i)), 1)
+		if err != nil {
+			t.Fatalf("Encode logical %d: %v", i, err)
+		}
+		logicalShards[db.shardIndex(physical)] = struct{}{}
+	}
+	if len(logicalShards) < 8 {
+		t.Fatalf("64 logical keys reached only %d/16 shards", len(logicalShards))
+	}
+}
+
+func TestSeekGEExactMVCCRangeKeepsSyntheticLowerBoundOnLogicalShard(t *testing.T) {
+	logical := []byte("pruned-delete-anchor")
+	version20, err := mvcckey.Encode(logical, 20)
+	if err != nil {
+		t.Fatalf("Encode version 20: %v", err)
+	}
+	version10, err := mvcckey.Encode(logical, 10)
+	if err != nil {
+		t.Fatalf("Encode version 10: %v", err)
+	}
+	lower, err := mvcckey.Encode(logical, 26)
+	if err != nil {
+		t.Fatalf("Encode lower: %v", err)
+	}
+	upper, err := mvcckey.AppendKeyVersionsUpper(nil, logical)
+	if err != nil {
+		t.Fatalf("AppendKeyVersionsUpper: %v", err)
+	}
+	backend := NewMockBackend()
+	backend.Set(version20, []byte("stale-20"))
+	backend.Set(version10, []byte("stale-10"))
+	db, err := Open(t.TempDir(), backend, Options{
+		FlushThreshold:     1 << 30,
+		MemtableShards:     16,
+		MaxQueuedMemtables: -1,
+		AllowUnsafe:        true,
+	})
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	if err := db.Delete(version20); err != nil {
+		t.Fatalf("Delete version 20: %v", err)
+	}
+	if err := db.Delete(version10); err != nil {
+		t.Fatalf("Delete version 10: %v", err)
+	}
+	if key, value, found, err := db.SeekGE(lower, upper); err != nil || found {
+		t.Fatalf("SeekGE after physical deletes: key=%x value=%q found=%t err=%v", key, value, found, err)
+	}
+}
+
+func TestSeekGEExactMVCCRangeDoesNotHideMalformedSuffix(t *testing.T) {
+	logical := []byte("malformed-record")
+	lower, err := mvcckey.Encode(logical, 9)
+	if err != nil {
+		t.Fatalf("Encode lower: %v", err)
+	}
+	upper, err := mvcckey.AppendKeyVersionsUpper(nil, logical)
+	if err != nil {
+		t.Fatalf("AppendKeyVersionsUpper: %v", err)
+	}
+	malformed := append(append([]byte(nil), lower...), 0)
+	db, err := Open(t.TempDir(), NewMockBackend(), Options{
+		FlushThreshold:     1 << 30,
+		MemtableShards:     16,
+		MaxQueuedMemtables: -1,
+		AllowUnsafe:        true,
+	})
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	if err := db.Set(malformed, []byte("corrupt")); err != nil {
+		t.Fatalf("Set malformed suffix: %v", err)
+	}
+	key, value, found, err := db.SeekGE(lower, upper)
+	if err != nil || !found || !bytes.Equal(key, malformed) || !bytes.Equal(value, []byte("corrupt")) {
+		t.Fatalf("SeekGE malformed suffix: key=%x value=%q found=%t err=%v", key, value, found, err)
+	}
+}
+
+func TestSeekGEExactMVCCRangeUsesSameShardImmutablePrecedence(t *testing.T) {
+	logical := []byte("queued-version")
+	version, err := mvcckey.Encode(logical, 20)
+	if err != nil {
+		t.Fatalf("Encode version: %v", err)
+	}
+	lower, err := mvcckey.Encode(logical, 26)
+	if err != nil {
+		t.Fatalf("Encode lower: %v", err)
+	}
+	upper, err := mvcckey.AppendKeyVersionsUpper(nil, logical)
+	if err != nil {
+		t.Fatalf("AppendKeyVersionsUpper: %v", err)
+	}
+
+	t.Run("hit", func(t *testing.T) {
+		db, err := Open(t.TempDir(), NewMockBackend(), Options{
+			FlushThreshold:     1 << 30,
+			MemtableShards:     16,
+			MaxQueuedMemtables: -1,
+			AllowUnsafe:        true,
+		})
+		if err != nil {
+			t.Fatalf("Open: %v", err)
+		}
+		t.Cleanup(func() { _ = db.Close() })
+		db.flushMu.Lock()
+		t.Cleanup(db.flushMu.Unlock)
+		if err := db.Set(version, []byte("queued")); err != nil {
+			t.Fatalf("Set queued version: %v", err)
+		}
+		rotatePointSuccessorMemtables(t, db)
+		before := db.Stats()
+		key, value, found, err := db.SeekGE(lower, upper)
+		if err != nil || !found || !bytes.Equal(key, version) || !bytes.Equal(value, []byte("queued")) {
+			t.Fatalf("SeekGE queued version: key=%x value=%q found=%t err=%v", key, value, found, err)
+		}
+		after := db.Stats()
+		if got := pointSuccessorStatDelta(t, before, after, "treedb.cache.point_successor.queue_hits_total"); got != 1 {
+			t.Fatalf("queue hits=%d want 1", got)
+		}
+	})
+
+	t.Run("physical tombstone", func(t *testing.T) {
+		backend := NewMockBackend()
+		backend.Set(version, []byte("stale"))
+		db, err := Open(t.TempDir(), backend, Options{
+			FlushThreshold:     1 << 30,
+			MemtableShards:     16,
+			MaxQueuedMemtables: -1,
+			AllowUnsafe:        true,
+		})
+		if err != nil {
+			t.Fatalf("Open: %v", err)
+		}
+		t.Cleanup(func() { _ = db.Close() })
+		db.flushMu.Lock()
+		t.Cleanup(db.flushMu.Unlock)
+		if err := db.Delete(version); err != nil {
+			t.Fatalf("Delete version: %v", err)
+		}
+		rotatePointSuccessorMemtables(t, db)
+		if key, value, found, err := db.SeekGE(lower, upper); err != nil || found {
+			t.Fatalf("SeekGE queued tombstone: key=%x value=%q found=%t err=%v", key, value, found, err)
+		}
+	})
+}
+
+func TestSeekGEExactMVCCRangeFallsBackForRangeSpans(t *testing.T) {
+	logical := []byte("range-span-control")
+	lower, err := mvcckey.Encode(logical, 9)
+	if err != nil {
+		t.Fatalf("Encode lower: %v", err)
+	}
+	upper, err := mvcckey.AppendKeyVersionsUpper(nil, logical)
+	if err != nil {
+		t.Fatalf("AppendKeyVersionsUpper: %v", err)
+	}
+	backend := NewMockBackend()
+	backend.Set(lower, []byte("published"))
+	db, err := Open(t.TempDir(), backend, Options{
+		ExternalCommandWAL: true,
+		FlushThreshold:     1 << 30,
+		MemtableShards:     16,
+		MaxQueuedMemtables: -1,
+		AllowUnsafe:        true,
+	})
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	if err := db.DeleteRangeAfterCommandWALAppend([]byte("raw-range-a"), []byte("raw-range-z"), func() error { return nil }); err != nil {
+		t.Fatalf("DeleteRangeAfterCommandWALAppend: %v", err)
+	}
+	if got := deleteRangeStatUint64(t, db.Stats(), "treedb.cache.range_span.active_spans"); got != 1 {
+		t.Fatalf("active range spans=%d want 1", got)
+	}
+	before := db.Stats()
+	key, value, found, err := db.SeekGE(lower, upper)
+	if err != nil || !found || !bytes.Equal(key, lower) || !bytes.Equal(value, []byte("published")) {
+		t.Fatalf("SeekGE with unrelated range span: key=%x value=%q found=%t err=%v", key, value, found, err)
+	}
+	after := db.Stats()
+	if got := pointSuccessorStatDelta(t, before, after, "treedb.cache.point_successor.mutable_probes_total"); got != 16 {
+		t.Fatalf("mutable probes=%d want generic all-shard fallback 16", got)
+	}
+}
+
+func pointSuccessorStatDelta(t testing.TB, before, after map[string]string, name string) uint64 {
+	t.Helper()
+	start, startErr := strconv.ParseUint(before[name], 10, 64)
+	end, endErr := strconv.ParseUint(after[name], 10, 64)
+	if startErr != nil || endErr != nil || end < start {
+		t.Fatalf("invalid %s counter %q -> %q", name, before[name], after[name])
+	}
+	return end - start
+}
+
+func TestSeekGEExactMVCCRangeUsesShardLocalInMemorySources(t *testing.T) {
+	const queuedSources = 32
+	logical := []byte("published-dgraph-posting")
+	lower, err := mvcckey.Encode(logical, 50)
+	if err != nil {
+		t.Fatalf("Encode lower: %v", err)
+	}
+	upper, err := mvcckey.AppendKeyVersionsUpper(nil, logical)
+	if err != nil {
+		t.Fatalf("AppendKeyVersionsUpper: %v", err)
+	}
+	backend := NewMockBackend()
+	backend.Set(lower, []byte("published"))
+	db, err := Open(t.TempDir(), backend, Options{
+		FlushThreshold:     1 << 30,
+		MemtableShards:     16,
+		MaxQueuedMemtables: -1,
+		AllowUnsafe:        true,
+	})
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	db.flushMu.Lock()
+	t.Cleanup(db.flushMu.Unlock)
+	target := db.shardIndex(lower)
+	created := 0
+	for candidate := 0; created < queuedSources; candidate++ {
+		key := []byte(fmt.Sprintf("unrelated-%06d", candidate))
+		if db.shardIndex(key) == target {
+			continue
+		}
+		if err := db.Set(key, []byte("queued")); err != nil {
+			t.Fatalf("Set(%q): %v", key, err)
+		}
+		rotatePointSuccessorMemtables(t, db)
+		created++
+	}
+
+	before := db.Stats()
+	key, value, found, err := db.SeekGE(lower, upper)
+	if err != nil || !found || !bytes.Equal(key, lower) || !bytes.Equal(value, []byte("published")) {
+		t.Fatalf("SeekGE legacy/global published root: key=%x value=%q found=%t err=%v", key, value, found, err)
+	}
+	after := db.Stats()
+	if got := pointSuccessorStatDelta(t, before, after, "treedb.cache.point_successor.mutable_probes_total"); got != 1 {
+		t.Fatalf("mutable probes=%d want 1 logical-key shard", got)
+	}
+	if got := pointSuccessorStatDelta(t, before, after, "treedb.cache.point_successor.queue_probes_total"); got != 0 {
+		t.Fatalf("queue probes=%d want 0 unrelated shard queues", got)
+	}
+	if got := pointSuccessorStatDelta(t, before, after, "treedb.cache.point_successor.backend_probes_total"); got != 1 {
+		t.Fatalf("backend probes=%d want authoritative global root", got)
+	}
+	if got := pointSuccessorStatDelta(t, before, after, "treedb.cache.point_successor.sources_total"); got != 2 {
+		t.Fatalf("sources=%d want target mutable plus global root", got)
+	}
+}
+
+func BenchmarkSeekGEExactMVCCShardAffinityPublishedHit(b *testing.B) {
+	const queuedSources = 96
+	logical := []byte("published-dgraph-posting")
+	lower, err := mvcckey.Encode(logical, 50)
+	if err != nil {
+		b.Fatalf("Encode lower: %v", err)
+	}
+	upper, err := mvcckey.AppendKeyVersionsUpper(nil, logical)
+	if err != nil {
+		b.Fatalf("AppendKeyVersionsUpper: %v", err)
+	}
+	backend := NewMockBackend()
+	backend.Set(lower, []byte("published"))
+	db, err := Open(b.TempDir(), backend, Options{
+		FlushThreshold:     1 << 30,
+		MemtableShards:     16,
+		MaxQueuedMemtables: -1,
+		AllowUnsafe:        true,
+	})
+	if err != nil {
+		b.Fatalf("Open: %v", err)
+	}
+	b.Cleanup(func() { _ = db.Close() })
+	db.flushMu.Lock()
+	b.Cleanup(db.flushMu.Unlock)
+	target := db.shardIndex(lower)
+	created := 0
+	for candidate := 0; created < queuedSources; candidate++ {
+		key := []byte(fmt.Sprintf("unrelated-%06d", candidate))
+		if db.shardIndex(key) == target {
+			continue
+		}
+		if err := db.Set(key, []byte("queued")); err != nil {
+			b.Fatalf("Set(%q): %v", key, err)
+		}
+		db.mu.Lock()
+		err = db.rotateMemtableLocked(false)
+		db.mu.Unlock()
+		if err != nil {
+			b.Fatalf("rotateMemtableLocked: %v", err)
+		}
+		created++
+	}
+	forcedGenericUpper := append(append([]byte(nil), upper...), 0)
+	for _, tc := range []struct {
+		name  string
+		upper []byte
+	}{
+		{name: "exact_mvcc_shard", upper: upper},
+		{name: "forced_generic_control", upper: forcedGenericUpper},
+	} {
+		b.Run(tc.name, func(b *testing.B) {
+			before := db.Stats()
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				key, value, found, err := db.SeekGE(lower, tc.upper)
+				if err != nil || !found || !bytes.Equal(key, lower) || !bytes.Equal(value, []byte("published")) {
+					b.Fatalf("SeekGE: key=%x value=%q found=%t err=%v", key, value, found, err)
+				}
+			}
+			b.StopTimer()
+			after := db.Stats()
+			reportPointSuccessorBenchCounter(b, before, after, "treedb.cache.point_successor.sources_total", "sources/op")
+			reportPointSuccessorBenchCounter(b, before, after, "treedb.cache.point_successor.mutable_probes_total", "mutable_probes/op")
+			reportPointSuccessorBenchCounter(b, before, after, "treedb.cache.point_successor.queue_probes_total", "queue_probes/op")
+			reportPointSuccessorBenchCounter(b, before, after, "treedb.cache.point_successor.backend_probes_total", "backend_probes/op")
+		})
+	}
+}

--- a/TreeDB/caching/point_successor.go
+++ b/TreeDB/caching/point_successor.go
@@ -8,6 +8,7 @@ import (
 	backenddb "github.com/snissn/gomap/TreeDB/db"
 	"github.com/snissn/gomap/TreeDB/internal/iterator"
 	"github.com/snissn/gomap/TreeDB/internal/memtable"
+	"github.com/snissn/gomap/TreeDB/internal/mvcckey"
 	"github.com/snissn/gomap/TreeDB/node"
 	"github.com/snissn/gomap/TreeDB/page"
 )
@@ -207,12 +208,20 @@ func (db *DB) SeekGE(start, end []byte) (key, value []byte, found bool, err erro
 	var mutables []memtable.Table
 	var queue []memtable.Table
 	var spans [][]batch.DeleteRange
+	pointShard := -1
 	if view != nil {
 		mutables = view.mutables
 		queue = view.queue
 		spans = view.queueRangeSpans
 		if snap, ok := liveIteratorRootDomainSnapshot(view); ok && len(snap.immutables) > 0 {
 			queue = snap.immutables
+		}
+		if _, ok := mvcckey.ExactVersionRange(start, end); ok && !memtableViewHasRangeSpans(view) {
+			pointShard = db.shardIndex(start)
+			if pointShard >= 0 && pointShard < len(view.rootPointShards) {
+				queue = view.rootPointShards[pointShard].immutables
+				spans = nil
+			}
 		}
 	}
 	var callSources uint64
@@ -250,7 +259,10 @@ func (db *DB) SeekGE(start, end []byte) (key, value []byte, found bool, err erro
 		best := pointSuccessorCandidate{}
 		priority := 0
 		if len(mutables) > 0 {
-			target := db.shardIndex(lower)
+			target := pointShard
+			if target < 0 {
+				target = db.shardIndex(lower)
+			}
 			if target >= 0 && target < len(mutables) {
 				candidate := initialCandidate
 				if target != initialTarget || !bytes.Equal(lower, start) {
@@ -267,6 +279,9 @@ func (db *DB) SeekGE(start, end []byte) (key, value []byte, found bool, err erro
 				}
 			}
 			for i, mt := range mutables {
+				if pointShard >= 0 {
+					break
+				}
 				if i == target {
 					continue
 				}

--- a/TreeDB/internal/mvcckey/codec.go
+++ b/TreeDB/internal/mvcckey/codec.go
@@ -134,9 +134,11 @@ func InNamespace(physical []byte) bool {
 // accepts a malformed or incomplete timestamp suffix. This keeps every key
 // that can sort inside one logical key's version range on the same in-memory
 // shard, so an exact-version read cannot hide malformed reserved-namespace
-// records that the MVCC layer must reject fail-closed.
+// records that the MVCC layer must reject fail-closed. The total physical
+// length is intentionally not bounded: an oversized malformed suffix still
+// sorts in that range and must retain the logical prefix's affinity.
 func VersionAffinityPrefix(physical []byte) (prefix []byte, ok bool) {
-	if len(physical) > MaxEncodedKeySize || !bytes.HasPrefix(physical, namespaceV1[:]) {
+	if !bytes.HasPrefix(physical, namespaceV1[:]) {
 		return nil, false
 	}
 	for i := len(namespaceV1); i < len(physical); {

--- a/TreeDB/internal/mvcckey/codec.go
+++ b/TreeDB/internal/mvcckey/codec.go
@@ -129,6 +129,65 @@ func InNamespace(physical []byte) bool {
 	return bytes.HasPrefix(physical, namespaceV1[:])
 }
 
+// VersionAffinityPrefix returns the allocation-free physical prefix through
+// the encoded logical-key terminator. Unlike VersionPrefix, it deliberately
+// accepts a malformed or incomplete timestamp suffix. This keeps every key
+// that can sort inside one logical key's version range on the same in-memory
+// shard, so an exact-version read cannot hide malformed reserved-namespace
+// records that the MVCC layer must reject fail-closed.
+func VersionAffinityPrefix(physical []byte) (prefix []byte, ok bool) {
+	if len(physical) > MaxEncodedKeySize || !bytes.HasPrefix(physical, namespaceV1[:]) {
+		return nil, false
+	}
+	for i := len(namespaceV1); i < len(physical); {
+		if physical[i] != 0 {
+			i++
+			continue
+		}
+		if i+1 >= len(physical) {
+			return nil, false
+		}
+		switch physical[i+1] {
+		case 0xff:
+			i += 2
+		case 0x00:
+			return physical[:i+2], true
+		default:
+			return nil, false
+		}
+	}
+	return nil, false
+}
+
+// VersionPrefix returns the allocation-free physical prefix shared by every
+// encoded version of one logical key. The returned slice aliases physical.
+// Malformed and non-MVCC keys return ok=false so generic callers retain their
+// existing full-key behavior.
+func VersionPrefix(physical []byte) (prefix []byte, ok bool) {
+	if len(physical) > MaxEncodedKeySize || !bytes.HasPrefix(physical, namespaceV1[:]) {
+		return nil, false
+	}
+	bodyEnd, _, _, err := inspect(physical)
+	if err != nil || bodyEnd+2+TimestampSize != len(physical) {
+		return nil, false
+	}
+	return physical[:bodyEnd+2], true
+}
+
+// ExactVersionRange reports whether [start,end) is the canonical range from
+// one encoded version lower bound through the exclusive upper bound of all
+// versions of that same logical key. The returned prefix aliases start.
+func ExactVersionRange(start, end []byte) (prefix []byte, ok bool) {
+	prefix, ok = VersionPrefix(start)
+	if !ok || len(end) != len(prefix) || len(prefix) == 0 || prefix[len(prefix)-1] != 0 {
+		return nil, false
+	}
+	if !bytes.Equal(prefix[:len(prefix)-1], end[:len(end)-1]) || end[len(end)-1] != 1 {
+		return nil, false
+	}
+	return prefix, true
+}
+
 // AppendNamespaceLower appends the inclusive lower bound of the v1 namespace.
 func AppendNamespaceLower(dst []byte) []byte {
 	return append(dst, namespaceV1[:]...)

--- a/TreeDB/internal/mvcckey/codec_test.go
+++ b/TreeDB/internal/mvcckey/codec_test.go
@@ -260,6 +260,58 @@ func TestTimestampExtremesSortNewestFirst(t *testing.T) {
 	}
 }
 
+func TestVersionPrefixAndExactVersionRange(t *testing.T) {
+	logical := []byte{'a', 0, 'b'}
+	first, err := Encode(logical, 1)
+	if err != nil {
+		t.Fatalf("Encode first: %v", err)
+	}
+	second, err := Encode(logical, 99)
+	if err != nil {
+		t.Fatalf("Encode second: %v", err)
+	}
+	firstPrefix, ok := VersionPrefix(first)
+	if !ok {
+		t.Fatal("VersionPrefix(first) rejected valid key")
+	}
+	secondPrefix, ok := VersionPrefix(second)
+	if !ok || !bytes.Equal(firstPrefix, secondPrefix) {
+		t.Fatalf("version prefixes differ: %x vs %x", firstPrefix, secondPrefix)
+	}
+	if affinityPrefix, ok := VersionAffinityPrefix(first); !ok || !bytes.Equal(affinityPrefix, firstPrefix) {
+		t.Fatalf("VersionAffinityPrefix(first)=(%x,%t), want %x,true", affinityPrefix, ok, firstPrefix)
+	}
+	upper, err := AppendKeyVersionsUpper(nil, logical)
+	if err != nil {
+		t.Fatalf("AppendKeyVersionsUpper: %v", err)
+	}
+	gotPrefix, ok := ExactVersionRange(second, upper)
+	if !ok || !bytes.Equal(gotPrefix, secondPrefix) {
+		t.Fatalf("ExactVersionRange prefix=%x ok=%t want %x,true", gotPrefix, ok, secondPrefix)
+	}
+
+	malformedSuffix := append(append([]byte(nil), first...), 0)
+	if affinityPrefix, ok := VersionAffinityPrefix(malformedSuffix); !ok || !bytes.Equal(affinityPrefix, firstPrefix) {
+		t.Fatalf("VersionAffinityPrefix(malformed suffix)=(%x,%t), want %x,true", affinityPrefix, ok, firstPrefix)
+	}
+	for _, malformed := range [][]byte{
+		nil,
+		[]byte("raw"),
+		append([]byte("raw-key"), 0, 0, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xfe),
+		append([]byte(nil), first[:len(first)-1]...),
+		malformedSuffix,
+	} {
+		if prefix, ok := VersionPrefix(malformed); ok || prefix != nil {
+			t.Fatalf("VersionPrefix(%x)=(%x,%t), want nil,false", malformed, prefix, ok)
+		}
+	}
+	badUpper := append([]byte(nil), upper...)
+	badUpper[len(badUpper)-1]++
+	if prefix, ok := ExactVersionRange(second, badUpper); ok || prefix != nil {
+		t.Fatalf("ExactVersionRange accepted noncanonical upper %x", badUpper)
+	}
+}
+
 func allBytes() []byte {
 	out := make([]byte, 256)
 	for i := range out {

--- a/TreeDB/internal/mvcckey/codec_test.go
+++ b/TreeDB/internal/mvcckey/codec_test.go
@@ -294,6 +294,13 @@ func TestVersionPrefixAndExactVersionRange(t *testing.T) {
 	if affinityPrefix, ok := VersionAffinityPrefix(malformedSuffix); !ok || !bytes.Equal(affinityPrefix, firstPrefix) {
 		t.Fatalf("VersionAffinityPrefix(malformed suffix)=(%x,%t), want %x,true", affinityPrefix, ok, firstPrefix)
 	}
+	oversizedMalformedSuffix := append(append([]byte(nil), first...), bytes.Repeat([]byte{0xa5}, MaxEncodedKeySize-len(first)+1)...)
+	if len(oversizedMalformedSuffix) <= MaxEncodedKeySize {
+		t.Fatalf("oversized malformed suffix length=%d want > %d", len(oversizedMalformedSuffix), MaxEncodedKeySize)
+	}
+	if affinityPrefix, ok := VersionAffinityPrefix(oversizedMalformedSuffix); !ok || !bytes.Equal(affinityPrefix, firstPrefix) {
+		t.Fatalf("VersionAffinityPrefix(oversized malformed suffix)=(%x,%t), want %x,true", affinityPrefix, ok, firstPrefix)
+	}
 	for _, malformed := range [][]byte{
 		nil,
 		[]byte("raw"),


### PR DESCRIPTION
Advances #3956 without closing it. Stable MVCC shard affinity removes the activated point-read fan-in, but the unchanged restricted Dgraph median remains about 14.3% below matched Badger, so the terminal parent stays open for one profiled successor.

## What changed

- Hash all valid physical versions of one external-MVCC logical key by their allocation-free encoded logical prefix.
- Give malformed timestamp suffixes the same affinity when they can sort inside that logical key's version range, preserving fail-closed visibility.
- Recognize only the canonical exact-version range and probe its one mutable shard plus shard-local immutable queue.
- Keep the authoritative global published-root iterator, preserving readability of roots written by older builds.
- Pin successor retries to the original logical-key shard after physical tombstones; generic raw ranges and all range-span views retain the old all-shard path.

The MVCC encoding, on-disk root format, command WAL, acknowledgements, flush/publication bytes, and generic raw-key behavior are unchanged.

## Correctness evidence

- `go test ./TreeDB/internal/mvcckey ./TreeDB/caching ./TreeDB/mvcc -count=1`
- `go test -race ./TreeDB/internal/mvcckey ./TreeDB/caching ./TreeDB/mvcc -count=1`
- `go test ./TreeDB ./TreeDB/db -count=1`
- New focused tests pass under `-race -count=3`.

The broad suite initially exposed two real candidate defects before publication: malformed reserved-namespace suffixes could be hidden, and re-hashing a synthetic lower bound after a physical tombstone could resurrect pruned history. Both now have direct regression tests. Additional coverage proves same-shard immutable hit/tombstone precedence and explicit fallback when any range span is active.

Independent read-only review found no concrete correctness issue after those fixes. It requested the immutable and range-span tests now included here.

## Deterministic performance evidence

With 16 mutable shards and 96 unrelated queued sources, the exact published-root lookup uses 2 sources (1 mutable, 0 queue, 1 backend) versus 113 for the forced-generic control (16 mutable, 96 queue, 1 backend):

- exact: 0.84-1.32 us/op, 296 B/op, 8 allocs/op;
- generic: 8.51-10.15 us/op, 296 B/op, 8 allocs/op;
- source reduction: 98.2%; time reduction: about 87%; allocations unchanged.

The matched 1,000,000-operation command-WAL relaxed singleton control is neutral within host noise: current-main median 4,917 ns/op versus candidate rerun median 4,884 ns/op, with the same 10-11 allocation range.

## Live Dgraph evidence

Unchanged Dgraph `cc51080c7c4b110f3b43410955abe781be5cc42b`, local replacement to this candidate, frozen 500-node / 100-warmup / 100,000-op / concurrency-4 relaxed shape:

- valid rows: 5,359.17, 5,239.76, 5,217.60 ops/s;
- median: 5,239.76 ops/s;
- median p50/p95/p99: 0.634/1.390/1.896 ms;
- schema, posting checksum/count, restart, and unsupported-feature validation passed in every row;
- no row was excluded for contamination.

This is about 13.7% above PR #3953's 4,606.74 median, but still about 14.3% below the frozen matched Badger median of 6,112 ops/s. The exact profile now attributes about 12.7% cumulative CPU to canonical flush/backend write, 9.8% to final commit, 9.0% to queued root publication, 4.0% to `GetAt`, and 2.1% to the backend successor iterator. That supports merging this bounded win while leaving #3956 and its parents open.

Because in-memory shard/lane placement can change flush grouping and root/allocator bytes, #3684 must be reopened and a new exact-candidate power-loss certificate published after merge before Dgraph #29 pins this result.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Performance Improvements**
  - Improved MVCC point lookups by limiting searches to the relevant shard when possible.
  - Reduced unnecessary cross-shard probing while preserving correct results for queued values, tombstones, and in-memory data.
  - Improved cache shard affinity for different versions of the same logical key.

- **Bug Fixes**
  - Preserved correct `SeekGE` behavior across physical deletes, malformed version suffixes, and range-based queries.

- **Tests**
  - Added comprehensive MVCC shard-affinity, lookup correctness, and performance benchmark coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->