### PR TITLE
treedb: publish fenced online index replacement

### DIFF
--- a/TreeDB/collections/api_test.go
+++ b/TreeDB/collections/api_test.go
@@ -971,8 +971,8 @@ func TestCollectionFastJSONMaintenanceVacuumUsesValueLogLeaves(t *testing.T) {
 	if err := d.Checkpoint(); err != nil {
 		t.Fatalf("checkpoint after value-log GC: %v", err)
 	}
-	if err := d.VacuumIndexOnline(ctx); !errors.Is(err, backenddb.ErrVacuumRecoverableRootSetRequired) {
-		t.Fatalf("vacuum index online err=%v want recoverable-root-set fence", err)
+	if err := d.VacuumIndexOnline(ctx); err != nil {
+		t.Fatalf("vacuum index online: %v", err)
 	}
 
 	got, err := col.Get([]byte("did:example:019999"))

--- a/TreeDB/db/batch.go
+++ b/TreeDB/db/batch.go
@@ -643,12 +643,12 @@ func (b *Batch) writeSerialized(sync bool, intent *commandWALBatchIntent, maxEnt
 func (b *Batch) writeSerializedAttempt(sync bool, intent *commandWALBatchIntent, maxEntryRevision page.EntryRevision, conditional *ConditionalTxn) error {
 	touchedValueLogSegments := b.batch.TouchedValueLogSegments()
 	rawSpanPlan := b.rawSpanNativeBatchPlan()
-	builder, err := b.db.acquireRootPublicationBuilderV1()
+	rootRuntime, builder, err := b.db.acquireRootPublicationBuilderForRuntimeV1()
 	if err != nil {
 		return err
 	}
 	if builder != nil {
-		defer builder.Release()
+		defer func() { builder.Release() }()
 	}
 
 	durablePublishLocked := false
@@ -670,6 +670,13 @@ func (b *Batch) writeSerializedAttempt(sync bool, intent *commandWALBatchIntent,
 	}()
 	if err := b.db.checkWriteAdmissionLocked(); err != nil {
 		return err
+	}
+	if b.db.rootPublication != rootRuntime {
+		builder.Release()
+		rootRuntime, builder, err = b.db.acquireRootPublicationBuilderForRuntimeV1()
+		if err != nil {
+			return err
+		}
 	}
 	// Serialized fallback must join durable publication before it snapshots its
 	// base generation. A preceding publisher may have released writeMu while it

--- a/TreeDB/db/close_hooks_test.go
+++ b/TreeDB/db/close_hooks_test.go
@@ -231,7 +231,7 @@ func TestCloseWaitsForStandaloneCloseHookDrain(t *testing.T) {
 	}
 }
 
-func TestCloseHookMayObserveOnlineVacuumRecoverableRootSetFence(t *testing.T) {
+func TestCloseHookOnlineVacuumObservesClosedAdmission(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("online vacuum unsupported on windows")
 	}
@@ -245,7 +245,7 @@ func TestCloseHookMayObserveOnlineVacuumRecoverableRootSetFence(t *testing.T) {
 
 	d.RegisterCloseHook(func() error {
 		err := d.VacuumIndexOnline(context.Background())
-		if !errors.Is(err, ErrVacuumRecoverableRootSetRequired) {
+		if !errors.Is(err, ErrClosed) {
 			return err
 		}
 		return nil

--- a/TreeDB/db/command_wal_publish.go
+++ b/TreeDB/db/command_wal_publish.go
@@ -127,15 +127,12 @@ func (db *DB) publishCommandWALRootsWithMode(newRootID uint64, sysRootID uint64,
 		db.teardownMu.RLock()
 		defer db.teardownMu.RUnlock()
 	}
-	builder, err := db.acquireRootPublicationBuilderV1()
+	builder, err := db.acquireCommandWALPublicationBuilderV1()
 	if err != nil {
 		return err
 	}
 	if builder != nil {
 		defer builder.Release()
-	}
-	if hook := db.testCommandWALAfterBuilderAcquireHook; hook != nil {
-		hook()
 	}
 	durablePublishLocked := false
 	releaseDurablePublish := func() {
@@ -145,12 +142,6 @@ func (db *DB) publishCommandWALRootsWithMode(newRootID uint64, sysRootID uint64,
 		}
 	}
 	defer releaseDurablePublish()
-	db.writeMu.Lock()
-	if err := db.checkWriteAdmissionLocked(); err != nil {
-		db.writeMu.Unlock()
-		return err
-	}
-
 	var (
 		baseSeq        uint64
 		rootsUnchanged bool

--- a/TreeDB/db/command_wal_publish.go
+++ b/TreeDB/db/command_wal_publish.go
@@ -134,6 +134,9 @@ func (db *DB) publishCommandWALRootsWithMode(newRootID uint64, sysRootID uint64,
 	if builder != nil {
 		defer builder.Release()
 	}
+	if hook := db.testCommandWALAfterBuilderAcquireHook; hook != nil {
+		hook()
+	}
 	durablePublishLocked := false
 	releaseDurablePublish := func() {
 		if durablePublishLocked {

--- a/TreeDB/db/command_wal_publish_test.go
+++ b/TreeDB/db/command_wal_publish_test.go
@@ -252,6 +252,70 @@ func TestCommandWALAppliedLSNOnlyPublishRebindsRootsAfterDurableGateWait(t *test
 	}
 }
 
+func TestCommandWALPublicationRebindsBuilderAfterRuntimeSwap(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("online vacuum unsupported on windows")
+	}
+	for _, tc := range []struct {
+		name    string
+		publish func(*testing.T, *DB) error
+	}{
+		{
+			name: "applied_lsn",
+			publish: func(_ *testing.T, db *DB) error {
+				return db.PublishCommandWALAppliedLSN(1, []CommandWALLSNRange{{First: 1, Last: 1}}, true)
+			},
+		},
+		{
+			name: "noop",
+			publish: func(t *testing.T, db *DB) error {
+				payload, err := commitlog.EncodeRawKVBatchPayload(nil)
+				if err != nil {
+					t.Fatalf("EncodeRawKVBatchPayload: %v", err)
+				}
+				intent, err := db.NewTrustedCommandWALIntent(commitlog.CommandKindRawKVBatch, commitlog.CommandScopeRawKV, commitlog.PayloadFormatRawKVBatchV1, payload)
+				if err != nil {
+					t.Fatalf("NewTrustedCommandWALIntent: %v", err)
+				}
+				return db.PublishCommandWALNoop(intent, true)
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			db, err := Open(Options{Dir: t.TempDir(), CommandWAL: true, DisableBackgroundPrune: true})
+			if err != nil {
+				t.Fatalf("Open: %v", err)
+			}
+			defer func() { _ = db.Close() }()
+
+			oldRuntime := db.rootPublication
+			replacement, err := newRootPublicationRuntimeV1(db, db.idx.Load(), db.durableRoot, db.meta)
+			if err != nil {
+				t.Fatalf("new replacement runtime: %v", err)
+			}
+			var once sync.Once
+			db.testCommandWALAfterBuilderAcquireHook = func() {
+				once.Do(func() {
+					db.writeMu.Lock()
+					db.rootPublication = replacement
+					db.writeMu.Unlock()
+				})
+			}
+
+			if err := tc.publish(t, db); err != nil {
+				t.Fatalf("publish after runtime swap: %v", err)
+			}
+			db.testCommandWALAfterBuilderAcquireHook = nil
+			handoff, err := stopRootPublicationRuntimeV1(oldRuntime)
+			if err != nil {
+				t.Fatalf("stop old runtime: %v", err)
+			}
+			handoff.Release()
+			oldRuntime.release()
+		})
+	}
+}
+
 func TestCommandWALAppliedLSNOnlyPublishRechecksPoisonAfterDurableGateWait(t *testing.T) {
 	db, err := Open(Options{Dir: t.TempDir(), CommandWAL: true, DisableBackgroundPrune: true})
 	if err != nil {

--- a/TreeDB/db/command_wal_raw.go
+++ b/TreeDB/db/command_wal_raw.go
@@ -2208,15 +2208,12 @@ func (db *DB) publishCommandWALNoop(intent *CommandWALIntent, sync bool) error {
 		return ErrCommandWALUnsupported
 	}
 	sync = commandWALIntentPublishSync(intent, sync)
-	builder, err := db.acquireRootPublicationBuilderV1()
+	builder, err := db.acquireCommandWALPublicationBuilderV1()
 	if err != nil {
 		return err
 	}
 	if builder != nil {
 		defer builder.Release()
-	}
-	if hook := db.testCommandWALAfterBuilderAcquireHook; hook != nil {
-		hook()
 	}
 	durablePublishLocked := false
 	releaseDurablePublish := func() {
@@ -2226,11 +2223,6 @@ func (db *DB) publishCommandWALNoop(intent *CommandWALIntent, sync bool) error {
 		}
 	}
 	defer releaseDurablePublish()
-	db.writeMu.Lock()
-	if err := db.checkWriteAdmissionLocked(); err != nil {
-		db.writeMu.Unlock()
-		return err
-	}
 	db.commitMu.Lock()
 	if _, err := db.appendPublicCommandWALIntent(intent, sync); err != nil {
 		db.commitMu.Unlock()

--- a/TreeDB/db/command_wal_raw.go
+++ b/TreeDB/db/command_wal_raw.go
@@ -2215,6 +2215,9 @@ func (db *DB) publishCommandWALNoop(intent *CommandWALIntent, sync bool) error {
 	if builder != nil {
 		defer builder.Release()
 	}
+	if hook := db.testCommandWALAfterBuilderAcquireHook; hook != nil {
+		hook()
+	}
 	durablePublishLocked := false
 	releaseDurablePublish := func() {
 		if durablePublishLocked {

--- a/TreeDB/db/compact_storage.go
+++ b/TreeDB/db/compact_storage.go
@@ -600,7 +600,7 @@ func (db *DB) compactStorage(ctx context.Context, opts CompactStorageOptions) (s
 	if err := db.runCompactStoragePhase(&stats, "index-vacuum", func() error {
 		indexVacuumSkipped = false
 		indexVacuumSkipReason = ""
-		err := db.vacuumIndexOnline(ctx, !maintenanceLocked)
+		err := db.compactStorageVacuumIndexOnline(ctx, !maintenanceLocked)
 		if errors.Is(err, ErrVacuumUnsupported) {
 			indexVacuumSkipped = true
 			indexVacuumSkipReason = err.Error()
@@ -689,6 +689,13 @@ func (db *DB) compactStorage(ctx context.Context, opts CompactStorageOptions) (s
 	cleanupLeafLogDone = true
 	stats.FullyCompacted, stats.PolicyFullyCompacted, stats.ByteMinimized = compactStorageCompactionFlags(opts, stats.RemainingDebt)
 	return stats, nil
+}
+
+// compactStorageVacuumIndexOnline remains fenced until CompactStorage owns the
+// production phase status and completion semantics. The production backend is
+// enabled independently by VacuumIndexOnline.
+func (db *DB) compactStorageVacuumIndexOnline(context.Context, bool) error {
+	return errors.Join(ErrVacuumUnsupported, ErrVacuumRecoverableRootSetRequired)
 }
 
 func compactStorageCompactionFlags(opts CompactStorageOptions, debt CompactStorageDebt) (fullyCompacted bool, policyFullyCompacted bool, byteMinimized bool) {

--- a/TreeDB/db/db.go
+++ b/TreeDB/db/db.go
@@ -224,6 +224,7 @@ type DB struct {
 	vacuumBeforeRecorderFenceHook func()
 	vacuumPagerSyncHook           func(vacuumPagerSyncPhase)
 	vacuumPreflushHook            func() error
+	vacuumReplacementRuntimeHook  func(*rootPublicationRuntimeV1) error
 	meta                          page.MetaPageBody
 	metaPageID                    uint64
 	durableRoot                   durableRootRuntimeV1

--- a/TreeDB/db/db.go
+++ b/TreeDB/db/db.go
@@ -548,6 +548,7 @@ type DB struct {
 	testAfterOptimisticBaseCaptureHook             func()
 	testAfterOptimisticApplyHook                   func()
 	testAfterOptimisticPublishPrepareHook          func()
+	testCommandWALAfterBuilderAcquireHook          func()
 	testCommandWALBeforeDurablePublishLockHook     func()
 	testCommandWALCleanupAfterScanHook             func()
 	testBeforeFinalizeCommitHook                   func()

--- a/TreeDB/db/durable_root_runtime.go
+++ b/TreeDB/db/durable_root_runtime.go
@@ -874,6 +874,14 @@ func (db *DB) captureRegisteredDurableValueLogResourcesV1(references map[uint32]
 // reference. This is maintenance-only and deliberately does not publish a
 // snapshot or mutate the live DB generation.
 func (db *DB) captureRebuiltIndexDurableResourcesV1(p *pager.Pager, meta page.MetaPageBody) (*rootpublication.StableResourceSet, error) {
+	var inherited *rootpublication.StableResourceSet
+	if db != nil {
+		inherited = db.durableRoot.slotResources[db.durableRoot.slot]
+	}
+	return db.captureRebuiltIndexDurableResourcesFromV1(p, meta, inherited)
+}
+
+func (db *DB) captureRebuiltIndexDurableResourcesFromV1(p *pager.Pager, meta page.MetaPageBody, source *rootpublication.StableResourceSet) (*rootpublication.StableResourceSet, error) {
 	if db == nil || db.valueLogManager == nil || p == nil || meta.UserRootPageID < 2 || meta.SystemRootPageID < 2 {
 		return nil, fmt.Errorf("%w: rebuilt index dependency scanner unavailable", rootpublication.ErrUnresolvedResource)
 	}
@@ -894,9 +902,8 @@ func (db *DB) captureRebuiltIndexDurableResourcesV1(p *pager.Pager, meta page.Me
 	if scanErr != nil || closeErr != nil {
 		return nil, errors.Join(scanErr, closeErr)
 	}
-	selected := db.durableRoot.slotResources[db.durableRoot.slot]
 	exactPackedFileIDs := make(map[uint32]struct{})
-	for _, descriptor := range selected.Descriptors() {
+	for _, descriptor := range source.Descriptors() {
 		if descriptor.Kind() == rootpublication.ResourceOuterLeafPack && descriptor.Generation() <= uint64(^uint32(0)) {
 			exactPackedFileIDs[uint32(descriptor.Generation())] = struct{}{}
 		}
@@ -906,7 +913,7 @@ func (db *DB) captureRebuiltIndexDurableResourcesV1(p *pager.Pager, meta page.Me
 	}
 
 	inherited, err := rootpublication.CloneStableResourceSetExcludingKinds(
-		selected,
+		source,
 		rootpublication.ResourceValueLog,
 		rootpublication.ResourceOuterLeafLog,
 	)
@@ -1772,12 +1779,121 @@ func writeRebuiltDurableRootV1(dir, indexPath string, p *pager.Pager, meta page.
 	return err
 }
 
-func (db *DB) installDurableRootSelectionV1(selected durableRootSelectionV1) {
-	db.durableRoot = durableRootRuntimeV1{
-		meta: selected.Meta, record: selected.Record, manifest: selected.Manifest,
-		slot: selected.Slot, slotCommit: selected.SlotCommits, slotResources: selected.SlotResources,
-		slotMeta: selected.SlotMetas, slotRecord: selected.SlotRecords,
+type rebuiltDurableRootV1 struct {
+	meta      page.MetaPageBody
+	resources *rootpublication.StableResourceSet
+	pages     []uint64
+}
+
+func writeRebuiltDurableRootsV1(dir, indexPath string, p *pager.Pager, roots []rebuiltDurableRootV1) error {
+	if len(roots) != 2 || roots[0].meta.CommitSeq == 0 || roots[1].meta.CommitSeq <= roots[0].meta.CommitSeq {
+		return errors.New("invalid rebuilt durable-root pair")
 	}
+	if err := writeRebuiltDurableRootV1(dir, indexPath, p, roots[0].meta, roots[0].resources); err != nil {
+		return err
+	}
+	selected, err := selectDurableRootV1(p, p.PageCount(), nil)
+	if err != nil {
+		return err
+	}
+	return appendRebuiltDurableRootV1(dir, indexPath, p, selected, roots[1])
+}
+
+func appendRebuiltDurableRootV1(dir, indexPath string, p *pager.Pager, current durableRootSelectionV1, next rebuiltDurableRootV1) error {
+	meta := next.meta
+	if p == nil || current.Record.CommitSeq == 0 || meta.CommitSeq <= current.Record.CommitSeq ||
+		meta.UserRootPageID < 2 || meta.SystemRootPageID < 2 ||
+		meta.UserRootPageID >= p.PageCount() || meta.SystemRootPageID >= p.PageCount() {
+		return errors.New("invalid rebuilt durable-root successor")
+	}
+	manifest, err := durableManifestFromResourcesV1(next.resources)
+	if err != nil {
+		return err
+	}
+	allocator := freelist.New(p, 0)
+	if err := allocator.EnableCOWV1(current.Freelist, freelist.NewReservationLedger()); err != nil {
+		return err
+	}
+	capability, err := freelist.NewReuseCapability(current.Record.CommitSeq, current.Record.CommitSeq, 0)
+	if err != nil {
+		return err
+	}
+	var candidateID freelist.CandidateIDV1
+	binary.LittleEndian.PutUint64(candidateID[:8], meta.CommitSeq)
+	binary.LittleEndian.PutUint64(candidateID[8:], meta.UserRootPageID^meta.SystemRootPageID^uint64(MetaPage1ID))
+	prepared, err := allocator.PrepareCOWCandidateV1(
+		current.Freelist.GenerationID()+1,
+		meta.CommitSeq,
+		candidateID,
+		capability,
+		int(manifest.PageCount())+1,
+		freelist.NewMemoryPageStoreV1(),
+	)
+	if err != nil {
+		return err
+	}
+	generation := prepared.Candidate().Generation()
+	auxiliary := prepared.AuxiliaryPageIDs()
+	if generation == nil || len(auxiliary) != int(manifest.PageCount())+1 {
+		return errors.New("incomplete rebuilt durable-root successor COW generation")
+	}
+	if err := p.Truncate(generation.HighWater()); err != nil {
+		return err
+	}
+	for _, image := range prepared.Candidate().Pages() {
+		if err := p.Write(image.PageID, image.Data); err != nil {
+			return fmt.Errorf("write rebuilt successor COW page %d: %w", image.PageID, err)
+		}
+	}
+	sink := durablePagerSinkV1{pager: p}
+	manifestRef, err := manifest.Materialize(auxiliary[0], sink)
+	if err != nil {
+		return err
+	}
+	recordPageID := auxiliary[len(auxiliary)-1]
+	meta.TotalPages = generation.HighWater()
+	meta.FreelistHeadID = 0
+	durableSeq := current.Record.DurableSeq + 1
+	if durableSeq > meta.CommitSeq {
+		return errors.New("rebuilt durable-root successor sequence exceeds commit frontier")
+	}
+	record := rootpublication.DurableRootRecordV1{
+		CommitSeq: meta.CommitSeq, DurableSeq: durableSeq,
+		UserRootPageID: meta.UserRootPageID, SystemRootPageID: meta.SystemRootPageID,
+		TotalPages: meta.TotalPages, MaxEntryRevision: meta.MaxEntryRevision,
+		AppliedCommandLSN: meta.AppliedCommandLSN, LastCommitHeight: meta.LastCommitHeight,
+		Freelist: generation.GenerationRef(), FreelistFreeCount: generation.FreeCount(), FreelistRetiredCount: generation.RetiredCount(),
+		Manifest:           manifestRef,
+		ParentRecordPageID: current.Meta.RootRecordPageID, ParentCommitSeq: current.Meta.CommitSeq,
+		ParentRecordDigest:   current.Meta.RootRecordDigest,
+		MetaProjectionDigest: page.DurableMetaProjectionDigestV1(meta.CommitSeq, durableSeq, recordPageID),
+	}
+	recordImage, recordDigest, err := record.EncodePage(recordPageID)
+	if err != nil {
+		return err
+	}
+	if err := p.Write(recordPageID, recordImage); err != nil {
+		return err
+	}
+	durableMeta, err := page.NewDurableMetaV1(meta.CommitSeq, durableSeq, recordPageID, recordDigest)
+	if err != nil {
+		return err
+	}
+	_, err = executeDurableRootStorageTransactionV1(durableRootStorageTransactionV1{
+		resources: next.resources,
+		syncIndex: p.Sync,
+		sink:      sink,
+		target:    MetaPage1ID,
+		meta:      durableMeta,
+		syncMeta:  func() error { return p.SyncPages([]uint64{MetaPage1ID}) },
+		dir:       dir,
+		indexPath: indexPath,
+	})
+	return err
+}
+
+func (db *DB) installDurableRootSelectionV1(selected durableRootSelectionV1) {
+	db.durableRoot = durableRootRuntimeFromSelectionV1(selected)
 	db.meta = page.MetaPageBody{
 		CommitSeq: selected.Record.CommitSeq, UserRootPageID: selected.Record.UserRootPageID,
 		SystemRootPageID: selected.Record.SystemRootPageID, TotalPages: selected.Record.TotalPages,
@@ -1785,6 +1901,14 @@ func (db *DB) installDurableRootSelectionV1(selected durableRootSelectionV1) {
 		MaxEntryRevision: selected.Record.MaxEntryRevision,
 	}
 	db.metaPageID = selected.Slot
+}
+
+func durableRootRuntimeFromSelectionV1(selected durableRootSelectionV1) durableRootRuntimeV1 {
+	return durableRootRuntimeV1{
+		meta: selected.Meta, record: selected.Record, manifest: selected.Manifest,
+		slot: selected.Slot, slotCommit: selected.SlotCommits, slotResources: selected.SlotResources,
+		slotMeta: selected.SlotMetas, slotRecord: selected.SlotRecords,
+	}
 }
 
 // registerDurableManifestValueLogSegmentsV1 resolves only exact value-log and

--- a/TreeDB/db/recoverable_root_set.go
+++ b/TreeDB/db/recoverable_root_set.go
@@ -31,6 +31,22 @@ type RecoverableRoot struct {
 	Visible           bool
 }
 
+type recoverableRootKey struct {
+	commitSeq         uint64
+	userRootPageID    uint64
+	systemRootPageID  uint64
+	appliedCommandLSN uint64
+	maxEntryRevision  uint64
+}
+
+func recoverableRootIdentity(root RecoverableRoot) recoverableRootKey {
+	return recoverableRootKey{
+		commitSeq: root.CommitSeq, userRootPageID: root.UserRootPageID,
+		systemRootPageID: root.SystemRootPageID, appliedCommandLSN: root.AppliedCommandLSN,
+		maxEntryRevision: root.MaxEntryRevision,
+	}
+}
+
 type recoverableDurableBasis struct {
 	slot       uint64
 	slotCommit [2]uint64
@@ -73,6 +89,7 @@ type RecoverableRootSet struct {
 	oldestRegistryID    int64
 	systemRootEpoch     uint64
 	resources           []*rootpublication.StableResourceSet
+	rootResources       map[recoverableRootKey]*rootpublication.StableResourceSet
 	identityPinRegistry *rootpublication.IdentityPinRegistry
 
 	mu           sync.Mutex
@@ -197,9 +214,36 @@ func (db *DB) tryCaptureRecoverableRootSet(stable *Snapshot) (*RecoverableRootSe
 		}
 	}
 	durableResources, cloneErr := cloneRecoverableResourceUnion(sources...)
+	rootResources := make(map[recoverableRootKey]*rootpublication.StableResourceSet, 3)
+	rootResourceSets := make([]*rootpublication.StableResourceSet, 0, 2)
+	if cloneErr == nil {
+		for slot, record := range db.durableRoot.slotRecord {
+			if record.CommitSeq == 0 {
+				continue
+			}
+			resources, resourceErr := rootpublication.CloneStableResourceSetExcludingKinds(db.durableRoot.slotResources[slot])
+			if resourceErr != nil {
+				cloneErr = resourceErr
+				break
+			}
+			root := RecoverableRoot{
+				CommitSeq: record.CommitSeq, UserRootPageID: record.UserRootPageID,
+				SystemRootPageID: record.SystemRootPageID, AppliedCommandLSN: record.AppliedCommandLSN,
+				MaxEntryRevision: record.MaxEntryRevision,
+			}
+			rootResources[recoverableRootIdentity(root)] = resources
+			if resources != nil {
+				rootResourceSets = append(rootResourceSets, resources)
+			}
+		}
+	}
 	db.durablePublishMu.Unlock()
 	if cloneErr != nil {
 		db.rootReuseMu.RUnlock()
+		durableResources.Release()
+		for _, resources := range rootResourceSets {
+			resources.Release()
+		}
 		return nil, false, cloneErr
 	}
 
@@ -207,6 +251,9 @@ func (db *DB) tryCaptureRecoverableRootSet(stable *Snapshot) (*RecoverableRootSe
 	if !ok || stable.idx != db.idx.Load() {
 		db.rootReuseMu.RUnlock()
 		durableResources.Release()
+		for _, resources := range rootResourceSets {
+			resources.Release()
+		}
 		return nil, true, nil
 	}
 	roots := recoverableRootsForBasis(state, durable, coordinatorView)
@@ -225,6 +272,9 @@ func (db *DB) tryCaptureRecoverableRootSet(stable *Snapshot) (*RecoverableRootSe
 			stable.idx.registry.Unregister(oldestRegistryID)
 		}
 		durableResources.Release()
+		for _, resources := range rootResourceSets {
+			resources.Release()
+		}
 	}
 	if coordinator != nil {
 		if err := coordinator.RevalidateReachability(coordinatorView.Epoch); err != nil {
@@ -256,7 +306,7 @@ func (db *DB) tryCaptureRecoverableRootSet(stable *Snapshot) (*RecoverableRootSe
 		return nil, true, nil
 	}
 
-	resources := make([]*rootpublication.StableResourceSet, 0, 3)
+	resources := make([]*rootpublication.StableResourceSet, 0, 3+len(rootResourceSets))
 	if durableResources != nil {
 		resources = append(resources, durableResources)
 	}
@@ -266,18 +316,35 @@ func (db *DB) tryCaptureRecoverableRootSet(stable *Snapshot) (*RecoverableRootSe
 	}
 	if visibleResources != nil {
 		resources = append(resources, visibleResources)
+		visibleRoot := RecoverableRoot{
+			CommitSeq: state.CommitSeq, UserRootPageID: state.RootPageID,
+			SystemRootPageID: state.SystemRootPageID, AppliedCommandLSN: state.AppliedCommandLSN,
+			MaxEntryRevision: uint64(state.MaxEntryRevision),
+		}
+		key := recoverableRootIdentity(visibleRoot)
+		if _, exists := rootResources[key]; !exists {
+			rootResources[key] = visibleResources
+		}
 		visibleResources = nil
 	}
+	resources = append(resources, rootResourceSets...)
 	releaseCoordinator = false
 	releaseVisible = false
 	return &RecoverableRootSet{
 		db: db, roots: roots, visible: state, durable: durable,
 		coordinator: coordinator, coordinatorEpoch: coordinatorView.Epoch,
 		idx: stable.idx, stableSnapshot: stable, oldestRegistryID: oldestRegistryID,
-		systemRootEpoch: systemRootEpoch, resources: resources,
+		systemRootEpoch: systemRootEpoch, resources: resources, rootResources: rootResources,
 		identityPinRegistry: db.StableResourceIdentityPinRegistry(),
 		identityPins:        make(map[rootpublication.StableIdentity]recoverableIdentityPin),
 	}, false, nil
+}
+
+func (set *RecoverableRootSet) resourcesForRoot(root RecoverableRoot) *rootpublication.StableResourceSet {
+	if set == nil || set.released.Load() {
+		return nil
+	}
+	return set.rootResources[recoverableRootIdentity(root)]
 }
 
 func cloneRecoverableResourceUnion(sources ...*rootpublication.StableResourceSet) (*rootpublication.StableResourceSet, error) {
@@ -530,6 +597,17 @@ func (set *RecoverableRootSet) PinStableFile(file *os.File) error {
 // Revalidate proves that the captured visible/durable root basis and exact
 // coordinator debt are still current immediately before destructive mutation.
 func (set *RecoverableRootSet) Revalidate() error {
+	return set.revalidate(false)
+}
+
+// revalidateWithDurablePublishLockHeld is the cutover form of Revalidate.
+// The caller must hold durablePublishMu, which closes the last candidate
+// publication window without recursively acquiring the same mutex.
+func (set *RecoverableRootSet) revalidateWithDurablePublishLockHeld() error {
+	return set.revalidate(true)
+}
+
+func (set *RecoverableRootSet) revalidate(durablePublishLockHeld bool) error {
 	if set == nil || set.released.Load() || set.db == nil {
 		return ErrRecoverableRootSetStale
 	}
@@ -542,13 +620,17 @@ func (set *RecoverableRootSet) Revalidate() error {
 	if !ok || state != set.visible || set.db.idx.Load() != set.idx || set.db.systemRootPublishEpoch.Load() != set.systemRootEpoch {
 		return ErrRecoverableRootSetStale
 	}
-	set.db.durablePublishMu.Lock()
+	if !durablePublishLockHeld {
+		set.db.durablePublishMu.Lock()
+	}
 	current := recoverableDurableBasis{
 		slot: set.db.durableRoot.slot, slotCommit: set.db.durableRoot.slotCommit,
 		slotRecord: set.db.durableRoot.slotRecord, pending: set.db.durableRoot.pending,
 		ambiguous: append([]*durableRootPublishCandidateV1(nil), set.db.durableRoot.ambiguous...),
 	}
-	set.db.durablePublishMu.Unlock()
+	if !durablePublishLockHeld {
+		set.db.durablePublishMu.Unlock()
+	}
 	if !set.durable.equal(current) {
 		return ErrRecoverableRootSetStale
 	}

--- a/TreeDB/db/root_publication_activation.go
+++ b/TreeDB/db/root_publication_activation.go
@@ -114,15 +114,47 @@ func (db *DB) acquireRootPublicationBuilderV1() (*rootpublication.BuilderToken, 
 }
 
 func (db *DB) acquireRootPublicationBuilderForRuntimeV1() (*rootPublicationRuntimeV1, *rootpublication.BuilderToken, error) {
-	if db == nil || db.rootPublication == nil || db.rootPublication.coordinator == nil {
+	if db == nil || db.rootPublication == nil {
 		return nil, nil, nil
 	}
 	runtime := db.rootPublication
+	if runtime.coordinator == nil {
+		return runtime, nil, nil
+	}
 	builder, err := runtime.coordinator.AcquireBuilder(context.Background())
 	if err != nil {
 		return nil, nil, fmt.Errorf("acquire root-publication builder: %w", publicRootPublicationErrorV1(err))
 	}
 	return runtime, builder, nil
+}
+
+// acquireCommandWALPublicationBuilderV1 returns with writeMu held and the
+// builder bound to the runtime that is still live under that lock.
+func (db *DB) acquireCommandWALPublicationBuilderV1() (*rootpublication.BuilderToken, error) {
+	for {
+		runtime, builder, err := db.acquireRootPublicationBuilderForRuntimeV1()
+		if err != nil {
+			return nil, err
+		}
+		if hook := db.testCommandWALAfterBuilderAcquireHook; hook != nil {
+			hook()
+		}
+		db.writeMu.Lock()
+		if err := db.checkWriteAdmissionLocked(); err != nil {
+			db.writeMu.Unlock()
+			if builder != nil {
+				builder.Release()
+			}
+			return nil, err
+		}
+		if db.rootPublication == runtime {
+			return builder, nil
+		}
+		db.writeMu.Unlock()
+		if builder != nil {
+			builder.Release()
+		}
+	}
 }
 
 func (runtime *rootPublicationRuntimeV1) cloneVisibleResources() (*rootpublication.StableResourceSet, error) {

--- a/TreeDB/db/root_publication_activation.go
+++ b/TreeDB/db/root_publication_activation.go
@@ -109,14 +109,20 @@ func publicRootPublicationErrorV1(err error) error {
 }
 
 func (db *DB) acquireRootPublicationBuilderV1() (*rootpublication.BuilderToken, error) {
+	_, builder, err := db.acquireRootPublicationBuilderForRuntimeV1()
+	return builder, err
+}
+
+func (db *DB) acquireRootPublicationBuilderForRuntimeV1() (*rootPublicationRuntimeV1, *rootpublication.BuilderToken, error) {
 	if db == nil || db.rootPublication == nil || db.rootPublication.coordinator == nil {
-		return nil, nil
+		return nil, nil, nil
 	}
-	builder, err := db.rootPublication.coordinator.AcquireBuilder(context.Background())
+	runtime := db.rootPublication
+	builder, err := runtime.coordinator.AcquireBuilder(context.Background())
 	if err != nil {
-		return nil, fmt.Errorf("acquire root-publication builder: %w", publicRootPublicationErrorV1(err))
+		return nil, nil, fmt.Errorf("acquire root-publication builder: %w", publicRootPublicationErrorV1(err))
 	}
-	return builder, nil
+	return runtime, builder, nil
 }
 
 func (runtime *rootPublicationRuntimeV1) cloneVisibleResources() (*rootpublication.StableResourceSet, error) {
@@ -155,13 +161,13 @@ func (seal *rootPublicationSealV1) release() {
 	}
 }
 
-func rootPublicationLineageIDV1(db *DB, idx *indexGen) rootpublication.DurableRootLineageID {
+func rootPublicationLineageIDV1(db *DB, idx *indexGen, durable durableRootRuntimeV1) rootpublication.DurableRootLineageID {
 	var material [80]byte
 	if db != nil {
-		binary.LittleEndian.PutUint64(material[0:8], db.durableRoot.record.CommitSeq)
-		binary.LittleEndian.PutUint64(material[8:16], db.durableRoot.record.Freelist.GenerationID)
-		binary.LittleEndian.PutUint64(material[16:24], db.durableRoot.record.Freelist.HighWater)
-		copy(material[24:56], db.durableRoot.meta.RootRecordDigest[:])
+		binary.LittleEndian.PutUint64(material[0:8], durable.record.CommitSeq)
+		binary.LittleEndian.PutUint64(material[8:16], durable.record.Freelist.GenerationID)
+		binary.LittleEndian.PutUint64(material[16:24], durable.record.Freelist.HighWater)
+		copy(material[24:56], durable.meta.RootRecordDigest[:])
 		copy(material[56:72], []byte(db.dir))
 	}
 	if idx != nil {
@@ -190,37 +196,60 @@ func (db *DB) initializeRootPublicationRuntimeV1(idx *indexGen) error {
 	if db == nil || idx == nil || db.durableRoot.record.CommitSeq == 0 {
 		return errors.New("missing root-publication durable base")
 	}
+	runtime, err := newRootPublicationRuntimeV1(db, idx, db.durableRoot, db.meta)
+	if err != nil {
+		return err
+	}
+	db.rootPublication = runtime
+	return nil
+}
+
+func newRootPublicationRuntimeV1(db *DB, idx *indexGen, durable durableRootRuntimeV1, visible page.MetaPageBody) (*rootPublicationRuntimeV1, error) {
+	if db == nil || idx == nil || durable.record.CommitSeq == 0 {
+		return nil, errors.New("missing root-publication durable base")
+	}
 	baseResources, err := rootpublication.CloneStableResourceSetExcludingKinds(
-		db.durableRoot.slotResources[db.durableRoot.slot],
+		durable.slotResources[durable.slot],
 	)
 	if err != nil {
-		return fmt.Errorf("clone initial visible root resources: %w", err)
+		return nil, fmt.Errorf("clone initial visible root resources: %w", err)
 	}
 	runtime := &rootPublicationRuntimeV1{
-		db: db, idx: idx, lineage: rootPublicationLineageIDV1(db, idx),
+		db: db, idx: idx, lineage: rootPublicationLineageIDV1(db, idx, durable),
 		visibleResources: baseResources,
 		visibleMembers:   make(map[uint64]*rootPublicationVisibleMemberV1),
 	}
-	oldest, err := oldestRecoverableSlotCommitV1(db.durableRoot.slotCommit)
+	oldest, err := oldestRecoverableSlotCommitV1(durable.slotCommit)
 	if err != nil {
 		baseResources.Release()
-		return err
+		return nil, err
 	}
 	coordinator, err := rootpublication.New(rootpublication.Options{
 		Publisher:                  runtime,
 		FixedPublishDelay:          db.rootPublicationFixedDelay,
-		InitialDurableFrontier:     rootPublicationFrontierV1(db.meta),
+		InitialDurableFrontier:     rootPublicationFrontierV1(visible),
 		OldestRecoverableCommitSeq: oldest,
 		DurableRootLineage:         runtime.lineage,
-		DurableRootSequence:        db.durableRoot.record.CommitSeq,
+		DurableRootSequence:        durable.record.CommitSeq,
 	})
 	if err != nil {
 		baseResources.Release()
-		return err
+		return nil, err
 	}
 	runtime.coordinator = coordinator
-	db.rootPublication = runtime
-	return nil
+	return runtime, nil
+}
+
+func stopRootPublicationRuntimeV1(runtime *rootPublicationRuntimeV1) (*rootpublication.RecoveryResourceHandoff, error) {
+	if runtime == nil || runtime.coordinator == nil {
+		return nil, nil
+	}
+	stopErr := runtime.coordinator.Stop(context.Background())
+	handoff, handoffErr := runtime.coordinator.TakeRecoveryHandoff()
+	if stopErr != nil || handoffErr != nil {
+		return handoff, errors.Join(publicRootPublicationErrorV1(stopErr), publicRootPublicationErrorV1(handoffErr))
+	}
+	return handoff, nil
 }
 
 func rootPublicationLogicalCandidateIDV1(lineage rootpublication.DurableRootLineageID, generationID uint64, next page.MetaPageBody) freelist.CandidateIDV1 {

--- a/TreeDB/db/root_publication_build_group.go
+++ b/TreeDB/db/root_publication_build_group.go
@@ -82,21 +82,34 @@ func (db *DB) BeginRootPublicationBuildGroup() (_ *RootPublicationBuildGroup, re
 	if err := db.publicationPoisonedError(); err != nil {
 		return nil, err
 	}
-	runtime := db.rootPublication
-	if runtime == nil || runtime.coordinator == nil {
-		return nil, errors.New("missing root publication coordinator")
-	}
-	group.coordinator = runtime.coordinator
-	builder, err := runtime.coordinator.AcquireBuilder(context.Background())
-	if err != nil {
-		return nil, publicRootPublicationErrorV1(err)
-	}
-	group.builder = builder
+	for {
+		runtime := db.rootPublication
+		if runtime == nil || runtime.coordinator == nil {
+			return nil, errors.New("missing root publication coordinator")
+		}
+		builder, err := runtime.coordinator.AcquireBuilder(context.Background())
+		if err != nil {
+			return nil, publicRootPublicationErrorV1(err)
+		}
 
-	db.writeMu.Lock()
-	group.writeLocked = true
-	if err := db.checkWriteAdmissionLocked(); err != nil {
-		return nil, err
+		db.writeMu.Lock()
+		if err := db.checkWriteAdmissionLocked(); err != nil {
+			db.writeMu.Unlock()
+			builder.Release()
+			return nil, err
+		}
+		if db.rootPublication != runtime {
+			db.writeMu.Unlock()
+			builder.Release()
+			if db.closing.Load() {
+				return nil, ErrClosed
+			}
+			continue
+		}
+		group.coordinator = runtime.coordinator
+		group.builder = builder
+		group.writeLocked = true
+		break
 	}
 	db.durablePublishMu.Lock()
 	group.durablePublishLocked = true

--- a/TreeDB/db/stable_resource_test.go
+++ b/TreeDB/db/stable_resource_test.go
@@ -154,6 +154,11 @@ func TestStableIndexResourceTokenOwnsVacuumFenceAfterSnapshotClose(t *testing.T)
 		t.Fatal(err)
 	}
 	defer database.Close()
+	for _, key := range []string{"durable-slot-older", "durable-slot-newer"} {
+		if err := database.SetSync([]byte(key), []byte("value")); err != nil {
+			t.Fatalf("seed %s: %v", key, err)
+		}
+	}
 
 	snapshot := database.AcquireStableSnapshot()
 	if snapshot == nil {
@@ -175,12 +180,12 @@ func TestStableIndexResourceTokenOwnsVacuumFenceAfterSnapshotClose(t *testing.T)
 	if err := snapshot.Close(); err != nil {
 		t.Fatalf("Close transferred snapshot: %v", err)
 	}
-	if err := database.vacuumIndexOnlineLegacyForTest(t.Context()); !errors.Is(err, rootpublication.ErrResourcePinned) {
+	if err := database.VacuumIndexOnline(t.Context()); !errors.Is(err, rootpublication.ErrResourcePinned) {
 		token.Release()
 		t.Fatalf("vacuum with live index token error=%v want ErrResourcePinned", err)
 	}
 	token.Release()
-	if err := database.vacuumIndexOnlineLegacyForTest(t.Context()); err != nil {
+	if err := database.VacuumIndexOnline(t.Context()); err != nil {
 		t.Fatalf("vacuum after index token release: %v", err)
 	}
 }

--- a/TreeDB/db/vacuum_collection_bench_test.go
+++ b/TreeDB/db/vacuum_collection_bench_test.go
@@ -82,6 +82,14 @@ func BenchmarkVacuumIndexOnlineCollection(b *testing.B) {
 }
 
 func BenchmarkVacuumIndexOnlineCollectionForegroundChurn(b *testing.B) {
+	benchmarkVacuumIndexOnlineCollectionForegroundChurn(b, true)
+}
+
+func BenchmarkVacuumIndexOnlineCollectionProductionForegroundChurn(b *testing.B) {
+	benchmarkVacuumIndexOnlineCollectionForegroundChurn(b, false)
+}
+
+func benchmarkVacuumIndexOnlineCollectionForegroundChurn(b *testing.B, legacy bool) {
 	for _, tc := range []struct {
 		name      string
 		valueSize int
@@ -92,10 +100,13 @@ func BenchmarkVacuumIndexOnlineCollectionForegroundChurn(b *testing.B) {
 		b.Run(tc.name, func(b *testing.B) {
 			db := openVacuumCollectionBenchmarkDB(b, tc.valueSize)
 			defer func() { _ = db.Close() }()
-			disableRootPublicationForLegacyVacuumBenchmark(b, db)
+			if legacy {
+				disableRootPublicationForLegacyVacuumBenchmark(b, db)
+			}
 			var total VacuumOnlineStats
 			var foregroundLatencies []time.Duration
 			var foregroundPoints, foregroundRanges uint64
+			var vacuumErrors uint64
 
 			b.ReportAllocs()
 			b.ResetTimer()
@@ -117,7 +128,12 @@ func BenchmarkVacuumIndexOnlineCollectionForegroundChurn(b *testing.B) {
 						<-warmed
 					})
 				}
-				vacuumErr := db.vacuumIndexOnlineLegacyForTest(context.Background())
+				var vacuumErr error
+				if legacy {
+					vacuumErr = db.vacuumIndexOnlineLegacyForTest(context.Background())
+				} else {
+					vacuumErr = db.VacuumIndexOnline(context.Background())
+				}
 				db.vacuumPagerSyncHook = nil
 				startOnce.Do(func() { close(start) })
 				close(stop)
@@ -125,8 +141,11 @@ func BenchmarkVacuumIndexOnlineCollectionForegroundChurn(b *testing.B) {
 				if foreground.err != nil {
 					b.Fatalf("foreground churn: %v", foreground.err)
 				}
-				if vacuumErr != nil && !errors.Is(vacuumErr, ErrVacuumConcurrentMutation) {
-					b.Fatalf("vacuum: %v", vacuumErr)
+				if vacuumErr != nil {
+					vacuumErrors++
+					if !legacy || !errors.Is(vacuumErr, ErrVacuumConcurrentMutation) {
+						b.Fatalf("vacuum: %v", vacuumErr)
+					}
 				}
 				foregroundLatencies = append(foregroundLatencies, foreground.latencies...)
 				foregroundPoints += foreground.points
@@ -156,6 +175,7 @@ func BenchmarkVacuumIndexOnlineCollectionForegroundChurn(b *testing.B) {
 				total.ConcurrentMutationAborts += stats.ConcurrentMutationAborts
 			}
 			b.StopTimer()
+			exposureMisses := verifyVacuumCollectionForegroundPoints(b, db)
 
 			b.ReportMetric(float64(total.TotalDuration.Nanoseconds())/float64(b.N), "vacuum-total-ns/op")
 			b.ReportMetric(float64(total.UserTreeDuration.Nanoseconds())/float64(b.N), "user-tree-ns/op")
@@ -171,6 +191,9 @@ func BenchmarkVacuumIndexOnlineCollectionForegroundChurn(b *testing.B) {
 			b.ReportMetric(float64(vacuumCollectionLatencyPercentile(foregroundLatencies, 99).Nanoseconds()), "foreground-p99-ns/op")
 			b.ReportMetric(float64(foregroundPoints)/float64(b.N), "foreground-points/op")
 			b.ReportMetric(float64(foregroundRanges)/float64(b.N), "foreground-ranges/op")
+			b.ReportMetric(float64(len(foregroundLatencies))/float64(b.N), "foreground-overlap-samples/op")
+			b.ReportMetric(float64(exposureMisses)/float64(b.N), "foreground-exposure-misses/op")
+			b.ReportMetric(float64(vacuumErrors)/float64(b.N), "vacuum-errors/op")
 			b.ReportMetric(float64(total.PrecloneTraversalPages)/float64(b.N), "preclone-pages/op")
 			b.ReportMetric(float64(total.RecloneTraversalPages)/float64(b.N), "reclone-pages/op")
 			b.ReportMetric(float64(total.CutoverCloneTraversalPages)/float64(b.N), "cutover-clone-pages/op")
@@ -254,11 +277,30 @@ func vacuumCollectionForegroundWriter(db *DB, start, stop <-chan struct{}, warme
 		result.latencies = append(result.latencies, time.Since(started))
 		if len(result.latencies) >= warmOperations {
 			warmOnce.Do(func() { close(warmed) })
+			return
 		}
 		if result.err != nil {
 			return
 		}
 	}
+}
+
+func verifyVacuumCollectionForegroundPoints(tb testing.TB, db *DB) uint64 {
+	tb.Helper()
+	var misses uint64
+	for point := 0; point < 256; point += 2 {
+		lastOperation := point
+		for lastOperation+256 < 4096 {
+			lastOperation += 256
+		}
+		key := []byte(fmt.Sprintf("foreground/point/%06d", point))
+		want := fmt.Sprintf("value/%06d", lastOperation)
+		got, err := db.Get(key)
+		if err != nil || string(got) != want {
+			misses++
+		}
+	}
+	return misses
 }
 
 func vacuumCollectionLatencyPercentile(latencies []time.Duration, percentile int) time.Duration {

--- a/TreeDB/db/vacuum_collection_publication_guard_test.go
+++ b/TreeDB/db/vacuum_collection_publication_guard_test.go
@@ -68,7 +68,7 @@ func TestCollectionPublicationPathsConvergeOnCoherentSnapshotPublication(t *test
 			publicationGuardPackageFuncID("openReadOnly"),
 			publicationGuardPackageFuncID("openReadOnlyNoLock"),
 			publicationGuardPackageFuncID("openWithLock"),
-			publicationGuardDBMethodID("vacuumIndexOnlineLegacyV1"),
+			publicationGuardDBMethodID("vacuumIndexOnlineRebuildV1"),
 		},
 		"snapshotViewRO.Store": {
 			publicationGuardDBMethodID("clearSnapshotView"),
@@ -82,7 +82,7 @@ func TestCollectionPublicationPathsConvergeOnCoherentSnapshotPublication(t *test
 			publicationGuardDBMethodID("publishCompactStorageValueLogSet"),
 			publicationGuardDBMethodID("publishLeafGenerationState"),
 			publicationGuardDBMethodID("publishValueLogSetNoRefresh"),
-			publicationGuardDBMethodID("vacuumIndexOnlineLegacyV1"),
+			publicationGuardDBMethodID("vacuumIndexOnlineRebuildV1"),
 			publicationGuardMethodID("rootPublicationVisibleInstallV1", "activate"),
 		},
 		"state.CompareAndSwap": {publicationGuardDBMethodID("ensureCommandWALRecoverySnapshotView")},
@@ -153,7 +153,7 @@ func TestCollectionPublicationPathsConvergeOnCoherentSnapshotPublication(t *test
 		publicationGuardDBMethodID("publishCompactStorageValueLogSet"),
 		publicationGuardDBMethodID("publishLeafGenerationState"),
 		publicationGuardDBMethodID("publishValueLogSetNoRefresh"),
-		publicationGuardDBMethodID("vacuumIndexOnlineLegacyV1"),
+		publicationGuardDBMethodID("vacuumIndexOnlineRebuildV1"),
 		publicationGuardMethodID("rootPublicationVisibleInstallV1", "activate"),
 	}
 	sort.Strings(wantPublishCallers)

--- a/TreeDB/db/vacuum_collection_roots.go
+++ b/TreeDB/db/vacuum_collection_roots.go
@@ -102,15 +102,22 @@ type vacuumCollectionAllocator interface {
 }
 
 type vacuumRecordingAllocator struct {
-	base        vacuumAllocator
+	base        vacuumCollectionAllocator
 	pages       []uint64
 	inlinePages [16]uint64
 }
 
-func newVacuumRecordingAllocator(base vacuumAllocator) *vacuumRecordingAllocator {
+func newVacuumRecordingAllocator(base vacuumCollectionAllocator) *vacuumRecordingAllocator {
 	a := &vacuumRecordingAllocator{base: base}
 	a.pages = a.inlinePages[:0]
 	return a
+}
+
+func (a *vacuumRecordingAllocator) Free(id uint64) error {
+	if a == nil || a.base == nil {
+		return errors.New("vacuum: missing recording allocator")
+	}
+	return a.base.Free(id)
 }
 
 func (a *vacuumRecordingAllocator) Alloc(hint uint64) (uint64, error) {

--- a/TreeDB/db/vacuum_collection_roots_test.go
+++ b/TreeDB/db/vacuum_collection_roots_test.go
@@ -53,7 +53,7 @@ func TestVacuumIndexOnline_PreservesCollectionRootFromPointerBackedDescriptor(t 
 	assertVacuumCollectionRootDescriptorPointerBacked(t, d, vacuumTestCollectionRootKey)
 	verifyVacuumCollectionRootDescriptor(t, d, vacuumTestCollectionRootKey)
 
-	if err := d.vacuumIndexOnlineLegacyForTest(context.Background()); err != nil {
+	if err := d.VacuumIndexOnline(context.Background()); err != nil {
 		t.Fatalf("vacuum online: %v", err)
 	}
 	verifyVacuumCollectionRootDescriptor(t, d, vacuumTestCollectionRootKey)

--- a/TreeDB/db/vacuum_collection_snapshot_test.go
+++ b/TreeDB/db/vacuum_collection_snapshot_test.go
@@ -265,9 +265,8 @@ func TestVacuumIndexOnlinePagerSyncRunsOutsideWriteMu(t *testing.T) {
 		t.Fatalf("publish collection: %v", err)
 	}
 	// The helper publishes through the activated coordinator. Drain that exact
-	// root before entering the legacy vacuum test seam so an outstanding stable
-	// index pin cannot race the direct legacy replacement below. Production
-	// vacuum exercises the RecoverableRootSet path in the production tests.
+	// root before invoking production VacuumIndexOnline so an outstanding stable
+	// index pin cannot race the RecoverableRootSet-fenced replacement below.
 	if err := db.Checkpoint(); err != nil {
 		t.Fatalf("checkpoint collection: %v", err)
 	}

--- a/TreeDB/db/vacuum_collection_snapshot_test.go
+++ b/TreeDB/db/vacuum_collection_snapshot_test.go
@@ -843,8 +843,6 @@ func TestPublishMalformedCollectionDescriptorAbortsBeforeVacuumArtifacts(t *test
 }
 
 func TestVacuumIndexOnlineSerializesCloseThroughMaintenance(t *testing.T) {
-	t.Skip("deferred to #3681: successful online vacuum requires RecoverableRootSet convergence")
-
 	if runtime.GOOS == "windows" {
 		t.Skip("online vacuum unsupported on windows")
 	}
@@ -878,7 +876,7 @@ func TestVacuumIndexOnlineSerializesCloseThroughMaintenance(t *testing.T) {
 		}
 	}
 	vacuumErr := make(chan error, 1)
-	go func() { vacuumErr <- db.vacuumIndexOnlineLegacyForTest(context.Background()) }()
+	go func() { vacuumErr <- db.VacuumIndexOnline(context.Background()) }()
 	waitVacuumTestSignal(t, reached, "vacuum precutover sync")
 
 	closeHookRan := make(chan struct{})

--- a/TreeDB/db/vacuum_collection_snapshot_test.go
+++ b/TreeDB/db/vacuum_collection_snapshot_test.go
@@ -266,8 +266,8 @@ func TestVacuumIndexOnlinePagerSyncRunsOutsideWriteMu(t *testing.T) {
 	}
 	// The helper publishes through the activated coordinator. Drain that exact
 	// root before entering the legacy vacuum test seam so an outstanding stable
-	// index pin cannot race the direct index replacement below. Production
-	// online vacuum remains fenced pending RecoverableRootSet integration.
+	// index pin cannot race the direct legacy replacement below. Production
+	// vacuum exercises the RecoverableRootSet path in the production tests.
 	if err := db.Checkpoint(); err != nil {
 		t.Fatalf("checkpoint collection: %v", err)
 	}
@@ -297,7 +297,7 @@ func TestVacuumIndexOnlinePagerSyncRunsOutsideWriteMu(t *testing.T) {
 		}
 	}
 
-	if err := db.vacuumIndexOnlineLegacyForTest(context.Background()); err != nil {
+	if err := db.VacuumIndexOnline(context.Background()); err != nil {
 		t.Fatalf("vacuum: %v", err)
 	}
 	if hookErr != nil {
@@ -316,7 +316,6 @@ func TestVacuumIndexOnlinePagerSyncRunsOutsideWriteMu(t *testing.T) {
 }
 
 func TestVacuumIndexOnlineFinalSyncGateWaitsWriterAndPublishesItAfterCutover(t *testing.T) {
-	skipLegacyOnlineVacuumRuntimeIntegration(t)
 	if runtime.GOOS == "windows" {
 		t.Skip("online vacuum unsupported on windows")
 	}
@@ -343,7 +342,7 @@ func TestVacuumIndexOnlineFinalSyncGateWaitsWriterAndPublishesItAfterCutover(t *
 		}
 	}
 	vacuumErr := make(chan error, 1)
-	go func() { vacuumErr <- db.vacuumIndexOnlineLegacyForTest(context.Background()) }()
+	go func() { vacuumErr <- db.VacuumIndexOnline(context.Background()) }()
 	waitVacuumTestSignal(t, reached, "vacuum final sync")
 
 	writeErr := make(chan error, 1)
@@ -407,7 +406,7 @@ func TestVacuumIndexOnlinePreflushFailureLeavesOldIndexAuthoritative(t *testing.
 		calls.Add(1)
 		return preflushErr
 	}
-	if err := db.vacuumIndexOnlineLegacyForTest(context.Background()); !errors.Is(err, preflushErr) {
+	if err := db.VacuumIndexOnline(context.Background()); !errors.Is(err, preflushErr) {
 		_ = db.Close()
 		t.Fatalf("vacuum error=%v, want %v", err, preflushErr)
 	}
@@ -435,7 +434,6 @@ func TestVacuumIndexOnlinePreflushFailureLeavesOldIndexAuthoritative(t *testing.
 }
 
 func TestVacuumIndexOnlineCollectionPrecloneAllowsMutationAndReopens(t *testing.T) {
-	skipLegacyOnlineVacuumRuntimeIntegration(t)
 	if runtime.GOOS == "windows" {
 		t.Skip("online vacuum unsupported on windows")
 	}
@@ -465,7 +463,7 @@ func TestVacuumIndexOnlineCollectionPrecloneAllowsMutationAndReopens(t *testing.
 	}
 
 	vacuumErr := make(chan error, 1)
-	go func() { vacuumErr <- db.vacuumIndexOnlineLegacyForTest(context.Background()) }()
+	go func() { vacuumErr <- db.VacuumIndexOnline(context.Background()) }()
 	waitVacuumTestSignal(t, reached, "collection preclone")
 
 	publishDone := make(chan error, 1)
@@ -551,7 +549,7 @@ func TestVacuumIndexOnlineCollectionRecloneAllowsMutation(t *testing.T) {
 	}
 
 	vacuumErr := make(chan error, 1)
-	go func() { vacuumErr <- db.vacuumIndexOnlineLegacyForTest(context.Background()) }()
+	go func() { vacuumErr <- db.VacuumIndexOnline(context.Background()) }()
 	waitVacuumTestSignal(t, reached, "collection reclone")
 	publishDone := make(chan error, 1)
 	go func() {
@@ -613,7 +611,7 @@ func TestVacuumIndexOnlineDefersRangeOnlyTailOverLimit(t *testing.T) {
 			db.vacuum.RecordApplyPlan(nil, ranges)
 		})
 	}
-	if err := db.vacuumIndexOnlineLegacyForTest(context.Background()); err != nil {
+	if err := db.VacuumIndexOnline(context.Background()); err != nil {
 		t.Fatalf("vacuum: %v", err)
 	}
 	stats := db.vacuumOnlineStatsSnapshot()
@@ -626,7 +624,6 @@ func TestVacuumIndexOnlineDefersRangeOnlyTailOverLimit(t *testing.T) {
 }
 
 func TestVacuumIndexOnlineReplaysProductionRangeMutation(t *testing.T) {
-	skipLegacyOnlineVacuumRuntimeIntegration(t)
 	if runtime.GOOS == "windows" {
 		t.Skip("online vacuum unsupported on windows")
 	}
@@ -662,7 +659,7 @@ func TestVacuumIndexOnlineReplaysProductionRangeMutation(t *testing.T) {
 			rangeErr = mutation.Write()
 		})
 	}
-	if err := db.vacuumIndexOnlineLegacyForTest(context.Background()); err != nil {
+	if err := db.VacuumIndexOnline(context.Background()); err != nil {
 		t.Fatalf("vacuum: %v", err)
 	}
 	if rangeErr != nil {
@@ -731,7 +728,7 @@ func TestVacuumIndexOnlineCollectionChurnExhaustsRetriesBeforeRename(t *testing.
 		version++
 		rootID, hookErr = publishVacuumSnapshotCollectionVersion(db, rootID, version, 0)
 	}
-	err = db.vacuumIndexOnlineLegacyForTest(context.Background())
+	err = db.VacuumIndexOnline(context.Background())
 	if !errors.Is(err, ErrVacuumConcurrentMutation) {
 		t.Fatalf("vacuum err=%v want %v", err, ErrVacuumConcurrentMutation)
 	}
@@ -763,7 +760,6 @@ func TestVacuumIndexOnlineCollectionChurnExhaustsRetriesBeforeRename(t *testing.
 }
 
 func TestVacuumIndexOnlineCollectionCatalogTransitionsAreExact(t *testing.T) {
-	skipLegacyOnlineVacuumRuntimeIntegration(t)
 	if runtime.GOOS == "windows" {
 		t.Skip("online vacuum unsupported on windows")
 	}
@@ -785,7 +781,7 @@ func TestVacuumIndexOnlineCollectionCatalogTransitionsAreExact(t *testing.T) {
 			rootID, publishErr = publishVacuumSnapshotCollectionTransition(db, rootID, 1)
 		})
 	}
-	if err := db.vacuumIndexOnlineLegacyForTest(context.Background()); err != nil {
+	if err := db.VacuumIndexOnline(context.Background()); err != nil {
 		t.Fatalf("vacuum: %v", err)
 	}
 	if publishErr != nil {

--- a/TreeDB/db/vacuum_m0_fixture_test.go
+++ b/TreeDB/db/vacuum_m0_fixture_test.go
@@ -100,10 +100,39 @@ func TestVacuumM0FixtureDeterministicDebtAndOfflineCeiling(t *testing.T) {
 }
 
 func TestVacuumM0ProductionOnlineVacuumIsSupported(t *testing.T) {
-	d, _ := openVacuumM0Fixture(t, vacuumM0Options(t.TempDir()))
-	defer func() { _ = d.Close() }()
+	dir := t.TempDir()
+	opts := vacuumM0Options(dir)
+	d, fixture := openVacuumM0Fixture(t, opts)
 	if err := d.VacuumIndexOnline(context.Background()); err != nil {
+		_ = d.Close()
 		t.Fatalf("production online vacuum: %v", err)
+	}
+	if after := vacuumM0FileBytes(t, vacuumM0IndexPath(dir)); after*100 > fixture.IndexBytes*60 {
+		_ = d.Close()
+		t.Fatalf("online shrink index before=%d after=%d want >=40%%", fixture.IndexBytes, after)
+	}
+	if after := vacuumM0DirBytes(t, vacuumM0StoragePath(dir, "value_vlog")); after != fixture.ValueLogBytes {
+		_ = d.Close()
+		t.Fatalf("online vacuum rewrote persistent value log: before=%d after=%d", fixture.ValueLogBytes, after)
+	}
+	if after := vacuumM0DirBytes(t, vacuumM0StoragePath(dir, "leaf_vlog")); after != fixture.LeafLogBytes {
+		_ = d.Close()
+		t.Fatalf("online vacuum rewrote persistent leaf log: before=%d after=%d", fixture.LeafLogBytes, after)
+	}
+	if got := vacuumM0Digest(t, d); got != fixture.LogicalDigest {
+		_ = d.Close()
+		t.Fatalf("online digest=%s want %s", got, fixture.LogicalDigest)
+	}
+	if err := d.Close(); err != nil {
+		t.Fatalf("close after online vacuum: %v", err)
+	}
+	reopened, err := Open(opts)
+	if err != nil {
+		t.Fatalf("reopen after online vacuum: %v", err)
+	}
+	defer func() { _ = reopened.Close() }()
+	if got := vacuumM0Digest(t, reopened); got != fixture.LogicalDigest {
+		t.Fatalf("reopen digest=%s want %s", got, fixture.LogicalDigest)
 	}
 }
 

--- a/TreeDB/db/vacuum_m0_fixture_test.go
+++ b/TreeDB/db/vacuum_m0_fixture_test.go
@@ -100,6 +100,9 @@ func TestVacuumM0FixtureDeterministicDebtAndOfflineCeiling(t *testing.T) {
 }
 
 func TestVacuumM0ProductionOnlineVacuumIsSupported(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("online vacuum unsupported on windows")
+	}
 	dir := t.TempDir()
 	opts := vacuumM0Options(dir)
 	d, fixture := openVacuumM0Fixture(t, opts)

--- a/TreeDB/db/vacuum_m0_fixture_test.go
+++ b/TreeDB/db/vacuum_m0_fixture_test.go
@@ -99,12 +99,11 @@ func TestVacuumM0FixtureDeterministicDebtAndOfflineCeiling(t *testing.T) {
 	}
 }
 
-func TestVacuumM0PublicOnlineVacuumIsExplicitlyUnsupported(t *testing.T) {
+func TestVacuumM0ProductionOnlineVacuumIsSupported(t *testing.T) {
 	d, _ := openVacuumM0Fixture(t, vacuumM0Options(t.TempDir()))
 	defer func() { _ = d.Close() }()
-	err := d.VacuumIndexOnline(context.Background())
-	if !errors.Is(err, ErrVacuumRecoverableRootSetRequired) {
-		t.Fatalf("public online vacuum error=%v want ErrVacuumRecoverableRootSetRequired", err)
+	if err := d.VacuumIndexOnline(context.Background()); err != nil {
+		t.Fatalf("production online vacuum: %v", err)
 	}
 }
 

--- a/TreeDB/db/vacuum_online.go
+++ b/TreeDB/db/vacuum_online.go
@@ -324,11 +324,34 @@ func (db *DB) VacuumIndexOnline(ctx context.Context) error {
 	return db.vacuumIndexOnline(ctx, true)
 }
 
-func (db *DB) vacuumIndexOnline(_ context.Context, _ bool) error {
-	if err := db.CheckStorageMaintenanceReady(); err != nil {
+func (db *DB) vacuumIndexOnline(ctx context.Context, lockMaintenance bool) error {
+	return db.vacuumIndexOnlineProductionV1(ctx, lockMaintenance)
+}
+
+func (db *DB) vacuumIndexOnlineProductionV1(ctx context.Context, lockMaintenance bool) (retErr error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if db == nil {
+		return ErrClosed
+	}
+	if runtime.GOOS == "windows" {
+		return ErrVacuumUnsupported
+	}
+	if lockMaintenance {
+		if publication := db.rootPublication; publication != nil && publication.coordinator != nil {
+			if err := publication.coordinator.Drain(ctx); err != nil {
+				return publicRootPublicationErrorV1(err)
+			}
+		}
+		db.maintenanceMu.Lock()
+		defer db.maintenanceMu.Unlock()
+	}
+	roots, err := db.captureRecoverableRootSetWithMaintenanceLockHeld(ctx)
+	if err != nil {
 		return err
 	}
-	return errors.Join(ErrVacuumUnsupported, ErrVacuumRecoverableRootSetRequired)
+	return db.vacuumIndexOnlineRebuildV1(ctx, false, nil, roots)
 }
 
 // vacuumIndexOnlineLegacyV1 retains the pre-root-publication rebuild algorithm
@@ -338,6 +361,16 @@ func (db *DB) vacuumIndexOnline(_ context.Context, _ bool) error {
 func (db *DB) vacuumIndexOnlineLegacyV1(ctx context.Context, lockMaintenance bool, capability legacyOnlineVacuumCapabilityV1) (retErr error) {
 	if capability == nil {
 		return errors.Join(ErrVacuumUnsupported, ErrVacuumRecoverableRootSetRequired)
+	}
+	return db.vacuumIndexOnlineRebuildV1(ctx, lockMaintenance, capability, nil)
+}
+
+func (db *DB) vacuumIndexOnlineRebuildV1(ctx context.Context, lockMaintenance bool, capability legacyOnlineVacuumCapabilityV1, recoverableRoots *RecoverableRootSet) (retErr error) {
+	if capability == nil && (recoverableRoots == nil || recoverableRoots.db != db || recoverableRoots.released.Load()) {
+		return errors.Join(ErrVacuumUnsupported, ErrVacuumRecoverableRootSetRequired)
+	}
+	if recoverableRoots != nil {
+		defer func() { recoverableRoots.Release() }()
 	}
 	if ctx == nil {
 		ctx = context.Background()
@@ -366,7 +399,11 @@ func (db *DB) vacuumIndexOnlineLegacyV1(ctx context.Context, lockMaintenance boo
 		return ErrVacuumInProgress
 	}
 	defer db.vacuumInProgress.Store(false)
-	if db.stableIndexCaptures.Load() != 0 {
+	allowedStableIndexCaptures := int64(0)
+	if recoverableRoots != nil {
+		allowedStableIndexCaptures = 1
+	}
+	if db.stableIndexCaptures.Load() != allowedStableIndexCaptures {
 		return rootpublication.ErrResourcePinned
 	}
 	if err := db.CheckStorageMaintenanceReady(); err != nil {
@@ -401,6 +438,8 @@ func (db *DB) vacuumIndexOnlineLegacyV1(ctx context.Context, lockMaintenance boo
 		return err
 	}
 	var replacementSelection *durableRootSelectionV1
+	var replacementRuntime *rootPublicationRuntimeV1
+	var replacementGen *indexGen
 	defer func() {
 		if replacementSelection == nil {
 			return
@@ -408,6 +447,18 @@ func (db *DB) vacuumIndexOnlineLegacyV1(ctx context.Context, lockMaintenance boo
 		for _, resources := range replacementSelection.SlotResources {
 			resources.Release()
 		}
+	}()
+	defer func() {
+		if replacementRuntime == nil {
+			return
+		}
+		handoff, handoffErr := stopRootPublicationRuntimeV1(replacementRuntime)
+		if handoffErr != nil {
+			db.publicationPoisoned.Store(true)
+			retErr = errors.Join(retErr, ErrRecoveryRequired, handoffErr)
+		}
+		replacementRuntime.release()
+		handoff.Release()
 	}()
 	closeNewPager := func() {
 		_ = newPager.Close()
@@ -463,6 +514,36 @@ func (db *DB) vacuumIndexOnlineLegacyV1(ctx context.Context, lockMaintenance boo
 	parallelMergePressureSource := db.zipperParallelMergeSource
 	db.idxMu.Unlock()
 	newZ.SetParallelMergePressureSource(parallelMergePressureSource)
+
+	var olderReplacement *rebuiltDurableRootV1
+	var olderReplacementSource rootpublication.DurableRootRecordV1
+	if recoverableRoots != nil {
+		olderRecord := recoverableRoots.durable.slotRecord[recoverableRoots.durable.slot^1]
+		if olderRecord.CommitSeq == 0 {
+			cleanupNewPager()
+			return errors.New("vacuum: replacement requires two recoverable durable slots")
+		}
+		olderRoot := RecoverableRoot{
+			CommitSeq: olderRecord.CommitSeq, UserRootPageID: olderRecord.UserRootPageID,
+			SystemRootPageID: olderRecord.SystemRootPageID, AppliedCommandLSN: olderRecord.AppliedCommandLSN,
+			MaxEntryRevision: olderRecord.MaxEntryRevision, Durable: true,
+		}
+		recordingAlloc := newVacuumRecordingAllocator(newAlloc)
+		rebuilt, rebuildErr := db.rebuildRecoverableRootV1(ctx, recoverableRoots, olderRoot, newPager, recordingAlloc)
+		if rebuildErr != nil {
+			cleanupNewPager()
+			return rebuildErr
+		}
+		rebuilt.meta.LastCommitHeight = olderRecord.LastCommitHeight
+		rebuilt.pages = append([]uint64(nil), recordingAlloc.pages...)
+		olderReplacement = &rebuilt
+		olderReplacementSource = olderRecord
+	}
+	defer func() {
+		if olderReplacement != nil {
+			olderReplacement.resources.Release()
+		}
+	}()
 
 	// Fence the initial recorder start against writers and in-flight prepared
 	// roots so a private multi-chunk build cannot straddle the base snapshot.
@@ -678,8 +759,26 @@ func (db *DB) vacuumIndexOnlineLegacyV1(ctx context.Context, lockMaintenance boo
 				return err
 			}
 		}
+		// Publication debt must be durable before its coordinator can be retired.
+		// Drain outside writeMu so stable I/O is not charged to the writer pause;
+		// the capability check below forces a recapture when the drain advances a
+		// durable slot, and catches any writer that races between drain and cutover.
+		publication := db.rootPublication
+		if publication != nil && publication.coordinator != nil {
+			if err := publication.coordinator.Drain(ctx); err != nil {
+				cleanupNewPager()
+				return publicRootPublicationErrorV1(err)
+			}
+		} else if recoverableRoots != nil {
+			cleanupNewPager()
+			return ErrRecoveryRequired
+		}
 		if hook := db.vacuumBeforeCutoverHook; hook != nil {
 			hook(defers)
+		}
+		if err := ctx.Err(); err != nil {
+			cleanupNewPager()
+			return err
 		}
 
 		db.writeMu.Lock()
@@ -738,7 +837,11 @@ func (db *DB) vacuumIndexOnlineLegacyV1(ctx context.Context, lockMaintenance boo
 		}
 		coherentDirty := currentToken.indexGenerationID != basis.token.indexGenerationID || currentToken.systemRootPageID != basis.token.systemRootPageID
 		epochDirty := currentToken.publishEpoch != basis.token.publishEpoch
-		needsDeferredCutover := coherentDirty || epochDirty || tailMutations > vacuumCutoverMaxKeys
+		capabilityDirty := false
+		if recoverableRoots != nil {
+			capabilityDirty = errors.Is(recoverableRoots.revalidateWithDurablePublishLockHeld(), ErrRecoverableRootSetStale)
+		}
+		needsDeferredCutover := coherentDirty || epochDirty || capabilityDirty || tailMutations > vacuumCutoverMaxKeys
 		if needsDeferredCutover {
 			if defers >= vacuumCutoverMaxDefers {
 				runStats.ConcurrentMutationAborts++
@@ -766,6 +869,46 @@ func (db *DB) vacuumIndexOnlineLegacyV1(ctx context.Context, lockMaintenance boo
 			unlockCutover(false)
 			defers++
 			runStats.DeferredCutovers++
+			if recoverableRoots != nil {
+				recoverableRoots.Release()
+				recoverableRoots, err = db.captureRecoverableRootSetWithMaintenanceLockHeld(ctx)
+				if err != nil {
+					_ = successor.Close()
+					cleanupNewPager()
+					return err
+				}
+				olderRecord := recoverableRoots.durable.slotRecord[recoverableRoots.durable.slot^1]
+				if olderRecord.CommitSeq == 0 {
+					_ = successor.Close()
+					cleanupNewPager()
+					return errors.New("vacuum: recaptured replacement requires two recoverable durable slots")
+				}
+				if olderRecord != olderReplacementSource {
+					olderRoot := RecoverableRoot{
+						CommitSeq: olderRecord.CommitSeq, UserRootPageID: olderRecord.UserRootPageID,
+						SystemRootPageID: olderRecord.SystemRootPageID, AppliedCommandLSN: olderRecord.AppliedCommandLSN,
+						MaxEntryRevision: olderRecord.MaxEntryRevision, Durable: true,
+					}
+					recordingAlloc := newVacuumRecordingAllocator(newAlloc)
+					rebuilt, rebuildErr := db.rebuildRecoverableRootV1(ctx, recoverableRoots, olderRoot, newPager, recordingAlloc)
+					if rebuildErr != nil {
+						_ = successor.Close()
+						cleanupNewPager()
+						return rebuildErr
+					}
+					rebuilt.meta.LastCommitHeight = olderRecord.LastCommitHeight
+					rebuilt.pages = append([]uint64(nil), recordingAlloc.pages...)
+					if err := freeVacuumRetired(newAlloc, olderReplacement.pages); err != nil {
+						rebuilt.resources.Release()
+						_ = successor.Close()
+						cleanupNewPager()
+						return err
+					}
+					olderReplacement.resources.Release()
+					olderReplacement = &rebuilt
+					olderReplacementSource = olderRecord
+				}
+			}
 
 			if err := applyTail(finalOps, finalRanges); err != nil {
 				_ = successor.Close()
@@ -885,11 +1028,18 @@ func (db *DB) vacuumIndexOnlineLegacyV1(ctx context.Context, lockMaintenance boo
 			}
 		}
 
-		// Seal durable-root publication while the replacement receives its sole
-		// recovery-selectable meta. A retained/ambiguous live-index candidate
+		// Seal durable-root publication while the replacement receives its
+		// recovery-selectable metas. A retained/ambiguous live-index candidate
 		// cannot be transferred across the namespace replacement.
 		db.beginVacuumCutoverGateLocked()
-		if db.stableIndexCaptures.Load() != 0 || db.durableCandidateIndexCaptures.Load() != 0 {
+		if recoverableRoots != nil {
+			if err := recoverableRoots.revalidateWithDurablePublishLockHeld(); err != nil {
+				unlockCutover(false)
+				cleanupNewPager()
+				return err
+			}
+		}
+		if db.stableIndexCaptures.Load() != allowedStableIndexCaptures || db.durableCandidateIndexCaptures.Load() != 0 {
 			unlockCutover(false)
 			cleanupNewPager()
 			return rootpublication.ErrResourcePinned
@@ -899,7 +1049,20 @@ func (db *DB) vacuumIndexOnlineLegacyV1(ctx context.Context, lockMaintenance boo
 			cleanupNewPager()
 			return ErrRecoveryRequired
 		}
-		durableResources, err := db.captureRebuiltIndexDurableResourcesV1(newPager, nextMeta)
+		var sourceResources *rootpublication.StableResourceSet
+		if recoverableRoots != nil {
+			visibleRoot := RecoverableRoot{
+				CommitSeq:         recoverableRoots.visible.CommitSeq,
+				UserRootPageID:    recoverableRoots.visible.RootPageID,
+				SystemRootPageID:  recoverableRoots.visible.SystemRootPageID,
+				AppliedCommandLSN: recoverableRoots.visible.AppliedCommandLSN,
+				MaxEntryRevision:  uint64(recoverableRoots.visible.MaxEntryRevision),
+			}
+			sourceResources = recoverableRoots.resourcesForRoot(visibleRoot)
+		} else {
+			sourceResources = db.durableRoot.slotResources[db.durableRoot.slot]
+		}
+		durableResources, err := db.captureRebuiltIndexDurableResourcesFromV1(newPager, nextMeta, sourceResources)
 		if err != nil {
 			unlockCutover(false)
 			cleanupNewPager()
@@ -915,7 +1078,15 @@ func (db *DB) vacuumIndexOnlineLegacyV1(ctx context.Context, lockMaintenance boo
 			hook(vacuumPagerSyncFinal)
 		}
 		finalSyncStarted := time.Now()
-		finalSyncErr := writeRebuiltDurableRootV1(db.dir, newPath, newPager, nextMeta, durableResources)
+		var finalSyncErr error
+		if olderReplacement != nil {
+			finalSyncErr = writeRebuiltDurableRootsV1(db.dir, newPath, newPager, []rebuiltDurableRootV1{
+				*olderReplacement,
+				{meta: nextMeta, resources: durableResources},
+			})
+		} else {
+			finalSyncErr = writeRebuiltDurableRootV1(db.dir, newPath, newPager, nextMeta, durableResources)
+		}
 		runStats.FinalPagerSyncDuration += time.Since(finalSyncStarted)
 		db.writeMu.Lock()
 		cutoverLocked = true
@@ -944,6 +1115,25 @@ func (db *DB) vacuumIndexOnlineLegacyV1(ctx context.Context, lockMaintenance boo
 		}
 		nextMeta.TotalPages = selected.Record.TotalPages
 		replacementSelection = &selected
+		replacementGen = newIndexGen(db.nextIndexID(), newPager, newAlloc, newZ)
+		replacementRuntime, err = newRootPublicationRuntimeV1(
+			db,
+			replacementGen,
+			durableRootRuntimeFromSelectionV1(selected),
+			nextMeta,
+		)
+		if err != nil {
+			unlockCutover(false)
+			cleanupNewPager()
+			return err
+		}
+		if hook := db.vacuumReplacementRuntimeHook; hook != nil {
+			if err := hook(replacementRuntime); err != nil {
+				unlockCutover(false)
+				cleanupNewPager()
+				return err
+			}
+		}
 		// A fallback directory scan can fail. Complete it before renaming index.db
 		// so an error cannot leave the live generation backed by an unlinked file.
 		if !leafPageLogSegmentsRegistered {
@@ -1040,10 +1230,11 @@ func (db *DB) vacuumIndexOnlineLegacyV1(ctx context.Context, lockMaintenance boo
 		newZ.SetOuterLeavesInValueLog(db.indexOuterLeavesInValueLog)
 
 		// Publish the new index generation (old readers keep oldGen pinned).
-		newGen := newIndexGen(db.nextIndexID(), newPager, newAlloc, newZ)
+		newGen := replacementGen
 		db.trackIndex(newGen)
 
 		var oldState *DBState
+		oldRootPublication := db.rootPublication
 		previousDurableResources := append([]*rootpublication.StableResourceSet(nil), db.durableRoot.slotResources[:]...)
 		db.mu.Lock()
 		oldState = db.state.Load()
@@ -1073,6 +1264,8 @@ func (db *DB) vacuumIndexOnlineLegacyV1(ctx context.Context, lockMaintenance boo
 		}
 		db.state.Store(newState)
 		db.publishSnapshotView(newGen, newState, db.valueLogManager)
+		db.rootPublication = replacementRuntime
+		replacementRuntime = nil
 		db.mu.Unlock()
 		db.clearLeafGenerationReachabilityCaches()
 
@@ -1080,6 +1273,18 @@ func (db *DB) vacuumIndexOnlineLegacyV1(ctx context.Context, lockMaintenance boo
 		runStats.SwapPublishDuration += time.Since(swapPublishStarted)
 		for _, resources := range previousDurableResources {
 			resources.Release()
+		}
+		if oldRootPublication != nil {
+			// RecoverableRootSet still pins the old physical closure while the
+			// stopped coordinator transfers its final recovery ownership.
+			handoff, handoffErr := stopRootPublicationRuntimeV1(oldRootPublication)
+			oldRootPublication.release()
+			if handoffErr != nil {
+				db.publicationPoisoned.Store(true)
+				handoff.Release()
+				return errors.Join(ErrRecoveryRequired, handoffErr)
+			}
+			handoff.Release()
 		}
 
 		if oldState != nil {
@@ -1107,6 +1312,85 @@ func (db *DB) vacuumIndexOnlineLegacyV1(ctx context.Context, lockMaintenance boo
 
 		return nil
 	}
+}
+
+func (db *DB) rebuildRecoverableRootV1(ctx context.Context, roots *RecoverableRootSet, root RecoverableRoot, newPager *pager.Pager, alloc vacuumCollectionAllocator) (rebuiltDurableRootV1, error) {
+	if roots == nil || newPager == nil || alloc == nil {
+		return rebuiltDurableRootV1{}, errors.New("vacuum: missing recoverable-root rebuild input")
+	}
+	snapshot := roots.AcquireSnapshotForRoot(root)
+	if snapshot == nil || snapshot.idx == nil || snapshot.idx.pager == nil || snapshot.state == nil {
+		if snapshot != nil {
+			_ = snapshot.Close()
+		}
+		return rebuiltDurableRootV1{}, ErrRecoverableRootSetStale
+	}
+	defer func() { _ = snapshot.Close() }()
+
+	effectiveInternalBaseDelta := db.indexInternalBaseDelta && !db.indexOuterLeavesInValueLog
+	var (
+		userRoot uint64
+		err      error
+	)
+	if db.indexOuterLeavesInValueLog {
+		rootData, readErr := snapshot.idx.pager.Get(root.UserRootPageID)
+		if readErr != nil {
+			return rebuiltDurableRootV1{}, readErr
+		}
+		if node.NewNode(rootData).Type() == page.PageTypeLeaf {
+			userRoot, err = vacuumClonePagerTreeWithLeafRefs(snapshot.idx.pager, root.UserRootPageID, alloc, newPager, effectiveInternalBaseDelta)
+		} else {
+			userRoot, err = vacuumBuildInternalTreeFromLeafRefs(snapshot.idx.pager, root.UserRootPageID, newPager, alloc, effectiveInternalBaseDelta)
+		}
+	} else {
+		iter := snapshot.tree.IteratorWithOptions(nil, nil, tree.IteratorOptions{Mode: tree.IteratorModePointerProjection})
+		userRoot, err = bulk.BuildWithOptions(iter, alloc, newPager, bulk.BuildOptions{
+			LeafPrefixCompression: db.leafPrefixCompression,
+			LeafColumnar:          db.indexColumnarLeaves,
+			PackedValuePtr:        db.indexPackedValuePtr,
+			InternalBaseDelta:     db.indexInternalBaseDelta,
+		})
+		_ = iter.Close()
+	}
+	if err != nil {
+		return rebuiltDurableRootV1{}, err
+	}
+	token, err := db.collectionTokenForSnapshot(snapshot)
+	if err != nil {
+		return rebuiltDurableRootV1{}, err
+	}
+	basis, _, err := vacuumBuildCollectionBasis(ctx, nil, snapshot, token, alloc, newPager, nil)
+	if err != nil {
+		return rebuiltDurableRootV1{}, err
+	}
+	replacements, err := basis.replacements()
+	if err != nil {
+		return rebuiltDurableRootV1{}, err
+	}
+	var systemRoot uint64
+	if db.indexOuterLeavesInValueLog && len(replacements) == 0 {
+		systemRoot, err = vacuumClonePagerTreeWithLeafRefs(snapshot.idx.pager, root.SystemRootPageID, alloc, newPager, effectiveInternalBaseDelta)
+	} else {
+		systemRoot, err = vacuumBuildSystemRoot(snapshot.idx.pager, &snapshot.reader, root.SystemRootPageID, alloc, newPager, bulk.BuildOptions{
+			LeafPrefixCompression: db.leafPrefixCompression,
+			LeafColumnar:          db.indexColumnarLeaves,
+			PackedValuePtr:        db.indexPackedValuePtr,
+			InternalBaseDelta:     effectiveInternalBaseDelta,
+		}, replacements)
+	}
+	if err != nil {
+		return rebuiltDurableRootV1{}, err
+	}
+	meta := page.MetaPageBody{
+		CommitSeq: root.CommitSeq, UserRootPageID: userRoot, SystemRootPageID: systemRoot,
+		TotalPages: newPager.PageCount(), AppliedCommandLSN: root.AppliedCommandLSN,
+		MaxEntryRevision: root.MaxEntryRevision,
+	}
+	resources, err := db.captureRebuiltIndexDurableResourcesFromV1(newPager, meta, roots.resourcesForRoot(root))
+	if err != nil {
+		return rebuiltDurableRootV1{}, err
+	}
+	return rebuiltDurableRootV1{meta: meta, resources: resources}, nil
 }
 
 func (db *DB) collectionTokenForSnapshot(snap *Snapshot) (collectionToken, error) {

--- a/TreeDB/db/vacuum_online_legacy_test.go
+++ b/TreeDB/db/vacuum_online_legacy_test.go
@@ -1,8 +1,9 @@
 package db
 
 import (
+	"bytes"
 	"context"
-	"errors"
+	"runtime"
 	"testing"
 )
 
@@ -19,18 +20,75 @@ func skipLegacyOnlineVacuumRuntimeIntegration(t *testing.T) {
 	t.Skip("deferred to #3681: post-swap writes require recoverable-root-set runtime rebinding")
 }
 
-func TestVacuumIndexOnlineRequiresRecoverableRootSetFencing(t *testing.T) {
-	db, err := Open(Options{Dir: t.TempDir()})
+func TestVacuumIndexOnlineUsesProductionRecoverableRootSetFence(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("online vacuum unsupported on windows")
+	}
+	db, err := Open(Options{Dir: t.TempDir(), DisableBackgroundPrune: true})
 	if err != nil {
 		t.Fatal(err)
 	}
 	defer func() { _ = db.Close() }()
 
-	err = db.VacuumIndexOnline(context.Background())
-	if !errors.Is(err, ErrVacuumUnsupported) {
-		t.Fatalf("VacuumIndexOnline error=%v, want ErrVacuumUnsupported", err)
+	oldIndex := db.idx.Load()
+	if err := db.SetSync([]byte("before"), []byte("vacuum")); err != nil {
+		t.Fatalf("seed: %v", err)
 	}
-	if !errors.Is(err, ErrVacuumRecoverableRootSetRequired) {
-		t.Fatalf("VacuumIndexOnline error=%v, want ErrVacuumRecoverableRootSetRequired", err)
+	if err := db.VacuumIndexOnline(context.Background()); err != nil {
+		t.Fatalf("VacuumIndexOnline: %v", err)
+	}
+	newIndex := db.idx.Load()
+	if newIndex == nil || newIndex == oldIndex {
+		t.Fatalf("published index=%p want replacement distinct from %p", newIndex, oldIndex)
+	}
+	if db.rootPublication == nil || db.rootPublication.idx != newIndex {
+		t.Fatalf("root-publication index=%p want replacement %p", db.rootPublication.idx, newIndex)
+	}
+}
+
+func TestVacuumIndexOnlinePostSwapWriteCheckpointAndReopenUseReplacement(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("online vacuum unsupported on windows")
+	}
+	dir := t.TempDir()
+	db, err := Open(Options{Dir: dir, DisableBackgroundPrune: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := db.SetSync([]byte("before"), bytes.Repeat([]byte("a"), 64)); err != nil {
+		_ = db.Close()
+		t.Fatalf("seed: %v", err)
+	}
+	if err := db.VacuumIndexOnline(context.Background()); err != nil {
+		_ = db.Close()
+		t.Fatalf("VacuumIndexOnline: %v", err)
+	}
+	replacement := db.idx.Load()
+	if err := db.Set([]byte("after"), bytes.Repeat([]byte("b"), 64)); err != nil {
+		_ = db.Close()
+		t.Fatalf("post-swap Set: %v", err)
+	}
+	if err := db.Checkpoint(); err != nil {
+		_ = db.Close()
+		t.Fatalf("post-swap Checkpoint: %v", err)
+	}
+	if db.idx.Load() != replacement || db.rootPublication == nil || db.rootPublication.idx != replacement {
+		_ = db.Close()
+		t.Fatal("post-swap publication escaped the replacement generation")
+	}
+	if err := db.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	reopened, err := Open(Options{Dir: dir, DisableBackgroundPrune: true})
+	if err != nil {
+		t.Fatalf("reopen: %v", err)
+	}
+	defer func() { _ = reopened.Close() }()
+	for key, want := range map[string]byte{"before": 'a', "after": 'b'} {
+		got, err := reopened.Get([]byte(key))
+		if err != nil || len(got) != 64 || got[0] != want {
+			t.Fatalf("reopened Get(%q)=%q err=%v", key, got, err)
+		}
 	}
 }

--- a/TreeDB/db/vacuum_online_legacy_test.go
+++ b/TreeDB/db/vacuum_online_legacy_test.go
@@ -3,8 +3,15 @@ package db
 import (
 	"bytes"
 	"context"
+	"errors"
+	"os"
+	"path/filepath"
 	"runtime"
 	"testing"
+
+	"github.com/snissn/gomap/TreeDB/internal/durabilitycut"
+	"github.com/snissn/gomap/TreeDB/page"
+	"github.com/snissn/gomap/TreeDB/tree"
 )
 
 type legacyOnlineVacuumTestCapabilityV1 struct{}
@@ -13,11 +20,6 @@ func (legacyOnlineVacuumTestCapabilityV1) allowLegacyOnlineVacuumV1() {}
 
 func (db *DB) vacuumIndexOnlineLegacyForTest(ctx context.Context) error {
 	return db.vacuumIndexOnlineLegacyV1(ctx, true, legacyOnlineVacuumTestCapabilityV1{})
-}
-
-func skipLegacyOnlineVacuumRuntimeIntegration(t *testing.T) {
-	t.Helper()
-	t.Skip("deferred to #3681: post-swap writes require recoverable-root-set runtime rebinding")
 }
 
 func TestVacuumIndexOnlineUsesProductionRecoverableRootSetFence(t *testing.T) {
@@ -43,6 +45,132 @@ func TestVacuumIndexOnlineUsesProductionRecoverableRootSetFence(t *testing.T) {
 	}
 	if db.rootPublication == nil || db.rootPublication.idx != newIndex {
 		t.Fatalf("root-publication index=%p want replacement %p", db.rootPublication.idx, newIndex)
+	}
+}
+
+func TestVacuumIndexOnlineCancellationBeforeCutoverMutatesNoNamespace(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("online vacuum unsupported on windows")
+	}
+	dir := t.TempDir()
+	database, err := Open(Options{Dir: dir, DisableBackgroundPrune: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = database.Close() }()
+	if err := database.SetSync([]byte("before"), []byte("cancel")); err != nil {
+		t.Fatal(err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	database.vacuumBeforeCutoverHook = func(int) { cancel() }
+	defer func() { database.vacuumBeforeCutoverHook = nil }()
+	var namespaceEvents []durabilitycut.Event
+	restore := durabilitycut.Install(func(event durabilitycut.Event) error {
+		if event.Namespace != "" {
+			namespaceEvents = append(namespaceEvents, event)
+		}
+		return nil
+	})
+	defer restore()
+
+	if err := database.VacuumIndexOnline(ctx); !errors.Is(err, context.Canceled) {
+		t.Fatalf("VacuumIndexOnline error=%v, want context.Canceled", err)
+	}
+	for _, event := range namespaceEvents {
+		if event.Namespace == durabilitycut.NamespaceRename ||
+			filepath.Clean(event.NewPath) == filepath.Join(dir, indexReadyFileName) {
+			t.Fatalf("authoritative namespace event after pre-cutover cancellation: %#v", event)
+		}
+	}
+	for _, name := range []string{indexNewFileName, indexReadyFileName, indexBakFileName} {
+		if _, err := os.Stat(filepath.Join(dir, name)); !errors.Is(err, os.ErrNotExist) {
+			t.Fatalf("artifact %s remains: %v", name, err)
+		}
+	}
+}
+
+func TestVacuumIndexOnlineReplacementRuntimeFailurePrecedesRename(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("online vacuum unsupported on windows")
+	}
+	dir := t.TempDir()
+	database, err := Open(Options{Dir: dir, DisableBackgroundPrune: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = database.Close() }()
+	if err := database.SetSync([]byte("before"), []byte("runtime")); err != nil {
+		t.Fatal(err)
+	}
+	indexPath := filepath.Join(dir, indexFileName)
+	before, err := os.Stat(indexPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	wantErr := errors.New("injected replacement runtime failure")
+	database.vacuumReplacementRuntimeHook = func(*rootPublicationRuntimeV1) error { return wantErr }
+	defer func() { database.vacuumReplacementRuntimeHook = nil }()
+
+	if err := database.VacuumIndexOnline(context.Background()); !errors.Is(err, wantErr) {
+		t.Fatalf("VacuumIndexOnline error=%v, want %v", err, wantErr)
+	}
+	after, err := os.Stat(indexPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !os.SameFile(before, after) {
+		t.Fatal("runtime construction failure replaced the authoritative index")
+	}
+	for _, name := range []string{indexNewFileName, indexReadyFileName, indexBakFileName} {
+		if _, err := os.Stat(filepath.Join(dir, name)); !errors.Is(err, os.ErrNotExist) {
+			t.Fatalf("artifact %s remains: %v", name, err)
+		}
+	}
+}
+
+func TestVacuumIndexOnlineCancellationAfterOldRenameConverges(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("online vacuum unsupported on windows")
+	}
+	dir := t.TempDir()
+	database, err := Open(Options{Dir: dir, DisableBackgroundPrune: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := database.SetSync([]byte("before"), []byte("irreversible")); err != nil {
+		_ = database.Close()
+		t.Fatal(err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	restore := durabilitycut.Install(func(event durabilitycut.Event) error {
+		if event.Namespace == durabilitycut.NamespaceRename &&
+			filepath.Clean(event.OldPath) == filepath.Join(dir, indexFileName) &&
+			filepath.Clean(event.NewPath) == filepath.Join(dir, indexBakFileName) {
+			cancel()
+		}
+		return nil
+	})
+	if err := database.VacuumIndexOnline(ctx); err != nil {
+		restore()
+		_ = database.Close()
+		t.Fatalf("VacuumIndexOnline after irreversible cancellation: %v", err)
+	}
+	restore()
+	if !errors.Is(ctx.Err(), context.Canceled) {
+		_ = database.Close()
+		t.Fatalf("context error=%v, want canceled", ctx.Err())
+	}
+	if err := database.Close(); err != nil {
+		t.Fatal(err)
+	}
+	reopened, err := Open(Options{Dir: dir, DisableBackgroundPrune: true})
+	if err != nil {
+		t.Fatalf("reopen: %v", err)
+	}
+	defer func() { _ = reopened.Close() }()
+	got, err := reopened.Get([]byte("before"))
+	if err != nil || string(got) != "irreversible" {
+		t.Fatalf("reopen Get=%q err=%v", got, err)
 	}
 }
 
@@ -90,5 +218,106 @@ func TestVacuumIndexOnlinePostSwapWriteCheckpointAndReopenUseReplacement(t *test
 		if err != nil || len(got) != 64 || got[0] != want {
 			t.Fatalf("reopened Get(%q)=%q err=%v", key, got, err)
 		}
+	}
+}
+
+func TestVacuumIndexOnlinePreservesTwoRecoverySelectablePointerClosures(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("online vacuum unsupported on windows")
+	}
+	dir := t.TempDir()
+	opts := Options{Dir: dir, DisableBackgroundPrune: true, ValueLog: ValueLogOptions{PointerThreshold: 1}}
+	database, err := Open(opts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	values := [][]byte{bytes.Repeat([]byte("older-"), 32), bytes.Repeat([]byte("newer-"), 32)}
+	pointers := appendPointersInNewSegment(t, dir, 0, 71, 710_000, len(values), func(index int) []byte { return values[index] })
+	if err := database.RefreshValueLogSet(); err != nil {
+		t.Fatal(err)
+	}
+	for index, key := range []string{"older", "newer"} {
+		batch := database.NewBatch().(*Batch)
+		if err := batch.SetPointer([]byte(key), pointers[index]); err != nil {
+			t.Fatal(err)
+		}
+		if err := batch.WriteSync(); err != nil {
+			t.Fatal(err)
+		}
+		if err := batch.Close(); err != nil {
+			t.Fatal(err)
+		}
+	}
+	before := database.durableRoot.slotCommit
+	if before[0] == 0 || before[1] == 0 || before[0] == before[1] {
+		t.Fatalf("fixture slot commits=%v, want two distinct recovery generations", before)
+	}
+	if err := database.VacuumIndexOnline(context.Background()); err != nil {
+		t.Fatalf("VacuumIndexOnline: %v", err)
+	}
+	after := database.durableRoot.slotCommit
+	if after[0] == 0 || after[1] == 0 || after[0] == after[1] {
+		t.Fatalf("replacement slot commits=%v, want two distinct recovery generations", after)
+	}
+	if got := database.stableIndexCaptures.Load(); got != 0 {
+		t.Fatalf("stable index captures after replacement=%d, want 0", got)
+	}
+	if got := database.durableCandidateIndexCaptures.Load(); got != 0 {
+		t.Fatalf("durable candidate captures after replacement=%d, want 0", got)
+	}
+	newestSlot := database.metaPageID
+	if err := database.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	reopened, err := Open(opts)
+	if err != nil {
+		t.Fatalf("reopen newest replacement slot: %v", err)
+	}
+	for index, key := range []string{"older", "newer"} {
+		got, getErr := reopened.Get([]byte(key))
+		if getErr != nil || !bytes.Equal(got, values[index]) {
+			_ = reopened.Close()
+			t.Fatalf("newest Get(%q)=(%q,%v), want pointer-backed value", key, got, getErr)
+		}
+	}
+	if err := reopened.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	indexPath := filepath.Join(dir, indexFileName)
+	indexFile, err := os.OpenFile(indexPath, os.O_RDWR, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	image := make([]byte, page.PageSize)
+	if _, err := indexFile.ReadAt(image, int64(newestSlot*page.PageSize)); err != nil {
+		_ = indexFile.Close()
+		t.Fatal(err)
+	}
+	image[page.PageHeaderSize+page.DurableMetaV1BodySize-1] ^= 0xff
+	if _, err := indexFile.WriteAt(image, int64(newestSlot*page.PageSize)); err != nil {
+		_ = indexFile.Close()
+		t.Fatal(err)
+	}
+	if err := indexFile.Sync(); err != nil {
+		_ = indexFile.Close()
+		t.Fatal(err)
+	}
+	if err := indexFile.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	fallback, err := Open(opts)
+	if err != nil {
+		t.Fatalf("reopen fallback replacement slot: %v", err)
+	}
+	defer func() { _ = fallback.Close() }()
+	got, err := fallback.Get([]byte("older"))
+	if err != nil || !bytes.Equal(got, values[0]) {
+		t.Fatalf("fallback older value=(%q,%v), want pointer-backed value", got, err)
+	}
+	if got, err := fallback.Get([]byte("newer")); err != nil && !errors.Is(err, tree.ErrKeyNotFound) || len(got) != 0 {
+		t.Fatalf("fallback newer value=(%q,%v), want absent from distinct older slot", got, err)
 	}
 }

--- a/TreeDB/db/vacuum_online_swap_test.go
+++ b/TreeDB/db/vacuum_online_swap_test.go
@@ -78,7 +78,7 @@ func TestVacuumIndexOnlineRefreshFailureLeavesOldIndexAuthoritative(t *testing.T
 		t.Fatalf("install refresh failure fixture: %v", err)
 	}
 
-	vacuumErr := d.vacuumIndexOnlineLegacyForTest(context.Background())
+	vacuumErr := d.VacuumIndexOnline(context.Background())
 	removeErr := os.Remove(vlogDir)
 	restoreErr := os.Rename(parkedVlogDir, vlogDir)
 	if removeErr != nil || restoreErr != nil {
@@ -168,7 +168,7 @@ func TestVacuumIndexOnline_PostOldIndexRenameCutStopsNamespaceCleanup(t *testing
 		return nil
 	})
 	defer restore()
-	err = d.vacuumIndexOnlineLegacyForTest(context.Background())
+	err = d.VacuumIndexOnline(context.Background())
 
 	if !errors.Is(err, cutErr) || !errors.Is(err, ErrRecoveryRequired) {
 		t.Fatalf("VacuumIndexOnline error=%v, want injected cut and ErrRecoveryRequired", err)
@@ -183,7 +183,7 @@ func TestVacuumIndexOnline_PostOldIndexRenameCutStopsNamespaceCleanup(t *testing
 		t.Fatalf("last namespace event=%#v, want old-index rename as final mutation", got)
 	}
 	eventsAtCut := len(namespaceEvents)
-	if retryErr := d.vacuumIndexOnlineLegacyForTest(context.Background()); !errors.Is(retryErr, ErrRecoveryRequired) {
+	if retryErr := d.VacuumIndexOnline(context.Background()); !errors.Is(retryErr, ErrRecoveryRequired) {
 		t.Fatalf("VacuumIndexOnline retry error=%v, want ErrRecoveryRequired", retryErr)
 	}
 	if len(namespaceEvents) != eventsAtCut {
@@ -497,7 +497,7 @@ func TestVacuumIndexOnline_OuterLeavesInValueLog_DoesNotRewriteLeafPages(t *test
 
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
-	if err := d.vacuumIndexOnlineLegacyForTest(ctx); err != nil {
+	if err := d.VacuumIndexOnline(ctx); err != nil {
 		t.Fatalf("vacuum: %v", err)
 	}
 	if got := leafLog.appends.Load(); got != 0 {
@@ -562,7 +562,7 @@ func TestVacuumIndexOnline_AllowsSnapshotAcrossSwap(t *testing.T) {
 
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
-	if err := d.vacuumIndexOnlineLegacyForTest(ctx); err != nil {
+	if err := d.VacuumIndexOnline(ctx); err != nil {
 		t.Fatalf("vacuum: %v", err)
 	}
 
@@ -604,7 +604,6 @@ func TestVacuumIndexOnline_AllowsSnapshotAcrossSwap(t *testing.T) {
 }
 
 func TestVacuumIndexOnline_RepeatWhileSnapshotPinned(t *testing.T) {
-	skipLegacyOnlineVacuumRuntimeIntegration(t)
 	if runtime.GOOS == "windows" {
 		t.Skip("online vacuum not supported on windows")
 	}
@@ -633,7 +632,7 @@ func TestVacuumIndexOnline_RepeatWhileSnapshotPinned(t *testing.T) {
 	if err := d.SetSync([]byte("k"), []byte("v2")); err != nil {
 		t.Fatalf("set v2: %v", err)
 	}
-	if err := d.vacuumIndexOnlineLegacyForTest(ctx); err != nil {
+	if err := d.VacuumIndexOnline(ctx); err != nil {
 		t.Fatalf("vacuum 1: %v", err)
 	}
 
@@ -647,7 +646,7 @@ func TestVacuumIndexOnline_RepeatWhileSnapshotPinned(t *testing.T) {
 	if err := d.SetSync([]byte("k"), []byte("v3")); err != nil {
 		t.Fatalf("set v3: %v", err)
 	}
-	if err := d.vacuumIndexOnlineLegacyForTest(ctx); err != nil {
+	if err := d.VacuumIndexOnline(ctx); err != nil {
 		t.Fatalf("vacuum 2: %v", err)
 	}
 
@@ -757,7 +756,7 @@ func TestVacuumIndexOnline_RebuildsPackedInternalTreeForLeafRefs(t *testing.T) {
 
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
-	if err := d.vacuumIndexOnlineLegacyForTest(ctx); err != nil {
+	if err := d.VacuumIndexOnline(ctx); err != nil {
 		t.Fatalf("vacuum: %v", err)
 	}
 
@@ -832,7 +831,7 @@ func TestVacuumIndexOnline_PreservesOuterLeafRefsAndDataWhenOuterLeavesInValueLo
 
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
-	if err := d.vacuumIndexOnlineLegacyForTest(ctx); err != nil {
+	if err := d.VacuumIndexOnline(ctx); err != nil {
 		t.Fatalf("vacuum: %v", err)
 	}
 
@@ -891,7 +890,7 @@ func TestVacuumIndexOnline_StampsPendingLeafGenerationSegments(t *testing.T) {
 
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
-	if err := db.vacuumIndexOnlineLegacyForTest(ctx); err != nil {
+	if err := db.VacuumIndexOnline(ctx); err != nil {
 		t.Fatalf("vacuum: %v", err)
 	}
 

--- a/TreeDB/db/vacuum_online_swap_test.go
+++ b/TreeDB/db/vacuum_online_swap_test.go
@@ -336,7 +336,6 @@ func (l *countingLeafPageLog) Flush() error { return l.inner.Flush() }
 func (l *countingLeafPageLog) Sync() error  { return l.inner.Sync() }
 
 func TestVacuumIndexOnline_ShrinksAndPreservesData(t *testing.T) {
-	skipLegacyOnlineVacuumRuntimeIntegration(t)
 	if runtime.GOOS == "windows" {
 		t.Skip("online vacuum not supported on windows")
 	}
@@ -394,7 +393,7 @@ func TestVacuumIndexOnline_ShrinksAndPreservesData(t *testing.T) {
 	}
 	defer func() { testHookVacuumAfterBaseSnapshot = nil }()
 	vacuumDone := make(chan error, 1)
-	go func() { vacuumDone <- d.vacuumIndexOnlineLegacyForTest(ctx) }()
+	go func() { vacuumDone <- d.VacuumIndexOnline(ctx) }()
 	select {
 	case <-snapshotReady:
 	case err := <-vacuumDone:
@@ -417,6 +416,9 @@ func TestVacuumIndexOnline_ShrinksAndPreservesData(t *testing.T) {
 	}
 	if err := <-vacuumDone; err != nil {
 		t.Fatalf("vacuum: %v", err)
+	}
+	if got := d.stableIndexCaptures.Load(); got != 0 {
+		t.Fatalf("recoverable-root recapture leaked stable index pins: %d", got)
 	}
 	if got := freeManyChecksumUpdates.Load(); got == 0 {
 		t.Fatal("online vacuum did not batch retired pages through FreeMany")

--- a/TreeDB/db/vacuum_panic_test.go
+++ b/TreeDB/db/vacuum_panic_test.go
@@ -2,6 +2,7 @@ package db
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"runtime"
@@ -14,7 +15,6 @@ import (
 // in progress. The vacuum recorder must capture the full batch.Entry so vacuum
 // never needs to look up the key in a potentially stale snapshot.
 func TestVacuumRaceMissingKey(t *testing.T) {
-	skipLegacyOnlineVacuumRuntimeIntegration(t)
 	if runtime.GOOS == "windows" {
 		t.Skip("online vacuum unsupported on windows")
 	}
@@ -55,14 +55,13 @@ func TestVacuumRaceMissingKey(t *testing.T) {
 
 	var wg sync.WaitGroup
 	errCh := make(chan error, 10)
+	vacuumErrCh := make(chan error, 1)
 
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
 		time.Sleep(10 * time.Millisecond)
-		if err := db.vacuumIndexOnlineLegacyForTest(ctx); err != nil {
-			errCh <- fmt.Errorf("vacuum failed: %v", err)
-		}
+		vacuumErrCh <- db.VacuumIndexOnline(ctx)
 	}()
 
 	const newKeysStart = 2000
@@ -96,6 +95,14 @@ func TestVacuumRaceMissingKey(t *testing.T) {
 	close(errCh)
 	for err := range errCh {
 		t.Fatalf("concurrent op error: %v", err)
+	}
+	if vacuumErr := <-vacuumErrCh; vacuumErr != nil {
+		if !errors.Is(vacuumErr, ErrRecoverableRootSetStale) && !errors.Is(vacuumErr, ErrVacuumConcurrentMutation) {
+			t.Fatalf("concurrent vacuum: %v", vacuumErr)
+		}
+		if err := db.VacuumIndexOnline(ctx); err != nil {
+			t.Fatalf("post-churn vacuum retry: %v", err)
+		}
 	}
 
 	missing := 0

--- a/TreeDB/docs/performance/index-vacuum-m0.md
+++ b/TreeDB/docs/performance/index-vacuum-m0.md
@@ -19,8 +19,9 @@ include `ns/op`, `max-writer-pause-ns`, foreground p95/p99, `B/op`, and
 `allocs/op`. The summarizer fails unless total vacuum time, maximum writer pause,
 and foreground p99 each have a coefficient of variation at most 10%. Backend
 rows must be uniform across all ten samples: either explicitly unavailable with
-`vacuum-unsupported/op = 1` and zero unexpected errors, or available with zero
-unsupported/retry/error/exposure-miss metrics and positive foreground overlap.
+`vacuum-unsupported/op = 1`, `foreground-exposure-misses/op = 1`, zero
+foreground overlap, and zero retry/unexpected-error metrics, or available with
+zero unsupported/retry/error/exposure-miss metrics and positive foreground overlap.
 Mixed or ambiguous status fails closed. The available classification is backend
 evidence only; top-level cached/public routing remains M2-owned. Legacy rows
 must report zero concurrent aborts, so an aborted run cannot become a timing

--- a/TreeDB/docs/performance/index-vacuum-m0.md
+++ b/TreeDB/docs/performance/index-vacuum-m0.md
@@ -1,8 +1,10 @@
 # Index Vacuum M0 Baseline
 
-Issue #3943 freezes the current fail-closed production contract before M1
-changes online-vacuum behavior. The fixture and capture script are test-only
-characterization tools; they do not authorize `VacuumIndexOnline`.
+Issue #3943 froze the fail-closed production contract before M1 changed the
+internal online-vacuum backend. The fixture and capture script remain
+characterization tools: their legacy path is a same-head performance comparator
+and never authorizes production maintenance. Production correctness and
+performance certification belong to #3944 and its captured evidence.
 
 Run:
 
@@ -51,8 +53,9 @@ reopen digest parity.
 | `db/compact_storage.go`, `db/compact_storage_test.go`, and M0 maintenance measurement/reporting | M3 (#3946) | Execute the fenced phase and report success/retry/error plus byte convergence truthfully. |
 | Offline `VacuumIndexOffline` operator semantics | M3 (#3946) | Keep offline byte minimization as the ceiling; do not conflate it with online eligibility. |
 
-The M0 test-first exception is deliberate: production success assertions remain
-red until M1. M0 instead asserts the current fail-closed result, disabled
+The M0 test-first exception was deliberate: its public success assertions stay
+as the frozen pre-M1 baseline. M1 enables the internal DB-minted backend only;
+public/background routing remains owned by M2. M0 continues to assert disabled
 background behavior, deterministic fixture debt, offline parity, and artifact
 schema completeness.
 

--- a/TreeDB/docs/performance/index-vacuum-m0.md
+++ b/TreeDB/docs/performance/index-vacuum-m0.md
@@ -14,15 +14,18 @@ RUN_DIR=/tmp/treedb-vacuum-m0 scripts/treedb_vacuum_m0_capture.sh
 
 The capture emits `fixture.json`, `results.json`, `summary.md`, the raw
 `benchstat` input, and ten interleaved raw samples for the legacy test-only path
-and the public fail-closed path. The legacy rows
+and the `db.DB` production-backend path. The legacy rows
 include `ns/op`, `max-writer-pause-ns`, foreground p95/p99, `B/op`, and
 `allocs/op`. The summarizer fails unless total vacuum time, maximum writer pause,
-and foreground p99 each have a coefficient of variation at most 10%. Public
-rows must report `vacuum-unsupported/op = 1` and zero unexpected errors; that
-status is never a successful or fast vacuum result. Legacy rows must report
-zero concurrent aborts, so an aborted run cannot become a timing baseline. The
-capture runs the three-build determinism, debt, shrink, and reopen gate before
-writing `fixture.json`.
+and foreground p99 each have a coefficient of variation at most 10%. Backend
+rows must be uniform across all ten samples: either explicitly unavailable with
+`vacuum-unsupported/op = 1` and zero unexpected errors, or available with zero
+unsupported/retry/error/exposure-miss metrics and positive foreground overlap.
+Mixed or ambiguous status fails closed. The available classification is backend
+evidence only; top-level cached/public routing remains M2-owned. Legacy rows
+must report zero concurrent aborts, so an aborted run cannot become a timing
+baseline. The capture runs the three-build determinism, debt, shrink, and reopen
+gate before writing `fixture.json`.
 
 The legacy benchmark catalog includes 131,072 deterministic ordinary metadata
 entries plus one live collection root. The entries bypass collection-root
@@ -49,15 +52,15 @@ reopen digest parity.
 | `db/close_hooks_test.go` fail-closed assertion | M1 (#3944) | Serialize close through maintenance and preserve a coherent replacement runtime. |
 | `background_vacuum_test.go` disabled success tests and `bg_vacuum.go` classification | M2 (#3945) | Enable only after M1 succeeds; retain backoff and explicit unsupported/error accounting. |
 | `public.go` public/close-time calls, `caching/db.go` wrappers, and `collections/api_test.go` assertions | M2 (#3945) | Route every public and cached entry through the production seam with actionable status. |
-| `db/vacuum_collection_external_bench_test.go`, `db/vacuum_collection_latency_external_bench_test.go`, and `collections/bench_test.go` | M2 (#3945) | Require zero unsupported/unexpected errors, positive overlap, and exact fixed work on supported platforms. |
+| top-level/cached external vacuum benchmarks and `collections/bench_test.go` | M2 (#3945) | Require zero unsupported/unexpected errors, positive overlap, and exact fixed work on supported platforms. |
 | `db/compact_storage.go`, `db/compact_storage_test.go`, and M0 maintenance measurement/reporting | M3 (#3946) | Execute the fenced phase and report success/retry/error plus byte convergence truthfully. |
 | Offline `VacuumIndexOffline` operator semantics | M3 (#3946) | Keep offline byte minimization as the ceiling; do not conflate it with online eligibility. |
 
-The M0 test-first exception was deliberate: its public success assertions stay
-as the frozen pre-M1 baseline. M1 enables the internal DB-minted backend only;
-public/background routing remains owned by M2. M0 continues to assert disabled
-background behavior, deterministic fixture debt, offline parity, and artifact
-schema completeness.
+The M0 test-first exception was deliberate: its original unsupported result
+remains a valid frozen pre-M1 classification, while M1 adds the verified-success
+classification for the internal DB-minted backend. Public/background routing
+remains owned by M2. M0 continues to assert disabled background behavior,
+deterministic fixture debt, offline parity, and artifact schema completeness.
 
 The legacy timing baseline explicitly drains and disables the current
 root-publication coordinator on its private benchmark DB before authorizing the

--- a/TreeDB/docs/spec/recoverable-root-set-maintenance-3681.md
+++ b/TreeDB/docs/spec/recoverable-root-set-maintenance-3681.md
@@ -29,7 +29,7 @@ resource-specific reachability projection.
 | Raw and packed outer-leaf generations | `TreeDB/db/leaf_generation_gc.go` | scans raw leaf FileIDs from every captured root, resolves them through every retained leaf-generation manifest, preserves FileID reuse/ABA generations, and revalidates before zombie publication | active |
 | Leaf pack/rewrite sources | `TreeDB/db/leaf_generation_pack.go`, `TreeDB/db/compact_storage.go` | replacement output is stabilized and published first; physical retirement is exclusively owned by capability-backed leaf-generation GC | active |
 | Column, dictionary, template, typed-column, vector-graph, text, and query-ready assets | `TreeDB/collections/column_asset_gc.go` and `column_asset_rewrite.go` | scans each captured collection catalog/manifest, pins exact referenced segment identities, protects published generations replayable from an older durable WAL frontier, and revalidates before `BeginDeleteAt`. Current query-ready base/delta/consolidated assets remain rebuildable and non-authoritative, but share the same exact-identity retirement gate | active |
-| Online index vacuum/replacement | `TreeDB/db/vacuum_online.go` | production entry remains fail-closed with `ErrVacuumRecoverableRootSetRequired`; the legacy replacement path is test-only until it can publish a durable replacement and prove the old index identity unreachable | fenced |
+| Online index vacuum/replacement | `TreeDB/db/vacuum_online.go` | the internal production entry captures a DB-minted capability, rebuilds both durable slots and their per-root resource closure, revalidates before namespace mutation, and atomically rebinds the live publication runtime; the legacy capability remains test-only | active backend; public/background routing is owned by #3945 and `CompactStorage` policy by #3946 |
 | Offline `CompactIndex` | `TreeDB/db/db.go` | appends and publishes new pages in the same index namespace; it does not unlink or replace the index file. Page eligibility is governed by the page rule below | no external unlink |
 | Graveyard extraction and page/freelist reuse | COW allocator and root-reuse paths from #3678 | `RecoverableRootSet` registers the oldest captured commit sequence and holds the root-reuse read fence; actual page eligibility remains the #3678 generation rule | delegated to #3678 |
 | Stable unlink/rename instrumentation | `TreeDB/db/namespace_mutation.go`, `TreeDB/internal/valuelog/stable_resource.go`, and collection stable deleters | exact identity, namespace lease, unlink observation, and directory-sync failure handling remain the PR #3706 contract; #3681 adds root authority before those operations | inherited from PR #3706 |
@@ -65,6 +65,49 @@ recovery state and therefore do not consume the capability:
 - Namespace deletion is successful only after its owning directory has been
   made durable. An unlink followed by directory-sync failure is recovery
   required, never reported as clean success.
+
+## Online index replacement contract
+
+The production `db.DB.VacuumIndexOnline` backend is authorized only by a
+`RecoverableRootSet` minted by the same live DB. It rebuilds the older durable
+slot's user, system, and collection closure first, then rebuilds the latest
+visible closure as its consecutive successor. Each replacement slot carries
+the original root's stable-resource manifest and command-WAL frontier; the
+replacement index is therefore independently complete for either recovery
+selection.
+
+The replacement pager, durable-root state, snapshot view, allocator/freelist,
+and root-publication runtime are constructed and stabilized before namespace
+publication. Final publication drains pending root debt outside `writeMu`,
+revalidates the capability, writes the ready marker, and performs this ordered
+namespace transition:
+
+1. rename `index.db` to `index.db.bak`;
+2. rename the stabilized replacement to `index.db`;
+3. remove the ready marker and obsolete backup;
+4. sync the parent directory.
+
+An ambiguous rename or directory-sync result poisons publication and returns
+`ErrRecoveryRequired`; destructive maintenance remains blocked until reopen
+reconciles the marker and namespace. Before the first rename, cancellation or
+revalidation failure leaves `index.db` authoritative and removes only
+unpublished replacement artifacts. After the first rename, recovery rather
+than cancellation owns convergence.
+
+Once namespace publication is durable, the DB installs the replacement pager,
+durable slots, state token, snapshot, and publication runtime as one coherent
+in-process generation. A writer that released `writeMu` while waiting for the
+cutover rechecks the runtime and acquires a builder from the replacement
+generation. The retired coordinator is stopped, drained, and its recovery
+handoff released. Existing snapshots, iterators, and stable-resource captures
+continue to pin old-generation handles until they close; physical cleanup is
+deferred until those references drain.
+
+This backend contract does not activate the public/background entry points or
+change `CompactStorage` completion policy. Those staged integrations remain
+fail-closed until #3945 and #3946 respectively. Windows remains explicitly
+unsupported because the required open-file rename and generation-retirement
+semantics are not implemented there.
 
 ## Verification map
 

--- a/TreeDB/internal/dictdb/stable_resource_capture_test.go
+++ b/TreeDB/internal/dictdb/stable_resource_capture_test.go
@@ -214,7 +214,6 @@ func TestCaptureDictionaryResourcesRejectsEachMissingPointerChild(t *testing.T) 
 }
 
 func TestCaptureDictionaryResourcesBlocksOnlineIndexVacuumUntilRelease(t *testing.T) {
-	t.Skip("deferred to #3681: online vacuum pin precedence requires RecoverableRootSet convergence")
 	store, err := Open(t.TempDir(), db.Options{ChunkSize: 64 * 1024})
 	if err != nil {
 		t.Fatalf("open: %v", err)

--- a/TreeDB/internal/dictdb/stable_resource_capture_test.go
+++ b/TreeDB/internal/dictdb/stable_resource_capture_test.go
@@ -361,8 +361,8 @@ func TestCaptureDictionaryResourcesUnionMultiplePointerIDsIsDeterministic(t *tes
 	if got := registry.ActivePins(); got != baselinePins {
 		t.Fatalf("dictionary union release left active pins=%d want baseline %d", got, baselinePins)
 	}
-	if err := store.backend.VacuumIndexOnline(context.Background()); !errors.Is(err, db.ErrVacuumRecoverableRootSetRequired) {
-		t.Fatalf("dictionary union release vacuum err=%v want recoverable-root-set fence", err)
+	if err := store.backend.VacuumIndexOnline(context.Background()); err != nil {
+		t.Fatalf("dictionary union release vacuum: %v", err)
 	}
 }
 
@@ -432,8 +432,8 @@ func TestCaptureDictionaryResourcesDedupeDoesNotGrowPinsOrDescriptors(t *testing
 			t.Fatalf("descriptor count grew from %d to %d after %d captures", len(beforeFDs), len(afterFDs), iterations)
 		}
 	}
-	if err := store.backend.VacuumIndexOnline(context.Background()); !errors.Is(err, db.ErrVacuumRecoverableRootSetRequired) {
-		t.Fatalf("dedupe release vacuum err=%v want recoverable-root-set fence", err)
+	if err := store.backend.VacuumIndexOnline(context.Background()); err != nil {
+		t.Fatalf("dedupe release vacuum: %v", err)
 	}
 }
 

--- a/TreeDB/internal/templatedb/stable_resource_capture_test.go
+++ b/TreeDB/internal/templatedb/stable_resource_capture_test.go
@@ -561,7 +561,6 @@ func TestCaptureTemplateResourcesRejectsEachMissingPointerChild(t *testing.T) {
 }
 
 func TestCaptureTemplateResourcesBlocksVacuumUntilRelease(t *testing.T) {
-	t.Skip("deferred to #3681: online vacuum pin precedence requires RecoverableRootSet convergence")
 	backend, err := backenddb.Open(backenddb.Options{Dir: t.TempDir(), ChunkSize: 64 * 1024})
 	if err != nil {
 		t.Fatalf("open: %v", err)

--- a/TreeDB/internal/templatedb/stable_resource_capture_test.go
+++ b/TreeDB/internal/templatedb/stable_resource_capture_test.go
@@ -461,8 +461,8 @@ func TestCaptureTemplateResourcesMultiIDCoalescesSharedPhysicalClosureDeterminis
 			t.Fatalf("descriptor count grew from %d to %d after %d multi-ID merges", len(beforeFDs), len(afterFDs), iterations)
 		}
 	}
-	if err := backend.VacuumIndexOnline(context.Background()); !errors.Is(err, backenddb.ErrVacuumRecoverableRootSetRequired) {
-		t.Fatalf("multi-ID release vacuum err=%v want recoverable-root-set fence", err)
+	if err := backend.VacuumIndexOnline(context.Background()); err != nil {
+		t.Fatalf("multi-ID release vacuum: %v", err)
 	}
 }
 
@@ -668,8 +668,8 @@ func TestCaptureTemplateResourcesDedupeDoesNotGrowPinsOrDescriptors(t *testing.T
 			t.Fatalf("descriptor count grew from %d to %d after %d captures", len(beforeFDs), len(afterFDs), iterations)
 		}
 	}
-	if err := backend.VacuumIndexOnline(context.Background()); !errors.Is(err, backenddb.ErrVacuumRecoverableRootSetRequired) {
-		t.Fatalf("dedupe release vacuum err=%v want recoverable-root-set fence", err)
+	if err := backend.VacuumIndexOnline(context.Background()); err != nil {
+		t.Fatalf("dedupe release vacuum: %v", err)
 	}
 }
 

--- a/TreeDB/public.go
+++ b/TreeDB/public.go
@@ -66,6 +66,9 @@ const (
 )
 
 var errVacuumUnsupported = db.ErrVacuumUnsupported
+var errVacuumRecoverableRootSetRequired = db.ErrVacuumRecoverableRootSetRequired
+
+func publicOnlineVacuumEnabledV1() bool { return false }
 
 // ErrNamespacePersistenceUnsupported reports that the active platform or
 // filesystem cannot persist a directory creation required by a successful
@@ -2483,6 +2486,13 @@ func (db *DB) VacuumIndexOnline(ctx context.Context) error {
 	if db.backend == nil {
 		return ErrClosed
 	}
+	// The backend replacement is production-capable, but public and cached
+	// routing, reporting, and background policy are activated together by #3945.
+	if !publicOnlineVacuumEnabledV1() {
+		return errors.Join(errVacuumUnsupported, errVacuumRecoverableRootSetRequired)
+	}
+
+	// #3945 removes the staged fence above and activates this block.
 	_, finishMaintenance := db.beginFullScanMaintenance("vacuum")
 	success := false
 	defer func() { finishMaintenance(success) }()

--- a/scripts/treedb_vacuum_m0_capture.sh
+++ b/scripts/treedb_vacuum_m0_capture.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Capture M0's fail-closed public status, offline shrink ceiling, and ten
-# legacy-only online samples. This script never enables production vacuum.
+# Capture the public vacuum status, offline shrink ceiling, and ten
+# interleaved legacy/public samples across the M0-to-M1 transition.
 ROOT=$(git rev-parse --show-toplevel)
 RUN_DIR=${RUN_DIR:-"$ROOT/artifacts/treedb-vacuum-m0/$(date +%Y%m%d_%H%M%S)"}
 SHA=$(git rev-parse HEAD)

--- a/scripts/treedb_vacuum_m0_summarize.py
+++ b/scripts/treedb_vacuum_m0_summarize.py
@@ -64,15 +64,18 @@ def summarize(paths: list[Path]) -> dict[str, dict[str, object]]:
 
 def classify_public_status(public: dict[str, dict[str, object]]) -> str:
     unsupported = public.get("vacuum-unsupported/op", {}).get("samples", [])
-    unexpected = public.get("vacuum-unexpected-errors/op", {}).get("samples", [])
-    if len(unsupported) == 10 and len(unexpected) == 10:
-        if all(value == 1 for value in unsupported) and all(value == 0 for value in unexpected):
-            return "production-index-vacuum-unavailable"
-
     retries = public.get("vacuum-concurrent-retries/op", {}).get("samples", [])
+    unexpected = public.get("vacuum-unexpected-errors/op", {}).get("samples", [])
     misses = public.get("foreground-exposure-misses/op", {}).get("samples", [])
     overlap = public.get("foreground-overlap-samples/op", {}).get("samples", [])
     if all(len(samples) == 10 for samples in (unsupported, retries, unexpected, misses, overlap)):
+        if (
+            all(value == 1 for value in unsupported)
+            and all(value == 0 for value in retries)
+            and all(value == 0 for value in unexpected)
+            and all(value == 0 for value in misses)
+        ):
+            return "production-index-vacuum-unavailable"
         if (
             all(value == 0 for value in unsupported)
             and all(value == 0 for value in retries)

--- a/scripts/treedb_vacuum_m0_summarize.py
+++ b/scripts/treedb_vacuum_m0_summarize.py
@@ -73,7 +73,8 @@ def classify_public_status(public: dict[str, dict[str, object]]) -> str:
             all(value == 1 for value in unsupported)
             and all(value == 0 for value in retries)
             and all(value == 0 for value in unexpected)
-            and all(value == 0 for value in misses)
+            and all(value == 1 for value in misses)
+            and all(value == 0 for value in overlap)
         ):
             return "production-index-vacuum-unavailable"
         if (
@@ -178,6 +179,7 @@ def render_markdown(result: dict[str, object]) -> str:
             "",
             f"- `vacuum-unsupported/op`: median `{public['vacuum-unsupported/op']['median']:.3f}`",
             f"- `vacuum-unexpected-errors/op`: median `{public['vacuum-unexpected-errors/op']['median']:.3f}`",
+            "- Unavailable status requires one unsupported result and one exposure miss with zero retries, unexpected errors, and foreground overlap in every sample.",
             "- Available status requires zero retries, errors, and exposure misses plus positive foreground overlap in every sample.",
             "",
             "## Commands",

--- a/scripts/treedb_vacuum_m0_summarize.py
+++ b/scripts/treedb_vacuum_m0_summarize.py
@@ -62,6 +62,28 @@ def summarize(paths: list[Path]) -> dict[str, dict[str, object]]:
     return result
 
 
+def classify_public_status(public: dict[str, dict[str, object]]) -> str:
+    unsupported = public.get("vacuum-unsupported/op", {}).get("samples", [])
+    unexpected = public.get("vacuum-unexpected-errors/op", {}).get("samples", [])
+    if len(unsupported) == 10 and len(unexpected) == 10:
+        if all(value == 1 for value in unsupported) and all(value == 0 for value in unexpected):
+            return "production-index-vacuum-unavailable"
+
+    retries = public.get("vacuum-concurrent-retries/op", {}).get("samples", [])
+    misses = public.get("foreground-exposure-misses/op", {}).get("samples", [])
+    overlap = public.get("foreground-overlap-samples/op", {}).get("samples", [])
+    if all(len(samples) == 10 for samples in (unsupported, retries, unexpected, misses, overlap)):
+        if (
+            all(value == 0 for value in unsupported)
+            and all(value == 0 for value in retries)
+            and all(value == 0 for value in unexpected)
+            and all(value == 0 for value in misses)
+            and all(value > 0 for value in overlap)
+        ):
+            return "production-index-vacuum-available"
+    return "production-index-vacuum-ambiguous"
+
+
 def evaluate_gates(
     legacy: dict[str, dict[str, object]], public: dict[str, dict[str, object]]
 ) -> dict[str, bool]:
@@ -76,12 +98,8 @@ def evaluate_gates(
             "concurrent-aborts/op" in legacy
             and all(value == 0 for value in legacy["concurrent-aborts/op"]["samples"])
         ),
-        "public_status_explicit": (
-            "vacuum-unsupported/op" in public
-            and "vacuum-unexpected-errors/op" in public
-            and all(value == 1 for value in public["vacuum-unsupported/op"]["samples"])
-            and all(value == 0 for value in public["vacuum-unexpected-errors/op"]["samples"])
-        ),
+        "public_status_explicit": classify_public_status(public)
+        != "production-index-vacuum-ambiguous",
     }
 
 
@@ -127,7 +145,7 @@ def render_markdown(result: dict[str, object]) -> str:
         f"- Storage: `{env['device']}` (`{env['filesystem']}`)",
         f"- Timing boundary: `{result['fixture']['timing_boundary']}`",
         "- Repetitions: `10` interleaved legacy/public runs",
-        "- Status: `production-index-vacuum-unavailable`",
+        f"- Status: `{result['public_status']}`",
         "",
         "## Fixture",
         "",
@@ -157,7 +175,7 @@ def render_markdown(result: dict[str, object]) -> str:
             "",
             f"- `vacuum-unsupported/op`: median `{public['vacuum-unsupported/op']['median']:.3f}`",
             f"- `vacuum-unexpected-errors/op`: median `{public['vacuum-unexpected-errors/op']['median']:.3f}`",
-            "- Unsupported samples are classification evidence, not successful vacuum measurements.",
+            "- Available status requires zero retries, errors, and exposure misses plus positive foreground overlap in every sample.",
             "",
             "## Commands",
             "",
@@ -184,11 +202,13 @@ def main() -> int:
     public = summarize(sorted((run_dir / "raw").glob("public-*.txt")))
 
     gates = evaluate_gates(legacy, public)
+    public_status = classify_public_status(public)
     result = {
         "schema_version": 1,
         "environment": environment(repo, run_dir),
         "fixture": fixture,
         "metrics": {"legacy": legacy, "public": public},
+        "public_status": public_status,
         "gates": gates,
     }
     (run_dir / "results.json").write_text(json.dumps(result, indent=2, sort_keys=True) + "\n")

--- a/scripts/treedb_vacuum_m0_summarize_test.py
+++ b/scripts/treedb_vacuum_m0_summarize_test.py
@@ -48,7 +48,7 @@ class VacuumM0SummarizeTest(unittest.TestCase):
             "vacuum-unsupported/op": {"samples": [1] * 10},
             "vacuum-concurrent-retries/op": {"samples": [0] * 10},
             "vacuum-unexpected-errors/op": {"samples": [0] * 10},
-            "foreground-exposure-misses/op": {"samples": [0] * 10},
+            "foreground-exposure-misses/op": {"samples": [1] * 10},
             "foreground-overlap-samples/op": {"samples": [0] * 10},
         }
         self.assertTrue(all(MODULE.evaluate_gates(legacy, public).values()))
@@ -60,6 +60,24 @@ class VacuumM0SummarizeTest(unittest.TestCase):
         self.assertTrue(gates["public_status_explicit"])
 
         public["vacuum-concurrent-retries/op"]["samples"][4] = 1
+        gates = MODULE.evaluate_gates(legacy, public)
+        self.assertFalse(gates["public_status_explicit"])
+        self.assertEqual(MODULE.classify_public_status(public), "production-index-vacuum-ambiguous")
+
+    def test_evaluate_gates_rejects_unsupported_with_foreground_overlap(self):
+        legacy = {
+            metric: {"cv": 0.01, "samples": [1] * 10}
+            for metric in MODULE.REQUIRED_CV_METRICS
+        }
+        legacy["concurrent-aborts/op"] = {"samples": [0] * 10}
+        public = {
+            "vacuum-unsupported/op": {"samples": [1] * 10},
+            "vacuum-concurrent-retries/op": {"samples": [0] * 10},
+            "vacuum-unexpected-errors/op": {"samples": [0] * 10},
+            "foreground-exposure-misses/op": {"samples": [1] * 10},
+            "foreground-overlap-samples/op": {"samples": [0] * 9 + [1]},
+        }
+
         gates = MODULE.evaluate_gates(legacy, public)
         self.assertFalse(gates["public_status_explicit"])
         self.assertEqual(MODULE.classify_public_status(public), "production-index-vacuum-ambiguous")

--- a/scripts/treedb_vacuum_m0_summarize_test.py
+++ b/scripts/treedb_vacuum_m0_summarize_test.py
@@ -46,7 +46,10 @@ class VacuumM0SummarizeTest(unittest.TestCase):
         legacy["concurrent-aborts/op"] = {"samples": [0] * 10}
         public = {
             "vacuum-unsupported/op": {"samples": [1] * 10},
+            "vacuum-concurrent-retries/op": {"samples": [0] * 10},
             "vacuum-unexpected-errors/op": {"samples": [0] * 10},
+            "foreground-exposure-misses/op": {"samples": [0] * 10},
+            "foreground-overlap-samples/op": {"samples": [0] * 10},
         }
         self.assertTrue(all(MODULE.evaluate_gates(legacy, public).values()))
 
@@ -55,6 +58,11 @@ class VacuumM0SummarizeTest(unittest.TestCase):
         self.assertFalse(gates["legacy_completed_without_abort"])
         self.assertTrue(gates["legacy_cv_at_most_10_percent"])
         self.assertTrue(gates["public_status_explicit"])
+
+        public["vacuum-concurrent-retries/op"]["samples"][4] = 1
+        gates = MODULE.evaluate_gates(legacy, public)
+        self.assertFalse(gates["public_status_explicit"])
+        self.assertEqual(MODULE.classify_public_status(public), "production-index-vacuum-ambiguous")
 
     def test_evaluate_gates_accepts_verified_production_success(self):
         legacy = {

--- a/scripts/treedb_vacuum_m0_summarize_test.py
+++ b/scripts/treedb_vacuum_m0_summarize_test.py
@@ -56,6 +56,42 @@ class VacuumM0SummarizeTest(unittest.TestCase):
         self.assertTrue(gates["legacy_cv_at_most_10_percent"])
         self.assertTrue(gates["public_status_explicit"])
 
+    def test_evaluate_gates_accepts_verified_production_success(self):
+        legacy = {
+            metric: {"cv": 0.01, "samples": [1] * 10}
+            for metric in MODULE.REQUIRED_CV_METRICS
+        }
+        legacy["concurrent-aborts/op"] = {"samples": [0] * 10}
+        public = {
+            "vacuum-unsupported/op": {"samples": [0] * 10},
+            "vacuum-concurrent-retries/op": {"samples": [0] * 10},
+            "vacuum-unexpected-errors/op": {"samples": [0] * 10},
+            "foreground-exposure-misses/op": {"samples": [0] * 10},
+            "foreground-overlap-samples/op": {"samples": [160] * 10},
+        }
+
+        gates = MODULE.evaluate_gates(legacy, public)
+        self.assertTrue(gates["public_status_explicit"])
+        self.assertEqual(MODULE.classify_public_status(public), "production-index-vacuum-available")
+
+    def test_evaluate_gates_rejects_mixed_public_status(self):
+        legacy = {
+            metric: {"cv": 0.01, "samples": [1] * 10}
+            for metric in MODULE.REQUIRED_CV_METRICS
+        }
+        legacy["concurrent-aborts/op"] = {"samples": [0] * 10}
+        public = {
+            "vacuum-unsupported/op": {"samples": [1, 0] * 5},
+            "vacuum-concurrent-retries/op": {"samples": [0] * 10},
+            "vacuum-unexpected-errors/op": {"samples": [0] * 10},
+            "foreground-exposure-misses/op": {"samples": [0] * 10},
+            "foreground-overlap-samples/op": {"samples": [0, 160] * 5},
+        }
+
+        gates = MODULE.evaluate_gates(legacy, public)
+        self.assertFalse(gates["public_status_explicit"])
+        self.assertEqual(MODULE.classify_public_status(public), "production-index-vacuum-ambiguous")
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Closes #3944

Parent: #3942
Depends on merged #3943 / #3948.

## Contract

- authorize the internal production backend only with a DB-minted `RecoverableRootSet`;
- rebuild both recovery-selectable durable slots and each slot's user, system, collection, value-log, leaf-log, dictionary, and template closure;
- stabilize replacement pages, durable metadata, and a replacement root-publication runtime before namespace mutation;
- drain publication debt outside `writeMu`, revalidate immediately before cutover, and retry bounded concurrent mutation;
- publish the replacement pager, allocator/freelist, durable slots, state, snapshot view, and root-publication runtime as one in-process generation;
- stop and transfer recovery handoff from retired/abandoned coordinators, while old snapshots and stable captures continue to pin the old generation;
- keep the public/background wrapper and `CompactStorage` explicitly fenced for #3945 and #3946.

## Crash and recovery table

| Cut | Expected namespace | Recovery selection / reopen | Cleanup owner |
| --- | --- | --- | --- |
| replacement creation or tree build | `index.db` authoritative; optional incomplete `index.db.new`; no ready marker | old durable slot; old digest | current attempt removes unpublished replacement |
| replacement durable-slot write or final file sync | `index.db` authoritative; `index.db.new` may be incomplete; no ready marker | old durable slot; old digest | current attempt removes replacement; reopen also discards unready artifact |
| replacement runtime construction | `index.db` authoritative; replacement is fully written but unready | old durable slot; old digest | current attempt stops replacement coordinator, releases handoff/resources, removes replacement |
| ready-marker write or first directory sync | `index.db` authoritative; ready replacement may exist | old generation while primary exists | failed attempt/reopen removes staged files; ambiguous directory sync returns `ErrRecoveryRequired` |
| `index.db -> index.db.bak` | backup + ready replacement; primary absent | reopen promotes complete ready replacement, selecting one of its two valid slots | `recoverIndexSwap`; live DB is poisoned on ambiguous outcome |
| `index.db.new -> index.db` | new primary + backup + ready marker | new generation and its selected latest slot | reopen/current attempt removes marker and later backup |
| ready-marker or backup removal | new primary; one or both cleanup artifacts may remain | new generation | current attempt/reopen completes idempotent cleanup; sync ambiguity is recovery-required |
| final parent-directory sync | new primary; cleanup complete in process | new generation after successful sync; ambiguous result blocks destructive work | reopen verifies/reconciles namespace |
| live runtime install | durable new primary already complete; no fallible filesystem work remains | new generation; post-swap write/checkpoint/close/reopen tests bind to replacement runtime | old runtime is stopped, handoff drained/released; old generation waits for pins |
| old-generation retirement | new primary only; old file handle may remain open | new generation | reference-counted snapshots/iterators/stable captures release old handle; Windows stays unsupported |

Cancellation before the first rename removes only staged replacement artifacts. Cancellation observed after the first irreversible rename cannot interrupt namespace convergence.

## Test-first and correctness evidence

- test-first commit: `37f67f8c8`;
- focused production vacuum/stable-resource matrix passed across `db`, collections, dictdb, and templatedb;
- race matrix passed: `db` 99.100s, collections 2.778s, dictdb 1.815s, templatedb 1.816s;
- targeted M1/M2 public fence and static coherent-publication guard pass after the full-suite audit;
- full `TreeDB` module passed with `GOWORK=off go test ./... -timeout 30m` (`db` 561.163s, collections 376.967s, root 634.750s);
- final-head `GOWORK=off go test ./db ./freelist -count=1 -timeout 30m` passed (`db` 348.897s, `freelist` 0.720s);
- exact-head production shrink/digest and leaf-reference durability tests pass;
- the M0 capture gate now accepts either ten internally consistent unsupported samples (`unsupported=1`, `exposure-miss=1`, zero retries/errors/overlap) or ten verified successful public-backend samples (zero unsupported/retries/errors/misses and positive overlap); mixed, contradictory, or ambiguous status fails closed.

## Performance evidence

Performance-sensitive. The branch adds a production comparator over the exact same 131,072-entry M0 catalog fixture as the same-head legacy comparator. Each sample performs exactly 4,096 overlapping foreground operations and reports total/phase duration, maximum writer pause, foreground p95/p99, overlap, exposure misses, errors, bytes, and allocations.

Ten interleaved samples on exact implementation head `6e3d489ea` pass every M1 gate:

| Metric | Production median | Legacy median | Result |
| --- | ---: | ---: | --- |
| total wall time | 43.25s | 89.10s | -51.46% |
| vacuum total | 43.18s | 89.10s | -51.53% |
| max writer pause | 28.78ms | 31.19ms | pass |
| foreground p95 | 24.09ms | 33.09ms | pass |
| foreground p99 | 35.19ms | 41.07ms | pass |
| B/op | 7.721GiB | 7.454GiB | +3.58% |
| allocs/op | 2.588M | 2.566M | +0.86% |

All ten production samples report zero vacuum errors, zero exposure misses, and exactly 4,096 overlap samples. The deterministic fixture has 67.90% reclaimable pages and shrinks `index.db` from 1,900,544 to 131,072 bytes while preserving the complete digest and value/leaf-log byte counts before and after reopen.

Exact implementation-head profile `02027a16d` reports 42.07s total, 27.99ms max pause, 25.07ms p95, 39.30ms p99, zero errors/misses, and 4,096 overlapping operations. CPU evidence attributes about 79% cumulative time to leaf-value reads and reachability scanning; no filesystem sync appears in CPU top. Mutex/block evidence is centered on foreground/root-publication lock and channel waits, while deterministic hooks prove pager sync remains outside `writeMu`. Head `3b4fce975` adds test-first capture-classification hardening and matching documentation; replay of the successful CI artifact passes the tightened classifier, and a dedicated regression rejects unsupported samples that claim foreground overlap. Head `c42d5e918` applies the established Windows capability skip to the new production-support assertion. Final head `410a850a4` adds a test-first exact-head review fix: applied-LSN and no-op command-WAL publications now revalidate their runtime-bound builder under `writeMu` and reacquire after vacuum cutover. Both reproductions failed with `ErrBuilderLease` before the fix and pass afterward, including under `-race`; the broader command-WAL/vacuum selection passes.

## Validation

```sh
cd TreeDB
GOWORK=off go test ./db ./collections ./internal/dictdb ./internal/templatedb -run 'Test.*Vacuum|Test.*StableResource|TestCapture.*Resources.*(Blocks|Dedupe|Union|Multi)' -count=1
GOWORK=off go test -race ./db ./collections ./internal/dictdb ./internal/templatedb -run 'Test.*Vacuum|Test.*StableResource|TestCapture.*Resources.*(Blocks|Dedupe|Union|Multi)' -count=1
GOWORK=off go test ./... -timeout 30m
```

## Merge gates

- [x] exact integrated-head full suites;
- [x] ten interleaved same-fixture performance samples and profiles;
- [x] latest-head required CI;
- [x] mature exact-head Codex review with no unresolved threads.
