### PR TITLE
fix(treedb): retain stale command WAL cleanup for retry

### DIFF
--- a/TreeDB/caching/command_wal_cleanup_test.go
+++ b/TreeDB/caching/command_wal_cleanup_test.go
@@ -1,0 +1,34 @@
+package caching
+
+import (
+	"errors"
+	"testing"
+
+	backenddb "github.com/snissn/gomap/TreeDB/db"
+)
+
+func TestCachingDBCheckpointCleanupTreatsStaleProofAsRetryable(t *testing.T) {
+	database := &DB{}
+	calls := 0
+	database.SetCommandWALCheckpointCleanupHook(func(bool) error {
+		calls++
+		return backenddb.ErrDurableWALCleanupProofStale
+	})
+
+	if err := database.cleanupCommandWALCheckpoint(true); err != nil {
+		t.Fatalf("cleanupCommandWALCheckpoint error=%v, want stale proof retained for retry", err)
+	}
+	if calls != 1 {
+		t.Fatalf("cleanup hook calls=%d, want 1", calls)
+	}
+}
+
+func TestCachingDBCheckpointCleanupPropagatesUnexpectedError(t *testing.T) {
+	want := errors.New("cleanup failed")
+	database := &DB{}
+	database.SetCommandWALCheckpointCleanupHook(func(bool) error { return want })
+
+	if err := database.cleanupCommandWALCheckpoint(true); !errors.Is(err, want) {
+		t.Fatalf("cleanupCommandWALCheckpoint error=%v, want %v", err, want)
+	}
+}

--- a/TreeDB/caching/db.go
+++ b/TreeDB/caching/db.go
@@ -24772,7 +24772,18 @@ func (db *DB) cleanupCommandWALCheckpoint(sync bool) error {
 	if cleanupHook == nil {
 		return nil
 	}
-	return cleanupHook(sync)
+	if err := cleanupHook(sync); err != nil {
+		// Command-WAL cleanup is opportunistic after this checkpoint has already
+		// established its durable boundary. A concurrent append/publication can
+		// invalidate only the deletion proof; retaining the WAL is safe and a
+		// later checkpoint will recapture it. Do not turn that expected retry
+		// condition into a sticky background error.
+		if errors.Is(err, backenddb.ErrDurableWALCleanupProofStale) {
+			return nil
+		}
+		return err
+	}
+	return nil
 }
 
 func (db *DB) canPiggybackCommandWALCheckpointPublish(sync bool) bool {


### PR DESCRIPTION
Fixes #3965

## Summary

A cached checkpoint may complete its durable boundary while concurrent command-WAL append/publication invalidates only the subsequent cleanup proof. Treat the typed `ErrDurableWALCleanupProofStale` result as retryable at the caching checkpoint hook: retain the WAL for a later cleanup pass rather than recording a sticky caching background error. Other cleanup errors still propagate.

The backend stale-proof rejection is unchanged: it still rejects a proof after append or durable-root advance before deletion.

## Evidence

Pre-fix deterministic red (on this branch before the implementation):

```sh
cd TreeDB && GOWORK=off go test ./caching -run "^TestCachingDBCheckpointCleanup" -count=1
```

Failed with `durable WAL cleanup proof stale` from the stale-hook case.

Green:

```sh
cd TreeDB && GOWORK=off go test ./caching -run "^TestCachingDBCheckpointCleanup" -count=1
cd TreeDB && GOWORK=off go test -race ./caching -run "^TestCachingDBCheckpointCleanup" -count=20
cd TreeDB && GOWORK=off go test ./db -run "^(TestCommandWALCleanupRejectsSnapshotAfterAppend|TestCommandWALCleanupRejectsSnapshotAfterDurableRootAdvance|TestNormalizeCommandWALCheckpointCleanupErrorPrefersStaleOverUnavailable)$" -count=1 -v
cd TreeDB && GOWORK=off go test -race . -run "^TestPowerLossCertificationAuthoritativeResourcesPublicReopen$" -count=1
```

The focused certification passed once locally. A subsequent 3-run stress had two passes and one separate injected power-loss-cut expectation mismatch (`collectionwal: recovery required` instead of the test cut sentinel), so this PR does not claim a clean repeated certification sweep.

## Performance / risk

This is a checkpoint cleanup guardrail only: it adds no I/O, locks, scans, or hot write-path work. On a stale proof, WAL reclamation is deferred to a later checkpoint; this is the existing conservative safety outcome.

## Non-goals

No WAL format, durable-root, value-log lifecycle, or index-vacuum changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved checkpoint cleanup reliability by treating stale cleanup proofs as retryable.
  * Continued to report unexpected cleanup errors instead of suppressing them.
* **Tests**
  * Added coverage for stale-proof handling and unexpected error propagation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->