### PR TITLE
fix(treedb): reclaim command WAL after empty checkpoint

### DIFF
--- a/TreeDB/command_wal_public_cached.go
+++ b/TreeDB/command_wal_public_cached.go
@@ -433,6 +433,19 @@ func (tdb *DB) cleanupPublicCommandWALCheckpoint(sync bool) error {
 	return tdb.backend.CleanupCommandWALCoveredSegmentsAtCheckpoint(sync)
 }
 
+func (tdb *DB) refreshPublicCommandWALCheckpointFallback() error {
+	if tdb == nil || !tdb.commandWALCached || tdb.backend == nil {
+		return nil
+	}
+	tdb.commandWALPublicOperationGate.Lock()
+	defer tdb.commandWALPublicOperationGate.Unlock()
+	first, last := tdb.publicCommandWALPendingRange()
+	if first != 0 || last != 0 {
+		return nil
+	}
+	return tdb.backend.RefreshCommandWALCheckpointFallback()
+}
+
 func (tdb *DB) syncPublicCommandWAL() error {
 	return tdb.forcePublicCommandWALGroupCommit()
 }

--- a/TreeDB/command_wal_public_test.go
+++ b/TreeDB/command_wal_public_test.go
@@ -2317,6 +2317,65 @@ func TestPublicCommandWALCheckpointCleansCoveredCommandJournalSegment(t *testing
 	}
 }
 
+func TestPublicCommandWALEmptyCheckpointReclaimsCoveredBenchmarkEpochs(t *testing.T) {
+	dir := t.TempDir()
+	db, err := Open(Options{Dir: dir, Durability: DurabilityWALOnRelaxed, CommandWAL: true, CommandWALStatsScan: true, DisableSideStores: true})
+	if err != nil {
+		t.Fatalf("Open command WAL: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	for _, epoch := range []string{"first", "second"} {
+		batch := db.NewBatch()
+		for i := 0; i < 64; i++ {
+			if err := batch.Set([]byte(fmt.Sprintf("%s-%03d", epoch, i)), []byte("value")); err != nil {
+				t.Fatalf("%s batch Set: %v", epoch, err)
+			}
+		}
+		if err := batch.Write(); err != nil {
+			t.Fatalf("%s batch Write: %v", epoch, err)
+		}
+		if err := batch.Close(); err != nil {
+			t.Fatalf("%s batch Close: %v", epoch, err)
+		}
+		if err := db.Checkpoint(); err != nil {
+			t.Fatalf("%s Checkpoint: %v", epoch, err)
+		}
+	}
+	before := publicCommandWALSegmentNames(t, dir)
+	if len(before) < 2 {
+		t.Fatalf("segments after two checkpointed epochs=%v, want closed command WAL generations", before)
+	}
+	stateBefore := db.backend.State()
+	nextLSNBefore := db.backend.CommandWALNextLSN()
+	if err := db.Checkpoint(); err != nil {
+		t.Fatalf("empty post-run Checkpoint: %v", err)
+	}
+	if got := db.backend.State().AppliedCommandLSN; got != stateBefore.AppliedCommandLSN {
+		t.Fatalf("AppliedCommandLSN after empty checkpoint=%d, want unchanged %d", got, stateBefore.AppliedCommandLSN)
+	}
+	if got := db.backend.CommandWALNextLSN(); got != nextLSNBefore {
+		t.Fatalf("next command WAL LSN after empty checkpoint=%d, want unchanged %d", got, nextLSNBefore)
+	}
+	after := publicCommandWALSegmentNames(t, dir)
+	if len(after) != 1 {
+		t.Fatalf("empty checkpoint retained covered benchmark epochs: before=%v after=%v", before, after)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatalf("Close after cleanup: %v", err)
+	}
+	db, err = Open(Options{Dir: dir, Durability: DurabilityWALOnRelaxed, CommandWAL: true, CommandWALStatsScan: true, DisableSideStores: true})
+	if err != nil {
+		t.Fatalf("reopen after cleanup: %v", err)
+	}
+	for _, key := range [][]byte{[]byte("first-000"), []byte("second-000")} {
+		got, err := db.Get(key)
+		if err != nil || string(got) != "value" {
+			t.Fatalf("Get(%q)=(%q, %v), want (value, nil)", key, got, err)
+		}
+	}
+}
+
 func TestPublicCommandWALAutoCheckpointUsesCommandWALBytes(t *testing.T) {
 	dir := t.TempDir()
 	db, err := Open(Options{

--- a/TreeDB/db/command_wal_publish.go
+++ b/TreeDB/db/command_wal_publish.go
@@ -1,6 +1,7 @@
 package db
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"io"
@@ -229,6 +230,67 @@ func (db *DB) PublishCommandWALAppliedLSN(appliedLSN uint64, covered []CommandWA
 	unlockCommandWALPublish := db.lockCommandWALRawPublishWithTeardown()
 	defer unlockCommandWALPublish()
 	return db.publishCurrentCommandWALRootsTeardownPinned(appliedLSN, covered, sync)
+}
+
+// RefreshCommandWALCheckpointFallback republishes the current durable root at
+// a checkpoint only when the recovery fallback slot still names an older
+// AppliedCommandLSN. It does not append a command frame or advance the LSN.
+//
+// This is intentionally a checkpoint-maintenance seam for the cached public
+// command-WAL owner. Callers must exclude new public command frames while
+// deciding whether a refresh is needed.
+func (db *DB) RefreshCommandWALCheckpointFallback() error {
+	if db == nil || !db.commandWAL {
+		return nil
+	}
+	// Keep the predicate and same-LSN publication in the raw-publish domain.
+	// The public cached owner holds its operation gate as well, but backend
+	// command-WAL publishers do not use that gate. Holding this existing
+	// backend serialization prevents an intervening command frame from making
+	// the sampled AppliedCommandLSN stale before the fallback is refreshed.
+	unlockCommandWALPublish := db.lockCommandWALRawPublishWithTeardown()
+	defer unlockCommandWALPublish()
+	db.durablePublishMu.Lock()
+	if db.durableRoot.slot > 1 {
+		db.durablePublishMu.Unlock()
+		return fmt.Errorf("command WAL checkpoint fallback: invalid selected root slot %d", db.durableRoot.slot)
+	}
+	selected := db.durableRoot.slotRecord[db.durableRoot.slot]
+	fallback := db.durableRoot.slotRecord[db.durableRoot.slot^1]
+	state := db.state.Load()
+	needsRefresh := state != nil && state.AppliedCommandLSN != 0 &&
+		selected.AppliedCommandLSN == state.AppliedCommandLSN &&
+		fallback.AppliedCommandLSN < selected.AppliedCommandLSN
+	db.durablePublishMu.Unlock()
+	if !needsRefresh {
+		return nil
+	}
+	// Call the inner publisher while retaining the raw-publish guard above;
+	// PublishCommandWALAppliedLSN would otherwise reacquire it. This remains a
+	// same-root, same-LSN metadata publication and cannot append a WAL frame.
+	if err := db.publishCurrentCommandWALRootsTeardownPinned(state.AppliedCommandLSN, nil, true); err != nil {
+		return err
+	}
+	if runtime := db.rootPublication; runtime != nil && runtime.coordinator != nil {
+		refreshed := db.state.Load()
+		if refreshed == nil {
+			return ErrClosed
+		}
+		if err := runtime.coordinator.WaitThrough(context.Background(), refreshed.CommitSeq); err != nil {
+			return publicRootPublicationErrorV1(err)
+		}
+	}
+	db.durablePublishMu.Lock()
+	defer db.durablePublishMu.Unlock()
+	if db.durableRoot.slot > 1 {
+		return fmt.Errorf("command WAL checkpoint fallback: invalid refreshed root slot %d", db.durableRoot.slot)
+	}
+	selected = db.durableRoot.slotRecord[db.durableRoot.slot]
+	fallback = db.durableRoot.slotRecord[db.durableRoot.slot^1]
+	if selected.AppliedCommandLSN != state.AppliedCommandLSN || fallback.AppliedCommandLSN != state.AppliedCommandLSN {
+		return fmt.Errorf("command WAL checkpoint fallback refresh did not converge: selected=%d fallback=%d want=%d", selected.AppliedCommandLSN, fallback.AppliedCommandLSN, state.AppliedCommandLSN)
+	}
+	return nil
 }
 
 func validateCommandWALPublishLocked(current page.MetaPageBody, newRootID uint64, sysRootID uint64, opts finalizeCommitOptions) error {

--- a/TreeDB/db/command_wal_publish_test.go
+++ b/TreeDB/db/command_wal_publish_test.go
@@ -73,6 +73,108 @@ func TestCommandWALAppliedCommandLSNMetaFieldRoundTrip(t *testing.T) {
 	}
 }
 
+func TestRefreshCommandWALCheckpointFallbackConvergesSlotsWithoutNewLSN(t *testing.T) {
+	dir := t.TempDir()
+	enableCommandWALFormat(t, dir)
+	db, err := Open(Options{Dir: dir, CommandWAL: true, DisableBackgroundPrune: true})
+	if err != nil {
+		t.Fatalf("Open command WAL DB: %v", err)
+	}
+	defer db.Close()
+
+	state := db.State()
+	if err := db.publishCommandWALRoots(state.RootPageID, state.SystemRootPageID, 1, []CommandWALLSNRange{{First: 1, Last: 1}}, true); err != nil {
+		t.Fatalf("publish first applied LSN: %v", err)
+	}
+	if err := db.rootPublication.coordinator.WaitThrough(context.Background(), db.State().CommitSeq); err != nil {
+		t.Fatalf("wait first durable root: %v", err)
+	}
+	state = db.State()
+	if err := db.publishCommandWALRoots(state.RootPageID, state.SystemRootPageID, 2, []CommandWALLSNRange{{First: 2, Last: 2}}, true); err != nil {
+		t.Fatalf("publish second applied LSN: %v", err)
+	}
+	if err := db.rootPublication.coordinator.WaitThrough(context.Background(), db.State().CommitSeq); err != nil {
+		t.Fatalf("wait second durable root: %v", err)
+	}
+	before := db.State()
+	if before == nil || before.AppliedCommandLSN == 0 {
+		t.Fatalf("state before refresh=%+v, want applied command WAL state", before)
+	}
+	nextLSN := db.CommandWALNextLSN()
+	db.durablePublishMu.Lock()
+	selected := db.durableRoot.slotRecord[db.durableRoot.slot]
+	fallback := db.durableRoot.slotRecord[db.durableRoot.slot^1]
+	db.durablePublishMu.Unlock()
+	if fallback.AppliedCommandLSN >= selected.AppliedCommandLSN {
+		t.Fatalf("test did not create lagging fallback: selected=%d fallback=%d", selected.AppliedCommandLSN, fallback.AppliedCommandLSN)
+	}
+
+	if err := db.RefreshCommandWALCheckpointFallback(); err != nil {
+		t.Fatalf("RefreshCommandWALCheckpointFallback: %v", err)
+	}
+	if got := db.State().AppliedCommandLSN; got != before.AppliedCommandLSN {
+		t.Fatalf("AppliedCommandLSN after refresh=%d, want unchanged %d", got, before.AppliedCommandLSN)
+	}
+	if got := db.CommandWALNextLSN(); got != nextLSN {
+		t.Fatalf("next command WAL LSN after refresh=%d, want unchanged %d", got, nextLSN)
+	}
+	db.durablePublishMu.Lock()
+	selected = db.durableRoot.slotRecord[db.durableRoot.slot]
+	fallback = db.durableRoot.slotRecord[db.durableRoot.slot^1]
+	db.durablePublishMu.Unlock()
+	if selected.AppliedCommandLSN != before.AppliedCommandLSN || fallback.AppliedCommandLSN != before.AppliedCommandLSN {
+		t.Fatalf("refreshed root slots selected=%d fallback=%d, want both %d", selected.AppliedCommandLSN, fallback.AppliedCommandLSN, before.AppliedCommandLSN)
+	}
+}
+
+func TestRefreshCommandWALCheckpointFallbackPublicationFailureRetainsFallback(t *testing.T) {
+	dir := t.TempDir()
+	enableCommandWALFormat(t, dir)
+	db, err := Open(Options{Dir: dir, CommandWAL: true, DisableBackgroundPrune: true})
+	if err != nil {
+		t.Fatalf("Open command WAL DB: %v", err)
+	}
+	if err := db.SetSync([]byte("first"), []byte("one")); err != nil {
+		t.Fatalf("SetSync first: %v", err)
+	}
+	if err := db.SetSync([]byte("second"), []byte("two")); err != nil {
+		t.Fatalf("SetSync second: %v", err)
+	}
+	if err := db.rootPublication.coordinator.WaitThrough(context.Background(), db.State().CommitSeq); err != nil {
+		t.Fatalf("wait durable command roots: %v", err)
+	}
+	before := db.State()
+	db.durablePublishMu.Lock()
+	fallbackBefore := db.durableRoot.slotRecord[db.durableRoot.slot^1].AppliedCommandLSN
+	db.durablePublishMu.Unlock()
+	if fallbackBefore >= before.AppliedCommandLSN {
+		t.Fatalf("test did not create lagging fallback: applied=%d fallback=%d", before.AppliedCommandLSN, fallbackBefore)
+	}
+
+	db.testFailWriteMeta.Store(true)
+	err = db.RefreshCommandWALCheckpointFallback()
+	db.testFailWriteMeta.Store(false)
+	if !errors.Is(err, errTestWriteMetaFailpoint) {
+		t.Fatalf("RefreshCommandWALCheckpointFallback error=%v, want write-meta failpoint", err)
+	}
+	db.durablePublishMu.Lock()
+	fallbackAfter := db.durableRoot.slotRecord[db.durableRoot.slot^1].AppliedCommandLSN
+	db.durablePublishMu.Unlock()
+	if fallbackAfter != fallbackBefore {
+		t.Fatalf("failed refresh changed fallback applied LSN=%d, want %d", fallbackAfter, fallbackBefore)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatalf("Close after failed refresh: %v", err)
+	}
+	reopened, err := Open(Options{Dir: dir, CommandWAL: true, DisableBackgroundPrune: true})
+	if err != nil {
+		t.Fatalf("reopen command WAL DB: %v", err)
+	}
+	defer reopened.Close()
+	assertDBValue(t, reopened, "first", "one")
+	assertDBValue(t, reopened, "second", "two")
+}
+
 func TestCommandWALAppliedLSNOnlyPublishPreservesValueLogRefTracker(t *testing.T) {
 	dir := t.TempDir()
 	db, err := Open(Options{

--- a/TreeDB/docs/spec/write-path-and-durability.md
+++ b/TreeDB/docs/spec/write-path-and-durability.md
@@ -420,6 +420,14 @@ plus new `AppliedLSN`, never a split state. A future
 checkpoint-without-publication mode must report command WAL debt and retain all
 required WAL segments and external refs.
 
+For a cached command-WAL checkpoint with no pending public frames, maintenance
+may republish the selected roots with the same `AppliedCommandLSN` only when
+the recovery-selectable fallback slot still has an older applied LSN. It writes
+no command-WAL frame and does not advance the next LSN; it waits for the
+fallback slot to converge before covered-segment cleanup can use that proof.
+If the publication fails, cleanup remains fail-closed and the older fallback
+continues to retain the required command-WAL coverage.
+
 The authoritative `AppliedLSN` must be selected by the same backend meta choice
 as the roots whose effects it covers. The V1 storage target is the
 in-page-marked meta-page field `AppliedCommandLSN`; the meta write must select

--- a/TreeDB/public.go
+++ b/TreeDB/public.go
@@ -2496,6 +2496,9 @@ func (db *DB) checkpointCachedForPublicCommandWAL() error {
 		return err
 	}
 	if db.commandWALCached && db.backend != nil {
+		if err := db.refreshPublicCommandWALCheckpointFallback(); err != nil {
+			return err
+		}
 		if err := db.backend.CleanupCommandWALCoveredSegmentsAtCheckpoint(true); err != nil {
 			return err
 		}


### PR DESCRIPTION
## Summary

- On a cached public command-WAL checkpoint with no pending public frames, refresh the recovery fallback root only when its `AppliedCommandLSN` lags the selected root.
- Republish the same roots and same applied LSN, wait for both recovery-selectable slots to converge, then use the existing exact cleanup proof.
- Keep the maintenance predicate inside both public-operation and backend raw-publish serialization; do not add a command frame or advance the next LSN.

Closes #3853

## Correctness

- Public two-epoch plus empty-checkpoint regression verifies covered command-WAL generations are reclaimed, applied/next LSNs are unchanged, and both epochs survive close/reopen.
- Backend test asserts direct fallback-slot convergence and no new LSN.
- Injected metadata-publication failure leaves the fallback unchanged and reopens safely; cleanup is not reached when refresh errors.
- No value-log retention or pruning behavior changed.

## Storage evidence

Exact reproduction on this branch:

```sh
GOWORK=off go build -o /tmp/gomap-3853-unified-bench-fixed ./cmd/unified_bench
/tmp/gomap-3853-unified-bench-fixed -dbs treedb -keys 100000 -profile wal_on_fast -checkpoint-between-tests -test sequential_write,random_write
```

The final TreeDB command-WAL footprint is `total=11 B files=2 other=11 B`; the clean-main baseline for the same reproduction was `total=22 MiB files=3 commit=22 MiB other=11 B`.

## Validation

```sh
GOWORK=off go test ./TreeDB -run "^(TestPublicCommandWALEmptyCheckpointReclaimsCoveredBenchmarkEpochs|TestPublicCommandWALCheckpointCleansCoveredCommandJournalSegment|TestPublicCommandWALCheckpointPostFrontierGenerationSurvivesCrashReopen)$" -count=1
GOWORK=off go test ./TreeDB/db -run "^(TestRefreshCommandWALCheckpointFallbackConvergesSlotsWithoutNewLSN|TestRefreshCommandWALCheckpointFallbackPublicationFailureRetainsFallback|TestCommandWALCheckpointEstablishesDurableCleanupProof|TestCommandWALCheckpointCleanupDeletesOnlyCoveredSegments|TestCommandWALCleanup.*)$" -count=1
GOWORK=off go test -race ./TreeDB -run "^TestPublicCommandWALEmptyCheckpointReclaimsCoveredBenchmarkEpochs$" -count=1
GOWORK=off go test -race ./TreeDB/db -run "^(TestRefreshCommandWALCheckpointFallbackConvergesSlotsWithoutNewLSN|TestRefreshCommandWALCheckpointFallbackPublicationFailureRetainsFallback)$" -count=1
```

The ordinary write path is unchanged. A conditional, empty post-run checkpoint now pays one same-root metadata/root publication only when the fallback lags; this is intentionally not a hot-path performance change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cached command-WAL checkpoint handling when no new changes are pending.
  * Ensured durable checkpoint state is refreshed before cleanup, allowing obsolete WAL segments to be safely reclaimed.
  * Preserved data availability and WAL coverage when checkpoint publication encounters an error.

* **Documentation**
  * Clarified checkpoint maintenance and durability behavior for cached command-WAL mode.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->