### PR TITLE
fix(treedb): normalize stale cleanup at backend boundary

### DIFF
--- a/TreeDB/caching/command_wal_cleanup_test.go
+++ b/TreeDB/caching/command_wal_cleanup_test.go
@@ -7,6 +7,42 @@ import (
 	backenddb "github.com/snissn/gomap/TreeDB/db"
 )
 
+type checkpointBoundaryBackend struct {
+	BackendDB
+	err   error
+	calls int
+}
+
+func (b *checkpointBoundaryBackend) Checkpoint() error {
+	b.calls++
+	return b.err
+}
+
+func TestBackendSyncBoundaryTreatsStaleCleanupProofAsRetryable(t *testing.T) {
+	backend := &checkpointBoundaryBackend{
+		err: errors.Join(
+			backenddb.ErrDurableWALCleanupProofStale,
+			errors.New("command WAL cleanup snapshot stale"),
+		),
+	}
+
+	if err := backendSyncBoundary(backend); err != nil {
+		t.Fatalf("backendSyncBoundary error=%v, want durable checkpoint success with cleanup retained", err)
+	}
+	if backend.calls != 1 {
+		t.Fatalf("checkpoint calls=%d, want 1", backend.calls)
+	}
+}
+
+func TestBackendSyncBoundaryPropagatesUnexpectedCheckpointError(t *testing.T) {
+	want := errors.New("checkpoint failed")
+	backend := &checkpointBoundaryBackend{err: want}
+
+	if err := backendSyncBoundary(backend); !errors.Is(err, want) {
+		t.Fatalf("backendSyncBoundary error=%v, want %v", err, want)
+	}
+}
+
 func TestCachingDBCheckpointCleanupTreatsStaleProofAsRetryable(t *testing.T) {
 	database := &DB{}
 	calls := 0

--- a/TreeDB/caching/db.go
+++ b/TreeDB/caching/db.go
@@ -8175,7 +8175,15 @@ func backendSyncBoundary(backend BackendDB) error {
 		return errors.New("cachingdb: missing backend")
 	}
 	if checkpointer, ok := backend.(backendCheckpointer); ok {
-		return checkpointer.Checkpoint()
+		err := checkpointer.Checkpoint()
+		// Backend checkpointing establishes the durable boundary before it
+		// attempts command-WAL cleanup. A concurrent append can invalidate only
+		// that cleanup proof; the retained WAL is safe and a later checkpoint
+		// can retry reclamation.
+		if errors.Is(err, backenddb.ErrDurableWALCleanupProofStale) {
+			return nil
+		}
+		return err
 	}
 	b := backend.NewBatch()
 	if b == nil {


### PR DESCRIPTION
## Summary

- treat `ErrDurableWALCleanupProofStale` as a successful durable boundary when it is returned directly by the backend `Checkpoint()` path
- retain the command WAL for later cleanup retry while preserving propagation of all unexpected checkpoint errors
- add deterministic boundary tests for the typed stale sentinel and unexpected errors

## Root cause

PR #3966 normalized the later caching cleanup hook, but the exact-merge main run reproduced the failure because `backendSyncBoundary` can return earlier from `backend.Checkpoint()`. Backend checkpointing establishes durability before opportunistic command-WAL cleanup; a concurrent append can invalidate only that cleanup proof. The stale sentinel then escaped into the caching background-error channel before the later cleanup hook was reached.

Post-merge evidence: https://github.com/snissn/gomap/actions/runs/30035369558, `race-check (linux)-2`, artifact lines 28888-28891.

## Validation

- `GOWORK=off go test ./caching -run "^(TestBackendSyncBoundary|TestCachingDBCheckpointCleanup)" -count=1`
- `GOWORK=off go test -race ./caching -run "^(TestBackendSyncBoundary|TestCachingDBCheckpointCleanup)" -count=20`
- `GOWORK=off go test -race . -run "^TestPowerLossCertificationAuthoritativeResourcesPublicReopen$" -count=3`
- `GOWORK=off go test ./caching -count=1`
- `git diff --check`

## Performance

This adds one typed `errors.Is` classification only after a backend checkpoint returns an error. It adds no successful-path I/O, locking, scans, allocations, or hot write-path work.

Fixes #3965

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved backend checkpoint handling so stale cleanup proof conditions no longer interrupt operations.
  * Unexpected checkpoint errors continue to be reported normally.
* **Tests**
  * Added coverage for retryable stale cleanup conditions and unexpected checkpoint failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->