### PR TITLE
perf(treedb): batch freelist state mutations

### DIFF
--- a/TreeDB/freelist/allocator_cow.go
+++ b/TreeDB/freelist/allocator_cow.go
@@ -209,7 +209,15 @@ func (a *Allocator) retireCOWLocked(ids []uint64, lastReachableCommitSeq uint64)
 		if id < 2 {
 			return errCannotFreePageZero
 		}
-		a.cow.txn.Retire(id, lastReachableCommitSeq)
+	}
+	if len(ids) == 1 {
+		a.cow.txn.Retire(ids[0], lastReachableCommitSeq)
+	} else {
+		retired := make([]retiredPage, len(ids))
+		for i, id := range ids {
+			retired[i] = retiredPage{id: id, lastReachableCommitSeq: lastReachableCommitSeq}
+		}
+		a.cow.txn.retireMany(retired)
 	}
 	a.stats.FreePages += uint64(len(ids))
 	if TestHookRetireCOWBeforeUnlock != nil {

--- a/TreeDB/freelist/allocator_cow_test.go
+++ b/TreeDB/freelist/allocator_cow_test.go
@@ -376,7 +376,7 @@ func TestAllocatorCOWCandidateRetirementsRollbackBeforePublish(t *testing.T) {
 		before := allocator.Counters()
 		if _, err := allocator.PrepareCOWCandidateRetiringV1(
 			2, 2, candidateIDFromString("failed-retirement-stage"), capability,
-			[]COWRetirementV1{{PageIDs: []uint64{4}, LastReachableCommitSeq: 1}},
+			[]COWRetirementV1{{PageIDs: []uint64{4, 5, 6}, LastReachableCommitSeq: 1}},
 			1, failingPageSinkV1{},
 		); err == nil {
 			t.Fatal("candidate preparation unexpectedly succeeded")
@@ -402,14 +402,14 @@ func TestAllocatorCOWCandidateRetirementsRollbackBeforePublish(t *testing.T) {
 		before := allocator.Counters()
 		prepared, err := allocator.PrepareCOWCandidateRetiringV1(
 			2, 2, candidateIDFromString("aborted-retirement-stage"), capability,
-			[]COWRetirementV1{{PageIDs: []uint64{4}, LastReachableCommitSeq: 1}},
+			[]COWRetirementV1{{PageIDs: []uint64{4, 5, 6}, LastReachableCommitSeq: 1}},
 			1, NewMemoryPageStoreV1(),
 		)
 		if err != nil {
 			t.Fatal(err)
 		}
-		if got := prepared.Candidate().Generation().RetiredCount(); got != 1 {
-			t.Fatalf("prepared retired=%d want 1", got)
+		if got := prepared.Candidate().Generation().RetiredCount(); got != 3 {
+			t.Fatalf("prepared retired=%d want 3", got)
 		}
 		if got := p.PageCount(); got != 8 {
 			t.Fatalf("pager pages after prepare=%d want 8", got)

--- a/TreeDB/freelist/generation_v1_test.go
+++ b/TreeDB/freelist/generation_v1_test.go
@@ -1,6 +1,7 @@
 package freelist
 
 import (
+	"bytes"
 	"encoding/binary"
 	"errors"
 	"testing"
@@ -543,6 +544,128 @@ func TestFreelistGenerationV1_OneChunkDeltaEmitsOnlyOnePath(t *testing.T) {
 	}
 	if stats.COWBytes != stats.COWPages*4096 {
 		t.Fatalf("bytes=%d pages=%d", stats.COWBytes, stats.COWPages)
+	}
+}
+
+func TestFreelistGenerationV1_BatchedRetirementMutatesEachChunkOnce(t *testing.T) {
+	base := MustNewFreelistGenerationV1(1, 1024, nil, nil)
+	txn := NewFreelistTxn(base, NewReservationLedger())
+	retired := make([]retiredPage, 0, 200)
+	for id := uint64(2); id < 202; id++ {
+		retired = append(retired, retiredPage{id: id, lastReachableCommitSeq: 1})
+	}
+	txn.retireMany(retired)
+
+	stats := txn.Stats()
+	if stats.StateMutationPaths != 1 || stats.StateMutationItems != uint64(len(retired)) {
+		t.Fatalf("batched retirement mutation work: paths=%d items=%d want 1/%d",
+			stats.StateMutationPaths, stats.StateMutationItems, len(retired))
+	}
+	candidate, err := txn.MaterializeCandidate(2, 2, candidateIDFromString("batched-retirement"), NewMemoryPageStoreV1())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := candidate.Generation().RetiredCount(); got != uint64(len(retired)) {
+		t.Fatalf("retired count=%d want %d", got, len(retired))
+	}
+}
+
+func TestFreelistGenerationV1_BatchedPruneMutatesEachChunkOnce(t *testing.T) {
+	retired := make(map[uint64]uint64, 200)
+	for id := uint64(2); id < 202; id++ {
+		retired[id] = 1
+	}
+	base := MustNewFreelistGenerationV1(1, 1024, nil, retired)
+	txn := NewFreelistTxn(base, NewReservationLedger())
+	capability, err := NewReuseCapability(2, 2, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	txn.PruneWithCapability(capability)
+
+	stats := txn.Stats()
+	if stats.StateMutationPaths != 1 || stats.StateMutationItems != uint64(len(retired)) {
+		t.Fatalf("batched prune mutation work: paths=%d items=%d want 1/%d",
+			stats.StateMutationPaths, stats.StateMutationItems, len(retired))
+	}
+	candidate, err := txn.MaterializeCandidate(2, 2, candidateIDFromString("batched-prune"), NewMemoryPageStoreV1())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := candidate.Generation().FreeCount(); got != uint64(len(retired)) {
+		t.Fatalf("free count=%d want %d", got, len(retired))
+	}
+}
+
+func TestFreelistGenerationV1_BatchedRetirementMatchesPerPageBytes(t *testing.T) {
+	base := materializeTestGeneration(t,
+		MustNewFreelistGenerationV1(1, 1024, []uint64{2, 300, 301, 700}, nil),
+		2, NewMemoryPageStoreV1(),
+	)
+	retired := []retiredPage{
+		{id: 300, lastReachableCommitSeq: 1},
+		{id: 2, lastReachableCommitSeq: 1},
+		{id: 301, lastReachableCommitSeq: 2},
+		{id: 2, lastReachableCommitSeq: 3},
+		{id: 700, lastReachableCommitSeq: 2},
+	}
+	legacy := NewFreelistTxn(base, NewReservationLedger())
+	for _, item := range retired {
+		legacy.retire(item.id, item.lastReachableCommitSeq)
+	}
+	batched := NewFreelistTxn(base, NewReservationLedger())
+	batched.retireMany(retired)
+
+	candidateID := candidateIDFromString("batched-byte-equivalence")
+	legacyCandidate, err := legacy.MaterializeCandidate(3, 3, candidateID, NewMemoryPageStoreV1())
+	if err != nil {
+		t.Fatal(err)
+	}
+	batchedCandidate, err := batched.MaterializeCandidate(3, 3, candidateID, NewMemoryPageStoreV1())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got, want := batchedCandidate.GenerationRef(), legacyCandidate.GenerationRef(); got != want {
+		t.Fatalf("batched generation ref=%+v want per-page %+v", got, want)
+	}
+	gotPages, wantPages := batchedCandidate.Pages(), legacyCandidate.Pages()
+	if len(gotPages) != len(wantPages) {
+		t.Fatalf("batched pages=%d want per-page %d", len(gotPages), len(wantPages))
+	}
+	for i := range wantPages {
+		if gotPages[i].PageID != wantPages[i].PageID || !bytes.Equal(gotPages[i].Data, wantPages[i].Data) {
+			t.Fatalf("batched page %d differs from per-page materialization", i)
+		}
+	}
+}
+
+func BenchmarkFreelistGenerationV1_RetirementMutation(b *testing.B) {
+	base := MustNewFreelistGenerationV1(1, 1024, nil, nil)
+	retired := make([]retiredPage, 0, 200)
+	for id := uint64(2); id < 202; id++ {
+		retired = append(retired, retiredPage{id: id, lastReachableCommitSeq: 1})
+	}
+	for _, row := range []struct {
+		name  string
+		apply func(*FreelistTxn)
+	}{
+		{name: "per-page-control", apply: func(txn *FreelistTxn) {
+			for _, item := range retired {
+				txn.retire(item.id, item.lastReachableCommitSeq)
+			}
+		}},
+		{name: "batched", apply: func(txn *FreelistTxn) { txn.retireMany(retired) }},
+	} {
+		b.Run(row.name, func(b *testing.B) {
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				txn := NewFreelistTxn(base, NewReservationLedger())
+				row.apply(txn)
+				stats := txn.Stats()
+				b.ReportMetric(float64(stats.StateMutationPaths), "mutation-paths/op")
+				b.ReportMetric(float64(stats.StateMutationItems), "mutation-items/op")
+			}
+		})
 	}
 }
 

--- a/TreeDB/freelist/generation_v1_txn.go
+++ b/TreeDB/freelist/generation_v1_txn.go
@@ -5,6 +5,7 @@ import (
 	"encoding/binary"
 	"fmt"
 	"math"
+	"sort"
 
 	"github.com/snissn/gomap/TreeDB/page"
 )
@@ -166,6 +167,7 @@ func (h RecoveryHorizon) capability() ReuseCapability {
 
 type FreelistTxnStats struct {
 	COWChunks, COWPages, COWBytes, LogicalDelta            uint64
+	StateMutationPaths, StateMutationItems                 uint64
 	AppendAllocations, ReuseAllocations, Reservations      uint64
 	FreeIDs, RetiredIDs, ReuseLag, PageVisits              uint64
 	GenerationID, ReservationRecords                       uint64
@@ -231,9 +233,7 @@ func BeginCandidateV1(base *FreelistGenerationV1, expectedParent GenerationRefV1
 	for _, id := range base.record.pageIDs {
 		t.replacedMetadata[id] = struct{}{}
 	}
-	for _, pending := range base.record.pendingMetadata() {
-		t.retire(pending.id, pending.lastReachableCommitSeq)
-	}
+	t.retireMany(base.record.pendingMetadata())
 	return t, nil
 }
 
@@ -273,10 +273,16 @@ func (t *FreelistTxn) markReplacedPath(chunkNo uint64) {
 	}
 }
 
-func (t *FreelistTxn) mutate(chunkNo uint64, f func(*stateChunk)) {
+func (t *FreelistTxn) mutateMany(chunkNo, items uint64, f func(*stateChunk)) {
 	t.markReplacedPath(chunkNo)
 	t.root = mutateChunk(t.root, chunkNo, 0, f)
 	t.changedChunks[chunkNo] = struct{}{}
+	t.stats.StateMutationPaths++
+	t.stats.StateMutationItems += items
+}
+
+func (t *FreelistTxn) mutate(chunkNo uint64, f func(*stateChunk)) {
+	t.mutateMany(chunkNo, 1, f)
 }
 
 func (t *FreelistTxn) Allocate(regionHint uint64) (uint64, error) {
@@ -402,6 +408,51 @@ func (t *FreelistTxn) retire(id, seq uint64) {
 	t.mutate(id>>freelistChunkShift, func(c *stateChunk) { c.setFree(offset, false); c.retired[offset] = seq })
 }
 
+// retireMany applies all retirements for one state chunk through a single
+// persistent-tree mutation. The previous one-ID-at-a-time path cloned the
+// same chunk and its full trie path repeatedly when a commit retired adjacent
+// index or allocator-metadata pages.
+func (t *FreelistTxn) retireMany(retired []retiredPage) {
+	if t == nil || t.consumed || len(retired) == 0 {
+		return
+	}
+	valid := retired[:0]
+	for _, item := range retired {
+		if item.id < 2 || item.id >= t.highWater || item.lastReachableCommitSeq == 0 {
+			continue
+		}
+		valid = append(valid, item)
+	}
+	if len(valid) == 0 {
+		return
+	}
+	if len(valid) == 1 {
+		t.retire(valid[0].id, valid[0].lastReachableCommitSeq)
+		return
+	}
+	// Stable ordering preserves last-writer behavior for duplicate IDs with
+	// different retirement sequences while making every chunk one run.
+	sort.SliceStable(valid, func(i, j int) bool {
+		return valid[i].id>>freelistChunkShift < valid[j].id>>freelistChunkShift
+	})
+	for start := 0; start < len(valid); {
+		chunkNo := valid[start].id >> freelistChunkShift
+		end := start + 1
+		for end < len(valid) && valid[end].id>>freelistChunkShift == chunkNo {
+			end++
+		}
+		items := valid[start:end]
+		t.mutateMany(chunkNo, uint64(len(items)), func(c *stateChunk) {
+			for _, item := range items {
+				offset := item.id & (freelistChunkSize - 1)
+				c.setFree(offset, false)
+				c.retired[offset] = item.lastReachableCommitSeq
+			}
+		})
+		start = end
+	}
+}
+
 func (t *FreelistTxn) Retire(id, seq uint64) {
 	if t != nil {
 		t.retire(id, seq)
@@ -446,11 +497,37 @@ func (t *FreelistTxn) PruneWithCapability(cap ReuseCapability) {
 	var promote []retiredPage
 	collectPrunable(t.root, 0, cap, &promote, &t.stats.PageVisits)
 	for _, retired := range promote {
-		offset := retired.id & (freelistChunkSize - 1)
-		t.mutate(retired.id>>freelistChunkShift, func(c *stateChunk) { c.retired[offset] = 0; c.setFree(offset, true) })
 		if lag := cap.oldestRecoverableCommitSeq - retired.lastReachableCommitSeq; lag > t.stats.ReuseLag {
 			t.stats.ReuseLag = lag
 		}
+	}
+	if len(promote) == 1 {
+		item := promote[0]
+		offset := item.id & (freelistChunkSize - 1)
+		t.mutate(item.id>>freelistChunkShift, func(c *stateChunk) {
+			c.retired[offset] = 0
+			c.setFree(offset, true)
+		})
+		return
+	}
+	sort.SliceStable(promote, func(i, j int) bool {
+		return promote[i].id>>freelistChunkShift < promote[j].id>>freelistChunkShift
+	})
+	for start := 0; start < len(promote); {
+		chunkNo := promote[start].id >> freelistChunkShift
+		end := start + 1
+		for end < len(promote) && promote[end].id>>freelistChunkShift == chunkNo {
+			end++
+		}
+		items := promote[start:end]
+		t.mutateMany(chunkNo, uint64(len(items)), func(c *stateChunk) {
+			for _, item := range items {
+				offset := item.id & (freelistChunkSize - 1)
+				c.retired[offset] = 0
+				c.setFree(offset, true)
+			}
+		})
+		start = end
 	}
 }
 


### PR DESCRIPTION
## Summary

- batch adjacent freelist retirements and capability-gated promotions into one persistent-trie mutation per affected 256-page chunk
- retain the original direct path for singleton retirement/prune work
- expose deterministic mutation-path/item counters and byte-equivalence regressions
- preserve candidate IDs, exact generation bytes/refs, ledger ownership, rollback, activation, publication ordering, and durable-root semantics

Refs #3823.

## Why this boundary

Tree nodes and materialized freelist pages are already immutable and structurally shared between generations. The remaining avoidable work was applying many adjacent retirements one ID at a time: each call cloned the same state chunk and its full trie path before candidate materialization. This change groups only those in-memory state mutations; it does not defer candidate construction, omit intermediate generations, alias candidate images, or change the coordinator/publication protocol.

## Deterministic attribution

`BenchmarkFreelistGenerationV1_RetirementMutation`, fixed 10,000x, three repeats:

- per-page control: 200 mutation paths for 200 items, 369-411 us/op, 1,037,442-1,037,445 B/op, 3,207 allocs/op
- batched: 1 mutation path for 200 items, 5.2-6.5 us/op, 5,912 B/op, 26 allocs/op

The regression suite also proves the batched materialization produces the exact same generation ref and page bytes as the former per-page sequence, including interleaved chunks and duplicate-ID last-writer behavior.

## Production foreground evidence

Matched same-host `BenchmarkConditionalTxnBaselineBatchWrite`, fixed 1,000x, five repeats per side:

| Metric | main `25db6252` | candidate `015e15a4` | Delta |
| --- | ---: | ---: | ---: |
| time | 287.2 us/op median | 212.7 us/op median | -25.96%, p=0.008 |
| bytes | 551.8 KiB/op median | 437.9 KiB/op median | -20.64%, p=0.008 |
| allocations | 736/op | 385/op | -47.69%, p=0.008 |

This harness retains the production accepted-candidate handoff, prevents asynchronous publication inside each measured foreground group, and drains through `Checkpoint` outside the timed interval.

## Local validation

- `go test ./TreeDB/freelist ./TreeDB/db -count=1`
- `go test -race ./TreeDB/freelist -count=1`
- `go test -race ./TreeDB/db -run 'Test(QueuedRootPublication|ActivatedRootPublication|RootPublication|DurableRoot|OpenFresh)' -count=1`
- `go vet ./TreeDB/freelist ./TreeDB/db`
- `git diff --check`

The full DB suite includes durable-root alternation/reopen, dependency fallback, accepted/pre-meta failure, visible-install abort, allocator poisoning/wakeup, auxiliary retirement, and root-publication build-group coverage. The expanded allocator rollback test uses multiple same-chunk retirements for both prepare failure and caller abort.

## Unchanged Dgraph evidence

Exact Dgraph `cc51080c7c4b110f3b43410955abe781be5cc42b`, this exact Gomap head via a local replacement, frozen 500-node / 100-warmup / 100,000-op / concurrency-4 relaxed workload:

- valid rows: 5,512.29, 5,186.74, and 5,544.87 ops/s; median 5,512.29 ops/s
- median-row p50/p95/p99: 0.611/1.282/1.761 ms
- +5.20% versus #3957's 5,239.76 median; -9.81% versus matched Badger at 6,112
- schema, posting checksum/count, unsupported-feature, restart, and reopen validation passed in all accepted rows
- two additional rows were excluded by the committed harness for load1 above 9 and are not counted

The unchanged 10,000-op durable smoke passed parity/restart and retained the expected group/sync shape (2,117 commits, 985 groups/syncs, max group 8). A same-window exact-#3957 control was also storage-limited; the matched five-sample durable singleton microbenchmark shows no statistically distinguishable change (`p=0.690`), identical 41,967 storage bytes/op, and median 14 allocs/op.

## Remaining merge gate

- latest-head repository CI/race/reopen

CodeRabbit reviewed the exact head with no actionable comments. Codex reviewed `015e15a4af21d10b7b0e58f0f79ade9daef3c440` with no major issues. There are zero unresolved review threads.

The unchanged live performance gate still misses matched Badger by more than 3%, so #3823 and its parents remain open with the next exclusive profile-backed blocker; this PR's bounded allocation win does not by itself promote TreeDB.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Batched page retirement and pruning now reduce repeated freelist state updates.
  * Retirement and promotion operations process related entries together for more efficient transactions.
  * Added mutation statistics to improve visibility into freelist transaction work.

* **Bug Fixes**
  * Preserved stable retirement ordering and ensured batched operations produce the same results and page data as individual updates.

* **Tests**
  * Added coverage for batched retirement, pruning, rollback behavior, and mutation efficiency.
  * Added benchmarks comparing batched and per-page retirement performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->