### PR TITLE
TreeDB: enable public and background online index vacuum

### DIFF
--- a/TreeDB/background_vacuum_test.go
+++ b/TreeDB/background_vacuum_test.go
@@ -616,6 +616,54 @@ func TestBackgroundIndexVacuumErrorOutcomes(t *testing.T) {
 	}
 }
 
+func TestBackgroundIndexVacuumPermanentProbeErrorReportedOncePerState(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("online vacuum not supported on windows")
+	}
+	var reports atomic.Int64
+	d := openBackgroundVacuumTestDB(t, Options{
+		BackgroundIndexVacuumInterval: -1,
+		NotifyError: func(error) {
+			reports.Add(1)
+		},
+	})
+
+	probeErr := errors.New("trigger report I/O failure")
+	var probes atomic.Int64
+	restore := setBackgroundIndexVacuumTriggerReportHookForTest(func(*DB, context.Context) (backenddb.IndexVacuumTriggerReport, error) {
+		probes.Add(1)
+		return backenddb.IndexVacuumTriggerReport{}, probeErr
+	})
+	defer restore()
+
+	d.bgVac.runOnce(d)
+	d.bgVac.runOnce(d)
+	if got := probes.Load(); got != 1 {
+		t.Fatalf("unchanged-state trigger probes=%d want 1", got)
+	}
+	if got := reports.Load(); got != 1 {
+		t.Fatalf("unchanged-state NotifyError calls=%d want 1", got)
+	}
+	stats := d.bgVac.Stats()
+	if stats.PermanentFailuresTotal != 1 || stats.LastOutcome != backgroundIndexVacuumOutcomeUnchanged || stats.LastErr != probeErr.Error() {
+		t.Fatalf("unexpected unchanged-state stats: %+v", stats)
+	}
+
+	if err := d.Set([]byte("new-state"), []byte("value")); err != nil {
+		t.Fatalf("mutate state: %v", err)
+	}
+	if err := d.Checkpoint(); err != nil {
+		t.Fatalf("checkpoint new state: %v", err)
+	}
+	d.bgVac.runOnce(d)
+	if got := probes.Load(); got != 2 {
+		t.Fatalf("changed-state trigger probes=%d want 2", got)
+	}
+	if got := reports.Load(); got != 2 {
+		t.Fatalf("changed-state NotifyError calls=%d want 2", got)
+	}
+}
+
 func TestBackgroundIndexVacuumReadOnlyStartsNoWorker(t *testing.T) {
 	dir := t.TempDir()
 	writable, err := Open(Options{Dir: dir, BackgroundIndexVacuumInterval: -1})

--- a/TreeDB/background_vacuum_test.go
+++ b/TreeDB/background_vacuum_test.go
@@ -823,6 +823,29 @@ func TestLockFullScanMaintenanceContextCancellationLeavesNoWaiters(t *testing.T)
 	mu.Unlock()
 }
 
+func TestLockFullScanMaintenanceContextRejectsCanceledContextBeforeIdleLock(t *testing.T) {
+	var mu sync.Mutex
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	if err := lockFullScanMaintenanceContext(ctx, &mu); !errors.Is(err, context.Canceled) {
+		t.Fatalf("lock error=%v, want context.Canceled", err)
+	}
+	if !mu.TryLock() {
+		t.Fatal("canceled maintenance lock call retained idle mutex")
+	}
+	mu.Unlock()
+
+	d := &DB{}
+	if _, _, err := d.beginFullScanMaintenanceContext(ctx, "vacuum"); !errors.Is(err, context.Canceled) {
+		t.Fatalf("begin maintenance error=%v, want context.Canceled", err)
+	}
+	if !d.maintenance.mu.TryLock() {
+		t.Fatal("canceled maintenance fast path retained mutex")
+	}
+	d.maintenance.mu.Unlock()
+}
+
 func TestVacuumIndexOnlineDoesNotHoldLifecycleWhileWaitingForMaintenance(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("online vacuum not supported on windows")

--- a/TreeDB/background_vacuum_test.go
+++ b/TreeDB/background_vacuum_test.go
@@ -31,6 +31,9 @@ func TestBackgroundIndexVacuumConcurrentMutationIsRetryOnly(t *testing.T) {
 	if backgroundIndexVacuumShouldReport(backenddb.ErrVacuumUnsupported) {
 		t.Fatal("unsupported capability classified as permanent background error")
 	}
+	if backgroundIndexVacuumShouldReport(backenddb.ErrDurableWALCleanupProofStale) {
+		t.Fatal("stale checkpoint-cleanup proof classified as permanent background error")
+	}
 }
 
 func TestBackgroundIndexVacuumIdleUnchangedCommitSkipsStructuralWalks(t *testing.T) {
@@ -504,15 +507,16 @@ func TestBackgroundIndexVacuumErrorOutcomes(t *testing.T) {
 		t.Skip("online vacuum not supported on windows")
 	}
 	tests := []struct {
-		name                 string
-		err                  error
-		wantRetryReason      string
-		wantOutcome          string
-		wantConcurrent       uint64
-		wantRecoverableRoots uint64
-		wantUnsupported      uint64
-		wantPermanent        uint64
-		wantReports          int64
+		name                  string
+		err                   error
+		wantRetryReason       string
+		wantOutcome           string
+		wantConcurrent        uint64
+		wantRecoverableRoots  uint64
+		wantCheckpointCleanup uint64
+		wantUnsupported       uint64
+		wantPermanent         uint64
+		wantReports           int64
 	}{
 		{
 			name:            "concurrent mutation",
@@ -527,6 +531,13 @@ func TestBackgroundIndexVacuumErrorOutcomes(t *testing.T) {
 			wantRetryReason:      backgroundIndexVacuumRetryReasonRecoverableRootSet,
 			wantOutcome:          backgroundIndexVacuumOutcomeRetry,
 			wantRecoverableRoots: 1,
+		},
+		{
+			name:                  "stale checkpoint cleanup",
+			err:                   backenddb.ErrDurableWALCleanupProofStale,
+			wantRetryReason:       backgroundIndexVacuumRetryReasonCheckpointCleanup,
+			wantOutcome:           backgroundIndexVacuumOutcomeRetry,
+			wantCheckpointCleanup: 1,
 		},
 		{
 			name:            "unsupported",
@@ -573,6 +584,7 @@ func TestBackgroundIndexVacuumErrorOutcomes(t *testing.T) {
 			}
 			if stats.RetryConcurrentMutationTotal != tc.wantConcurrent ||
 				stats.RetryRecoverableRootSetTotal != tc.wantRecoverableRoots ||
+				stats.RetryCheckpointCleanupTotal != tc.wantCheckpointCleanup ||
 				stats.UnsupportedTotal != tc.wantUnsupported ||
 				stats.PermanentFailuresTotal != tc.wantPermanent {
 				t.Fatalf("unexpected counters: %+v", stats)

--- a/TreeDB/background_vacuum_test.go
+++ b/TreeDB/background_vacuum_test.go
@@ -1,6 +1,7 @@
 package treedb
 
 import (
+	"context"
 	"encoding/binary"
 	"errors"
 	"fmt"
@@ -495,6 +496,181 @@ func TestBackgroundIndexVacuumDisabledIntervalStartsNoWorker(t *testing.T) {
 	}
 	if err := d.Close(); err != nil {
 		t.Fatalf("close: %v", err)
+	}
+}
+
+func TestBackgroundIndexVacuumErrorOutcomes(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("online vacuum not supported on windows")
+	}
+	tests := []struct {
+		name                 string
+		err                  error
+		wantRetryReason      string
+		wantOutcome          string
+		wantConcurrent       uint64
+		wantRecoverableRoots uint64
+		wantUnsupported      uint64
+		wantPermanent        uint64
+		wantReports          int64
+	}{
+		{
+			name:            "concurrent mutation",
+			err:             backenddb.ErrVacuumConcurrentMutation,
+			wantRetryReason: backgroundIndexVacuumRetryReasonConcurrentMutation,
+			wantOutcome:     backgroundIndexVacuumOutcomeRetry,
+			wantConcurrent:  1,
+		},
+		{
+			name:                 "stale recoverable roots",
+			err:                  backenddb.ErrRecoverableRootSetStale,
+			wantRetryReason:      backgroundIndexVacuumRetryReasonRecoverableRootSet,
+			wantOutcome:          backgroundIndexVacuumOutcomeRetry,
+			wantRecoverableRoots: 1,
+		},
+		{
+			name:            "unsupported",
+			err:             backenddb.ErrVacuumUnsupported,
+			wantRetryReason: backgroundIndexVacuumRetryReasonNone,
+			wantOutcome:     backgroundIndexVacuumOutcomeUnsupported,
+			wantUnsupported: 1,
+		},
+		{
+			name:            "permanent",
+			err:             errors.New("vacuum I/O failure"),
+			wantRetryReason: backgroundIndexVacuumRetryReasonNone,
+			wantOutcome:     backgroundIndexVacuumOutcomePermanentFailure,
+			wantPermanent:   1,
+			wantReports:     1,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var reports atomic.Int64
+			d := openBackgroundVacuumTestDB(t, Options{
+				BackgroundIndexVacuumInterval: -1,
+				NotifyError: func(error) {
+					reports.Add(1)
+				},
+			})
+			seedBackgroundVacuumUserPages(t, d, 64)
+			d.bgVac.spanRatioPPM = 1
+			d.bgVac.freelistReclaimablePages = ^uint64(0)
+			d.bgVac.collectionRootPages = ^uint64(0)
+
+			var calls atomic.Int64
+			restore := setBackgroundIndexVacuumRunHookForTest(func(*DB, context.Context) error {
+				calls.Add(1)
+				return tc.err
+			})
+			defer restore()
+
+			d.bgVac.runOnce(d)
+			stats := d.bgVac.Stats()
+			if stats.LastRetryReason != tc.wantRetryReason || stats.LastOutcome != tc.wantOutcome {
+				t.Fatalf("retry=%q outcome=%q want retry=%q outcome=%q", stats.LastRetryReason, stats.LastOutcome, tc.wantRetryReason, tc.wantOutcome)
+			}
+			if stats.RetryConcurrentMutationTotal != tc.wantConcurrent ||
+				stats.RetryRecoverableRootSetTotal != tc.wantRecoverableRoots ||
+				stats.UnsupportedTotal != tc.wantUnsupported ||
+				stats.PermanentFailuresTotal != tc.wantPermanent {
+				t.Fatalf("unexpected counters: %+v", stats)
+			}
+			if got := reports.Load(); got != tc.wantReports {
+				t.Fatalf("NotifyError calls=%d want %d", got, tc.wantReports)
+			}
+			publicStats := d.Stats()
+			if got := publicStats["treedb.bg_vacuum.last_retry_reason"]; got != tc.wantRetryReason {
+				t.Fatalf("public last retry reason=%q want %q", got, tc.wantRetryReason)
+			}
+			if got := publicStats["treedb.bg_vacuum.last_outcome"]; got != tc.wantOutcome {
+				t.Fatalf("public last outcome=%q want %q", got, tc.wantOutcome)
+			}
+
+			if tc.wantUnsupported != 0 || tc.wantPermanent != 0 {
+				d.bgVac.runOnce(d)
+				if got := calls.Load(); got != 1 {
+					t.Fatalf("vacuum calls after terminal unchanged outcome=%d want 1", got)
+				}
+				if got := reports.Load(); got != tc.wantReports {
+					t.Fatalf("NotifyError calls after unchanged tick=%d want %d", got, tc.wantReports)
+				}
+				if got := d.bgVac.Stats().LastErr; got != tc.err.Error() {
+					t.Fatalf("retained last error=%q want %q", got, tc.err.Error())
+				}
+			}
+		})
+	}
+}
+
+func TestBackgroundIndexVacuumReadOnlyStartsNoWorker(t *testing.T) {
+	dir := t.TempDir()
+	writable, err := Open(Options{Dir: dir, BackgroundIndexVacuumInterval: -1})
+	if err != nil {
+		t.Fatalf("open writable fixture: %v", err)
+	}
+	if err := writable.Set([]byte("key"), []byte("value")); err != nil {
+		t.Fatalf("set: %v", err)
+	}
+	if err := writable.Close(); err != nil {
+		t.Fatalf("close writable fixture: %v", err)
+	}
+
+	readOnly, err := Open(Options{
+		Dir:                           dir,
+		ReadOnly:                      true,
+		BackgroundIndexVacuumInterval: time.Hour,
+	})
+	if err != nil {
+		t.Fatalf("open read-only: %v", err)
+	}
+	if got := readOnly.Stats()["treedb.bg_vacuum.enabled"]; got != "false" {
+		t.Fatalf("read-only background vacuum enabled=%q want false", got)
+	}
+	if err := readOnly.Close(); err != nil {
+		t.Fatalf("close read-only: %v", err)
+	}
+}
+
+func TestBackgroundIndexVacuumCloseCancelsActivePass(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("online vacuum not supported on windows")
+	}
+	d, err := Open(Options{
+		Dir:                               t.TempDir(),
+		BackgroundIndexVacuumInterval:     time.Hour,
+		BackgroundIndexVacuumSpanRatioPPM: 1,
+	})
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	seedBackgroundVacuumUserPages(t, d, 64)
+
+	started := make(chan struct{})
+	restore := setBackgroundIndexVacuumRunHookForTest(func(_ *DB, ctx context.Context) error {
+		close(started)
+		<-ctx.Done()
+		return ctx.Err()
+	})
+	defer restore()
+
+	d.bgVac.Kick()
+	select {
+	case <-started:
+	case <-time.After(5 * time.Second):
+		t.Fatal("background vacuum did not start")
+	}
+
+	closed := make(chan error, 1)
+	go func() { closed <- d.Close() }()
+	select {
+	case err := <-closed:
+		if err != nil {
+			t.Fatalf("close: %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("Close did not cancel active background vacuum")
 	}
 }
 

--- a/TreeDB/background_vacuum_test.go
+++ b/TreeDB/background_vacuum_test.go
@@ -790,10 +790,15 @@ func TestLockFullScanMaintenanceContextCancellationLeavesNoWaiters(t *testing.T)
 	const waiters = 64
 	contexts := make([]context.CancelFunc, waiters)
 	done := make(chan error, waiters)
+	var callers sync.WaitGroup
 	for i := range contexts {
 		ctx, cancel := context.WithCancel(context.Background())
 		contexts[i] = cancel
-		go func() { done <- lockFullScanMaintenanceContext(ctx, &mu) }()
+		callers.Add(1)
+		go func() {
+			defer callers.Done()
+			done <- lockFullScanMaintenanceContext(ctx, &mu)
+		}()
 	}
 	time.Sleep(20 * time.Millisecond)
 	for _, cancel := range contexts {
@@ -804,6 +809,7 @@ func TestLockFullScanMaintenanceContextCancellationLeavesNoWaiters(t *testing.T)
 			t.Fatalf("lock wait error=%v, want context.Canceled", err)
 		}
 	}
+	callers.Wait()
 
 	runtime.Gosched()
 	blockedGoroutines := runtime.NumGoroutine()

--- a/TreeDB/background_vacuum_test.go
+++ b/TreeDB/background_vacuum_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"runtime"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -779,6 +780,41 @@ func TestVacuumIndexOnlineContextCancelsWhileWaitingForMaintenance(t *testing.T)
 	case <-time.After(2 * time.Second):
 		t.Fatal("VacuumIndexOnline did not cancel while waiting for maintenance")
 	}
+}
+
+func TestLockFullScanMaintenanceContextCancellationLeavesNoWaiters(t *testing.T) {
+	var mu sync.Mutex
+	mu.Lock()
+	baselineGoroutines := runtime.NumGoroutine()
+
+	const waiters = 64
+	contexts := make([]context.CancelFunc, waiters)
+	done := make(chan error, waiters)
+	for i := range contexts {
+		ctx, cancel := context.WithCancel(context.Background())
+		contexts[i] = cancel
+		go func() { done <- lockFullScanMaintenanceContext(ctx, &mu) }()
+	}
+	time.Sleep(20 * time.Millisecond)
+	for _, cancel := range contexts {
+		cancel()
+	}
+	for range contexts {
+		if err := <-done; !errors.Is(err, context.Canceled) {
+			t.Fatalf("lock wait error=%v, want context.Canceled", err)
+		}
+	}
+
+	runtime.Gosched()
+	blockedGoroutines := runtime.NumGoroutine()
+	mu.Unlock()
+	if blockedGoroutines > baselineGoroutines+waiters/4 {
+		t.Fatalf("goroutines after cancellation=%d baseline=%d; canceled lock waiters remain parked", blockedGoroutines, baselineGoroutines)
+	}
+	if !mu.TryLock() {
+		t.Fatal("canceled maintenance lock calls left queued mutex waiters")
+	}
+	mu.Unlock()
 }
 
 func TestVacuumIndexOnlineDoesNotHoldLifecycleWhileWaitingForMaintenance(t *testing.T) {

--- a/TreeDB/background_vacuum_test.go
+++ b/TreeDB/background_vacuum_test.go
@@ -12,6 +12,7 @@ import (
 
 	backenddb "github.com/snissn/gomap/TreeDB/db"
 	"github.com/snissn/gomap/TreeDB/internal/memtable"
+	"github.com/snissn/gomap/TreeDB/internal/rootpublication"
 )
 
 func TestBackgroundIndexVacuumConcurrentMutationIsRetryOnly(t *testing.T) {
@@ -33,6 +34,9 @@ func TestBackgroundIndexVacuumConcurrentMutationIsRetryOnly(t *testing.T) {
 	}
 	if backgroundIndexVacuumShouldReport(backenddb.ErrDurableWALCleanupProofStale) {
 		t.Fatal("stale checkpoint-cleanup proof classified as permanent background error")
+	}
+	if backgroundIndexVacuumShouldReport(rootpublication.ErrResourcePinned) {
+		t.Fatal("pinned stable resource classified as permanent background error")
 	}
 }
 
@@ -514,6 +518,7 @@ func TestBackgroundIndexVacuumErrorOutcomes(t *testing.T) {
 		wantConcurrent        uint64
 		wantRecoverableRoots  uint64
 		wantCheckpointCleanup uint64
+		wantResourcePinned    uint64
 		wantUnsupported       uint64
 		wantPermanent         uint64
 		wantReports           int64
@@ -538,6 +543,13 @@ func TestBackgroundIndexVacuumErrorOutcomes(t *testing.T) {
 			wantRetryReason:       backgroundIndexVacuumRetryReasonCheckpointCleanup,
 			wantOutcome:           backgroundIndexVacuumOutcomeRetry,
 			wantCheckpointCleanup: 1,
+		},
+		{
+			name:               "pinned stable resource",
+			err:                rootpublication.ErrResourcePinned,
+			wantRetryReason:    backgroundIndexVacuumRetryReasonResourcePinned,
+			wantOutcome:        backgroundIndexVacuumOutcomeRetry,
+			wantResourcePinned: 1,
 		},
 		{
 			name:            "unsupported",
@@ -585,6 +597,7 @@ func TestBackgroundIndexVacuumErrorOutcomes(t *testing.T) {
 			if stats.RetryConcurrentMutationTotal != tc.wantConcurrent ||
 				stats.RetryRecoverableRootSetTotal != tc.wantRecoverableRoots ||
 				stats.RetryCheckpointCleanupTotal != tc.wantCheckpointCleanup ||
+				stats.RetryResourcePinnedTotal != tc.wantResourcePinned ||
 				stats.UnsupportedTotal != tc.wantUnsupported ||
 				stats.PermanentFailuresTotal != tc.wantPermanent {
 				t.Fatalf("unexpected counters: %+v", stats)
@@ -599,6 +612,9 @@ func TestBackgroundIndexVacuumErrorOutcomes(t *testing.T) {
 			if got := publicStats["treedb.bg_vacuum.last_outcome"]; got != tc.wantOutcome {
 				t.Fatalf("public last outcome=%q want %q", got, tc.wantOutcome)
 			}
+			if got := publicStats["treedb.bg_vacuum.retry_resource_pinned_total"]; got != fmt.Sprint(tc.wantResourcePinned) {
+				t.Fatalf("public pinned retry total=%q want %d", got, tc.wantResourcePinned)
+			}
 
 			if tc.wantUnsupported != 0 || tc.wantPermanent != 0 {
 				d.bgVac.runOnce(d)
@@ -610,6 +626,14 @@ func TestBackgroundIndexVacuumErrorOutcomes(t *testing.T) {
 				}
 				if got := d.bgVac.Stats().LastErr; got != tc.err.Error() {
 					t.Fatalf("retained last error=%q want %q", got, tc.err.Error())
+				}
+			} else if tc.wantResourcePinned != 0 {
+				d.bgVac.runOnce(d)
+				if got := calls.Load(); got != 2 {
+					t.Fatalf("vacuum calls after pinned retry=%d want 2", got)
+				}
+				if got := reports.Load(); got != 0 {
+					t.Fatalf("NotifyError calls after pinned retry=%d want 0", got)
 				}
 			}
 		})

--- a/TreeDB/background_vacuum_test.go
+++ b/TreeDB/background_vacuum_test.go
@@ -757,6 +757,50 @@ func TestVacuumIndexOnlineContextCancelsWhileWaitingForMaintenance(t *testing.T)
 	}
 }
 
+func TestVacuumIndexOnlineDoesNotHoldLifecycleWhileWaitingForMaintenance(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("online vacuum not supported on windows")
+	}
+	d := openBackgroundVacuumTestDB(t, Options{BackgroundIndexVacuumInterval: -1})
+	d.maintenance.mu.Lock()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	vacuumDone := make(chan error, 1)
+	go func() { vacuumDone <- d.VacuumIndexOnline(ctx) }()
+	time.Sleep(25 * time.Millisecond)
+
+	lifecycleAcquired := make(chan struct{})
+	releaseLifecycle := make(chan struct{})
+	go func() {
+		d.lifecycleMu.Lock()
+		close(lifecycleAcquired)
+		<-releaseLifecycle
+		d.lifecycleMu.Unlock()
+	}()
+	select {
+	case <-lifecycleAcquired:
+	case <-time.After(100 * time.Millisecond):
+		cancel()
+		d.maintenance.mu.Unlock()
+		<-lifecycleAcquired
+		close(releaseLifecycle)
+		<-vacuumDone
+		t.Fatal("lifecycle writer blocked behind vacuum waiting for maintenance")
+	}
+
+	cancel()
+	close(releaseLifecycle)
+	d.maintenance.mu.Unlock()
+	select {
+	case err := <-vacuumDone:
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("VacuumIndexOnline error=%v, want context.Canceled", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("vacuum did not cancel after maintenance released")
+	}
+}
+
 func BenchmarkBackgroundIndexVacuumBacklog(b *testing.B) {
 	d := openBackgroundVacuumTestDB(b, Options{BackgroundIndexVacuumInterval: -1})
 	seedBackgroundVacuumUserPages(b, d, 128)

--- a/TreeDB/background_vacuum_test.go
+++ b/TreeDB/background_vacuum_test.go
@@ -734,6 +734,29 @@ func TestBackgroundIndexVacuumCloseCancelsActivePass(t *testing.T) {
 	}
 }
 
+func TestVacuumIndexOnlineContextCancelsWhileWaitingForMaintenance(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("online vacuum not supported on windows")
+	}
+	d := openBackgroundVacuumTestDB(t, Options{BackgroundIndexVacuumInterval: -1})
+	d.maintenance.mu.Lock()
+	defer d.maintenance.mu.Unlock()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() { done <- d.VacuumIndexOnline(ctx) }()
+	cancel()
+
+	select {
+	case err := <-done:
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("VacuumIndexOnline error=%v, want context.Canceled", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("VacuumIndexOnline did not cancel while waiting for maintenance")
+	}
+}
+
 func BenchmarkBackgroundIndexVacuumBacklog(b *testing.B) {
 	d := openBackgroundVacuumTestDB(b, Options{BackgroundIndexVacuumInterval: -1})
 	seedBackgroundVacuumUserPages(b, d, 128)

--- a/TreeDB/background_vacuum_test.go
+++ b/TreeDB/background_vacuum_test.go
@@ -24,6 +24,12 @@ func TestBackgroundIndexVacuumConcurrentMutationIsRetryOnly(t *testing.T) {
 	if backgroundIndexVacuumShouldReport(backenddb.ErrVacuumRecoverableRootSetRequired) {
 		t.Fatal("recoverable-root-set fence classified as permanent background error")
 	}
+	if backgroundIndexVacuumShouldReport(backenddb.ErrRecoverableRootSetStale) {
+		t.Fatal("stale recoverable-root-set classified as permanent background error")
+	}
+	if backgroundIndexVacuumShouldReport(backenddb.ErrVacuumUnsupported) {
+		t.Fatal("unsupported capability classified as permanent background error")
+	}
 }
 
 func TestBackgroundIndexVacuumIdleUnchangedCommitSkipsStructuralWalks(t *testing.T) {
@@ -331,7 +337,6 @@ func TestBackgroundIndexVacuumTriggerPredicatesIndependentDebt(t *testing.T) {
 }
 
 func TestBackgroundIndexVacuumFreelistDebtTriggersVacuum(t *testing.T) {
-	t.Skip("deferred to #3681: successful online vacuum requires RecoverableRootSet convergence")
 	if runtime.GOOS == "windows" {
 		t.Skip("online vacuum not supported on windows")
 	}
@@ -366,12 +371,13 @@ func TestBackgroundIndexVacuumFreelistDebtTriggersVacuum(t *testing.T) {
 }
 
 func TestBackgroundIndexVacuumCollectionRootDebtTriggersVacuum(t *testing.T) {
-	t.Skip("deferred to #3681: successful online vacuum requires RecoverableRootSet convergence")
 	if runtime.GOOS == "windows" {
 		t.Skip("online vacuum not supported on windows")
 	}
 	d := openBackgroundVacuumTestDB(t, Options{
 		KeepRecent:                    1,
+		Durability:                    DurabilityWALOffRelaxed,
+		ResolvedProfile:               backenddb.ProfileNoWALFast,
 		BackgroundIndexVacuumInterval: -1,
 	})
 	seedBackgroundVacuumCollectionRootDebt(t, d)
@@ -440,13 +446,16 @@ func assertNoBackgroundVacuumFullFragmentationWalks(t *testing.T, counts map[bac
 	}
 }
 
-func TestBackgroundIndexVacuumRemainsDisabledUntilRecoverableRootSetFenced(t *testing.T) {
+func TestBackgroundIndexVacuumStartsWhenConfigured(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("online vacuum not supported on windows")
+	}
 	dir := t.TempDir()
 
 	d, err := Open(Options{
 		Dir:                               dir,
 		KeepRecent:                        1,
-		BackgroundIndexVacuumInterval:     5 * time.Millisecond,
+		BackgroundIndexVacuumInterval:     time.Hour,
 		BackgroundIndexVacuumSpanRatioPPM: 1,
 	})
 	if err != nil {
@@ -454,13 +463,36 @@ func TestBackgroundIndexVacuumRemainsDisabledUntilRecoverableRootSetFenced(t *te
 	}
 
 	stats := d.Stats()
-	if got := stats["treedb.bg_vacuum.enabled"]; got != "false" {
-		t.Fatalf("background vacuum enabled=%q want false pending #3681", got)
+	if got := stats["treedb.bg_vacuum.enabled"]; got != "true" {
+		t.Fatalf("background vacuum enabled=%q want true", got)
 	}
 	if got := stats["treedb.bg_vacuum.vacuums"]; got != "0" {
-		t.Fatalf("background vacuum runs=%q want 0 pending #3681", got)
+		t.Fatalf("background vacuum runs=%q want 0 before first tick", got)
 	}
 
+	if err := d.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+}
+
+func TestBackgroundIndexVacuumDisabledIntervalStartsNoWorker(t *testing.T) {
+	d, err := Open(Options{
+		Dir:                           t.TempDir(),
+		BackgroundIndexVacuumInterval: -1,
+	})
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	stats := d.Stats()
+	if got := stats["treedb.bg_vacuum.enabled"]; got != "false" {
+		t.Fatalf("background vacuum enabled=%q want false", got)
+	}
+	if got := stats["treedb.bg_vacuum.runs"]; got != "0" {
+		t.Fatalf("background vacuum runs=%q want 0", got)
+	}
+	if got := stats["treedb.bg_vacuum.trigger_probes"]; got != "0" {
+		t.Fatalf("background vacuum probes=%q want 0", got)
+	}
 	if err := d.Close(); err != nil {
 		t.Fatalf("close: %v", err)
 	}

--- a/TreeDB/bg_vacuum.go
+++ b/TreeDB/bg_vacuum.go
@@ -14,7 +14,10 @@ import (
 func backgroundIndexVacuumShouldReport(err error) bool {
 	return err != nil &&
 		!errors.Is(err, backenddb.ErrVacuumConcurrentMutation) &&
-		!errors.Is(err, backenddb.ErrVacuumRecoverableRootSetRequired)
+		!errors.Is(err, backenddb.ErrVacuumRecoverableRootSetRequired) &&
+		!errors.Is(err, backenddb.ErrRecoverableRootSetStale) &&
+		!errors.Is(err, backenddb.ErrVacuumUnsupported) &&
+		!errors.Is(err, context.Canceled)
 }
 
 const (
@@ -28,6 +31,18 @@ const (
 	backgroundIndexVacuumDebtReasonUser                            = "user"
 	backgroundIndexVacuumDebtReasonFreelist                        = "freelist"
 	backgroundIndexVacuumDebtReasonCollectionRoots                 = "collection_roots"
+	backgroundIndexVacuumRetryReasonNone                           = "none"
+	backgroundIndexVacuumRetryReasonConcurrentMutation             = "concurrent_mutation"
+	backgroundIndexVacuumRetryReasonRecoverableRootSet             = "recoverable_root_set"
+	backgroundIndexVacuumOutcomeNone                               = "none"
+	backgroundIndexVacuumOutcomeBacklogSkip                        = "backlog_skip"
+	backgroundIndexVacuumOutcomeUnchanged                          = "unchanged"
+	backgroundIndexVacuumOutcomeNoDebt                             = "no_debt"
+	backgroundIndexVacuumOutcomeRetry                              = "retry"
+	backgroundIndexVacuumOutcomeUnsupported                        = "unsupported"
+	backgroundIndexVacuumOutcomePermanentFailure                   = "permanent_failure"
+	backgroundIndexVacuumOutcomeSuccess                            = "success"
+	backgroundIndexVacuumOutcomeCanceled                           = "canceled"
 )
 
 type bgIndexVacuumConfig struct {
@@ -85,16 +100,23 @@ type bgIndexVacuumWorker struct {
 	stopCh   chan struct{}
 	doneCh   chan struct{}
 	kickCh   chan struct{}
+	cancel   context.CancelFunc
 
-	runMu          sync.Mutex
-	runs           atomic.Uint64
-	probes         atomic.Uint64
-	vacuums        atomic.Uint64
-	lastRunUnix    atomic.Int64
-	lastVacuumUnix atomic.Int64
-	lastSpanRatio  atomic.Uint64
-	lastPages      atomic.Uint64
-	lastErr        atomic.Value // string
+	runMu                        sync.Mutex
+	runs                         atomic.Uint64
+	probes                       atomic.Uint64
+	vacuums                      atomic.Uint64
+	lastRunUnix                  atomic.Int64
+	lastVacuumUnix               atomic.Int64
+	lastSpanRatio                atomic.Uint64
+	lastPages                    atomic.Uint64
+	lastErr                      atomic.Value // string
+	lastRetryReason              atomic.Value // string
+	lastOutcome                  atomic.Value // string
+	retryConcurrentMutationTotal atomic.Uint64
+	retryRecoverableRootSetTotal atomic.Uint64
+	unsupportedTotal             atomic.Uint64
+	permanentFailuresTotal       atomic.Uint64
 
 	backlogConsecutiveSkips atomic.Uint64
 	backlogSkips            atomic.Uint64
@@ -113,6 +135,7 @@ type bgIndexVacuumWorker struct {
 	lastProbeFreelistValid          bool
 	lastProbeValid                  bool
 	retryProbe                      bool
+	unsupported                     bool
 }
 
 var bgIndexVacuumBacklogBytesHook struct {
@@ -123,6 +146,11 @@ var bgIndexVacuumBacklogBytesHook struct {
 var bgIndexVacuumFreelistDebtSnapshotHook struct {
 	mu sync.RWMutex
 	fn func(*DB) (backenddb.IndexVacuumFreelistDebtSnapshot, bool)
+}
+
+var bgIndexVacuumRunHook struct {
+	mu sync.RWMutex
+	fn func(*DB, context.Context) error
 }
 
 func setBackgroundIndexVacuumBacklogBytesHookForTest(fn func(*DB) int64) func() {
@@ -147,6 +175,28 @@ func setBackgroundIndexVacuumFreelistDebtSnapshotHookForTest(fn func(*DB) (backe
 		bgIndexVacuumFreelistDebtSnapshotHook.fn = prev
 		bgIndexVacuumFreelistDebtSnapshotHook.mu.Unlock()
 	}
+}
+
+func setBackgroundIndexVacuumRunHookForTest(fn func(*DB, context.Context) error) func() {
+	bgIndexVacuumRunHook.mu.Lock()
+	prev := bgIndexVacuumRunHook.fn
+	bgIndexVacuumRunHook.fn = fn
+	bgIndexVacuumRunHook.mu.Unlock()
+	return func() {
+		bgIndexVacuumRunHook.mu.Lock()
+		bgIndexVacuumRunHook.fn = prev
+		bgIndexVacuumRunHook.mu.Unlock()
+	}
+}
+
+func backgroundIndexVacuumRun(db *DB, ctx context.Context) error {
+	bgIndexVacuumRunHook.mu.RLock()
+	hook := bgIndexVacuumRunHook.fn
+	bgIndexVacuumRunHook.mu.RUnlock()
+	if hook != nil {
+		return hook(db, ctx)
+	}
+	return db.VacuumIndexOnline(ctx)
 }
 
 func backgroundIndexVacuumBacklogBytes(db *DB) int64 {
@@ -194,8 +244,12 @@ func (w *bgIndexVacuumWorker) Start(db *DB, cfg bgIndexVacuumConfig) {
 	w.stopCh = make(chan struct{})
 	w.doneCh = make(chan struct{})
 	w.kickCh = make(chan struct{}, 1)
+	ctx, cancel := context.WithCancel(context.Background())
+	w.cancel = cancel
 	w.lastErr.Store("")
 	w.lastDebtReason.Store(backgroundIndexVacuumDebtReasonNone)
+	w.lastRetryReason.Store(backgroundIndexVacuumRetryReasonNone)
+	w.lastOutcome.Store(backgroundIndexVacuumOutcomeNone)
 
 	go func() {
 		defer close(w.doneCh)
@@ -211,7 +265,7 @@ func (w *bgIndexVacuumWorker) Start(db *DB, cfg bgIndexVacuumConfig) {
 			case <-ticker.C:
 			}
 
-			w.runOnce(db)
+			w.runOnceContext(ctx, db)
 		}
 	}()
 }
@@ -238,6 +292,7 @@ func (w *bgIndexVacuumWorker) Stop() {
 		return
 	}
 	w.stopOnce.Do(func() {
+		w.cancel()
 		close(w.stopCh)
 		<-w.doneCh
 		w.enabled.Store(false)
@@ -245,12 +300,19 @@ func (w *bgIndexVacuumWorker) Stop() {
 }
 
 func (w *bgIndexVacuumWorker) runOnce(db *DB) {
+	w.runOnceContext(context.Background(), db)
+}
+
+func (w *bgIndexVacuumWorker) runOnceContext(ctx context.Context, db *DB) {
 	if db == nil || db.backend == nil {
 		return
 	}
 
 	w.runMu.Lock()
 	defer w.runMu.Unlock()
+	if w.unsupported {
+		return
+	}
 
 	now := time.Now()
 	state, ok := db.backend.StateToken()
@@ -267,6 +329,7 @@ func (w *bgIndexVacuumWorker) runOnce(db *DB) {
 			consecutive++
 			w.backlogConsecutiveSkips.Store(consecutive)
 			w.backlogSkips.Add(1)
+			w.lastOutcome.Store(backgroundIndexVacuumOutcomeBacklogSkip)
 			w.finishRun(now, "")
 			return
 		}
@@ -278,6 +341,7 @@ func (w *bgIndexVacuumWorker) runOnce(db *DB) {
 	}
 
 	if !forcedAfterBacklog && w.lastProbeValid && !w.retryProbe && state.CommitSeq == w.lastProbeCommitSeq && !w.freelistDebtChangedSinceLastProbe(db) {
+		w.lastOutcome.Store(backgroundIndexVacuumOutcomeUnchanged)
 		w.finishRun(now, "")
 		return
 	}
@@ -285,7 +349,9 @@ func (w *bgIndexVacuumWorker) runOnce(db *DB) {
 	rep, err := db.backend.IndexVacuumTriggerReport()
 	w.probes.Add(1)
 	if err != nil {
-		w.retryProbe = true
+		w.retryProbe = false
+		w.permanentFailuresTotal.Add(1)
+		w.lastOutcome.Store(backgroundIndexVacuumOutcomePermanentFailure)
 		w.finishRun(now, err.Error())
 		db.reportError(err)
 		return
@@ -302,12 +368,13 @@ func (w *bgIndexVacuumWorker) runOnce(db *DB) {
 	w.lastDebtReason.Store(reason)
 	if reason == backgroundIndexVacuumDebtReasonNone {
 		w.retryProbe = false
+		w.lastOutcome.Store(backgroundIndexVacuumOutcomeNoDebt)
 		w.finishRun(now, "")
 		return
 	}
 
-	if err := db.VacuumIndexOnline(context.Background()); err != nil {
-		w.retryProbe = true
+	if err := backgroundIndexVacuumRun(db, ctx); err != nil {
+		w.recordVacuumError(err)
 		w.finishRun(now, err.Error())
 		// A bounded online-vacuum pass may lose its cutover race to foreground
 		// mutations. That is expected retry control flow: retain it in worker
@@ -319,9 +386,42 @@ func (w *bgIndexVacuumWorker) runOnce(db *DB) {
 	}
 
 	w.retryProbe = false
+	w.lastRetryReason.Store(backgroundIndexVacuumRetryReasonNone)
+	w.lastOutcome.Store(backgroundIndexVacuumOutcomeSuccess)
+	w.lastErr.Store("")
 	w.vacuums.Add(1)
 	w.finishRun(now, "")
 	w.lastVacuumUnix.Store(now.Unix())
+}
+
+func (w *bgIndexVacuumWorker) recordVacuumError(err error) {
+	switch {
+	case errors.Is(err, backenddb.ErrVacuumUnsupported):
+		w.retryProbe = false
+		w.unsupported = true
+		w.unsupportedTotal.Add(1)
+		w.lastRetryReason.Store(backgroundIndexVacuumRetryReasonNone)
+		w.lastOutcome.Store(backgroundIndexVacuumOutcomeUnsupported)
+	case errors.Is(err, context.Canceled):
+		w.retryProbe = false
+		w.lastRetryReason.Store(backgroundIndexVacuumRetryReasonNone)
+		w.lastOutcome.Store(backgroundIndexVacuumOutcomeCanceled)
+	case errors.Is(err, backenddb.ErrVacuumConcurrentMutation):
+		w.retryProbe = true
+		w.retryConcurrentMutationTotal.Add(1)
+		w.lastRetryReason.Store(backgroundIndexVacuumRetryReasonConcurrentMutation)
+		w.lastOutcome.Store(backgroundIndexVacuumOutcomeRetry)
+	case errors.Is(err, backenddb.ErrRecoverableRootSetStale), errors.Is(err, backenddb.ErrVacuumRecoverableRootSetRequired):
+		w.retryProbe = true
+		w.retryRecoverableRootSetTotal.Add(1)
+		w.lastRetryReason.Store(backgroundIndexVacuumRetryReasonRecoverableRootSet)
+		w.lastOutcome.Store(backgroundIndexVacuumOutcomeRetry)
+	default:
+		w.retryProbe = false
+		w.permanentFailuresTotal.Add(1)
+		w.lastRetryReason.Store(backgroundIndexVacuumRetryReasonNone)
+		w.lastOutcome.Store(backgroundIndexVacuumOutcomePermanentFailure)
+	}
 }
 
 func (w *bgIndexVacuumWorker) freelistDebtChangedSinceLastProbe(db *DB) bool {
@@ -340,7 +440,9 @@ func (w *bgIndexVacuumWorker) freelistDebtChangedSinceLastProbe(db *DB) bool {
 func (w *bgIndexVacuumWorker) finishRun(now time.Time, err string) {
 	w.runs.Add(1)
 	w.lastRunUnix.Store(now.Unix())
-	w.lastErr.Store(err)
+	if err != "" {
+		w.lastErr.Store(err)
+	}
 }
 
 func (w *bgIndexVacuumWorker) recordLastTriggerReport(rep backenddb.IndexVacuumTriggerReport) {
@@ -446,11 +548,18 @@ type bgIndexVacuumStats struct {
 	BacklogForcedRuns       uint64
 	LastBacklogBytes        int64
 
-	LastRunUnix    int64
-	LastVacuumUnix int64
-	LastSpanRatio  uint64
-	LastPages      uint64
-	LastErr        string
+	LastRunUnix     int64
+	LastVacuumUnix  int64
+	LastSpanRatio   uint64
+	LastPages       uint64
+	LastErr         string
+	LastRetryReason string
+	LastOutcome     string
+
+	RetryConcurrentMutationTotal uint64
+	RetryRecoverableRootSetTotal uint64
+	UnsupportedTotal             uint64
+	PermanentFailuresTotal       uint64
 
 	LastFreelistReclaimablePages uint64
 	LastFreelistReclaimableRatio uint64
@@ -481,6 +590,10 @@ func (w *bgIndexVacuumWorker) Stats() bgIndexVacuumStats {
 		LastVacuumUnix:               w.lastVacuumUnix.Load(),
 		LastSpanRatio:                w.lastSpanRatio.Load(),
 		LastPages:                    w.lastPages.Load(),
+		RetryConcurrentMutationTotal: w.retryConcurrentMutationTotal.Load(),
+		RetryRecoverableRootSetTotal: w.retryRecoverableRootSetTotal.Load(),
+		UnsupportedTotal:             w.unsupportedTotal.Load(),
+		PermanentFailuresTotal:       w.permanentFailuresTotal.Load(),
 		LastFreelistReclaimablePages: w.lastFreelistReclaimablePages.Load(),
 		LastFreelistReclaimableRatio: w.lastFreelistReclaimableRatio.Load(),
 		LastCollectionRootPages:      w.lastCollectionRootPages.Load(),
@@ -494,6 +607,18 @@ func (w *bgIndexVacuumWorker) Stats() bgIndexVacuumStats {
 	}
 	if out.LastDebtReason == "" {
 		out.LastDebtReason = backgroundIndexVacuumDebtReasonNone
+	}
+	if v := w.lastRetryReason.Load(); v != nil {
+		out.LastRetryReason, _ = v.(string)
+	}
+	if out.LastRetryReason == "" {
+		out.LastRetryReason = backgroundIndexVacuumRetryReasonNone
+	}
+	if v := w.lastOutcome.Load(); v != nil {
+		out.LastOutcome, _ = v.(string)
+	}
+	if out.LastOutcome == "" {
+		out.LastOutcome = backgroundIndexVacuumOutcomeNone
 	}
 	return out
 }
@@ -511,6 +636,12 @@ func bgIndexVacuumStatsInto(out map[string]string, w *bgIndexVacuumWorker) {
 	out["treedb.bg_vacuum.runs"] = fmt.Sprintf("%d", stats.Runs)
 	out["treedb.bg_vacuum.trigger_probes"] = fmt.Sprintf("%d", stats.Probes)
 	out["treedb.bg_vacuum.vacuums"] = fmt.Sprintf("%d", stats.Vacuums)
+	out["treedb.bg_vacuum.retry_concurrent_mutation_total"] = fmt.Sprintf("%d", stats.RetryConcurrentMutationTotal)
+	out["treedb.bg_vacuum.retry_recoverable_root_set_total"] = fmt.Sprintf("%d", stats.RetryRecoverableRootSetTotal)
+	out["treedb.bg_vacuum.unsupported_total"] = fmt.Sprintf("%d", stats.UnsupportedTotal)
+	out["treedb.bg_vacuum.permanent_failures_total"] = fmt.Sprintf("%d", stats.PermanentFailuresTotal)
+	out["treedb.bg_vacuum.last_retry_reason"] = stats.LastRetryReason
+	out["treedb.bg_vacuum.last_outcome"] = stats.LastOutcome
 	out["treedb.bg_vacuum.backlog_skips_consecutive"] = fmt.Sprintf("%d", stats.BacklogConsecutiveSkips)
 	out["treedb.bg_vacuum.backlog_skips_total"] = fmt.Sprintf("%d", stats.BacklogSkips)
 	out["treedb.bg_vacuum.backlog_forced_runs"] = fmt.Sprintf("%d", stats.BacklogForcedRuns)

--- a/TreeDB/bg_vacuum.go
+++ b/TreeDB/bg_vacuum.go
@@ -349,9 +349,15 @@ func (w *bgIndexVacuumWorker) runOnceContext(ctx context.Context, db *DB) {
 		return
 	}
 
-	rep, err := db.backend.IndexVacuumTriggerReport()
+	rep, err := db.backend.IndexVacuumTriggerReportContext(ctx)
 	w.probes.Add(1)
 	if err != nil {
+		if errors.Is(err, context.Canceled) {
+			w.retryProbe = false
+			w.lastOutcome.Store(backgroundIndexVacuumOutcomeCanceled)
+			w.finishRun(now, err.Error())
+			return
+		}
 		w.retryProbe = false
 		w.permanentFailuresTotal.Add(1)
 		w.lastOutcome.Store(backgroundIndexVacuumOutcomePermanentFailure)

--- a/TreeDB/bg_vacuum.go
+++ b/TreeDB/bg_vacuum.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	backenddb "github.com/snissn/gomap/TreeDB/db"
+	"github.com/snissn/gomap/TreeDB/internal/rootpublication"
 )
 
 func backgroundIndexVacuumShouldReport(err error) bool {
@@ -17,6 +18,7 @@ func backgroundIndexVacuumShouldReport(err error) bool {
 		!errors.Is(err, backenddb.ErrVacuumRecoverableRootSetRequired) &&
 		!errors.Is(err, backenddb.ErrRecoverableRootSetStale) &&
 		!errors.Is(err, backenddb.ErrDurableWALCleanupProofStale) &&
+		!errors.Is(err, rootpublication.ErrResourcePinned) &&
 		!errors.Is(err, backenddb.ErrVacuumUnsupported) &&
 		!errors.Is(err, context.Canceled)
 }
@@ -36,6 +38,7 @@ const (
 	backgroundIndexVacuumRetryReasonConcurrentMutation             = "concurrent_mutation"
 	backgroundIndexVacuumRetryReasonRecoverableRootSet             = "recoverable_root_set"
 	backgroundIndexVacuumRetryReasonCheckpointCleanup              = "checkpoint_cleanup"
+	backgroundIndexVacuumRetryReasonResourcePinned                 = "resource_pinned"
 	backgroundIndexVacuumOutcomeNone                               = "none"
 	backgroundIndexVacuumOutcomeBacklogSkip                        = "backlog_skip"
 	backgroundIndexVacuumOutcomeUnchanged                          = "unchanged"
@@ -118,6 +121,7 @@ type bgIndexVacuumWorker struct {
 	retryConcurrentMutationTotal atomic.Uint64
 	retryRecoverableRootSetTotal atomic.Uint64
 	retryCheckpointCleanupTotal  atomic.Uint64
+	retryResourcePinnedTotal     atomic.Uint64
 	unsupportedTotal             atomic.Uint64
 	permanentFailuresTotal       atomic.Uint64
 
@@ -464,6 +468,11 @@ func (w *bgIndexVacuumWorker) recordVacuumError(err error) {
 		w.retryCheckpointCleanupTotal.Add(1)
 		w.lastRetryReason.Store(backgroundIndexVacuumRetryReasonCheckpointCleanup)
 		w.lastOutcome.Store(backgroundIndexVacuumOutcomeRetry)
+	case errors.Is(err, rootpublication.ErrResourcePinned):
+		w.retryProbe = true
+		w.retryResourcePinnedTotal.Add(1)
+		w.lastRetryReason.Store(backgroundIndexVacuumRetryReasonResourcePinned)
+		w.lastOutcome.Store(backgroundIndexVacuumOutcomeRetry)
 	default:
 		w.retryProbe = false
 		w.permanentFailuresTotal.Add(1)
@@ -607,6 +616,7 @@ type bgIndexVacuumStats struct {
 	RetryConcurrentMutationTotal uint64
 	RetryRecoverableRootSetTotal uint64
 	RetryCheckpointCleanupTotal  uint64
+	RetryResourcePinnedTotal     uint64
 	UnsupportedTotal             uint64
 	PermanentFailuresTotal       uint64
 
@@ -642,6 +652,7 @@ func (w *bgIndexVacuumWorker) Stats() bgIndexVacuumStats {
 		RetryConcurrentMutationTotal: w.retryConcurrentMutationTotal.Load(),
 		RetryRecoverableRootSetTotal: w.retryRecoverableRootSetTotal.Load(),
 		RetryCheckpointCleanupTotal:  w.retryCheckpointCleanupTotal.Load(),
+		RetryResourcePinnedTotal:     w.retryResourcePinnedTotal.Load(),
 		UnsupportedTotal:             w.unsupportedTotal.Load(),
 		PermanentFailuresTotal:       w.permanentFailuresTotal.Load(),
 		LastFreelistReclaimablePages: w.lastFreelistReclaimablePages.Load(),
@@ -689,6 +700,7 @@ func bgIndexVacuumStatsInto(out map[string]string, w *bgIndexVacuumWorker) {
 	out["treedb.bg_vacuum.retry_concurrent_mutation_total"] = fmt.Sprintf("%d", stats.RetryConcurrentMutationTotal)
 	out["treedb.bg_vacuum.retry_recoverable_root_set_total"] = fmt.Sprintf("%d", stats.RetryRecoverableRootSetTotal)
 	out["treedb.bg_vacuum.retry_checkpoint_cleanup_total"] = fmt.Sprintf("%d", stats.RetryCheckpointCleanupTotal)
+	out["treedb.bg_vacuum.retry_resource_pinned_total"] = fmt.Sprintf("%d", stats.RetryResourcePinnedTotal)
 	out["treedb.bg_vacuum.unsupported_total"] = fmt.Sprintf("%d", stats.UnsupportedTotal)
 	out["treedb.bg_vacuum.permanent_failures_total"] = fmt.Sprintf("%d", stats.PermanentFailuresTotal)
 	out["treedb.bg_vacuum.last_retry_reason"] = stats.LastRetryReason

--- a/TreeDB/bg_vacuum.go
+++ b/TreeDB/bg_vacuum.go
@@ -156,6 +156,11 @@ var bgIndexVacuumRunHook struct {
 	fn func(*DB, context.Context) error
 }
 
+var bgIndexVacuumTriggerReportHook struct {
+	mu sync.RWMutex
+	fn func(*DB, context.Context) (backenddb.IndexVacuumTriggerReport, error)
+}
+
 func setBackgroundIndexVacuumBacklogBytesHookForTest(fn func(*DB) int64) func() {
 	bgIndexVacuumBacklogBytesHook.mu.Lock()
 	prev := bgIndexVacuumBacklogBytesHook.fn
@@ -190,6 +195,28 @@ func setBackgroundIndexVacuumRunHookForTest(fn func(*DB, context.Context) error)
 		bgIndexVacuumRunHook.fn = prev
 		bgIndexVacuumRunHook.mu.Unlock()
 	}
+}
+
+func setBackgroundIndexVacuumTriggerReportHookForTest(fn func(*DB, context.Context) (backenddb.IndexVacuumTriggerReport, error)) func() {
+	bgIndexVacuumTriggerReportHook.mu.Lock()
+	prev := bgIndexVacuumTriggerReportHook.fn
+	bgIndexVacuumTriggerReportHook.fn = fn
+	bgIndexVacuumTriggerReportHook.mu.Unlock()
+	return func() {
+		bgIndexVacuumTriggerReportHook.mu.Lock()
+		bgIndexVacuumTriggerReportHook.fn = prev
+		bgIndexVacuumTriggerReportHook.mu.Unlock()
+	}
+}
+
+func backgroundIndexVacuumTriggerReport(db *DB, ctx context.Context) (backenddb.IndexVacuumTriggerReport, error) {
+	bgIndexVacuumTriggerReportHook.mu.RLock()
+	hook := bgIndexVacuumTriggerReportHook.fn
+	bgIndexVacuumTriggerReportHook.mu.RUnlock()
+	if hook != nil {
+		return hook(db, ctx)
+	}
+	return db.backend.IndexVacuumTriggerReportContext(ctx)
 }
 
 func backgroundIndexVacuumRun(db *DB, ctx context.Context) error {
@@ -349,7 +376,7 @@ func (w *bgIndexVacuumWorker) runOnceContext(ctx context.Context, db *DB) {
 		return
 	}
 
-	rep, err := db.backend.IndexVacuumTriggerReportContext(ctx)
+	rep, err := backgroundIndexVacuumTriggerReport(db, ctx)
 	w.probes.Add(1)
 	if err != nil {
 		if errors.Is(err, context.Canceled) {
@@ -359,6 +386,13 @@ func (w *bgIndexVacuumWorker) runOnceContext(ctx context.Context, db *DB) {
 			return
 		}
 		w.retryProbe = false
+		w.lastProbeCommitSeq = state.CommitSeq
+		if snap, ok := backgroundIndexVacuumFreelistDebtSnapshot(db); ok {
+			w.lastProbeFreelistReclaimable = snap.FreelistReclaimable
+			w.lastProbeFreelistReclaimablePPM = snap.FreelistReclaimablePPM
+			w.lastProbeFreelistValid = snap.FreelistReclaimableValid
+		}
+		w.lastProbeValid = true
 		w.permanentFailuresTotal.Add(1)
 		w.lastOutcome.Store(backgroundIndexVacuumOutcomePermanentFailure)
 		w.finishRun(now, err.Error())

--- a/TreeDB/bg_vacuum.go
+++ b/TreeDB/bg_vacuum.go
@@ -16,6 +16,7 @@ func backgroundIndexVacuumShouldReport(err error) bool {
 		!errors.Is(err, backenddb.ErrVacuumConcurrentMutation) &&
 		!errors.Is(err, backenddb.ErrVacuumRecoverableRootSetRequired) &&
 		!errors.Is(err, backenddb.ErrRecoverableRootSetStale) &&
+		!errors.Is(err, backenddb.ErrDurableWALCleanupProofStale) &&
 		!errors.Is(err, backenddb.ErrVacuumUnsupported) &&
 		!errors.Is(err, context.Canceled)
 }
@@ -34,6 +35,7 @@ const (
 	backgroundIndexVacuumRetryReasonNone                           = "none"
 	backgroundIndexVacuumRetryReasonConcurrentMutation             = "concurrent_mutation"
 	backgroundIndexVacuumRetryReasonRecoverableRootSet             = "recoverable_root_set"
+	backgroundIndexVacuumRetryReasonCheckpointCleanup              = "checkpoint_cleanup"
 	backgroundIndexVacuumOutcomeNone                               = "none"
 	backgroundIndexVacuumOutcomeBacklogSkip                        = "backlog_skip"
 	backgroundIndexVacuumOutcomeUnchanged                          = "unchanged"
@@ -115,6 +117,7 @@ type bgIndexVacuumWorker struct {
 	lastOutcome                  atomic.Value // string
 	retryConcurrentMutationTotal atomic.Uint64
 	retryRecoverableRootSetTotal atomic.Uint64
+	retryCheckpointCleanupTotal  atomic.Uint64
 	unsupportedTotal             atomic.Uint64
 	permanentFailuresTotal       atomic.Uint64
 
@@ -416,6 +419,11 @@ func (w *bgIndexVacuumWorker) recordVacuumError(err error) {
 		w.retryRecoverableRootSetTotal.Add(1)
 		w.lastRetryReason.Store(backgroundIndexVacuumRetryReasonRecoverableRootSet)
 		w.lastOutcome.Store(backgroundIndexVacuumOutcomeRetry)
+	case errors.Is(err, backenddb.ErrDurableWALCleanupProofStale):
+		w.retryProbe = true
+		w.retryCheckpointCleanupTotal.Add(1)
+		w.lastRetryReason.Store(backgroundIndexVacuumRetryReasonCheckpointCleanup)
+		w.lastOutcome.Store(backgroundIndexVacuumOutcomeRetry)
 	default:
 		w.retryProbe = false
 		w.permanentFailuresTotal.Add(1)
@@ -558,6 +566,7 @@ type bgIndexVacuumStats struct {
 
 	RetryConcurrentMutationTotal uint64
 	RetryRecoverableRootSetTotal uint64
+	RetryCheckpointCleanupTotal  uint64
 	UnsupportedTotal             uint64
 	PermanentFailuresTotal       uint64
 
@@ -592,6 +601,7 @@ func (w *bgIndexVacuumWorker) Stats() bgIndexVacuumStats {
 		LastPages:                    w.lastPages.Load(),
 		RetryConcurrentMutationTotal: w.retryConcurrentMutationTotal.Load(),
 		RetryRecoverableRootSetTotal: w.retryRecoverableRootSetTotal.Load(),
+		RetryCheckpointCleanupTotal:  w.retryCheckpointCleanupTotal.Load(),
 		UnsupportedTotal:             w.unsupportedTotal.Load(),
 		PermanentFailuresTotal:       w.permanentFailuresTotal.Load(),
 		LastFreelistReclaimablePages: w.lastFreelistReclaimablePages.Load(),
@@ -638,6 +648,7 @@ func bgIndexVacuumStatsInto(out map[string]string, w *bgIndexVacuumWorker) {
 	out["treedb.bg_vacuum.vacuums"] = fmt.Sprintf("%d", stats.Vacuums)
 	out["treedb.bg_vacuum.retry_concurrent_mutation_total"] = fmt.Sprintf("%d", stats.RetryConcurrentMutationTotal)
 	out["treedb.bg_vacuum.retry_recoverable_root_set_total"] = fmt.Sprintf("%d", stats.RetryRecoverableRootSetTotal)
+	out["treedb.bg_vacuum.retry_checkpoint_cleanup_total"] = fmt.Sprintf("%d", stats.RetryCheckpointCleanupTotal)
 	out["treedb.bg_vacuum.unsupported_total"] = fmt.Sprintf("%d", stats.UnsupportedTotal)
 	out["treedb.bg_vacuum.permanent_failures_total"] = fmt.Sprintf("%d", stats.PermanentFailuresTotal)
 	out["treedb.bg_vacuum.last_retry_reason"] = stats.LastRetryReason

--- a/TreeDB/caching/checkpoint_test.go
+++ b/TreeDB/caching/checkpoint_test.go
@@ -75,6 +75,55 @@ func TestCachingDB_CheckpointContextCancelsBeforeFrontierDrain(t *testing.T) {
 	}
 }
 
+func TestCachingDB_CheckpointContextQueuesBehindActiveReaders(t *testing.T) {
+	db, err := Open(t.TempDir(), NewMockBackend(), Options{})
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	db.writeMu.RLock()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	done := make(chan error, 1)
+	go func() { done <- db.CheckpointContext(ctx) }()
+	deadline := time.Now().Add(withRaceTimeout(2 * time.Second))
+	for !db.checkpointing.Load() {
+		if time.Now().After(deadline) {
+			db.writeMu.RUnlock()
+			t.Fatal("checkpoint did not reach write ownership wait")
+		}
+		time.Sleep(time.Millisecond)
+	}
+	// Allow the checkpoint waiter to enter RWMutex.Lock after publishing the
+	// checkpoint state observed above.
+	time.Sleep(withRaceTimeout(10 * time.Millisecond))
+
+	lateReader := make(chan struct{})
+	go func() {
+		db.writeMu.RLock()
+		close(lateReader)
+		db.writeMu.RUnlock()
+	}()
+	select {
+	case <-lateReader:
+		db.writeMu.RUnlock()
+		t.Fatal("later reader bypassed queued checkpoint writer")
+	case <-time.After(withRaceTimeout(25 * time.Millisecond)):
+	}
+
+	db.writeMu.RUnlock()
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("CheckpointContext: %v", err)
+		}
+	case <-time.After(withRaceTimeout(2 * time.Second)):
+		t.Fatal("queued checkpoint did not finish after reader released")
+	}
+	awaitCheckpointTestSignal(t, lateReader, "late reader after checkpoint")
+}
+
 func countCommitLogFiles(entries []os.DirEntry) int {
 	n := 0
 	for _, ent := range entries {

--- a/TreeDB/caching/checkpoint_test.go
+++ b/TreeDB/caching/checkpoint_test.go
@@ -152,6 +152,9 @@ func TestCachingDB_CanceledCheckpointDoesNotLeaveWriteWaiter(t *testing.T) {
 		}
 		time.Sleep(time.Millisecond)
 	}
+	// Checkpointing is published immediately before the contended write-lock
+	// path. Give the waiter time to enter that path before cancellation.
+	time.Sleep(10 * time.Millisecond)
 	cancel()
 	select {
 	case err := <-done:

--- a/TreeDB/caching/checkpoint_test.go
+++ b/TreeDB/caching/checkpoint_test.go
@@ -2,6 +2,7 @@ package caching
 
 import (
 	"bytes"
+	"context"
 	"errors"
 	"fmt"
 	"os"
@@ -13,6 +14,66 @@ import (
 
 	backenddb "github.com/snissn/gomap/TreeDB/db"
 )
+
+func TestCachingDB_CheckpointContextCancelsWhileWaitingForFlushOwnership(t *testing.T) {
+	db, err := Open(t.TempDir(), NewMockBackend(), Options{})
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	db.flushMu.Lock()
+	defer db.flushMu.Unlock()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() { done <- db.CheckpointContext(ctx) }()
+	cancel()
+
+	select {
+	case err := <-done:
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("CheckpointContext error=%v, want context.Canceled", err)
+		}
+	case <-time.After(withRaceTimeout(2 * time.Second)):
+		t.Fatal("CheckpointContext did not cancel while waiting for flush ownership")
+	}
+}
+
+func TestCachingDB_CheckpointContextCancelsBeforeFrontierDrain(t *testing.T) {
+	db, err := Open(t.TempDir(), NewMockBackend(), Options{FlushThreshold: 1 << 30})
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+	if err := db.Set([]byte("key"), []byte("value")); err != nil {
+		t.Fatalf("Set: %v", err)
+	}
+
+	reached := make(chan struct{})
+	release := make(chan struct{})
+	db.testBeforeCheckpointFrontierDrain = func() {
+		close(reached)
+		<-release
+	}
+	defer func() { db.testBeforeCheckpointFrontierDrain = nil }()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() { done <- db.CheckpointContext(ctx) }()
+	awaitCheckpointTestSignal(t, reached, "checkpoint frontier drain")
+	cancel()
+	close(release)
+
+	select {
+	case err := <-done:
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("CheckpointContext error=%v, want context.Canceled", err)
+		}
+	case <-time.After(withRaceTimeout(2 * time.Second)):
+		t.Fatal("CheckpointContext did not cancel before draining the frontier")
+	}
+}
 
 func countCommitLogFiles(entries []os.DirEntry) int {
 	n := 0

--- a/TreeDB/caching/checkpoint_test.go
+++ b/TreeDB/caching/checkpoint_test.go
@@ -99,16 +99,18 @@ func TestCachingDB_CheckpointContextQueuesBehindActiveReaders(t *testing.T) {
 	// checkpoint state observed above.
 	time.Sleep(withRaceTimeout(10 * time.Millisecond))
 
-	lateReader := make(chan struct{})
+	lateReader := make(chan error, 1)
 	go func() {
-		db.writeMu.RLock()
-		close(lateReader)
-		db.writeMu.RUnlock()
+		err := db.beginDirectWrite()
+		if err == nil {
+			db.writeMu.RUnlock()
+		}
+		lateReader <- err
 	}()
 	select {
-	case <-lateReader:
+	case err := <-lateReader:
 		db.writeMu.RUnlock()
-		t.Fatal("later reader bypassed queued checkpoint writer")
+		t.Fatalf("later writer bypassed queued checkpoint: %v", err)
 	case <-time.After(withRaceTimeout(25 * time.Millisecond)):
 	}
 
@@ -121,7 +123,66 @@ func TestCachingDB_CheckpointContextQueuesBehindActiveReaders(t *testing.T) {
 	case <-time.After(withRaceTimeout(2 * time.Second)):
 		t.Fatal("queued checkpoint did not finish after reader released")
 	}
-	awaitCheckpointTestSignal(t, lateReader, "late reader after checkpoint")
+	select {
+	case err := <-lateReader:
+		if err != nil {
+			t.Fatalf("late writer after checkpoint: %v", err)
+		}
+	case <-time.After(withRaceTimeout(2 * time.Second)):
+		t.Fatal("timed out waiting for late writer after checkpoint")
+	}
+}
+
+func TestCachingDB_CanceledCheckpointDoesNotLeaveWriteWaiter(t *testing.T) {
+	db, err := Open(t.TempDir(), NewMockBackend(), Options{})
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	db.writeMu.RLock()
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() { done <- db.CheckpointContext(ctx) }()
+	deadline := time.Now().Add(withRaceTimeout(2 * time.Second))
+	for !db.checkpointing.Load() {
+		if time.Now().After(deadline) {
+			db.writeMu.RUnlock()
+			t.Fatal("checkpoint did not reach write ownership wait")
+		}
+		time.Sleep(time.Millisecond)
+	}
+	cancel()
+	select {
+	case err := <-done:
+		if !errors.Is(err, context.Canceled) {
+			db.writeMu.RUnlock()
+			t.Fatalf("CheckpointContext error=%v, want context.Canceled", err)
+		}
+	case <-time.After(withRaceTimeout(2 * time.Second)):
+		db.writeMu.RUnlock()
+		t.Fatal("CheckpointContext did not cancel while waiting for write ownership")
+	}
+
+	lateWriter := make(chan error, 1)
+	go func() {
+		err := db.beginDirectWrite()
+		if err == nil {
+			db.writeMu.RUnlock()
+		}
+		lateWriter <- err
+	}()
+	select {
+	case err := <-lateWriter:
+		if err != nil {
+			db.writeMu.RUnlock()
+			t.Fatalf("beginDirectWrite after canceled checkpoint: %v", err)
+		}
+	case <-time.After(withRaceTimeout(100 * time.Millisecond)):
+		db.writeMu.RUnlock()
+		t.Fatal("canceled checkpoint left a writeMu waiter blocking later writes")
+	}
+	db.writeMu.RUnlock()
 }
 
 func countCommitLogFiles(entries []os.DirEntry) int {

--- a/TreeDB/caching/checkpoint_test.go
+++ b/TreeDB/caching/checkpoint_test.go
@@ -7,8 +7,10 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strconv"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -38,6 +40,47 @@ func TestCachingDB_CheckpointContextCancelsWhileWaitingForFlushOwnership(t *test
 	case <-time.After(withRaceTimeout(2 * time.Second)):
 		t.Fatal("CheckpointContext did not cancel while waiting for flush ownership")
 	}
+}
+
+func TestLockCheckpointMutexContextCancellationLeavesNoWaiters(t *testing.T) {
+	var mu sync.Mutex
+	mu.Lock()
+	baselineGoroutines := runtime.NumGoroutine()
+
+	const waiters = 64
+	contexts := make([]context.CancelFunc, waiters)
+	done := make(chan error, waiters)
+	var callers sync.WaitGroup
+	for i := range contexts {
+		ctx, cancel := context.WithCancel(context.Background())
+		contexts[i] = cancel
+		callers.Add(1)
+		go func() {
+			defer callers.Done()
+			done <- lockCheckpointMutexContext(ctx, &mu)
+		}()
+	}
+	time.Sleep(20 * time.Millisecond)
+	for _, cancel := range contexts {
+		cancel()
+	}
+	for range contexts {
+		if err := <-done; !errors.Is(err, context.Canceled) {
+			t.Fatalf("lock wait error=%v, want context.Canceled", err)
+		}
+	}
+	callers.Wait()
+
+	runtime.Gosched()
+	blockedGoroutines := runtime.NumGoroutine()
+	mu.Unlock()
+	if blockedGoroutines > baselineGoroutines+waiters/4 {
+		t.Fatalf("goroutines after cancellation=%d baseline=%d; canceled flush waiters remain parked", blockedGoroutines, baselineGoroutines)
+	}
+	if !mu.TryLock() {
+		t.Fatal("canceled checkpoint lock calls left queued mutex waiters")
+	}
+	mu.Unlock()
 }
 
 func TestCachingDB_CheckpointContextCancelsBeforeFrontierDrain(t *testing.T) {

--- a/TreeDB/caching/db.go
+++ b/TreeDB/caching/db.go
@@ -24134,26 +24134,16 @@ func (db *DB) waitForActiveCheckpointContext(ctx context.Context) error {
 		db.checkpointMu.Unlock()
 		return nil
 	}
-	for {
-		db.checkpointMu.Lock()
-		active := db.checkpointing.Load()
-		db.checkpointMu.Unlock()
-		if !active {
-			return nil
-		}
-		timer := time.NewTimer(time.Millisecond)
+	ticker := time.NewTicker(time.Millisecond)
+	defer ticker.Stop()
+	for db.checkpointing.Load() {
 		select {
 		case <-ctx.Done():
-			if !timer.Stop() {
-				select {
-				case <-timer.C:
-				default:
-				}
-			}
 			return ctx.Err()
-		case <-timer.C:
+		case <-ticker.C:
 		}
 	}
+	return nil
 }
 
 func (db *DB) checkpointContext(ctx context.Context) error {

--- a/TreeDB/caching/db.go
+++ b/TreeDB/caching/db.go
@@ -24125,6 +24125,28 @@ func lockCheckpointMutexContext(ctx context.Context, mu checkpointTryLocker) err
 	}
 }
 
+func lockCheckpointWriteMutexContext(ctx context.Context, mu *sync.RWMutex) error {
+	if ctx.Done() == nil {
+		mu.Lock()
+		return nil
+	}
+	ticker := time.NewTicker(time.Millisecond)
+	defer ticker.Stop()
+	for {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		if mu.TryLock() {
+			return nil
+		}
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-ticker.C:
+		}
+	}
+}
+
 func (db *DB) waitForActiveCheckpointContext(ctx context.Context) error {
 	if ctx.Done() == nil {
 		db.checkpointMu.Lock()
@@ -24262,7 +24284,10 @@ func (db *DB) checkpointContext(ctx context.Context) error {
 		db.checkpointMu.Unlock()
 	}
 
-	if err := lockCheckpointMutexContext(ctx, &db.writeMu); err != nil {
+	// checkpointing and checkpointWriteCutoverActive already stop new cached
+	// writers at admission. Poll here so cancellation cannot leave an orphaned
+	// RWMutex writer that continues blocking readers after this call returns.
+	if err := lockCheckpointWriteMutexContext(ctx, &db.writeMu); err != nil {
 		return err
 	}
 	cutoverStart := time.Now()

--- a/TreeDB/caching/db.go
+++ b/TreeDB/caching/db.go
@@ -24102,26 +24102,17 @@ func lockCheckpointMutexContext(ctx context.Context, mu checkpointTryLocker) err
 	if err := ctx.Err(); err != nil {
 		return err
 	}
-	if mu.TryLock() {
-		return nil
-	}
-
-	acquired := make(chan struct{})
-	abandon := make(chan struct{})
-	go func() {
-		mu.Lock()
-		select {
-		case acquired <- struct{}{}:
-		case <-abandon:
-			mu.Unlock()
+	ticker := time.NewTicker(time.Millisecond)
+	defer ticker.Stop()
+	for {
+		if mu.TryLock() {
+			return nil
 		}
-	}()
-	select {
-	case <-acquired:
-		return nil
-	case <-ctx.Done():
-		close(abandon)
-		return ctx.Err()
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-ticker.C:
+		}
 	}
 }
 

--- a/TreeDB/caching/db.go
+++ b/TreeDB/caching/db.go
@@ -24091,6 +24091,7 @@ func (db *DB) CheckpointContext(ctx context.Context) error {
 type checkpointTryLocker interface {
 	Lock()
 	TryLock() bool
+	Unlock()
 }
 
 func lockCheckpointMutexContext(ctx context.Context, mu checkpointTryLocker) error {
@@ -24098,22 +24099,29 @@ func lockCheckpointMutexContext(ctx context.Context, mu checkpointTryLocker) err
 		mu.Lock()
 		return nil
 	}
-	for {
-		if mu.TryLock() {
-			return nil
-		}
-		timer := time.NewTimer(time.Millisecond)
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	if mu.TryLock() {
+		return nil
+	}
+
+	acquired := make(chan struct{})
+	abandon := make(chan struct{})
+	go func() {
+		mu.Lock()
 		select {
-		case <-ctx.Done():
-			if !timer.Stop() {
-				select {
-				case <-timer.C:
-				default:
-				}
-			}
-			return ctx.Err()
-		case <-timer.C:
+		case acquired <- struct{}{}:
+		case <-abandon:
+			mu.Unlock()
 		}
+	}()
+	select {
+	case <-acquired:
+		return nil
+	case <-ctx.Done():
+		close(abandon)
+		return ctx.Err()
 	}
 }
 

--- a/TreeDB/caching/db.go
+++ b/TreeDB/caching/db.go
@@ -24075,11 +24075,88 @@ func (db *DB) observePublishWatermarkLagDrift(backlogBytes int64, now time.Time)
 //   - forces a backend sync boundary (even if the queue is empty),
 //   - removes all older WAL segments (keeping only the currently-open one).
 func (db *DB) Checkpoint() error {
+	return db.checkpointContext(context.Background())
+}
+
+// CheckpointContext is Checkpoint with cooperative cancellation while waiting
+// for checkpoint ownership and between durability stages. An in-flight storage
+// syscall is allowed to complete before cancellation is observed.
+func (db *DB) CheckpointContext(ctx context.Context) error {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	return db.checkpointContext(ctx)
+}
+
+type checkpointTryLocker interface {
+	Lock()
+	TryLock() bool
+}
+
+func lockCheckpointMutexContext(ctx context.Context, mu checkpointTryLocker) error {
+	if ctx.Done() == nil {
+		mu.Lock()
+		return nil
+	}
+	for {
+		if mu.TryLock() {
+			return nil
+		}
+		timer := time.NewTimer(time.Millisecond)
+		select {
+		case <-ctx.Done():
+			if !timer.Stop() {
+				select {
+				case <-timer.C:
+				default:
+				}
+			}
+			return ctx.Err()
+		case <-timer.C:
+		}
+	}
+}
+
+func (db *DB) waitForActiveCheckpointContext(ctx context.Context) error {
+	if ctx.Done() == nil {
+		db.checkpointMu.Lock()
+		for db.checkpointing.Load() {
+			db.checkpointCond.Wait()
+		}
+		db.checkpointMu.Unlock()
+		return nil
+	}
+	for {
+		db.checkpointMu.Lock()
+		active := db.checkpointing.Load()
+		db.checkpointMu.Unlock()
+		if !active {
+			return nil
+		}
+		timer := time.NewTimer(time.Millisecond)
+		select {
+		case <-ctx.Done():
+			if !timer.Stop() {
+				select {
+				case <-timer.C:
+				default:
+				}
+			}
+			return ctx.Err()
+		case <-timer.C:
+		}
+	}
+}
+
+func (db *DB) checkpointContext(ctx context.Context) error {
 	if db == nil {
 		return nil
 	}
 	if db.closing.Load() {
 		return errDBClosing
+	}
+	if err := ctx.Err(); err != nil {
+		return err
 	}
 	start := time.Now()
 	defer func() {
@@ -24122,7 +24199,9 @@ func (db *DB) Checkpoint() error {
 	defer addAtomicInt64FloorZero(&db.checkpointFlushPreemptActive, -1)
 	barrierWaitStart := time.Now()
 	flushMuWaitStart := barrierWaitStart
-	db.flushMu.Lock()
+	if err := lockCheckpointMutexContext(ctx, &db.flushMu); err != nil {
+		return err
+	}
 	flushMuWaitDur := time.Since(flushMuWaitStart)
 	barrierWaitDur := time.Since(barrierWaitStart)
 	db.observeCheckpointBarrierWait(barrierWaitDur)
@@ -24137,11 +24216,14 @@ func (db *DB) Checkpoint() error {
 			db.flushMu.Unlock()
 		}
 	}
-	lockFlushMu := func() {
+	lockFlushMu := func() error {
 		if !flushMuHeld {
-			db.flushMu.Lock()
+			if err := lockCheckpointMutexContext(ctx, &db.flushMu); err != nil {
+				return err
+			}
 			flushMuHeld = true
 		}
+		return nil
 	}
 	defer unlockFlushMu()
 
@@ -24156,12 +24238,12 @@ func (db *DB) Checkpoint() error {
 		}
 		db.checkpointMu.Unlock()
 		unlockFlushMu()
-		db.checkpointMu.Lock()
-		for db.checkpointing.Load() {
-			db.checkpointCond.Wait()
+		if err := db.waitForActiveCheckpointContext(ctx); err != nil {
+			return err
 		}
-		db.checkpointMu.Unlock()
-		lockFlushMu()
+		if err := lockFlushMu(); err != nil {
+			return err
+		}
 	}
 
 	db.resetCheckpointFlushAllLastStats()
@@ -24182,7 +24264,9 @@ func (db *DB) Checkpoint() error {
 		db.checkpointMu.Unlock()
 	}
 
-	db.writeMu.Lock()
+	if err := lockCheckpointMutexContext(ctx, &db.writeMu); err != nil {
+		return err
+	}
 	cutoverStart := time.Now()
 	releaseWriteMu := func() {
 		d := time.Since(cutoverStart)
@@ -24192,6 +24276,11 @@ func (db *DB) Checkpoint() error {
 	}
 	if hook := db.testBeforeCheckpointFrontierCapture; hook != nil {
 		hook()
+	}
+	if err := ctx.Err(); err != nil {
+		releaseWriteMu()
+		endWriteCutover()
+		return err
 	}
 
 	// Rotate mutable into the flush queue and ensure future writes land in a fresh
@@ -24222,6 +24311,9 @@ func (db *DB) Checkpoint() error {
 		db.mu.Unlock()
 		releaseWriteMu()
 		endWriteCutover()
+		if err := ctx.Err(); err != nil {
+			return err
+		}
 		backendBoundaryStart := time.Now()
 		err := backendSyncBoundary(db.backend)
 		recordCheckpointStageSince(&db.checkpointStageBackendBoundary, backendBoundaryStart)
@@ -24251,12 +24343,18 @@ func (db *DB) Checkpoint() error {
 			if hook := db.testAfterCheckpointFrontierCapture; hook != nil {
 				hook()
 			}
+			if err := ctx.Err(); err != nil {
+				return err
+			}
 			if publishHook := db.loadCommandWALCheckpointPublishHook(); publishHook != nil {
 				commandWALAppliedLSN, commandWALRanges, err := publishHook(true)
 				if err != nil {
 					return err
 				}
 				if _, err := db.publishCommandWALCheckpointApplied(commandWALAppliedLSN, commandWALRanges); err != nil {
+					return err
+				}
+				if err := ctx.Err(); err != nil {
 					return err
 				}
 				backendBoundaryStart := time.Now()
@@ -24310,6 +24408,9 @@ func (db *DB) Checkpoint() error {
 	if hook := db.testAfterCheckpointFrontierCapture; hook != nil {
 		hook()
 	}
+	if err := ctx.Err(); err != nil {
+		return err
+	}
 
 	walRotateStart := time.Now()
 	errCh := make(chan error, len(rotateLaneIDs))
@@ -24332,10 +24433,16 @@ func (db *DB) Checkpoint() error {
 		}
 	}
 	recordCheckpointStageSince(&db.checkpointStageWALRotate, walRotateStart)
+	if err := ctx.Err(); err != nil {
+		return err
+	}
 	wroteDuringWALRotate := db.nextRID.Load() != ridBeforeWALRotate
 	valueLogFlushStart := time.Now()
 	if err := db.checkpointFlushValueLogLanes(); err != nil {
 		recordCheckpointStageSince(&db.checkpointStageValueLogFlush, valueLogFlushStart)
+		return err
+	}
+	if err := ctx.Err(); err != nil {
 		return err
 	}
 	valueLogFlushDur := time.Since(valueLogFlushStart)
@@ -24365,6 +24472,9 @@ func (db *DB) Checkpoint() error {
 	// Flush all queued memtables with backend sync.
 	if hook := db.testBeforeCheckpointFrontierDrain; hook != nil {
 		hook()
+	}
+	if err := ctx.Err(); err != nil {
+		return err
 	}
 	leafLogAppendWaitBefore := db.flushApplyLeafLogAppendWaitNs.Load()
 	reducerPublishBefore := db.backendFlushApplyReducerPublishNs()
@@ -24404,7 +24514,10 @@ func (db *DB) Checkpoint() error {
 		ownedDrainStart := time.Now()
 		db.flushCheckpointFrontierLocked(true, nil, frontier)
 		ownedDrainDur = time.Since(ownedDrainStart)
-		lockFlushMu()
+		if err := lockFlushMu(); err != nil {
+			db.clearActiveCheckpointFrontier()
+			return err
+		}
 		db.clearActiveCheckpointFrontier()
 		db.observeCheckpointSharedDrainWait(time.Since(flushAllStart))
 	}
@@ -24422,6 +24535,9 @@ func (db *DB) Checkpoint() error {
 		db.mu.RUnlock()
 	}
 	recordCheckpointStageSince(&db.checkpointStageFlushAll, flushAllStart)
+	if err := ctx.Err(); err != nil {
+		return err
+	}
 	leafLogAppendWaitAfter := db.flushApplyLeafLogAppendWaitNs.Load()
 	leafValueLogSyncNs := uint64(valueLogFlushDur.Nanoseconds()) + saturatingSubUint64(leafLogAppendWaitAfter, leafLogAppendWaitBefore)
 	db.checkpointStageLeafValueLogSync.record(time.Duration(leafValueLogSyncNs))
@@ -24469,6 +24585,9 @@ func (db *DB) Checkpoint() error {
 	// WriteSync only proves the command-WAL prefix when command WAL is enabled,
 	// and relaxed publication may only enqueue a root candidate, so explicitly
 	// wait through the backend checkpoint before trimming the command WAL.
+	if err := ctx.Err(); err != nil {
+		return err
+	}
 	backendBoundaryStart := time.Now()
 	commitErr := backendSyncBoundary(db.backend)
 	recordCheckpointStageSince(&db.checkpointStageBackendBoundary, backendBoundaryStart)

--- a/TreeDB/caching/vlog_dict.go
+++ b/TreeDB/caching/vlog_dict.go
@@ -2,15 +2,27 @@ package caching
 
 import (
 	"context"
+	"errors"
 	"log"
 	"math/bits"
 	"time"
 
 	"github.com/snissn/compress/zstd"
+	backenddb "github.com/snissn/gomap/TreeDB/db"
 	"github.com/snissn/gomap/TreeDB/internal/compression"
 	"github.com/snissn/gomap/TreeDB/internal/outerleaf"
 	"github.com/snissn/gomap/TreeDB/internal/valuelog"
 )
+
+func (db *DB) reportValueLogDictPublishError(err error) {
+	// Dictionary publication is retried from the unchanged active profile. A
+	// stale cleanup proof means the durable write raced another command-WAL
+	// append; cleanup retained the WAL and a later pass can safely converge.
+	if errors.Is(err, backenddb.ErrDurableWALCleanupProofStale) {
+		return
+	}
+	db.reportError(err)
+}
 
 const (
 	// Scale trainer sampling by payload bytes so large batches of small values
@@ -1089,7 +1101,7 @@ func (db *DB) applyValueLogDictProfileForClass(class vlogDictClass) {
 			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 			defer cancel()
 			if err := ks.SetK(ctx, dictID, profileK); err != nil {
-				db.reportError(err)
+				db.reportValueLogDictPublishError(err)
 				return
 			}
 			db.valueLogDictCurrentKByClass[class].Store(uint32(profileK))
@@ -1124,7 +1136,7 @@ func (db *DB) applyValueLogDictProfileForClass(class vlogDictClass) {
 	defer cancel()
 	dictID, err := writer.PutDictBytes(ctx, profile.Dict)
 	if err != nil {
-		db.reportError(err)
+		db.reportValueLogDictPublishError(err)
 		return
 	}
 	classMode := db.dictClassMode()
@@ -1134,26 +1146,26 @@ func (db *DB) applyValueLogDictProfileForClass(class vlogDictClass) {
 		_, hasClassReader := store.(dictStoreCurrentByClass)
 		if hasClassWriter && hasClassReader {
 			if err := byClassWriter.SetCurrentForClass(ctx, vlogDictClassSuffix(class), dictID); err != nil {
-				db.reportError(err)
+				db.reportValueLogDictPublishError(err)
 				return
 			}
 			if class == vlogDictClassSingleValue {
 				// Keep legacy global current in sync for mode switches/reopen paths
 				// that read only the global marker.
 				if err := writer.SetCurrent(ctx, dictID); err != nil {
-					db.reportError(err)
+					db.reportValueLogDictPublishError(err)
 					return
 				}
 				publishedViaGlobalCurrent = true
 			}
 		} else if err := writer.SetCurrent(ctx, dictID); err != nil {
-			db.reportError(err)
+			db.reportValueLogDictPublishError(err)
 			return
 		} else {
 			publishedViaGlobalCurrent = true
 		}
 	} else if err := writer.SetCurrent(ctx, dictID); err != nil {
-		db.reportError(err)
+		db.reportValueLogDictPublishError(err)
 		return
 	} else {
 		publishedViaGlobalCurrent = true
@@ -1173,7 +1185,7 @@ func (db *DB) applyValueLogDictProfileForClass(class vlogDictClass) {
 	}
 	if ks, ok := store.(dictStoreK); ok {
 		if err := ks.SetK(ctx, dictID, profileK); err != nil {
-			db.reportError(err)
+			db.reportValueLogDictPublishError(err)
 		}
 	}
 	db.valueLogDictLastAppliedDictHashByClass[class].Store(profile.DictHash)

--- a/TreeDB/caching/vlog_dict.go
+++ b/TreeDB/caching/vlog_dict.go
@@ -1139,6 +1139,15 @@ func (db *DB) applyValueLogDictProfileForClass(class vlogDictClass) {
 		db.reportValueLogDictPublishError(err)
 		return
 	}
+	// Persist the dictionary's compression parameter before publishing its
+	// current marker. A retryable metadata failure must leave the old profile
+	// current so a later publisher pass can retry the complete operation.
+	if ks, ok := store.(dictStoreK); ok {
+		if err := ks.SetK(ctx, dictID, profileK); err != nil {
+			db.reportValueLogDictPublishError(err)
+			return
+		}
+	}
 	classMode := db.dictClassMode()
 	publishedViaGlobalCurrent := false
 	if classMode == vlogDictClassModeSplitOuterLeaf {
@@ -1182,11 +1191,6 @@ func (db *DB) applyValueLogDictProfileForClass(class vlogDictClass) {
 	if class == vlogDictClassSingleValue || classMode != vlogDictClassModeSplitOuterLeaf || publishedViaGlobalCurrent {
 		db.dictCurrentCached.Store(dictID)
 		db.dictCurrentOps.Store(0)
-	}
-	if ks, ok := store.(dictStoreK); ok {
-		if err := ks.SetK(ctx, dictID, profileK); err != nil {
-			db.reportValueLogDictPublishError(err)
-		}
 	}
 	db.valueLogDictLastAppliedDictHashByClass[class].Store(profile.DictHash)
 	db.valueLogDictLastAppliedDictIDByClass[class].Store(dictID)

--- a/TreeDB/caching/vlog_dict_k_update_test.go
+++ b/TreeDB/caching/vlog_dict_k_update_test.go
@@ -42,6 +42,19 @@ type blockingDictStoreForConcurrentPublishTest struct {
 	releaseFirst  chan struct{}
 }
 
+type staleOnceDictStoreForPublishTest struct {
+	*legacyDictStoreForClassPublishTest
+	putCalls int
+}
+
+func (s *staleOnceDictStoreForPublishTest) PutDictBytes(ctx context.Context, dict []byte) (uint64, error) {
+	s.putCalls++
+	if s.putCalls == 1 {
+		return 0, db.ErrDurableWALCleanupProofStale
+	}
+	return s.legacyDictStoreForClassPublishTest.PutDictBytes(ctx, dict)
+}
+
 func newBlockingDictStoreForConcurrentPublishTest() *blockingDictStoreForConcurrentPublishTest {
 	return &blockingDictStoreForConcurrentPublishTest{
 		dicts:         make(map[uint64][]byte),
@@ -292,6 +305,51 @@ func TestApplyValueLogDictProfileForClass_SerializesConcurrentPublishers(t *test
 	}
 	if got := database.valueLogDictLastAppliedDictHashByClass[vlogDictClassSingleValue].Load(); got != dictHash {
 		t.Fatalf("last applied dictionary hash=%x want %x", got, dictHash)
+	}
+}
+
+func TestApplyValueLogDictProfileForClass_RetriesStaleCleanupWithoutBackgroundError(t *testing.T) {
+	tr := &compression.Trainer{}
+	dictBytes := []byte("retryable-dictionary")
+	dictHash := xxhash.Sum64(dictBytes)
+	tr.AcceptProfile(&compression.ActiveProfile{
+		DictHash:     dictHash,
+		DictBytes:    len(dictBytes),
+		Dict:         dictBytes,
+		K:            8,
+		PayloadRatio: 0.6,
+		TotalRatio:   0.6,
+		Timestamp:    time.Now(),
+	})
+
+	store := &staleOnceDictStoreForPublishTest{
+		legacyDictStoreForClassPublishTest: &legacyDictStoreForClassPublishTest{
+			dicts: make(map[uint64][]byte),
+		},
+	}
+	notifications := 0
+	database := &DB{
+		dictStore: store,
+		notifyError: func(error) {
+			notifications++
+		},
+	}
+	database.valueLogDictTrainerByClass[vlogDictClassSingleValue] = tr
+
+	database.applyValueLogDictProfileForClass(vlogDictClassSingleValue)
+	if notifications != 0 || database.backgroundError() != nil {
+		t.Fatalf("stale cleanup poisoned background state: notifications=%d err=%v", notifications, database.backgroundError())
+	}
+	if got := database.valueLogDictLastAppliedDictHashByClass[vlogDictClassSingleValue].Load(); got != 0 {
+		t.Fatalf("stale cleanup consumed candidate hash=%x want 0", got)
+	}
+
+	database.applyValueLogDictProfileForClass(vlogDictClassSingleValue)
+	if store.putCalls != 2 {
+		t.Fatalf("dictionary PutDictBytes calls=%d want 2", store.putCalls)
+	}
+	if got := database.valueLogDictLastAppliedDictHashByClass[vlogDictClassSingleValue].Load(); got != dictHash {
+		t.Fatalf("retried dictionary hash=%x want %x", got, dictHash)
 	}
 }
 

--- a/TreeDB/caching/vlog_dict_k_update_test.go
+++ b/TreeDB/caching/vlog_dict_k_update_test.go
@@ -47,12 +47,40 @@ type staleOnceDictStoreForPublishTest struct {
 	putCalls int
 }
 
+type staleKOnceDictStoreForPublishTest struct {
+	*legacyDictStoreForClassPublishTest
+	putCalls  int
+	setKCalls int
+	kByID     map[uint64]int
+}
+
 func (s *staleOnceDictStoreForPublishTest) PutDictBytes(ctx context.Context, dict []byte) (uint64, error) {
 	s.putCalls++
 	if s.putCalls == 1 {
 		return 0, db.ErrDurableWALCleanupProofStale
 	}
 	return s.legacyDictStoreForClassPublishTest.PutDictBytes(ctx, dict)
+}
+
+func (s *staleKOnceDictStoreForPublishTest) PutDictBytes(ctx context.Context, dict []byte) (uint64, error) {
+	s.putCalls++
+	return s.legacyDictStoreForClassPublishTest.PutDictBytes(ctx, dict)
+}
+
+func (s *staleKOnceDictStoreForPublishTest) SetK(_ context.Context, dictID uint64, k int) error {
+	s.setKCalls++
+	if s.setKCalls == 1 {
+		return db.ErrDurableWALCleanupProofStale
+	}
+	if s.kByID == nil {
+		s.kByID = make(map[uint64]int)
+	}
+	s.kByID[dictID] = k
+	return nil
+}
+
+func (s *staleKOnceDictStoreForPublishTest) GetK(_ context.Context, dictID uint64) (int, error) {
+	return s.kByID[dictID], nil
 }
 
 func newBlockingDictStoreForConcurrentPublishTest() *blockingDictStoreForConcurrentPublishTest {
@@ -350,6 +378,54 @@ func TestApplyValueLogDictProfileForClass_RetriesStaleCleanupWithoutBackgroundEr
 	}
 	if got := database.valueLogDictLastAppliedDictHashByClass[vlogDictClassSingleValue].Load(); got != dictHash {
 		t.Fatalf("retried dictionary hash=%x want %x", got, dictHash)
+	}
+}
+
+func TestApplyValueLogDictProfileForClass_RetriesStaleKWithoutApplyingProfile(t *testing.T) {
+	tr := &compression.Trainer{}
+	dictBytes := []byte("retryable-dictionary-k")
+	dictHash := xxhash.Sum64(dictBytes)
+	tr.AcceptProfile(&compression.ActiveProfile{
+		DictHash:     dictHash,
+		DictBytes:    len(dictBytes),
+		Dict:         dictBytes,
+		K:            8,
+		PayloadRatio: 0.6,
+		TotalRatio:   0.6,
+		Timestamp:    time.Now(),
+	})
+
+	store := &staleKOnceDictStoreForPublishTest{
+		legacyDictStoreForClassPublishTest: &legacyDictStoreForClassPublishTest{
+			dicts: make(map[uint64][]byte),
+		},
+	}
+	notifications := 0
+	database := &DB{
+		dictStore: store,
+		notifyError: func(error) {
+			notifications++
+		},
+	}
+	database.valueLogDictTrainerByClass[vlogDictClassSingleValue] = tr
+
+	database.applyValueLogDictProfileForClass(vlogDictClassSingleValue)
+	if notifications != 0 || database.backgroundError() != nil {
+		t.Fatalf("stale K cleanup poisoned background state: notifications=%d err=%v", notifications, database.backgroundError())
+	}
+	if got := database.valueLogDictLastAppliedDictHashByClass[vlogDictClassSingleValue].Load(); got != 0 {
+		t.Fatalf("stale K cleanup applied candidate hash=%x want 0", got)
+	}
+
+	database.applyValueLogDictProfileForClass(vlogDictClassSingleValue)
+	if store.putCalls != 2 || store.setKCalls != 2 {
+		t.Fatalf("publish calls PutDictBytes=%d SetK=%d want 2 each", store.putCalls, store.setKCalls)
+	}
+	if got := database.valueLogDictLastAppliedDictHashByClass[vlogDictClassSingleValue].Load(); got != dictHash {
+		t.Fatalf("retried dictionary hash=%x want %x", got, dictHash)
+	}
+	if got := store.kByID[store.currentID]; got != 8 {
+		t.Fatalf("persisted K for current dictionary=%d want 8", got)
 	}
 }
 

--- a/TreeDB/db/command_wal_cleanup_proof.go
+++ b/TreeDB/db/command_wal_cleanup_proof.go
@@ -11,7 +11,10 @@ import (
 
 var (
 	errDurableWALCleanupProofUnavailable = errors.New("durable WAL cleanup proof unavailable")
-	errDurableWALCleanupProofStale       = errors.New("durable WAL cleanup proof stale")
+	// ErrDurableWALCleanupProofStale reports that command-WAL cleanup authority
+	// changed before deletion. Callers may retry from a fresh checkpoint cut.
+	ErrDurableWALCleanupProofStale = errors.New("durable WAL cleanup proof stale")
+	errDurableWALCleanupProofStale = ErrDurableWALCleanupProofStale
 )
 
 type durableWALCleanupRootV1 struct {

--- a/TreeDB/db/command_wal_publish_test.go
+++ b/TreeDB/db/command_wal_publish_test.go
@@ -1677,6 +1677,10 @@ func TestCommandWALCleanupRejectsSnapshotAfterAppend(t *testing.T) {
 	if !errors.Is(err, commitlog.ErrCommandWALCleanupSnapshotStale) {
 		t.Fatalf("CleanupCommandWALCoveredSegments error=%v, want cleanup snapshot stale", err)
 	}
+	err = db.CleanupCommandWALCoveredSegmentsAtCheckpoint(false)
+	if !errors.Is(err, ErrDurableWALCleanupProofStale) {
+		t.Fatalf("checkpoint cleanup error=%v, want durable cleanup retry sentinel", err)
+	}
 	if _, statErr := os.Stat(filepath.Join(WALDirPath(dir), "commit-l0-000001.log")); statErr != nil {
 		t.Fatalf("covered segment removed under stale append snapshot: %v", statErr)
 	}

--- a/TreeDB/db/command_wal_publish_test.go
+++ b/TreeDB/db/command_wal_publish_test.go
@@ -1723,6 +1723,16 @@ func TestCommandWALCleanupAdvancesJournalNamespaceGeneration(t *testing.T) {
 	}
 }
 
+func TestNormalizeCommandWALCheckpointCleanupErrorPrefersStaleOverUnavailable(t *testing.T) {
+	err := normalizeCommandWALCheckpointCleanupError(errors.Join(
+		errDurableWALCleanupProofUnavailable,
+		errDurableWALCleanupProofStale,
+	))
+	if !errors.Is(err, ErrDurableWALCleanupProofStale) {
+		t.Fatalf("checkpoint cleanup error=%v, want durable cleanup retry sentinel", err)
+	}
+}
+
 func TestCommandWALCleanupRejectsSnapshotAfterDurableRootAdvance(t *testing.T) {
 	dir := t.TempDir()
 	writeCommandWALFrame(t, dir, 1, 1)

--- a/TreeDB/db/command_wal_raw.go
+++ b/TreeDB/db/command_wal_raw.go
@@ -648,11 +648,15 @@ func (db *DB) cleanupCommandWALCoveredSegmentsAtCheckpointV1(maintenanceAlreadyH
 	} else {
 		err = db.CleanupCommandWALCoveredSegments(false)
 	}
-	if errors.Is(err, errDurableWALCleanupProofUnavailable) {
-		return nil
-	}
+	return normalizeCommandWALCheckpointCleanupError(err)
+}
+
+func normalizeCommandWALCheckpointCleanupError(err error) error {
 	if errors.Is(err, errDurableWALCleanupProofStale) || errors.Is(err, commitlog.ErrCommandWALCleanupSnapshotStale) {
 		return errors.Join(ErrDurableWALCleanupProofStale, err)
+	}
+	if errors.Is(err, errDurableWALCleanupProofUnavailable) {
+		return nil
 	}
 	return err
 }

--- a/TreeDB/db/command_wal_raw.go
+++ b/TreeDB/db/command_wal_raw.go
@@ -651,6 +651,9 @@ func (db *DB) cleanupCommandWALCoveredSegmentsAtCheckpointV1(maintenanceAlreadyH
 	if errors.Is(err, errDurableWALCleanupProofUnavailable) {
 		return nil
 	}
+	if errors.Is(err, errDurableWALCleanupProofStale) || errors.Is(err, commitlog.ErrCommandWALCleanupSnapshotStale) {
+		return errors.Join(ErrDurableWALCleanupProofStale, err)
+	}
 	return err
 }
 

--- a/TreeDB/db/fragmentation.go
+++ b/TreeDB/db/fragmentation.go
@@ -1,6 +1,7 @@
 package db
 
 import (
+	"context"
 	"fmt"
 	"sort"
 	"sync"
@@ -150,6 +151,18 @@ func (db *DB) IndexVacuumFreelistDebtSnapshot() (IndexVacuumFreelistDebtSnapshot
 // full-report map parsing; freelist reclaimable debt uses seeded incremental
 // counters rather than walking the on-disk freelist chain.
 func (db *DB) IndexVacuumTriggerReport() (IndexVacuumTriggerReport, error) {
+	return db.IndexVacuumTriggerReportContext(context.Background())
+}
+
+// IndexVacuumTriggerReportContext returns the automatic-vacuum trigger report
+// and stops its user and collection tree walks when ctx is canceled.
+func (db *DB) IndexVacuumTriggerReportContext(ctx context.Context) (IndexVacuumTriggerReport, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if err := ctx.Err(); err != nil {
+		return IndexVacuumTriggerReport{}, err
+	}
 	emitFragmentationProbeEvent(FragmentationProbeEventTriggerReport)
 
 	snap := db.AcquireSnapshot()
@@ -168,6 +181,9 @@ func (db *DB) IndexVacuumTriggerReport() (IndexVacuumTriggerReport, error) {
 
 	emitFragmentationProbeEvent(FragmentationProbeEventTriggerUserTreeWalk)
 	err := snap.tree.WalkPages(func(pageID uint64, _ node.Node) error {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
 		if out.UserPages == 0 {
 			out.UserMinPageID = pageID
 			out.UserMaxPageID = pageID
@@ -208,7 +224,7 @@ func (db *DB) IndexVacuumTriggerReport() (IndexVacuumTriggerReport, error) {
 	}
 
 	emitFragmentationProbeEvent(FragmentationProbeEventTriggerCollectionRootWalk)
-	if collection, err := collectionRootFragmentationStats(snap.idx, snap.state); err == nil {
+	if collection, err := collectionRootFragmentationStatsWithContext(ctx, snap.idx, snap.state); err == nil {
 		out.CollectionRootCount = collection.roots
 		out.CollectionRootPagerRoots = collection.pagerRoots
 		out.CollectionRootPages = collection.pages
@@ -224,6 +240,8 @@ func (db *DB) IndexVacuumTriggerReport() (IndexVacuumTriggerReport, error) {
 				out.CollectionRootSpanRatioValid = true
 			}
 		}
+	} else if ctx.Err() != nil {
+		return out, ctx.Err()
 	}
 	return out, nil
 }
@@ -375,17 +393,30 @@ type collectionRootFragmentation struct {
 }
 
 func collectionRootFragmentationStats(idx *indexGen, state *DBState) (collectionRootFragmentation, error) {
+	return collectionRootFragmentationStatsWithContext(context.Background(), idx, state)
+}
+
+func collectionRootFragmentationStatsWithContext(ctx context.Context, idx *indexGen, state *DBState) (collectionRootFragmentation, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if err := ctx.Err(); err != nil {
+		return collectionRootFragmentation{}, err
+	}
 	out := collectionRootFragmentation{uniquePageIDs: make(map[uint64]struct{})}
 	if idx == nil || idx.pager == nil || state == nil || state.SystemRootPageID == 0 {
 		return out, nil
 	}
 	reader := newValueReader(state.ValueLogSet)
-	descriptors, err := vacuumCollectCollectionRootDescriptors(idx.pager, reader, state.SystemRootPageID)
+	descriptors, err := vacuumCollectCollectionRootDescriptorsWithContext(ctx, idx.pager, reader, state.SystemRootPageID)
 	if err != nil {
 		return out, err
 	}
 	out.roots = uint64(len(descriptors))
 	for _, descriptor := range descriptors {
+		if err := ctx.Err(); err != nil {
+			return out, err
+		}
 		rootID := descriptor.rootID
 		if rootID == 0 {
 			continue
@@ -393,6 +424,9 @@ func collectionRootFragmentationStats(idx *indexGen, state *DBState) (collection
 		out.pagerRoots++
 		tr := tree.New(idx.pager, reader, rootID)
 		if err := tr.WalkPages(func(pageID uint64, n node.Node) error {
+			if err := ctx.Err(); err != nil {
+				return err
+			}
 			if _, seen := out.uniquePageIDs[pageID]; seen {
 				out.duplicatePages++
 				return nil

--- a/TreeDB/db/fragmentation_trigger_test.go
+++ b/TreeDB/db/fragmentation_trigger_test.go
@@ -2,10 +2,35 @@ package db
 
 import (
 	"bytes"
+	"context"
+	"errors"
 	"fmt"
 	"strconv"
 	"testing"
 )
+
+func TestIndexVacuumTriggerReportContextCanceledBeforeProbe(t *testing.T) {
+	d := openFragmentationTriggerFixture(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	if _, err := d.IndexVacuumTriggerReportContext(ctx); !errors.Is(err, context.Canceled) {
+		t.Fatalf("trigger report error=%v want context canceled", err)
+	}
+}
+
+func TestIndexVacuumTriggerReportContextCancelsCollectionWalk(t *testing.T) {
+	d := openFragmentationTriggerFixture(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	restore := SetFragmentationProbeHookForTest(func(event FragmentationProbeEvent) {
+		if event == FragmentationProbeEventTriggerCollectionRootWalk {
+			cancel()
+		}
+	})
+	defer restore()
+	if _, err := d.IndexVacuumTriggerReportContext(ctx); !errors.Is(err, context.Canceled) {
+		t.Fatalf("trigger report error=%v want context canceled", err)
+	}
+}
 
 func TestIndexVacuumTriggerReportMatchesFragmentationSpan(t *testing.T) {
 	d := openFragmentationTriggerFixture(t)

--- a/TreeDB/db/vacuum_collection_latency_external_bench_test.go
+++ b/TreeDB/db/vacuum_collection_latency_external_bench_test.go
@@ -42,10 +42,11 @@ func BenchmarkPL06ExternalVacuumCollectionForegroundChurn(b *testing.B) {
 				case vacuumErr == nil:
 				case errors.Is(vacuumErr, dbpkg.ErrVacuumRecoverableRootSetRequired), errors.Is(vacuumErr, dbpkg.ErrVacuumUnsupported):
 					unsupported++
-				case errors.Is(vacuumErr, dbpkg.ErrVacuumConcurrentMutation):
+				case pl06PublicVacuumConcurrentRetry(vacuumErr):
 					concurrentRetries++
 				default:
 					unexpected++
+					b.Logf("unexpected vacuum error: %T: %v", vacuumErr, vacuumErr)
 				}
 				if exposureMiss {
 					exposureMisses++
@@ -78,6 +79,27 @@ func BenchmarkPL06ExternalVacuumCollectionForegroundChurn(b *testing.B) {
 			b.ReportMetric(float64(concurrentRetries)/float64(b.N), "vacuum-concurrent-retries/op")
 			b.ReportMetric(float64(unexpected)/float64(b.N), "vacuum-unexpected-errors/op")
 		})
+	}
+}
+
+func pl06PublicVacuumConcurrentRetry(err error) bool {
+	return errors.Is(err, dbpkg.ErrVacuumConcurrentMutation) ||
+		errors.Is(err, dbpkg.ErrRecoverableRootSetStale) ||
+		errors.Is(err, dbpkg.ErrDurableWALCleanupProofStale)
+}
+
+func TestPL06PublicVacuumRetryClassification(t *testing.T) {
+	for _, err := range []error{
+		dbpkg.ErrVacuumConcurrentMutation,
+		dbpkg.ErrRecoverableRootSetStale,
+		dbpkg.ErrDurableWALCleanupProofStale,
+	} {
+		if !pl06PublicVacuumConcurrentRetry(err) {
+			t.Fatalf("error %v was not classified as a concurrent retry", err)
+		}
+	}
+	if pl06PublicVacuumConcurrentRetry(errors.New("I/O failure")) {
+		t.Fatal("permanent error was classified as a concurrent retry")
 	}
 }
 

--- a/TreeDB/docs/performance/index-vacuum-m0.md
+++ b/TreeDB/docs/performance/index-vacuum-m0.md
@@ -21,7 +21,8 @@ and foreground p99 each have a coefficient of variation at most 10%. Backend
 rows must be uniform across all ten samples: either explicitly unavailable with
 `vacuum-unsupported/op = 1`, `foreground-exposure-misses/op = 1`, zero
 foreground overlap, and zero retry/unexpected-error metrics, or available with
-zero unsupported/retry/error/exposure-miss metrics and positive foreground overlap.
+zero unsupported/unexpected-error/exposure-miss metrics, only typed transient
+retries, positive overlap in every sample, and at least one successful sample.
 Mixed or ambiguous status fails closed. The available classification is backend
 evidence only; top-level cached/public routing remains M2-owned. Legacy rows
 must report zero concurrent aborts, so an aborted run cannot become a timing

--- a/TreeDB/docs/performance/index-vacuum-m0.md
+++ b/TreeDB/docs/performance/index-vacuum-m0.md
@@ -60,7 +60,8 @@ reopen digest parity.
 The M0 test-first exception was deliberate: its original unsupported result
 remains a valid frozen pre-M1 classification, while M1 adds the verified-success
 classification for the internal DB-minted backend. Public/background routing
-remains owned by M2. M0 continues to assert disabled background behavior,
+is activated by M2 while this M0 artifact remains a frozen pre-activation
+baseline. M0 continues to assert disabled background behavior,
 deterministic fixture debt, offline parity, and artifact schema completeness.
 
 The legacy timing baseline explicitly drains and disables the current

--- a/TreeDB/docs/spec/concurrency-paradigms.md
+++ b/TreeDB/docs/spec/concurrency-paradigms.md
@@ -433,6 +433,8 @@ Notes:
 - Background prune defaults: interval `250ms`, max pages `4096`, max duration `25ms`.
 - Cached auto-checkpoint defaults: interval `30s`, idle trigger `2s`, size trigger `2GiB`.
 - Background index vacuum defaults: interval `30s`, span ratio threshold `1_200_000` ppm.
+- Background index vacuum starts only for writable supported-platform opens; a negative interval disables it. Close cancels and joins an active pass.
+- Expected cutover races are recorded as retry outcomes. Unsupported capability quiesces the worker, while permanent failures remain visible through stats and `NotifyError` without repeating on an unchanged state.
 
 ### 6.6 Environment flags that change maintenance sequencing
 

--- a/TreeDB/docs/spec/recoverable-root-set-maintenance-3681.md
+++ b/TreeDB/docs/spec/recoverable-root-set-maintenance-3681.md
@@ -29,7 +29,7 @@ resource-specific reachability projection.
 | Raw and packed outer-leaf generations | `TreeDB/db/leaf_generation_gc.go` | scans raw leaf FileIDs from every captured root, resolves them through every retained leaf-generation manifest, preserves FileID reuse/ABA generations, and revalidates before zombie publication | active |
 | Leaf pack/rewrite sources | `TreeDB/db/leaf_generation_pack.go`, `TreeDB/db/compact_storage.go` | replacement output is stabilized and published first; physical retirement is exclusively owned by capability-backed leaf-generation GC | active |
 | Column, dictionary, template, typed-column, vector-graph, text, and query-ready assets | `TreeDB/collections/column_asset_gc.go` and `column_asset_rewrite.go` | scans each captured collection catalog/manifest, pins exact referenced segment identities, protects published generations replayable from an older durable WAL frontier, and revalidates before `BeginDeleteAt`. Current query-ready base/delta/consolidated assets remain rebuildable and non-authoritative, but share the same exact-identity retirement gate | active |
-| Online index vacuum/replacement | `TreeDB/db/vacuum_online.go` | the internal production entry captures a DB-minted capability, rebuilds both durable slots and their per-root resource closure, revalidates before namespace mutation, and atomically rebinds the live publication runtime; the legacy capability remains test-only | active backend; public/background routing is owned by #3945 and `CompactStorage` policy by #3946 |
+| Online index vacuum/replacement | `TreeDB/db/vacuum_online.go`, `TreeDB/public.go`, and `TreeDB/bg_vacuum.go` | the production entry captures a DB-minted capability, rebuilds both durable slots and their per-root resource closure, revalidates before namespace mutation, and atomically rebinds the live publication runtime; the public wrapper checkpoints cached state before replacement and reconciles it afterward | active on supported writable opens; `CompactStorage` policy remains owned by #3946 |
 | Offline `CompactIndex` | `TreeDB/db/db.go` | appends and publishes new pages in the same index namespace; it does not unlink or replace the index file. Page eligibility is governed by the page rule below | no external unlink |
 | Graveyard extraction and page/freelist reuse | COW allocator and root-reuse paths from #3678 | `RecoverableRootSet` registers the oldest captured commit sequence and holds the root-reuse read fence; actual page eligibility remains the #3678 generation rule | delegated to #3678 |
 | Stable unlink/rename instrumentation | `TreeDB/db/namespace_mutation.go`, `TreeDB/internal/valuelog/stable_resource.go`, and collection stable deleters | exact identity, namespace lease, unlink observation, and directory-sync failure handling remain the PR #3706 contract; #3681 adds root authority before those operations | inherited from PR #3706 |
@@ -103,11 +103,26 @@ handoff released. Existing snapshots, iterators, and stable-resource captures
 continue to pin old-generation handles until they close; physical cleanup is
 deferred until those references drain.
 
-This backend contract does not activate the public/background entry points or
-change `CompactStorage` completion policy. Those staged integrations remain
-fail-closed until #3945 and #3946 respectively. Windows remains explicitly
-unsupported because the required open-file rename and generation-retirement
-semantics are not implemented there.
+The public `DB.VacuumIndexOnline` entry checkpoints cached state before calling
+the production backend and reconciles the cached runtime after a successful
+replacement. Writable non-Windows opens start the background worker when the
+normalized interval is positive (`0` selects the 30-second default and a
+negative value disables it). Read-only and Windows opens do not start it.
+Windows remains explicitly unsupported because the required open-file rename
+and generation-retirement semantics are not implemented there.
+
+The background worker preserves unchanged-commit probe suppression and the
+user-page, freelist, collection-root, and bounded-backlog triggers. Concurrent
+mutation and stale recoverable-root-set results are retry outcomes and do not
+invoke `NotifyError`. An unsupported result quiesces the worker without a retry
+loop. Permanent failures invoke `NotifyError` once for the unchanged state and
+remain in `treedb.bg_vacuum.last_err`; retry class and terminal outcome are
+separately exposed by `last_retry_reason`, `last_outcome`, and their cumulative
+counters. `Close` cancels an active pass and waits for the worker before closing
+maintenance or storage resources.
+
+This activation does not change `CompactStorage` completion policy, which
+remains owned by #3946.
 
 ## Verification map
 

--- a/TreeDB/docs/spec/recoverable-root-set-maintenance-3681.md
+++ b/TreeDB/docs/spec/recoverable-root-set-maintenance-3681.md
@@ -113,8 +113,8 @@ and generation-retirement semantics are not implemented there.
 
 The background worker preserves unchanged-commit probe suppression and the
 user-page, freelist, collection-root, and bounded-backlog triggers. Concurrent
-mutation and stale recoverable-root-set results are retry outcomes and do not
-invoke `NotifyError`. An unsupported result quiesces the worker without a retry
+mutation, stale recoverable-root-set results, and stale command-WAL cleanup
+proofs are retry outcomes and do not invoke `NotifyError`. An unsupported result quiesces the worker without a retry
 loop. Permanent failures invoke `NotifyError` once for the unchanged state and
 remain in `treedb.bg_vacuum.last_err`; retry class and terminal outcome are
 separately exposed by `last_retry_reason`, `last_outcome`, and their cumulative

--- a/TreeDB/maintenance_leaf_vlog_test.go
+++ b/TreeDB/maintenance_leaf_vlog_test.go
@@ -3,7 +3,6 @@ package treedb_test
 import (
 	"bytes"
 	"context"
-	"errors"
 	"fmt"
 	"math/rand"
 	"os"
@@ -148,12 +147,12 @@ func TestVacuumIndexOnline_LeafPagesInValueLog_PreservesLeafRefWrites(t *testing
 
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
-	if err := db.VacuumIndexOnline(ctx); !errors.Is(err, treedbdb.ErrVacuumRecoverableRootSetRequired) {
-		t.Fatalf("vacuum err=%v want recoverable-root-set fence", err)
+	if err := db.VacuumIndexOnline(ctx); err != nil {
+		t.Fatalf("vacuum: %v", err)
 	}
 
-	// The rejected maintenance attempt must leave the live leaf-log root fully
-	// writable and checkpointable.
+	// The published replacement must leave the live leaf-log root fully writable
+	// and checkpointable.
 	if err := db.Set([]byte("k010"), []byte("updated")); err != nil {
 		t.Fatalf("set updated: %v", err)
 	}
@@ -166,6 +165,23 @@ func TestVacuumIndexOnline_LeafPagesInValueLog_PreservesLeafRefWrites(t *testing
 
 	metaAfter := readMainMeta(t, dir)
 	requireMainRootLeafLogChildren(t, dir, metaAfter.UserRootPageID)
+
+	reopened, err := treedb.Open(opts)
+	if err != nil {
+		t.Fatalf("reopen: %v", err)
+	}
+	got, err := reopened.Get([]byte("k010"))
+	if err != nil {
+		_ = reopened.Close()
+		t.Fatalf("get updated after reopen: %v", err)
+	}
+	if !bytes.Equal(got, []byte("updated")) {
+		_ = reopened.Close()
+		t.Fatalf("updated value after reopen=%q want updated", got)
+	}
+	if err := reopened.Close(); err != nil {
+		t.Fatalf("close reopened: %v", err)
+	}
 }
 
 func TestVacuumIndexOffline_LeafPagesInValueLog_ReopenParity(t *testing.T) {

--- a/TreeDB/public.go
+++ b/TreeDB/public.go
@@ -30,6 +30,8 @@ import (
 // Options configures TreeDB. It is re-exported from TreeDB/db for convenience.
 type Options = db.Options
 
+var errVacuumUnsupported = db.ErrVacuumUnsupported
+
 // EntryRevision is TreeDB's native per-entry revision metadata. Revision zero is
 // reserved for legacy entries that do not carry revision metadata.
 type EntryRevision = page.EntryRevision
@@ -64,11 +66,6 @@ const (
 	FlushAdmissionPolicyOff      = db.FlushAdmissionPolicyOff
 	FlushAdmissionPolicyAuto     = db.FlushAdmissionPolicyAuto
 )
-
-var errVacuumUnsupported = db.ErrVacuumUnsupported
-var errVacuumRecoverableRootSetRequired = db.ErrVacuumRecoverableRootSetRequired
-
-func publicOnlineVacuumEnabledV1() bool { return false }
 
 // ErrNamespacePersistenceUnsupported reports that the active platform or
 // filesystem cannot persist a directory creation required by a successful
@@ -1139,10 +1136,24 @@ func openResolved(opts Options) (*DB, error) {
 		cached.StartAutoCheckpoint(autoInterval, maxWALBytes, idleInterval)
 	}
 
-	// #3681 owns RecoverableRootSet convergence for destructive maintenance.
-	// Until that fence is available, do not launch a worker whose only online
-	// operation is deliberately unsupported. Explicit VacuumIndexOnline calls
-	// still fail closed with ErrVacuumRecoverableRootSetRequired.
+	vacuumInterval := opts.BackgroundIndexVacuumInterval
+	if vacuumInterval == 0 {
+		vacuumInterval = 30 * time.Second
+	}
+	if vacuumInterval < 0 {
+		vacuumInterval = 0
+	}
+	if vacuumInterval > 0 && !opts.ReadOnly && runtime.GOOS != "windows" {
+		out.bgVac.Start(out, bgIndexVacuumConfig{
+			Interval:                    vacuumInterval,
+			SpanRatioPPM:                opts.BackgroundIndexVacuumSpanRatioPPM,
+			MaxBacklogSkips:             opts.BackgroundIndexVacuumMaxBacklogSkips,
+			FreelistReclaimableRatioPPM: opts.BackgroundIndexVacuumFreelistReclaimableRatioPPM,
+			FreelistReclaimablePages:    opts.BackgroundIndexVacuumFreelistReclaimablePages,
+			CollectionRootSpanRatioPPM:  opts.BackgroundIndexVacuumCollectionRootSpanRatioPPM,
+			CollectionRootPages:         opts.BackgroundIndexVacuumCollectionRootPages,
+		})
+	}
 	cached.SetStatsHook(out.publicCachedExpvarStatsInto)
 
 	return out, nil
@@ -2486,13 +2497,6 @@ func (db *DB) VacuumIndexOnline(ctx context.Context) error {
 	if db.backend == nil {
 		return ErrClosed
 	}
-	// The backend replacement is production-capable, but public and cached
-	// routing, reporting, and background policy are activated together by #3945.
-	if !publicOnlineVacuumEnabledV1() {
-		return errors.Join(errVacuumUnsupported, errVacuumRecoverableRootSetRequired)
-	}
-
-	// #3945 removes the staged fence above and activates this block.
 	_, finishMaintenance := db.beginFullScanMaintenance("vacuum")
 	success := false
 	defer func() { finishMaintenance(success) }()

--- a/TreeDB/public.go
+++ b/TreeDB/public.go
@@ -604,10 +604,17 @@ func lockFullScanMaintenanceContext(ctx context.Context, mu *sync.Mutex) error {
 		mu.Lock()
 		return nil
 	}
+	if err := ctx.Err(); err != nil {
+		return err
+	}
 	ticker := time.NewTicker(time.Millisecond)
 	defer ticker.Stop()
 	for {
 		if mu.TryLock() {
+			if err := ctx.Err(); err != nil {
+				mu.Unlock()
+				return err
+			}
 			return nil
 		}
 		select {
@@ -623,8 +630,14 @@ func (db *DB) beginFullScanMaintenanceContext(ctx context.Context, op string) (t
 		return 0, func(bool) {}, nil
 	}
 	wait := time.Duration(0)
+	if err := ctx.Err(); err != nil {
+		return wait, func(bool) {}, err
+	}
 	if db.maintenance.mu.TryLock() {
-		// uncontended fast path
+		if err := ctx.Err(); err != nil {
+			db.maintenance.mu.Unlock()
+			return wait, func(bool) {}, err
+		}
 	} else {
 		waitStart := time.Now()
 		err := lockFullScanMaintenanceContext(ctx, &db.maintenance.mu)

--- a/TreeDB/public.go
+++ b/TreeDB/public.go
@@ -604,25 +604,17 @@ func lockFullScanMaintenanceContext(ctx context.Context, mu *sync.Mutex) error {
 		mu.Lock()
 		return nil
 	}
-	if err := ctx.Err(); err != nil {
-		return err
-	}
-	acquired := make(chan struct{})
-	abandon := make(chan struct{})
-	go func() {
-		mu.Lock()
-		select {
-		case acquired <- struct{}{}:
-		case <-abandon:
-			mu.Unlock()
+	ticker := time.NewTicker(time.Millisecond)
+	defer ticker.Stop()
+	for {
+		if mu.TryLock() {
+			return nil
 		}
-	}()
-	select {
-	case <-acquired:
-		return nil
-	case <-ctx.Done():
-		close(abandon)
-		return ctx.Err()
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-ticker.C:
+		}
 	}
 }
 

--- a/TreeDB/public.go
+++ b/TreeDB/public.go
@@ -2537,6 +2537,11 @@ func (db *DB) VacuumIndexOnline(ctx context.Context) error {
 	if err := ctx.Err(); err != nil {
 		return err
 	}
+	// Reject unsupported platforms before maintenance acquisition or cached
+	// checkpointing so this API remains non-mutating when it cannot run.
+	if runtime.GOOS == "windows" {
+		return errVacuumUnsupported
+	}
 	_, finishMaintenance, err := db.beginFullScanMaintenanceContext(ctx, "vacuum")
 	if err != nil {
 		return err

--- a/TreeDB/public.go
+++ b/TreeDB/public.go
@@ -595,15 +595,37 @@ func (db *DB) beginPublicOperation() error {
 }
 
 func (db *DB) beginFullScanMaintenance(op string) (time.Duration, func(success bool)) {
+	wait, finish, _ := db.beginFullScanMaintenanceContext(context.Background(), op)
+	return wait, finish
+}
+
+func (db *DB) beginFullScanMaintenanceContext(ctx context.Context, op string) (time.Duration, func(success bool), error) {
 	if db == nil {
-		return 0, func(bool) {}
+		return 0, func(bool) {}, nil
 	}
 	wait := time.Duration(0)
 	if db.maintenance.mu.TryLock() {
 		// uncontended fast path
 	} else {
 		waitStart := time.Now()
-		db.maintenance.mu.Lock()
+		for !db.maintenance.mu.TryLock() {
+			timer := time.NewTimer(time.Millisecond)
+			select {
+			case <-ctx.Done():
+				if !timer.Stop() {
+					select {
+					case <-timer.C:
+					default:
+					}
+				}
+				wait = time.Since(waitStart)
+				db.maintenance.deferrals.Add(1)
+				db.maintenance.waitTotal.Add(wait.Nanoseconds())
+				atomicStoreMaxInt64(&db.maintenance.waitMax, wait.Nanoseconds())
+				return wait, func(bool) {}, ctx.Err()
+			case <-timer.C:
+			}
+		}
 		wait = time.Since(waitStart)
 		db.maintenance.deferrals.Add(1)
 		db.maintenance.waitTotal.Add(wait.Nanoseconds())
@@ -628,7 +650,7 @@ func (db *DB) beginFullScanMaintenance(op string) (time.Duration, func(success b
 		}
 		db.maintenance.active.Store(maintenanceOpNone)
 		db.maintenance.mu.Unlock()
-	}
+	}, nil
 }
 
 func maintenanceStatsInto(stats map[string]string, m *maintenanceCoordinator) {
@@ -2491,13 +2513,23 @@ func (db *DB) CompactIndex() error {
 // a short writer pause. Disk space from the old index is reclaimed once any old
 // snapshots/iterators drain.
 func (db *DB) VacuumIndexOnline(ctx context.Context) error {
-	if err := db.ensureOpen(); err != nil {
+	if err := db.beginPublicOperation(); err != nil {
 		return err
 	}
+	defer db.lifecycleMu.RUnlock()
 	if db.backend == nil {
 		return ErrClosed
 	}
-	_, finishMaintenance := db.beginFullScanMaintenance("vacuum")
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	_, finishMaintenance, err := db.beginFullScanMaintenanceContext(ctx, "vacuum")
+	if err != nil {
+		return err
+	}
 	success := false
 	defer func() { finishMaintenance(success) }()
 
@@ -2506,9 +2538,12 @@ func (db *DB) VacuumIndexOnline(ctx context.Context) error {
 	// that temporarily "forgets" keys that only existed in memtables/WAL, which
 	// can break higher layers that assume a stable durable boundary.
 	if db.cached != nil {
-		if err := db.cached.Checkpoint(); err != nil {
+		if err := db.cached.CheckpointContext(ctx); err != nil {
 			return err
 		}
+	}
+	if err := ctx.Err(); err != nil {
+		return err
 	}
 
 	if err := db.reconcileCachedBackendMaintenance(db.backend.VacuumIndexOnline(ctx)); err != nil {

--- a/TreeDB/public.go
+++ b/TreeDB/public.go
@@ -599,6 +599,33 @@ func (db *DB) beginFullScanMaintenance(op string) (time.Duration, func(success b
 	return wait, finish
 }
 
+func lockFullScanMaintenanceContext(ctx context.Context, mu *sync.Mutex) error {
+	if ctx.Done() == nil {
+		mu.Lock()
+		return nil
+	}
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	acquired := make(chan struct{})
+	abandon := make(chan struct{})
+	go func() {
+		mu.Lock()
+		select {
+		case acquired <- struct{}{}:
+		case <-abandon:
+			mu.Unlock()
+		}
+	}()
+	select {
+	case <-acquired:
+		return nil
+	case <-ctx.Done():
+		close(abandon)
+		return ctx.Err()
+	}
+}
+
 func (db *DB) beginFullScanMaintenanceContext(ctx context.Context, op string) (time.Duration, func(success bool), error) {
 	if db == nil {
 		return 0, func(bool) {}, nil
@@ -608,28 +635,14 @@ func (db *DB) beginFullScanMaintenanceContext(ctx context.Context, op string) (t
 		// uncontended fast path
 	} else {
 		waitStart := time.Now()
-		for !db.maintenance.mu.TryLock() {
-			timer := time.NewTimer(time.Millisecond)
-			select {
-			case <-ctx.Done():
-				if !timer.Stop() {
-					select {
-					case <-timer.C:
-					default:
-					}
-				}
-				wait = time.Since(waitStart)
-				db.maintenance.deferrals.Add(1)
-				db.maintenance.waitTotal.Add(wait.Nanoseconds())
-				atomicStoreMaxInt64(&db.maintenance.waitMax, wait.Nanoseconds())
-				return wait, func(bool) {}, ctx.Err()
-			case <-timer.C:
-			}
-		}
+		err := lockFullScanMaintenanceContext(ctx, &db.maintenance.mu)
 		wait = time.Since(waitStart)
 		db.maintenance.deferrals.Add(1)
 		db.maintenance.waitTotal.Add(wait.Nanoseconds())
 		atomicStoreMaxInt64(&db.maintenance.waitMax, wait.Nanoseconds())
+		if err != nil {
+			return wait, func(bool) {}, err
+		}
 	}
 	db.maintenance.active.Store(maintenanceOpCode(op))
 
@@ -2513,13 +2526,6 @@ func (db *DB) CompactIndex() error {
 // a short writer pause. Disk space from the old index is reclaimed once any old
 // snapshots/iterators drain.
 func (db *DB) VacuumIndexOnline(ctx context.Context) error {
-	if err := db.beginPublicOperation(); err != nil {
-		return err
-	}
-	defer db.lifecycleMu.RUnlock()
-	if db.backend == nil {
-		return ErrClosed
-	}
 	if ctx == nil {
 		ctx = context.Background()
 	}
@@ -2532,6 +2538,13 @@ func (db *DB) VacuumIndexOnline(ctx context.Context) error {
 	}
 	success := false
 	defer func() { finishMaintenance(success) }()
+	if err := db.beginPublicOperation(); err != nil {
+		return err
+	}
+	defer db.lifecycleMu.RUnlock()
+	if db.backend == nil {
+		return ErrClosed
+	}
 
 	// In cached mode, ensure the backend reflects all buffered writes before
 	// rebuilding/switching the index file. This avoids exposing a backend state

--- a/TreeDB/vacuum_public_bench_test.go
+++ b/TreeDB/vacuum_public_bench_test.go
@@ -1,0 +1,301 @@
+package treedb
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"sort"
+	"sync"
+	"testing"
+	"time"
+
+	backenddb "github.com/snissn/gomap/TreeDB/db"
+)
+
+func TestPublicVacuumIndexOnlineHighDebtShrinkAndReopen(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("online vacuum not supported on windows")
+	}
+	d, beforeBytes, beforeDigest := openPublicVacuumComparisonFixture(t)
+	dir := d.dir
+	if err := d.VacuumIndexOnline(context.Background()); err != nil {
+		t.Fatalf("public online vacuum: %v", err)
+	}
+	afterBytes := publicVacuumIndexBytes(t, dir)
+	if afterBytes*100 > beforeBytes*60 {
+		t.Fatalf("public online shrink before=%d after=%d want >=40%%", beforeBytes, afterBytes)
+	}
+	if got := publicVacuumDigest(t, d); got != beforeDigest {
+		t.Fatalf("digest after public vacuum=%x want %x", got, beforeDigest)
+	}
+	if err := d.SetSync([]byte("public-vacuum/post"), []byte("post-vacuum")); err != nil {
+		t.Fatalf("post-vacuum write: %v", err)
+	}
+	if err := d.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+
+	reopened, err := Open(publicVacuumComparisonOptions(dir))
+	if err != nil {
+		t.Fatalf("reopen: %v", err)
+	}
+	defer reopened.Close()
+	if got, err := reopened.Get([]byte("public-vacuum/post")); err != nil || !bytes.Equal(got, []byte("post-vacuum")) {
+		t.Fatalf("post-vacuum value after reopen=%q err=%v", got, err)
+	}
+}
+
+func BenchmarkPublicVacuumVsDirectBackend(b *testing.B) {
+	if runtime.GOOS == "windows" {
+		b.Skip("online vacuum not supported on windows")
+	}
+	for _, tc := range []struct {
+		name string
+		run  func(*DB) error
+	}{
+		{name: "public", run: func(d *DB) error { return d.VacuumIndexOnline(context.Background()) }},
+		{name: "direct_backend", run: func(d *DB) error { return d.backend.VacuumIndexOnline(context.Background()) }},
+	} {
+		b.Run(tc.name, func(b *testing.B) {
+			d, _, digest := openPublicVacuumComparisonFixture(b)
+			defer d.Close()
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				if err := tc.run(d); err != nil {
+					b.Fatalf("vacuum: %v", err)
+				}
+			}
+			b.StopTimer()
+			if got := publicVacuumDigest(b, d); got != digest {
+				b.Fatalf("digest after vacuum=%x want %x", got, digest)
+			}
+		})
+	}
+}
+
+func BenchmarkPublicVacuumForegroundChurn(b *testing.B) {
+	if runtime.GOOS == "windows" {
+		b.Skip("online vacuum not supported on windows")
+	}
+	d, _, _ := openPublicVacuumComparisonFixture(b)
+	dir := d.dir
+	b.ReportAllocs()
+	b.ResetTimer()
+	latencies := make([]time.Duration, 0, b.N*publicVacuumChurnOperations)
+	var overlap, exposureMisses, vacuumErrors uint64
+	for round := 0; round < b.N; round++ {
+		result := runPublicVacuumChurnRound(d, round)
+		latencies = append(latencies, result.latencies...)
+		overlap += result.overlap
+		exposureMisses += result.exposureMisses
+		if result.vacuumErr != nil {
+			vacuumErrors++
+		}
+		if result.foregroundErr != nil {
+			b.Fatalf("foreground churn: %v", result.foregroundErr)
+		}
+	}
+	b.StopTimer()
+	if vacuumErrors != 0 || exposureMisses != 0 || overlap == 0 {
+		b.Fatalf("vacuum errors=%d exposure misses=%d overlap=%d", vacuumErrors, exposureMisses, overlap)
+	}
+	if len(latencies) != b.N*publicVacuumChurnOperations {
+		b.Fatalf("foreground samples=%d want %d", len(latencies), b.N*publicVacuumChurnOperations)
+	}
+	if err := d.Checkpoint(); err != nil {
+		b.Fatalf("final checkpoint: %v", err)
+	}
+	digest := publicVacuumDigest(b, d)
+	if err := d.Close(); err != nil {
+		b.Fatalf("close: %v", err)
+	}
+	reopened, err := Open(publicVacuumComparisonOptions(dir))
+	if err != nil {
+		b.Fatalf("reopen: %v", err)
+	}
+	if got := publicVacuumDigest(b, reopened); got != digest {
+		_ = reopened.Close()
+		b.Fatalf("reopen digest=%x want %x", got, digest)
+	}
+	if err := reopened.Close(); err != nil {
+		b.Fatalf("reopen close: %v", err)
+	}
+	b.ReportMetric(float64(publicVacuumPercentile(latencies, 95).Nanoseconds()), "foreground-p95-ns")
+	b.ReportMetric(float64(publicVacuumPercentile(latencies, 99).Nanoseconds()), "foreground-p99-ns")
+	b.ReportMetric(float64(overlap)/float64(b.N), "foreground-overlap-samples/op")
+	b.ReportMetric(float64(exposureMisses)/float64(b.N), "foreground-exposure-misses/op")
+	b.ReportMetric(float64(vacuumErrors)/float64(b.N), "vacuum-errors/op")
+}
+
+const (
+	publicVacuumChurnWorkers             = 4
+	publicVacuumChurnOperationsPerWorker = 40
+	publicVacuumChurnOperations          = publicVacuumChurnWorkers * publicVacuumChurnOperationsPerWorker
+)
+
+type publicVacuumChurnResult struct {
+	latencies      []time.Duration
+	overlap        uint64
+	exposureMisses uint64
+	vacuumErr      error
+	foregroundErr  error
+}
+
+func runPublicVacuumChurnRound(d *DB, round int) publicVacuumChurnResult {
+	vacuumDone := make(chan error, 1)
+	vacuumFinished := make(chan struct{})
+	go func() {
+		vacuumDone <- d.VacuumIndexOnline(context.Background())
+		close(vacuumFinished)
+	}()
+
+	start := make(chan struct{})
+	results := make(chan publicVacuumChurnResult, publicVacuumChurnWorkers)
+	var ready sync.WaitGroup
+	ready.Add(publicVacuumChurnWorkers)
+	for worker := 0; worker < publicVacuumChurnWorkers; worker++ {
+		go func(worker int) {
+			ready.Done()
+			<-start
+			result := publicVacuumChurnResult{latencies: make([]time.Duration, 0, publicVacuumChurnOperationsPerWorker)}
+			for operation := 0; operation < publicVacuumChurnOperationsPerWorker; operation++ {
+				sequence := round*publicVacuumChurnOperations + worker*publicVacuumChurnOperationsPerWorker + operation
+				key := []byte(fmt.Sprintf("public-vacuum/foreground/%06d", sequence%256))
+				value := []byte(fmt.Sprintf("value/%06d", sequence))
+				started := time.Now()
+				if err := d.Set(key, value); err != nil {
+					result.foregroundErr = err
+					break
+				}
+				got, err := d.Get(key)
+				result.latencies = append(result.latencies, time.Since(started))
+				if err != nil {
+					result.foregroundErr = err
+					break
+				}
+				if !bytes.Equal(got, value) {
+					result.exposureMisses++
+				}
+				select {
+				case <-vacuumFinished:
+				default:
+					result.overlap++
+				}
+			}
+			results <- result
+		}(worker)
+	}
+	ready.Wait()
+	close(start)
+
+	out := publicVacuumChurnResult{latencies: make([]time.Duration, 0, publicVacuumChurnOperations)}
+	for worker := 0; worker < publicVacuumChurnWorkers; worker++ {
+		result := <-results
+		out.latencies = append(out.latencies, result.latencies...)
+		out.overlap += result.overlap
+		out.exposureMisses += result.exposureMisses
+		if out.foregroundErr == nil {
+			out.foregroundErr = result.foregroundErr
+		}
+	}
+	out.vacuumErr = <-vacuumDone
+	return out
+}
+
+func publicVacuumPercentile(values []time.Duration, percentile int) time.Duration {
+	sorted := append([]time.Duration(nil), values...)
+	sort.Slice(sorted, func(i, j int) bool { return sorted[i] < sorted[j] })
+	index := (len(sorted)*percentile + 99) / 100
+	if index < 1 {
+		index = 1
+	}
+	if index > len(sorted) {
+		index = len(sorted)
+	}
+	return sorted[index-1]
+}
+
+func openPublicVacuumComparisonFixture(tb testing.TB) (*DB, int64, [32]byte) {
+	tb.Helper()
+	dir := tb.TempDir()
+	d, err := Open(publicVacuumComparisonOptions(dir))
+	if err != nil {
+		tb.Fatalf("open: %v", err)
+	}
+	value := bytes.Repeat([]byte("v"), 512)
+	for generation := 0; generation < 3; generation++ {
+		batch := d.NewBatch()
+		for key := 0; key < 2048; key++ {
+			value[0] = byte(generation + key%251)
+			if err := batch.Set([]byte(fmt.Sprintf("public-vacuum/%04d", key)), value); err != nil {
+				tb.Fatalf("set generation=%d key=%d: %v", generation, key, err)
+			}
+		}
+		if err := batch.WriteSync(); err != nil {
+			tb.Fatalf("write generation=%d: %v", generation, err)
+		}
+		if err := batch.Close(); err != nil {
+			tb.Fatalf("close generation=%d: %v", generation, err)
+		}
+	}
+	if err := d.CompactIndex(); err != nil {
+		tb.Fatalf("compact fixture: %v", err)
+	}
+	for generation := 0; generation < 2; generation++ {
+		if err := d.SetSync([]byte("public-vacuum/0000"), bytes.Repeat([]byte{byte(240 + generation)}, 512)); err != nil {
+			tb.Fatalf("advance durable slot=%d: %v", generation, err)
+		}
+	}
+	return d, publicVacuumIndexBytes(tb, dir), publicVacuumDigest(tb, d)
+}
+
+func publicVacuumComparisonOptions(dir string) Options {
+	return Options{
+		Dir:                           dir,
+		ChunkSize:                     32 << 10,
+		KeepRecent:                    1,
+		PreferAppendAlloc:             true,
+		BackgroundIndexVacuumInterval: -1,
+		ResolvedProfile:               backenddb.ProfileNoWALFast,
+		Durability:                    DurabilityWALOffRelaxed,
+	}
+}
+
+func publicVacuumIndexBytes(tb testing.TB, dir string) int64 {
+	tb.Helper()
+	path := filepath.Join(dir, "maindb", "index.db")
+	if _, err := os.Stat(path); os.IsNotExist(err) {
+		path = filepath.Join(dir, "index.db")
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		tb.Fatalf("stat index: %v", err)
+	}
+	return info.Size()
+}
+
+func publicVacuumDigest(tb testing.TB, d *DB) [32]byte {
+	tb.Helper()
+	h := sha256.New()
+	it, err := d.Iterator(nil, nil)
+	if err != nil {
+		tb.Fatalf("iterator: %v", err)
+	}
+	defer it.Close()
+	for it.Valid() {
+		h.Write(it.Key())
+		h.Write(it.Value())
+		it.Next()
+	}
+	if err := it.Error(); err != nil {
+		tb.Fatalf("iterator: %v", err)
+	}
+	var digest [32]byte
+	copy(digest[:], h.Sum(nil))
+	return digest
+}

--- a/TreeDB/vacuum_public_windows_test.go
+++ b/TreeDB/vacuum_public_windows_test.go
@@ -1,0 +1,35 @@
+//go:build windows
+
+package treedb
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	backenddb "github.com/snissn/gomap/TreeDB/db"
+)
+
+func TestVacuumIndexOnlineUnsupportedDoesNotCheckpointCachedWrites(t *testing.T) {
+	database, err := Open(Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer func() { _ = database.Close() }()
+	if err := database.Set([]byte("dirty"), []byte("value")); err != nil {
+		t.Fatalf("Set: %v", err)
+	}
+
+	checkpointCalls := 0
+	database.cached.SetCommandWALCheckpointPublishHook(func(bool) (uint64, []backenddb.CommandWALLSNRange, error) {
+		checkpointCalls++
+		return 0, nil, errors.New("unexpected checkpoint")
+	})
+
+	if err := database.VacuumIndexOnline(context.Background()); !errors.Is(err, backenddb.ErrVacuumUnsupported) {
+		t.Fatalf("VacuumIndexOnline error=%v want ErrVacuumUnsupported", err)
+	}
+	if checkpointCalls != 0 {
+		t.Fatalf("unsupported vacuum checkpoint calls=%d want 0", checkpointCalls)
+	}
+}

--- a/scripts/treedb_vacuum_m0_summarize.py
+++ b/scripts/treedb_vacuum_m0_summarize.py
@@ -79,7 +79,8 @@ def classify_public_status(public: dict[str, dict[str, object]]) -> str:
             return "production-index-vacuum-unavailable"
         if (
             all(value == 0 for value in unsupported)
-            and all(value == 0 for value in retries)
+            and all(value in (0, 1) for value in retries)
+            and any(value == 0 for value in retries)
             and all(value == 0 for value in unexpected)
             and all(value == 0 for value in misses)
             and all(value > 0 for value in overlap)
@@ -180,7 +181,7 @@ def render_markdown(result: dict[str, object]) -> str:
             f"- `vacuum-unsupported/op`: median `{public['vacuum-unsupported/op']['median']:.3f}`",
             f"- `vacuum-unexpected-errors/op`: median `{public['vacuum-unexpected-errors/op']['median']:.3f}`",
             "- Unavailable status requires one unsupported result and one exposure miss with zero retries, unexpected errors, and foreground overlap in every sample.",
-            "- Available status requires zero retries, errors, and exposure misses plus positive foreground overlap in every sample.",
+            "- Available status requires at least one successful vacuum, only typed transient retries, zero unexpected errors/exposure misses, and positive foreground overlap in every sample.",
             "",
             "## Commands",
             "",

--- a/scripts/treedb_vacuum_m0_summarize_test.py
+++ b/scripts/treedb_vacuum_m0_summarize_test.py
@@ -59,7 +59,15 @@ class VacuumM0SummarizeTest(unittest.TestCase):
         self.assertTrue(gates["legacy_cv_at_most_10_percent"])
         self.assertTrue(gates["public_status_explicit"])
 
+        public["vacuum-unsupported/op"]["samples"] = [0] * 10
+        public["foreground-exposure-misses/op"]["samples"] = [0] * 10
+        public["foreground-overlap-samples/op"]["samples"] = [160] * 10
         public["vacuum-concurrent-retries/op"]["samples"][4] = 1
+        gates = MODULE.evaluate_gates(legacy, public)
+        self.assertTrue(gates["public_status_explicit"])
+        self.assertEqual(MODULE.classify_public_status(public), "production-index-vacuum-available")
+
+        public["vacuum-concurrent-retries/op"]["samples"] = [1] * 10
         gates = MODULE.evaluate_gates(legacy, public)
         self.assertFalse(gates["public_status_explicit"])
         self.assertEqual(MODULE.classify_public_status(public), "production-index-vacuum-ambiguous")


### PR DESCRIPTION
Closes #3945
Parent #3942
Depends on merged #3944

## Summary

- activate `DB.VacuumIndexOnline` through the existing cached checkpoint, production backend replacement, and cached-runtime reconciliation path
- start the debt-aware background worker only for enabled writable supported-platform opens
- classify concurrent mutation, recoverable-root staleness, cleanup-proof staleness, and stable-resource pins as retry control flow; quiesce unsupported capability; retain/report permanent failures once per unchanged state
- cancel and join active background maintenance during `Close`
- expose retry reason, terminal outcome, and cumulative retry/unsupported/permanent counters in public stats
- add public high-debt shrink/reopen, deterministic lifecycle/error, unchanged-state scan suppression, and same-fixture performance gates

## Test-First Evidence

Commit `ddca949ba` enabled the M2 contract before implementation. It failed against the staged fence because public vacuum returned unsupported/recoverable-root-required, the worker did not start, independent freelist/collection-root debt produced no vacuum, and stale capability was classified as permanent.

## Correctness

- `GOWORK=off go test . ./db -run 'TestBackgroundIndexVacuum|Test.*VacuumIndexOnline' -count=1` passes.
- Exact-head focused tests pass across `TreeDB`, `db`, and `caching`.
- `GOWORK=off go test -race . ./db ./caching -run 'TestBackgroundIndexVacuum|TestIndexVacuumTriggerReport|Test.*VacuumIndexOnline|TestLockFullScanMaintenanceContext|TestLockCheckpointMutexContext|TestCachingDB_CheckpointContext|TestCachingDB_CanceledCheckpoint|TestCommandWALCleanupRejectsSnapshotAfterAppend|TestNormalizeCommandWALCheckpointCleanupError|TestApplyValueLogDictProfileForClass_RetriesStale.*|Test.*Close|Test.*DurableWALCleanupProof' -count=1 -timeout=30m` passes (`TreeDB` 26.160s, `db` 90.110s, `caching` 4.518s).
- Cancellation tests cover maintenance-lock wait, cache checkpoint ownership wait, and cancellation between checkpoint stages. Ordinary checkpoints retain the existing blocking path; cancellation never interrupts an in-flight storage syscall.
- Already-canceled maintenance requests are rejected before both the helper and public fast-path lock acquisitions; 20 race-enabled repetitions pass.
- Dictionary publication treats typed stale cleanup proofs as retryable without notifying or poisoning background state. K metadata is persisted before publishing the current marker; a failing-before regression proves a stale K write leaves the old profile authoritative and retries the complete publication. Twenty race-enabled focused repetitions and a 10-run authoritative-resource race reproduction pass.
- Windows rejects the unsupported public API before maintenance acquisition or cached checkpointing. A Windows-only regression dirties cached state and proves the checkpoint publish hook is never called; the Windows test binary cross-compiles locally.
- Public high-debt shrink/reopen gate passes 3/3 runs. It enforces at least 40% index shrink, digest parity, post-vacuum write success, and reopen readability.
- CI at `4ccc61033` passed 30 shards but production flushthrash exposed the command journal's second stale-cleanup class. `fba42bb3b` normalizes both stale-proof variants to the non-poisoning checkpoint retry sentinel while preserving the precise explicit-cleanup error. Latest-head CI is required again.

## Performance

Exact head: `e137c3e4f`

Command:

```sh
for pair in $(seq 0 19); do
	if (( pair % 2 == 0 )); then
		cases='public direct_backend'
	else
		cases='direct_backend public'
	fi
	for case in $cases; do
		GOWORK=off go test . -run '^$' \
			-bench "^BenchmarkPublicVacuumVsDirectBackend/${case}$" \
			-count=1 -benchtime=1x -benchmem
	done
done
```

The earlier grouped 20-sample diagnostic ran every public sample before every
direct sample and produced a misleading 1.299x ratio under host bimodality. The
final gate uses ten process-level pairs with alternating first case. Same-fixture
paired medians:

| Metric | Public wrapper | Direct backend | Ratio |
| --- | ---: | ---: | ---: |
| duration | 465.7 ms | 416.7 ms | 1.118x |
| bytes/op | 3.963 MB | 3.961 MB | 1.001x |
| allocs/op | 2.730k | 2.701k | 1.011x |

The pooled run was extended to 20 alternating process-level pairs after the first ten landed asymmetrically across the host's approximately 413 ms and 540 ms modes. The independent duration medians therefore read 1.118x, while the median of same-fixture paired duration ratios is 1.006x. Allocation and byte ratios remain inside the 1.10x gate; the paired estimator is the relevant wrapper-cost signal under the observed bimodality. The final platform-only branch is one comparison before maintenance acquisition and does not alter the supported-platform vacuum body.

Public fixed churn across 20 exact-head samples:

- `vacuum-errors/op = 0`
- `foreground-exposure-misses/op = 0`
- `foreground-overlap-samples/op = 3200/3200`
- median p95 `10.47 us`; median p99 `46.12 us`
- final checkpoint/close/reopen digest parity is asserted by the benchmark

The committed M0 capture now classifies recoverable-root and cleanup-proof staleness with concurrent mutation as typed transient retries. Production availability requires at least one successful run, only typed retry non-successes, zero unexpected errors/exposure misses, and positive overlap in every sample. A constrained 50-sample run observed one typed retry and zero unexpected errors.

Raw earlier profile artifacts: `/mnt/fast4tb/gomap-3945-evidence/0198d1d1e/`. Exact-head paired and churn command output is recorded in the execution log and summarized above.

## Platform And Scope

Windows remains explicitly unsupported and does not start the worker. Read-only and negative-interval opens also start no worker. This PR does not change `CompactStorage`; #3946 owns that policy integration.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Online index vacuum is now available through the public database API.
  * Added automatic background index vacuum for supported writable databases, with configurable scheduling and tuning.
  * Added detailed vacuum status reporting, including outcomes, retry reasons, unsupported operations, and failure counts.
  * Vacuum operations now cancel cleanly when the database closes and preserve data across subsequent writes and reopen.

* **Documentation**
  * Documented background vacuum activation, retry behavior, error handling, and shutdown semantics.

* **Tests**
  * Added coverage for vacuum scheduling, retries, cancellation, persistence, performance, and concurrent workloads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
