### PR TITLE
perf(treedb): compact empty command WAL debt

### DIFF
--- a/TreeDB/caching/db.go
+++ b/TreeDB/caching/db.go
@@ -8374,7 +8374,7 @@ type Options struct {
 	// WALMaxSegmentBytes caps the size of a single WAL segment payload.
 	// 0 uses the default limit.
 	WALMaxSegmentBytes int64
-	// JournalCompression enables best-effort zstd compression for journal/commitlog
+	// JournalCompression enables best-effort zstd compression for generic journal/commitlog
 	// segments (metadata only). The writer only keeps compressed bytes when they
 	// are smaller than the raw payload, so compression never causes size
 	// amplification.

--- a/TreeDB/db/command_wal_debt.go
+++ b/TreeDB/db/command_wal_debt.go
@@ -44,6 +44,10 @@ type commandWALDependencyDebtEntry struct {
 	lastLSN       uint64
 	resources     []*rootpublication.StableResourceSet
 	rotationFiles []*rootpublication.StableResourceToken
+	// createdAt remains the original physical-range creation time if a
+	// coalesced empty range is partially trimmed. Reported max age is therefore
+	// conservative physical-range age, rather than the age of only its
+	// remaining LSNs.
 	createdAt     time.Time
 	// retriesPerLSN is uniform across this entry's inclusive LSN range. Empty
 	// ranges are split at retry frontiers so partial release preserves exact

--- a/TreeDB/db/command_wal_debt.go
+++ b/TreeDB/db/command_wal_debt.go
@@ -48,7 +48,7 @@ type commandWALDependencyDebtEntry struct {
 	// coalesced empty range is partially trimmed. Reported max age is therefore
 	// conservative physical-range age, rather than the age of only its
 	// remaining LSNs.
-	createdAt     time.Time
+	createdAt time.Time
 	// retriesPerLSN is uniform across this entry's inclusive LSN range. Empty
 	// ranges are split at retry frontiers so partial release preserves exact
 	// logical retry accounting without retaining one entry per relaxed command.

--- a/TreeDB/db/command_wal_debt.go
+++ b/TreeDB/db/command_wal_debt.go
@@ -29,7 +29,11 @@ func (debt *CommandWALDependencyDebt) entryCountThrough(lsn uint64) uint64 {
 		if entry.firstLSN > lsn {
 			break
 		}
-		count++
+		last := entry.lastLSN
+		if last > lsn {
+			last = lsn
+		}
+		count += last - entry.firstLSN + 1
 	}
 	debt.mu.Unlock()
 	return count
@@ -41,7 +45,10 @@ type commandWALDependencyDebtEntry struct {
 	resources     []*rootpublication.StableResourceSet
 	rotationFiles []*rootpublication.StableResourceToken
 	createdAt     time.Time
-	retries       uint64
+	// retriesPerLSN is uniform across this entry's inclusive LSN range. Empty
+	// ranges are split at retry frontiers so partial release preserves exact
+	// logical retry accounting without retaining one entry per relaxed command.
+	retriesPerLSN uint64
 }
 
 func (debt *CommandWALDependencyDebt) add(lsn uint64, rotationFiles []*rootpublication.StableResourceToken, resources ...*rootpublication.StableResourceSet) error {
@@ -58,6 +65,20 @@ func (debt *CommandWALDependencyDebt) add(lsn uint64, rotationFiles []*rootpubli
 	defer debt.mu.Unlock()
 	if n := len(debt.entries); n != 0 && lsn <= debt.entries[n-1].lastLSN {
 		return fmt.Errorf("treedb: command WAL dependency debt LSN %d is not after %d", lsn, debt.entries[n-1].lastLSN)
+	}
+	// Most relaxed point commands carry no external physical dependency and do
+	// not rotate the command journal. Keep their exact LSN coverage, but merge
+	// adjacent empty records instead of retaining one heap entry per write until
+	// the next durable boundary. Dependency-bearing entries must remain separate
+	// because their resource/token ownership and retry accounting are exact.
+	if len(owned) == 0 && len(rotationFiles) == 0 {
+		if n := len(debt.entries); n != 0 {
+			previous := &debt.entries[n-1]
+			if len(previous.resources) == 0 && len(previous.rotationFiles) == 0 && previous.retriesPerLSN == 0 && previous.lastLSN+1 == lsn {
+				previous.lastLSN = lsn
+				return nil
+			}
+		}
 	}
 	debt.entries = append(debt.entries, commandWALDependencyDebtEntry{
 		firstLSN: lsn, lastLSN: lsn, resources: append([]*rootpublication.StableResourceSet(nil), owned...),
@@ -245,11 +266,33 @@ func (debt *CommandWALDependencyDebt) noteRetryThrough(lsn uint64) {
 	}
 	debt.mu.Lock()
 	defer debt.mu.Unlock()
-	for i := range debt.entries {
+	for i := 0; i < len(debt.entries); i++ {
 		if debt.entries[i].firstLSN > lsn {
 			break
 		}
-		debt.entries[i].retries++
+		if lsn < debt.entries[i].lastLSN && len(debt.entries[i].resources) == 0 && len(debt.entries[i].rotationFiles) == 0 {
+			// Retry accounting is per logical command. Split an empty coalesced
+			// range at the retry frontier before incrementing so a later partial
+			// release drops exactly the retry counts it covered.
+			tail := debt.entries[i]
+			tail.firstLSN = lsn + 1
+			// The range may already have previous retry attempts. Both halves
+			// retain that uniform per-LSN history; the covered prefix receives
+			// one additional retry below.
+			tail.retriesPerLSN = debt.entries[i].retriesPerLSN
+			debt.entries[i].lastLSN = lsn
+			debt.entries = append(debt.entries, commandWALDependencyDebtEntry{})
+			copy(debt.entries[i+2:], debt.entries[i+1:])
+			debt.entries[i+1] = tail
+		}
+		last := debt.entries[i].lastLSN
+		if last > lsn {
+			last = lsn
+		}
+		debt.entries[i].retriesPerLSN++
+		if last == lsn {
+			break
+		}
 	}
 }
 
@@ -262,10 +305,6 @@ func (debt *CommandWALDependencyDebt) releaseThrough(lsn uint64) {
 	for cut < len(debt.entries) && debt.entries[cut].lastLSN <= lsn {
 		cut++
 	}
-	if cut == 0 {
-		debt.mu.Unlock()
-		return
-	}
 	physical := false
 	for i := 0; i < cut; i++ {
 		if len(debt.entries[i].resources) != 0 || len(debt.entries[i].rotationFiles) != 0 {
@@ -273,17 +312,28 @@ func (debt *CommandWALDependencyDebt) releaseThrough(lsn uint64) {
 			break
 		}
 	}
-	if !physical {
+	if cut != 0 && !physical {
 		copy(debt.entries, debt.entries[cut:])
 		clear(debt.entries[len(debt.entries)-cut:])
 		debt.entries = debt.entries[:len(debt.entries)-cut]
-		debt.mu.Unlock()
-		return
 	}
-	released := append([]commandWALDependencyDebtEntry(nil), debt.entries[:cut]...)
-	copy(debt.entries, debt.entries[cut:])
-	clear(debt.entries[len(debt.entries)-cut:])
-	debt.entries = debt.entries[:len(debt.entries)-cut]
+	var released []commandWALDependencyDebtEntry
+	if cut != 0 && physical {
+		released = append([]commandWALDependencyDebtEntry(nil), debt.entries[:cut]...)
+		copy(debt.entries, debt.entries[cut:])
+		clear(debt.entries[len(debt.entries)-cut:])
+		debt.entries = debt.entries[:len(debt.entries)-cut]
+	}
+	// A coalesced empty range has no resource ownership to split. Trim the
+	// already-covered prefix so a later append can continue from the remaining
+	// exact LSN frontier. Never split a resource-bearing entry: its ownership is
+	// deliberately indivisible until the entire entry is covered.
+	if len(debt.entries) != 0 {
+		entry := &debt.entries[0]
+		if entry.firstLSN <= lsn && lsn < entry.lastLSN && len(entry.resources) == 0 && len(entry.rotationFiles) == 0 {
+			entry.firstLSN = lsn + 1
+		}
+	}
 	debt.mu.Unlock()
 	for _, entry := range released {
 		for _, resource := range entry.resources {
@@ -326,10 +376,11 @@ func (debt *CommandWALDependencyDebt) stats(now time.Time) commandWALDependencyD
 	}
 	debt.mu.Lock()
 	sets := make([]*rootpublication.StableResourceSet, 0)
-	stats := commandWALDependencyDebtStats{entries: uint64(len(debt.entries))}
+	stats := commandWALDependencyDebtStats{}
 	for _, entry := range debt.entries {
+		stats.entries += entry.lastLSN - entry.firstLSN + 1
 		sets = append(sets, entry.resources...)
-		stats.retries += entry.retries
+		stats.retries += (entry.lastLSN - entry.firstLSN + 1) * entry.retriesPerLSN
 		if age := now.Sub(entry.createdAt); age > stats.oldest {
 			stats.oldest = age
 		}

--- a/TreeDB/db/command_wal_debt_test.go
+++ b/TreeDB/db/command_wal_debt_test.go
@@ -1,0 +1,150 @@
+package db
+
+import (
+	"testing"
+	"time"
+
+	"github.com/snissn/gomap/TreeDB/internal/rootpublication"
+)
+
+func TestCommandWALDependencyDebtCoalescesOnlyAdjacentEmptyEntries(t *testing.T) {
+	var debt CommandWALDependencyDebt
+	for _, lsn := range []uint64{1, 2, 3} {
+		if err := debt.add(lsn, nil); err != nil {
+			t.Fatalf("add empty LSN %d: %v", lsn, err)
+		}
+	}
+	debt.mu.Lock()
+	if got := len(debt.entries); got != 1 {
+		debt.mu.Unlock()
+		t.Fatalf("physical empty debt entries=%d, want 1", got)
+	}
+	if got := debt.entries[0]; got.firstLSN != 1 || got.lastLSN != 3 {
+		debt.mu.Unlock()
+		t.Fatalf("coalesced range=%d..%d, want 1..3", got.firstLSN, got.lastLSN)
+	}
+	debt.mu.Unlock()
+	if got := debt.entryCountThrough(2); got != 2 {
+		t.Fatalf("logical entries through 2=%d, want 2", got)
+	}
+	debt.noteRetryThrough(2)
+	stats := debt.stats(time.Now())
+	if got := stats.entries; got != 3 {
+		t.Fatalf("stats logical entries=%d, want 3", got)
+	}
+	if got := stats.retries; got != 2 {
+		t.Fatalf("stats logical retries=%d, want 2", got)
+	}
+	debt.releaseThrough(2)
+	debt.mu.Lock()
+	if got := debt.entries[0]; got.firstLSN != 3 || got.lastLSN != 3 {
+		debt.mu.Unlock()
+		t.Fatalf("partial release range=%d..%d, want 3..3", got.firstLSN, got.lastLSN)
+	}
+	debt.mu.Unlock()
+	stats = debt.stats(time.Now())
+	if got := stats.retries; got != 0 {
+		t.Fatalf("remaining retries after partial release=%d, want 0", got)
+	}
+	if err := debt.add(4, nil); err != nil {
+		t.Fatalf("add after partial release: %v", err)
+	}
+	debt.mu.Lock()
+	if got := debt.entries[0]; got.firstLSN != 3 || got.lastLSN != 4 {
+		debt.mu.Unlock()
+		t.Fatalf("post-release coalesced range=%d..%d, want 3..4", got.firstLSN, got.lastLSN)
+	}
+	debt.mu.Unlock()
+	debt.releaseThrough(4)
+	if got := debt.entryCountThrough(4); got != 0 {
+		t.Fatalf("logical entries after full release=%d, want 0", got)
+	}
+}
+
+func TestCommandWALDependencyDebtPartialReleaseDoesNotSplitPhysicalEntry(t *testing.T) {
+	debt := CommandWALDependencyDebt{entries: []commandWALDependencyDebtEntry{{
+		firstLSN:  10,
+		lastLSN:   12,
+		resources: []*rootpublication.StableResourceSet{{}},
+	}}}
+	debt.releaseThrough(11)
+	debt.mu.Lock()
+	defer debt.mu.Unlock()
+	if got := debt.entries; len(got) != 1 || got[0].firstLSN != 10 || got[0].lastLSN != 12 {
+		t.Fatalf("partial release split physical entry: %+v, want unchanged 10..12", got)
+	}
+}
+
+func TestCommandWALDependencyDebtAddAfterRetryStartsFreshRange(t *testing.T) {
+	var debt CommandWALDependencyDebt
+	for _, lsn := range []uint64{1, 2} {
+		if err := debt.add(lsn, nil); err != nil {
+			t.Fatalf("add LSN %d: %v", lsn, err)
+		}
+	}
+	debt.noteRetryThrough(2)
+	if err := debt.add(3, nil); err != nil {
+		t.Fatalf("add after retry: %v", err)
+	}
+	debt.mu.Lock()
+	if got := debt.entries; len(got) != 2 || got[0].firstLSN != 1 || got[0].lastLSN != 2 || got[0].retriesPerLSN != 1 || got[1].firstLSN != 3 || got[1].lastLSN != 3 || got[1].retriesPerLSN != 0 {
+		debt.mu.Unlock()
+		t.Fatalf("entries after retry then add=%+v, want retry range 1..2 plus fresh 3", got)
+	}
+	debt.mu.Unlock()
+	debt.noteRetryThrough(2)
+	debt.releaseThrough(2)
+	stats := debt.stats(time.Now())
+	if got := stats.entries; got != 1 {
+		t.Fatalf("remaining logical entries=%d, want 1", got)
+	}
+	if got := stats.retries; got != 0 {
+		t.Fatalf("remaining logical retries=%d, want 0", got)
+	}
+	if err := debt.add(4, nil); err != nil {
+		t.Fatalf("add after partial retry/release: %v", err)
+	}
+	debt.mu.Lock()
+	defer debt.mu.Unlock()
+	if got := debt.entries; len(got) != 1 || got[0].firstLSN != 3 || got[0].lastLSN != 4 || got[0].retriesPerLSN != 0 {
+		t.Fatalf("fresh tail after partial retry/release=%+v, want retry-free 3..4", got)
+	}
+}
+
+func TestCommandWALDependencyDebtNestedRetryAndPartialReleaseAccounting(t *testing.T) {
+	var debt CommandWALDependencyDebt
+	for lsn := uint64(1); lsn <= 5; lsn++ {
+		if err := debt.add(lsn, nil); err != nil {
+			t.Fatalf("add LSN %d: %v", lsn, err)
+		}
+	}
+	debt.noteRetryThrough(3) // retries: 1,1,1,0,0
+	debt.noteRetryThrough(2) // retries: 2,2,1,0,0
+	if got := debt.stats(time.Now()).retries; got != 5 {
+		t.Fatalf("nested retry total=%d, want 5", got)
+	}
+	debt.releaseThrough(1) // retries: 2,1,0,0
+	if got := debt.stats(time.Now()).retries; got != 3 {
+		t.Fatalf("retry total after release through 1=%d, want 3", got)
+	}
+	debt.releaseThrough(2) // retries: 1,0,0
+	if got := debt.stats(time.Now()).retries; got != 1 {
+		t.Fatalf("retry total after release through 2=%d, want 1", got)
+	}
+	debt.mu.Lock()
+	defer debt.mu.Unlock()
+	if got := debt.entries; len(got) != 2 || got[0].firstLSN != 3 || got[0].lastLSN != 3 || got[0].retriesPerLSN != 1 || got[1].firstLSN != 4 || got[1].lastLSN != 5 || got[1].retriesPerLSN != 0 {
+		t.Fatalf("nested retry ranges=%+v, want retried 3 plus clean 4..5", got)
+	}
+}
+
+func BenchmarkCommandWALDependencyDebtAddEmpty(b *testing.B) {
+	var debt CommandWALDependencyDebt
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if err := debt.add(uint64(i+1), nil); err != nil {
+			b.Fatal(err)
+		}
+	}
+}

--- a/TreeDB/db/db.go
+++ b/TreeDB/db/db.go
@@ -1431,7 +1431,7 @@ type Options struct {
 	// WALMaxSegmentBytes, which remains a per-frame payload cap. 0 disables
 	// runtime command-WAL rotation.
 	CommandWALSegmentTargetBytes int64
-	// JournalCompression enables best-effort zstd compression for cached-mode
+	// JournalCompression enables best-effort zstd compression for generic cached-mode
 	// journal/commitlog segments (metadata only).
 	//
 	// The redo log will only keep compressed bytes when they are smaller than the

--- a/TreeDB/docs/spec/concurrency-paradigms.md
+++ b/TreeDB/docs/spec/concurrency-paradigms.md
@@ -404,7 +404,7 @@ Notes:
 | --- | --- |
 | `Options.JournalLanes` | Number of active WAL/vlog lanes (partition factor for append paths). |
 | `Options.WALMaxSegmentBytes` | Segment rotation pressure; changes append/rotation cadence. |
-| `Options.JournalCompression` | WAL write CPU/IO tradeoff; may shift worker bottlenecks. |
+| `Options.JournalCompression` | Generic journal/commitlog CPU/IO tradeoff; strict V2 command-WAL frames remain raw and are not compressed. |
 | `Options.ValueLog.PointerThreshold` | Changes fraction of writes routed through value-log workers. |
 | `Options.ValueLog.ForcePointers` | Forces value-log path for all puts; increases vlog lane pressure. |
 

--- a/TreeDB/docs/spec/write-path-and-durability.md
+++ b/TreeDB/docs/spec/write-path-and-durability.md
@@ -234,6 +234,14 @@ replay for old raw record batches after `command_wal_v2` activation. Complete
 command frames whose dependencies or external refs are missing fail recovery
 closed unless the command kind defines a formal idempotent skip rule.
 
+`Options.JournalCompression` is not command-frame compression. Strict V2
+command frames remain raw length/CRC-bounded segment records even when generic
+commitlog compression is requested, so torn-tail inspection can classify the
+frame identity, LSN, and durability class before replay. A compressed command
+WAL therefore requires a dedicated payload-aware format and recovery proof;
+turning on generic segment compression is intentionally rejected by strict V2
+readers and is not a write-throughput optimization.
+
 Command-WAL collection writes add a stronger visibility boundary for command kinds
 that are `WAL-supported`: no collection read, scan, uniqueness check,
 update/delete planner, or pending-state merge may observe a mutation before its

--- a/cmd/unified_bench/adapter_treedb.go
+++ b/cmd/unified_bench/adapter_treedb.go
@@ -64,7 +64,7 @@ var (
 	treedbLeafPageReadCacheWriteAdmission = flag.String("treedb-leaf-page-read-cache-write-admission", "immediate", "TreeDB: write-side outer-leaf read-cache admission policy (immediate|adaptive)")
 	treedbChunkSize                       = flag.Int64("treedb-chunk-size", defaultTreeDBChunkSizeBytes, "TreeDB: pager chunk size in bytes (default 256KiB)")
 	treedbJournalLanes                    = flag.Int("treedb-journal-lanes", 0, "TreeDB: journal/value-log lane count (0=coalescing-safe auto; explicit values override)")
-	treedbJournalCompress                 = flag.Bool("treedb-journal-compress", false, "TreeDB: compress journal/commitlog segments (zstd)")
+	treedbJournalCompress                 = flag.Bool("treedb-journal-compress", false, "TreeDB: request generic journal compression; strict command-WAL V2 frames remain raw")
 	treedbKeepRecent                      = flag.Uint64("treedb-keep-recent", 0, "TreeDB: KeepRecent commit versions to retain before page reuse (0=default; cached defaults to 1)")
 	treedbMaxQueuedMems                   = flag.Int("treedb-max-queued-memtables", 0, "TreeDB (cached): max queued immutable memtables before backpressure flush (0=default, <0=disable)")
 	treedbSlowdownBacklogSeconds          = flag.Float64("treedb-slowdown-backlog-seconds", 1, "TreeDB (cached): begin writer backpressure when queued flush backlog exceeds this many seconds (0=disabled)")

--- a/docs/benchmarks/treedb_issue3852_wal_on_fast_closeout_2026-07-23.md
+++ b/docs/benchmarks/treedb_issue3852_wal_on_fast_closeout_2026-07-23.md
@@ -11,12 +11,13 @@ The baseline was `origin/main` at
 `11b95c696e0594ba8aed17634d09cb7aa24dfdd7`. The candidate was built from the
 #3852 change. Each database was run twice in alternating TreeDB/LevelDB order
 on the same host (Intel Core i5-11400F, six physical cores, `GOMAXPROCS=12`).
-The profile is `command_wal_relaxed` (`wal_on_relaxed`) with
-`read_integrity=verify`.
+The unified-bench profile is `wal_on_fast`, which selects TreeDB's
+`command_wal_relaxed` mode with `read_integrity=verify`.
 
 ```sh
-TMPDIR=/mnt/fast4tb/tmp BIN=/path/to/unified-bench \
-  -dbs treedb|leveldb -keys 500000 -profile wal_on_fast \
+BIN=/path/to/unified-bench
+TMPDIR=/mnt/fast4tb/tmp "$BIN" -dbs treedb|leveldb -keys 500000 \
+  -profile wal_on_fast \
   -checkpoint-between-tests -test sequential_write,random_write \
   -profile-dir <artifact-dir>
 ```
@@ -90,6 +91,5 @@ GOWORK=off go test ./TreeDB/db -run '^TestCommandWALDependencyDebt' -count=1
 GOWORK=off go test -race ./TreeDB/db -run '^TestCommandWALDependencyDebt' -count=1
 GOWORK=off go test ./TreeDB/internal/commitlog -run '^(TestCommandFrameV2RejectsCompressedSegmentStorage|TestCommandJournalV2CompressionOptionWritesStrictlyReopenableRawFrames|TestCommandJournal.*)' -count=1
 GOWORK=off go test ./TreeDB -run '^(TestPublicCommandWALCheckpointCleansCoveredCommandJournalSegment|TestPublicCommandWALEmptyCheckpointReclaimsCoveredBenchmarkEpochs|TestPublicCommandWALGroupCommitFastRelaxedPublicationsOverlapWithoutCoordinator)$' -count=1
-GOWORK=off go test ./cmd/unified_bench -run '^TestApplyProfile_WALOnFast' -count=1
+GOWORK=off go test ./cmd/unified_bench -run '^TestApplyProfile_FastAndWALOnFastEnableIndexOptimizations$' -count=1
 ```
-

--- a/docs/benchmarks/treedb_issue3852_wal_on_fast_closeout_2026-07-23.md
+++ b/docs/benchmarks/treedb_issue3852_wal_on_fast_closeout_2026-07-23.md
@@ -16,10 +16,14 @@ The unified-bench profile is `wal_on_fast`, which selects TreeDB's
 
 ```sh
 BIN=/path/to/unified-bench
-TMPDIR=/mnt/fast4tb/tmp "$BIN" -dbs treedb|leveldb -keys 500000 \
+TMPDIR=/mnt/fast4tb/tmp "$BIN" -dbs treedb -keys 500000 \
   -profile wal_on_fast \
   -checkpoint-between-tests -test sequential_write,random_write \
-  -profile-dir <artifact-dir>
+  -profile-dir <treedb-artifact-dir>
+TMPDIR=/mnt/fast4tb/tmp "$BIN" -dbs leveldb -keys 500000 \
+  -profile wal_on_fast \
+  -checkpoint-between-tests -test sequential_write,random_write \
+  -profile-dir <leveldb-artifact-dir>
 ```
 
 The full alternating matrix below is retained because this workload is subject

--- a/docs/benchmarks/treedb_issue3852_wal_on_fast_closeout_2026-07-23.md
+++ b/docs/benchmarks/treedb_issue3852_wal_on_fast_closeout_2026-07-23.md
@@ -1,0 +1,95 @@
+# TreeDB #3852 `wal_on_fast` write-path closeout
+
+This report records the benchmark evidence and deliberately narrow disposition
+for #3852. The implementation coalesces retry-free, empty command-WAL
+dependency debt into logical LSN ranges; it does not change the command-WAL
+format or checkpoint protocol.
+
+## Method
+
+The baseline was `origin/main` at
+`11b95c696e0594ba8aed17634d09cb7aa24dfdd7`. The candidate was built from the
+#3852 change. Each database was run twice in alternating TreeDB/LevelDB order
+on the same host (Intel Core i5-11400F, six physical cores, `GOMAXPROCS=12`).
+The profile is `command_wal_relaxed` (`wal_on_relaxed`) with
+`read_integrity=verify`.
+
+```sh
+TMPDIR=/mnt/fast4tb/tmp BIN=/path/to/unified-bench \
+  -dbs treedb|leveldb -keys 500000 -profile wal_on_fast \
+  -checkpoint-between-tests -test sequential_write,random_write \
+  -profile-dir <artifact-dir>
+```
+
+The full alternating matrix below is retained because this workload is subject
+to host-level variation; it is directional evidence, not a statistical
+certification.
+
+## Alternating matrix
+
+All figures are operations/second. Ratios are TreeDB divided by LevelDB.
+
+| Build and order | TreeDB sequential | LevelDB sequential | Sequential ratio | TreeDB random | LevelDB random | Random ratio |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: |
+| Baseline, TreeDB-A / LevelDB-A | 333,150 | 557,600 | 59.75% | 334,536 | 299,610 | 111.66% |
+| Baseline, TreeDB-B / LevelDB-B | 330,731 | 565,365 | 58.50% | 329,318 | 301,220 | 109.33% |
+| #3852, TreeDB-A / LevelDB-A | 349,421 | 540,146 | 64.69% | 332,902 | 282,722 | 117.75% |
+| #3852, LevelDB-B / TreeDB-B | 356,928 | 517,747 | 68.94% | 334,618 | 311,040 | 107.58% |
+
+The mean TreeDB sequential result rose from 331,941 to 353,175 operations/s
+(+6.4%). The normalized sequential mean rose from 59.1% to 66.8% (+7.7
+percentage points, +13.1% relative). TreeDB random writes were effectively
+flat, from 331,927 to 333,760 operations/s (+0.6%), while remaining ahead of
+LevelDB in every run. LevelDB's sequential mean varied from 561,483 to
+528,947 operations/s, so absolute cross-build comparator changes are treated
+as host noise rather than attributed to #3852.
+
+## Allocation attribution and disposition
+
+The baseline sequential-write allocation profile contained 531.69 MB total;
+`CommandWALDependencyDebt.add` accounted for 237.09 MB (44.59%). The same
+profile also attributed 119.01 MB cumulatively to payload encoding, including
+53.50 MB in `writeRawKVBatchPayloadTo`. Its CPU profile showed
+`setDirectAfterCommandWALAppendWithPreparedRevision` at 85.80% cumulative and
+commitlog journal append at 25.44% cumulative.
+
+After #3852, the sequential-write allocation profile was 301.00 MB total and
+no longer listed `CommandWALDependencyDebt.add`: a 43.4% total-allocation
+reduction. The focused debt benchmark also measured 15.35--15.53 ns/op with
+0 B/op and 0 allocs/op across three runs. This supports the scoped conclusion:
+eliminating one physical debt entry per ordinary relaxed command improves the
+write path without a material random-write regression.
+
+## Compressed-WAL disposition
+
+Generic `Options.JournalCompression` is not a candidate fix for this strict
+V2 command-WAL workload. V2 frame reads reject compressed segment storage
+(`ErrCommandWALV2CompressedRecordUnsupported`), while V2 writers deliberately
+use raw, checksummed segments so tail inspection can establish frame identity,
+LSN, and durability class. Existing coverage includes
+`TestCommandFrameV2RejectsCompressedSegmentStorage` and
+`TestCommandJournalV2CompressionOptionWritesStrictlyReopenableRawFrames`.
+
+A compressed command WAL would require a dedicated payload-aware format and
+new replay, corruption/torn-tail, reopen, storage, and CPU validation. It was
+therefore explicitly out of scope for #3852 rather than silently benchmarked
+through the generic compression switch.
+
+## Residuals and validation
+
+TreeDB's pre-random checkpoint was about 227--252 ms both before and after the
+change. Its post-run checkpoint remained about 6.7--7.0 s, versus about
+1.2--1.3 s for LevelDB. That residual checkpoint gap is not addressed by this
+write-path-only change.
+
+The benchmark retained TreeDB's post-cleanup storage shape (`maindb/wal`: 11 B
+across two files; index: 4 MiB; leaf value log: 16 MiB). Focused validation:
+
+```sh
+GOWORK=off go test ./TreeDB/db -run '^TestCommandWALDependencyDebt' -count=1
+GOWORK=off go test -race ./TreeDB/db -run '^TestCommandWALDependencyDebt' -count=1
+GOWORK=off go test ./TreeDB/internal/commitlog -run '^(TestCommandFrameV2RejectsCompressedSegmentStorage|TestCommandJournalV2CompressionOptionWritesStrictlyReopenableRawFrames|TestCommandJournal.*)' -count=1
+GOWORK=off go test ./TreeDB -run '^(TestPublicCommandWALCheckpointCleansCoveredCommandJournalSegment|TestPublicCommandWALEmptyCheckpointReclaimsCoveredBenchmarkEpochs|TestPublicCommandWALGroupCommitFastRelaxedPublicationsOverlapWithoutCoordinator)$' -count=1
+GOWORK=off go test ./cmd/unified_bench -run '^TestApplyProfile_WALOnFast' -count=1
+```
+


### PR DESCRIPTION
## Summary

- Compact only consecutive, retry-free command-WAL dependency-debt entries that have neither external-resource nor rotation-file ownership. The range retains exact LSN coverage and logical metrics.
- Preserve exact partial retry/release behavior by splitting empty ranges at retry frontiers and storing uniform retries per LSN; resource-bearing entries are never split.
- Clarify that `JournalCompression` and `-treedb-journal-compress` do not compress strict V2 command frames.

Closes #3852

## Attribution

The issue workload uses `command_wal_relaxed` with verified read integrity. Its 500k point-write hot path appended one empty dependency-debt object for each relaxed command until checkpoint. CPU profiles located the write path in cached command-WAL append; the sequential allocation profile attributed **237.09 MiB / 44.59%** of 531.69 MiB to `CommandWALDependencyDebt.add`.

This patch makes that empty ownership bookkeeping O(number of dependency/rotation boundaries), not O(number of relaxed point commands), without changing command frames, flush/sync policy, apply behavior, or cleanup proof rules.

## Alternating 500k matrix

All commands used the exact issue shape, same host/configuration, `TMPDIR=/mnt/fast4tb/tmp`, and separate profile directories:

```sh
BIN=.../unified-bench
$BIN -dbs treedb  -keys 500000 -profile wal_on_fast -checkpoint-between-tests -test sequential_write,random_write -profile-dir <dir>
$BIN -dbs leveldb -keys 500000 -profile wal_on_fast -checkpoint-between-tests -test sequential_write,random_write -profile-dir <dir>
```

| phase/order | TreeDB sequential | LevelDB sequential | TreeDB/LevelDB | TreeDB random | LevelDB random | TreeDB/LevelDB |
|---|---:|---:|---:|---:|---:|---:|
| base T-A / L-A | 333,150 | 557,600 | 59.75% | 334,536 | 299,610 | 111.66% |
| base T-B / L-B | 330,731 | 565,365 | 58.50% | 329,318 | 301,220 | 109.33% |
| patched T-A / L-A | 349,421 | 540,146 | 64.69% | 332,902 | 282,722 | 117.75% |
| patched L-B / T-B | 356,928 | 517,747 | 68.94% | 334,618 | 311,040 | 107.58% |
| mean | **353,175** (+6.4% vs base) | 528,947 | **66.8%** (vs 59.1%) | **333,760** (+0.6%) | 296,881 | **112.7%** (vs 110.5%) |

The sequential gap is materially reduced: normalized TreeDB/LevelDB sequential throughput improved by 7.7 percentage points / 13.1% relative. Random writes were already at parity/ahead on this host and show no material regression; their LevelDB samples were noisier. TreeDB post-run checkpoint time remains about 6.7–7.0s versus LevelDB about 1.2–1.3s and is intentionally outside this write-path-only change. Storage remains TreeDB `wal: total=11 B files=2 other=11 B`, with no value-log or WAL-cleanup change.

Artifacts: `/mnt/fast4tb/tmp/gomap-3852-baseline/{treedb-a,leveldb-a,treedb-b,leveldb-b}` and `/mnt/fast4tb/tmp/gomap-3852-after/{treedb-a,leveldb-a,treedb-b,leveldb-b}`. The patched sequential allocation profile fell to 301.00 MiB total; the prior 237.09 MiB `CommandWALDependencyDebt.add` allocation is absent.

Focused microbenchmark:

```text
BenchmarkCommandWALDependencyDebtAddEmpty-12  15.35–15.53 ns/op  0 B/op  0 allocs/op
```

## Compressed-WAL disposition

This is deliberately **not** a generic compression rollout. `Options.JournalCompression` can request generic commitlog compression, but strict V2 command frames are written raw and strict readers reject compressed records. That preserves torn-tail classification using the frame identity, LSN, and durability class. A viable compressed command WAL needs a dedicated payload-aware on-disk format plus replay, corruption/torn-tail, reopen, storage, and CPU tradeoff validation; it is outside this narrow safe write-path optimization.

## Validation

```sh
GOWORK=off go test ./TreeDB/db -run "^TestCommandWALDependencyDebt" -count=1
GOWORK=off go test -race ./TreeDB/db -run "^TestCommandWALDependencyDebt" -count=1
GOWORK=off go test ./TreeDB/db -run "^(TestCommandWALCheckpointEstablishesDurableCleanupProof|TestCommandWALCheckpointCleanupDeletesOnlyCoveredSegments|TestCommandWAL.*Recovery|TestCommandWAL.*Reopen)" -count=1
GOWORK=off go test ./TreeDB/internal/commitlog -run "^(TestCommandFrameV2RejectsCompressedSegmentStorage|TestCommandJournalV2CompressionOptionWritesStrictlyReopenableRawFrames|TestCommandJournal.*)" -count=1
GOWORK=off go test -race ./TreeDB -run "^(TestPublicCommandWALCheckpointCleansCoveredCommandJournalSegment|TestPublicCommandWALGroupCommitFastRelaxedPublicationsOverlapWithoutCoordinator)$" -count=1
GOWORK=off go test ./cmd/unified_bench -run "^TestApplyProfile_FastAndWALOnFastEnableIndexOptimizations$" -count=1
```

No AI review requested and no merge performed.

## Durable benchmark record

The exact matrix, allocation attribution, compressed-WAL disposition, and residual checkpoint gap are retained in [closeout report](https://github.com/snissn/gomap/blob/caf1e7062016470d5175f2185ab057d43b96d294/docs/benchmarks/treedb_issue3852_wal_on_fast_closeout_2026-07-23.md).