### PR TITLE
TreeDB: replicate vector partition generation lifecycle

### DIFF
--- a/TreeDB/cmd/treedb_vector_partition_m5_bench/benchmark.go
+++ b/TreeDB/cmd/treedb_vector_partition_m5_bench/benchmark.go
@@ -121,6 +121,7 @@ func newBenchmarkEnvironment(collection *collections.Collection, status collecti
 		SourceRowCount:        status.Manifest.SourceRowCount,
 		PartitionGeneration:   status.Manifest.Generation,
 		RouterGeneration:      status.Manifest.RouterGeneration,
+		ReadySetDigest:        status.Manifest.ReadySetDigest,
 		TargetGroupID:         cluster.groupID,
 		TargetNodeID:          cluster.leader.id,
 		PartitionIDs:          []uint32{partition},

--- a/TreeDB/collections/vector_partition_lifecycle_public_v1.go
+++ b/TreeDB/collections/vector_partition_lifecycle_public_v1.go
@@ -53,6 +53,63 @@ func (c *Collection) ActiveVectorPartitionManifestWithContextV1(ctx context.Cont
 	return manifest, err
 }
 
+// PreparedVectorPartitionManifestWithContextV1 opens one complete local
+// generation without consulting the standalone active pointer. It is the M7
+// readiness seam: the returned bytes are exact-generation local evidence only,
+// never cluster activation authority.
+func (c *Collection) PreparedVectorPartitionManifestWithContextV1(ctx context.Context, index string, generation uint64) (VectorPartitionManifestV1, error) {
+	if c == nil || c.db == nil {
+		return VectorPartitionManifestV1{}, errors.New("collections: closed collection")
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if err := ctx.Err(); err != nil {
+		return VectorPartitionManifestV1{}, err
+	}
+	var manifest VectorPartitionManifestV1
+	err := WithVectorPartitionStorageBarrierV1(c.db.Dir(), func() error {
+		unlock := c.lockMutation()
+		defer unlock.Unlock()
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		store, err := OpenExistingVectorPartitionStoreV1(c.db.Dir())
+		if err != nil {
+			return err
+		}
+		loaded, present, err := store.loadVectorPartitionLifecycleAuthorityWithContextV1(ctx, c.name, index)
+		if err != nil {
+			return err
+		}
+		entry, ok := loaded.state.Generations[generation]
+		if !present || !ok || entry.Manifest == nil || entry.Deleting || entry.Manifest.State != "ready" {
+			return fmt.Errorf("%w: generation %d is not prepared and ready", ErrVectorPartitionManifestInvalid, generation)
+		}
+		manifest, err = vectorPartitionLifecycleManifestWithContextV1(ctx, loaded.state, generation, false)
+		if err != nil {
+			return err
+		}
+		snap := c.db.AcquireSnapshot()
+		if snap == nil {
+			return errors.New("collections: vector partition source snapshot unavailable")
+		}
+		source, sourceErr := c.vectorPartitionSourceIdentityAtSnapshotV1(index, snap)
+		closeErr := snap.Close()
+		if sourceErr != nil || closeErr != nil {
+			return errors.Join(sourceErr, closeErr)
+		}
+		if manifest.SourceGeneration != source.Generation || manifest.SourceChecksum != source.Checksum || manifest.SourceSchemaHash != source.SchemaHash || manifest.SourceRowCount != source.RowCount {
+			return errors.New("collections: vector partition source identity mismatch")
+		}
+		return ctx.Err()
+	})
+	if err != nil {
+		return VectorPartitionManifestV1{}, err
+	}
+	return manifest, nil
+}
+
 // ActiveVectorPartitionManifestAndAuthorityTokenWithContextV1 opens the full
 // lifecycle and source authority once and returns the leased token used for
 // bounded warm checks. The caller must Release the token.
@@ -313,6 +370,18 @@ func vectorPartitionManifestCanonicalEqualV1(a, b VectorPartitionManifestV1) boo
 }
 
 func (s *VectorPartitionStoreV1) persistVectorPartitionManifestLifecycleV1(m VectorPartitionManifestV1) error {
+	return s.persistVectorPartitionManifestLifecycleModeV1(m, true)
+}
+
+// stageVectorPartitionManifestLifecycleV1 publishes a complete local
+// generation without changing the standalone active pointer. M7 uses this
+// prepared-only seam while the replicated catalog/meta lifecycle collects
+// group readiness and decides the cluster-wide cutover.
+func (s *VectorPartitionStoreV1) stageVectorPartitionManifestLifecycleV1(m VectorPartitionManifestV1) error {
+	return s.persistVectorPartitionManifestLifecycleModeV1(m, false)
+}
+
+func (s *VectorPartitionStoreV1) persistVectorPartitionManifestLifecycleModeV1(m VectorPartitionManifestV1, activate bool) error {
 	loaded, present, err := s.loadVectorPartitionLifecycleAuthorityV1(m.Collection, m.IndexName)
 	if err != nil {
 		return err
@@ -381,6 +450,9 @@ func (s *VectorPartitionStoreV1) persistVectorPartitionManifestLifecycleV1(m Vec
 			}
 		} else if entry.Manifest.State != "ready" || !vectorPartitionManifestCanonicalEqualV1(*entry.Manifest, m) {
 			return fmt.Errorf("%w: generation %d already published with different bytes", ErrVectorPartitionManifestInvalid, m.Generation)
+		}
+		if !activate {
+			return nil
 		}
 		if loaded.state.ActiveGeneration == m.Generation {
 			return nil

--- a/TreeDB/collections/vector_partition_m7_stage_test.go
+++ b/TreeDB/collections/vector_partition_m7_stage_test.go
@@ -1,0 +1,83 @@
+package collections
+
+import (
+	"errors"
+	"os"
+	"testing"
+)
+
+func TestStageVectorPartitionManifestV1PublishesPreparedWithoutLocalActivation(t *testing.T) {
+	requireVectorPartitionPersistenceV1(t)
+	_, database, collection, definition := openColumnGraphTypedColumnVectorTestCollection1782(t, 3, 2, []columnGraphRebuildInputRowV2A{
+		{id: "a", vector: []float32{1, 0, 0}},
+		{id: "b", vector: []float32{0, 1, 0}},
+	})
+	defer database.Close()
+	if _, err := collection.RebuildVectorIndex(definition.Name); err != nil {
+		t.Fatal(err)
+	}
+	source, err := collection.VectorPartitionSourceIdentityV1(definition.Name)
+	if err != nil {
+		t.Fatal(err)
+	}
+	manifest := testVectorPartitionManifestV1()
+	manifest.IndexName = definition.Name
+	manifest.IndexDefinitionDigest = VectorIndexDefinitionDigestV1(definition)
+	manifest.SourceGeneration = source.Generation
+	manifest.SourceChecksum = source.Checksum
+	manifest.SourceSchemaHash = source.SchemaHash
+	manifest.SourceRowCount = source.RowCount
+	manifest, resources := vectorPartitionManifestWithFreshStableAssetsV1(t, database, collection, manifest, 9701)
+
+	if err := collection.StageVectorPartitionManifestV1(manifest, resources); err != nil {
+		t.Fatal(err)
+	}
+	store, err := OpenExistingVectorPartitionStoreV1(database.Dir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	prepared, err := store.Open(manifest.Collection, manifest.IndexName, manifest.Generation)
+	if err != nil || !vectorPartitionManifestCanonicalEqualV1(prepared, manifest) {
+		t.Fatalf("prepared=%+v err=%v", prepared, err)
+	}
+	if _, err := store.OpenActive(manifest.Collection, manifest.IndexName); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("staged generation unexpectedly became locally active: %v", err)
+	}
+	opened, err := collection.PreparedVectorPartitionManifestWithContextV1(t.Context(), manifest.IndexName, manifest.Generation)
+	if err != nil || !vectorPartitionManifestCanonicalEqualV1(opened, manifest) {
+		t.Fatalf("prepared open=%+v err=%v", opened, err)
+	}
+	if _, err := collection.ActiveVectorPartitionManifestWithContextV1(t.Context(), manifest.IndexName, manifest.Generation); err == nil {
+		t.Fatal("prepared generation passed standalone active admission")
+	}
+}
+
+func TestStageVectorPartitionManifestLifecycleV1PreservesExistingActive(t *testing.T) {
+	requireVectorPartitionPersistenceV1(t)
+	store, err := OpenVectorPartitionStoreV1(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	active := testVectorPartitionManifestV1()
+	if err := store.publishValidatedReady(active); err != nil {
+		t.Fatal(err)
+	}
+	staged := cloneVectorPartitionManifestForCheckpointV1(active)
+	staged.Generation++
+	staged.RouterGeneration = staged.Generation
+	for i := range staged.Assets {
+		staged.Assets[i].Ref.Generation = staged.Generation
+	}
+	staged.RouterAsset.Ref.Generation = staged.Generation
+	staged.Canonicalize()
+	if err := store.stageVectorPartitionManifestLifecycleV1(staged); err != nil {
+		t.Fatal(err)
+	}
+	got, err := store.OpenActive(active.Collection, active.IndexName)
+	if err != nil || got.Generation != active.Generation {
+		t.Fatalf("active generation=%d err=%v want %d", got.Generation, err, active.Generation)
+	}
+	if prepared, err := store.Open(staged.Collection, staged.IndexName, staged.Generation); err != nil || prepared.Generation != staged.Generation {
+		t.Fatalf("staged generation=%d err=%v", prepared.Generation, err)
+	}
+}

--- a/TreeDB/collections/vector_partition_manifest.go
+++ b/TreeDB/collections/vector_partition_manifest.go
@@ -3354,8 +3354,21 @@ type VectorPartitionStatusV1 struct {
 }
 
 // PublishVectorPartitionManifestV1 binds the durable generation to this
-// collection's currently declared vector-index definition before publication.
+// collection's currently declared vector-index definition before publication
+// and retains the standalone local-activation behavior.
 func (c *Collection) PublishVectorPartitionManifestV1(m VectorPartitionManifestV1, resources *rootpublication.StableResourceSet) error {
+	return c.publishVectorPartitionManifestModeV1(m, resources, true)
+}
+
+// StageVectorPartitionManifestV1 durably publishes a building or ready
+// generation without changing the local active pointer. A ready generation is
+// therefore usable as M7 group-readiness evidence but cannot be served until
+// the replicated catalog/meta lifecycle activates it.
+func (c *Collection) StageVectorPartitionManifestV1(m VectorPartitionManifestV1, resources *rootpublication.StableResourceSet) error {
+	return c.publishVectorPartitionManifestModeV1(m, resources, false)
+}
+
+func (c *Collection) publishVectorPartitionManifestModeV1(m VectorPartitionManifestV1, resources *rootpublication.StableResourceSet, activate bool) error {
 	if c == nil || c.db == nil {
 		if resources != nil {
 			resources.Release()
@@ -3443,8 +3456,13 @@ func (c *Collection) PublishVectorPartitionManifestV1(m VectorPartitionManifestV
 		if e != nil {
 			return e
 		}
-		mutationErr := s.persistVectorPartitionManifestLifecycleV1(m)
-		if m.State == "ready" {
+		var mutationErr error
+		if activate {
+			mutationErr = s.persistVectorPartitionManifestLifecycleV1(m)
+		} else {
+			mutationErr = s.stageVectorPartitionManifestLifecycleV1(m)
+		}
+		if activate && m.State == "ready" {
 			syncVectorPartitionActiveAuthorityFromStoreV1(c.db.Dir(), s, c.name, m.IndexName)
 		}
 		return mutationErr

--- a/TreeDB/collections/vector_partition_router_v1.go
+++ b/TreeDB/collections/vector_partition_router_v1.go
@@ -838,6 +838,37 @@ func (c *Collection) OpenVectorPartitionRouterV1(index string) (*VectorPartition
 // used by the bounded M6 coordinator. The legacy entry point remains a
 // background-context wrapper.
 func (c *Collection) OpenVectorPartitionRouterWithContextV1(ctx context.Context, index string) (*VectorPartitionRouterV1, VectorPartitionRouterOpenStatusV1, error) {
+	return c.openVectorPartitionRouterWithContextV1(ctx, index, func(ctx context.Context, store *VectorPartitionStoreV1) (VectorPartitionManifestV1, error) {
+		return store.OpenActiveWithContext(ctx, c.name, index)
+	})
+}
+
+// OpenPreparedVectorPartitionRouterForGenerationWithContextV1 opens one exact
+// locally prepared generation without consulting the standalone active
+// pointer. Replicated lifecycle authority remains responsible for admitting
+// that generation before the caller performs routing or shard dispatch.
+func (c *Collection) OpenPreparedVectorPartitionRouterForGenerationWithContextV1(ctx context.Context, index string, generation uint64) (*VectorPartitionRouterV1, VectorPartitionRouterOpenStatusV1, error) {
+	if generation == 0 {
+		return nil, VectorPartitionRouterOpenStatusV1{FailureReason: "collections: invalid vector partition router generation"}, errors.New("collections: invalid vector partition router generation")
+	}
+	return c.openVectorPartitionRouterWithContextV1(ctx, index, func(ctx context.Context, store *VectorPartitionStoreV1) (VectorPartitionManifestV1, error) {
+		loaded, present, err := store.loadVectorPartitionLifecycleAuthorityWithContextV1(ctx, c.name, index)
+		if err != nil {
+			return VectorPartitionManifestV1{}, err
+		}
+		entry, ok := loaded.state.Generations[generation]
+		if !present || !ok || entry.Manifest == nil || entry.Deleting || entry.Manifest.State != "ready" {
+			return VectorPartitionManifestV1{}, fmt.Errorf("%w: generation %d is not prepared and ready", ErrVectorPartitionManifestInvalid, generation)
+		}
+		return vectorPartitionLifecycleManifestWithContextV1(ctx, loaded.state, generation, false)
+	})
+}
+
+func (c *Collection) openVectorPartitionRouterWithContextV1(
+	ctx context.Context,
+	index string,
+	load func(context.Context, *VectorPartitionStoreV1) (VectorPartitionManifestV1, error),
+) (*VectorPartitionRouterV1, VectorPartitionRouterOpenStatusV1, error) {
 	var router *VectorPartitionRouterV1
 	var status VectorPartitionRouterOpenStatusV1
 	started := time.Now()
@@ -848,7 +879,7 @@ func (c *Collection) OpenVectorPartitionRouterWithContextV1(ctx context.Context,
 		status.FailureReason = err.Error()
 		return nil, status, err
 	}
-	if c == nil || c.db == nil {
+	if c == nil || c.db == nil || load == nil {
 		status.FailureReason = "collections: closed collection"
 		return nil, status, errors.New(status.FailureReason)
 	}
@@ -860,14 +891,14 @@ func (c *Collection) OpenVectorPartitionRouterWithContextV1(ctx context.Context,
 		if err != nil {
 			return err
 		}
-		manifest, err := store.OpenActiveWithContext(ctx, c.name, index)
+		manifest, err := load(ctx, store)
 		if err != nil {
 			return err
 		}
 		if manifest.State != "ready" ||
 			manifest.RouterGeneration != manifest.Generation ||
 			manifest.RouterAsset.Ref.Generation != manifest.Generation {
-			return errors.New("collections: vector partition router active generation is not ready")
+			return errors.New("collections: vector partition router generation is not ready")
 		}
 		if len(manifest.Representatives) == 0 {
 			return errors.New("collections: vector partition router ready generation has no representative mapping")

--- a/TreeDB/collections/vector_partition_router_v1_test.go
+++ b/TreeDB/collections/vector_partition_router_v1_test.go
@@ -466,12 +466,34 @@ func TestPartitionRouterBuildPublishSearchReopenAndPinsV1(t *testing.T) {
 	if err != nil {
 		t.Fatalf("open router after DB reopen: %v", err)
 	}
-	defer router.Close()
 	result, err := router.Search([]float32{0, 1}, VectorPartitionRouterSearchOptionsV1{
 		Mode: VectorPartitionRouterModeExactV1, CandidateBudget: 4, PartitionProbes: 1,
 	})
 	if err != nil || result.Partitions[0].PartitionID != 1 {
 		t.Fatalf("reopened exact result=%+v err=%v", result, err)
+	}
+	if err := router.Close(); err != nil {
+		t.Fatal(err)
+	}
+	store, err = OpenExistingVectorPartitionStoreV1(database.Dir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := store.deactivateVectorPartitionLifecycleV1(collection.name, def.Name); err != nil {
+		t.Fatalf("deactivate standalone pointer: %v", err)
+	}
+	if _, _, err := collection.OpenVectorPartitionRouterWithContextV1(t.Context(), def.Name); err == nil {
+		t.Fatal("standalone router opened after local active pointer was removed")
+	}
+	preparedRouter, preparedStatus, err := collection.OpenPreparedVectorPartitionRouterForGenerationWithContextV1(t.Context(), def.Name, building.Generation)
+	if err != nil {
+		t.Fatalf("exact prepared router open status=%+v err=%v", preparedStatus, err)
+	}
+	if preparedStatus.Generation != building.Generation {
+		t.Fatalf("prepared router generation=%d want %d", preparedStatus.Generation, building.Generation)
+	}
+	if err := preparedRouter.Close(); err != nil {
+		t.Fatal(err)
 	}
 }
 

--- a/TreeDB/docs/performance/vector-partition-m7.md
+++ b/TreeDB/docs/performance/vector-partition-m7.md
@@ -1,0 +1,49 @@
+# Vector partition M7 lifecycle microbenchmarks
+
+Date: 2026-07-25  
+Host: Linux/amd64, 11th Gen Intel Core i5-11400F @ 2.60GHz, 12 logical CPUs  
+Scope: bounded in-process lifecycle primitives only; M7 remains experimental.
+
+## Reproduction
+
+```sh
+GOWORK=off go test ./TreeDB/internal/raftplacement \
+  -run '^$' \
+  -bench '^BenchmarkVectorPartitionLifecycle' \
+  -benchtime=10000x \
+  -count=3 \
+  -benchmem
+```
+
+The benchmark uses one bounded group and the smallest valid lifecycle identity.
+It is not a network, disk, Raft quorum, builder, or upload measurement.
+
+## Result
+
+| Primitive | ns/op range | B/op | allocs/op | Notes |
+| --- | ---: | ---: | ---: | --- |
+| canonical begin-build command encode | 1,974-2,085 | 1,401-1,405 | 7 | deterministic wire encoding |
+| pure begin-build record apply | 15,628-15,810 | 6,416-6,417 | 49 | validation plus canonical record construction; no catalog lock or Raft submit |
+| one-group ready-set digest verification | 2,413-2,476 | 1,201 | 11 | canonical identity/group/readiness digest |
+| two-generation mutation-proof selection | 131.0-132.4 | 0 | 0 | pending invalidation preferred over prepared candidate |
+
+The test uses fixed iterations rather than a duration target, so these ranges
+are reproducible microbenchmark samples rather than a throughput acceptance
+claim. The encoded command and snapshot paths remain bounded by
+`MaxVectorPartitionLifecycleCommandBytesV1` (1 MiB),
+`MaxVectorPartitionLifecycleRecordBytesV1` (1 MiB), and
+`MaxCatalogMetaSnapshotBytesV1` (8 MiB); catalog status reports retained wire
+bytes for records, while `VectorPartitionLifecycleMutationFencesV1` exposes
+the bounded pending-fence operator state.
+
+## Explicitly unavailable phases
+
+M7 has no production generation-builder orchestration, remote asset upload
+pipeline, or distributed barrier implementation in this repository. Therefore
+there is no honest measurement for build, stage/upload, prepare barrier,
+catalog-meta Raft quorum submit, or multi-node failover/rejoin latency.
+Those phases are **not implemented/measured**, and this document must not be
+read as production readiness evidence. The implemented fail-closed lifecycle
+seams are command encoding/reduction, catalog-authority fencing, nativewire and
+Mongo mutation admission/confirmation, snapshot restoration, and cleanup
+guards.

--- a/TreeDB/docs/performance/vector-partition-m7.md
+++ b/TreeDB/docs/performance/vector-partition-m7.md
@@ -48,8 +48,9 @@ and begin-build rejects an epoch that the mutation advanced after capture.
 Once begin-build commits, later distinct mutations remain blocked through
 build, stage, and prepare. The mutation barrier is keyed by the deterministic
 command/idempotency identity, survives snapshot/restore, rejects distinct
-concurrent mutations, and is released only after committed-recoverable data
-submission and all per-index invalidation confirmations.
+concurrent mutations, and is released only after the data bridge proves commit
+plus deterministic local apply, independent of the requested response
+acknowledgment, and all per-index invalidation confirmations.
 
 ## Explicitly unavailable phases
 

--- a/TreeDB/docs/performance/vector-partition-m7.md
+++ b/TreeDB/docs/performance/vector-partition-m7.md
@@ -34,15 +34,30 @@ claim. The encoded command and snapshot paths remain bounded by
 `MaxVectorPartitionLifecycleCommandBytesV1` (1 MiB),
 `MaxVectorPartitionLifecycleRecordBytesV1` (1 MiB), and
 `MaxCatalogMetaSnapshotBytesV1` (8 MiB); catalog status reports retained wire
-bytes for records, while `VectorPartitionLifecycleMutationFencesV1` exposes
-the bounded pending-fence operator state.
+bytes for records, while `VectorPartitionLifecycleMutationFencesV1` and
+`VectorPartitionCollectionMutationBarriersV1` expose the bounded pending-fence
+operator state.
+
+## Source-capture and mutation ordering
+
+The build coordinator reads `BuildSourceMutationEpochV1` before it captures
+group read/apply proofs, then supplies that epoch to `BeginBuildV1`. A relevant
+nativewire mutation first publishes a collection-keyed barrier through the
+catalog/meta Raft owner. The barrier rejects a build already in source capture,
+and begin-build rejects an epoch that the mutation advanced after capture.
+Once begin-build commits, later distinct mutations remain blocked through
+build, stage, and prepare. The mutation barrier is keyed by the deterministic
+command/idempotency identity, survives snapshot/restore, rejects distinct
+concurrent mutations, and is released only after committed-recoverable data
+submission and all per-index invalidation confirmations.
 
 ## Explicitly unavailable phases
 
 M7 has no production generation-builder orchestration, remote asset upload
-pipeline, or distributed barrier implementation in this repository. Therefore
-there is no honest measurement for build, stage/upload, prepare barrier,
-catalog-meta Raft quorum submit, or multi-node failover/rejoin latency.
+pipeline, or multi-group source-proof capture harness in this repository.
+Therefore there is no honest measurement for build, stage/upload, source-proof
+capture duration, catalog-meta Raft quorum submit, or multi-node
+failover/rejoin latency.
 Those phases are **not implemented/measured**, and this document must not be
 read as production readiness evidence. The implemented fail-closed lifecycle
 seams are command encoding/reduction, catalog-authority fencing, nativewire and

--- a/TreeDB/docs/performance/vector-partition-m7.md
+++ b/TreeDB/docs/performance/vector-partition-m7.md
@@ -56,6 +56,13 @@ after the data bridge proves commit plus deterministic local apply, independent
 of the requested response acknowledgment, and all per-index invalidation
 confirmations.
 
+Post-commit confirmation uses a bounded internal context detached from client
+cancellation and deadlines. Search admission likewise cannot consult the raw
+replica-local catalog cache: the serving adapter performs a quorum-verified
+meta-Raft leader fence and requires the local catalog applied index to have
+caught up before validating the active generation. Followers without a routed
+proof and replicas behind that fence fail closed.
+
 ## Explicitly unavailable phases
 
 M7 has no production generation-builder orchestration, remote asset upload

--- a/TreeDB/docs/performance/vector-partition-m7.md
+++ b/TreeDB/docs/performance/vector-partition-m7.md
@@ -48,9 +48,13 @@ and begin-build rejects an epoch that the mutation advanced after capture.
 Once begin-build commits, later distinct mutations remain blocked through
 build, stage, and prepare. The mutation barrier is keyed by the deterministic
 command/idempotency identity, survives snapshot/restore, rejects distinct
-concurrent mutations, and is released only after the data bridge proves commit
-plus deterministic local apply, independent of the requested response
-acknowledgment, and all per-index invalidation confirmations.
+concurrent mutations, and retains the 64 most recent completed identities per
+collection as a bounded durable exact-replay window. Older identities rely on
+the data Raft layer's durable idempotency result and may conservatively reopen
+catalog admission before that result is returned. The barrier is released only
+after the data bridge proves commit plus deterministic local apply, independent
+of the requested response acknowledgment, and all per-index invalidation
+confirmations.
 
 ## Explicitly unavailable phases
 

--- a/TreeDB/docs/performance/vector-partition-m7.md
+++ b/TreeDB/docs/performance/vector-partition-m7.md
@@ -1,7 +1,8 @@
 # Vector partition M7 lifecycle microbenchmarks
 
-Date: 2026-07-25  
-Host: Linux/amd64, 11th Gen Intel Core i5-11400F @ 2.60GHz, 12 logical CPUs  
+Date: 2026-07-25
+
+Host: Linux/amd64, 11th Gen Intel Core i5-11400F @ 2.60GHz, 12 logical CPUs
 Scope: bounded in-process lifecycle primitives only; M7 remains experimental.
 
 ## Reproduction

--- a/TreeDB/docs/spec/storage-format.md
+++ b/TreeDB/docs/spec/storage-format.md
@@ -148,6 +148,28 @@ original and rewritten asset debt until physical GC completes. Pre-alpha
 binaries reject old `.vpm`, `.active`, `.retired`, `.inactive`, and `.deleting`
 authority; there is no fallback or migration path.
 
+### Catalog/meta Raft lifecycle snapshot
+
+The catalog/meta Raft FSM snapshot is canonical JSON format version 1 with an
+8 MiB outer limit. It stores `format`, `applied_index`, the canonical catalog
+`record`, the exact `last_command`, and an optional base64-encoded
+`vector_partition_lifecycle` byte payload. When the vector-partition lifecycle
+feature is enabled, that inner payload is itself canonical JSON format version
+1 containing ordered `records`, `mutation_fences`, and
+`collection_mutation_barriers` arrays.
+
+The lifecycle payload permits at most 4,096 generation records, 4,096
+per-index mutation fences, and 4,096 collection barriers. Each collection
+barrier retains at most 64 completed operation identities. These inner bounds
+are enforced before the complete base64-expanded outer snapshot is checked
+against the 8 MiB limit. Restore rejects unknown fields, duplicate identities,
+noncanonical ordering or encoding, catalog-identity mismatches, multiple active
+generations for an index or serving name, and malformed barriers or fences. A
+pending per-index fence must have exactly one matching unconfirmed invalidated
+generation record at the same mutation epoch and cannot coexist with an active
+generation. The snapshot is installed all-or-nothing; invalid lifecycle state
+never publishes the catalog record or applied index.
+
 Before a writable public open can succeed, TreeDB establishes the complete
 directory dependency chain from the outer database root through `maindb`,
 enabled side-store roots, and each backend's `wal`, `value_vlog`, `leaf_vlog`,

--- a/TreeDB/docs/spec/vector-partition-raft-v1.md
+++ b/TreeDB/docs/spec/vector-partition-raft-v1.md
@@ -178,6 +178,13 @@ failover, replay, snapshot/rejoin, backup restore, and cleanup all preserve
 the same fail-closed recovery debt. The retained source watermark remains after
 confirmed cleanup, preventing an older delayed candidate from resurrecting.
 
+`VectorPartitionLifecycleCoordinatorV1` provides the bounded meta-Raft
+workflow: begin (with exact source/catalog/mutation identity), caller-owned
+group build/stage readiness callback, group-ready recording, prepare,
+activation/cutover, abort, retire, cleanability, per-group cleanup, completion,
+and recovery status. The callback returns only a validated bounded readiness
+proof; M7 does not fabricate remote asset upload or network transport.
+
 V1 distributed responses contain response-owned stable IDs and scores only.
 Missing owner, stale generation, malformed/capped asset, unsupported
 consistency, or shard failure is an explicit error with no incomplete result.

--- a/TreeDB/docs/spec/vector-partition-raft-v1.md
+++ b/TreeDB/docs/spec/vector-partition-raft-v1.md
@@ -185,8 +185,10 @@ the barrier only after local encoding and route preflight succeed, then owns it
 by deterministic command/idempotency digest until the data result is committed,
 deterministically applied, and every affected per-index fence is confirmed.
 This confirmation is independent of the client-selected response acknowledgment
-policy. Exact retries reuse the same barrier; a distinct concurrent mutation is
-refused. This closes
+policy and runs under a bounded internal context after commit/apply, so client
+cancellation or deadline expiry cannot strand the fence between the data apply
+and catalog confirmation. Exact retries reuse the same barrier; a distinct
+concurrent mutation is refused. This closes
 the first-generation race where no active index record yet exists to invalidate.
 
 Fence state is included in the canonical catalog snapshot and is exposed to
@@ -211,6 +213,14 @@ pointer. M6 opens the exact prepared router generation named by replicated
 placement, then M7 validates that router against catalog authority before any
 router search or shard dispatch. A missing, stale, corrupt, or locally
 unprepared exact generation fails closed.
+
+Every replicated lifecycle validation first performs a fresh quorum-verified
+meta-Raft leader read and waits for the local catalog FSM through that fence.
+The concrete replica-local catalog authority intentionally does not implement
+the serving interface; only the linearizable adapter can do so. A follower
+without routed meta-leader proof, or a local catalog view behind the returned
+catalog command index, fails closed rather than serving its cached active
+generation.
 
 `VectorPartitionLifecycleCoordinatorV1` provides the bounded meta-Raft
 workflow: begin (with exact source/catalog/mutation identity), caller-owned

--- a/TreeDB/docs/spec/vector-partition-raft-v1.md
+++ b/TreeDB/docs/spec/vector-partition-raft-v1.md
@@ -144,6 +144,11 @@ are `building`, `ready`, `cutover`, and `invalidated`.
 length-capped before allocation on its declared owner. A `cutover` is atomic
 over the complete generation.
 
+The M7 state machine below refines this earlier coarse vocabulary. Its
+persisted states are `building`, `staged`, `prepared`, `active`, `invalidated`,
+`retired`, and `cleanable`; `cutover` is the guarded atomic operation that
+replaces one active generation with another, not a persisted state.
+
 V1 is snapshot-bound: insert, delete, embedding replacement, index-definition
 change, source snapshot replacement, or any committed mutation affecting a
 referenced vector invalidates the generation before the mutation becomes
@@ -169,6 +174,15 @@ is made. A second relevant mutation cannot reuse a pending proof. Relevant
 mutations are also refused while any generation for that collection/index is
 building, staged, or prepared, so source capture is never concurrent with a
 data mutation.
+
+The per-index fences are coordinated by a second, collection-keyed replicated
+barrier. A build reads the collection mutation epoch before source capture and
+must commit that exact watermark at begin-build. A relevant data command opens
+the barrier only after local encoding and route preflight succeed, then owns it
+by deterministic command/idempotency digest until the data result is committed
+and recoverable and every affected per-index fence is confirmed. Exact retries
+reuse the same barrier; a distinct concurrent mutation is refused. This closes
+the first-generation race where no active index record yet exists to invalidate.
 
 Fence state is included in the canonical catalog snapshot and is exposed to
 operators with its collection, index name, epoch, and pending bit. Retire and

--- a/TreeDB/docs/spec/vector-partition-raft-v1.md
+++ b/TreeDB/docs/spec/vector-partition-raft-v1.md
@@ -152,6 +152,32 @@ it MUST NOT mix generations or return partial top-k. A Raft read-index only
 proves the group applied point; it does not make an older snapshot-built
 generation fresh.
 
+### M7 replicated mutation fence
+
+The catalog authority records a bounded, canonical mutation fence per
+`(database, catalog, collection, index_name)`. Invalidating an active
+generation advances that fence and marks it **pending** before the relevant
+data command is admitted. While pending, lifecycle build and activation both
+fail closed, including a candidate whose claimed source epoch equals the
+fence. The shared nativewire and Mongo submitters confirm the fence only after
+their data-Raft bridge returns a committed, locally recoverable result.
+
+A failed, ambiguous, or crashed data submit intentionally leaves the fence
+pending: serving remains unavailable until recovery proves the data outcome and
+commits the exact confirmation, or a separately authorized repair disposition
+is made. A second relevant mutation cannot reuse a pending proof. Relevant
+mutations are also refused while any generation for that collection/index is
+building, staged, or prepared, so source capture is never concurrent with a
+data mutation.
+
+Fence state is included in the canonical catalog snapshot and is exposed to
+operators with its collection, index name, epoch, and pending bit. Retire and
+cleanup of an invalidated generation are blocked while its fence is pending;
+this preserves the exact record required for confirmation. Thus crash,
+failover, replay, snapshot/rejoin, backup restore, and cleanup all preserve
+the same fail-closed recovery debt. The retained source watermark remains after
+confirmed cleanup, preventing an older delayed candidate from resurrecting.
+
 V1 distributed responses contain response-owned stable IDs and scores only.
 Missing owner, stale generation, malformed/capped asset, unsupported
 consistency, or shard failure is an explicit error with no incomplete result.

--- a/TreeDB/docs/spec/vector-partition-raft-v1.md
+++ b/TreeDB/docs/spec/vector-partition-raft-v1.md
@@ -165,7 +165,10 @@ generation advances that fence and marks it **pending** before the relevant
 data command is admitted. While pending, lifecycle build and activation both
 fail closed, including a candidate whose claimed source epoch equals the
 fence. The shared nativewire and Mongo submitters confirm the fence only after
-their data-Raft bridge returns a committed, locally recoverable result.
+their data-Raft bridge proves commit and completes deterministic local apply.
+That proof is independent of the client-selected response acknowledgment:
+successful `visible`, `flushed`, and `synced` requests release the same fence
+as `raft_committed`; failed or ambiguous submits do not.
 
 A failed, ambiguous, or crashed data submit intentionally leaves the fence
 pending: serving remains unavailable until recovery proves the data outcome and
@@ -179,9 +182,11 @@ The per-index fences are coordinated by a second, collection-keyed replicated
 barrier. A build reads the collection mutation epoch before source capture and
 must commit that exact watermark at begin-build. A relevant data command opens
 the barrier only after local encoding and route preflight succeed, then owns it
-by deterministic command/idempotency digest until the data result is committed
-and recoverable and every affected per-index fence is confirmed. Exact retries
-reuse the same barrier; a distinct concurrent mutation is refused. This closes
+by deterministic command/idempotency digest until the data result is committed,
+deterministically applied, and every affected per-index fence is confirmed.
+This confirmation is independent of the client-selected response acknowledgment
+policy. Exact retries reuse the same barrier; a distinct concurrent mutation is
+refused. This closes
 the first-generation race where no active index record yet exists to invalidate.
 
 Fence state is included in the canonical catalog snapshot and is exposed to
@@ -191,6 +196,21 @@ this preserves the exact record required for confirmation. Thus crash,
 failover, replay, snapshot/rejoin, backup restore, and cleanup all preserve
 the same fail-closed recovery debt. The retained source watermark remains after
 confirmed cleanup, preventing an older delayed candidate from resurrecting.
+
+Serving keeps two SHA-256 identities distinct. The local manifest
+`ReadySetDigest` binds that generation's placements and assets. The replicated
+lifecycle ready-set digest binds the lifecycle identity plus every required
+group readiness proof. Catalog authority returns the latter after validating
+the exact active generation; the coordinator carries it through each shard
+request and response proof, while local asset opening continues to validate
+the manifest digest. They are never compared as though they were the same
+hash.
+
+Replicated activation also does not mutate or consult the standalone M1 active
+pointer. M6 opens the exact prepared router generation named by replicated
+placement, then M7 validates that router against catalog authority before any
+router search or shard dispatch. A missing, stale, corrupt, or locally
+unprepared exact generation fails closed.
 
 `VectorPartitionLifecycleCoordinatorV1` provides the bounded meta-Raft
 workflow: begin (with exact source/catalog/mutation identity), caller-owned

--- a/TreeDB/internal/raftcluster/catalog_meta_raft.go
+++ b/TreeDB/internal/raftcluster/catalog_meta_raft.go
@@ -37,6 +37,13 @@ type CatalogMetaBackupStateV1 interface {
 	ValidateCatalogMetaBackupRestoreTargetV1() error
 }
 
+// CatalogMetaAppliedStateV1 exposes the last catalog command installed in the
+// local applied view. A value is safe for serving only when returned after the
+// provider's quorum-verified linearizable read fence.
+type CatalogMetaAppliedStateV1 interface {
+	CatalogMetaAppliedIndexV1() (uint64, bool)
+}
+
 type CatalogMetaApplyCapabilityV1 struct{ granted bool }
 type CatalogMetaRestoreCapabilityV1 struct{ granted bool }
 
@@ -167,6 +174,74 @@ func (p *CatalogMetaRaftProviderV1) ClusterAdmissionStatus(ctx context.Context) 
 		return FollowerAdmission(NodeID(leader), "catalog meta raft follower"), nil
 	}
 	return UnavailableAdmission("catalog meta leader unavailable"), nil
+}
+
+// LinearizableCatalogMetaAppliedIndexV1 verifies current leadership with the
+// voter quorum, waits for all prior committed FSM work locally, then returns
+// the catalog command index installed in that applied view. Followers fail
+// closed; a cross-node caller must route this operation to the meta leader and
+// arrange local catch-up before using the returned index.
+func (p *CatalogMetaRaftProviderV1) LinearizableCatalogMetaAppliedIndexV1(ctx context.Context) (uint64, error) {
+	if p == nil || p.raft == nil || p.state == nil {
+		return 0, ErrInvalidHashicorpRaftProvider
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if err := ctx.Err(); err != nil {
+		return 0, err
+	}
+	status, err := p.ClusterAdmissionStatus(ctx)
+	if err != nil {
+		return 0, err
+	}
+	if status.Unavailable {
+		return 0, ErrHashicorpRaftUnavailable
+	}
+	if !status.Leader {
+		return 0, ErrNotLeader
+	}
+	if err := waitHashicorpRaftFuture(ctx, p.raft.VerifyLeader()); err != nil {
+		return 0, mapCatalogMetaLinearizableReadErrorV1(err)
+	}
+	if err := waitHashicorpRaftFuture(ctx, p.raft.Barrier(p.applyTimeout)); err != nil {
+		return 0, mapCatalogMetaLinearizableReadErrorV1(err)
+	}
+	status, err = p.ClusterAdmissionStatus(ctx)
+	if err != nil {
+		return 0, err
+	}
+	if !status.Leader {
+		return 0, ErrNotLeader
+	}
+	appliedState, ok := p.state.(CatalogMetaAppliedStateV1)
+	if !ok {
+		return 0, errors.Join(ErrInvalidHashicorpRaftProvider, fmt.Errorf("catalog state does not expose applied index"))
+	}
+	applied, ok := appliedState.CatalogMetaAppliedIndexV1()
+	if !ok {
+		return 0, ErrHashicorpRaftUnavailable
+	}
+	return applied, nil
+}
+
+func mapCatalogMetaLinearizableReadErrorV1(err error) error {
+	switch {
+	case err == nil:
+		return nil
+	case errors.Is(err, context.Canceled), errors.Is(err, context.DeadlineExceeded):
+		return err
+	case errors.Is(err, hraft.ErrNotLeader),
+		errors.Is(err, hraft.ErrLeadershipLost),
+		errors.Is(err, hraft.ErrLeadershipTransferInProgress):
+		return errors.Join(ErrNotLeader, err)
+	case errors.Is(err, hraft.ErrRaftShutdown),
+		errors.Is(err, hraft.ErrEnqueueTimeout),
+		errors.Is(err, hraft.ErrAbortedByRestore):
+		return errors.Join(ErrHashicorpRaftUnavailable, err)
+	default:
+		return errors.Join(ErrHashicorpRaftUnavailable, err)
+	}
 }
 func (p *CatalogMetaRaftProviderV1) Close() error {
 	if p == nil {

--- a/TreeDB/internal/raftcluster/catalog_meta_raft.go
+++ b/TreeDB/internal/raftcluster/catalog_meta_raft.go
@@ -12,11 +12,11 @@ import (
 	hraft "github.com/hashicorp/raft"
 )
 
-// Catalog snapshots contain two independently command-bounded byte fields
-// encoded as base64 in a JSON envelope. Keep this transport boundary aligned
-// with raftplacement.MaxCatalogMetaSnapshotBytesV1 without importing the
-// schema package back into raftcluster.
-const catalogMetaRaftSnapshotMaxBytesV1 = 3 << 20
+// Catalog snapshots contain independently bounded catalog command/record and
+// vector-lifecycle byte fields encoded as base64 in a JSON envelope. Keep this
+// transport boundary aligned with raftplacement.MaxCatalogMetaSnapshotBytesV1
+// without importing the schema package back into raftcluster.
+const catalogMetaRaftSnapshotMaxBytesV1 = 8 << 20
 
 // CatalogMetaCommittedStateV1 is implemented by raftplacement's authority.
 // The dependency inversion keeps raftcluster independent of catalog schema

--- a/TreeDB/internal/raftcluster/catalog_meta_raft_test.go
+++ b/TreeDB/internal/raftcluster/catalog_meta_raft_test.go
@@ -48,6 +48,10 @@ func TestCatalogMetaRaftProviderCommitsOnlyAfterLeaderApplyAndSnapshots(t *testi
 	if term == 0 || index == 0 || !bytes.Equal(state.command, []byte("generation-1")) || state.index != index {
 		t.Fatalf("term/index/state=%d/%d/%q/%d", term, index, state.command, state.index)
 	}
+	linearizableIndex, err := p.LinearizableCatalogMetaAppliedIndexV1(ctx)
+	if err != nil || linearizableIndex != index {
+		t.Fatalf("linearizable applied index=%d err=%v want %d", linearizableIndex, err, index)
+	}
 	if err := p.SnapshotCatalogMetaV1(ctx); err != nil {
 		t.Fatal(err)
 	}
@@ -69,6 +73,9 @@ func TestCatalogMetaRaftProviderFollowerAndCancellationFailClosed(t *testing.T) 
 	p := &CatalogMetaRaftProviderV1{}
 	if _, _, err := p.SubmitCatalogMetaCommandV1(context.Background(), []byte("x")); !errors.Is(err, ErrInvalidHashicorpRaftProvider) {
 		t.Fatalf("err=%v", err)
+	}
+	if _, err := p.LinearizableCatalogMetaAppliedIndexV1(context.Background()); !errors.Is(err, ErrInvalidHashicorpRaftProvider) {
+		t.Fatalf("linearizable read err=%v want ErrInvalidHashicorpRaftProvider", err)
 	}
 }
 
@@ -614,6 +621,9 @@ func (s *catalogMetaRaftTestState) InstallCatalogMetaSnapshotBytesV1(capability 
 	}
 	s.command = bytes.Clone(b)
 	return nil
+}
+func (s *catalogMetaRaftTestState) CatalogMetaAppliedIndexV1() (uint64, bool) {
+	return s.index, true
 }
 
 var _ io.Closer = (*catalogMetaNoopCloser)(nil)

--- a/TreeDB/internal/raftcluster/config.go
+++ b/TreeDB/internal/raftcluster/config.go
@@ -16,13 +16,18 @@ const (
 	// not imply a selected Raft library or production HA behavior.
 	FeatureSingleGroupProvider  FeatureName = "treedb.raftcluster.single_group_provider"
 	FeatureCatalogMetaAuthority FeatureName = "treedb.raftcluster.catalog_meta_authority"
+	// FeatureVectorPartitionLifecycle gates the M7 catalog/meta lifecycle and
+	// invalidation-before-mutation contract. It is opt-in during pre-alpha;
+	// legacy clusters do not acquire the new admission requirement implicitly.
+	FeatureVectorPartitionLifecycle FeatureName = "treedb.raftcluster.vector_partition_lifecycle"
 )
 
 var (
 	SupportedConfigVersion = Version{Major: 1, Minor: 0}
 	SupportedFeatureFloors = map[FeatureName]Version{
-		FeatureSingleGroupProvider:  {Major: 1, Minor: 0},
-		FeatureCatalogMetaAuthority: {Major: 1, Minor: 0},
+		FeatureSingleGroupProvider:      {Major: 1, Minor: 0},
+		FeatureCatalogMetaAuthority:     {Major: 1, Minor: 0},
+		FeatureVectorPartitionLifecycle: {Major: 1, Minor: 0},
 	}
 
 	ErrInvalidConfig       = errors.New("raftcluster: invalid config")

--- a/TreeDB/internal/raftcluster/config.go
+++ b/TreeDB/internal/raftcluster/config.go
@@ -150,6 +150,27 @@ type Provider interface {
 	Config() ResolvedConfig
 }
 
+// FeatureRequirementProviderV1 exposes feature requirements for composite
+// command submitters that do not have one single ResolvedConfig.
+type FeatureRequirementProviderV1 interface {
+	RequiresFeatureV1(FeatureName) (bool, error)
+}
+
+// FeatureSetRequiresV1 reports whether a validated feature set requires at
+// least the supported floor for name.
+func FeatureSetRequiresV1(features FeatureSet, name FeatureName) bool {
+	floor, known := SupportedFeatureFloors[name]
+	if !known {
+		return false
+	}
+	for _, required := range features.Required {
+		if required.Name == name && required.Version.Major == floor.Major && required.Version.Minor >= floor.Minor {
+			return true
+		}
+	}
+	return false
+}
+
 // ProviderFactory creates a provider from a validated single-group config. It
 // is a factory boundary, not an admission or consensus API.
 type ProviderFactory interface {

--- a/TreeDB/internal/raftcluster/dispatcher.go
+++ b/TreeDB/internal/raftcluster/dispatcher.go
@@ -97,6 +97,34 @@ type GroupRoutedSubmitter struct {
 	catalogRouteValidator CatalogRouteValidatorV1
 }
 
+// RequiresFeatureV1 derives a composite requirement from the configured data
+// groups. A requirement on any group applies to the shared routed submit
+// boundary; otherwise one group could bypass a cluster-wide safety feature.
+func (s *GroupRoutedSubmitter) RequiresFeatureV1(name FeatureName) (bool, error) {
+	if s == nil || s.registry.empty() {
+		return false, ErrInvalidSubmitter
+	}
+	for _, groupID := range s.registry.GroupIDs() {
+		submitter, ok := s.registry.Lookup(groupID)
+		if !ok {
+			continue
+		}
+		if requirements, ok := submitter.(FeatureRequirementProviderV1); ok {
+			required, err := requirements.RequiresFeatureV1(name)
+			if err != nil {
+				return false, err
+			}
+			if required {
+				return true, nil
+			}
+		}
+		if provider, ok := submitter.(Provider); ok && FeatureSetRequiresV1(provider.Config().Features, name) {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
 func newCatalogMetaGroupRoutedSubmitter(registry GroupSubmitterRegistryV1, validator CatalogRouteValidatorV1) (*GroupRoutedSubmitter, error) {
 	if registry.empty() {
 		return nil, errors.Join(ErrInvalidSubmitter, fmt.Errorf("group submitter registry is required"))

--- a/TreeDB/internal/raftcluster/dispatcher.go
+++ b/TreeDB/internal/raftcluster/dispatcher.go
@@ -148,6 +148,17 @@ func NewCatalogMetaGroupRoutedSubmitter(registry GroupSubmitterRegistryV1, valid
 }
 
 func (s *GroupRoutedSubmitter) SubmitCommandEntryV1(ctx context.Context, entry []byte, metadata raftentry.RequestMetadataV1) (SubmitResultV1, error) {
+	return s.submitCommandEntryV1(ctx, entry, metadata, nil)
+}
+
+func (s *GroupRoutedSubmitter) SubmitCommandEntryWithPreCommitV1(ctx context.Context, entry []byte, metadata raftentry.RequestMetadataV1, preCommit func(context.Context) error) (SubmitResultV1, error) {
+	if preCommit == nil {
+		return SubmitResultV1{}, errors.Join(ErrInvalidSubmitter, fmt.Errorf("pre-commit callback is required"))
+	}
+	return s.submitCommandEntryV1(ctx, entry, metadata, preCommit)
+}
+
+func (s *GroupRoutedSubmitter) submitCommandEntryV1(ctx context.Context, entry []byte, metadata raftentry.RequestMetadataV1, preCommit func(context.Context) error) (SubmitResultV1, error) {
 	if s == nil || s.registry.empty() {
 		return SubmitResultV1{}, ErrInvalidSubmitter
 	}
@@ -167,6 +178,13 @@ func (s *GroupRoutedSubmitter) SubmitCommandEntryV1(ctx context.Context, entry [
 	submitter, ok := s.registry.Lookup(target.GroupID)
 	if !ok {
 		return SubmitResultV1{}, errors.Join(ErrRouteTargetUnknown, routeErrorWithMetadata(metadata, "route group %q is not configured locally", target.GroupID))
+	}
+	if preCommit != nil {
+		atomicSubmitter, ok := submitter.(CommandSubmitterWithPreCommitV1)
+		if !ok {
+			return SubmitResultV1{}, errors.Join(ErrInvalidSubmitter, fmt.Errorf("route group %q does not support serialized pre-commit callbacks", target.GroupID))
+		}
+		return atomicSubmitter.SubmitCommandEntryWithPreCommitV1(ctx, bytes.Clone(entry), cloneRequestMetadataV1(metadata), preCommit)
 	}
 	return submitter.SubmitCommandEntryV1(ctx, bytes.Clone(entry), cloneRequestMetadataV1(metadata))
 }

--- a/TreeDB/internal/raftcluster/dispatcher_test.go
+++ b/TreeDB/internal/raftcluster/dispatcher_test.go
@@ -12,10 +12,11 @@ import (
 )
 
 type recordingGroupSubmitter struct {
-	groupID GroupID
-	status  AdmissionStatus
-	err     error
-	calls   []recordingGroupSubmitCall
+	groupID  GroupID
+	features FeatureSet
+	status   AdmissionStatus
+	err      error
+	calls    []recordingGroupSubmitCall
 }
 
 type recordingGroupSubmitCall struct {
@@ -48,7 +49,7 @@ func (s *submitOnlyGroupSubmitter) SubmitCommandEntryV1(context.Context, []byte,
 }
 
 func (s *recordingGroupSubmitter) Config() ResolvedConfig {
-	return ResolvedConfig{GroupID: s.groupID}
+	return ResolvedConfig{GroupID: s.groupID, Features: s.features}
 }
 
 func (s *recordingGroupSubmitter) ClusterAdmissionStatus(context.Context) (AdmissionStatus, error) {
@@ -408,6 +409,25 @@ func TestGroupRoutedSubmitterAdmissionMissingProviderFailsClosed(t *testing.T) {
 	}
 	if !status.Unavailable || !strings.Contains(status.Reason, "group \"group-b\" admission provider is unavailable") {
 		t.Fatalf("ClusterAdmissionStatus=%+v want unavailable missing group-b admission provider", status)
+	}
+}
+
+func TestGroupRoutedSubmitterRequiresFeatureWhenAnyGroupEnablesIt(t *testing.T) {
+	features := DefaultFeatureSet()
+	features.Required = append(features.Required, RequiredFeature{
+		Name:    FeatureVectorPartitionLifecycle,
+		Version: SupportedFeatureFloors[FeatureVectorPartitionLifecycle],
+	})
+	dispatcher := newTestGroupRoutedSubmitter(t,
+		&recordingGroupSubmitter{groupID: "group-a"},
+		&recordingGroupSubmitter{groupID: "group-b", features: features},
+	)
+	required, err := dispatcher.RequiresFeatureV1(FeatureVectorPartitionLifecycle)
+	if err != nil {
+		t.Fatalf("RequiresFeatureV1: %v", err)
+	}
+	if !required {
+		t.Fatal("vector partition lifecycle requirement=false want true from group-b config")
 	}
 }
 

--- a/TreeDB/internal/raftcluster/dispatcher_test.go
+++ b/TreeDB/internal/raftcluster/dispatcher_test.go
@@ -86,6 +86,13 @@ func (s *recordingGroupSubmitter) SubmitCommandEntryV1(_ context.Context, entry 
 	}, nil
 }
 
+func (s *recordingGroupSubmitter) SubmitCommandEntryWithPreCommitV1(ctx context.Context, entry []byte, metadata raftentry.RequestMetadataV1, preCommit func(context.Context) error) (SubmitResultV1, error) {
+	if err := preCommit(ctx); err != nil {
+		return SubmitResultV1{}, err
+	}
+	return s.SubmitCommandEntryV1(ctx, entry, metadata)
+}
+
 func (s *recordingGroupSubmitter) snapshot() []recordingGroupSubmitCall {
 	out := make([]recordingGroupSubmitCall, len(s.calls))
 	for i := range s.calls {
@@ -428,6 +435,47 @@ func TestGroupRoutedSubmitterRequiresFeatureWhenAnyGroupEnablesIt(t *testing.T) 
 	}
 	if !required {
 		t.Fatal("vector partition lifecycle requirement=false want true from group-b config")
+	}
+}
+
+func TestGroupRoutedSubmitterDelegatesSerializedPreCommitV1(t *testing.T) {
+	groupA := &recordingGroupSubmitter{groupID: "group-a"}
+	dispatcher := newTestGroupRoutedSubmitter(t, groupA)
+	called := false
+	if _, err := dispatcher.SubmitCommandEntryWithPreCommitV1(context.Background(), testClusterCommandEntry(t, 7), routeMetadata("group-a", iwire.AckRaftCommitted), func(context.Context) error {
+		called = true
+		if calls := groupA.snapshot(); len(calls) != 0 {
+			t.Fatalf("data submit ran before pre-commit callback: calls=%d", len(calls))
+		}
+		return nil
+	}); err != nil {
+		t.Fatalf("SubmitCommandEntryWithPreCommitV1: %v", err)
+	}
+	if !called || len(groupA.snapshot()) != 1 {
+		t.Fatalf("callback/submits=%v/%d want true/1", called, len(groupA.snapshot()))
+	}
+}
+
+func TestGroupRoutedSubmitterRejectsMissingSerializedPreCommitV1(t *testing.T) {
+	groupA := &submitOnlyGroupSubmitter{groupID: "group-a"}
+	registry, err := NewGroupSubmitterRegistryV1([]GroupSubmitterV1{{GroupID: "group-a", Submitter: groupA}})
+	if err != nil {
+		t.Fatalf("NewGroupSubmitterRegistryV1: %v", err)
+	}
+	dispatcher, err := NewCatalogMetaGroupRoutedSubmitter(registry, &recordingCatalogRouteValidator{})
+	if err != nil {
+		t.Fatalf("NewCatalogMetaGroupRoutedSubmitter: %v", err)
+	}
+	called := false
+	_, err = dispatcher.SubmitCommandEntryWithPreCommitV1(context.Background(), testClusterCommandEntry(t, 7), routeMetadata("group-a", iwire.AckRaftCommitted), func(context.Context) error {
+		called = true
+		return nil
+	})
+	if !errors.Is(err, ErrInvalidSubmitter) {
+		t.Fatalf("SubmitCommandEntryWithPreCommitV1 err=%v want invalid submitter", err)
+	}
+	if called {
+		t.Fatal("pre-commit callback ran without a serialized target submitter")
 	}
 }
 

--- a/TreeDB/internal/raftcluster/submit.go
+++ b/TreeDB/internal/raftcluster/submit.go
@@ -376,6 +376,18 @@ type CommandSubmitterV1 interface {
 	SubmitCommandEntryV1(context.Context, []byte, raftentry.RequestMetadataV1) (SubmitResultV1, error)
 }
 
+// CommandSubmitterWithPreCommitV1 extends the submit boundary with a callback
+// that runs only after deterministic data preflight succeeds and immediately
+// before the command enters the commit source. Implementations must serialize
+// the callback with the corresponding preflight and commit attempt.
+//
+// The callback is used by cross-group lifecycle coordination that must not be
+// published for a command the data layer has already rejected as definitely
+// uncommitted.
+type CommandSubmitterWithPreCommitV1 interface {
+	SubmitCommandEntryWithPreCommitV1(context.Context, []byte, raftentry.RequestMetadataV1, func(context.Context) error) (SubmitResultV1, error)
+}
+
 func NewSingleGroupSubmitter(opts SingleGroupSubmitterOptions) (*SingleGroupSubmitter, error) {
 	cluster, err := Validate(opts.Cluster)
 	if err != nil {
@@ -429,6 +441,21 @@ func (s *SingleGroupSubmitter) ClusterAdmissionStatus(ctx context.Context) (Admi
 }
 
 func (s *SingleGroupSubmitter) SubmitCommandEntryV1(ctx context.Context, entry []byte, metadata raftentry.RequestMetadataV1) (SubmitResultV1, error) {
+	return s.submitCommandEntryV1(ctx, entry, metadata, nil)
+}
+
+// SubmitCommandEntryWithPreCommitV1 runs preCommit after the deterministic
+// data preflight and before commit while holding the submitter serialization
+// boundary. A callback error is definitive: the data command was not offered
+// to the commit source.
+func (s *SingleGroupSubmitter) SubmitCommandEntryWithPreCommitV1(ctx context.Context, entry []byte, metadata raftentry.RequestMetadataV1, preCommit func(context.Context) error) (SubmitResultV1, error) {
+	if preCommit == nil {
+		return SubmitResultV1{}, errors.Join(ErrInvalidSubmitter, fmt.Errorf("pre-commit callback is required"))
+	}
+	return s.submitCommandEntryV1(ctx, entry, metadata, preCommit)
+}
+
+func (s *SingleGroupSubmitter) submitCommandEntryV1(ctx context.Context, entry []byte, metadata raftentry.RequestMetadataV1, preCommit func(context.Context) error) (SubmitResultV1, error) {
 	if s == nil || s.commit == nil || s.preflight == nil || s.applier == nil || s.catalogProvider == nil {
 		return SubmitResultV1{}, ErrInvalidSubmitter
 	}
@@ -495,6 +522,12 @@ func (s *SingleGroupSubmitter) SubmitCommandEntryV1(ctx context.Context, entry [
 	if allowStaleCreateRetry && !preflightResult.KnownIdempotencyReplay {
 		s.submitMu.Unlock()
 		return SubmitResultV1{}, guardErr
+	}
+	if preCommit != nil {
+		if err := preCommit(ctx); err != nil {
+			s.submitMu.Unlock()
+			return SubmitResultV1{}, err
+		}
 	}
 	request := CommitCommandEntryV1Request{
 		GroupID:                  s.cluster.GroupID,

--- a/TreeDB/internal/raftcluster/submit.go
+++ b/TreeDB/internal/raftcluster/submit.go
@@ -525,26 +525,26 @@ func (s *SingleGroupSubmitter) SubmitCommandEntryV1(ctx context.Context, entry [
 		s.submitMu.Unlock()
 		return SubmitResultV1{ApplyResult: applyResult, CommittedEntry: committed, Evidence: commitResult.Evidence}, errors.Join(ErrLocalApplyNotRecoverable, fmt.Errorf("apply status %s", applyResult.Status))
 	}
+	result := SubmitResultV1{
+		ActualAck:        actualAck,
+		CommittedApplied: true,
+		DecodedEntry:     decoded,
+		ApplyResult:      applyResult,
+		CommittedEntry:   committed,
+		Evidence:         commitResult.Evidence,
+	}
 	postCatalogVersion, postHasCatalogVersion, err := s.catalogProvider.CurrentCatalogVersion(ctx)
 	if err != nil {
 		s.submitMu.Unlock()
-		return SubmitResultV1{ApplyResult: applyResult, CommittedEntry: committed, Evidence: commitResult.Evidence}, errors.Join(ErrLocalApplyNotRecoverable, err)
+		return result, errors.Join(ErrLocalApplyNotRecoverable, err)
 	}
 	if !postHasCatalogVersion {
 		s.submitMu.Unlock()
-		return SubmitResultV1{ApplyResult: applyResult, CommittedEntry: committed, Evidence: commitResult.Evidence}, errors.Join(ErrLocalApplyNotRecoverable, ErrMissingCatalogVersion)
+		return result, errors.Join(ErrLocalApplyNotRecoverable, ErrMissingCatalogVersion)
 	}
-	result := SubmitResultV1{
-		ActualAck:            actualAck,
-		CommittedRecoverable: actualAck == iwire.AckRaftCommitted && s.syncLocalWAL,
-		CommittedApplied:     true,
-		DecodedEntry:         decoded,
-		ApplyResult:          applyResult,
-		CommittedEntry:       committed,
-		Evidence:             commitResult.Evidence,
-		CatalogVersion:       postCatalogVersion,
-		HasCatalogVersion:    postHasCatalogVersion,
-	}
+	result.CommittedRecoverable = actualAck == iwire.AckRaftCommitted && s.syncLocalWAL
+	result.CatalogVersion = postCatalogVersion
+	result.HasCatalogVersion = postHasCatalogVersion
 	s.submitMu.Unlock()
 	return result, nil
 }

--- a/TreeDB/internal/raftcluster/submit.go
+++ b/TreeDB/internal/raftcluster/submit.go
@@ -356,12 +356,17 @@ type SingleGroupSubmitter struct {
 type SubmitResultV1 struct {
 	ActualAck            iwire.AckPolicy
 	CommittedRecoverable bool
-	DecodedEntry         raftentry.CommandEntryV1
-	ApplyResult          raftentry.ApplyResultV1
-	CommittedEntry       CommittedCommandEntryV1
-	Evidence             CommitEvidenceV1
-	CatalogVersion       uint64
-	HasCatalogVersion    bool
+	// CommittedApplied is independent of the client-selected acknowledgment
+	// policy. It is true only after this submitter has validated the committed
+	// entry and completed local deterministic apply, so lifecycle callers may
+	// close post-commit fences even when the response requests a local ack.
+	CommittedApplied  bool
+	DecodedEntry      raftentry.CommandEntryV1
+	ApplyResult       raftentry.ApplyResultV1
+	CommittedEntry    CommittedCommandEntryV1
+	Evidence          CommitEvidenceV1
+	CatalogVersion    uint64
+	HasCatalogVersion bool
 }
 
 // CommandSubmitterV1 is the in-process boundary for submitting deterministic
@@ -532,6 +537,7 @@ func (s *SingleGroupSubmitter) SubmitCommandEntryV1(ctx context.Context, entry [
 	result := SubmitResultV1{
 		ActualAck:            actualAck,
 		CommittedRecoverable: actualAck == iwire.AckRaftCommitted && s.syncLocalWAL,
+		CommittedApplied:     true,
 		DecodedEntry:         decoded,
 		ApplyResult:          applyResult,
 		CommittedEntry:       committed,

--- a/TreeDB/internal/raftcluster/submit_test.go
+++ b/TreeDB/internal/raftcluster/submit_test.go
@@ -48,8 +48,8 @@ func TestSingleGroupSubmitterLeaderCommitsAppliesAndReturnsRaftCommitted(t *test
 	if err != nil {
 		t.Fatalf("SubmitCommandEntryV1: %v", err)
 	}
-	if result.ActualAck != iwire.AckRaftCommitted || !result.CommittedRecoverable {
-		t.Fatalf("ack/recoverable=%d/%v want raft_committed/true", result.ActualAck, result.CommittedRecoverable)
+	if result.ActualAck != iwire.AckRaftCommitted || !result.CommittedRecoverable || !result.CommittedApplied {
+		t.Fatalf("ack/recoverable/applied=%d/%v/%v want raft_committed/true/true", result.ActualAck, result.CommittedRecoverable, result.CommittedApplied)
 	}
 	if result.Evidence.Kind != CommitEvidenceProductionConsensusV1 || !result.Evidence.ProvesProductionConsensus() {
 		t.Fatalf("evidence=%+v does not prove production consensus", result.Evidence)
@@ -95,8 +95,8 @@ func TestSingleGroupSubmitterLowerAckDoesNotClaimRaftCommitted(t *testing.T) {
 	if err != nil {
 		t.Fatalf("SubmitCommandEntryV1 visible: %v", err)
 	}
-	if result.ActualAck != iwire.AckVisible || result.CommittedRecoverable {
-		t.Fatalf("ack/recoverable=%d/%v want visible/false", result.ActualAck, result.CommittedRecoverable)
+	if result.ActualAck != iwire.AckVisible || result.CommittedRecoverable || !result.CommittedApplied {
+		t.Fatalf("ack/recoverable/applied=%d/%v/%v want visible/false/true", result.ActualAck, result.CommittedRecoverable, result.CommittedApplied)
 	}
 	if len(applier.snapshot()) != 1 {
 		t.Fatal("visible submit did not apply through committed bridge")

--- a/TreeDB/internal/raftcluster/submit_test.go
+++ b/TreeDB/internal/raftcluster/submit_test.go
@@ -722,6 +722,9 @@ func TestSingleGroupSubmitterRejectsMissingPostApplyCatalogVersion(t *testing.T)
 	if result.CommittedRecoverable {
 		t.Fatal("missing post-apply catalog version reported committed recoverable")
 	}
+	if !result.CommittedApplied {
+		t.Fatal("missing post-apply catalog version discarded committed-applied evidence")
+	}
 	if result.HasCatalogVersion {
 		t.Fatalf("result HasCatalogVersion=%v want false", result.HasCatalogVersion)
 	}

--- a/TreeDB/internal/raftcluster/submit_test.go
+++ b/TreeDB/internal/raftcluster/submit_test.go
@@ -608,6 +608,75 @@ func TestSingleGroupSubmitterPreflightsBeforeCommitApply(t *testing.T) {
 	}
 }
 
+func TestSingleGroupSubmitterSerializesPreCommitAfterPreflightBeforeCommitV1(t *testing.T) {
+	entry := testClusterCommandEntry(t, 7)
+	preflightErr := errors.New("idempotency key conflicts with a different command")
+	var order []string
+	rejected := newTestSingleGroupSubmitter(t, SingleGroupSubmitterOptions{
+		AdmissionProvider: StaticAdmissionProvider{Status: LeaderAdmission()},
+		CommitSource: CommitSourceFunc(func(context.Context, CommitCommandEntryV1Request) (CommitCommandEntryV1Result, error) {
+			order = append(order, "commit")
+			return CommitCommandEntryV1Result{}, nil
+		}),
+		Preflight: CommandEntryPreflightFunc(func(context.Context, CommandEntryPreflightRequestV1) (CommandEntryPreflightResultV1, error) {
+			order = append(order, "preflight")
+			return CommandEntryPreflightResultV1{}, preflightErr
+		}),
+		Applier:                &recordingClusterApplier{result: raftentry.ApplyResultV1{Status: raftentry.ApplyStatusApplied}},
+		CatalogVersionProvider: staticCatalogVersion(7),
+	})
+	_, err := rejected.SubmitCommandEntryWithPreCommitV1(context.Background(), entry, raftentry.RequestMetadataV1{AckPolicy: iwire.AckRaftCommitted}, func(context.Context) error {
+		order = append(order, "lifecycle-admission")
+		return nil
+	})
+	if !errors.Is(err, preflightErr) {
+		t.Fatalf("rejected submit err=%v want preflight conflict", err)
+	}
+	if got, want := strings.Join(order, ","), "preflight"; got != want {
+		t.Fatalf("rejected submit order=%q want %q", got, want)
+	}
+
+	order = nil
+	applier := &recordingClusterApplier{result: raftentry.ApplyResultV1{Status: raftentry.ApplyStatusApplied}}
+	accepted := newTestSingleGroupSubmitter(t, SingleGroupSubmitterOptions{
+		AdmissionProvider: StaticAdmissionProvider{Status: LeaderAdmission()},
+		CommitSource: CommitSourceFunc(func(_ context.Context, req CommitCommandEntryV1Request) (CommitCommandEntryV1Result, error) {
+			order = append(order, "commit")
+			return CommitCommandEntryV1Result{
+				Entry: CommittedCommandEntryV1{
+					Term:                     1,
+					Index:                    1,
+					Bytes:                    bytes.Clone(req.EntryBytes),
+					CurrentCatalogVersion:    req.CurrentCatalogVersion,
+					HasCurrentCatalogVersion: req.HasCurrentCatalogVersion,
+					SyncLocalCommandWAL:      req.SyncLocalCommandWAL,
+					RequestMetadata:          cloneRequestMetadataV1(req.RequestMetadata),
+					ExpectedTarget:           req.ExpectedTarget,
+				},
+				Evidence: CommitEvidenceV1{
+					Kind: CommitEvidenceProductionConsensusV1, GroupID: "group-a", NodeID: "node-a", LeaderID: "node-a",
+					Term: 1, Index: 1, Committed: true, ProductionConsensus: true,
+				},
+			}, nil
+		}),
+		Preflight: CommandEntryPreflightFunc(func(context.Context, CommandEntryPreflightRequestV1) (CommandEntryPreflightResultV1, error) {
+			order = append(order, "preflight")
+			return CommandEntryPreflightResultV1{}, nil
+		}),
+		Applier:                applier,
+		CatalogVersionProvider: staticCatalogVersion(7),
+	})
+	if _, err := accepted.SubmitCommandEntryWithPreCommitV1(context.Background(), entry, raftentry.RequestMetadataV1{AckPolicy: iwire.AckRaftCommitted}, func(context.Context) error {
+		order = append(order, "lifecycle-admission")
+		return nil
+	}); err != nil {
+		t.Fatalf("accepted submit: %v", err)
+	}
+	if got, want := strings.Join(order, ","), "preflight,lifecycle-admission,commit"; got != want {
+		t.Fatalf("accepted submit order=%q want %q", got, want)
+	}
+}
+
 func TestSingleGroupSubmitterAdmissionRejectsBeforeCommitApply(t *testing.T) {
 	for _, tc := range []struct {
 		name    string

--- a/TreeDB/internal/raftplacement/catalog.go
+++ b/TreeDB/internal/raftplacement/catalog.go
@@ -20,7 +20,8 @@ const (
 var (
 	SupportedCatalogVersion = raftcluster.Version{Major: 1, Minor: 0}
 	SupportedFeatureFloors  = map[raftcluster.FeatureName]raftcluster.Version{
-		FeatureCollectionGroups: {Major: 1, Minor: 0},
+		FeatureCollectionGroups:                     {Major: 1, Minor: 0},
+		raftcluster.FeatureVectorPartitionLifecycle: {Major: 1, Minor: 0},
 	}
 
 	ErrInvalidCatalog           = errors.New("raftplacement: invalid catalog")

--- a/TreeDB/internal/raftplacement/catalog_meta.go
+++ b/TreeDB/internal/raftplacement/catalog_meta.go
@@ -206,6 +206,10 @@ type CatalogMetaAuthorityV1 struct {
 	// admitted, so a generation built from an older source cannot activate
 	// after a crash, replay, or a cleanup of the invalidated record.
 	mutationFences map[vectorPartitionLifecycleServingKeyV1]vectorPartitionLifecycleMutationFenceStateV1
+	// collectionMutationBarriers serialize relevant data mutations against
+	// first-generation source capture. They are replicated and snapshotted;
+	// process-local admission locks are intentionally insufficient here.
+	collectionMutationBarriers map[CollectionRefV1]vectorPartitionCollectionMutationBarrierStateV1
 }
 
 func NewCatalogMetaAuthorityV1() *CatalogMetaAuthorityV1 { return &CatalogMetaAuthorityV1{} }
@@ -288,6 +292,9 @@ func DecodeCatalogMetaCommandV1(raw []byte) (CatalogMetaCommandV1, error) {
 func (a *CatalogMetaAuthorityV1) applyCommittedCatalogMetaV1(raw []byte, appliedIndex uint64) (CatalogMetaStatusV1, error) {
 	if a == nil {
 		return CatalogMetaStatusV1{}, ErrCatalogMetaUnavailable
+	}
+	if vectorPartitionCollectionMutationCommandBytesV1(raw) {
+		return a.applyCommittedVectorPartitionCollectionMutationV1(raw, appliedIndex)
 	}
 	if vectorPartitionLifecycleCommandBytesV1(raw) {
 		return a.applyCommittedVectorPartitionLifecycleV1(raw, appliedIndex)
@@ -503,7 +510,7 @@ func (a *CatalogMetaAuthorityV1) ExportCatalogMetaSnapshotV1() (CatalogMetaSnaps
 	if a.record.Epoch == 0 {
 		return CatalogMetaSnapshotV1{}, ErrCatalogMetaUnavailable
 	}
-	lifecycle, err := encodeVectorPartitionLifecycleSnapshotV1(a.lifecycle, a.mutationFences)
+	lifecycle, err := encodeVectorPartitionLifecycleSnapshotV1(a.lifecycle, a.mutationFences, a.collectionMutationBarriers)
 	if err != nil {
 		return CatalogMetaSnapshotV1{}, err
 	}
@@ -542,7 +549,7 @@ func (a *CatalogMetaAuthorityV1) installCatalogMetaSnapshotV1(snapshot CatalogMe
 		!bytes.Equal(snapshot.Record, commandRecord) {
 		return CatalogMetaStatusV1{}, errors.Join(ErrInvalidCatalogMeta, ErrCatalogMetaConflict, fmt.Errorf("snapshot last command does not exactly install its record"))
 	}
-	lifecycle, active, activeNames, mutationFences, err := decodeVectorPartitionLifecycleSnapshotV1(snapshot.VectorPartitionLifecycle, record)
+	lifecycle, active, activeNames, mutationFences, collectionMutationBarriers, err := decodeVectorPartitionLifecycleSnapshotV1(snapshot.VectorPartitionLifecycle, record)
 	if err != nil {
 		return CatalogMetaStatusV1{}, err
 	}
@@ -559,7 +566,7 @@ func (a *CatalogMetaAuthorityV1) installCatalogMetaSnapshotV1(snapshot CatalogMe
 			return CatalogMetaStatusV1{}, ErrCatalogMetaStaleEpoch
 		}
 		if snapshot.AppliedIndex == a.applied {
-			currentLifecycle, err := encodeVectorPartitionLifecycleSnapshotV1(a.lifecycle, a.mutationFences)
+			currentLifecycle, err := encodeVectorPartitionLifecycleSnapshotV1(a.lifecycle, a.mutationFences, a.collectionMutationBarriers)
 			if err != nil {
 				return CatalogMetaStatusV1{}, err
 			}
@@ -572,6 +579,7 @@ func (a *CatalogMetaAuthorityV1) installCatalogMetaSnapshotV1(snapshot CatalogMe
 		a.active = active
 		a.activeNames = activeNames
 		a.mutationFences = mutationFences
+		a.collectionMutationBarriers = collectionMutationBarriers
 		a.lifecycleBytes = vectorPartitionLifecycleRetainedBytesV1(lifecycle)
 		a.applied = snapshot.AppliedIndex
 		a.refusal = ""
@@ -595,6 +603,7 @@ func (a *CatalogMetaAuthorityV1) installCatalogMetaSnapshotV1(snapshot CatalogMe
 	a.active = active
 	a.activeNames = activeNames
 	a.mutationFences = mutationFences
+	a.collectionMutationBarriers = collectionMutationBarriers
 	a.lifecycleBytes = vectorPartitionLifecycleRetainedBytesV1(lifecycle)
 	return a.statusLocked(), nil
 }

--- a/TreeDB/internal/raftplacement/catalog_meta.go
+++ b/TreeDB/internal/raftplacement/catalog_meta.go
@@ -517,6 +517,28 @@ func (a *CatalogMetaAuthorityV1) ExportCatalogMetaSnapshotV1() (CatalogMetaSnaps
 	return CatalogMetaSnapshotV1{Format: CatalogMetaFormatV1, AppliedIndex: a.applied, Record: bytes.Clone(a.recordBytes), LastCommand: bytes.Clone(a.command), VectorPartitionLifecycle: lifecycle}, nil
 }
 
+// validateProspectiveCatalogMetaSnapshotLockedV1 proves that a lifecycle
+// mutation leaves the complete outer catalog snapshot exportable. The
+// lifecycle payload is itself encoded as base64 by encoding/json, so checking
+// only its decoded length is insufficient.
+func (a *CatalogMetaAuthorityV1) validateProspectiveCatalogMetaSnapshotLockedV1(lifecycle []byte, appliedIndex uint64) error {
+	snapshot := CatalogMetaSnapshotV1{
+		Format:                   CatalogMetaFormatV1,
+		AppliedIndex:             appliedIndex,
+		Record:                   a.recordBytes,
+		LastCommand:              a.command,
+		VectorPartitionLifecycle: lifecycle,
+	}
+	raw, err := json.Marshal(snapshot)
+	if err != nil {
+		return errors.Join(ErrInvalidCatalogMeta, err)
+	}
+	if len(raw) > MaxCatalogMetaSnapshotBytesV1 {
+		return errors.Join(ErrCatalogMetaLimit, fmt.Errorf("snapshot is %d bytes", len(raw)))
+	}
+	return preflightCatalogMetaSnapshotJSONV1(raw)
+}
+
 func (a *CatalogMetaAuthorityV1) installCatalogMetaSnapshotV1(snapshot CatalogMetaSnapshotV1) (CatalogMetaStatusV1, error) {
 	if a == nil {
 		return CatalogMetaStatusV1{}, ErrCatalogMetaUnavailable
@@ -580,7 +602,7 @@ func (a *CatalogMetaAuthorityV1) installCatalogMetaSnapshotV1(snapshot CatalogMe
 		a.activeNames = activeNames
 		a.mutationFences = mutationFences
 		a.collectionMutationBarriers = collectionMutationBarriers
-		a.lifecycleBytes = vectorPartitionLifecycleRetainedBytesV1(lifecycle)
+		a.lifecycleBytes = uint64(len(snapshot.VectorPartitionLifecycle))
 		a.applied = snapshot.AppliedIndex
 		a.refusal = ""
 		return a.statusLocked(), nil
@@ -604,7 +626,7 @@ func (a *CatalogMetaAuthorityV1) installCatalogMetaSnapshotV1(snapshot CatalogMe
 	a.activeNames = activeNames
 	a.mutationFences = mutationFences
 	a.collectionMutationBarriers = collectionMutationBarriers
-	a.lifecycleBytes = vectorPartitionLifecycleRetainedBytesV1(lifecycle)
+	a.lifecycleBytes = uint64(len(snapshot.VectorPartitionLifecycle))
 	return a.statusLocked(), nil
 }
 

--- a/TreeDB/internal/raftplacement/catalog_meta.go
+++ b/TreeDB/internal/raftplacement/catalog_meta.go
@@ -22,7 +22,7 @@ import (
 const (
 	CatalogMetaFormatV1                    uint16 = 1
 	MaxCatalogMetaCommandBytesV1                  = 1 << 20
-	MaxCatalogMetaSnapshotBytesV1                 = 3 << 20
+	MaxCatalogMetaSnapshotBytesV1                 = 8 << 20
 	MaxCatalogMetaStringBytesV1                   = 128
 	MaxCatalogMetaDigestBytesV1                   = sha256.Size * 2
 	MaxCatalogMetaNestingDepthV1                  = 8
@@ -87,10 +87,11 @@ type CatalogMetaStatusV1 struct {
 // canonical record rather than a local cache serialization, so rejoin and
 // backup/restore share the same validation path as Raft replay.
 type CatalogMetaSnapshotV1 struct {
-	Format       uint16 `json:"format"`
-	AppliedIndex uint64 `json:"applied_index"`
-	Record       []byte `json:"record"`
-	LastCommand  []byte `json:"last_command"`
+	Format                   uint16 `json:"format"`
+	AppliedIndex             uint64 `json:"applied_index"`
+	Record                   []byte `json:"record"`
+	LastCommand              []byte `json:"last_command"`
+	VectorPartitionLifecycle []byte `json:"vector_partition_lifecycle,omitempty"`
 }
 
 // ApplyCatalogMetaCommittedV1, ExportCatalogMetaSnapshotBytesV1, and
@@ -189,13 +190,17 @@ func (a *CatalogMetaAuthorityV1) installCatalogMetaSnapshotBytesV1(raw []byte) e
 // only capability-bearing Raft Apply or Restore callbacks may publish a
 // generation. Reads take an RLock and do not contact the meta leader.
 type CatalogMetaAuthorityV1 struct {
-	mu          sync.RWMutex
-	record      CatalogMetaRecordV1
-	resolved    ResolvedCatalogV1
-	recordBytes []byte
-	command     []byte
-	applied     uint64
-	refusal     string
+	mu             sync.RWMutex
+	record         CatalogMetaRecordV1
+	resolved       ResolvedCatalogV1
+	recordBytes    []byte
+	command        []byte
+	applied        uint64
+	refusal        string
+	lifecycleBytes uint64
+	lifecycle      map[VectorPartitionLifecycleIdentityV1]VectorPartitionLifecycleRecordV1
+	active         map[VectorPartitionLifecycleIndexIdentityV1]VectorPartitionLifecycleIdentityV1
+	activeNames    map[vectorPartitionLifecycleServingKeyV1]VectorPartitionLifecycleIdentityV1
 }
 
 func NewCatalogMetaAuthorityV1() *CatalogMetaAuthorityV1 { return &CatalogMetaAuthorityV1{} }
@@ -279,6 +284,9 @@ func (a *CatalogMetaAuthorityV1) applyCommittedCatalogMetaV1(raw []byte, applied
 	if a == nil {
 		return CatalogMetaStatusV1{}, ErrCatalogMetaUnavailable
 	}
+	if vectorPartitionLifecycleCommandBytesV1(raw) {
+		return a.applyCommittedVectorPartitionLifecycleV1(raw, appliedIndex)
+	}
 	command, err := DecodeCatalogMetaCommandV1(raw)
 	if err != nil {
 		return CatalogMetaStatusV1{}, err
@@ -311,6 +319,9 @@ func (a *CatalogMetaAuthorityV1) applyCommittedCatalogMetaV1(raw []byte, applied
 		if err := validateCatalogMetaTopologyTransitionV1(a.resolved, resolved); err != nil {
 			return CatalogMetaStatusV1{}, err
 		}
+		if err := a.validateVectorPartitionLifecycleCatalogTransitionLockedV1(); err != nil {
+			return CatalogMetaStatusV1{}, err
+		}
 	}
 	a.record = command.Record
 	a.resolved = resolved
@@ -318,6 +329,7 @@ func (a *CatalogMetaAuthorityV1) applyCommittedCatalogMetaV1(raw []byte, applied
 	a.command = bytes.Clone(raw)
 	a.applied = appliedIndex
 	a.refusal = ""
+	a.clearVectorPartitionLifecycleLockedV1()
 	return a.statusLocked(), nil
 }
 
@@ -486,7 +498,11 @@ func (a *CatalogMetaAuthorityV1) ExportCatalogMetaSnapshotV1() (CatalogMetaSnaps
 	if a.record.Epoch == 0 {
 		return CatalogMetaSnapshotV1{}, ErrCatalogMetaUnavailable
 	}
-	return CatalogMetaSnapshotV1{Format: CatalogMetaFormatV1, AppliedIndex: a.applied, Record: bytes.Clone(a.recordBytes), LastCommand: bytes.Clone(a.command)}, nil
+	lifecycle, err := encodeVectorPartitionLifecycleSnapshotV1(a.lifecycle)
+	if err != nil {
+		return CatalogMetaSnapshotV1{}, err
+	}
+	return CatalogMetaSnapshotV1{Format: CatalogMetaFormatV1, AppliedIndex: a.applied, Record: bytes.Clone(a.recordBytes), LastCommand: bytes.Clone(a.command), VectorPartitionLifecycle: lifecycle}, nil
 }
 
 func (a *CatalogMetaAuthorityV1) installCatalogMetaSnapshotV1(snapshot CatalogMetaSnapshotV1) (CatalogMetaStatusV1, error) {
@@ -521,6 +537,10 @@ func (a *CatalogMetaAuthorityV1) installCatalogMetaSnapshotV1(snapshot CatalogMe
 		!bytes.Equal(snapshot.Record, commandRecord) {
 		return CatalogMetaStatusV1{}, errors.Join(ErrInvalidCatalogMeta, ErrCatalogMetaConflict, fmt.Errorf("snapshot last command does not exactly install its record"))
 	}
+	lifecycle, active, activeNames, err := decodeVectorPartitionLifecycleSnapshotV1(snapshot.VectorPartitionLifecycle, record)
+	if err != nil {
+		return CatalogMetaStatusV1{}, err
+	}
 	a.mu.Lock()
 	defer a.mu.Unlock()
 	if a.record.Epoch > record.Epoch {
@@ -530,10 +550,32 @@ func (a *CatalogMetaAuthorityV1) installCatalogMetaSnapshotV1(snapshot CatalogMe
 		if a.record.Digest != record.Digest || !bytes.Equal(a.recordBytes, snapshot.Record) {
 			return CatalogMetaStatusV1{}, ErrCatalogMetaConflict
 		}
+		if snapshot.AppliedIndex < a.applied {
+			return CatalogMetaStatusV1{}, ErrCatalogMetaStaleEpoch
+		}
+		if snapshot.AppliedIndex == a.applied {
+			currentLifecycle, err := encodeVectorPartitionLifecycleSnapshotV1(a.lifecycle)
+			if err != nil {
+				return CatalogMetaStatusV1{}, err
+			}
+			if !bytes.Equal(currentLifecycle, snapshot.VectorPartitionLifecycle) {
+				return CatalogMetaStatusV1{}, ErrCatalogMetaConflict
+			}
+			return a.statusLocked(), nil
+		}
+		a.lifecycle = lifecycle
+		a.active = active
+		a.activeNames = activeNames
+		a.lifecycleBytes = vectorPartitionLifecycleRetainedBytesV1(lifecycle)
+		a.applied = snapshot.AppliedIndex
+		a.refusal = ""
 		return a.statusLocked(), nil
 	}
 	if a.record.Epoch != 0 {
 		if err := validateCatalogMetaTopologyTransitionV1(a.resolved, resolved); err != nil {
+			return CatalogMetaStatusV1{}, err
+		}
+		if err := a.validateVectorPartitionLifecycleCatalogTransitionLockedV1(); err != nil {
 			return CatalogMetaStatusV1{}, err
 		}
 	}
@@ -543,6 +585,10 @@ func (a *CatalogMetaAuthorityV1) installCatalogMetaSnapshotV1(snapshot CatalogMe
 	a.command = bytes.Clone(snapshot.LastCommand)
 	a.applied = snapshot.AppliedIndex
 	a.refusal = ""
+	a.lifecycle = lifecycle
+	a.active = active
+	a.activeNames = activeNames
+	a.lifecycleBytes = vectorPartitionLifecycleRetainedBytesV1(lifecycle)
 	return a.statusLocked(), nil
 }
 
@@ -552,7 +598,7 @@ func (a *CatalogMetaAuthorityV1) statusLocked() CatalogMetaStatusV1 {
 		Digest:            a.record.Digest,
 		AppliedIndex:      a.applied,
 		Features:          cloneFeatureSet(a.record.Catalog.Features),
-		RetainedWireBytes: uint64(len(a.recordBytes) + len(a.command)),
+		RetainedWireBytes: uint64(len(a.recordBytes)+len(a.command)) + a.lifecycleBytes,
 		Refusal:           a.refusal,
 	}
 }

--- a/TreeDB/internal/raftplacement/catalog_meta.go
+++ b/TreeDB/internal/raftplacement/catalog_meta.go
@@ -205,7 +205,7 @@ type CatalogMetaAuthorityV1 struct {
 	// invalidation advances it before the corresponding data mutation is
 	// admitted, so a generation built from an older source cannot activate
 	// after a crash, replay, or a cleanup of the invalidated record.
-	mutationFences map[vectorPartitionLifecycleServingKeyV1]uint64
+	mutationFences map[vectorPartitionLifecycleServingKeyV1]vectorPartitionLifecycleMutationFenceStateV1
 }
 
 func NewCatalogMetaAuthorityV1() *CatalogMetaAuthorityV1 { return &CatalogMetaAuthorityV1{} }

--- a/TreeDB/internal/raftplacement/catalog_meta.go
+++ b/TreeDB/internal/raftplacement/catalog_meta.go
@@ -106,6 +106,18 @@ func (a *CatalogMetaAuthorityV1) ApplyCatalogMetaCommittedV1(capability raftclus
 	return err
 }
 
+// CatalogMetaAppliedIndexV1 returns the last catalog command index installed
+// in this local applied view. Raft read fences use it after a quorum-verified
+// barrier; callers must not treat the value alone as linearizability proof.
+func (a *CatalogMetaAuthorityV1) CatalogMetaAppliedIndexV1() (uint64, bool) {
+	if a == nil {
+		return 0, false
+	}
+	a.mu.RLock()
+	defer a.mu.RUnlock()
+	return a.applied, true
+}
+
 func (a *CatalogMetaAuthorityV1) ExportCatalogMetaSnapshotBytesV1() ([]byte, error) {
 	s, err := a.ExportCatalogMetaSnapshotV1()
 	if err != nil {

--- a/TreeDB/internal/raftplacement/catalog_meta.go
+++ b/TreeDB/internal/raftplacement/catalog_meta.go
@@ -201,6 +201,11 @@ type CatalogMetaAuthorityV1 struct {
 	lifecycle      map[VectorPartitionLifecycleIdentityV1]VectorPartitionLifecycleRecordV1
 	active         map[VectorPartitionLifecycleIndexIdentityV1]VectorPartitionLifecycleIdentityV1
 	activeNames    map[vectorPartitionLifecycleServingKeyV1]VectorPartitionLifecycleIdentityV1
+	// mutationFences is a durable per-serving-name watermark.  An
+	// invalidation advances it before the corresponding data mutation is
+	// admitted, so a generation built from an older source cannot activate
+	// after a crash, replay, or a cleanup of the invalidated record.
+	mutationFences map[vectorPartitionLifecycleServingKeyV1]uint64
 }
 
 func NewCatalogMetaAuthorityV1() *CatalogMetaAuthorityV1 { return &CatalogMetaAuthorityV1{} }
@@ -498,7 +503,7 @@ func (a *CatalogMetaAuthorityV1) ExportCatalogMetaSnapshotV1() (CatalogMetaSnaps
 	if a.record.Epoch == 0 {
 		return CatalogMetaSnapshotV1{}, ErrCatalogMetaUnavailable
 	}
-	lifecycle, err := encodeVectorPartitionLifecycleSnapshotV1(a.lifecycle)
+	lifecycle, err := encodeVectorPartitionLifecycleSnapshotV1(a.lifecycle, a.mutationFences)
 	if err != nil {
 		return CatalogMetaSnapshotV1{}, err
 	}
@@ -537,7 +542,7 @@ func (a *CatalogMetaAuthorityV1) installCatalogMetaSnapshotV1(snapshot CatalogMe
 		!bytes.Equal(snapshot.Record, commandRecord) {
 		return CatalogMetaStatusV1{}, errors.Join(ErrInvalidCatalogMeta, ErrCatalogMetaConflict, fmt.Errorf("snapshot last command does not exactly install its record"))
 	}
-	lifecycle, active, activeNames, err := decodeVectorPartitionLifecycleSnapshotV1(snapshot.VectorPartitionLifecycle, record)
+	lifecycle, active, activeNames, mutationFences, err := decodeVectorPartitionLifecycleSnapshotV1(snapshot.VectorPartitionLifecycle, record)
 	if err != nil {
 		return CatalogMetaStatusV1{}, err
 	}
@@ -554,7 +559,7 @@ func (a *CatalogMetaAuthorityV1) installCatalogMetaSnapshotV1(snapshot CatalogMe
 			return CatalogMetaStatusV1{}, ErrCatalogMetaStaleEpoch
 		}
 		if snapshot.AppliedIndex == a.applied {
-			currentLifecycle, err := encodeVectorPartitionLifecycleSnapshotV1(a.lifecycle)
+			currentLifecycle, err := encodeVectorPartitionLifecycleSnapshotV1(a.lifecycle, a.mutationFences)
 			if err != nil {
 				return CatalogMetaStatusV1{}, err
 			}
@@ -566,6 +571,7 @@ func (a *CatalogMetaAuthorityV1) installCatalogMetaSnapshotV1(snapshot CatalogMe
 		a.lifecycle = lifecycle
 		a.active = active
 		a.activeNames = activeNames
+		a.mutationFences = mutationFences
 		a.lifecycleBytes = vectorPartitionLifecycleRetainedBytesV1(lifecycle)
 		a.applied = snapshot.AppliedIndex
 		a.refusal = ""
@@ -588,6 +594,7 @@ func (a *CatalogMetaAuthorityV1) installCatalogMetaSnapshotV1(snapshot CatalogMe
 	a.lifecycle = lifecycle
 	a.active = active
 	a.activeNames = activeNames
+	a.mutationFences = mutationFences
 	a.lifecycleBytes = vectorPartitionLifecycleRetainedBytesV1(lifecycle)
 	return a.statusLocked(), nil
 }

--- a/TreeDB/internal/raftplacement/catalog_meta_collection_mutation_v1.go
+++ b/TreeDB/internal/raftplacement/catalog_meta_collection_mutation_v1.go
@@ -12,7 +12,10 @@ import (
 	"github.com/snissn/gomap/TreeDB/internal/raftcluster"
 )
 
-const maxVectorPartitionCollectionMutationBarriersV1 = 4096
+const (
+	maxVectorPartitionCollectionMutationBarriersV1   = 4096
+	maxVectorPartitionCollectionCompletedMutationsV1 = 64
+)
 
 type vectorPartitionCollectionMutationCommandKindV1 string
 
@@ -33,16 +36,23 @@ type vectorPartitionCollectionMutationCommandV1 struct {
 }
 
 type vectorPartitionCollectionMutationBarrierV1 struct {
-	Collection      CollectionRefV1 `json:"collection"`
-	Epoch           uint64          `json:"epoch"`
-	Pending         bool            `json:"pending"`
-	OperationDigest string          `json:"operation_digest"`
+	Collection      CollectionRefV1                                `json:"collection"`
+	Epoch           uint64                                         `json:"epoch"`
+	Pending         bool                                           `json:"pending"`
+	OperationDigest string                                         `json:"operation_digest"`
+	Completed       []vectorPartitionCollectionCompletedMutationV1 `json:"completed,omitempty"`
+}
+
+type vectorPartitionCollectionCompletedMutationV1 struct {
+	Epoch           uint64 `json:"epoch"`
+	OperationDigest string `json:"operation_digest"`
 }
 
 type vectorPartitionCollectionMutationBarrierStateV1 struct {
 	Epoch           uint64
 	Pending         bool
 	OperationDigest string
+	Completed       []vectorPartitionCollectionCompletedMutationV1
 }
 
 // VectorPartitionCollectionMutationBarrierStatusV1 is the durable collection-
@@ -53,6 +63,65 @@ type VectorPartitionCollectionMutationBarrierStatusV1 struct {
 	Epoch           uint64
 	Pending         bool
 	OperationDigest string
+}
+
+func cloneVectorPartitionCollectionMutationBarrierStateV1(state vectorPartitionCollectionMutationBarrierStateV1) vectorPartitionCollectionMutationBarrierStateV1 {
+	state.Completed = append([]vectorPartitionCollectionCompletedMutationV1(nil), state.Completed...)
+	return state
+}
+
+func findVectorPartitionCollectionCompletedMutationV1(state vectorPartitionCollectionMutationBarrierStateV1, operationDigest string) (vectorPartitionCollectionCompletedMutationV1, bool) {
+	for _, completed := range state.Completed {
+		if completed.OperationDigest == operationDigest {
+			return completed, true
+		}
+	}
+	return vectorPartitionCollectionCompletedMutationV1{}, false
+}
+
+func appendVectorPartitionCollectionCompletedMutationV1(state *vectorPartitionCollectionMutationBarrierStateV1, completed vectorPartitionCollectionCompletedMutationV1) {
+	if _, exists := findVectorPartitionCollectionCompletedMutationV1(*state, completed.OperationDigest); exists {
+		return
+	}
+	state.Completed = append(state.Completed, completed)
+	if len(state.Completed) > maxVectorPartitionCollectionCompletedMutationsV1 {
+		state.Completed = append([]vectorPartitionCollectionCompletedMutationV1(nil), state.Completed[len(state.Completed)-maxVectorPartitionCollectionCompletedMutationsV1:]...)
+	}
+}
+
+func validateVectorPartitionCollectionMutationBarrierStateV1(state vectorPartitionCollectionMutationBarrierStateV1) error {
+	if state.Epoch == 0 || !isSHA256HexVectorPartitionV1(state.OperationDigest) || len(state.Completed) > maxVectorPartitionCollectionCompletedMutationsV1 {
+		return ErrInvalidVectorPartitionLifecycle
+	}
+	seen := make(map[string]struct{}, len(state.Completed))
+	previousEpoch := uint64(0)
+	for _, completed := range state.Completed {
+		if completed.Epoch == 0 || completed.Epoch <= previousEpoch || completed.Epoch > state.Epoch || !isSHA256HexVectorPartitionV1(completed.OperationDigest) {
+			return ErrInvalidVectorPartitionLifecycle
+		}
+		if _, duplicate := seen[completed.OperationDigest]; duplicate {
+			return ErrVectorPartitionLifecycleConflict
+		}
+		seen[completed.OperationDigest] = struct{}{}
+		previousEpoch = completed.Epoch
+	}
+	if state.Pending {
+		if len(state.Completed) > 0 && state.Completed[len(state.Completed)-1].Epoch >= state.Epoch {
+			return ErrInvalidVectorPartitionLifecycle
+		}
+		if _, duplicate := seen[state.OperationDigest]; duplicate {
+			return ErrVectorPartitionLifecycleConflict
+		}
+		return nil
+	}
+	if len(state.Completed) == 0 {
+		return ErrInvalidVectorPartitionLifecycle
+	}
+	latest := state.Completed[len(state.Completed)-1]
+	if latest.Epoch != state.Epoch || latest.OperationDigest != state.OperationDigest {
+		return ErrInvalidVectorPartitionLifecycle
+	}
+	return nil
 }
 
 func encodeVectorPartitionCollectionMutationCommandV1(command vectorPartitionCollectionMutationCommandV1) ([]byte, error) {
@@ -161,11 +230,18 @@ func (a *CatalogMetaAuthorityV1) applyCommittedVectorPartitionCollectionMutation
 		a.collectionMutationBarriers = make(map[CollectionRefV1]vectorPartitionCollectionMutationBarrierStateV1)
 	}
 	current, exists := a.collectionMutationBarriers[command.Collection]
-	original := current
+	current = cloneVectorPartitionCollectionMutationBarrierStateV1(current)
+	original := cloneVectorPartitionCollectionMutationBarrierStateV1(current)
 	switch command.Kind {
 	case vectorPartitionBeginCollectionMutationV1:
 		if exists && current.OperationDigest == command.OperationDigest {
 			if current.Epoch != command.MutationEpoch {
+				return CatalogMetaStatusV1{}, ErrVectorPartitionLifecycleConflict
+			}
+			return a.statusLocked(), nil
+		}
+		if completed, ok := findVectorPartitionCollectionCompletedMutationV1(current, command.OperationDigest); ok {
+			if completed.Epoch != command.MutationEpoch {
 				return CatalogMetaStatusV1{}, ErrVectorPartitionLifecycleConflict
 			}
 			return a.statusLocked(), nil
@@ -189,8 +265,14 @@ func (a *CatalogMetaAuthorityV1) applyCommittedVectorPartitionCollectionMutation
 				return CatalogMetaStatusV1{}, errors.Join(ErrVectorPartitionLifecycleGuard, fmt.Errorf("generation %d source capture is in progress", identity.Generation))
 			}
 		}
-		a.collectionMutationBarriers[command.Collection] = vectorPartitionCollectionMutationBarrierStateV1{Epoch: command.MutationEpoch, Pending: true, OperationDigest: command.OperationDigest}
+		a.collectionMutationBarriers[command.Collection] = vectorPartitionCollectionMutationBarrierStateV1{Epoch: command.MutationEpoch, Pending: true, OperationDigest: command.OperationDigest, Completed: current.Completed}
 	case vectorPartitionConfirmCollectionMutationV1:
+		if completed, ok := findVectorPartitionCollectionCompletedMutationV1(current, command.OperationDigest); ok {
+			if completed.Epoch != command.MutationEpoch {
+				return CatalogMetaStatusV1{}, ErrVectorPartitionLifecycleConflict
+			}
+			return a.statusLocked(), nil
+		}
 		if !exists || current.Epoch != command.MutationEpoch || current.OperationDigest != command.OperationDigest {
 			return CatalogMetaStatusV1{}, errors.Join(ErrVectorPartitionLifecycleGuard, fmt.Errorf("collection mutation confirmation does not own the barrier"))
 		}
@@ -202,6 +284,7 @@ func (a *CatalogMetaAuthorityV1) applyCommittedVectorPartitionCollectionMutation
 				return CatalogMetaStatusV1{}, errors.Join(ErrVectorPartitionLifecycleGuard, fmt.Errorf("index %q mutation fence %d remains pending", key.IndexName, fence.Epoch))
 			}
 		}
+		appendVectorPartitionCollectionCompletedMutationV1(&current, vectorPartitionCollectionCompletedMutationV1{Epoch: current.Epoch, OperationDigest: current.OperationDigest})
 		current.Pending = false
 		a.collectionMutationBarriers[command.Collection] = current
 	}
@@ -226,6 +309,36 @@ func (a *CatalogMetaAuthorityV1) applyCommittedVectorPartitionCollectionMutation
 	a.lifecycleBytes = uint64(len(snapshot))
 	a.refusal = ""
 	return a.statusLocked(), nil
+}
+
+// VectorPartitionCollectionMutationOperationV1 resolves an exact operation
+// from the current barrier or the bounded durable completion window.
+func (a *CatalogMetaAuthorityV1) VectorPartitionCollectionMutationOperationV1(collection CollectionRefV1, operationDigest string) (VectorPartitionCollectionMutationBarrierStatusV1, bool, error) {
+	if a == nil {
+		return VectorPartitionCollectionMutationBarrierStatusV1{}, false, ErrCatalogMetaUnavailable
+	}
+	if err := validateCollectionRef(collection); err != nil {
+		return VectorPartitionCollectionMutationBarrierStatusV1{}, false, err
+	}
+	if !isSHA256HexVectorPartitionV1(operationDigest) {
+		return VectorPartitionCollectionMutationBarrierStatusV1{}, false, errors.Join(ErrInvalidVectorPartitionLifecycle, fmt.Errorf("invalid mutation operation digest"))
+	}
+	a.mu.RLock()
+	defer a.mu.RUnlock()
+	if a.record.Epoch == 0 {
+		return VectorPartitionCollectionMutationBarrierStatusV1{}, false, ErrCatalogMetaUnavailable
+	}
+	barrier, ok := a.collectionMutationBarriers[collection]
+	if !ok {
+		return VectorPartitionCollectionMutationBarrierStatusV1{Collection: collection}, false, nil
+	}
+	if barrier.OperationDigest == operationDigest {
+		return VectorPartitionCollectionMutationBarrierStatusV1{Collection: collection, Epoch: barrier.Epoch, Pending: barrier.Pending, OperationDigest: barrier.OperationDigest}, true, nil
+	}
+	if completed, found := findVectorPartitionCollectionCompletedMutationV1(barrier, operationDigest); found {
+		return VectorPartitionCollectionMutationBarrierStatusV1{Collection: collection, Epoch: completed.Epoch, Pending: false, OperationDigest: completed.OperationDigest}, true, nil
+	}
+	return VectorPartitionCollectionMutationBarrierStatusV1{Collection: collection, Epoch: barrier.Epoch, Pending: barrier.Pending}, false, nil
 }
 
 func (a *CatalogMetaAuthorityV1) VectorPartitionCollectionMutationBarrierV1(collection CollectionRefV1) (VectorPartitionCollectionMutationBarrierStatusV1, bool, error) {
@@ -295,12 +408,16 @@ func (c VectorPartitionLifecycleCoordinatorV1) BeginRelevantCollectionMutationV1
 	if !isSHA256HexVectorPartitionV1(operationDigest) {
 		return VectorPartitionCollectionMutationBarrierStatusV1{}, errors.Join(ErrInvalidVectorPartitionLifecycle, fmt.Errorf("invalid mutation operation digest"))
 	}
-	current, exists, err := c.Authority.VectorPartitionCollectionMutationBarrierV1(collection)
+	exact, found, err := c.Authority.VectorPartitionCollectionMutationOperationV1(collection, operationDigest)
 	if err != nil {
 		return VectorPartitionCollectionMutationBarrierStatusV1{}, err
 	}
-	if exists && current.OperationDigest == operationDigest {
-		return current, nil
+	if found {
+		return exact, nil
+	}
+	current, _, err := c.Authority.VectorPartitionCollectionMutationBarrierV1(collection)
+	if err != nil {
+		return VectorPartitionCollectionMutationBarrierStatusV1{}, err
 	}
 	if current.Pending {
 		return VectorPartitionCollectionMutationBarrierStatusV1{}, errors.Join(ErrVectorPartitionLifecycleGuard, fmt.Errorf("different collection mutation epoch %d is pending", current.Epoch))
@@ -331,7 +448,7 @@ func (c VectorPartitionLifecycleCoordinatorV1) ConfirmRelevantCollectionMutation
 	if c.Authority == nil || c.Committer == nil {
 		return ErrCatalogMetaUnavailable
 	}
-	current, exists, err := c.Authority.VectorPartitionCollectionMutationBarrierV1(collection)
+	current, exists, err := c.Authority.VectorPartitionCollectionMutationOperationV1(collection, operationDigest)
 	if err != nil {
 		return err
 	}

--- a/TreeDB/internal/raftplacement/catalog_meta_collection_mutation_v1.go
+++ b/TreeDB/internal/raftplacement/catalog_meta_collection_mutation_v1.go
@@ -161,6 +161,7 @@ func (a *CatalogMetaAuthorityV1) applyCommittedVectorPartitionCollectionMutation
 		a.collectionMutationBarriers = make(map[CollectionRefV1]vectorPartitionCollectionMutationBarrierStateV1)
 	}
 	current, exists := a.collectionMutationBarriers[command.Collection]
+	original := current
 	switch command.Kind {
 	case vectorPartitionBeginCollectionMutationV1:
 		if exists && current.OperationDigest == command.OperationDigest {
@@ -204,7 +205,25 @@ func (a *CatalogMetaAuthorityV1) applyCommittedVectorPartitionCollectionMutation
 		current.Pending = false
 		a.collectionMutationBarriers[command.Collection] = current
 	}
+	snapshot, err := encodeVectorPartitionLifecycleSnapshotV1(a.lifecycle, a.mutationFences, a.collectionMutationBarriers)
+	if err != nil {
+		if exists {
+			a.collectionMutationBarriers[command.Collection] = original
+		} else {
+			delete(a.collectionMutationBarriers, command.Collection)
+		}
+		return CatalogMetaStatusV1{}, err
+	}
+	if err := a.validateProspectiveCatalogMetaSnapshotLockedV1(snapshot, appliedIndex); err != nil {
+		if exists {
+			a.collectionMutationBarriers[command.Collection] = original
+		} else {
+			delete(a.collectionMutationBarriers, command.Collection)
+		}
+		return CatalogMetaStatusV1{}, err
+	}
 	a.applied = appliedIndex
+	a.lifecycleBytes = uint64(len(snapshot))
 	a.refusal = ""
 	return a.statusLocked(), nil
 }

--- a/TreeDB/internal/raftplacement/catalog_meta_collection_mutation_v1.go
+++ b/TreeDB/internal/raftplacement/catalog_meta_collection_mutation_v1.go
@@ -1,0 +1,336 @@
+package raftplacement
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"sort"
+
+	"github.com/snissn/gomap/TreeDB/internal/raftcluster"
+)
+
+const maxVectorPartitionCollectionMutationBarriersV1 = 4096
+
+type vectorPartitionCollectionMutationCommandKindV1 string
+
+const (
+	vectorPartitionBeginCollectionMutationV1   vectorPartitionCollectionMutationCommandKindV1 = "begin_collection_mutation_v1"
+	vectorPartitionConfirmCollectionMutationV1 vectorPartitionCollectionMutationCommandKindV1 = "confirm_collection_mutation_v1"
+)
+
+type vectorPartitionCollectionMutationCommandV1 struct {
+	Format                uint16                                         `json:"format"`
+	Kind                  vectorPartitionCollectionMutationCommandKindV1 `json:"kind"`
+	Collection            CollectionRefV1                                `json:"collection"`
+	CatalogEpoch          uint64                                         `json:"catalog_epoch"`
+	CatalogDigest         string                                         `json:"catalog_digest"`
+	ExpectedMutationEpoch uint64                                         `json:"expected_mutation_epoch"`
+	MutationEpoch         uint64                                         `json:"mutation_epoch"`
+	OperationDigest       string                                         `json:"operation_digest"`
+}
+
+type vectorPartitionCollectionMutationBarrierV1 struct {
+	Collection      CollectionRefV1 `json:"collection"`
+	Epoch           uint64          `json:"epoch"`
+	Pending         bool            `json:"pending"`
+	OperationDigest string          `json:"operation_digest"`
+}
+
+type vectorPartitionCollectionMutationBarrierStateV1 struct {
+	Epoch           uint64
+	Pending         bool
+	OperationDigest string
+}
+
+// VectorPartitionCollectionMutationBarrierStatusV1 is the durable collection-
+// wide source-capture fence. Epoch is retained after confirmation so a source
+// captured before the mutation cannot later begin or activate a generation.
+type VectorPartitionCollectionMutationBarrierStatusV1 struct {
+	Collection      CollectionRefV1
+	Epoch           uint64
+	Pending         bool
+	OperationDigest string
+}
+
+func encodeVectorPartitionCollectionMutationCommandV1(command vectorPartitionCollectionMutationCommandV1) ([]byte, error) {
+	command.Format = VectorPartitionLifecycleFormatV1
+	if err := validateCollectionRef(command.Collection); err != nil {
+		return nil, errors.Join(ErrInvalidVectorPartitionLifecycle, err)
+	}
+	if command.CatalogEpoch == 0 || !isSHA256HexVectorPartitionV1(command.CatalogDigest) ||
+		command.MutationEpoch == 0 || !isSHA256HexVectorPartitionV1(command.OperationDigest) {
+		return nil, errors.Join(ErrInvalidVectorPartitionLifecycle, fmt.Errorf("invalid collection mutation proof"))
+	}
+	switch command.Kind {
+	case vectorPartitionBeginCollectionMutationV1:
+		if command.MutationEpoch != command.ExpectedMutationEpoch+1 {
+			return nil, errors.Join(ErrInvalidVectorPartitionLifecycle, fmt.Errorf("collection mutation epoch is not contiguous"))
+		}
+	case vectorPartitionConfirmCollectionMutationV1:
+		if command.ExpectedMutationEpoch != command.MutationEpoch {
+			return nil, errors.Join(ErrInvalidVectorPartitionLifecycle, fmt.Errorf("collection mutation confirmation epoch mismatch"))
+		}
+	default:
+		return nil, errors.Join(ErrInvalidVectorPartitionLifecycle, fmt.Errorf("unknown collection mutation command kind %q", command.Kind))
+	}
+	raw, err := json.Marshal(command)
+	if err != nil {
+		return nil, errors.Join(ErrInvalidVectorPartitionLifecycle, err)
+	}
+	if len(raw) > MaxVectorPartitionLifecycleCommandBytesV1 {
+		return nil, errors.Join(ErrVectorPartitionLifecycleLimit, fmt.Errorf("collection mutation command is %d bytes", len(raw)))
+	}
+	return raw, nil
+}
+
+func decodeVectorPartitionCollectionMutationCommandV1(raw []byte) (vectorPartitionCollectionMutationCommandV1, error) {
+	if len(raw) == 0 || len(raw) > MaxVectorPartitionLifecycleCommandBytesV1 {
+		return vectorPartitionCollectionMutationCommandV1{}, ErrVectorPartitionLifecycleLimit
+	}
+	var command vectorPartitionCollectionMutationCommandV1
+	decoder := json.NewDecoder(bytes.NewReader(raw))
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(&command); err != nil {
+		return vectorPartitionCollectionMutationCommandV1{}, errors.Join(ErrInvalidVectorPartitionLifecycle, err)
+	}
+	if err := decoder.Decode(&struct{}{}); !errors.Is(err, io.EOF) {
+		return vectorPartitionCollectionMutationCommandV1{}, errors.Join(ErrInvalidVectorPartitionLifecycle, fmt.Errorf("trailing collection mutation command data"))
+	}
+	canonical, err := encodeVectorPartitionCollectionMutationCommandV1(command)
+	if err != nil {
+		return vectorPartitionCollectionMutationCommandV1{}, err
+	}
+	if !bytes.Equal(raw, canonical) {
+		return vectorPartitionCollectionMutationCommandV1{}, errors.Join(ErrInvalidVectorPartitionLifecycle, fmt.Errorf("collection mutation command is not canonical"))
+	}
+	return command, nil
+}
+
+func vectorPartitionCollectionMutationCommandBytesV1(raw []byte) bool {
+	var envelope struct {
+		Kind vectorPartitionCollectionMutationCommandKindV1 `json:"kind"`
+	}
+	if len(raw) == 0 || len(raw) > MaxVectorPartitionLifecycleCommandBytesV1 || json.Unmarshal(raw, &envelope) != nil {
+		return false
+	}
+	return envelope.Kind == vectorPartitionBeginCollectionMutationV1 || envelope.Kind == vectorPartitionConfirmCollectionMutationV1
+}
+
+func (a *CatalogMetaAuthorityV1) effectiveCollectionMutationEpochLockedV1(collection CollectionRefV1) uint64 {
+	epoch := uint64(1) // epoch one is the no-mutation source-capture baseline.
+	if barrier := a.collectionMutationBarriers[collection]; barrier.Epoch > epoch {
+		epoch = barrier.Epoch
+	}
+	for identity, record := range a.lifecycle {
+		if identity.Index.Collection != collection {
+			continue
+		}
+		if record.MutationEpoch > epoch {
+			epoch = record.MutationEpoch
+		}
+		if record.InvalidationEpoch > epoch {
+			epoch = record.InvalidationEpoch
+		}
+	}
+	return epoch
+}
+
+func (a *CatalogMetaAuthorityV1) applyCommittedVectorPartitionCollectionMutationV1(raw []byte, appliedIndex uint64) (CatalogMetaStatusV1, error) {
+	command, err := decodeVectorPartitionCollectionMutationCommandV1(raw)
+	if err != nil {
+		return CatalogMetaStatusV1{}, err
+	}
+	if a == nil {
+		return CatalogMetaStatusV1{}, ErrCatalogMetaUnavailable
+	}
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	if a.record.Epoch == 0 {
+		return CatalogMetaStatusV1{}, ErrCatalogMetaUnavailable
+	}
+	if !catalogMetaFeatureEnabledV1(a.record.Catalog.Features, raftcluster.FeatureVectorPartitionLifecycle) {
+		return CatalogMetaStatusV1{}, errors.Join(ErrUnsupportedFeature, fmt.Errorf("catalog does not require %s", raftcluster.FeatureVectorPartitionLifecycle))
+	}
+	if command.CatalogEpoch != a.record.Epoch || command.CatalogDigest != a.record.Digest {
+		return CatalogMetaStatusV1{}, errors.Join(ErrVectorPartitionLifecycleIdentity, fmt.Errorf("collection mutation catalog proof does not match current authority"))
+	}
+	if a.collectionMutationBarriers == nil {
+		a.collectionMutationBarriers = make(map[CollectionRefV1]vectorPartitionCollectionMutationBarrierStateV1)
+	}
+	current, exists := a.collectionMutationBarriers[command.Collection]
+	switch command.Kind {
+	case vectorPartitionBeginCollectionMutationV1:
+		if exists && current.OperationDigest == command.OperationDigest {
+			if current.Epoch != command.MutationEpoch {
+				return CatalogMetaStatusV1{}, ErrVectorPartitionLifecycleConflict
+			}
+			return a.statusLocked(), nil
+		}
+		if current.Pending {
+			return CatalogMetaStatusV1{}, errors.Join(ErrVectorPartitionLifecycleGuard, fmt.Errorf("collection mutation epoch %d is pending", current.Epoch))
+		}
+		if !exists && len(a.collectionMutationBarriers) >= maxVectorPartitionCollectionMutationBarriersV1 {
+			return CatalogMetaStatusV1{}, errors.Join(ErrVectorPartitionLifecycleLimit, fmt.Errorf("collection mutation barriers=%d", len(a.collectionMutationBarriers)))
+		}
+		effective := a.effectiveCollectionMutationEpochLockedV1(command.Collection)
+		if command.ExpectedMutationEpoch != effective || command.MutationEpoch != effective+1 {
+			return CatalogMetaStatusV1{}, errors.Join(ErrVectorPartitionLifecycleStale, fmt.Errorf("collection mutation epoch=%d/%d want %d/%d", command.ExpectedMutationEpoch, command.MutationEpoch, effective, effective+1))
+		}
+		for identity, record := range a.lifecycle {
+			if identity.Index.Collection != command.Collection {
+				continue
+			}
+			switch record.State {
+			case VectorPartitionLifecycleBuildingV1, VectorPartitionLifecycleStagedV1, VectorPartitionLifecyclePreparedV1:
+				return CatalogMetaStatusV1{}, errors.Join(ErrVectorPartitionLifecycleGuard, fmt.Errorf("generation %d source capture is in progress", identity.Generation))
+			}
+		}
+		a.collectionMutationBarriers[command.Collection] = vectorPartitionCollectionMutationBarrierStateV1{Epoch: command.MutationEpoch, Pending: true, OperationDigest: command.OperationDigest}
+	case vectorPartitionConfirmCollectionMutationV1:
+		if !exists || current.Epoch != command.MutationEpoch || current.OperationDigest != command.OperationDigest {
+			return CatalogMetaStatusV1{}, errors.Join(ErrVectorPartitionLifecycleGuard, fmt.Errorf("collection mutation confirmation does not own the barrier"))
+		}
+		if !current.Pending {
+			return a.statusLocked(), nil
+		}
+		for key, fence := range a.mutationFences {
+			if key.Collection == command.Collection && fence.Pending {
+				return CatalogMetaStatusV1{}, errors.Join(ErrVectorPartitionLifecycleGuard, fmt.Errorf("index %q mutation fence %d remains pending", key.IndexName, fence.Epoch))
+			}
+		}
+		current.Pending = false
+		a.collectionMutationBarriers[command.Collection] = current
+	}
+	a.applied = appliedIndex
+	a.refusal = ""
+	return a.statusLocked(), nil
+}
+
+func (a *CatalogMetaAuthorityV1) VectorPartitionCollectionMutationBarrierV1(collection CollectionRefV1) (VectorPartitionCollectionMutationBarrierStatusV1, bool, error) {
+	if a == nil {
+		return VectorPartitionCollectionMutationBarrierStatusV1{}, false, ErrCatalogMetaUnavailable
+	}
+	if err := validateCollectionRef(collection); err != nil {
+		return VectorPartitionCollectionMutationBarrierStatusV1{}, false, err
+	}
+	a.mu.RLock()
+	defer a.mu.RUnlock()
+	if a.record.Epoch == 0 {
+		return VectorPartitionCollectionMutationBarrierStatusV1{}, false, ErrCatalogMetaUnavailable
+	}
+	barrier, ok := a.collectionMutationBarriers[collection]
+	if !ok {
+		return VectorPartitionCollectionMutationBarrierStatusV1{Collection: collection, Epoch: a.effectiveCollectionMutationEpochLockedV1(collection)}, false, nil
+	}
+	return VectorPartitionCollectionMutationBarrierStatusV1{Collection: collection, Epoch: barrier.Epoch, Pending: barrier.Pending, OperationDigest: barrier.OperationDigest}, true, nil
+}
+
+func (a *CatalogMetaAuthorityV1) VectorPartitionCollectionMutationBarriersV1() []VectorPartitionCollectionMutationBarrierStatusV1 {
+	if a == nil {
+		return nil
+	}
+	a.mu.RLock()
+	defer a.mu.RUnlock()
+	statuses := make([]VectorPartitionCollectionMutationBarrierStatusV1, 0, len(a.collectionMutationBarriers))
+	for collection, barrier := range a.collectionMutationBarriers {
+		statuses = append(statuses, VectorPartitionCollectionMutationBarrierStatusV1{Collection: collection, Epoch: barrier.Epoch, Pending: barrier.Pending, OperationDigest: barrier.OperationDigest})
+	}
+	sort.Slice(statuses, func(i, j int) bool {
+		a, b := statuses[i].Collection, statuses[j].Collection
+		if a.Database != b.Database {
+			return a.Database < b.Database
+		}
+		if a.Catalog != b.Catalog {
+			return a.Catalog < b.Catalog
+		}
+		return a.Collection < b.Collection
+	})
+	return statuses
+}
+
+// BuildSourceMutationEpochV1 must be read before capturing the group source
+// proofs. BeginBuildV1 rechecks the returned epoch after capture, while a
+// committed begin-build blocks a later distinct mutation until build abort or
+// cutover. The two checks close both sides of the source-capture race.
+func (c VectorPartitionLifecycleCoordinatorV1) BuildSourceMutationEpochV1(collection CollectionRefV1) (uint64, error) {
+	if c.Authority == nil {
+		return 0, ErrCatalogMetaUnavailable
+	}
+	status, _, err := c.Authority.VectorPartitionCollectionMutationBarrierV1(collection)
+	if err != nil {
+		return 0, err
+	}
+	if status.Pending {
+		return 0, errors.Join(ErrVectorPartitionLifecycleGuard, fmt.Errorf("collection mutation epoch %d is pending", status.Epoch))
+	}
+	return status.Epoch, nil
+}
+
+func (c VectorPartitionLifecycleCoordinatorV1) BeginRelevantCollectionMutationV1(ctx context.Context, collection CollectionRefV1, operationDigest string) (VectorPartitionCollectionMutationBarrierStatusV1, error) {
+	if c.Authority == nil || c.Committer == nil {
+		return VectorPartitionCollectionMutationBarrierStatusV1{}, ErrCatalogMetaUnavailable
+	}
+	if !isSHA256HexVectorPartitionV1(operationDigest) {
+		return VectorPartitionCollectionMutationBarrierStatusV1{}, errors.Join(ErrInvalidVectorPartitionLifecycle, fmt.Errorf("invalid mutation operation digest"))
+	}
+	current, exists, err := c.Authority.VectorPartitionCollectionMutationBarrierV1(collection)
+	if err != nil {
+		return VectorPartitionCollectionMutationBarrierStatusV1{}, err
+	}
+	if exists && current.OperationDigest == operationDigest {
+		return current, nil
+	}
+	if current.Pending {
+		return VectorPartitionCollectionMutationBarrierStatusV1{}, errors.Join(ErrVectorPartitionLifecycleGuard, fmt.Errorf("different collection mutation epoch %d is pending", current.Epoch))
+	}
+	proof, err := c.Authority.CurrentCatalogProof(ctx)
+	if err != nil {
+		return VectorPartitionCollectionMutationBarrierStatusV1{}, err
+	}
+	command := vectorPartitionCollectionMutationCommandV1{Kind: vectorPartitionBeginCollectionMutationV1, Collection: collection, CatalogEpoch: proof.Epoch, CatalogDigest: proof.Digest, ExpectedMutationEpoch: current.Epoch, MutationEpoch: current.Epoch + 1, OperationDigest: operationDigest}
+	raw, err := encodeVectorPartitionCollectionMutationCommandV1(command)
+	if err != nil {
+		return VectorPartitionCollectionMutationBarrierStatusV1{}, err
+	}
+	if _, _, err := c.Committer.SubmitCatalogMetaCommandV1(ctx, raw); err != nil {
+		return VectorPartitionCollectionMutationBarrierStatusV1{}, err
+	}
+	status, _, err := c.Authority.VectorPartitionCollectionMutationBarrierV1(collection)
+	if err != nil || status.OperationDigest != operationDigest || status.Epoch != command.MutationEpoch {
+		if err != nil {
+			return VectorPartitionCollectionMutationBarrierStatusV1{}, err
+		}
+		return VectorPartitionCollectionMutationBarrierStatusV1{}, ErrCatalogMetaUnavailable
+	}
+	return status, nil
+}
+
+func (c VectorPartitionLifecycleCoordinatorV1) ConfirmRelevantCollectionMutationV1(ctx context.Context, collection CollectionRefV1, operationDigest string) error {
+	if c.Authority == nil || c.Committer == nil {
+		return ErrCatalogMetaUnavailable
+	}
+	current, exists, err := c.Authority.VectorPartitionCollectionMutationBarrierV1(collection)
+	if err != nil {
+		return err
+	}
+	if !exists || current.OperationDigest != operationDigest {
+		return errors.Join(ErrVectorPartitionLifecycleGuard, fmt.Errorf("collection mutation confirmation has no matching barrier"))
+	}
+	if !current.Pending {
+		return nil
+	}
+	proof, err := c.Authority.CurrentCatalogProof(ctx)
+	if err != nil {
+		return err
+	}
+	command := vectorPartitionCollectionMutationCommandV1{Kind: vectorPartitionConfirmCollectionMutationV1, Collection: collection, CatalogEpoch: proof.Epoch, CatalogDigest: proof.Digest, ExpectedMutationEpoch: current.Epoch, MutationEpoch: current.Epoch, OperationDigest: operationDigest}
+	raw, err := encodeVectorPartitionCollectionMutationCommandV1(command)
+	if err != nil {
+		return err
+	}
+	_, _, err = c.Committer.SubmitCatalogMetaCommandV1(ctx, raw)
+	return err
+}

--- a/TreeDB/internal/raftplacement/catalog_meta_decode.go
+++ b/TreeDB/internal/raftplacement/catalog_meta_decode.go
@@ -13,15 +13,16 @@ import (
 )
 
 const (
-	maxCatalogMetaJSONKeyBytesV1       = 32
-	maxCatalogMetaJSONNumberBytesV1    = 20
-	maxCatalogMetaJSONObjectsV1        = 25000
-	maxCatalogMetaJSONArraysV1         = 5000
-	maxCatalogMetaJSONNestedElementsV1 = MaxCatalogMetaFeaturesV1 + MaxCatalogMetaGroupsV1 + MaxCatalogMetaPlacementsV1 + MaxCatalogMetaPartitionsV1 + MaxCatalogMetaGroupsV1*MaxCatalogMetaMembersPerGroupV1
-	maxCatalogMetaSnapshotFieldBytesV1 = ((MaxCatalogMetaCommandBytesV1 + 2) / 3) * 4
-	catalogMetaPreflightCommandV1      = "command"
-	catalogMetaPreflightRecordV1       = "record"
-	catalogMetaPreflightSnapshotV1     = "snapshot"
+	maxCatalogMetaJSONKeyBytesV1                = 32
+	maxCatalogMetaJSONNumberBytesV1             = 20
+	maxCatalogMetaJSONObjectsV1                 = 25000
+	maxCatalogMetaJSONArraysV1                  = 5000
+	maxCatalogMetaJSONNestedElementsV1          = MaxCatalogMetaFeaturesV1 + MaxCatalogMetaGroupsV1 + MaxCatalogMetaPlacementsV1 + MaxCatalogMetaPartitionsV1 + MaxCatalogMetaGroupsV1*MaxCatalogMetaMembersPerGroupV1
+	maxCatalogMetaSnapshotFieldBytesV1          = ((MaxCatalogMetaCommandBytesV1 + 2) / 3) * 4
+	maxCatalogMetaLifecycleSnapshotFieldBytesV1 = ((MaxCatalogMetaSnapshotBytesV1 + 2) / 3) * 4
+	catalogMetaPreflightCommandV1               = "command"
+	catalogMetaPreflightRecordV1                = "record"
+	catalogMetaPreflightSnapshotV1              = "snapshot"
 )
 
 // catalogMetaJSONPreflightV1 walks the complete JSON token stream before
@@ -135,7 +136,7 @@ func (p *catalogMetaJSONPreflightV1) snapshot() error {
 			_, _, err := p.nullableString(maxCatalogMetaSnapshotFieldBytesV1, key)
 			return err
 		case "vector_partition_lifecycle":
-			_, _, err := p.nullableString(MaxCatalogMetaSnapshotBytesV1, key)
+			_, _, err := p.nullableString(maxCatalogMetaLifecycleSnapshotFieldBytesV1, key)
 			return err
 		default:
 			return p.unknownField(catalogMetaPreflightSnapshotV1, key)

--- a/TreeDB/internal/raftplacement/catalog_meta_decode.go
+++ b/TreeDB/internal/raftplacement/catalog_meta_decode.go
@@ -134,6 +134,9 @@ func (p *catalogMetaJSONPreflightV1) snapshot() error {
 		case "record", "last_command":
 			_, _, err := p.nullableString(maxCatalogMetaSnapshotFieldBytesV1, key)
 			return err
+		case "vector_partition_lifecycle":
+			_, _, err := p.nullableString(MaxCatalogMetaSnapshotBytesV1, key)
+			return err
 		default:
 			return p.unknownField(catalogMetaPreflightSnapshotV1, key)
 		}

--- a/TreeDB/internal/raftplacement/catalog_meta_lifecycle.go
+++ b/TreeDB/internal/raftplacement/catalog_meta_lifecycle.go
@@ -342,7 +342,8 @@ func catalogMetaFeatureEnabledV1(features raftcluster.FeatureSet, name raftclust
 
 // ValidateVectorPartitionGenerationSearchV1 implements nativewire's M7
 // constant-time replicated authority seam without importing the transport
-// package back into raftplacement.
+// package back into raftplacement. It returns the authoritative lifecycle
+// ready-set digest; callers must not substitute the local manifest digest.
 func (a *CatalogMetaAuthorityV1) ValidateVectorPartitionGenerationSearchV1(
 	ctx context.Context,
 	collection CollectionRefV1,
@@ -353,30 +354,32 @@ func (a *CatalogMetaAuthorityV1) ValidateVectorPartitionGenerationSearchV1(
 	sourceChecksum uint64,
 	sourceSchemaHash uint64,
 	sourceRowCount uint64,
-	readySetDigest string,
-) error {
+) (string, error) {
 	if a == nil {
-		return ErrCatalogMetaUnavailable
+		return "", ErrCatalogMetaUnavailable
 	}
 	if ctx == nil {
 		ctx = context.Background()
 	}
 	if err := ctx.Err(); err != nil {
-		return err
+		return "", err
 	}
 	a.mu.RLock()
 	defer a.mu.RUnlock()
 	identity, ok := a.activeNames[vectorPartitionLifecycleServingKeyV1{Collection: collection, IndexName: index}]
 	if !ok {
-		return errors.Join(ErrVectorPartitionLifecycleGuard, fmt.Errorf("no active generation"))
+		return "", errors.Join(ErrVectorPartitionLifecycleGuard, fmt.Errorf("no active generation"))
 	}
 	record, ok := a.lifecycle[identity]
 	if !ok || identity.Generation != generation || identity.Index.IndexDefinitionDigest != indexDefinitionDigest ||
 		identity.Source.Generation != sourceGeneration || identity.Source.Checksum != sourceChecksum ||
 		identity.Source.SchemaHash != sourceSchemaHash || identity.Source.RowCount != sourceRowCount {
-		return ErrVectorPartitionLifecycleIdentity
+		return "", ErrVectorPartitionLifecycleIdentity
 	}
-	return record.CanSearch(VectorPartitionLifecycleSearchProofV1{Identity: identity, ReadySetDigest: readySetDigest})
+	if err := record.CanSearch(VectorPartitionLifecycleSearchProofV1{Identity: identity, ReadySetDigest: record.ReadySetDigest}); err != nil {
+		return "", err
+	}
+	return record.ReadySetDigest, nil
 }
 
 func (a *CatalogMetaAuthorityV1) VectorPartitionLifecycleRecordV1(identity VectorPartitionLifecycleIdentityV1) (VectorPartitionLifecycleRecordV1, bool) {

--- a/TreeDB/internal/raftplacement/catalog_meta_lifecycle.go
+++ b/TreeDB/internal/raftplacement/catalog_meta_lifecycle.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"slices"
 	"sort"
 
 	"github.com/snissn/gomap/TreeDB/internal/raftcluster"
@@ -397,7 +398,7 @@ func (a *CatalogMetaAuthorityV1) VectorPartitionLifecycleRecordV1(identity Vecto
 	a.mu.RLock()
 	defer a.mu.RUnlock()
 	record, ok := a.lifecycle[identity]
-	return record, ok
+	return cloneVectorPartitionLifecycleRecordV1(record), ok
 }
 
 func (a *CatalogMetaAuthorityV1) VectorPartitionLifecycleStatusesV1() []VectorPartitionLifecycleAuthorityStatusV1 {
@@ -639,9 +640,16 @@ func vectorPartitionLifecycleIdentityLessV1(a, b VectorPartitionLifecycleIdentit
 func cloneVectorPartitionLifecycleRecordsV1(source map[VectorPartitionLifecycleIdentityV1]VectorPartitionLifecycleRecordV1) map[VectorPartitionLifecycleIdentityV1]VectorPartitionLifecycleRecordV1 {
 	clone := make(map[VectorPartitionLifecycleIdentityV1]VectorPartitionLifecycleRecordV1, len(source))
 	for key, value := range source {
-		clone[key] = value
+		clone[key] = cloneVectorPartitionLifecycleRecordV1(value)
 	}
 	return clone
+}
+
+func cloneVectorPartitionLifecycleRecordV1(record VectorPartitionLifecycleRecordV1) VectorPartitionLifecycleRecordV1 {
+	record.RequiredGroups = slices.Clone(record.RequiredGroups)
+	record.ReadyGroups = slices.Clone(record.ReadyGroups)
+	record.CleanedGroups = slices.Clone(record.CleanedGroups)
+	return record
 }
 
 func cloneVectorPartitionLifecycleActiveV1(source map[VectorPartitionLifecycleIndexIdentityV1]VectorPartitionLifecycleIdentityV1) map[VectorPartitionLifecycleIndexIdentityV1]VectorPartitionLifecycleIdentityV1 {

--- a/TreeDB/internal/raftplacement/catalog_meta_lifecycle.go
+++ b/TreeDB/internal/raftplacement/catalog_meta_lifecycle.go
@@ -176,6 +176,13 @@ func (a *CatalogMetaAuthorityV1) applyCommittedVectorPartitionLifecycleV1(raw []
 	if current.LastCommandDigest == commandDigest {
 		return a.statusLocked(), nil
 	}
+	if command.Kind == VectorPartitionLifecycleInvalidateV1 && command.InvalidationEpoch <= fence.Epoch {
+		return CatalogMetaStatusV1{}, errors.Join(ErrVectorPartitionLifecycleGuard,
+			fmt.Errorf("invalidation epoch %d does not advance durable fence %d", command.InvalidationEpoch, fence.Epoch))
+	}
+	if command.Kind == VectorPartitionLifecycleConfirmMutationV1 && (fence.Epoch != command.MutationEpoch || !fence.Pending) {
+		return CatalogMetaStatusV1{}, errors.Join(ErrVectorPartitionLifecycleGuard, fmt.Errorf("mutation confirmation does not own a pending fence"))
+	}
 	// A pending fence is the durable recovery debt for a data mutation whose
 	// outcome has not yet been confirmed.  Lifecycle cleanup must not discard
 	// its invalidated source record: confirmation needs that exact record and
@@ -195,6 +202,10 @@ func (a *CatalogMetaAuthorityV1) applyCommittedVectorPartitionLifecycleV1(raw []
 			return CatalogMetaStatusV1{}, errors.Join(ErrVectorPartitionLifecycleGuard, fmt.Errorf("serving name is already active at generation %d", activeIdentity.Generation))
 		}
 	}
+	originalLifecycle := cloneVectorPartitionLifecycleRecordsV1(a.lifecycle)
+	originalActive := cloneVectorPartitionLifecycleActiveV1(a.active)
+	originalActiveNames := cloneVectorPartitionLifecycleActiveNamesV1(a.activeNames)
+	originalMutationFences := cloneVectorPartitionLifecycleMutationFencesV1(a.mutationFences)
 	if command.Kind == VectorPartitionLifecycleActivateV1 && command.PreviousActiveGeneration != 0 {
 		previousIdentity, previous, ok := findVectorPartitionLifecycleGenerationLockedV1(a.lifecycle, identity.Index, command.PreviousActiveGeneration)
 		if !ok {
@@ -234,18 +245,28 @@ func (a *CatalogMetaAuthorityV1) applyCommittedVectorPartitionLifecycleV1(raw []
 		}
 	}
 	if command.Kind == VectorPartitionLifecycleInvalidateV1 {
-		if command.InvalidationEpoch > fence.Epoch {
-			a.mutationFences[servingKey] = vectorPartitionLifecycleMutationFenceStateV1{Epoch: command.InvalidationEpoch, Pending: true}
-		}
+		a.mutationFences[servingKey] = vectorPartitionLifecycleMutationFenceStateV1{Epoch: command.InvalidationEpoch, Pending: true}
 	}
 	if command.Kind == VectorPartitionLifecycleConfirmMutationV1 {
-		if fence.Epoch != command.MutationEpoch || !fence.Pending {
-			return CatalogMetaStatusV1{}, errors.Join(ErrVectorPartitionLifecycleGuard, fmt.Errorf("mutation confirmation does not own a pending fence"))
-		}
 		a.mutationFences[servingKey] = vectorPartitionLifecycleMutationFenceStateV1{Epoch: fence.Epoch}
 	}
+	snapshot, err := encodeVectorPartitionLifecycleSnapshotV1(a.lifecycle, a.mutationFences, a.collectionMutationBarriers)
+	if err != nil {
+		a.lifecycle = originalLifecycle
+		a.active = originalActive
+		a.activeNames = originalActiveNames
+		a.mutationFences = originalMutationFences
+		return CatalogMetaStatusV1{}, err
+	}
+	if err := a.validateProspectiveCatalogMetaSnapshotLockedV1(snapshot, appliedIndex); err != nil {
+		a.lifecycle = originalLifecycle
+		a.active = originalActive
+		a.activeNames = originalActiveNames
+		a.mutationFences = originalMutationFences
+		return CatalogMetaStatusV1{}, err
+	}
 	a.applied = appliedIndex
-	a.lifecycleBytes = vectorPartitionLifecycleRetainedBytesV1(a.lifecycle)
+	a.lifecycleBytes = uint64(len(snapshot))
 	a.refusal = ""
 	return a.statusLocked(), nil
 }
@@ -254,6 +275,11 @@ func (a *CatalogMetaAuthorityV1) validateVectorPartitionLifecycleCatalogTransiti
 	for collection, barrier := range a.collectionMutationBarriers {
 		if barrier.Pending {
 			return errors.Join(ErrVectorPartitionLifecycleGuard, fmt.Errorf("catalog transition blocked by collection %s/%s/%s mutation epoch %d", collection.Database, collection.Catalog, collection.Collection, barrier.Epoch))
+		}
+	}
+	for key, fence := range a.mutationFences {
+		if fence.Pending {
+			return errors.Join(ErrVectorPartitionLifecycleGuard, fmt.Errorf("catalog transition blocked by collection %s/%s/%s index %q mutation epoch %d", key.Collection.Database, key.Collection.Catalog, key.Collection.Collection, key.IndexName, fence.Epoch))
 		}
 	}
 	for identity, record := range a.lifecycle {
@@ -577,16 +603,55 @@ func vectorPartitionLifecycleIdentityLessV1(a, b VectorPartitionLifecycleIdentit
 	if a.Index.CatalogEpoch != b.Index.CatalogEpoch {
 		return a.Index.CatalogEpoch < b.Index.CatalogEpoch
 	}
-	return a.Generation < b.Generation
+	if a.Index.IndexDefinitionDigest != b.Index.IndexDefinitionDigest {
+		return a.Index.IndexDefinitionDigest < b.Index.IndexDefinitionDigest
+	}
+	if a.Index.CatalogDigest != b.Index.CatalogDigest {
+		return a.Index.CatalogDigest < b.Index.CatalogDigest
+	}
+	if a.Generation != b.Generation {
+		return a.Generation < b.Generation
+	}
+	if a.Source.Generation != b.Source.Generation {
+		return a.Source.Generation < b.Source.Generation
+	}
+	if a.Source.Checksum != b.Source.Checksum {
+		return a.Source.Checksum < b.Source.Checksum
+	}
+	if a.Source.SchemaHash != b.Source.SchemaHash {
+		return a.Source.SchemaHash < b.Source.SchemaHash
+	}
+	return a.Source.RowCount < b.Source.RowCount
 }
 
-func vectorPartitionLifecycleRetainedBytesV1(records map[VectorPartitionLifecycleIdentityV1]VectorPartitionLifecycleRecordV1) uint64 {
-	var total uint64
-	for _, record := range records {
-		raw, err := EncodeVectorPartitionLifecycleRecordV1(record)
-		if err == nil {
-			total += uint64(len(raw))
-		}
+func cloneVectorPartitionLifecycleRecordsV1(source map[VectorPartitionLifecycleIdentityV1]VectorPartitionLifecycleRecordV1) map[VectorPartitionLifecycleIdentityV1]VectorPartitionLifecycleRecordV1 {
+	clone := make(map[VectorPartitionLifecycleIdentityV1]VectorPartitionLifecycleRecordV1, len(source))
+	for key, value := range source {
+		clone[key] = value
 	}
-	return total
+	return clone
+}
+
+func cloneVectorPartitionLifecycleActiveV1(source map[VectorPartitionLifecycleIndexIdentityV1]VectorPartitionLifecycleIdentityV1) map[VectorPartitionLifecycleIndexIdentityV1]VectorPartitionLifecycleIdentityV1 {
+	clone := make(map[VectorPartitionLifecycleIndexIdentityV1]VectorPartitionLifecycleIdentityV1, len(source))
+	for key, value := range source {
+		clone[key] = value
+	}
+	return clone
+}
+
+func cloneVectorPartitionLifecycleActiveNamesV1(source map[vectorPartitionLifecycleServingKeyV1]VectorPartitionLifecycleIdentityV1) map[vectorPartitionLifecycleServingKeyV1]VectorPartitionLifecycleIdentityV1 {
+	clone := make(map[vectorPartitionLifecycleServingKeyV1]VectorPartitionLifecycleIdentityV1, len(source))
+	for key, value := range source {
+		clone[key] = value
+	}
+	return clone
+}
+
+func cloneVectorPartitionLifecycleMutationFencesV1(source map[vectorPartitionLifecycleServingKeyV1]vectorPartitionLifecycleMutationFenceStateV1) map[vectorPartitionLifecycleServingKeyV1]vectorPartitionLifecycleMutationFenceStateV1 {
+	clone := make(map[vectorPartitionLifecycleServingKeyV1]vectorPartitionLifecycleMutationFenceStateV1, len(source))
+	for key, value := range source {
+		clone[key] = value
+	}
+	return clone
 }

--- a/TreeDB/internal/raftplacement/catalog_meta_lifecycle.go
+++ b/TreeDB/internal/raftplacement/catalog_meta_lifecycle.go
@@ -158,6 +158,19 @@ func (a *CatalogMetaAuthorityV1) applyCommittedVectorPartitionLifecycleV1(raw []
 	if current.LastCommandDigest == commandDigest {
 		return a.statusLocked(), nil
 	}
+	// A pending fence is the durable recovery debt for a data mutation whose
+	// outcome has not yet been confirmed.  Lifecycle cleanup must not discard
+	// its invalidated source record: confirmation needs that exact record and
+	// proof, including after snapshot/rejoin.  Keep the pure per-record reducer
+	// generic; this cross-record safety rule belongs to catalog authority.
+	if fence.Pending && current.InvalidationEpoch != 0 {
+		switch command.Kind {
+		case VectorPartitionLifecycleRetireV1, VectorPartitionLifecycleMarkCleanableV1,
+			VectorPartitionLifecycleRecordGroupCleanupV1, VectorPartitionLifecycleCompleteCleanupV1:
+			return CatalogMetaStatusV1{}, errors.Join(ErrVectorPartitionLifecycleGuard,
+				fmt.Errorf("cleanup is blocked by pending mutation fence %d", fence.Epoch))
+		}
+	}
 	if command.Kind == VectorPartitionLifecycleActivateV1 {
 		if activeIdentity, ok := a.activeNames[servingKey]; ok && activeIdentity != identity &&
 			(command.PreviousActiveGeneration == 0 || activeIdentity.Index != identity.Index || activeIdentity.Generation != command.PreviousActiveGeneration) {

--- a/TreeDB/internal/raftplacement/catalog_meta_lifecycle.go
+++ b/TreeDB/internal/raftplacement/catalog_meta_lifecycle.go
@@ -33,6 +33,12 @@ type vectorPartitionLifecycleMutationFenceV1 struct {
 	Collection CollectionRefV1 `json:"collection"`
 	IndexName  string          `json:"index_name"`
 	Epoch      uint64          `json:"epoch"`
+	Pending    bool            `json:"pending"`
+}
+
+type vectorPartitionLifecycleMutationFenceStateV1 struct {
+	Epoch   uint64
+	Pending bool
 }
 
 // VectorPartitionLifecycleAuthorityStatusV1 is the bounded operator view of
@@ -47,6 +53,7 @@ type VectorPartitionLifecycleAuthorityStatusV1 struct {
 	RequiredGroups         int
 	InvalidationReason     string
 	InvalidationEpoch      uint64
+	MutationConfirmed      bool
 	SupersededByGeneration uint64
 	CleanedGroups          int
 	RetainedWireBytes      uint64
@@ -92,7 +99,7 @@ func (a *CatalogMetaAuthorityV1) applyCommittedVectorPartitionLifecycleV1(raw []
 		a.activeNames = make(map[vectorPartitionLifecycleServingKeyV1]VectorPartitionLifecycleIdentityV1)
 	}
 	if a.mutationFences == nil {
-		a.mutationFences = make(map[vectorPartitionLifecycleServingKeyV1]uint64)
+		a.mutationFences = make(map[vectorPartitionLifecycleServingKeyV1]vectorPartitionLifecycleMutationFenceStateV1)
 	}
 
 	identity := command.Identity
@@ -102,10 +109,14 @@ func (a *CatalogMetaAuthorityV1) applyCommittedVectorPartitionLifecycleV1(raw []
 	// submitted.  Checking both build and activation makes a candidate that
 	// raced that entry fail closed, including after restore/replay and after
 	// the invalidated record has been cleaned up.
+	fence := a.mutationFences[servingKey]
+	if (command.Kind == VectorPartitionLifecycleBeginBuildV1 || command.Kind == VectorPartitionLifecycleActivateV1) && fence.Pending {
+		return CatalogMetaStatusV1{}, errors.Join(ErrVectorPartitionLifecycleGuard, fmt.Errorf("candidate source is blocked by pending mutation fence %d", fence.Epoch))
+	}
 	if (command.Kind == VectorPartitionLifecycleBeginBuildV1 || command.Kind == VectorPartitionLifecycleActivateV1) &&
-		command.MutationEpoch < a.mutationFences[servingKey] {
+		command.MutationEpoch < fence.Epoch {
 		return CatalogMetaStatusV1{}, errors.Join(ErrVectorPartitionLifecycleGuard,
-			fmt.Errorf("candidate source mutation epoch %d predates durable fence %d", command.MutationEpoch, a.mutationFences[servingKey]))
+			fmt.Errorf("candidate source mutation epoch %d predates durable fence %d", command.MutationEpoch, fence.Epoch))
 	}
 	current := a.lifecycle[identity]
 	commandDigest := sha256HexVectorPartitionLifecycleV1(raw)
@@ -157,9 +168,15 @@ func (a *CatalogMetaAuthorityV1) applyCommittedVectorPartitionLifecycleV1(raw []
 		}
 	}
 	if command.Kind == VectorPartitionLifecycleInvalidateV1 {
-		if command.InvalidationEpoch > a.mutationFences[servingKey] {
-			a.mutationFences[servingKey] = command.InvalidationEpoch
+		if command.InvalidationEpoch > fence.Epoch {
+			a.mutationFences[servingKey] = vectorPartitionLifecycleMutationFenceStateV1{Epoch: command.InvalidationEpoch, Pending: true}
 		}
+	}
+	if command.Kind == VectorPartitionLifecycleConfirmMutationV1 {
+		if fence.Epoch != command.MutationEpoch || !fence.Pending {
+			return CatalogMetaStatusV1{}, errors.Join(ErrVectorPartitionLifecycleGuard, fmt.Errorf("mutation confirmation does not own a pending fence"))
+		}
+		a.mutationFences[servingKey] = vectorPartitionLifecycleMutationFenceStateV1{Epoch: fence.Epoch}
 	}
 	a.applied = appliedIndex
 	a.lifecycleBytes = vectorPartitionLifecycleRetainedBytesV1(a.lifecycle)
@@ -288,6 +305,7 @@ func (a *CatalogMetaAuthorityV1) VectorPartitionLifecycleStatusesV1() []VectorPa
 			Active:      a.active[identity.Index] == identity,
 			ReadyGroups: len(record.ReadyGroups), RequiredGroups: len(record.RequiredGroups),
 			InvalidationReason: record.InvalidationReason, InvalidationEpoch: record.InvalidationEpoch,
+			MutationConfirmed:      record.MutationConfirmed,
 			SupersededByGeneration: record.SupersededByGeneration,
 			CleanedGroups:          len(record.CleanedGroups), RetainedWireBytes: uint64(len(raw)),
 		})
@@ -298,7 +316,7 @@ func (a *CatalogMetaAuthorityV1) VectorPartitionLifecycleStatusesV1() []VectorPa
 	return statuses
 }
 
-func encodeVectorPartitionLifecycleSnapshotV1(records map[VectorPartitionLifecycleIdentityV1]VectorPartitionLifecycleRecordV1, fences map[vectorPartitionLifecycleServingKeyV1]uint64) ([]byte, error) {
+func encodeVectorPartitionLifecycleSnapshotV1(records map[VectorPartitionLifecycleIdentityV1]VectorPartitionLifecycleRecordV1, fences map[vectorPartitionLifecycleServingKeyV1]vectorPartitionLifecycleMutationFenceStateV1) ([]byte, error) {
 	if len(records) == 0 && len(fences) == 0 {
 		return nil, nil
 	}
@@ -320,11 +338,11 @@ func encodeVectorPartitionLifecycleSnapshotV1(records map[VectorPartitionLifecyc
 	sort.Slice(payload.Records, func(i, j int) bool {
 		return vectorPartitionLifecycleIdentityLessV1(payload.Records[i].Identity, payload.Records[j].Identity)
 	})
-	for key, epoch := range fences {
-		if err := validateCollectionRef(key.Collection); err != nil || key.IndexName == "" || epoch == 0 {
+	for key, fence := range fences {
+		if err := validateCollectionRef(key.Collection); err != nil || key.IndexName == "" || fence.Epoch == 0 {
 			return nil, errors.Join(ErrInvalidVectorPartitionLifecycle, fmt.Errorf("invalid mutation fence"))
 		}
-		payload.MutationFences = append(payload.MutationFences, vectorPartitionLifecycleMutationFenceV1{Collection: key.Collection, IndexName: key.IndexName, Epoch: epoch})
+		payload.MutationFences = append(payload.MutationFences, vectorPartitionLifecycleMutationFenceV1{Collection: key.Collection, IndexName: key.IndexName, Epoch: fence.Epoch, Pending: fence.Pending})
 	}
 	sort.Slice(payload.MutationFences, func(i, j int) bool {
 		a, b := payload.MutationFences[i], payload.MutationFences[j]
@@ -353,13 +371,13 @@ func decodeVectorPartitionLifecycleSnapshotV1(raw []byte, catalog CatalogMetaRec
 	map[VectorPartitionLifecycleIdentityV1]VectorPartitionLifecycleRecordV1,
 	map[VectorPartitionLifecycleIndexIdentityV1]VectorPartitionLifecycleIdentityV1,
 	map[vectorPartitionLifecycleServingKeyV1]VectorPartitionLifecycleIdentityV1,
-	map[vectorPartitionLifecycleServingKeyV1]uint64,
+	map[vectorPartitionLifecycleServingKeyV1]vectorPartitionLifecycleMutationFenceStateV1,
 	error,
 ) {
 	records := make(map[VectorPartitionLifecycleIdentityV1]VectorPartitionLifecycleRecordV1)
 	active := make(map[VectorPartitionLifecycleIndexIdentityV1]VectorPartitionLifecycleIdentityV1)
 	activeNames := make(map[vectorPartitionLifecycleServingKeyV1]VectorPartitionLifecycleIdentityV1)
-	fences := make(map[vectorPartitionLifecycleServingKeyV1]uint64)
+	fences := make(map[vectorPartitionLifecycleServingKeyV1]vectorPartitionLifecycleMutationFenceStateV1)
 	if len(raw) == 0 {
 		return records, active, activeNames, fences, nil
 	}
@@ -415,7 +433,7 @@ func decodeVectorPartitionLifecycleSnapshotV1(raw []byte, catalog CatalogMetaRec
 		if _, duplicate := fences[key]; duplicate {
 			return nil, nil, nil, nil, ErrVectorPartitionLifecycleConflict
 		}
-		fences[key] = fence.Epoch
+		fences[key] = vectorPartitionLifecycleMutationFenceStateV1{Epoch: fence.Epoch, Pending: fence.Pending}
 	}
 	canonical, err := encodeVectorPartitionLifecycleSnapshotV1(records, fences)
 	if err != nil {

--- a/TreeDB/internal/raftplacement/catalog_meta_lifecycle.go
+++ b/TreeDB/internal/raftplacement/catalog_meta_lifecycle.go
@@ -466,10 +466,10 @@ func encodeVectorPartitionLifecycleSnapshotV1(records map[VectorPartitionLifecyc
 		return a.IndexName < b.IndexName
 	})
 	for collection, barrier := range barriers {
-		if err := validateCollectionRef(collection); err != nil || barrier.Epoch == 0 || !isSHA256HexVectorPartitionV1(barrier.OperationDigest) {
+		if err := validateCollectionRef(collection); err != nil || validateVectorPartitionCollectionMutationBarrierStateV1(barrier) != nil {
 			return nil, errors.Join(ErrInvalidVectorPartitionLifecycle, fmt.Errorf("invalid collection mutation barrier"))
 		}
-		payload.CollectionMutationBarriers = append(payload.CollectionMutationBarriers, vectorPartitionCollectionMutationBarrierV1{Collection: collection, Epoch: barrier.Epoch, Pending: barrier.Pending, OperationDigest: barrier.OperationDigest})
+		payload.CollectionMutationBarriers = append(payload.CollectionMutationBarriers, vectorPartitionCollectionMutationBarrierV1{Collection: collection, Epoch: barrier.Epoch, Pending: barrier.Pending, OperationDigest: barrier.OperationDigest, Completed: append([]vectorPartitionCollectionCompletedMutationV1(nil), barrier.Completed...)})
 	}
 	sort.Slice(payload.CollectionMutationBarriers, func(i, j int) bool {
 		a, b := payload.CollectionMutationBarriers[i].Collection, payload.CollectionMutationBarriers[j].Collection
@@ -566,13 +566,14 @@ func decodeVectorPartitionLifecycleSnapshotV1(raw []byte, catalog CatalogMetaRec
 		fences[key] = vectorPartitionLifecycleMutationFenceStateV1{Epoch: fence.Epoch, Pending: fence.Pending}
 	}
 	for _, barrier := range payload.CollectionMutationBarriers {
-		if err := validateCollectionRef(barrier.Collection); err != nil || barrier.Epoch == 0 || !isSHA256HexVectorPartitionV1(barrier.OperationDigest) {
+		state := vectorPartitionCollectionMutationBarrierStateV1{Epoch: barrier.Epoch, Pending: barrier.Pending, OperationDigest: barrier.OperationDigest, Completed: append([]vectorPartitionCollectionCompletedMutationV1(nil), barrier.Completed...)}
+		if err := validateCollectionRef(barrier.Collection); err != nil || validateVectorPartitionCollectionMutationBarrierStateV1(state) != nil {
 			return nil, nil, nil, nil, nil, errors.Join(ErrInvalidVectorPartitionLifecycle, fmt.Errorf("invalid collection mutation barrier"))
 		}
 		if _, duplicate := barriers[barrier.Collection]; duplicate {
 			return nil, nil, nil, nil, nil, ErrVectorPartitionLifecycleConflict
 		}
-		barriers[barrier.Collection] = vectorPartitionCollectionMutationBarrierStateV1{Epoch: barrier.Epoch, Pending: barrier.Pending, OperationDigest: barrier.OperationDigest}
+		barriers[barrier.Collection] = state
 	}
 	canonical, err := encodeVectorPartitionLifecycleSnapshotV1(records, fences, barriers)
 	if err != nil {

--- a/TreeDB/internal/raftplacement/catalog_meta_lifecycle.go
+++ b/TreeDB/internal/raftplacement/catalog_meta_lifecycle.go
@@ -574,6 +574,29 @@ func decodeVectorPartitionLifecycleSnapshotV1(raw []byte, catalog CatalogMetaRec
 		}
 		fences[key] = vectorPartitionLifecycleMutationFenceStateV1{Epoch: fence.Epoch, Pending: fence.Pending}
 	}
+	pendingMatches := make(map[vectorPartitionLifecycleServingKeyV1]int)
+	for _, record := range records {
+		key := vectorPartitionLifecycleServingKeyV1{Collection: record.Identity.Index.Collection, IndexName: record.Identity.Index.IndexName}
+		fence := fences[key]
+		if fence.Pending && record.State == VectorPartitionLifecycleInvalidatedV1 &&
+			record.InvalidationEpoch == fence.Epoch && !record.MutationConfirmed {
+			pendingMatches[key]++
+		}
+	}
+	for key, fence := range fences {
+		if !fence.Pending {
+			continue
+		}
+		if _, serving := activeNames[key]; serving {
+			return nil, nil, nil, nil, nil, errors.Join(ErrInvalidVectorPartitionLifecycle,
+				fmt.Errorf("pending mutation fence %d accompanies an active generation", fence.Epoch))
+		}
+		matching := pendingMatches[key]
+		if matching != 1 {
+			return nil, nil, nil, nil, nil, errors.Join(ErrInvalidVectorPartitionLifecycle,
+				fmt.Errorf("pending mutation fence %d has %d matching invalidated generation records", fence.Epoch, matching))
+		}
+	}
 	for _, barrier := range payload.CollectionMutationBarriers {
 		state := vectorPartitionCollectionMutationBarrierStateV1{Epoch: barrier.Epoch, Pending: barrier.Pending, OperationDigest: barrier.OperationDigest, Completed: append([]vectorPartitionCollectionCompletedMutationV1(nil), barrier.Completed...)}
 		if err := validateCollectionRef(barrier.Collection); err != nil || validateVectorPartitionCollectionMutationBarrierStateV1(state) != nil {

--- a/TreeDB/internal/raftplacement/catalog_meta_lifecycle.go
+++ b/TreeDB/internal/raftplacement/catalog_meta_lifecycle.go
@@ -12,7 +12,10 @@ import (
 	"github.com/snissn/gomap/TreeDB/internal/raftcluster"
 )
 
-const maxVectorPartitionLifecycleSnapshotRecordsV1 = 4096
+const (
+	maxVectorPartitionLifecycleSnapshotRecordsV1 = 4096
+	maxVectorPartitionLifecycleMutationFencesV1  = 4096
+)
 
 type vectorPartitionLifecycleServingKeyV1 struct {
 	Collection CollectionRefV1
@@ -144,7 +147,12 @@ func (a *CatalogMetaAuthorityV1) applyCommittedVectorPartitionLifecycleV1(raw []
 	// submitted.  Checking both build and activation makes a candidate that
 	// raced that entry fail closed, including after restore/replay and after
 	// the invalidated record has been cleaned up.
-	fence := a.mutationFences[servingKey]
+	fence, fenceExists := a.mutationFences[servingKey]
+	if command.Kind == VectorPartitionLifecycleInvalidateV1 && !fenceExists &&
+		len(a.mutationFences) >= maxVectorPartitionLifecycleMutationFencesV1 {
+		return CatalogMetaStatusV1{}, errors.Join(ErrVectorPartitionLifecycleLimit,
+			fmt.Errorf("mutation fences=%d", len(a.mutationFences)))
+	}
 	if (command.Kind == VectorPartitionLifecycleBeginBuildV1 || command.Kind == VectorPartitionLifecycleActivateV1) && fence.Pending {
 		return CatalogMetaStatusV1{}, errors.Join(ErrVectorPartitionLifecycleGuard, fmt.Errorf("candidate source is blocked by pending mutation fence %d", fence.Epoch))
 	}
@@ -371,6 +379,9 @@ func encodeVectorPartitionLifecycleSnapshotV1(records map[VectorPartitionLifecyc
 	if len(records) > maxVectorPartitionLifecycleSnapshotRecordsV1 {
 		return nil, errors.Join(ErrVectorPartitionLifecycleLimit, fmt.Errorf("snapshot records=%d", len(records)))
 	}
+	if len(fences) > maxVectorPartitionLifecycleMutationFencesV1 {
+		return nil, errors.Join(ErrVectorPartitionLifecycleLimit, fmt.Errorf("snapshot mutation fences=%d", len(fences)))
+	}
 	payload := vectorPartitionLifecycleSnapshotV1{Format: VectorPartitionLifecycleFormatV1, Records: make([]VectorPartitionLifecycleRecordV1, 0, len(records)), MutationFences: make([]vectorPartitionLifecycleMutationFenceV1, 0, len(fences))}
 	for _, record := range records {
 		raw, err := EncodeVectorPartitionLifecycleRecordV1(record)
@@ -387,7 +398,8 @@ func encodeVectorPartitionLifecycleSnapshotV1(records map[VectorPartitionLifecyc
 		return vectorPartitionLifecycleIdentityLessV1(payload.Records[i].Identity, payload.Records[j].Identity)
 	})
 	for key, fence := range fences {
-		if err := validateCollectionRef(key.Collection); err != nil || key.IndexName == "" || fence.Epoch == 0 {
+		if err := validateCollectionRef(key.Collection); err != nil ||
+			validateVectorPartitionLifecycleNameV1("index name", key.IndexName) != nil || fence.Epoch == 0 {
 			return nil, errors.Join(ErrInvalidVectorPartitionLifecycle, fmt.Errorf("invalid mutation fence"))
 		}
 		payload.MutationFences = append(payload.MutationFences, vectorPartitionLifecycleMutationFenceV1{Collection: key.Collection, IndexName: key.IndexName, Epoch: fence.Epoch, Pending: fence.Pending})
@@ -441,7 +453,9 @@ func decodeVectorPartitionLifecycleSnapshotV1(raw []byte, catalog CatalogMetaRec
 	if err := decoder.Decode(&struct{}{}); !errors.Is(err, io.EOF) {
 		return nil, nil, nil, nil, errors.Join(ErrInvalidVectorPartitionLifecycle, fmt.Errorf("trailing lifecycle snapshot data"))
 	}
-	if payload.Format != VectorPartitionLifecycleFormatV1 || len(payload.Records) > maxVectorPartitionLifecycleSnapshotRecordsV1 {
+	if payload.Format != VectorPartitionLifecycleFormatV1 ||
+		len(payload.Records) > maxVectorPartitionLifecycleSnapshotRecordsV1 ||
+		len(payload.MutationFences) > maxVectorPartitionLifecycleMutationFencesV1 {
 		return nil, nil, nil, nil, ErrVectorPartitionLifecycleLimit
 	}
 	for _, record := range payload.Records {
@@ -474,7 +488,8 @@ func decodeVectorPartitionLifecycleSnapshotV1(raw []byte, catalog CatalogMetaRec
 		}
 	}
 	for _, fence := range payload.MutationFences {
-		if err := validateCollectionRef(fence.Collection); err != nil || fence.IndexName == "" || fence.Epoch == 0 {
+		if err := validateCollectionRef(fence.Collection); err != nil ||
+			validateVectorPartitionLifecycleNameV1("index name", fence.IndexName) != nil || fence.Epoch == 0 {
 			return nil, nil, nil, nil, errors.Join(ErrInvalidVectorPartitionLifecycle, fmt.Errorf("invalid mutation fence"))
 		}
 		key := vectorPartitionLifecycleServingKeyV1{Collection: fence.Collection, IndexName: fence.IndexName}

--- a/TreeDB/internal/raftplacement/catalog_meta_lifecycle.go
+++ b/TreeDB/internal/raftplacement/catalog_meta_lifecycle.go
@@ -20,8 +20,19 @@ type vectorPartitionLifecycleServingKeyV1 struct {
 }
 
 type vectorPartitionLifecycleSnapshotV1 struct {
-	Format  uint16                             `json:"format"`
-	Records []VectorPartitionLifecycleRecordV1 `json:"records"`
+	Format         uint16                                    `json:"format"`
+	Records        []VectorPartitionLifecycleRecordV1        `json:"records"`
+	MutationFences []vectorPartitionLifecycleMutationFenceV1 `json:"mutation_fences"`
+}
+
+// vectorPartitionLifecycleMutationFenceV1 is retained independently of the
+// generation records.  Cleanup may remove an invalidated generation, but it
+// must never remove the source watermark which prevents an older candidate
+// from becoming active after a mutation.
+type vectorPartitionLifecycleMutationFenceV1 struct {
+	Collection CollectionRefV1 `json:"collection"`
+	IndexName  string          `json:"index_name"`
+	Epoch      uint64          `json:"epoch"`
 }
 
 // VectorPartitionLifecycleAuthorityStatusV1 is the bounded operator view of
@@ -80,15 +91,28 @@ func (a *CatalogMetaAuthorityV1) applyCommittedVectorPartitionLifecycleV1(raw []
 	if a.activeNames == nil {
 		a.activeNames = make(map[vectorPartitionLifecycleServingKeyV1]VectorPartitionLifecycleIdentityV1)
 	}
+	if a.mutationFences == nil {
+		a.mutationFences = make(map[vectorPartitionLifecycleServingKeyV1]uint64)
+	}
 
 	identity := command.Identity
+	servingKey := vectorPartitionLifecycleServingKeyV1{Collection: identity.Index.Collection, IndexName: identity.Index.IndexName}
+	// MutationEpoch is the immutable source watermark captured by the build.
+	// A durable invalidation fence is set before a relevant data entry may be
+	// submitted.  Checking both build and activation makes a candidate that
+	// raced that entry fail closed, including after restore/replay and after
+	// the invalidated record has been cleaned up.
+	if (command.Kind == VectorPartitionLifecycleBeginBuildV1 || command.Kind == VectorPartitionLifecycleActivateV1) &&
+		command.MutationEpoch < a.mutationFences[servingKey] {
+		return CatalogMetaStatusV1{}, errors.Join(ErrVectorPartitionLifecycleGuard,
+			fmt.Errorf("candidate source mutation epoch %d predates durable fence %d", command.MutationEpoch, a.mutationFences[servingKey]))
+	}
 	current := a.lifecycle[identity]
 	commandDigest := sha256HexVectorPartitionLifecycleV1(raw)
 	if current.LastCommandDigest == commandDigest {
 		return a.statusLocked(), nil
 	}
 	if command.Kind == VectorPartitionLifecycleActivateV1 {
-		servingKey := vectorPartitionLifecycleServingKeyV1{Collection: identity.Index.Collection, IndexName: identity.Index.IndexName}
 		if activeIdentity, ok := a.activeNames[servingKey]; ok && activeIdentity != identity &&
 			(command.PreviousActiveGeneration == 0 || activeIdentity.Index != identity.Index || activeIdentity.Generation != command.PreviousActiveGeneration) {
 			return CatalogMetaStatusV1{}, errors.Join(ErrVectorPartitionLifecycleGuard, fmt.Errorf("serving name is already active at generation %d", activeIdentity.Generation))
@@ -132,6 +156,11 @@ func (a *CatalogMetaAuthorityV1) applyCommittedVectorPartitionLifecycleV1(raw []
 			a.clearVectorPartitionLifecycleActiveLockedV1(identity)
 		}
 	}
+	if command.Kind == VectorPartitionLifecycleInvalidateV1 {
+		if command.InvalidationEpoch > a.mutationFences[servingKey] {
+			a.mutationFences[servingKey] = command.InvalidationEpoch
+		}
+	}
 	a.applied = appliedIndex
 	a.lifecycleBytes = vectorPartitionLifecycleRetainedBytesV1(a.lifecycle)
 	a.refusal = ""
@@ -151,6 +180,7 @@ func (a *CatalogMetaAuthorityV1) clearVectorPartitionLifecycleLockedV1() {
 	a.lifecycle = nil
 	a.active = nil
 	a.activeNames = nil
+	a.mutationFences = nil
 	a.lifecycleBytes = 0
 }
 
@@ -268,14 +298,14 @@ func (a *CatalogMetaAuthorityV1) VectorPartitionLifecycleStatusesV1() []VectorPa
 	return statuses
 }
 
-func encodeVectorPartitionLifecycleSnapshotV1(records map[VectorPartitionLifecycleIdentityV1]VectorPartitionLifecycleRecordV1) ([]byte, error) {
-	if len(records) == 0 {
+func encodeVectorPartitionLifecycleSnapshotV1(records map[VectorPartitionLifecycleIdentityV1]VectorPartitionLifecycleRecordV1, fences map[vectorPartitionLifecycleServingKeyV1]uint64) ([]byte, error) {
+	if len(records) == 0 && len(fences) == 0 {
 		return nil, nil
 	}
 	if len(records) > maxVectorPartitionLifecycleSnapshotRecordsV1 {
 		return nil, errors.Join(ErrVectorPartitionLifecycleLimit, fmt.Errorf("snapshot records=%d", len(records)))
 	}
-	payload := vectorPartitionLifecycleSnapshotV1{Format: VectorPartitionLifecycleFormatV1, Records: make([]VectorPartitionLifecycleRecordV1, 0, len(records))}
+	payload := vectorPartitionLifecycleSnapshotV1{Format: VectorPartitionLifecycleFormatV1, Records: make([]VectorPartitionLifecycleRecordV1, 0, len(records)), MutationFences: make([]vectorPartitionLifecycleMutationFenceV1, 0, len(fences))}
 	for _, record := range records {
 		raw, err := EncodeVectorPartitionLifecycleRecordV1(record)
 		if err != nil {
@@ -289,6 +319,25 @@ func encodeVectorPartitionLifecycleSnapshotV1(records map[VectorPartitionLifecyc
 	}
 	sort.Slice(payload.Records, func(i, j int) bool {
 		return vectorPartitionLifecycleIdentityLessV1(payload.Records[i].Identity, payload.Records[j].Identity)
+	})
+	for key, epoch := range fences {
+		if err := validateCollectionRef(key.Collection); err != nil || key.IndexName == "" || epoch == 0 {
+			return nil, errors.Join(ErrInvalidVectorPartitionLifecycle, fmt.Errorf("invalid mutation fence"))
+		}
+		payload.MutationFences = append(payload.MutationFences, vectorPartitionLifecycleMutationFenceV1{Collection: key.Collection, IndexName: key.IndexName, Epoch: epoch})
+	}
+	sort.Slice(payload.MutationFences, func(i, j int) bool {
+		a, b := payload.MutationFences[i], payload.MutationFences[j]
+		if a.Collection.Database != b.Collection.Database {
+			return a.Collection.Database < b.Collection.Database
+		}
+		if a.Collection.Catalog != b.Collection.Catalog {
+			return a.Collection.Catalog < b.Collection.Catalog
+		}
+		if a.Collection.Collection != b.Collection.Collection {
+			return a.Collection.Collection < b.Collection.Collection
+		}
+		return a.IndexName < b.IndexName
 	})
 	raw, err := json.Marshal(payload)
 	if err != nil {
@@ -304,66 +353,78 @@ func decodeVectorPartitionLifecycleSnapshotV1(raw []byte, catalog CatalogMetaRec
 	map[VectorPartitionLifecycleIdentityV1]VectorPartitionLifecycleRecordV1,
 	map[VectorPartitionLifecycleIndexIdentityV1]VectorPartitionLifecycleIdentityV1,
 	map[vectorPartitionLifecycleServingKeyV1]VectorPartitionLifecycleIdentityV1,
+	map[vectorPartitionLifecycleServingKeyV1]uint64,
 	error,
 ) {
 	records := make(map[VectorPartitionLifecycleIdentityV1]VectorPartitionLifecycleRecordV1)
 	active := make(map[VectorPartitionLifecycleIndexIdentityV1]VectorPartitionLifecycleIdentityV1)
 	activeNames := make(map[vectorPartitionLifecycleServingKeyV1]VectorPartitionLifecycleIdentityV1)
+	fences := make(map[vectorPartitionLifecycleServingKeyV1]uint64)
 	if len(raw) == 0 {
-		return records, active, activeNames, nil
+		return records, active, activeNames, fences, nil
 	}
 	if len(raw) > MaxCatalogMetaSnapshotBytesV1 {
-		return nil, nil, nil, ErrCatalogMetaLimit
+		return nil, nil, nil, nil, ErrCatalogMetaLimit
 	}
 	var payload vectorPartitionLifecycleSnapshotV1
 	decoder := json.NewDecoder(bytes.NewReader(raw))
 	decoder.DisallowUnknownFields()
 	if err := decoder.Decode(&payload); err != nil {
-		return nil, nil, nil, errors.Join(ErrInvalidVectorPartitionLifecycle, err)
+		return nil, nil, nil, nil, errors.Join(ErrInvalidVectorPartitionLifecycle, err)
 	}
 	if err := decoder.Decode(&struct{}{}); !errors.Is(err, io.EOF) {
-		return nil, nil, nil, errors.Join(ErrInvalidVectorPartitionLifecycle, fmt.Errorf("trailing lifecycle snapshot data"))
+		return nil, nil, nil, nil, errors.Join(ErrInvalidVectorPartitionLifecycle, fmt.Errorf("trailing lifecycle snapshot data"))
 	}
 	if payload.Format != VectorPartitionLifecycleFormatV1 || len(payload.Records) > maxVectorPartitionLifecycleSnapshotRecordsV1 {
-		return nil, nil, nil, ErrVectorPartitionLifecycleLimit
+		return nil, nil, nil, nil, ErrVectorPartitionLifecycleLimit
 	}
 	for _, record := range payload.Records {
 		encoded, err := EncodeVectorPartitionLifecycleRecordV1(record)
 		if err != nil {
-			return nil, nil, nil, err
+			return nil, nil, nil, nil, err
 		}
 		record, err = DecodeVectorPartitionLifecycleRecordV1(encoded)
 		if err != nil {
-			return nil, nil, nil, err
+			return nil, nil, nil, nil, err
 		}
 		identity := record.Identity
 		if identity.Index.CatalogEpoch != catalog.Epoch || identity.Index.CatalogDigest != catalog.Digest {
-			return nil, nil, nil, ErrVectorPartitionLifecycleIdentity
+			return nil, nil, nil, nil, ErrVectorPartitionLifecycleIdentity
 		}
 		if _, duplicate := records[identity]; duplicate {
-			return nil, nil, nil, ErrVectorPartitionLifecycleConflict
+			return nil, nil, nil, nil, ErrVectorPartitionLifecycleConflict
 		}
 		records[identity] = record
 		if record.State == VectorPartitionLifecycleActiveV1 {
 			if _, duplicate := active[identity.Index]; duplicate {
-				return nil, nil, nil, errors.Join(ErrVectorPartitionLifecycleConflict, fmt.Errorf("multiple active generations for one index"))
+				return nil, nil, nil, nil, errors.Join(ErrVectorPartitionLifecycleConflict, fmt.Errorf("multiple active generations for one index"))
 			}
 			servingKey := vectorPartitionLifecycleServingKeyV1{Collection: identity.Index.Collection, IndexName: identity.Index.IndexName}
 			if _, duplicate := activeNames[servingKey]; duplicate {
-				return nil, nil, nil, errors.Join(ErrVectorPartitionLifecycleConflict, fmt.Errorf("multiple active generations for one serving name"))
+				return nil, nil, nil, nil, errors.Join(ErrVectorPartitionLifecycleConflict, fmt.Errorf("multiple active generations for one serving name"))
 			}
 			active[identity.Index] = identity
 			activeNames[servingKey] = identity
 		}
 	}
-	canonical, err := encodeVectorPartitionLifecycleSnapshotV1(records)
+	for _, fence := range payload.MutationFences {
+		if err := validateCollectionRef(fence.Collection); err != nil || fence.IndexName == "" || fence.Epoch == 0 {
+			return nil, nil, nil, nil, errors.Join(ErrInvalidVectorPartitionLifecycle, fmt.Errorf("invalid mutation fence"))
+		}
+		key := vectorPartitionLifecycleServingKeyV1{Collection: fence.Collection, IndexName: fence.IndexName}
+		if _, duplicate := fences[key]; duplicate {
+			return nil, nil, nil, nil, ErrVectorPartitionLifecycleConflict
+		}
+		fences[key] = fence.Epoch
+	}
+	canonical, err := encodeVectorPartitionLifecycleSnapshotV1(records, fences)
 	if err != nil {
-		return nil, nil, nil, err
+		return nil, nil, nil, nil, err
 	}
 	if !bytes.Equal(raw, canonical) {
-		return nil, nil, nil, errors.Join(ErrInvalidVectorPartitionLifecycle, fmt.Errorf("lifecycle snapshot is not canonical"))
+		return nil, nil, nil, nil, errors.Join(ErrInvalidVectorPartitionLifecycle, fmt.Errorf("lifecycle snapshot is not canonical"))
 	}
-	return records, active, activeNames, nil
+	return records, active, activeNames, fences, nil
 }
 
 func vectorPartitionLifecycleIdentityLessV1(a, b VectorPartitionLifecycleIdentityV1) bool {

--- a/TreeDB/internal/raftplacement/catalog_meta_lifecycle.go
+++ b/TreeDB/internal/raftplacement/catalog_meta_lifecycle.go
@@ -59,6 +59,41 @@ type VectorPartitionLifecycleAuthorityStatusV1 struct {
 	RetainedWireBytes      uint64
 }
 
+// VectorPartitionLifecycleMutationFenceStatusV1 exposes durable pending
+// mutation recovery debt even after a generation record has been cleaned.
+type VectorPartitionLifecycleMutationFenceStatusV1 struct {
+	Collection CollectionRefV1
+	IndexName  string
+	Epoch      uint64
+	Pending    bool
+}
+
+func (a *CatalogMetaAuthorityV1) VectorPartitionLifecycleMutationFencesV1() []VectorPartitionLifecycleMutationFenceStatusV1 {
+	if a == nil {
+		return nil
+	}
+	a.mu.RLock()
+	defer a.mu.RUnlock()
+	statuses := make([]VectorPartitionLifecycleMutationFenceStatusV1, 0, len(a.mutationFences))
+	for key, fence := range a.mutationFences {
+		statuses = append(statuses, VectorPartitionLifecycleMutationFenceStatusV1{Collection: key.Collection, IndexName: key.IndexName, Epoch: fence.Epoch, Pending: fence.Pending})
+	}
+	sort.Slice(statuses, func(i, j int) bool {
+		a, b := statuses[i], statuses[j]
+		if a.Collection.Database != b.Collection.Database {
+			return a.Collection.Database < b.Collection.Database
+		}
+		if a.Collection.Catalog != b.Collection.Catalog {
+			return a.Collection.Catalog < b.Collection.Catalog
+		}
+		if a.Collection.Collection != b.Collection.Collection {
+			return a.Collection.Collection < b.Collection.Collection
+		}
+		return a.IndexName < b.IndexName
+	})
+	return statuses
+}
+
 func vectorPartitionLifecycleCommandBytesV1(raw []byte) bool {
 	if len(raw) == 0 || len(raw) > MaxVectorPartitionLifecycleCommandBytesV1 {
 		return false

--- a/TreeDB/internal/raftplacement/catalog_meta_lifecycle.go
+++ b/TreeDB/internal/raftplacement/catalog_meta_lifecycle.go
@@ -340,12 +340,17 @@ func catalogMetaFeatureEnabledV1(features raftcluster.FeatureSet, name raftclust
 	return false
 }
 
-// ValidateVectorPartitionGenerationSearchV1 implements nativewire's M7
-// constant-time replicated authority seam without importing the transport
-// package back into raftplacement. It returns the authoritative lifecycle
-// ready-set digest; callers must not substitute the local manifest digest.
-func (a *CatalogMetaAuthorityV1) ValidateVectorPartitionGenerationSearchV1(
+// ValidateVectorPartitionGenerationSearchAtAppliedIndexV1 validates against a
+// local catalog view that has caught up through requiredAppliedIndex. The
+// required index must come from a fresh linearizable meta-Raft read fence; the
+// local applied index by itself is not proof of quorum freshness.
+//
+// This deliberately does not implement nativewire's serving interface. That
+// prevents a replica-local CatalogMetaAuthorityV1 from being wired directly
+// into search without the linearizable fence adapter.
+func (a *CatalogMetaAuthorityV1) ValidateVectorPartitionGenerationSearchAtAppliedIndexV1(
 	ctx context.Context,
+	requiredAppliedIndex uint64,
 	collection CollectionRefV1,
 	index string,
 	generation uint64,
@@ -366,6 +371,9 @@ func (a *CatalogMetaAuthorityV1) ValidateVectorPartitionGenerationSearchV1(
 	}
 	a.mu.RLock()
 	defer a.mu.RUnlock()
+	if requiredAppliedIndex == 0 || a.applied < requiredAppliedIndex {
+		return "", errors.Join(ErrCatalogMetaUnavailable, fmt.Errorf("catalog applied index %d is behind required linearizable index %d", a.applied, requiredAppliedIndex))
+	}
 	identity, ok := a.activeNames[vectorPartitionLifecycleServingKeyV1{Collection: collection, IndexName: index}]
 	if !ok {
 		return "", errors.Join(ErrVectorPartitionLifecycleGuard, fmt.Errorf("no active generation"))

--- a/TreeDB/internal/raftplacement/catalog_meta_lifecycle.go
+++ b/TreeDB/internal/raftplacement/catalog_meta_lifecycle.go
@@ -23,9 +23,10 @@ type vectorPartitionLifecycleServingKeyV1 struct {
 }
 
 type vectorPartitionLifecycleSnapshotV1 struct {
-	Format         uint16                                    `json:"format"`
-	Records        []VectorPartitionLifecycleRecordV1        `json:"records"`
-	MutationFences []vectorPartitionLifecycleMutationFenceV1 `json:"mutation_fences"`
+	Format                     uint16                                       `json:"format"`
+	Records                    []VectorPartitionLifecycleRecordV1           `json:"records"`
+	MutationFences             []vectorPartitionLifecycleMutationFenceV1    `json:"mutation_fences"`
+	CollectionMutationBarriers []vectorPartitionCollectionMutationBarrierV1 `json:"collection_mutation_barriers"`
 }
 
 // vectorPartitionLifecycleMutationFenceV1 is retained independently of the
@@ -142,6 +143,7 @@ func (a *CatalogMetaAuthorityV1) applyCommittedVectorPartitionLifecycleV1(raw []
 
 	identity := command.Identity
 	servingKey := vectorPartitionLifecycleServingKeyV1{Collection: identity.Index.Collection, IndexName: identity.Index.IndexName}
+	collectionBarrier := a.collectionMutationBarriers[identity.Index.Collection]
 	// MutationEpoch is the immutable source watermark captured by the build.
 	// A durable invalidation fence is set before a relevant data entry may be
 	// submitted.  Checking both build and activation makes a candidate that
@@ -155,6 +157,14 @@ func (a *CatalogMetaAuthorityV1) applyCommittedVectorPartitionLifecycleV1(raw []
 	}
 	if (command.Kind == VectorPartitionLifecycleBeginBuildV1 || command.Kind == VectorPartitionLifecycleActivateV1) && fence.Pending {
 		return CatalogMetaStatusV1{}, errors.Join(ErrVectorPartitionLifecycleGuard, fmt.Errorf("candidate source is blocked by pending mutation fence %d", fence.Epoch))
+	}
+	if (command.Kind == VectorPartitionLifecycleBeginBuildV1 || command.Kind == VectorPartitionLifecycleActivateV1) && collectionBarrier.Pending {
+		return CatalogMetaStatusV1{}, errors.Join(ErrVectorPartitionLifecycleGuard, fmt.Errorf("candidate source is blocked by pending collection mutation barrier %d", collectionBarrier.Epoch))
+	}
+	if (command.Kind == VectorPartitionLifecycleBeginBuildV1 || command.Kind == VectorPartitionLifecycleActivateV1) &&
+		command.MutationEpoch < collectionBarrier.Epoch {
+		return CatalogMetaStatusV1{}, errors.Join(ErrVectorPartitionLifecycleGuard,
+			fmt.Errorf("candidate source mutation epoch %d predates collection mutation barrier %d", command.MutationEpoch, collectionBarrier.Epoch))
 	}
 	if (command.Kind == VectorPartitionLifecycleBeginBuildV1 || command.Kind == VectorPartitionLifecycleActivateV1) &&
 		command.MutationEpoch < fence.Epoch {
@@ -241,6 +251,11 @@ func (a *CatalogMetaAuthorityV1) applyCommittedVectorPartitionLifecycleV1(raw []
 }
 
 func (a *CatalogMetaAuthorityV1) validateVectorPartitionLifecycleCatalogTransitionLockedV1() error {
+	for collection, barrier := range a.collectionMutationBarriers {
+		if barrier.Pending {
+			return errors.Join(ErrVectorPartitionLifecycleGuard, fmt.Errorf("catalog transition blocked by collection %s/%s/%s mutation epoch %d", collection.Database, collection.Catalog, collection.Collection, barrier.Epoch))
+		}
+	}
 	for identity, record := range a.lifecycle {
 		if record.State != VectorPartitionLifecycleAbsentV1 {
 			return errors.Join(ErrVectorPartitionLifecycleGuard, fmt.Errorf("catalog transition blocked by generation %d in state %q", identity.Generation, record.State))
@@ -254,6 +269,7 @@ func (a *CatalogMetaAuthorityV1) clearVectorPartitionLifecycleLockedV1() {
 	a.active = nil
 	a.activeNames = nil
 	a.mutationFences = nil
+	a.collectionMutationBarriers = nil
 	a.lifecycleBytes = 0
 }
 
@@ -372,8 +388,8 @@ func (a *CatalogMetaAuthorityV1) VectorPartitionLifecycleStatusesV1() []VectorPa
 	return statuses
 }
 
-func encodeVectorPartitionLifecycleSnapshotV1(records map[VectorPartitionLifecycleIdentityV1]VectorPartitionLifecycleRecordV1, fences map[vectorPartitionLifecycleServingKeyV1]vectorPartitionLifecycleMutationFenceStateV1) ([]byte, error) {
-	if len(records) == 0 && len(fences) == 0 {
+func encodeVectorPartitionLifecycleSnapshotV1(records map[VectorPartitionLifecycleIdentityV1]VectorPartitionLifecycleRecordV1, fences map[vectorPartitionLifecycleServingKeyV1]vectorPartitionLifecycleMutationFenceStateV1, barriers map[CollectionRefV1]vectorPartitionCollectionMutationBarrierStateV1) ([]byte, error) {
+	if len(records) == 0 && len(fences) == 0 && len(barriers) == 0 {
 		return nil, nil
 	}
 	if len(records) > maxVectorPartitionLifecycleSnapshotRecordsV1 {
@@ -382,7 +398,10 @@ func encodeVectorPartitionLifecycleSnapshotV1(records map[VectorPartitionLifecyc
 	if len(fences) > maxVectorPartitionLifecycleMutationFencesV1 {
 		return nil, errors.Join(ErrVectorPartitionLifecycleLimit, fmt.Errorf("snapshot mutation fences=%d", len(fences)))
 	}
-	payload := vectorPartitionLifecycleSnapshotV1{Format: VectorPartitionLifecycleFormatV1, Records: make([]VectorPartitionLifecycleRecordV1, 0, len(records)), MutationFences: make([]vectorPartitionLifecycleMutationFenceV1, 0, len(fences))}
+	if len(barriers) > maxVectorPartitionCollectionMutationBarriersV1 {
+		return nil, errors.Join(ErrVectorPartitionLifecycleLimit, fmt.Errorf("snapshot collection mutation barriers=%d", len(barriers)))
+	}
+	payload := vectorPartitionLifecycleSnapshotV1{Format: VectorPartitionLifecycleFormatV1, Records: make([]VectorPartitionLifecycleRecordV1, 0, len(records)), MutationFences: make([]vectorPartitionLifecycleMutationFenceV1, 0, len(fences)), CollectionMutationBarriers: make([]vectorPartitionCollectionMutationBarrierV1, 0, len(barriers))}
 	for _, record := range records {
 		raw, err := EncodeVectorPartitionLifecycleRecordV1(record)
 		if err != nil {
@@ -417,6 +436,22 @@ func encodeVectorPartitionLifecycleSnapshotV1(records map[VectorPartitionLifecyc
 		}
 		return a.IndexName < b.IndexName
 	})
+	for collection, barrier := range barriers {
+		if err := validateCollectionRef(collection); err != nil || barrier.Epoch == 0 || !isSHA256HexVectorPartitionV1(barrier.OperationDigest) {
+			return nil, errors.Join(ErrInvalidVectorPartitionLifecycle, fmt.Errorf("invalid collection mutation barrier"))
+		}
+		payload.CollectionMutationBarriers = append(payload.CollectionMutationBarriers, vectorPartitionCollectionMutationBarrierV1{Collection: collection, Epoch: barrier.Epoch, Pending: barrier.Pending, OperationDigest: barrier.OperationDigest})
+	}
+	sort.Slice(payload.CollectionMutationBarriers, func(i, j int) bool {
+		a, b := payload.CollectionMutationBarriers[i].Collection, payload.CollectionMutationBarriers[j].Collection
+		if a.Database != b.Database {
+			return a.Database < b.Database
+		}
+		if a.Catalog != b.Catalog {
+			return a.Catalog < b.Catalog
+		}
+		return a.Collection < b.Collection
+	})
 	raw, err := json.Marshal(payload)
 	if err != nil {
 		return nil, errors.Join(ErrInvalidVectorPartitionLifecycle, err)
@@ -432,56 +467,59 @@ func decodeVectorPartitionLifecycleSnapshotV1(raw []byte, catalog CatalogMetaRec
 	map[VectorPartitionLifecycleIndexIdentityV1]VectorPartitionLifecycleIdentityV1,
 	map[vectorPartitionLifecycleServingKeyV1]VectorPartitionLifecycleIdentityV1,
 	map[vectorPartitionLifecycleServingKeyV1]vectorPartitionLifecycleMutationFenceStateV1,
+	map[CollectionRefV1]vectorPartitionCollectionMutationBarrierStateV1,
 	error,
 ) {
 	records := make(map[VectorPartitionLifecycleIdentityV1]VectorPartitionLifecycleRecordV1)
 	active := make(map[VectorPartitionLifecycleIndexIdentityV1]VectorPartitionLifecycleIdentityV1)
 	activeNames := make(map[vectorPartitionLifecycleServingKeyV1]VectorPartitionLifecycleIdentityV1)
 	fences := make(map[vectorPartitionLifecycleServingKeyV1]vectorPartitionLifecycleMutationFenceStateV1)
+	barriers := make(map[CollectionRefV1]vectorPartitionCollectionMutationBarrierStateV1)
 	if len(raw) == 0 {
-		return records, active, activeNames, fences, nil
+		return records, active, activeNames, fences, barriers, nil
 	}
 	if len(raw) > MaxCatalogMetaSnapshotBytesV1 {
-		return nil, nil, nil, nil, ErrCatalogMetaLimit
+		return nil, nil, nil, nil, nil, ErrCatalogMetaLimit
 	}
 	var payload vectorPartitionLifecycleSnapshotV1
 	decoder := json.NewDecoder(bytes.NewReader(raw))
 	decoder.DisallowUnknownFields()
 	if err := decoder.Decode(&payload); err != nil {
-		return nil, nil, nil, nil, errors.Join(ErrInvalidVectorPartitionLifecycle, err)
+		return nil, nil, nil, nil, nil, errors.Join(ErrInvalidVectorPartitionLifecycle, err)
 	}
 	if err := decoder.Decode(&struct{}{}); !errors.Is(err, io.EOF) {
-		return nil, nil, nil, nil, errors.Join(ErrInvalidVectorPartitionLifecycle, fmt.Errorf("trailing lifecycle snapshot data"))
+		return nil, nil, nil, nil, nil, errors.Join(ErrInvalidVectorPartitionLifecycle, fmt.Errorf("trailing lifecycle snapshot data"))
 	}
 	if payload.Format != VectorPartitionLifecycleFormatV1 ||
 		len(payload.Records) > maxVectorPartitionLifecycleSnapshotRecordsV1 ||
-		len(payload.MutationFences) > maxVectorPartitionLifecycleMutationFencesV1 {
-		return nil, nil, nil, nil, ErrVectorPartitionLifecycleLimit
+		len(payload.MutationFences) > maxVectorPartitionLifecycleMutationFencesV1 ||
+		len(payload.CollectionMutationBarriers) > maxVectorPartitionCollectionMutationBarriersV1 {
+		return nil, nil, nil, nil, nil, ErrVectorPartitionLifecycleLimit
 	}
 	for _, record := range payload.Records {
 		encoded, err := EncodeVectorPartitionLifecycleRecordV1(record)
 		if err != nil {
-			return nil, nil, nil, nil, err
+			return nil, nil, nil, nil, nil, err
 		}
 		record, err = DecodeVectorPartitionLifecycleRecordV1(encoded)
 		if err != nil {
-			return nil, nil, nil, nil, err
+			return nil, nil, nil, nil, nil, err
 		}
 		identity := record.Identity
 		if identity.Index.CatalogEpoch != catalog.Epoch || identity.Index.CatalogDigest != catalog.Digest {
-			return nil, nil, nil, nil, ErrVectorPartitionLifecycleIdentity
+			return nil, nil, nil, nil, nil, ErrVectorPartitionLifecycleIdentity
 		}
 		if _, duplicate := records[identity]; duplicate {
-			return nil, nil, nil, nil, ErrVectorPartitionLifecycleConflict
+			return nil, nil, nil, nil, nil, ErrVectorPartitionLifecycleConflict
 		}
 		records[identity] = record
 		if record.State == VectorPartitionLifecycleActiveV1 {
 			if _, duplicate := active[identity.Index]; duplicate {
-				return nil, nil, nil, nil, errors.Join(ErrVectorPartitionLifecycleConflict, fmt.Errorf("multiple active generations for one index"))
+				return nil, nil, nil, nil, nil, errors.Join(ErrVectorPartitionLifecycleConflict, fmt.Errorf("multiple active generations for one index"))
 			}
 			servingKey := vectorPartitionLifecycleServingKeyV1{Collection: identity.Index.Collection, IndexName: identity.Index.IndexName}
 			if _, duplicate := activeNames[servingKey]; duplicate {
-				return nil, nil, nil, nil, errors.Join(ErrVectorPartitionLifecycleConflict, fmt.Errorf("multiple active generations for one serving name"))
+				return nil, nil, nil, nil, nil, errors.Join(ErrVectorPartitionLifecycleConflict, fmt.Errorf("multiple active generations for one serving name"))
 			}
 			active[identity.Index] = identity
 			activeNames[servingKey] = identity
@@ -490,22 +528,31 @@ func decodeVectorPartitionLifecycleSnapshotV1(raw []byte, catalog CatalogMetaRec
 	for _, fence := range payload.MutationFences {
 		if err := validateCollectionRef(fence.Collection); err != nil ||
 			validateVectorPartitionLifecycleNameV1("index name", fence.IndexName) != nil || fence.Epoch == 0 {
-			return nil, nil, nil, nil, errors.Join(ErrInvalidVectorPartitionLifecycle, fmt.Errorf("invalid mutation fence"))
+			return nil, nil, nil, nil, nil, errors.Join(ErrInvalidVectorPartitionLifecycle, fmt.Errorf("invalid mutation fence"))
 		}
 		key := vectorPartitionLifecycleServingKeyV1{Collection: fence.Collection, IndexName: fence.IndexName}
 		if _, duplicate := fences[key]; duplicate {
-			return nil, nil, nil, nil, ErrVectorPartitionLifecycleConflict
+			return nil, nil, nil, nil, nil, ErrVectorPartitionLifecycleConflict
 		}
 		fences[key] = vectorPartitionLifecycleMutationFenceStateV1{Epoch: fence.Epoch, Pending: fence.Pending}
 	}
-	canonical, err := encodeVectorPartitionLifecycleSnapshotV1(records, fences)
+	for _, barrier := range payload.CollectionMutationBarriers {
+		if err := validateCollectionRef(barrier.Collection); err != nil || barrier.Epoch == 0 || !isSHA256HexVectorPartitionV1(barrier.OperationDigest) {
+			return nil, nil, nil, nil, nil, errors.Join(ErrInvalidVectorPartitionLifecycle, fmt.Errorf("invalid collection mutation barrier"))
+		}
+		if _, duplicate := barriers[barrier.Collection]; duplicate {
+			return nil, nil, nil, nil, nil, ErrVectorPartitionLifecycleConflict
+		}
+		barriers[barrier.Collection] = vectorPartitionCollectionMutationBarrierStateV1{Epoch: barrier.Epoch, Pending: barrier.Pending, OperationDigest: barrier.OperationDigest}
+	}
+	canonical, err := encodeVectorPartitionLifecycleSnapshotV1(records, fences, barriers)
 	if err != nil {
-		return nil, nil, nil, nil, err
+		return nil, nil, nil, nil, nil, err
 	}
 	if !bytes.Equal(raw, canonical) {
-		return nil, nil, nil, nil, errors.Join(ErrInvalidVectorPartitionLifecycle, fmt.Errorf("lifecycle snapshot is not canonical"))
+		return nil, nil, nil, nil, nil, errors.Join(ErrInvalidVectorPartitionLifecycle, fmt.Errorf("lifecycle snapshot is not canonical"))
 	}
-	return records, active, activeNames, fences, nil
+	return records, active, activeNames, fences, barriers, nil
 }
 
 func vectorPartitionLifecycleIdentityLessV1(a, b VectorPartitionLifecycleIdentityV1) bool {

--- a/TreeDB/internal/raftplacement/catalog_meta_lifecycle.go
+++ b/TreeDB/internal/raftplacement/catalog_meta_lifecycle.go
@@ -1,0 +1,403 @@
+package raftplacement
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"sort"
+
+	"github.com/snissn/gomap/TreeDB/internal/raftcluster"
+)
+
+const maxVectorPartitionLifecycleSnapshotRecordsV1 = 4096
+
+type vectorPartitionLifecycleServingKeyV1 struct {
+	Collection CollectionRefV1
+	IndexName  string
+}
+
+type vectorPartitionLifecycleSnapshotV1 struct {
+	Format  uint16                             `json:"format"`
+	Records []VectorPartitionLifecycleRecordV1 `json:"records"`
+}
+
+// VectorPartitionLifecycleAuthorityStatusV1 is the bounded operator view of
+// one replicated generation. Local reader/snapshot/backup pins remain inputs
+// to the cleanup command and are not guessed by catalog authority.
+type VectorPartitionLifecycleAuthorityStatusV1 struct {
+	Identity               VectorPartitionLifecycleIdentityV1
+	State                  VectorPartitionLifecycleStateV1
+	Revision               uint64
+	Active                 bool
+	ReadyGroups            int
+	RequiredGroups         int
+	InvalidationReason     string
+	InvalidationEpoch      uint64
+	SupersededByGeneration uint64
+	CleanedGroups          int
+	RetainedWireBytes      uint64
+}
+
+func vectorPartitionLifecycleCommandBytesV1(raw []byte) bool {
+	if len(raw) == 0 || len(raw) > MaxVectorPartitionLifecycleCommandBytesV1 {
+		return false
+	}
+	var envelope struct {
+		Kind VectorPartitionLifecycleCommandKindV1 `json:"kind"`
+	}
+	return json.Unmarshal(raw, &envelope) == nil && envelope.Kind != ""
+}
+
+func (a *CatalogMetaAuthorityV1) applyCommittedVectorPartitionLifecycleV1(raw []byte, appliedIndex uint64) (CatalogMetaStatusV1, error) {
+	command, err := DecodeVectorPartitionLifecycleCommandV1(raw)
+	if err != nil {
+		return CatalogMetaStatusV1{}, err
+	}
+	if a == nil {
+		return CatalogMetaStatusV1{}, ErrCatalogMetaUnavailable
+	}
+
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	if a.record.Epoch == 0 {
+		return CatalogMetaStatusV1{}, ErrCatalogMetaUnavailable
+	}
+	if !catalogMetaFeatureEnabledV1(a.record.Catalog.Features, raftcluster.FeatureVectorPartitionLifecycle) {
+		return CatalogMetaStatusV1{}, errors.Join(ErrUnsupportedFeature, fmt.Errorf("catalog does not require %s", raftcluster.FeatureVectorPartitionLifecycle))
+	}
+	if command.Identity.Index.CatalogEpoch != a.record.Epoch || command.Identity.Index.CatalogDigest != a.record.Digest {
+		return CatalogMetaStatusV1{}, errors.Join(ErrVectorPartitionLifecycleIdentity, fmt.Errorf("lifecycle catalog proof does not match current authority"))
+	}
+	if a.lifecycle == nil {
+		a.lifecycle = make(map[VectorPartitionLifecycleIdentityV1]VectorPartitionLifecycleRecordV1)
+	}
+	if a.active == nil {
+		a.active = make(map[VectorPartitionLifecycleIndexIdentityV1]VectorPartitionLifecycleIdentityV1)
+	}
+	if a.activeNames == nil {
+		a.activeNames = make(map[vectorPartitionLifecycleServingKeyV1]VectorPartitionLifecycleIdentityV1)
+	}
+
+	identity := command.Identity
+	current := a.lifecycle[identity]
+	commandDigest := sha256HexVectorPartitionLifecycleV1(raw)
+	if current.LastCommandDigest == commandDigest {
+		return a.statusLocked(), nil
+	}
+	if command.Kind == VectorPartitionLifecycleActivateV1 {
+		servingKey := vectorPartitionLifecycleServingKeyV1{Collection: identity.Index.Collection, IndexName: identity.Index.IndexName}
+		if activeIdentity, ok := a.activeNames[servingKey]; ok && activeIdentity != identity &&
+			(command.PreviousActiveGeneration == 0 || activeIdentity.Index != identity.Index || activeIdentity.Generation != command.PreviousActiveGeneration) {
+			return CatalogMetaStatusV1{}, errors.Join(ErrVectorPartitionLifecycleGuard, fmt.Errorf("serving name is already active at generation %d", activeIdentity.Generation))
+		}
+	}
+	if command.Kind == VectorPartitionLifecycleActivateV1 && command.PreviousActiveGeneration != 0 {
+		previousIdentity, previous, ok := findVectorPartitionLifecycleGenerationLockedV1(a.lifecycle, identity.Index, command.PreviousActiveGeneration)
+		if !ok {
+			return CatalogMetaStatusV1{}, errors.Join(ErrVectorPartitionLifecycleGuard, fmt.Errorf("previous active generation %d is missing", command.PreviousActiveGeneration))
+		}
+		if previous.LastCommandDigest == commandDigest && current.LastCommandDigest == commandDigest {
+			return a.statusLocked(), nil
+		}
+		activeIdentity, active := a.active[identity.Index]
+		if !active || (activeIdentity != previousIdentity && activeIdentity != identity) {
+			return CatalogMetaStatusV1{}, errors.Join(ErrVectorPartitionLifecycleGuard, fmt.Errorf("cutover predecessor is not the sole active generation"))
+		}
+		retired, activated, err := ApplyVectorPartitionLifecycleCutoverV1(previous, current, command)
+		if err != nil {
+			return CatalogMetaStatusV1{}, err
+		}
+		a.lifecycle[previousIdentity] = retired
+		a.lifecycle[identity] = activated
+		a.setVectorPartitionLifecycleActiveLockedV1(identity)
+	} else {
+		if command.Kind == VectorPartitionLifecycleActivateV1 {
+			if activeIdentity, ok := a.active[identity.Index]; ok && activeIdentity != identity {
+				return CatalogMetaStatusV1{}, errors.Join(ErrVectorPartitionLifecycleGuard, fmt.Errorf("activation requires an atomic cutover from generation %d", activeIdentity.Generation))
+			}
+		}
+		next, err := ApplyVectorPartitionLifecycleCommandV1(current, command)
+		if err != nil {
+			return CatalogMetaStatusV1{}, err
+		}
+		a.lifecycle[identity] = next
+		switch next.State {
+		case VectorPartitionLifecycleActiveV1:
+			a.setVectorPartitionLifecycleActiveLockedV1(identity)
+		case VectorPartitionLifecycleInvalidatedV1, VectorPartitionLifecycleRetiredV1,
+			VectorPartitionLifecycleCleanableV1, VectorPartitionLifecycleAbsentV1:
+			a.clearVectorPartitionLifecycleActiveLockedV1(identity)
+		}
+	}
+	a.applied = appliedIndex
+	a.lifecycleBytes = vectorPartitionLifecycleRetainedBytesV1(a.lifecycle)
+	a.refusal = ""
+	return a.statusLocked(), nil
+}
+
+func (a *CatalogMetaAuthorityV1) validateVectorPartitionLifecycleCatalogTransitionLockedV1() error {
+	for identity, record := range a.lifecycle {
+		if record.State != VectorPartitionLifecycleAbsentV1 {
+			return errors.Join(ErrVectorPartitionLifecycleGuard, fmt.Errorf("catalog transition blocked by generation %d in state %q", identity.Generation, record.State))
+		}
+	}
+	return nil
+}
+
+func (a *CatalogMetaAuthorityV1) clearVectorPartitionLifecycleLockedV1() {
+	a.lifecycle = nil
+	a.active = nil
+	a.activeNames = nil
+	a.lifecycleBytes = 0
+}
+
+func (a *CatalogMetaAuthorityV1) setVectorPartitionLifecycleActiveLockedV1(identity VectorPartitionLifecycleIdentityV1) {
+	a.active[identity.Index] = identity
+	a.activeNames[vectorPartitionLifecycleServingKeyV1{Collection: identity.Index.Collection, IndexName: identity.Index.IndexName}] = identity
+}
+
+func (a *CatalogMetaAuthorityV1) clearVectorPartitionLifecycleActiveLockedV1(identity VectorPartitionLifecycleIdentityV1) {
+	if a.active[identity.Index] == identity {
+		delete(a.active, identity.Index)
+	}
+	key := vectorPartitionLifecycleServingKeyV1{Collection: identity.Index.Collection, IndexName: identity.Index.IndexName}
+	if a.activeNames[key] == identity {
+		delete(a.activeNames, key)
+	}
+}
+
+func findVectorPartitionLifecycleGenerationLockedV1(
+	records map[VectorPartitionLifecycleIdentityV1]VectorPartitionLifecycleRecordV1,
+	index VectorPartitionLifecycleIndexIdentityV1,
+	generation uint64,
+) (VectorPartitionLifecycleIdentityV1, VectorPartitionLifecycleRecordV1, bool) {
+	for identity, record := range records {
+		if identity.Index == index && identity.Generation == generation {
+			return identity, record, true
+		}
+	}
+	return VectorPartitionLifecycleIdentityV1{}, VectorPartitionLifecycleRecordV1{}, false
+}
+
+func catalogMetaFeatureEnabledV1(features raftcluster.FeatureSet, name raftcluster.FeatureName) bool {
+	floor, known := SupportedFeatureFloors[name]
+	if !known {
+		return false
+	}
+	for _, required := range features.Required {
+		if required.Name == name && required.Version.Major == floor.Major && required.Version.Minor >= floor.Minor {
+			return true
+		}
+	}
+	return false
+}
+
+// ValidateVectorPartitionGenerationSearchV1 implements nativewire's M7
+// constant-time replicated authority seam without importing the transport
+// package back into raftplacement.
+func (a *CatalogMetaAuthorityV1) ValidateVectorPartitionGenerationSearchV1(
+	ctx context.Context,
+	collection CollectionRefV1,
+	index string,
+	generation uint64,
+	indexDefinitionDigest string,
+	sourceGeneration uint64,
+	sourceChecksum uint64,
+	sourceSchemaHash uint64,
+	sourceRowCount uint64,
+	readySetDigest string,
+) error {
+	if a == nil {
+		return ErrCatalogMetaUnavailable
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	a.mu.RLock()
+	defer a.mu.RUnlock()
+	identity, ok := a.activeNames[vectorPartitionLifecycleServingKeyV1{Collection: collection, IndexName: index}]
+	if !ok {
+		return errors.Join(ErrVectorPartitionLifecycleGuard, fmt.Errorf("no active generation"))
+	}
+	record, ok := a.lifecycle[identity]
+	if !ok || identity.Generation != generation || identity.Index.IndexDefinitionDigest != indexDefinitionDigest ||
+		identity.Source.Generation != sourceGeneration || identity.Source.Checksum != sourceChecksum ||
+		identity.Source.SchemaHash != sourceSchemaHash || identity.Source.RowCount != sourceRowCount {
+		return ErrVectorPartitionLifecycleIdentity
+	}
+	return record.CanSearch(VectorPartitionLifecycleSearchProofV1{Identity: identity, ReadySetDigest: readySetDigest})
+}
+
+func (a *CatalogMetaAuthorityV1) VectorPartitionLifecycleRecordV1(identity VectorPartitionLifecycleIdentityV1) (VectorPartitionLifecycleRecordV1, bool) {
+	if a == nil {
+		return VectorPartitionLifecycleRecordV1{}, false
+	}
+	a.mu.RLock()
+	defer a.mu.RUnlock()
+	record, ok := a.lifecycle[identity]
+	return record, ok
+}
+
+func (a *CatalogMetaAuthorityV1) VectorPartitionLifecycleStatusesV1() []VectorPartitionLifecycleAuthorityStatusV1 {
+	if a == nil {
+		return nil
+	}
+	a.mu.RLock()
+	defer a.mu.RUnlock()
+	statuses := make([]VectorPartitionLifecycleAuthorityStatusV1, 0, len(a.lifecycle))
+	for identity, record := range a.lifecycle {
+		raw, _ := EncodeVectorPartitionLifecycleRecordV1(record)
+		statuses = append(statuses, VectorPartitionLifecycleAuthorityStatusV1{
+			Identity: identity, State: record.State, Revision: record.Revision,
+			Active:      a.active[identity.Index] == identity,
+			ReadyGroups: len(record.ReadyGroups), RequiredGroups: len(record.RequiredGroups),
+			InvalidationReason: record.InvalidationReason, InvalidationEpoch: record.InvalidationEpoch,
+			SupersededByGeneration: record.SupersededByGeneration,
+			CleanedGroups:          len(record.CleanedGroups), RetainedWireBytes: uint64(len(raw)),
+		})
+	}
+	sort.Slice(statuses, func(i, j int) bool {
+		return vectorPartitionLifecycleIdentityLessV1(statuses[i].Identity, statuses[j].Identity)
+	})
+	return statuses
+}
+
+func encodeVectorPartitionLifecycleSnapshotV1(records map[VectorPartitionLifecycleIdentityV1]VectorPartitionLifecycleRecordV1) ([]byte, error) {
+	if len(records) == 0 {
+		return nil, nil
+	}
+	if len(records) > maxVectorPartitionLifecycleSnapshotRecordsV1 {
+		return nil, errors.Join(ErrVectorPartitionLifecycleLimit, fmt.Errorf("snapshot records=%d", len(records)))
+	}
+	payload := vectorPartitionLifecycleSnapshotV1{Format: VectorPartitionLifecycleFormatV1, Records: make([]VectorPartitionLifecycleRecordV1, 0, len(records))}
+	for _, record := range records {
+		raw, err := EncodeVectorPartitionLifecycleRecordV1(record)
+		if err != nil {
+			return nil, err
+		}
+		canonical, err := DecodeVectorPartitionLifecycleRecordV1(raw)
+		if err != nil {
+			return nil, err
+		}
+		payload.Records = append(payload.Records, canonical)
+	}
+	sort.Slice(payload.Records, func(i, j int) bool {
+		return vectorPartitionLifecycleIdentityLessV1(payload.Records[i].Identity, payload.Records[j].Identity)
+	})
+	raw, err := json.Marshal(payload)
+	if err != nil {
+		return nil, errors.Join(ErrInvalidVectorPartitionLifecycle, err)
+	}
+	if len(raw) > MaxCatalogMetaSnapshotBytesV1 {
+		return nil, errors.Join(ErrCatalogMetaLimit, fmt.Errorf("lifecycle snapshot is %d bytes", len(raw)))
+	}
+	return raw, nil
+}
+
+func decodeVectorPartitionLifecycleSnapshotV1(raw []byte, catalog CatalogMetaRecordV1) (
+	map[VectorPartitionLifecycleIdentityV1]VectorPartitionLifecycleRecordV1,
+	map[VectorPartitionLifecycleIndexIdentityV1]VectorPartitionLifecycleIdentityV1,
+	map[vectorPartitionLifecycleServingKeyV1]VectorPartitionLifecycleIdentityV1,
+	error,
+) {
+	records := make(map[VectorPartitionLifecycleIdentityV1]VectorPartitionLifecycleRecordV1)
+	active := make(map[VectorPartitionLifecycleIndexIdentityV1]VectorPartitionLifecycleIdentityV1)
+	activeNames := make(map[vectorPartitionLifecycleServingKeyV1]VectorPartitionLifecycleIdentityV1)
+	if len(raw) == 0 {
+		return records, active, activeNames, nil
+	}
+	if len(raw) > MaxCatalogMetaSnapshotBytesV1 {
+		return nil, nil, nil, ErrCatalogMetaLimit
+	}
+	var payload vectorPartitionLifecycleSnapshotV1
+	decoder := json.NewDecoder(bytes.NewReader(raw))
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(&payload); err != nil {
+		return nil, nil, nil, errors.Join(ErrInvalidVectorPartitionLifecycle, err)
+	}
+	if err := decoder.Decode(&struct{}{}); !errors.Is(err, io.EOF) {
+		return nil, nil, nil, errors.Join(ErrInvalidVectorPartitionLifecycle, fmt.Errorf("trailing lifecycle snapshot data"))
+	}
+	if payload.Format != VectorPartitionLifecycleFormatV1 || len(payload.Records) > maxVectorPartitionLifecycleSnapshotRecordsV1 {
+		return nil, nil, nil, ErrVectorPartitionLifecycleLimit
+	}
+	for _, record := range payload.Records {
+		encoded, err := EncodeVectorPartitionLifecycleRecordV1(record)
+		if err != nil {
+			return nil, nil, nil, err
+		}
+		record, err = DecodeVectorPartitionLifecycleRecordV1(encoded)
+		if err != nil {
+			return nil, nil, nil, err
+		}
+		identity := record.Identity
+		if identity.Index.CatalogEpoch != catalog.Epoch || identity.Index.CatalogDigest != catalog.Digest {
+			return nil, nil, nil, ErrVectorPartitionLifecycleIdentity
+		}
+		if _, duplicate := records[identity]; duplicate {
+			return nil, nil, nil, ErrVectorPartitionLifecycleConflict
+		}
+		records[identity] = record
+		if record.State == VectorPartitionLifecycleActiveV1 {
+			if _, duplicate := active[identity.Index]; duplicate {
+				return nil, nil, nil, errors.Join(ErrVectorPartitionLifecycleConflict, fmt.Errorf("multiple active generations for one index"))
+			}
+			servingKey := vectorPartitionLifecycleServingKeyV1{Collection: identity.Index.Collection, IndexName: identity.Index.IndexName}
+			if _, duplicate := activeNames[servingKey]; duplicate {
+				return nil, nil, nil, errors.Join(ErrVectorPartitionLifecycleConflict, fmt.Errorf("multiple active generations for one serving name"))
+			}
+			active[identity.Index] = identity
+			activeNames[servingKey] = identity
+		}
+	}
+	canonical, err := encodeVectorPartitionLifecycleSnapshotV1(records)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	if !bytes.Equal(raw, canonical) {
+		return nil, nil, nil, errors.Join(ErrInvalidVectorPartitionLifecycle, fmt.Errorf("lifecycle snapshot is not canonical"))
+	}
+	return records, active, activeNames, nil
+}
+
+func vectorPartitionLifecycleIdentityLessV1(a, b VectorPartitionLifecycleIdentityV1) bool {
+	if a.Index.Collection.Database != b.Index.Collection.Database {
+		return a.Index.Collection.Database < b.Index.Collection.Database
+	}
+	if a.Index.Collection.Catalog != b.Index.Collection.Catalog {
+		return a.Index.Collection.Catalog < b.Index.Collection.Catalog
+	}
+	if a.Index.Collection.Collection != b.Index.Collection.Collection {
+		return a.Index.Collection.Collection < b.Index.Collection.Collection
+	}
+	if a.Index.IndexName != b.Index.IndexName {
+		return a.Index.IndexName < b.Index.IndexName
+	}
+	if a.Index.CollectionIncarnation != b.Index.CollectionIncarnation {
+		return a.Index.CollectionIncarnation < b.Index.CollectionIncarnation
+	}
+	if a.Index.IndexEpoch != b.Index.IndexEpoch {
+		return a.Index.IndexEpoch < b.Index.IndexEpoch
+	}
+	if a.Index.CatalogEpoch != b.Index.CatalogEpoch {
+		return a.Index.CatalogEpoch < b.Index.CatalogEpoch
+	}
+	return a.Generation < b.Generation
+}
+
+func vectorPartitionLifecycleRetainedBytesV1(records map[VectorPartitionLifecycleIdentityV1]VectorPartitionLifecycleRecordV1) uint64 {
+	var total uint64
+	for _, record := range records {
+		raw, err := EncodeVectorPartitionLifecycleRecordV1(record)
+		if err == nil {
+			total += uint64(len(raw))
+		}
+	}
+	return total
+}

--- a/TreeDB/internal/raftplacement/catalog_meta_lifecycle_test.go
+++ b/TreeDB/internal/raftplacement/catalog_meta_lifecycle_test.go
@@ -404,7 +404,7 @@ func TestCatalogMetaLifecycleMutationFencesAreBoundedBeforePublicationV1(t *test
 		fences[vectorPartitionLifecycleServingKeyV1{Collection: collection, IndexName: fmt.Sprintf("idx-%04d", i)}] =
 			vectorPartitionLifecycleMutationFenceStateV1{Epoch: 1}
 	}
-	if _, err := encodeVectorPartitionLifecycleSnapshotV1(nil, fences); !errors.Is(err, ErrVectorPartitionLifecycleLimit) {
+	if _, err := encodeVectorPartitionLifecycleSnapshotV1(nil, fences, nil); !errors.Is(err, ErrVectorPartitionLifecycleLimit) {
 		t.Fatalf("oversized mutation-fence snapshot err=%v", err)
 	}
 

--- a/TreeDB/internal/raftplacement/catalog_meta_lifecycle_test.go
+++ b/TreeDB/internal/raftplacement/catalog_meta_lifecycle_test.go
@@ -365,6 +365,44 @@ func TestCatalogMetaLifecycleMutationFenceRejectsRacingCandidateAfterRestoreV1(t
 	}
 }
 
+func TestCatalogMetaLifecycleSnapshotRejectsInconsistentPendingFenceV1(t *testing.T) {
+	authority, catalog := newCatalogMetaLifecycleTestAuthorityV1(t, true)
+	applied := uint64(1)
+	identity := catalogMetaLifecycleTestIdentityV1(catalog, 6, 10)
+	active := catalogMetaLifecycleBuildPreparedV1(t, authority, &applied, identity, 0, 9)
+	active = catalogMetaLifecycleApplyV1(t, authority, &applied, catalogMetaLifecycleTestCommandV1(active, VectorPartitionLifecycleActivateV1, func(c *VectorPartitionLifecycleCommandV1) {
+		c.MutationEpoch = 9
+	}))
+	invalidated := catalogMetaLifecycleApplyV1(t, authority, &applied, catalogMetaLifecycleTestCommandV1(active, VectorPartitionLifecycleInvalidateV1, func(c *VectorPartitionLifecycleCommandV1) {
+		c.Reason, c.InvalidationEpoch = "relevant mutation", 10
+	}))
+	key := vectorPartitionLifecycleServingKeyV1{Collection: identity.Index.Collection, IndexName: identity.Index.IndexName}
+	fences := map[vectorPartitionLifecycleServingKeyV1]vectorPartitionLifecycleMutationFenceStateV1{
+		key: {Epoch: 10, Pending: true},
+	}
+	wrongEpoch := invalidated
+	wrongEpoch.InvalidationEpoch++
+	tests := []struct {
+		name    string
+		records map[VectorPartitionLifecycleIdentityV1]VectorPartitionLifecycleRecordV1
+	}{
+		{name: "missing invalidated record", records: map[VectorPartitionLifecycleIdentityV1]VectorPartitionLifecycleRecordV1{}},
+		{name: "active record", records: map[VectorPartitionLifecycleIdentityV1]VectorPartitionLifecycleRecordV1{identity: active}},
+		{name: "mismatched invalidation epoch", records: map[VectorPartitionLifecycleIdentityV1]VectorPartitionLifecycleRecordV1{identity: wrongEpoch}},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			raw, err := encodeVectorPartitionLifecycleSnapshotV1(test.records, fences, nil)
+			if err != nil {
+				t.Fatalf("encode adversarial snapshot: %v", err)
+			}
+			if _, _, _, _, _, err := decodeVectorPartitionLifecycleSnapshotV1(raw, catalog); !errors.Is(err, ErrInvalidVectorPartitionLifecycle) {
+				t.Fatalf("inconsistent pending fence err=%v", err)
+			}
+		})
+	}
+}
+
 func TestCatalogMetaLifecycleSameCatalogSnapshotAdvancesButNeverRollsBack(t *testing.T) {
 	source, catalog := newCatalogMetaLifecycleTestAuthorityV1(t, true)
 	target, _ := newCatalogMetaLifecycleTestAuthorityV1(t, true)

--- a/TreeDB/internal/raftplacement/catalog_meta_lifecycle_test.go
+++ b/TreeDB/internal/raftplacement/catalog_meta_lifecycle_test.go
@@ -711,12 +711,19 @@ func catalogMetaLifecycleTestCommandV1(
 }
 
 func catalogMetaLifecycleValidateSearchV1(authority *CatalogMetaAuthorityV1, identity VectorPartitionLifecycleIdentityV1, readySetDigest string) error {
-	return authority.ValidateVectorPartitionGenerationSearchV1(
+	got, err := authority.ValidateVectorPartitionGenerationSearchV1(
 		context.Background(), identity.Index.Collection, identity.Index.IndexName,
 		identity.Generation, identity.Index.IndexDefinitionDigest,
 		identity.Source.Generation, identity.Source.Checksum, identity.Source.SchemaHash,
-		identity.Source.RowCount, readySetDigest,
+		identity.Source.RowCount,
 	)
+	if err != nil {
+		return err
+	}
+	if got != readySetDigest {
+		return errors.Join(ErrVectorPartitionLifecycleGuard, fmt.Errorf("ready-set digest mismatch"))
+	}
+	return nil
 }
 
 func mustEncodeCatalogMetaLifecycleCommandV1(t *testing.T, command VectorPartitionLifecycleCommandV1) []byte {

--- a/TreeDB/internal/raftplacement/catalog_meta_lifecycle_test.go
+++ b/TreeDB/internal/raftplacement/catalog_meta_lifecycle_test.go
@@ -1,0 +1,472 @@
+package raftplacement
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/snissn/gomap/TreeDB/internal/raftcluster"
+)
+
+func TestCatalogMetaLifecycleFeatureFloorAndExactRetry(t *testing.T) {
+	t.Run("missing feature floor refuses lifecycle", func(t *testing.T) {
+		authority, catalog := newCatalogMetaLifecycleTestAuthorityV1(t, false)
+		identity := catalogMetaLifecycleTestIdentityV1(catalog, 7, 11)
+		command := catalogMetaLifecycleTestBeginV1(identity, 0, 10)
+		raw := mustEncodeCatalogMetaLifecycleCommandV1(t, command)
+		if _, err := authority.applyCommittedCatalogMetaV1(raw, 2); !errors.Is(err, ErrUnsupportedFeature) {
+			t.Fatalf("lifecycle without feature floor err=%v", err)
+		}
+		if _, ok := authority.VectorPartitionLifecycleRecordV1(identity); ok {
+			t.Fatal("feature-floor rejection published lifecycle state")
+		}
+		status, ok := authority.Status()
+		if !ok || status.AppliedIndex != 1 {
+			t.Fatalf("status after rejection=%+v available=%v", status, ok)
+		}
+	})
+
+	t.Run("exact retry preserves lifecycle revision", func(t *testing.T) {
+		authority, catalog := newCatalogMetaLifecycleTestAuthorityV1(t, true)
+		identity := catalogMetaLifecycleTestIdentityV1(catalog, 7, 11)
+		raw := mustEncodeCatalogMetaLifecycleCommandV1(t, catalogMetaLifecycleTestBeginV1(identity, 0, 10))
+		first, err := authority.applyCommittedCatalogMetaV1(raw, 2)
+		if err != nil {
+			t.Fatalf("first apply: %v", err)
+		}
+		before, ok := authority.VectorPartitionLifecycleRecordV1(identity)
+		if !ok {
+			t.Fatal("first apply did not publish lifecycle record")
+		}
+		retry, err := authority.applyCommittedCatalogMetaV1(raw, 3)
+		if err != nil {
+			t.Fatalf("exact retry: %v", err)
+		}
+		after, ok := authority.VectorPartitionLifecycleRecordV1(identity)
+		if !ok || !reflect.DeepEqual(after, before) {
+			t.Fatalf("retry record=%+v available=%v want %+v", after, ok, before)
+		}
+		if first.AppliedIndex != 2 || retry.AppliedIndex != 2 || after.Revision != 1 {
+			t.Fatalf("first/retry/record=%+v / %+v / %+v", first, retry, after)
+		}
+	})
+}
+
+func TestCatalogMetaLifecycleAtomicCutoverInvalidationCleanupAndStatus(t *testing.T) {
+	authority, catalog := newCatalogMetaLifecycleTestAuthorityV1(t, true)
+	applied := uint64(1)
+
+	oldIdentity := catalogMetaLifecycleTestIdentityV1(catalog, 6, 10)
+	old := catalogMetaLifecycleBuildPreparedV1(t, authority, &applied, oldIdentity, 0, 9)
+	old = catalogMetaLifecycleApplyV1(t, authority, &applied, catalogMetaLifecycleTestCommandV1(old, VectorPartitionLifecycleActivateV1, func(command *VectorPartitionLifecycleCommandV1) {
+		command.MutationEpoch = 9
+	}))
+	if old.State != VectorPartitionLifecycleActiveV1 {
+		t.Fatalf("old state=%q", old.State)
+	}
+	collisionIdentity := catalogMetaLifecycleTestIdentityV1(catalog, 7, 11)
+	collisionIdentity.Index.IndexEpoch++
+	collisionIdentity.Index.IndexDefinitionDigest = strings.Repeat("c", 64)
+	collision := catalogMetaLifecycleBuildPreparedV1(t, authority, &applied, collisionIdentity, 0, 10)
+	collisionActivate := catalogMetaLifecycleTestCommandV1(collision, VectorPartitionLifecycleActivateV1, func(command *VectorPartitionLifecycleCommandV1) {
+		command.MutationEpoch = 10
+	})
+	if _, err := authority.applyCommittedCatalogMetaV1(mustEncodeCatalogMetaLifecycleCommandV1(t, collisionActivate), applied+1); !errors.Is(err, ErrVectorPartitionLifecycleGuard) {
+		t.Fatalf("same serving-name activation err=%v", err)
+	}
+
+	newIdentity := catalogMetaLifecycleTestIdentityV1(catalog, 7, 11)
+	candidate := catalogMetaLifecycleBuildPreparedV1(t, authority, &applied, newIdentity, oldIdentity.Generation, 10)
+	cutover := catalogMetaLifecycleTestCommandV1(candidate, VectorPartitionLifecycleActivateV1, func(command *VectorPartitionLifecycleCommandV1) {
+		command.PreviousActiveGeneration = oldIdentity.Generation
+		command.PreviousActiveRevision = old.Revision
+		command.MutationEpoch = 10
+	})
+	catalogMetaLifecycleApplyV1(t, authority, &applied, cutover)
+
+	retired, ok := authority.VectorPartitionLifecycleRecordV1(oldIdentity)
+	if !ok || retired.State != VectorPartitionLifecycleRetiredV1 ||
+		retired.SupersededByGeneration != newIdentity.Generation || retired.InvalidationEpoch != 0 {
+		t.Fatalf("retired record=%+v available=%v", retired, ok)
+	}
+	active, ok := authority.VectorPartitionLifecycleRecordV1(newIdentity)
+	if !ok || active.State != VectorPartitionLifecycleActiveV1 {
+		t.Fatalf("active record=%+v available=%v", active, ok)
+	}
+
+	if err := catalogMetaLifecycleValidateSearchV1(authority, oldIdentity, retired.ReadySetDigest); !errors.Is(err, ErrVectorPartitionLifecycleIdentity) {
+		t.Fatalf("superseded search err=%v", err)
+	}
+	if err := catalogMetaLifecycleValidateSearchV1(authority, newIdentity, active.ReadySetDigest); err != nil {
+		t.Fatalf("active search: %v", err)
+	}
+	if err := catalogMetaLifecycleValidateSearchV1(authority, newIdentity, strings.Repeat("f", 64)); !errors.Is(err, ErrVectorPartitionLifecycleGuard) {
+		t.Fatalf("wrong ready-set search err=%v", err)
+	}
+
+	statuses := authority.VectorPartitionLifecycleStatusesV1()
+	if len(statuses) != 3 || statuses[0].Identity.Generation != 6 || statuses[1].Identity != newIdentity ||
+		statuses[2].Identity != collisionIdentity || statuses[0].Active || !statuses[1].Active || statuses[2].Active {
+		t.Fatalf("unsorted or dual-active statuses=%+v", statuses)
+	}
+	for _, status := range statuses {
+		if status.RequiredGroups != 1 || status.ReadyGroups != 1 ||
+			status.RetainedWireBytes == 0 || status.RetainedWireBytes > MaxVectorPartitionLifecycleRecordBytesV1 {
+			t.Fatalf("unbounded/incomplete operator status=%+v", status)
+		}
+	}
+
+	badInvalidate := catalogMetaLifecycleTestCommandV1(active, VectorPartitionLifecycleInvalidateV1, func(command *VectorPartitionLifecycleCommandV1) {
+		command.Reason = "relevant vector update"
+		command.InvalidationEpoch = active.MutationEpoch
+	})
+	raw := mustEncodeCatalogMetaLifecycleCommandV1(t, badInvalidate)
+	if _, err := authority.applyCommittedCatalogMetaV1(raw, applied+1); !errors.Is(err, ErrVectorPartitionLifecycleGuard) {
+		t.Fatalf("non-advancing invalidation err=%v", err)
+	}
+	stillActive, _ := authority.VectorPartitionLifecycleRecordV1(newIdentity)
+	if stillActive.State != VectorPartitionLifecycleActiveV1 {
+		t.Fatalf("refused invalidation changed state=%q", stillActive.State)
+	}
+
+	active = catalogMetaLifecycleApplyV1(t, authority, &applied, catalogMetaLifecycleTestCommandV1(active, VectorPartitionLifecycleInvalidateV1, func(command *VectorPartitionLifecycleCommandV1) {
+		command.Reason = "relevant vector update"
+		command.InvalidationEpoch = active.MutationEpoch + 1
+	}))
+	if err := catalogMetaLifecycleValidateSearchV1(authority, newIdentity, active.ReadySetDigest); !errors.Is(err, ErrVectorPartitionLifecycleGuard) {
+		t.Fatalf("invalidated generation remained searchable: %v", err)
+	}
+
+	pinned := catalogMetaLifecycleTestCommandV1(retired, VectorPartitionLifecycleMarkCleanableV1, func(command *VectorPartitionLifecycleCommandV1) {
+		command.References.ReaderPins = 1
+	})
+	if _, err := authority.applyCommittedCatalogMetaV1(mustEncodeCatalogMetaLifecycleCommandV1(t, pinned), applied+1); !errors.Is(err, ErrVectorPartitionLifecycleGuard) {
+		t.Fatalf("pinned superseded cleanup err=%v", err)
+	}
+	retired = catalogMetaLifecycleApplyV1(t, authority, &applied, catalogMetaLifecycleTestCommandV1(retired, VectorPartitionLifecycleMarkCleanableV1, nil))
+	if retired.State != VectorPartitionLifecycleCleanableV1 {
+		t.Fatalf("superseded cleanable state=%q", retired.State)
+	}
+}
+
+func TestCatalogMetaLifecycleSnapshotCanonicalRoundTripAndFailClosed(t *testing.T) {
+	authority, oldIdentity, newIdentity := catalogMetaLifecycleTestAuthorityWithCutoverV1(t)
+	first, err := authority.ExportCatalogMetaSnapshotBytesV1()
+	if err != nil {
+		t.Fatalf("export snapshot: %v", err)
+	}
+	second, err := authority.ExportCatalogMetaSnapshotBytesV1()
+	if err != nil {
+		t.Fatalf("second export: %v", err)
+	}
+	if !bytes.Equal(first, second) {
+		t.Fatal("snapshot bytes are not deterministic")
+	}
+
+	restored := NewCatalogMetaAuthorityV1()
+	if err := restored.installCatalogMetaSnapshotBytesV1(bytes.Clone(first)); err != nil {
+		t.Fatalf("restore canonical snapshot: %v", err)
+	}
+	oldRecord, oldOK := restored.VectorPartitionLifecycleRecordV1(oldIdentity)
+	newRecord, newOK := restored.VectorPartitionLifecycleRecordV1(newIdentity)
+	if !oldOK || !newOK || oldRecord.State != VectorPartitionLifecycleRetiredV1 ||
+		newRecord.State != VectorPartitionLifecycleActiveV1 {
+		t.Fatalf("restored old/new=%+v/%v %+v/%v", oldRecord, oldOK, newRecord, newOK)
+	}
+	if err := catalogMetaLifecycleValidateSearchV1(restored, newIdentity, newRecord.ReadySetDigest); err != nil {
+		t.Fatalf("restored search admission: %v", err)
+	}
+
+	var outer CatalogMetaSnapshotV1
+	if err := json.Unmarshal(first, &outer); err != nil {
+		t.Fatal(err)
+	}
+	var lifecycle vectorPartitionLifecycleSnapshotV1
+	if err := json.Unmarshal(outer.VectorPartitionLifecycle, &lifecycle); err != nil {
+		t.Fatal(err)
+	}
+	if len(lifecycle.Records) != 2 {
+		t.Fatalf("snapshot lifecycle records=%d", len(lifecycle.Records))
+	}
+
+	t.Run("noncanonical order", func(t *testing.T) {
+		candidate := outer
+		payload := lifecycle
+		payload.Records = append([]VectorPartitionLifecycleRecordV1(nil), lifecycle.Records...)
+		payload.Records[0], payload.Records[1] = payload.Records[1], payload.Records[0]
+		candidate.VectorPartitionLifecycle = mustJSONCatalogMetaLifecycleV1(t, payload)
+		raw := mustJSONCatalogMetaLifecycleV1(t, candidate)
+		target := NewCatalogMetaAuthorityV1()
+		if err := target.installCatalogMetaSnapshotBytesV1(raw); !errors.Is(err, ErrInvalidVectorPartitionLifecycle) {
+			t.Fatalf("noncanonical lifecycle err=%v", err)
+		}
+		if _, ok := target.Status(); ok {
+			t.Fatal("noncanonical lifecycle snapshot published catalog state")
+		}
+	})
+
+	t.Run("dual active", func(t *testing.T) {
+		candidate := outer
+		payload := lifecycle
+		payload.Records = append([]VectorPartitionLifecycleRecordV1(nil), lifecycle.Records...)
+		payload.Records[0].State = VectorPartitionLifecycleActiveV1
+		payload.Records[0].SupersededByGeneration = 0
+		candidate.VectorPartitionLifecycle = mustJSONCatalogMetaLifecycleV1(t, payload)
+		raw := mustJSONCatalogMetaLifecycleV1(t, candidate)
+		target := NewCatalogMetaAuthorityV1()
+		if err := target.installCatalogMetaSnapshotBytesV1(raw); !errors.Is(err, ErrVectorPartitionLifecycleConflict) {
+			t.Fatalf("dual-active lifecycle err=%v", err)
+		}
+		if _, ok := target.Status(); ok {
+			t.Fatal("dual-active lifecycle snapshot published catalog state")
+		}
+	})
+
+	t.Run("malformed", func(t *testing.T) {
+		candidate := outer
+		candidate.VectorPartitionLifecycle = []byte(`{"format":1,"records":[],"unknown":true}`)
+		raw := mustJSONCatalogMetaLifecycleV1(t, candidate)
+		target := NewCatalogMetaAuthorityV1()
+		if err := target.installCatalogMetaSnapshotBytesV1(raw); !errors.Is(err, ErrInvalidVectorPartitionLifecycle) {
+			t.Fatalf("malformed lifecycle err=%v", err)
+		}
+		if _, ok := target.Status(); ok {
+			t.Fatal("malformed lifecycle snapshot published catalog state")
+		}
+	})
+}
+
+func TestCatalogMetaLifecycleSameCatalogSnapshotAdvancesButNeverRollsBack(t *testing.T) {
+	source, catalog := newCatalogMetaLifecycleTestAuthorityV1(t, true)
+	target, _ := newCatalogMetaLifecycleTestAuthorityV1(t, true)
+	stale, err := target.ExportCatalogMetaSnapshotV1()
+	if err != nil {
+		t.Fatalf("export stale snapshot: %v", err)
+	}
+	identity := catalogMetaLifecycleTestIdentityV1(catalog, 7, 11)
+	command := catalogMetaLifecycleTestBeginV1(identity, 0, 10)
+	if _, err := source.applyCommittedCatalogMetaV1(mustEncodeCatalogMetaLifecycleCommandV1(t, command), 2); err != nil {
+		t.Fatalf("apply source lifecycle: %v", err)
+	}
+	advanced, err := source.ExportCatalogMetaSnapshotV1()
+	if err != nil {
+		t.Fatalf("export advanced snapshot: %v", err)
+	}
+	if _, err := target.installCatalogMetaSnapshotV1(advanced); err != nil {
+		t.Fatalf("install same-catalog advancement: %v", err)
+	}
+	if record, ok := target.VectorPartitionLifecycleRecordV1(identity); !ok || record.State != VectorPartitionLifecycleBuildingV1 {
+		t.Fatalf("advanced lifecycle record=%+v available=%v", record, ok)
+	}
+	if _, err := target.installCatalogMetaSnapshotV1(stale); !errors.Is(err, ErrCatalogMetaStaleEpoch) {
+		t.Fatalf("same-catalog rollback err=%v", err)
+	}
+	if record, ok := target.VectorPartitionLifecycleRecordV1(identity); !ok || record.State != VectorPartitionLifecycleBuildingV1 {
+		t.Fatalf("rollback changed lifecycle record=%+v available=%v", record, ok)
+	}
+}
+
+func TestCatalogMetaLifecycleGuardsCatalogTransitionUntilCleanup(t *testing.T) {
+	authority, catalog := newCatalogMetaLifecycleTestAuthorityV1(t, true)
+	applied := uint64(1)
+	identity := catalogMetaLifecycleTestIdentityV1(catalog, 7, 11)
+	record := catalogMetaLifecycleBuildPreparedV1(t, authority, &applied, identity, 0, 10)
+	record = catalogMetaLifecycleApplyV1(t, authority, &applied, catalogMetaLifecycleTestCommandV1(record, VectorPartitionLifecycleActivateV1, func(command *VectorPartitionLifecycleCommandV1) {
+		command.MutationEpoch = 10
+	}))
+
+	nextCatalog := catalogMetaLifecycleCatalogV1(true)
+	nextCatalog.Groups[0].LeaderHint = "node-c"
+	nextCommand := mustCatalogMetaCommand(t, 1, 2, nextCatalog)
+	if _, err := authority.applyCommittedCatalogMetaV1(nextCommand, applied+1); !errors.Is(err, ErrVectorPartitionLifecycleGuard) {
+		t.Fatalf("catalog transition with active lifecycle err=%v", err)
+	}
+
+	record = catalogMetaLifecycleApplyV1(t, authority, &applied, catalogMetaLifecycleTestCommandV1(record, VectorPartitionLifecycleInvalidateV1, func(command *VectorPartitionLifecycleCommandV1) {
+		command.Reason = "catalog transition"
+		command.InvalidationEpoch = 11
+	}))
+	record = catalogMetaLifecycleApplyV1(t, authority, &applied, catalogMetaLifecycleTestCommandV1(record, VectorPartitionLifecycleRetireV1, nil))
+	record = catalogMetaLifecycleApplyV1(t, authority, &applied, catalogMetaLifecycleTestCommandV1(record, VectorPartitionLifecycleMarkCleanableV1, nil))
+	record = catalogMetaLifecycleApplyV1(t, authority, &applied, catalogMetaLifecycleTestCommandV1(record, VectorPartitionLifecycleRecordGroupCleanupV1, func(command *VectorPartitionLifecycleCommandV1) {
+		command.GroupID = "group-a"
+	}))
+	catalogMetaLifecycleApplyV1(t, authority, &applied, catalogMetaLifecycleTestCommandV1(record, VectorPartitionLifecycleCompleteCleanupV1, nil))
+
+	status, err := authority.applyCommittedCatalogMetaV1(nextCommand, applied+1)
+	if err != nil {
+		t.Fatalf("catalog transition after cleanup: %v", err)
+	}
+	if status.Epoch != 2 {
+		t.Fatalf("catalog epoch=%d want 2", status.Epoch)
+	}
+	if statuses := authority.VectorPartitionLifecycleStatusesV1(); len(statuses) != 0 {
+		t.Fatalf("cleaned lifecycle tombstones survived catalog replacement: %+v", statuses)
+	}
+}
+
+func catalogMetaLifecycleTestAuthorityWithCutoverV1(t *testing.T) (*CatalogMetaAuthorityV1, VectorPartitionLifecycleIdentityV1, VectorPartitionLifecycleIdentityV1) {
+	t.Helper()
+	authority, catalog := newCatalogMetaLifecycleTestAuthorityV1(t, true)
+	applied := uint64(1)
+	oldIdentity := catalogMetaLifecycleTestIdentityV1(catalog, 6, 10)
+	old := catalogMetaLifecycleBuildPreparedV1(t, authority, &applied, oldIdentity, 0, 9)
+	old = catalogMetaLifecycleApplyV1(t, authority, &applied, catalogMetaLifecycleTestCommandV1(old, VectorPartitionLifecycleActivateV1, func(command *VectorPartitionLifecycleCommandV1) {
+		command.MutationEpoch = 9
+	}))
+	newIdentity := catalogMetaLifecycleTestIdentityV1(catalog, 7, 11)
+	candidate := catalogMetaLifecycleBuildPreparedV1(t, authority, &applied, newIdentity, oldIdentity.Generation, 10)
+	catalogMetaLifecycleApplyV1(t, authority, &applied, catalogMetaLifecycleTestCommandV1(candidate, VectorPartitionLifecycleActivateV1, func(command *VectorPartitionLifecycleCommandV1) {
+		command.PreviousActiveGeneration = oldIdentity.Generation
+		command.PreviousActiveRevision = old.Revision
+		command.MutationEpoch = 10
+	}))
+	return authority, oldIdentity, newIdentity
+}
+
+func newCatalogMetaLifecycleTestAuthorityV1(t *testing.T, enabled bool) (*CatalogMetaAuthorityV1, CatalogMetaRecordV1) {
+	t.Helper()
+	catalog := catalogMetaLifecycleCatalogV1(enabled)
+	record, err := NewCatalogMetaRecordV1(1, catalog)
+	if err != nil {
+		t.Fatalf("catalog record: %v", err)
+	}
+	raw, err := EncodeCatalogMetaCommandV1(CatalogMetaCommandV1{ExpectedEpoch: 0, Record: record})
+	if err != nil {
+		t.Fatalf("catalog command: %v", err)
+	}
+	authority := NewCatalogMetaAuthorityV1()
+	if _, err := authority.applyCommittedCatalogMetaV1(raw, 1); err != nil {
+		t.Fatalf("install catalog: %v", err)
+	}
+	return authority, record
+}
+
+func catalogMetaLifecycleCatalogV1(enabled bool) CatalogV1 {
+	catalog := validCatalog()
+	catalog.Features = DefaultFeatureSet()
+	if enabled {
+		catalog.Features.Required = append(catalog.Features.Required, raftcluster.RequiredFeature{
+			Name:    raftcluster.FeatureVectorPartitionLifecycle,
+			Version: SupportedFeatureFloors[raftcluster.FeatureVectorPartitionLifecycle],
+		})
+	}
+	return catalog
+}
+
+func catalogMetaLifecycleTestIdentityV1(catalog CatalogMetaRecordV1, generation, sourceGeneration uint64) VectorPartitionLifecycleIdentityV1 {
+	return VectorPartitionLifecycleIdentityV1{
+		Index: VectorPartitionLifecycleIndexIdentityV1{
+			Collection:            CollectionRefV1{Database: DefaultDatabase, Catalog: DefaultCatalog, Collection: "users"},
+			CollectionIncarnation: 3,
+			IndexName:             "embedding",
+			IndexDefinitionDigest: strings.Repeat("a", 64),
+			IndexEpoch:            4,
+			CatalogEpoch:          catalog.Epoch,
+			CatalogDigest:         catalog.Digest,
+		},
+		Source: VectorPartitionLifecycleSourceIdentityV1{
+			Generation: sourceGeneration,
+			Checksum:   sourceGeneration + 1,
+			SchemaHash: sourceGeneration + 2,
+			RowCount:   100,
+		},
+		Generation: generation,
+	}
+}
+
+func catalogMetaLifecycleTestBeginV1(identity VectorPartitionLifecycleIdentityV1, previousGeneration, mutationEpoch uint64) VectorPartitionLifecycleCommandV1 {
+	return VectorPartitionLifecycleCommandV1{
+		Kind: VectorPartitionLifecycleBeginBuildV1, ExpectedState: VectorPartitionLifecycleAbsentV1,
+		Identity: identity, RequiredGroups: []raftcluster.GroupID{"group-a"},
+		PreviousActiveGeneration: previousGeneration, MutationEpoch: mutationEpoch,
+	}
+}
+
+func catalogMetaLifecycleBuildPreparedV1(
+	t *testing.T,
+	authority *CatalogMetaAuthorityV1,
+	applied *uint64,
+	identity VectorPartitionLifecycleIdentityV1,
+	previousGeneration uint64,
+	mutationEpoch uint64,
+) VectorPartitionLifecycleRecordV1 {
+	t.Helper()
+	record := catalogMetaLifecycleApplyV1(t, authority, applied, catalogMetaLifecycleTestBeginV1(identity, previousGeneration, mutationEpoch))
+	record = catalogMetaLifecycleApplyV1(t, authority, applied, catalogMetaLifecycleTestCommandV1(record, VectorPartitionLifecycleRecordGroupReadyV1, func(command *VectorPartitionLifecycleCommandV1) {
+		command.GroupReady = VectorPartitionLifecycleGroupReadyV1{
+			GroupID: "group-a", AppliedIndex: *applied, AssetSetDigest: strings.Repeat("b", 64),
+		}
+	}))
+	digest, err := VectorPartitionLifecycleReadySetDigestV1(record.Identity, record.RequiredGroups, record.ReadyGroups)
+	if err != nil {
+		t.Fatalf("ready-set digest: %v", err)
+	}
+	return catalogMetaLifecycleApplyV1(t, authority, applied, catalogMetaLifecycleTestCommandV1(record, VectorPartitionLifecyclePrepareV1, func(command *VectorPartitionLifecycleCommandV1) {
+		command.ReadySetDigest = digest
+	}))
+}
+
+func catalogMetaLifecycleApplyV1(
+	t *testing.T,
+	authority *CatalogMetaAuthorityV1,
+	applied *uint64,
+	command VectorPartitionLifecycleCommandV1,
+) VectorPartitionLifecycleRecordV1 {
+	t.Helper()
+	raw := mustEncodeCatalogMetaLifecycleCommandV1(t, command)
+	*applied = *applied + 1
+	if _, err := authority.applyCommittedCatalogMetaV1(raw, *applied); err != nil {
+		t.Fatalf("apply %q: %v", command.Kind, err)
+	}
+	record, ok := authority.VectorPartitionLifecycleRecordV1(command.Identity)
+	if !ok {
+		t.Fatalf("apply %q did not retain record", command.Kind)
+	}
+	return record
+}
+
+func catalogMetaLifecycleTestCommandV1(
+	record VectorPartitionLifecycleRecordV1,
+	kind VectorPartitionLifecycleCommandKindV1,
+	mutate func(*VectorPartitionLifecycleCommandV1),
+) VectorPartitionLifecycleCommandV1 {
+	command := VectorPartitionLifecycleCommandV1{
+		Kind: kind, ExpectedRevision: record.Revision, ExpectedState: record.State, Identity: record.Identity,
+	}
+	if mutate != nil {
+		mutate(&command)
+	}
+	return command
+}
+
+func catalogMetaLifecycleValidateSearchV1(authority *CatalogMetaAuthorityV1, identity VectorPartitionLifecycleIdentityV1, readySetDigest string) error {
+	return authority.ValidateVectorPartitionGenerationSearchV1(
+		context.Background(), identity.Index.Collection, identity.Index.IndexName,
+		identity.Generation, identity.Index.IndexDefinitionDigest,
+		identity.Source.Generation, identity.Source.Checksum, identity.Source.SchemaHash,
+		identity.Source.RowCount, readySetDigest,
+	)
+}
+
+func mustEncodeCatalogMetaLifecycleCommandV1(t *testing.T, command VectorPartitionLifecycleCommandV1) []byte {
+	t.Helper()
+	raw, err := EncodeVectorPartitionLifecycleCommandV1(command)
+	if err != nil {
+		t.Fatalf("encode %q: %v", command.Kind, err)
+	}
+	return raw
+}
+
+func mustJSONCatalogMetaLifecycleV1(t *testing.T, value any) []byte {
+	t.Helper()
+	raw, err := json.Marshal(value)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return raw
+}

--- a/TreeDB/internal/raftplacement/catalog_meta_lifecycle_test.go
+++ b/TreeDB/internal/raftplacement/catalog_meta_lifecycle_test.go
@@ -240,6 +240,66 @@ func TestCatalogMetaLifecycleSnapshotCanonicalRoundTripAndFailClosed(t *testing.
 	})
 }
 
+func TestCatalogMetaLifecycleMutationFenceRejectsRacingCandidateAfterRestoreV1(t *testing.T) {
+	authority, catalog := newCatalogMetaLifecycleTestAuthorityV1(t, true)
+	applied := uint64(1)
+	activeIdentity := catalogMetaLifecycleTestIdentityV1(catalog, 6, 10)
+	active := catalogMetaLifecycleBuildPreparedV1(t, authority, &applied, activeIdentity, 0, 9)
+	active = catalogMetaLifecycleApplyV1(t, authority, &applied, catalogMetaLifecycleTestCommandV1(active, VectorPartitionLifecycleActivateV1, func(c *VectorPartitionLifecycleCommandV1) {
+		c.MutationEpoch = 9
+	}))
+
+	// This candidate captured the old source while the active generation was
+	// still serving.  It is prepared before the data mutation admission races
+	// through its durable invalidation.
+	staleIdentity := catalogMetaLifecycleTestIdentityV1(catalog, 7, 11)
+	stale := catalogMetaLifecycleBuildPreparedV1(t, authority, &applied, staleIdentity, activeIdentity.Generation, 9)
+	active = catalogMetaLifecycleApplyV1(t, authority, &applied, catalogMetaLifecycleTestCommandV1(active, VectorPartitionLifecycleInvalidateV1, func(c *VectorPartitionLifecycleCommandV1) {
+		c.Reason, c.InvalidationEpoch = "relevant mutation", 10
+	}))
+
+	// Crash/failover after invalidation but before the data submit must retain
+	// the fence.  A replayed stale activation cannot re-open serving.
+	snapshot, err := authority.ExportCatalogMetaSnapshotBytesV1()
+	if err != nil {
+		t.Fatalf("export fenced snapshot: %v", err)
+	}
+	restored := NewCatalogMetaAuthorityV1()
+	if err := restored.installCatalogMetaSnapshotBytesV1(snapshot); err != nil {
+		t.Fatalf("restore fenced snapshot: %v", err)
+	}
+	activate := catalogMetaLifecycleTestCommandV1(stale, VectorPartitionLifecycleActivateV1, func(c *VectorPartitionLifecycleCommandV1) {
+		c.PreviousActiveGeneration, c.PreviousActiveRevision, c.MutationEpoch = activeIdentity.Generation, active.Revision, 9
+	})
+	if _, err := restored.applyCommittedCatalogMetaV1(mustEncodeCatalogMetaLifecycleCommandV1(t, activate), applied+1); !errors.Is(err, ErrVectorPartitionLifecycleGuard) {
+		t.Fatalf("stale activation after restore err=%v", err)
+	}
+	// Cleanup is allowed to reclaim the invalidated generation's assets, but
+	// not the durable mutation fence.  A delayed/replayed candidate remains
+	// refused after the source record has reached its terminal absent state.
+	active = catalogMetaLifecycleApplyV1(t, restored, &applied, catalogMetaLifecycleTestCommandV1(active, VectorPartitionLifecycleRetireV1, nil))
+	active = catalogMetaLifecycleApplyV1(t, restored, &applied, catalogMetaLifecycleTestCommandV1(active, VectorPartitionLifecycleMarkCleanableV1, nil))
+	active = catalogMetaLifecycleApplyV1(t, restored, &applied, catalogMetaLifecycleTestCommandV1(active, VectorPartitionLifecycleRecordGroupCleanupV1, func(c *VectorPartitionLifecycleCommandV1) {
+		c.GroupID = "group-a"
+	}))
+	catalogMetaLifecycleApplyV1(t, restored, &applied, catalogMetaLifecycleTestCommandV1(active, VectorPartitionLifecycleCompleteCleanupV1, nil))
+	if _, err := restored.applyCommittedCatalogMetaV1(mustEncodeCatalogMetaLifecycleCommandV1(t, activate), applied+1); !errors.Is(err, ErrVectorPartitionLifecycleGuard) {
+		t.Fatalf("stale activation after cleanup err=%v", err)
+	}
+
+	// A replacement built from the post-mutation source watermark is allowed;
+	// this is the recovery path after a submit failure leaves the old generation
+	// invalidated and the data writer retries/rebuilds.
+	freshIdentity := catalogMetaLifecycleTestIdentityV1(catalog, 8, 12)
+	fresh := catalogMetaLifecycleBuildPreparedV1(t, restored, &applied, freshIdentity, 0, 10)
+	fresh = catalogMetaLifecycleApplyV1(t, restored, &applied, catalogMetaLifecycleTestCommandV1(fresh, VectorPartitionLifecycleActivateV1, func(c *VectorPartitionLifecycleCommandV1) {
+		c.MutationEpoch = 10
+	}))
+	if fresh.State != VectorPartitionLifecycleActiveV1 {
+		t.Fatalf("fresh post-fence generation state=%q", fresh.State)
+	}
+}
+
 func TestCatalogMetaLifecycleSameCatalogSnapshotAdvancesButNeverRollsBack(t *testing.T) {
 	source, catalog := newCatalogMetaLifecycleTestAuthorityV1(t, true)
 	target, _ := newCatalogMetaLifecycleTestAuthorityV1(t, true)

--- a/TreeDB/internal/raftplacement/catalog_meta_lifecycle_test.go
+++ b/TreeDB/internal/raftplacement/catalog_meta_lifecycle_test.go
@@ -397,6 +397,147 @@ func TestCatalogMetaLifecycleGuardsCatalogTransitionUntilCleanup(t *testing.T) {
 	}
 }
 
+func TestCatalogMetaLifecycleRefusesFenceMismatchBeforeReducerPublicationV1(t *testing.T) {
+	authority, catalog := newCatalogMetaLifecycleTestAuthorityV1(t, true)
+	applied := uint64(1)
+	identity := catalogMetaLifecycleTestIdentityV1(catalog, 7, 11)
+	active := catalogMetaLifecycleBuildPreparedV1(t, authority, &applied, identity, 0, 9)
+	active = catalogMetaLifecycleApplyV1(t, authority, &applied, catalogMetaLifecycleTestCommandV1(active, VectorPartitionLifecycleActivateV1, func(command *VectorPartitionLifecycleCommandV1) {
+		command.MutationEpoch = 9
+	}))
+	key := vectorPartitionLifecycleServingKeyV1{Collection: identity.Index.Collection, IndexName: identity.Index.IndexName}
+	authority.mu.Lock()
+	authority.mutationFences[key] = vectorPartitionLifecycleMutationFenceStateV1{Epoch: 11, Pending: true}
+	authority.mu.Unlock()
+
+	invalidate := catalogMetaLifecycleTestCommandV1(active, VectorPartitionLifecycleInvalidateV1, func(command *VectorPartitionLifecycleCommandV1) {
+		command.Reason = "stale invalidation"
+		command.InvalidationEpoch = 10
+	})
+	if _, err := authority.applyCommittedCatalogMetaV1(mustEncodeCatalogMetaLifecycleCommandV1(t, invalidate), applied+1); !errors.Is(err, ErrVectorPartitionLifecycleGuard) {
+		t.Fatalf("non-advancing durable invalidation err=%v", err)
+	}
+	if got, ok := authority.VectorPartitionLifecycleRecordV1(identity); !ok || !reflect.DeepEqual(got, active) {
+		t.Fatalf("refused invalidation published record=%+v available=%v want %+v", got, ok, active)
+	}
+	if got := authority.VectorPartitionLifecycleMutationFencesV1(); len(got) != 1 || got[0].Epoch != 11 || !got[0].Pending {
+		t.Fatalf("refused invalidation changed fence=%+v", got)
+	}
+
+	// A valid-looking record confirmation must also fail before reducer
+	// publication when it does not own the exact durable fence.
+	authority.mu.Lock()
+	invalidated, err := ApplyVectorPartitionLifecycleCommandV1(active, invalidate)
+	if err != nil {
+		authority.mu.Unlock()
+		t.Fatal(err)
+	}
+	authority.lifecycle[identity] = invalidated
+	authority.clearVectorPartitionLifecycleActiveLockedV1(identity)
+	authority.mu.Unlock()
+	confirm := catalogMetaLifecycleTestCommandV1(invalidated, VectorPartitionLifecycleConfirmMutationV1, func(command *VectorPartitionLifecycleCommandV1) {
+		command.MutationEpoch = 10
+	})
+	if _, err := authority.applyCommittedCatalogMetaV1(mustEncodeCatalogMetaLifecycleCommandV1(t, confirm), applied+1); !errors.Is(err, ErrVectorPartitionLifecycleGuard) {
+		t.Fatalf("non-owner confirmation err=%v", err)
+	}
+	if got, ok := authority.VectorPartitionLifecycleRecordV1(identity); !ok || !reflect.DeepEqual(got, invalidated) {
+		t.Fatalf("refused confirmation published record=%+v available=%v want %+v", got, ok, invalidated)
+	}
+}
+
+func TestCatalogMetaLifecycleCatalogTransitionRefusesPendingFenceWithoutRecordV1(t *testing.T) {
+	authority, _ := newCatalogMetaLifecycleTestAuthorityV1(t, true)
+	collection := CollectionRefV1{Database: DefaultDatabase, Catalog: DefaultCatalog, Collection: "docs"}
+	authority.mu.Lock()
+	authority.mutationFences = map[vectorPartitionLifecycleServingKeyV1]vectorPartitionLifecycleMutationFenceStateV1{
+		{Collection: collection, IndexName: "embedding"}: {Epoch: 7, Pending: true},
+	}
+	authority.mu.Unlock()
+
+	nextCatalog := catalogMetaLifecycleCatalogV1(true)
+	nextCatalog.Groups[0].LeaderHint = "node-c"
+	if _, err := authority.applyCommittedCatalogMetaV1(mustCatalogMetaCommand(t, 1, 2, nextCatalog), 2); !errors.Is(err, ErrVectorPartitionLifecycleGuard) {
+		t.Fatalf("catalog transition with pending fence err=%v", err)
+	}
+	if status, ok := authority.Status(); !ok || status.Epoch != 1 {
+		t.Fatalf("pending-fence refusal published status=%+v available=%v", status, ok)
+	}
+}
+
+func TestVectorPartitionLifecycleIdentityComparatorIsTotalV1(t *testing.T) {
+	_, catalog := newCatalogMetaLifecycleTestAuthorityV1(t, true)
+	base := catalogMetaLifecycleTestIdentityV1(catalog, 7, 11)
+	tests := []struct {
+		name string
+		edit func(*VectorPartitionLifecycleIdentityV1)
+	}{
+		{"index definition digest", func(v *VectorPartitionLifecycleIdentityV1) { v.Index.IndexDefinitionDigest = strings.Repeat("f", 64) }},
+		{"catalog digest", func(v *VectorPartitionLifecycleIdentityV1) { v.Index.CatalogDigest = strings.Repeat("f", 64) }},
+		{"generation", func(v *VectorPartitionLifecycleIdentityV1) { v.Generation++ }},
+		{"source generation", func(v *VectorPartitionLifecycleIdentityV1) { v.Source.Generation++ }},
+		{"source checksum", func(v *VectorPartitionLifecycleIdentityV1) { v.Source.Checksum++ }},
+		{"source schema", func(v *VectorPartitionLifecycleIdentityV1) { v.Source.SchemaHash++ }},
+		{"source row count", func(v *VectorPartitionLifecycleIdentityV1) { v.Source.RowCount++ }},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			other := base
+			test.edit(&other)
+			if vectorPartitionLifecycleIdentityLessV1(base, other) == vectorPartitionLifecycleIdentityLessV1(other, base) {
+				t.Fatalf("distinct identities compare equal: base=%+v other=%+v", base, other)
+			}
+		})
+	}
+}
+
+func TestCatalogMetaLifecycleProspectiveOuterSnapshotIsBoundedV1(t *testing.T) {
+	authority, _ := newCatalogMetaLifecycleTestAuthorityV1(t, true)
+	// The decoded lifecycle payload is below 8 MiB, but base64 expansion makes
+	// the complete catalog snapshot exceed the durable outer bound.
+	lifecycle := bytes.Repeat([]byte{'x'}, MaxCatalogMetaSnapshotBytesV1*3/4)
+	authority.mu.RLock()
+	err := authority.validateProspectiveCatalogMetaSnapshotLockedV1(lifecycle, 2)
+	authority.mu.RUnlock()
+	if !errors.Is(err, ErrCatalogMetaLimit) {
+		t.Fatalf("prospective oversized outer snapshot err=%v", err)
+	}
+}
+
+func TestCatalogMetaLifecycleRecordCapRefusesBeforePublicationV1(t *testing.T) {
+	authority, catalog := newCatalogMetaLifecycleTestAuthorityV1(t, true)
+	base := catalogMetaLifecycleTestIdentityV1(catalog, 1, 1)
+	records := make(map[VectorPartitionLifecycleIdentityV1]VectorPartitionLifecycleRecordV1, maxVectorPartitionLifecycleSnapshotRecordsV1)
+	for i := 0; i < maxVectorPartitionLifecycleSnapshotRecordsV1; i++ {
+		identity := base
+		identity.Generation = uint64(i + 1)
+		identity.Source.Generation = uint64(i + 1)
+		record, err := ApplyVectorPartitionLifecycleCommandV1(VectorPartitionLifecycleRecordV1{}, catalogMetaLifecycleTestBeginV1(identity, 0, 1))
+		if err != nil {
+			t.Fatalf("seed lifecycle %d: %v", i, err)
+		}
+		records[identity] = record
+	}
+	authority.mu.Lock()
+	authority.lifecycle = records
+	authority.mu.Unlock()
+
+	overflow := base
+	overflow.Generation = maxVectorPartitionLifecycleSnapshotRecordsV1 + 1
+	overflow.Source.Generation = overflow.Generation
+	before, _ := authority.Status()
+	if _, err := authority.applyCommittedCatalogMetaV1(mustEncodeCatalogMetaLifecycleCommandV1(t, catalogMetaLifecycleTestBeginV1(overflow, 0, 1)), before.AppliedIndex+1); !errors.Is(err, ErrVectorPartitionLifecycleLimit) {
+		t.Fatalf("lifecycle record overflow err=%v", err)
+	}
+	if _, ok := authority.VectorPartitionLifecycleRecordV1(overflow); ok {
+		t.Fatal("record overflow published the refused generation")
+	}
+	after, _ := authority.Status()
+	if after.AppliedIndex != before.AppliedIndex || len(authority.VectorPartitionLifecycleStatusesV1()) != maxVectorPartitionLifecycleSnapshotRecordsV1 {
+		t.Fatalf("record overflow changed authority before=%+v after=%+v records=%d", before, after, len(authority.VectorPartitionLifecycleStatusesV1()))
+	}
+}
+
 func TestCatalogMetaLifecycleMutationFencesAreBoundedBeforePublicationV1(t *testing.T) {
 	collection := CollectionRefV1{Database: DefaultDatabase, Catalog: DefaultCatalog, Collection: "docs"}
 	fences := make(map[vectorPartitionLifecycleServingKeyV1]vectorPartitionLifecycleMutationFenceStateV1, maxVectorPartitionLifecycleMutationFencesV1+1)

--- a/TreeDB/internal/raftplacement/catalog_meta_lifecycle_test.go
+++ b/TreeDB/internal/raftplacement/catalog_meta_lifecycle_test.go
@@ -57,6 +57,38 @@ func TestCatalogMetaLifecycleFeatureFloorAndExactRetry(t *testing.T) {
 	})
 }
 
+func TestCatalogMetaLifecycleRecordReturnsDeepCopy(t *testing.T) {
+	authority := NewCatalogMetaAuthorityV1()
+	identity := VectorPartitionLifecycleIdentityV1{Generation: 7}
+	authority.lifecycle = make(map[VectorPartitionLifecycleIdentityV1]VectorPartitionLifecycleRecordV1)
+	authority.lifecycle[identity] = VectorPartitionLifecycleRecordV1{
+		Identity:       identity,
+		RequiredGroups: []raftcluster.GroupID{"group-a"},
+		ReadyGroups: []VectorPartitionLifecycleGroupReadyV1{{
+			GroupID:        "group-a",
+			AppliedIndex:   11,
+			AssetSetDigest: strings.Repeat("a", 64),
+		}},
+		CleanedGroups: []raftcluster.GroupID{"group-a"},
+	}
+
+	got, ok := authority.VectorPartitionLifecycleRecordV1(identity)
+	if !ok {
+		t.Fatal("VectorPartitionLifecycleRecordV1 record unavailable")
+	}
+	got.RequiredGroups[0] = "tampered-required"
+	got.ReadyGroups[0].GroupID = "tampered-ready"
+	got.CleanedGroups[0] = "tampered-cleaned"
+
+	retained, ok := authority.VectorPartitionLifecycleRecordV1(identity)
+	if !ok {
+		t.Fatal("VectorPartitionLifecycleRecordV1 retained record unavailable")
+	}
+	if retained.RequiredGroups[0] != "group-a" || retained.ReadyGroups[0].GroupID != "group-a" || retained.CleanedGroups[0] != "group-a" {
+		t.Fatalf("returned slice mutation changed authority record: %+v", retained)
+	}
+}
+
 func TestCatalogMetaLifecycleAtomicCutoverInvalidationCleanupAndStatus(t *testing.T) {
 	authority, catalog := newCatalogMetaLifecycleTestAuthorityV1(t, true)
 	applied := uint64(1)

--- a/TreeDB/internal/raftplacement/catalog_meta_lifecycle_test.go
+++ b/TreeDB/internal/raftplacement/catalog_meta_lifecycle_test.go
@@ -105,6 +105,14 @@ func TestCatalogMetaLifecycleAtomicCutoverInvalidationCleanupAndStatus(t *testin
 	if err := catalogMetaLifecycleValidateSearchV1(authority, newIdentity, active.ReadySetDigest); err != nil {
 		t.Fatalf("active search: %v", err)
 	}
+	if _, err := authority.ValidateVectorPartitionGenerationSearchAtAppliedIndexV1(
+		context.Background(), applied+1, newIdentity.Index.Collection, newIdentity.Index.IndexName,
+		newIdentity.Generation, newIdentity.Index.IndexDefinitionDigest,
+		newIdentity.Source.Generation, newIdentity.Source.Checksum, newIdentity.Source.SchemaHash,
+		newIdentity.Source.RowCount,
+	); !errors.Is(err, ErrCatalogMetaUnavailable) {
+		t.Fatalf("search against stale local applied view err=%v want ErrCatalogMetaUnavailable", err)
+	}
 	if err := catalogMetaLifecycleValidateSearchV1(authority, newIdentity, strings.Repeat("f", 64)); !errors.Is(err, ErrVectorPartitionLifecycleGuard) {
 		t.Fatalf("wrong ready-set search err=%v", err)
 	}
@@ -711,8 +719,12 @@ func catalogMetaLifecycleTestCommandV1(
 }
 
 func catalogMetaLifecycleValidateSearchV1(authority *CatalogMetaAuthorityV1, identity VectorPartitionLifecycleIdentityV1, readySetDigest string) error {
-	got, err := authority.ValidateVectorPartitionGenerationSearchV1(
-		context.Background(), identity.Index.Collection, identity.Index.IndexName,
+	appliedIndex, ok := authority.CatalogMetaAppliedIndexV1()
+	if !ok {
+		return ErrCatalogMetaUnavailable
+	}
+	got, err := authority.ValidateVectorPartitionGenerationSearchAtAppliedIndexV1(
+		context.Background(), appliedIndex, identity.Index.Collection, identity.Index.IndexName,
 		identity.Generation, identity.Index.IndexDefinitionDigest,
 		identity.Source.Generation, identity.Source.Checksum, identity.Source.SchemaHash,
 		identity.Source.RowCount,

--- a/TreeDB/internal/raftplacement/catalog_meta_lifecycle_test.go
+++ b/TreeDB/internal/raftplacement/catalog_meta_lifecycle_test.go
@@ -268,6 +268,14 @@ func TestCatalogMetaLifecycleMutationFenceRejectsRacingCandidateAfterRestoreV1(t
 	if err := restored.installCatalogMetaSnapshotBytesV1(snapshot); err != nil {
 		t.Fatalf("restore fenced snapshot: %v", err)
 	}
+	fences := restored.VectorPartitionLifecycleMutationFencesV1()
+	if len(fences) != 1 || !fences[0].Pending || fences[0].Epoch != 10 || fences[0].Collection != activeIdentity.Index.Collection || fences[0].IndexName != activeIdentity.Index.IndexName {
+		t.Fatalf("restored pending-fence operator state=%+v", fences)
+	}
+	retireWhilePending := catalogMetaLifecycleTestCommandV1(active, VectorPartitionLifecycleRetireV1, nil)
+	if _, err := restored.applyCommittedCatalogMetaV1(mustEncodeCatalogMetaLifecycleCommandV1(t, retireWhilePending), applied+1); !errors.Is(err, ErrVectorPartitionLifecycleGuard) {
+		t.Fatalf("cleanup during pending mutation err=%v", err)
+	}
 	activate := catalogMetaLifecycleTestCommandV1(stale, VectorPartitionLifecycleActivateV1, func(c *VectorPartitionLifecycleCommandV1) {
 		c.PreviousActiveGeneration, c.PreviousActiveRevision, c.MutationEpoch = activeIdentity.Generation, active.Revision, 9
 	})
@@ -365,6 +373,9 @@ func TestCatalogMetaLifecycleGuardsCatalogTransitionUntilCleanup(t *testing.T) {
 	record = catalogMetaLifecycleApplyV1(t, authority, &applied, catalogMetaLifecycleTestCommandV1(record, VectorPartitionLifecycleInvalidateV1, func(command *VectorPartitionLifecycleCommandV1) {
 		command.Reason = "catalog transition"
 		command.InvalidationEpoch = 11
+	}))
+	record = catalogMetaLifecycleApplyV1(t, authority, &applied, catalogMetaLifecycleTestCommandV1(record, VectorPartitionLifecycleConfirmMutationV1, func(command *VectorPartitionLifecycleCommandV1) {
+		command.MutationEpoch = 11
 	}))
 	record = catalogMetaLifecycleApplyV1(t, authority, &applied, catalogMetaLifecycleTestCommandV1(record, VectorPartitionLifecycleRetireV1, nil))
 	record = catalogMetaLifecycleApplyV1(t, authority, &applied, catalogMetaLifecycleTestCommandV1(record, VectorPartitionLifecycleMarkCleanableV1, nil))

--- a/TreeDB/internal/raftplacement/catalog_meta_lifecycle_test.go
+++ b/TreeDB/internal/raftplacement/catalog_meta_lifecycle_test.go
@@ -274,6 +274,22 @@ func TestCatalogMetaLifecycleMutationFenceRejectsRacingCandidateAfterRestoreV1(t
 	if _, err := restored.applyCommittedCatalogMetaV1(mustEncodeCatalogMetaLifecycleCommandV1(t, activate), applied+1); !errors.Is(err, ErrVectorPartitionLifecycleGuard) {
 		t.Fatalf("stale activation after restore err=%v", err)
 	}
+	// Equal-to-fence is adversarial too: the number alone cannot prove that
+	// the data entry committed, so build/source capture remains blocked while
+	// the durable mutation outcome is pending.
+	equalIdentity := catalogMetaLifecycleTestIdentityV1(catalog, 8, 12)
+	equalBegin := catalogMetaLifecycleTestBeginV1(equalIdentity, 0, 10)
+	if _, err := restored.applyCommittedCatalogMetaV1(mustEncodeCatalogMetaLifecycleCommandV1(t, equalBegin), applied+1); !errors.Is(err, ErrVectorPartitionLifecycleGuard) {
+		t.Fatalf("equal-fence build during pending mutation err=%v", err)
+	}
+	// This models the only release path: the data Raft result is definitive,
+	// then its exact invalidation proof is committed as confirmation.
+	active = catalogMetaLifecycleApplyV1(t, restored, &applied, catalogMetaLifecycleTestCommandV1(active, VectorPartitionLifecycleConfirmMutationV1, func(c *VectorPartitionLifecycleCommandV1) {
+		c.MutationEpoch = 10
+	}))
+	if !active.MutationConfirmed {
+		t.Fatal("committed mutation did not release pending fence")
+	}
 	// Cleanup is allowed to reclaim the invalidated generation's assets, but
 	// not the durable mutation fence.  A delayed/replayed candidate remains
 	// refused after the source record has reached its terminal absent state.
@@ -290,7 +306,7 @@ func TestCatalogMetaLifecycleMutationFenceRejectsRacingCandidateAfterRestoreV1(t
 	// A replacement built from the post-mutation source watermark is allowed;
 	// this is the recovery path after a submit failure leaves the old generation
 	// invalidated and the data writer retries/rebuilds.
-	freshIdentity := catalogMetaLifecycleTestIdentityV1(catalog, 8, 12)
+	freshIdentity := catalogMetaLifecycleTestIdentityV1(catalog, 9, 13)
 	fresh := catalogMetaLifecycleBuildPreparedV1(t, restored, &applied, freshIdentity, 0, 10)
 	fresh = catalogMetaLifecycleApplyV1(t, restored, &applied, catalogMetaLifecycleTestCommandV1(fresh, VectorPartitionLifecycleActivateV1, func(c *VectorPartitionLifecycleCommandV1) {
 		c.MutationEpoch = 10

--- a/TreeDB/internal/raftplacement/catalog_meta_lifecycle_test.go
+++ b/TreeDB/internal/raftplacement/catalog_meta_lifecycle_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"reflect"
 	"strings"
 	"testing"
@@ -393,6 +394,43 @@ func TestCatalogMetaLifecycleGuardsCatalogTransitionUntilCleanup(t *testing.T) {
 	}
 	if statuses := authority.VectorPartitionLifecycleStatusesV1(); len(statuses) != 0 {
 		t.Fatalf("cleaned lifecycle tombstones survived catalog replacement: %+v", statuses)
+	}
+}
+
+func TestCatalogMetaLifecycleMutationFencesAreBoundedBeforePublicationV1(t *testing.T) {
+	collection := CollectionRefV1{Database: DefaultDatabase, Catalog: DefaultCatalog, Collection: "docs"}
+	fences := make(map[vectorPartitionLifecycleServingKeyV1]vectorPartitionLifecycleMutationFenceStateV1, maxVectorPartitionLifecycleMutationFencesV1+1)
+	for i := 0; i <= maxVectorPartitionLifecycleMutationFencesV1; i++ {
+		fences[vectorPartitionLifecycleServingKeyV1{Collection: collection, IndexName: fmt.Sprintf("idx-%04d", i)}] =
+			vectorPartitionLifecycleMutationFenceStateV1{Epoch: 1}
+	}
+	if _, err := encodeVectorPartitionLifecycleSnapshotV1(nil, fences); !errors.Is(err, ErrVectorPartitionLifecycleLimit) {
+		t.Fatalf("oversized mutation-fence snapshot err=%v", err)
+	}
+
+	authority, catalog := newCatalogMetaLifecycleTestAuthorityV1(t, true)
+	applied := uint64(1)
+	identity := catalogMetaLifecycleTestIdentityV1(catalog, 7, 11)
+	active := catalogMetaLifecycleBuildPreparedV1(t, authority, &applied, identity, 0, 9)
+	active = catalogMetaLifecycleApplyV1(t, authority, &applied, catalogMetaLifecycleTestCommandV1(active, VectorPartitionLifecycleActivateV1, func(command *VectorPartitionLifecycleCommandV1) {
+		command.MutationEpoch = 9
+	}))
+	authority.mu.Lock()
+	authority.mutationFences = make(map[vectorPartitionLifecycleServingKeyV1]vectorPartitionLifecycleMutationFenceStateV1, maxVectorPartitionLifecycleMutationFencesV1)
+	for i := 0; i < maxVectorPartitionLifecycleMutationFencesV1; i++ {
+		authority.mutationFences[vectorPartitionLifecycleServingKeyV1{Collection: collection, IndexName: fmt.Sprintf("idx-%04d", i)}] =
+			vectorPartitionLifecycleMutationFenceStateV1{Epoch: 1}
+	}
+	authority.mu.Unlock()
+	invalidate := catalogMetaLifecycleTestCommandV1(active, VectorPartitionLifecycleInvalidateV1, func(command *VectorPartitionLifecycleCommandV1) {
+		command.Reason = "bounded fence test"
+		command.InvalidationEpoch = 10
+	})
+	if _, err := authority.applyCommittedCatalogMetaV1(mustEncodeCatalogMetaLifecycleCommandV1(t, invalidate), applied+1); !errors.Is(err, ErrVectorPartitionLifecycleLimit) {
+		t.Fatalf("new mutation fence past cap err=%v", err)
+	}
+	if retained, ok := authority.VectorPartitionLifecycleRecordV1(identity); !ok || retained.State != VectorPartitionLifecycleActiveV1 || retained.Revision != active.Revision {
+		t.Fatalf("fence-cap refusal mutated active record: %+v available=%v", retained, ok)
 	}
 }
 

--- a/TreeDB/internal/raftplacement/vector_partition_lifecycle_coordinator_v1.go
+++ b/TreeDB/internal/raftplacement/vector_partition_lifecycle_coordinator_v1.go
@@ -52,6 +52,17 @@ func (c VectorPartitionLifecycleCoordinatorV1) Submit(ctx context.Context, comma
 	return record, nil
 }
 
+func (c VectorPartitionLifecycleCoordinatorV1) validateConfirmedMutationProofV1(identity VectorPartitionLifecycleIndexIdentityV1, proof VectorPartitionLifecycleMutationProofV1, label string) error {
+	if proof.ActiveGeneration == 0 {
+		return nil
+	}
+	record, ok := c.Authority.lifecycleRecordForIndexGenerationV1(identity, proof.ActiveGeneration)
+	if !ok || !record.MutationConfirmed {
+		return errors.Join(ErrVectorPartitionLifecycleGuard, fmt.Errorf("%s relevant mutation is pending outcome confirmation", label))
+	}
+	return nil
+}
+
 // MutationProofV1 returns a durable proof for a relevant mutation. It fails
 // closed for a build in progress or an identity that no longer names the
 // active generation. If the exact generation is active, callers must first
@@ -172,11 +183,8 @@ func (c VectorPartitionLifecycleCoordinatorV1) invalidateBeforeRelevantMutationV
 		return proof, err
 	}
 	if !active {
-		if proof.ActiveGeneration != 0 {
-			record, ok := c.Authority.lifecycleRecordForIndexGenerationV1(identity, proof.ActiveGeneration)
-			if !ok || !record.MutationConfirmed {
-				return VectorPartitionLifecycleMutationProofV1{}, errors.Join(ErrVectorPartitionLifecycleGuard, fmt.Errorf("prior relevant mutation is pending outcome confirmation"))
-			}
+		if err := c.validateConfirmedMutationProofV1(identity, proof, "prior"); err != nil {
+			return VectorPartitionLifecycleMutationProofV1{}, err
 		}
 		return proof, err
 	}
@@ -200,11 +208,8 @@ func (c VectorPartitionLifecycleCoordinatorV1) invalidateBeforeRelevantMutationV
 		// A concurrent/replayed invalidation is safe only if the newly applied
 		// record independently proves the ordering for this exact identity.
 		if retry, retryActive, retryErr := c.Authority.MutationProofV1(identity); retryErr == nil && !retryActive {
-			if retry.ActiveGeneration != 0 {
-				record, ok := c.Authority.lifecycleRecordForIndexGenerationV1(identity, retry.ActiveGeneration)
-				if !ok || !record.MutationConfirmed {
-					return VectorPartitionLifecycleMutationProofV1{}, errors.Join(ErrVectorPartitionLifecycleGuard, fmt.Errorf("concurrent relevant mutation is pending outcome confirmation"))
-				}
+			if confirmErr := c.validateConfirmedMutationProofV1(identity, retry, "concurrent"); confirmErr != nil {
+				return VectorPartitionLifecycleMutationProofV1{}, confirmErr
 			}
 			return retry, nil
 		}

--- a/TreeDB/internal/raftplacement/vector_partition_lifecycle_coordinator_v1.go
+++ b/TreeDB/internal/raftplacement/vector_partition_lifecycle_coordinator_v1.go
@@ -147,6 +147,20 @@ func (a *CatalogMetaAuthorityV1) lifecycleRecordForIndexGenerationV1(index Vecto
 // command refusal. This makes retry idempotent without weakening the ordering
 // invariant.
 func (c VectorPartitionLifecycleCoordinatorV1) InvalidateBeforeRelevantMutationV1(ctx context.Context, identity VectorPartitionLifecycleIndexIdentityV1, reason string) (VectorPartitionLifecycleMutationProofV1, error) {
+	return c.invalidateBeforeRelevantMutationV1(ctx, identity, reason, 0)
+}
+
+// InvalidateBeforeRelevantMutationAtEpochV1 binds per-index invalidation to
+// the already-open collection mutation barrier. This prevents independent
+// index fences from being confirmed by different concurrent data mutations.
+func (c VectorPartitionLifecycleCoordinatorV1) InvalidateBeforeRelevantMutationAtEpochV1(ctx context.Context, identity VectorPartitionLifecycleIndexIdentityV1, reason string, mutationEpoch uint64) (VectorPartitionLifecycleMutationProofV1, error) {
+	if mutationEpoch == 0 {
+		return VectorPartitionLifecycleMutationProofV1{}, errors.Join(ErrVectorPartitionLifecycleGuard, fmt.Errorf("collection mutation epoch is required"))
+	}
+	return c.invalidateBeforeRelevantMutationV1(ctx, identity, reason, mutationEpoch)
+}
+
+func (c VectorPartitionLifecycleCoordinatorV1) invalidateBeforeRelevantMutationV1(ctx context.Context, identity VectorPartitionLifecycleIndexIdentityV1, reason string, mutationEpoch uint64) (VectorPartitionLifecycleMutationProofV1, error) {
 	if c.Authority == nil || c.Committer == nil {
 		return VectorPartitionLifecycleMutationProofV1{}, ErrCatalogMetaUnavailable
 	}
@@ -170,10 +184,17 @@ func (c VectorPartitionLifecycleCoordinatorV1) InvalidateBeforeRelevantMutationV
 	if !ok {
 		return VectorPartitionLifecycleMutationProofV1{}, errors.Join(ErrVectorPartitionLifecycleGuard, fmt.Errorf("active generation %d disappeared before invalidation", proof.ActiveGeneration))
 	}
+	invalidationEpoch := record.MutationEpoch + 1
+	if mutationEpoch != 0 {
+		if mutationEpoch <= record.MutationEpoch {
+			return VectorPartitionLifecycleMutationProofV1{}, errors.Join(ErrVectorPartitionLifecycleGuard, fmt.Errorf("collection mutation epoch %d does not follow source epoch %d", mutationEpoch, record.MutationEpoch))
+		}
+		invalidationEpoch = mutationEpoch
+	}
 	command := VectorPartitionLifecycleCommandV1{
 		Kind: VectorPartitionLifecycleInvalidateV1, ExpectedRevision: record.Revision,
 		ExpectedState: VectorPartitionLifecycleActiveV1, Identity: record.Identity,
-		Reason: reason, InvalidationEpoch: record.MutationEpoch + 1,
+		Reason: reason, InvalidationEpoch: invalidationEpoch,
 	}
 	if _, err := c.Submit(ctx, command); err != nil {
 		// A concurrent/replayed invalidation is safe only if the newly applied

--- a/TreeDB/internal/raftplacement/vector_partition_lifecycle_coordinator_v1.go
+++ b/TreeDB/internal/raftplacement/vector_partition_lifecycle_coordinator_v1.go
@@ -150,3 +150,26 @@ func (c VectorPartitionLifecycleCoordinatorV1) InvalidateBeforeRelevantMutationV
 	}
 	return proof, nil
 }
+
+// ConfirmRelevantMutationV1 clears the durable build/activation freeze only
+// after the caller has a definitive committed-data result.  If a process
+// crashes or a submit is ambiguous before this call, the fence intentionally
+// remains pending and recovery must prove the data outcome before confirming.
+func (c VectorPartitionLifecycleCoordinatorV1) ConfirmRelevantMutationV1(ctx context.Context, proof VectorPartitionLifecycleMutationProofV1) error {
+	if c.Authority == nil || c.Committer == nil {
+		return ErrCatalogMetaUnavailable
+	}
+	if proof.ActiveGeneration == 0 || proof.InvalidationEpoch == 0 {
+		return errors.Join(ErrVectorPartitionLifecycleGuard, fmt.Errorf("mutation confirmation requires exact invalidation proof"))
+	}
+	record, ok := c.Authority.lifecycleRecordForIndexGenerationV1(proof.IndexIdentity, proof.ActiveGeneration)
+	if !ok || record.State != VectorPartitionLifecycleInvalidatedV1 || record.InvalidationEpoch != proof.InvalidationEpoch {
+		return errors.Join(ErrVectorPartitionLifecycleGuard, fmt.Errorf("mutation confirmation has no matching invalidated generation"))
+	}
+	_, err := c.Submit(ctx, VectorPartitionLifecycleCommandV1{
+		Kind: VectorPartitionLifecycleConfirmMutationV1, ExpectedRevision: record.Revision,
+		ExpectedState: VectorPartitionLifecycleInvalidatedV1, Identity: record.Identity,
+		MutationEpoch: proof.InvalidationEpoch,
+	})
+	return err
+}

--- a/TreeDB/internal/raftplacement/vector_partition_lifecycle_coordinator_v1.go
+++ b/TreeDB/internal/raftplacement/vector_partition_lifecycle_coordinator_v1.go
@@ -121,7 +121,16 @@ func (c VectorPartitionLifecycleCoordinatorV1) InvalidateBeforeRelevantMutationV
 		return VectorPartitionLifecycleMutationProofV1{}, err
 	}
 	proof, active, err := c.Authority.MutationProofV1(identity)
-	if err != nil || !active {
+	if err != nil {
+		return proof, err
+	}
+	if !active {
+		if proof.ActiveGeneration != 0 {
+			record, ok := c.Authority.lifecycleRecordForIndexGenerationV1(identity, proof.ActiveGeneration)
+			if !ok || !record.MutationConfirmed {
+				return VectorPartitionLifecycleMutationProofV1{}, errors.Join(ErrVectorPartitionLifecycleGuard, fmt.Errorf("prior relevant mutation is pending outcome confirmation"))
+			}
+		}
 		return proof, err
 	}
 	record, ok := c.Authority.lifecycleRecordForIndexGenerationV1(identity, proof.ActiveGeneration)
@@ -137,6 +146,12 @@ func (c VectorPartitionLifecycleCoordinatorV1) InvalidateBeforeRelevantMutationV
 		// A concurrent/replayed invalidation is safe only if the newly applied
 		// record independently proves the ordering for this exact identity.
 		if retry, retryActive, retryErr := c.Authority.MutationProofV1(identity); retryErr == nil && !retryActive {
+			if retry.ActiveGeneration != 0 {
+				record, ok := c.Authority.lifecycleRecordForIndexGenerationV1(identity, retry.ActiveGeneration)
+				if !ok || !record.MutationConfirmed {
+					return VectorPartitionLifecycleMutationProofV1{}, errors.Join(ErrVectorPartitionLifecycleGuard, fmt.Errorf("concurrent relevant mutation is pending outcome confirmation"))
+				}
+			}
 			return retry, nil
 		}
 		return VectorPartitionLifecycleMutationProofV1{}, err

--- a/TreeDB/internal/raftplacement/vector_partition_lifecycle_coordinator_v1.go
+++ b/TreeDB/internal/raftplacement/vector_partition_lifecycle_coordinator_v1.go
@@ -23,14 +23,21 @@ type VectorPartitionLifecycleCoordinatorV1 struct {
 	Committer VectorPartitionLifecycleCommitterV1
 }
 
+func (c VectorPartitionLifecycleCoordinatorV1) validateConfiguredV1() error {
+	if c.Authority == nil || c.Committer == nil {
+		return ErrCatalogMetaUnavailable
+	}
+	return nil
+}
+
 // Submit commits one already-guarded deterministic lifecycle command and
 // returns its locally applied record. The meta-Raft provider only returns after
 // its Apply callback, so a missing record after a successful commit is treated
 // as a fail-closed configuration error rather than silently trusting a local
 // cache.
 func (c VectorPartitionLifecycleCoordinatorV1) Submit(ctx context.Context, command VectorPartitionLifecycleCommandV1) (VectorPartitionLifecycleRecordV1, error) {
-	if c.Authority == nil || c.Committer == nil {
-		return VectorPartitionLifecycleRecordV1{}, ErrCatalogMetaUnavailable
+	if err := c.validateConfiguredV1(); err != nil {
+		return VectorPartitionLifecycleRecordV1{}, err
 	}
 	if ctx == nil {
 		ctx = context.Background()

--- a/TreeDB/internal/raftplacement/vector_partition_lifecycle_coordinator_v1.go
+++ b/TreeDB/internal/raftplacement/vector_partition_lifecycle_coordinator_v1.go
@@ -1,0 +1,152 @@
+package raftplacement
+
+import (
+	"context"
+	"errors"
+	"fmt"
+)
+
+// VectorPartitionLifecycleCommitterV1 is the narrow meta-Raft submission
+// seam used by the lifecycle coordinator. raftcluster's catalog-meta provider
+// implements this method directly; keeping the interface here avoids a
+// reverse dependency from the catalog schema to a particular Raft provider.
+type VectorPartitionLifecycleCommitterV1 interface {
+	SubmitCatalogMetaCommandV1(context.Context, []byte) (term uint64, index uint64, err error)
+}
+
+// VectorPartitionLifecycleCoordinatorV1 submits lifecycle transitions through
+// the sole catalog/meta owner and reads the resulting applied record. It is
+// intentionally not a local state owner: a successful method return always
+// corresponds to a record published by the configured replicated authority.
+type VectorPartitionLifecycleCoordinatorV1 struct {
+	Authority *CatalogMetaAuthorityV1
+	Committer VectorPartitionLifecycleCommitterV1
+}
+
+// Submit commits one already-guarded deterministic lifecycle command and
+// returns its locally applied record. The meta-Raft provider only returns after
+// its Apply callback, so a missing record after a successful commit is treated
+// as a fail-closed configuration error rather than silently trusting a local
+// cache.
+func (c VectorPartitionLifecycleCoordinatorV1) Submit(ctx context.Context, command VectorPartitionLifecycleCommandV1) (VectorPartitionLifecycleRecordV1, error) {
+	if c.Authority == nil || c.Committer == nil {
+		return VectorPartitionLifecycleRecordV1{}, ErrCatalogMetaUnavailable
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if err := ctx.Err(); err != nil {
+		return VectorPartitionLifecycleRecordV1{}, err
+	}
+	raw, err := EncodeVectorPartitionLifecycleCommandV1(command)
+	if err != nil {
+		return VectorPartitionLifecycleRecordV1{}, err
+	}
+	if _, _, err := c.Committer.SubmitCatalogMetaCommandV1(ctx, raw); err != nil {
+		return VectorPartitionLifecycleRecordV1{}, err
+	}
+	record, ok := c.Authority.VectorPartitionLifecycleRecordV1(command.Identity)
+	if !ok {
+		return VectorPartitionLifecycleRecordV1{}, errors.Join(ErrCatalogMetaUnavailable, fmt.Errorf("lifecycle command committed without locally applied record"))
+	}
+	return record, nil
+}
+
+// MutationProofV1 returns a durable proof for a relevant mutation. It fails
+// closed for a build in progress or an identity that no longer names the
+// active generation. If the exact generation is active, callers must first
+// submit InvalidateBeforeRelevantMutationV1.
+func (a *CatalogMetaAuthorityV1) MutationProofV1(identity VectorPartitionLifecycleIndexIdentityV1) (VectorPartitionLifecycleMutationProofV1, bool, error) {
+	if a == nil {
+		return VectorPartitionLifecycleMutationProofV1{}, false, ErrCatalogMetaUnavailable
+	}
+	if err := validateVectorPartitionLifecycleIndexIdentityV1(identity); err != nil {
+		return VectorPartitionLifecycleMutationProofV1{}, false, err
+	}
+	a.mu.RLock()
+	defer a.mu.RUnlock()
+	if a.record.Epoch == 0 {
+		return VectorPartitionLifecycleMutationProofV1{}, false, ErrCatalogMetaUnavailable
+	}
+	servingKey := vectorPartitionLifecycleServingKeyV1{Collection: identity.Collection, IndexName: identity.IndexName}
+	active, hasActive := a.activeNames[servingKey]
+	if hasActive && active.Index != identity {
+		// A DDL/recreate caller with a stale identity must not bypass the
+		// active generation merely because the names still match.
+		return VectorPartitionLifecycleMutationProofV1{}, false, ErrVectorPartitionLifecycleIdentity
+	}
+	if !hasActive {
+		for candidate, record := range a.lifecycle {
+			if candidate.Index == identity && record.State != VectorPartitionLifecycleAbsentV1 {
+				proof := VectorPartitionLifecycleMutationProofV1{IndexIdentity: identity, ActiveGeneration: candidate.Generation, InvalidationEpoch: record.InvalidationEpoch}
+				if err := record.CanCommitRelevantMutation(proof); err != nil {
+					return VectorPartitionLifecycleMutationProofV1{}, false, err
+				}
+				return proof, false, nil
+			}
+		}
+		return VectorPartitionLifecycleMutationProofV1{IndexIdentity: identity}, false, nil
+	}
+	record, ok := a.lifecycle[active]
+	if !ok || record.State != VectorPartitionLifecycleActiveV1 {
+		return VectorPartitionLifecycleMutationProofV1{}, false, errors.Join(ErrVectorPartitionLifecycleGuard, fmt.Errorf("active lifecycle record is unavailable"))
+	}
+	return VectorPartitionLifecycleMutationProofV1{IndexIdentity: identity, ActiveGeneration: active.Generation}, true, nil
+}
+
+func (a *CatalogMetaAuthorityV1) lifecycleRecordForIndexGenerationV1(index VectorPartitionLifecycleIndexIdentityV1, generation uint64) (VectorPartitionLifecycleRecordV1, bool) {
+	if a == nil {
+		return VectorPartitionLifecycleRecordV1{}, false
+	}
+	a.mu.RLock()
+	defer a.mu.RUnlock()
+	_, record, ok := findVectorPartitionLifecycleGenerationLockedV1(a.lifecycle, index, generation)
+	return record, ok
+}
+
+// InvalidateBeforeRelevantMutationV1 is the common admission point for every
+// nativewire, Mongo, shared-submit, replay, and retry path that can classify a
+// mutation as relevant. It never permits a local mutation while a matching
+// active generation exists: it first commits invalidation and only then returns
+// the proof that downstream submit code must carry to commit the mutation.
+//
+// A retry that races the first invalidation recomputes the proof after a stale
+// command refusal. This makes retry idempotent without weakening the ordering
+// invariant.
+func (c VectorPartitionLifecycleCoordinatorV1) InvalidateBeforeRelevantMutationV1(ctx context.Context, identity VectorPartitionLifecycleIndexIdentityV1, reason string) (VectorPartitionLifecycleMutationProofV1, error) {
+	if c.Authority == nil || c.Committer == nil {
+		return VectorPartitionLifecycleMutationProofV1{}, ErrCatalogMetaUnavailable
+	}
+	if err := validateVectorPartitionLifecycleReasonV1(reason); err != nil {
+		return VectorPartitionLifecycleMutationProofV1{}, err
+	}
+	proof, active, err := c.Authority.MutationProofV1(identity)
+	if err != nil || !active {
+		return proof, err
+	}
+	record, ok := c.Authority.lifecycleRecordForIndexGenerationV1(identity, proof.ActiveGeneration)
+	if !ok {
+		return VectorPartitionLifecycleMutationProofV1{}, errors.Join(ErrVectorPartitionLifecycleGuard, fmt.Errorf("active generation %d disappeared before invalidation", proof.ActiveGeneration))
+	}
+	command := VectorPartitionLifecycleCommandV1{
+		Kind: VectorPartitionLifecycleInvalidateV1, ExpectedRevision: record.Revision,
+		ExpectedState: VectorPartitionLifecycleActiveV1, Identity: record.Identity,
+		Reason: reason, InvalidationEpoch: record.MutationEpoch + 1,
+	}
+	if _, err := c.Submit(ctx, command); err != nil {
+		// A concurrent/replayed invalidation is safe only if the newly applied
+		// record independently proves the ordering for this exact identity.
+		if retry, retryActive, retryErr := c.Authority.MutationProofV1(identity); retryErr == nil && !retryActive {
+			return retry, nil
+		}
+		return VectorPartitionLifecycleMutationProofV1{}, err
+	}
+	proof, active, err = c.Authority.MutationProofV1(identity)
+	if err != nil {
+		return VectorPartitionLifecycleMutationProofV1{}, err
+	}
+	if active {
+		return VectorPartitionLifecycleMutationProofV1{}, errors.Join(ErrVectorPartitionLifecycleGuard, fmt.Errorf("invalidation did not remove active generation"))
+	}
+	return proof, nil
+}

--- a/TreeDB/internal/raftplacement/vector_partition_lifecycle_coordinator_v1.go
+++ b/TreeDB/internal/raftplacement/vector_partition_lifecycle_coordinator_v1.go
@@ -76,14 +76,13 @@ func (a *CatalogMetaAuthorityV1) MutationProofV1(identity VectorPartitionLifecyc
 		return VectorPartitionLifecycleMutationProofV1{}, false, ErrVectorPartitionLifecycleIdentity
 	}
 	if !hasActive {
-		for candidate, record := range a.lifecycle {
-			if candidate.Index == identity && record.State != VectorPartitionLifecycleAbsentV1 {
-				proof := VectorPartitionLifecycleMutationProofV1{IndexIdentity: identity, ActiveGeneration: candidate.Generation, InvalidationEpoch: record.InvalidationEpoch}
-				if err := record.CanCommitRelevantMutation(proof); err != nil {
-					return VectorPartitionLifecycleMutationProofV1{}, false, err
-				}
-				return proof, false, nil
+		candidate, record, found := selectMutationProofRecordLockedV1(a.lifecycle, identity)
+		if found {
+			proof := VectorPartitionLifecycleMutationProofV1{IndexIdentity: identity, ActiveGeneration: candidate.Generation, InvalidationEpoch: record.InvalidationEpoch}
+			if err := record.CanCommitRelevantMutation(proof); err != nil {
+				return VectorPartitionLifecycleMutationProofV1{}, false, err
 			}
+			return proof, false, nil
 		}
 		return VectorPartitionLifecycleMutationProofV1{IndexIdentity: identity}, false, nil
 	}
@@ -92,6 +91,40 @@ func (a *CatalogMetaAuthorityV1) MutationProofV1(identity VectorPartitionLifecyc
 		return VectorPartitionLifecycleMutationProofV1{}, false, errors.Join(ErrVectorPartitionLifecycleGuard, fmt.Errorf("active lifecycle record is unavailable"))
 	}
 	return VectorPartitionLifecycleMutationProofV1{IndexIdentity: identity, ActiveGeneration: active.Generation}, true, nil
+}
+
+// selectMutationProofRecordLockedV1 gives no-active mutation admission a
+// deterministic, safety-first meaning. A pending invalidation wins over every
+// other retained generation; otherwise the newest exact generation wins. Map
+// iteration must never choose which generation blocks or authorizes a write.
+func selectMutationProofRecordLockedV1(records map[VectorPartitionLifecycleIdentityV1]VectorPartitionLifecycleRecordV1, index VectorPartitionLifecycleIndexIdentityV1) (VectorPartitionLifecycleIdentityV1, VectorPartitionLifecycleRecordV1, bool) {
+	var selectedIdentity VectorPartitionLifecycleIdentityV1
+	var selectedRecord VectorPartitionLifecycleRecordV1
+	found := false
+	rank := func(record VectorPartitionLifecycleRecordV1) int {
+		if record.State == VectorPartitionLifecycleInvalidatedV1 && !record.MutationConfirmed {
+			return 3
+		}
+		switch record.State {
+		case VectorPartitionLifecycleBuildingV1, VectorPartitionLifecycleStagedV1, VectorPartitionLifecyclePreparedV1:
+			return 2
+		case VectorPartitionLifecycleInvalidatedV1, VectorPartitionLifecycleRetiredV1, VectorPartitionLifecycleCleanableV1:
+			return 1
+		default:
+			return 0
+		}
+	}
+	for candidate, record := range records {
+		if candidate.Index != index || record.State == VectorPartitionLifecycleAbsentV1 {
+			continue
+		}
+		if !found || rank(record) > rank(selectedRecord) ||
+			(rank(record) == rank(selectedRecord) && (candidate.Generation > selectedIdentity.Generation ||
+				(candidate.Generation == selectedIdentity.Generation && record.Revision > selectedRecord.Revision))) {
+			selectedIdentity, selectedRecord, found = candidate, record, true
+		}
+	}
+	return selectedIdentity, selectedRecord, found
 }
 
 func (a *CatalogMetaAuthorityV1) lifecycleRecordForIndexGenerationV1(index VectorPartitionLifecycleIndexIdentityV1, generation uint64) (VectorPartitionLifecycleRecordV1, bool) {

--- a/TreeDB/internal/raftplacement/vector_partition_lifecycle_coordinator_v1_test.go
+++ b/TreeDB/internal/raftplacement/vector_partition_lifecycle_coordinator_v1_test.go
@@ -19,10 +19,49 @@ type lifecycleCoordinatorCommitterV1 struct {
 type lifecycleTestBuilderV1 struct {
 	ready VectorPartitionLifecycleGroupReadyV1
 	err   error
+	call  *bool
 }
 
 func (b lifecycleTestBuilderV1) BuildAndStageVectorPartitionGroupV1(context.Context, VectorPartitionLifecycleIdentityV1, raftcluster.GroupID) (VectorPartitionLifecycleGroupReadyV1, error) {
+	if b.call != nil {
+		*b.call = true
+	}
 	return b.ready, b.err
+}
+
+func TestVectorPartitionLifecycleWorkflowFailsClosedWhenUnconfiguredV1(t *testing.T) {
+	identity := VectorPartitionLifecycleIdentityV1{}
+	ready := VectorPartitionLifecycleGroupReadyV1{}
+	refs := VectorPartitionLifecycleReferencesV1{}
+	for _, coordinator := range []VectorPartitionLifecycleCoordinatorV1{
+		{},
+		{Authority: NewCatalogMetaAuthorityV1()},
+	} {
+		builderCalled := false
+		checks := []func() error{
+			func() error { _, err := coordinator.BeginBuildV1(t.Context(), identity, nil, 0, 0); return err },
+			func() error { _, err := coordinator.RecordGroupReadyV1(t.Context(), identity, ready); return err },
+			func() error {
+				_, err := coordinator.BuildAndRecordGroupReadyV1(t.Context(), lifecycleTestBuilderV1{call: &builderCalled}, identity, "group-a")
+				return err
+			},
+			func() error { _, err := coordinator.PrepareV1(t.Context(), identity); return err },
+			func() error { _, err := coordinator.ActivateV1(t.Context(), identity); return err },
+			func() error { _, err := coordinator.AbortV1(t.Context(), identity, "abort"); return err },
+			func() error { _, err := coordinator.RetireV1(t.Context(), identity); return err },
+			func() error { _, err := coordinator.MarkCleanableV1(t.Context(), identity, refs); return err },
+			func() error { _, err := coordinator.RecordGroupCleanupV1(t.Context(), identity, "group-a"); return err },
+			func() error { _, err := coordinator.CompleteCleanupV1(t.Context(), identity); return err },
+		}
+		for i, check := range checks {
+			if err := check(); !errors.Is(err, ErrCatalogMetaUnavailable) {
+				t.Fatalf("coordinator=%+v check=%d err=%v want catalog-meta unavailable", coordinator, i, err)
+			}
+		}
+		if builderCalled {
+			t.Fatalf("coordinator=%+v invoked builder before configuration validation", coordinator)
+		}
+	}
 }
 
 func (c *lifecycleCoordinatorCommitterV1) SubmitCatalogMetaCommandV1(_ context.Context, raw []byte) (uint64, uint64, error) {

--- a/TreeDB/internal/raftplacement/vector_partition_lifecycle_coordinator_v1_test.go
+++ b/TreeDB/internal/raftplacement/vector_partition_lifecycle_coordinator_v1_test.go
@@ -184,6 +184,92 @@ func TestVectorPartitionCollectionMutationBarrierRetryConflictAndRestoreV1(t *te
 	}
 }
 
+func TestVectorPartitionCollectionMutationBarrierRetainsOlderCompletedRetryV1(t *testing.T) {
+	authority, catalog := newCatalogMetaLifecycleTestAuthorityV1(t, true)
+	committer := &lifecycleCoordinatorCommitterV1{authority: authority, index: 1}
+	coordinator := VectorPartitionLifecycleCoordinatorV1{Authority: authority, Committer: committer}
+	collection := catalogMetaLifecycleTestIdentityV1(catalog, 7, 11).Index.Collection
+	opA := fmt.Sprintf("%064x", 1)
+	opB := fmt.Sprintf("%064x", 2)
+
+	first, err := coordinator.BeginRelevantCollectionMutationV1(t.Context(), collection, opA)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := coordinator.ConfirmRelevantCollectionMutationV1(t.Context(), collection, opA); err != nil {
+		t.Fatal(err)
+	}
+	second, err := coordinator.BeginRelevantCollectionMutationV1(t.Context(), collection, opB)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := coordinator.ConfirmRelevantCollectionMutationV1(t.Context(), collection, opB); err != nil {
+		t.Fatal(err)
+	}
+	if second.Epoch != first.Epoch+1 {
+		t.Fatalf("mutation epochs first=%d second=%d", first.Epoch, second.Epoch)
+	}
+
+	beforeReplay := committer.index
+	replay, err := coordinator.BeginRelevantCollectionMutationV1(t.Context(), collection, opA)
+	if err != nil || replay.Pending || replay.Epoch != first.Epoch || replay.OperationDigest != opA {
+		t.Fatalf("older completed replay=%+v err=%v", replay, err)
+	}
+	if err := coordinator.ConfirmRelevantCollectionMutationV1(t.Context(), collection, opA); err != nil {
+		t.Fatalf("older completed confirm: %v", err)
+	}
+	if committer.index != beforeReplay {
+		t.Fatalf("older completed replay committed new catalog entries: before=%d after=%d", beforeReplay, committer.index)
+	}
+
+	snapshot, err := authority.ExportCatalogMetaSnapshotV1()
+	if err != nil {
+		t.Fatal(err)
+	}
+	restored := NewCatalogMetaAuthorityV1()
+	if _, err := restored.installCatalogMetaSnapshotV1(snapshot); err != nil {
+		t.Fatal(err)
+	}
+	restoredCommitter := &lifecycleCoordinatorCommitterV1{authority: restored, index: snapshot.AppliedIndex}
+	restoredCoordinator := VectorPartitionLifecycleCoordinatorV1{Authority: restored, Committer: restoredCommitter}
+	restoredReplay, err := restoredCoordinator.BeginRelevantCollectionMutationV1(t.Context(), collection, opA)
+	if err != nil || restoredReplay.Pending || restoredReplay.Epoch != first.Epoch || restoredCommitter.index != snapshot.AppliedIndex {
+		t.Fatalf("restored older replay=%+v err=%v applied=%d", restoredReplay, err, restoredCommitter.index)
+	}
+}
+
+func TestVectorPartitionCollectionMutationCompletedReplayWindowIsBoundedV1(t *testing.T) {
+	authority, catalog := newCatalogMetaLifecycleTestAuthorityV1(t, true)
+	committer := &lifecycleCoordinatorCommitterV1{authority: authority, index: 1}
+	coordinator := VectorPartitionLifecycleCoordinatorV1{Authority: authority, Committer: committer}
+	collection := catalogMetaLifecycleTestIdentityV1(catalog, 7, 11).Index.Collection
+	operations := make([]string, maxVectorPartitionCollectionCompletedMutationsV1+2)
+	for i := range operations {
+		operations[i] = fmt.Sprintf("%064x", i+1)
+		if _, err := coordinator.BeginRelevantCollectionMutationV1(t.Context(), collection, operations[i]); err != nil {
+			t.Fatalf("begin %d: %v", i, err)
+		}
+		if err := coordinator.ConfirmRelevantCollectionMutationV1(t.Context(), collection, operations[i]); err != nil {
+			t.Fatalf("confirm %d: %v", i, err)
+		}
+	}
+
+	barrier := authority.collectionMutationBarriers[collection]
+	if len(barrier.Completed) != maxVectorPartitionCollectionCompletedMutationsV1 {
+		t.Fatalf("completed history=%d want %d", len(barrier.Completed), maxVectorPartitionCollectionCompletedMutationsV1)
+	}
+	if _, found, err := authority.VectorPartitionCollectionMutationOperationV1(collection, operations[0]); err != nil || found {
+		t.Fatalf("evicted operation found=%v err=%v", found, err)
+	}
+	retained, found, err := authority.VectorPartitionCollectionMutationOperationV1(collection, operations[2])
+	if err != nil || !found || retained.Pending || retained.OperationDigest != operations[2] {
+		t.Fatalf("oldest retained operation=%+v found=%v err=%v", retained, found, err)
+	}
+	if _, err := authority.ExportCatalogMetaSnapshotV1(); err != nil {
+		t.Fatalf("bounded history snapshot: %v", err)
+	}
+}
+
 func TestVectorPartitionCollectionMutationBarrierOwnsIndexInvalidationV1(t *testing.T) {
 	authority, catalog := newCatalogMetaLifecycleTestAuthorityV1(t, true)
 	committer := &lifecycleCoordinatorCommitterV1{authority: authority, index: 1}

--- a/TreeDB/internal/raftplacement/vector_partition_lifecycle_coordinator_v1_test.go
+++ b/TreeDB/internal/raftplacement/vector_partition_lifecycle_coordinator_v1_test.go
@@ -15,6 +15,15 @@ type lifecycleCoordinatorCommitterV1 struct {
 	fail      error
 }
 
+type lifecycleTestBuilderV1 struct {
+	ready VectorPartitionLifecycleGroupReadyV1
+	err   error
+}
+
+func (b lifecycleTestBuilderV1) BuildAndStageVectorPartitionGroupV1(context.Context, VectorPartitionLifecycleIdentityV1, raftcluster.GroupID) (VectorPartitionLifecycleGroupReadyV1, error) {
+	return b.ready, b.err
+}
+
 func (c *lifecycleCoordinatorCommitterV1) SubmitCatalogMetaCommandV1(_ context.Context, raw []byte) (uint64, uint64, error) {
 	if c.fail != nil {
 		return 0, 0, c.fail
@@ -137,6 +146,9 @@ func TestVectorPartitionLifecycleWorkflowRetriesV1(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	if retry, err := c.MarkCleanableV1(t.Context(), identity, VectorPartitionLifecycleReferencesV1{}); err != nil || !reflect.DeepEqual(retry, r) {
+		t.Fatalf("cleanable retry=%+v err=%v", retry, err)
+	}
 	r, err = c.RecordGroupCleanupV1(t.Context(), identity, "group-a")
 	if err != nil {
 		t.Fatal(err)
@@ -153,6 +165,65 @@ func TestVectorPartitionLifecycleWorkflowRetriesV1(t *testing.T) {
 	}
 	if statuses, fences, err := c.RecoveryStatusV1(); err != nil || len(statuses) != 1 || len(fences) != 1 || fences[0].Pending {
 		t.Fatalf("recovery statuses=%+v fences=%+v err=%v", statuses, fences, err)
+	}
+}
+
+func TestVectorPartitionLifecycleWorkflowCutoverAbortAndBuilderV1(t *testing.T) {
+	a, catalog := newCatalogMetaLifecycleTestAuthorityV1(t, true)
+	committer := &lifecycleCoordinatorCommitterV1{authority: a, index: 1}
+	c := VectorPartitionLifecycleCoordinatorV1{Authority: a, Committer: committer}
+	oldID := catalogMetaLifecycleTestIdentityV1(catalog, 6, 10)
+	old := catalogMetaLifecycleBuildPreparedV1(t, a, &committer.index, oldID, 0, 9)
+	old = catalogMetaLifecycleApplyV1(t, a, &committer.index, catalogMetaLifecycleTestCommandV1(old, VectorPartitionLifecycleActivateV1, func(x *VectorPartitionLifecycleCommandV1) { x.MutationEpoch = 9 }))
+	newID := catalogMetaLifecycleTestIdentityV1(catalog, 7, 11)
+	new := catalogMetaLifecycleBuildPreparedV1(t, a, &committer.index, newID, oldID.Generation, 10)
+	got, err := c.ActivateV1(t.Context(), newID)
+	if err != nil || got.State != VectorPartitionLifecycleActiveV1 {
+		t.Fatalf("cutover=%+v err=%v", got, err)
+	}
+	if retry, err := c.ActivateV1(t.Context(), newID); err != nil || !reflect.DeepEqual(retry, got) {
+		t.Fatalf("cutover retry=%+v err=%v", retry, err)
+	}
+	oldAfter, _ := a.VectorPartitionLifecycleRecordV1(oldID)
+	if oldAfter.State != VectorPartitionLifecycleRetiredV1 {
+		t.Fatalf("old=%q", oldAfter.State)
+	}
+	// A stale explicit predecessor cannot bypass the reducer guard.
+	bad := catalogMetaLifecycleTestCommandV1(new, VectorPartitionLifecycleActivateV1, func(x *VectorPartitionLifecycleCommandV1) {
+		x.PreviousActiveGeneration = oldID.Generation
+		x.PreviousActiveRevision = old.Revision + 1
+		x.MutationEpoch = 10
+	})
+	if _, err := a.applyCommittedCatalogMetaV1(mustEncodeCatalogMetaLifecycleCommandV1(t, bad), committer.index+1); !errors.Is(err, ErrVectorPartitionLifecycleStale) && !errors.Is(err, ErrVectorPartitionLifecycleGuard) {
+		t.Fatalf("bad predecessor err=%v", err)
+	}
+
+	abortID := catalogMetaLifecycleTestIdentityV1(catalog, 8, 12)
+	if _, err := c.BeginBuildV1(t.Context(), abortID, []raftcluster.GroupID{"group-a"}, 0, 11); err != nil {
+		t.Fatal(err)
+	}
+	aborted, err := c.AbortV1(t.Context(), abortID, "cancelled")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if retry, err := c.AbortV1(t.Context(), abortID, "different"); err != nil || !reflect.DeepEqual(retry, aborted) {
+		t.Fatalf("abort retry=%+v err=%v", retry, err)
+	}
+
+	buildID := catalogMetaLifecycleTestIdentityV1(catalog, 9, 13)
+	if _, err := c.BeginBuildV1(t.Context(), buildID, []raftcluster.GroupID{"group-a"}, 0, 12); err != nil {
+		t.Fatal(err)
+	}
+	badBuilder := lifecycleTestBuilderV1{ready: VectorPartitionLifecycleGroupReadyV1{GroupID: "wrong", AppliedIndex: 1, AssetSetDigest: "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"}}
+	if _, err := c.BuildAndRecordGroupReadyV1(t.Context(), badBuilder, buildID, "group-a"); err == nil {
+		t.Fatal("wrong group builder accepted")
+	}
+	if r, _ := a.VectorPartitionLifecycleRecordV1(buildID); len(r.ReadyGroups) != 0 {
+		t.Fatal("bad builder published readiness")
+	}
+	good := lifecycleTestBuilderV1{ready: VectorPartitionLifecycleGroupReadyV1{GroupID: "group-a", AppliedIndex: 1, AssetSetDigest: "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"}}
+	if _, err := c.BuildAndRecordGroupReadyV1(t.Context(), good, buildID, "group-a"); err != nil {
+		t.Fatal(err)
 	}
 }
 

--- a/TreeDB/internal/raftplacement/vector_partition_lifecycle_coordinator_v1_test.go
+++ b/TreeDB/internal/raftplacement/vector_partition_lifecycle_coordinator_v1_test.go
@@ -48,12 +48,13 @@ func TestVectorPartitionLifecycleCoordinatorInvalidatesBeforeRelevantMutationV1(
 		t.Fatalf("proof did not admit mutation after durable invalidation: %v", err)
 	}
 
-	// A replay/retry is a no-op admission: no second invalidation command is
-	// needed and the exact first invalidation proof is retained.
+	// A concurrent retry cannot reuse a pending fence: only the data commit
+	// path may confirm it, so a second mutation is refused rather than sharing
+	// the first mutation's invalidation proof.
 	before := committer.index
 	retry, err := coordinator.InvalidateBeforeRelevantMutationV1(t.Context(), identity.Index, "vector field update")
-	if err != nil || retry != proof || committer.index != before {
-		t.Fatalf("retry proof=%+v err=%v index=%d want %+v/%d", retry, err, committer.index, proof, before)
+	if !errors.Is(err, ErrVectorPartitionLifecycleGuard) || committer.index != before {
+		t.Fatalf("retry proof=%+v err=%v index=%d", retry, err, committer.index)
 	}
 }
 

--- a/TreeDB/internal/raftplacement/vector_partition_lifecycle_coordinator_v1_test.go
+++ b/TreeDB/internal/raftplacement/vector_partition_lifecycle_coordinator_v1_test.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"errors"
 	"testing"
+
+	"github.com/snissn/gomap/TreeDB/internal/raftcluster"
 )
 
 type lifecycleCoordinatorCommitterV1 struct {
@@ -75,6 +77,66 @@ func TestSelectMutationProofRecordPrefersPendingGenerationDeterministicallyV1(t 
 		gotIdentity, gotRecord, ok := selectMutationProofRecordLockedV1(records, identity.Index)
 		if !ok || gotIdentity != older || gotRecord.InvalidationEpoch != 12 || gotRecord.MutationConfirmed {
 			t.Fatalf("selection %d identity=%+v record=%+v found=%v", i, gotIdentity, gotRecord, ok)
+		}
+	}
+}
+
+func BenchmarkVectorPartitionLifecycleCommandEncodeV1(b *testing.B) {
+	identity := vectorPartitionLifecycleTestIdentityV1()
+	command := VectorPartitionLifecycleCommandV1{
+		Kind: VectorPartitionLifecycleBeginBuildV1, ExpectedState: VectorPartitionLifecycleAbsentV1,
+		Identity: identity, RequiredGroups: []raftcluster.GroupID{"group-a"}, MutationEpoch: 9,
+	}
+	b.ReportAllocs()
+	b.SetBytes(512)
+	for b.Loop() {
+		if _, err := EncodeVectorPartitionLifecycleCommandV1(command); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkVectorPartitionLifecycleApplyBeginV1(b *testing.B) {
+	identity := vectorPartitionLifecycleTestIdentityV1()
+	command := VectorPartitionLifecycleCommandV1{
+		Kind: VectorPartitionLifecycleBeginBuildV1, ExpectedState: VectorPartitionLifecycleAbsentV1,
+		Identity: identity, RequiredGroups: []raftcluster.GroupID{"group-a"}, MutationEpoch: 9,
+	}
+	b.ReportAllocs()
+	for b.Loop() {
+		if _, err := ApplyVectorPartitionLifecycleCommandV1(VectorPartitionLifecycleRecordV1{}, command); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkVectorPartitionLifecycleReadySetDigestV1(b *testing.B) {
+	identity := vectorPartitionLifecycleTestIdentityV1()
+	groups := []raftcluster.GroupID{"group-a"}
+	ready := []VectorPartitionLifecycleGroupReadyV1{{GroupID: "group-a", AppliedIndex: 17, AssetSetDigest: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"}}
+	b.ReportAllocs()
+	b.SetBytes(128)
+	for b.Loop() {
+		if _, err := VectorPartitionLifecycleReadySetDigestV1(identity, groups, ready); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkVectorPartitionLifecycleMutationProofSelectV1(b *testing.B) {
+	identity := vectorPartitionLifecycleTestIdentityV1()
+	pending := identity
+	pending.Generation = 7
+	prepared := identity
+	prepared.Generation = 8
+	records := map[VectorPartitionLifecycleIdentityV1]VectorPartitionLifecycleRecordV1{
+		pending:  {State: VectorPartitionLifecycleInvalidatedV1, Identity: pending, Revision: 4, InvalidationEpoch: 10},
+		prepared: {State: VectorPartitionLifecyclePreparedV1, Identity: prepared, Revision: 3},
+	}
+	b.ReportAllocs()
+	for b.Loop() {
+		if _, _, ok := selectMutationProofRecordLockedV1(records, identity.Index); !ok {
+			b.Fatal("no selected lifecycle record")
 		}
 	}
 }

--- a/TreeDB/internal/raftplacement/vector_partition_lifecycle_coordinator_v1_test.go
+++ b/TreeDB/internal/raftplacement/vector_partition_lifecycle_coordinator_v1_test.go
@@ -1,0 +1,92 @@
+package raftplacement
+
+import (
+	"context"
+	"errors"
+	"testing"
+)
+
+type lifecycleCoordinatorCommitterV1 struct {
+	authority *CatalogMetaAuthorityV1
+	index     uint64
+	fail      error
+}
+
+func (c *lifecycleCoordinatorCommitterV1) SubmitCatalogMetaCommandV1(_ context.Context, raw []byte) (uint64, uint64, error) {
+	if c.fail != nil {
+		return 0, 0, c.fail
+	}
+	c.index++
+	if _, err := c.authority.applyCommittedCatalogMetaV1(raw, c.index); err != nil {
+		return 0, 0, err
+	}
+	return 1, c.index, nil
+}
+
+func TestVectorPartitionLifecycleCoordinatorInvalidatesBeforeRelevantMutationV1(t *testing.T) {
+	authority, catalog := newCatalogMetaLifecycleTestAuthorityV1(t, true)
+	committer := &lifecycleCoordinatorCommitterV1{authority: authority, index: 1}
+	coordinator := VectorPartitionLifecycleCoordinatorV1{Authority: authority, Committer: committer}
+	identity := catalogMetaLifecycleTestIdentityV1(catalog, 7, 11)
+	active := catalogMetaLifecycleBuildPreparedV1(t, authority, &committer.index, identity, 0, 9)
+	active = catalogMetaLifecycleApplyV1(t, authority, &committer.index, catalogMetaLifecycleTestCommandV1(active, VectorPartitionLifecycleActivateV1, func(c *VectorPartitionLifecycleCommandV1) {
+		c.MutationEpoch = 9
+	}))
+
+	proof, err := coordinator.InvalidateBeforeRelevantMutationV1(t.Context(), identity.Index, "vector field update")
+	if err != nil {
+		t.Fatalf("InvalidateBeforeRelevantMutationV1: %v", err)
+	}
+	if proof.ActiveGeneration != identity.Generation || proof.InvalidationEpoch != active.MutationEpoch+1 {
+		t.Fatalf("proof=%+v", proof)
+	}
+	record, ok := authority.VectorPartitionLifecycleRecordV1(identity)
+	if !ok || record.State != VectorPartitionLifecycleInvalidatedV1 {
+		t.Fatalf("record=%+v available=%v", record, ok)
+	}
+	if err := record.CanCommitRelevantMutation(proof); err != nil {
+		t.Fatalf("proof did not admit mutation after durable invalidation: %v", err)
+	}
+
+	// A replay/retry is a no-op admission: no second invalidation command is
+	// needed and the exact first invalidation proof is retained.
+	before := committer.index
+	retry, err := coordinator.InvalidateBeforeRelevantMutationV1(t.Context(), identity.Index, "vector field update")
+	if err != nil || retry != proof || committer.index != before {
+		t.Fatalf("retry proof=%+v err=%v index=%d want %+v/%d", retry, err, committer.index, proof, before)
+	}
+}
+
+func TestVectorPartitionLifecycleCoordinatorFailsClosedForPreparedOrStaleIdentityV1(t *testing.T) {
+	authority, catalog := newCatalogMetaLifecycleTestAuthorityV1(t, true)
+	committer := &lifecycleCoordinatorCommitterV1{authority: authority, index: 1}
+	coordinator := VectorPartitionLifecycleCoordinatorV1{Authority: authority, Committer: committer}
+	identity := catalogMetaLifecycleTestIdentityV1(catalog, 7, 11)
+	prepared := catalogMetaLifecycleBuildPreparedV1(t, authority, &committer.index, identity, 0, 9)
+	if _, err := coordinator.InvalidateBeforeRelevantMutationV1(t.Context(), identity.Index, "vector insert"); !errors.Is(err, ErrVectorPartitionLifecycleGuard) {
+		t.Fatalf("prepared admission err=%v", err)
+	}
+
+	active := catalogMetaLifecycleApplyV1(t, authority, &committer.index, catalogMetaLifecycleTestCommandV1(prepared, VectorPartitionLifecycleActivateV1, func(c *VectorPartitionLifecycleCommandV1) {
+		c.MutationEpoch = 9
+	}))
+	stale := identity.Index
+	stale.IndexEpoch++
+	if _, err := coordinator.InvalidateBeforeRelevantMutationV1(t.Context(), stale, "index ddl"); !errors.Is(err, ErrVectorPartitionLifecycleIdentity) {
+		t.Fatalf("stale identity admission err=%v", err)
+	}
+	still, _ := authority.VectorPartitionLifecycleRecordV1(identity)
+	if still.State != VectorPartitionLifecycleActiveV1 || still.Revision != active.Revision {
+		t.Fatalf("stale identity changed active state: %+v", still)
+	}
+}
+
+func TestVectorPartitionLifecycleCoordinatorSubmitRequiresAppliedAuthorityV1(t *testing.T) {
+	authority, catalog := newCatalogMetaLifecycleTestAuthorityV1(t, true)
+	identity := catalogMetaLifecycleTestIdentityV1(catalog, 7, 11)
+	command := catalogMetaLifecycleTestBeginV1(identity, 0, 9)
+	coordinator := VectorPartitionLifecycleCoordinatorV1{Authority: authority, Committer: &lifecycleCoordinatorCommitterV1{authority: authority, index: 1, fail: errors.New("leader unavailable")}}
+	if _, err := coordinator.Submit(t.Context(), command); err == nil {
+		t.Fatal("Submit succeeded after rejected meta commit")
+	}
+}

--- a/TreeDB/internal/raftplacement/vector_partition_lifecycle_coordinator_v1_test.go
+++ b/TreeDB/internal/raftplacement/vector_partition_lifecycle_coordinator_v1_test.go
@@ -3,6 +3,7 @@ package raftplacement
 import (
 	"context"
 	"errors"
+	"reflect"
 	"testing"
 
 	"github.com/snissn/gomap/TreeDB/internal/raftcluster"
@@ -78,6 +79,77 @@ func TestSelectMutationProofRecordPrefersPendingGenerationDeterministicallyV1(t 
 		if !ok || gotIdentity != older || gotRecord.InvalidationEpoch != 12 || gotRecord.MutationConfirmed {
 			t.Fatalf("selection %d identity=%+v record=%+v found=%v", i, gotIdentity, gotRecord, ok)
 		}
+	}
+}
+
+func TestVectorPartitionLifecycleWorkflowRetriesV1(t *testing.T) {
+	authority, catalog := newCatalogMetaLifecycleTestAuthorityV1(t, true)
+	committer := &lifecycleCoordinatorCommitterV1{authority: authority, index: 1}
+	c := VectorPartitionLifecycleCoordinatorV1{Authority: authority, Committer: committer}
+	identity := catalogMetaLifecycleTestIdentityV1(catalog, 7, 11)
+	r, err := c.BeginBuildV1(t.Context(), identity, []raftcluster.GroupID{"group-a"}, 0, 9)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if retry, err := c.BeginBuildV1(t.Context(), identity, []raftcluster.GroupID{"group-a"}, 0, 9); err != nil || !reflect.DeepEqual(retry, r) {
+		t.Fatalf("begin retry=%+v err=%v", retry, err)
+	}
+	ready := VectorPartitionLifecycleGroupReadyV1{GroupID: "group-a", AppliedIndex: 2, AssetSetDigest: "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"}
+	r, err = c.RecordGroupReadyV1(t.Context(), identity, ready)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if retry, err := c.RecordGroupReadyV1(t.Context(), identity, ready); err != nil || !reflect.DeepEqual(retry, r) {
+		t.Fatalf("ready retry=%+v err=%v", retry, err)
+	}
+	r, err = c.PrepareV1(t.Context(), identity)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if retry, err := c.PrepareV1(t.Context(), identity); err != nil || !reflect.DeepEqual(retry, r) {
+		t.Fatalf("prepare retry=%+v err=%v", retry, err)
+	}
+	r, err = c.ActivateV1(t.Context(), identity)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if retry, err := c.ActivateV1(t.Context(), identity); err != nil || !reflect.DeepEqual(retry, r) {
+		t.Fatalf("activate retry=%+v err=%v", retry, err)
+	}
+	proof, err := c.InvalidateBeforeRelevantMutationV1(t.Context(), identity.Index, "test mutation")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := c.ConfirmRelevantMutationV1(t.Context(), proof); err != nil {
+		t.Fatal(err)
+	}
+	r, err = c.RetireV1(t.Context(), identity)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if retry, err := c.RetireV1(t.Context(), identity); err != nil || !reflect.DeepEqual(retry, r) {
+		t.Fatalf("retire retry=%+v err=%v", retry, err)
+	}
+	r, err = c.MarkCleanableV1(t.Context(), identity, VectorPartitionLifecycleReferencesV1{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	r, err = c.RecordGroupCleanupV1(t.Context(), identity, "group-a")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if retry, err := c.RecordGroupCleanupV1(t.Context(), identity, "group-a"); err != nil || !reflect.DeepEqual(retry, r) {
+		t.Fatalf("cleanup retry=%+v err=%v", retry, err)
+	}
+	r, err = c.CompleteCleanupV1(t.Context(), identity)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if retry, err := c.CompleteCleanupV1(t.Context(), identity); err != nil || !reflect.DeepEqual(retry, r) {
+		t.Fatalf("complete retry=%+v err=%v", retry, err)
+	}
+	if statuses, fences, err := c.RecoveryStatusV1(); err != nil || len(statuses) != 1 || len(fences) != 1 || fences[0].Pending {
+		t.Fatalf("recovery statuses=%+v fences=%+v err=%v", statuses, fences, err)
 	}
 }
 

--- a/TreeDB/internal/raftplacement/vector_partition_lifecycle_coordinator_v1_test.go
+++ b/TreeDB/internal/raftplacement/vector_partition_lifecycle_coordinator_v1_test.go
@@ -91,6 +91,9 @@ func TestVectorPartitionLifecycleWorkflowRetriesV1(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	if _, err := c.BeginBuildV1(t.Context(), identity, []raftcluster.GroupID{"group-b"}, 0, 9); !errors.Is(err, ErrVectorPartitionLifecycleConflict) {
+		t.Fatalf("conflicting begin retry err=%v", err)
+	}
 	if retry, err := c.BeginBuildV1(t.Context(), identity, []raftcluster.GroupID{"group-a"}, 0, 9); err != nil || !reflect.DeepEqual(retry, r) {
 		t.Fatalf("begin retry=%+v err=%v", retry, err)
 	}

--- a/TreeDB/internal/raftplacement/vector_partition_lifecycle_coordinator_v1_test.go
+++ b/TreeDB/internal/raftplacement/vector_partition_lifecycle_coordinator_v1_test.go
@@ -58,6 +58,27 @@ func TestVectorPartitionLifecycleCoordinatorInvalidatesBeforeRelevantMutationV1(
 	}
 }
 
+func TestSelectMutationProofRecordPrefersPendingGenerationDeterministicallyV1(t *testing.T) {
+	identity := vectorPartitionLifecycleTestIdentityV1()
+	older := identity
+	older.Generation = 7
+	newer := identity
+	newer.Generation = 9
+	prepared := identity
+	prepared.Generation = 10
+	records := map[VectorPartitionLifecycleIdentityV1]VectorPartitionLifecycleRecordV1{
+		older:    {State: VectorPartitionLifecycleInvalidatedV1, Identity: older, Revision: 4, InvalidationEpoch: 12},
+		newer:    {State: VectorPartitionLifecycleInvalidatedV1, Identity: newer, Revision: 8, InvalidationEpoch: 11, MutationConfirmed: true},
+		prepared: {State: VectorPartitionLifecyclePreparedV1, Identity: prepared, Revision: 9},
+	}
+	for i := 0; i < 100; i++ {
+		gotIdentity, gotRecord, ok := selectMutationProofRecordLockedV1(records, identity.Index)
+		if !ok || gotIdentity != older || gotRecord.InvalidationEpoch != 12 || gotRecord.MutationConfirmed {
+			t.Fatalf("selection %d identity=%+v record=%+v found=%v", i, gotIdentity, gotRecord, ok)
+		}
+	}
+}
+
 func TestVectorPartitionLifecycleCoordinatorFailsClosedForPreparedOrStaleIdentityV1(t *testing.T) {
 	authority, catalog := newCatalogMetaLifecycleTestAuthorityV1(t, true)
 	committer := &lifecycleCoordinatorCommitterV1{authority: authority, index: 1}

--- a/TreeDB/internal/raftplacement/vector_partition_lifecycle_coordinator_v1_test.go
+++ b/TreeDB/internal/raftplacement/vector_partition_lifecycle_coordinator_v1_test.go
@@ -3,6 +3,7 @@ package raftplacement
 import (
 	"context"
 	"errors"
+	"fmt"
 	"reflect"
 	"testing"
 
@@ -67,6 +68,124 @@ func TestVectorPartitionLifecycleCoordinatorInvalidatesBeforeRelevantMutationV1(
 	retry, err := coordinator.InvalidateBeforeRelevantMutationV1(t.Context(), identity.Index, "vector field update")
 	if !errors.Is(err, ErrVectorPartitionLifecycleGuard) || committer.index != before {
 		t.Fatalf("retry proof=%+v err=%v index=%d", retry, err, committer.index)
+	}
+}
+
+func TestVectorPartitionCollectionMutationBarrierClosesFirstGenerationSourceRaceV1(t *testing.T) {
+	authority, catalog := newCatalogMetaLifecycleTestAuthorityV1(t, true)
+	committer := &lifecycleCoordinatorCommitterV1{authority: authority, index: 1}
+	coordinator := VectorPartitionLifecycleCoordinatorV1{Authority: authority, Committer: committer}
+	collection := catalogMetaLifecycleTestIdentityV1(catalog, 7, 11).Index.Collection
+	before, err := coordinator.BuildSourceMutationEpochV1(collection)
+	if err != nil || before != 1 {
+		t.Fatalf("initial build epoch=%d err=%v", before, err)
+	}
+	opA := "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	barrier, err := coordinator.BeginRelevantCollectionMutationV1(t.Context(), collection, opA)
+	if err != nil || !barrier.Pending || barrier.Epoch != before+1 {
+		t.Fatalf("barrier=%+v err=%v", barrier, err)
+	}
+	identity := catalogMetaLifecycleTestIdentityV1(catalog, 7, 11)
+	if _, err := coordinator.BeginBuildV1(t.Context(), identity, []raftcluster.GroupID{"group-a"}, 0, before); !errors.Is(err, ErrVectorPartitionLifecycleGuard) {
+		t.Fatalf("pending barrier admitted stale first-generation build: %v", err)
+	}
+	if err := coordinator.ConfirmRelevantCollectionMutationV1(t.Context(), collection, opA); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := coordinator.BeginBuildV1(t.Context(), identity, []raftcluster.GroupID{"group-a"}, 0, before); !errors.Is(err, ErrVectorPartitionLifecycleGuard) {
+		t.Fatalf("completed barrier admitted stale captured source: %v", err)
+	}
+	if _, err := coordinator.BeginBuildV1(t.Context(), identity, []raftcluster.GroupID{"group-a"}, 0, barrier.Epoch); err != nil {
+		t.Fatalf("fresh source build: %v", err)
+	}
+	opB := "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+	if _, err := coordinator.BeginRelevantCollectionMutationV1(t.Context(), collection, opB); !errors.Is(err, ErrVectorPartitionLifecycleGuard) {
+		t.Fatalf("mutation raced source capture: %v", err)
+	}
+}
+
+func TestVectorPartitionCollectionMutationBarrierRetryConflictAndRestoreV1(t *testing.T) {
+	authority, catalog := newCatalogMetaLifecycleTestAuthorityV1(t, true)
+	committer := &lifecycleCoordinatorCommitterV1{authority: authority, index: 1}
+	coordinator := VectorPartitionLifecycleCoordinatorV1{Authority: authority, Committer: committer}
+	collection := catalogMetaLifecycleTestIdentityV1(catalog, 7, 11).Index.Collection
+	opA := "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	opB := "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+	first, err := coordinator.BeginRelevantCollectionMutationV1(t.Context(), collection, opA)
+	if err != nil {
+		t.Fatal(err)
+	}
+	beforeRetry := committer.index
+	retry, err := coordinator.BeginRelevantCollectionMutationV1(t.Context(), collection, opA)
+	if err != nil || retry != first || committer.index != beforeRetry {
+		t.Fatalf("exact retry=%+v err=%v applied=%d", retry, err, committer.index)
+	}
+	if _, err := coordinator.BeginRelevantCollectionMutationV1(t.Context(), collection, opB); !errors.Is(err, ErrVectorPartitionLifecycleGuard) {
+		t.Fatalf("distinct concurrent operation err=%v", err)
+	}
+	snapshot, err := authority.ExportCatalogMetaSnapshotV1()
+	if err != nil {
+		t.Fatal(err)
+	}
+	restored := NewCatalogMetaAuthorityV1()
+	if _, err := restored.installCatalogMetaSnapshotV1(snapshot); err != nil {
+		t.Fatal(err)
+	}
+	restoredCommitter := &lifecycleCoordinatorCommitterV1{authority: restored, index: snapshot.AppliedIndex}
+	restoredCoordinator := VectorPartitionLifecycleCoordinatorV1{Authority: restored, Committer: restoredCommitter}
+	if _, err := restoredCoordinator.BeginRelevantCollectionMutationV1(t.Context(), collection, opB); !errors.Is(err, ErrVectorPartitionLifecycleGuard) {
+		t.Fatalf("restored pending barrier admitted distinct operation: %v", err)
+	}
+	if err := restoredCoordinator.ConfirmRelevantCollectionMutationV1(t.Context(), collection, opA); err != nil {
+		t.Fatal(err)
+	}
+	completedReplay, err := restoredCoordinator.BeginRelevantCollectionMutationV1(t.Context(), collection, opA)
+	if err != nil || completedReplay.Pending || completedReplay.Epoch != first.Epoch {
+		t.Fatalf("completed replay=%+v err=%v", completedReplay, err)
+	}
+}
+
+func TestVectorPartitionCollectionMutationBarrierOwnsIndexInvalidationV1(t *testing.T) {
+	authority, catalog := newCatalogMetaLifecycleTestAuthorityV1(t, true)
+	committer := &lifecycleCoordinatorCommitterV1{authority: authority, index: 1}
+	coordinator := VectorPartitionLifecycleCoordinatorV1{Authority: authority, Committer: committer}
+	identity := catalogMetaLifecycleTestIdentityV1(catalog, 7, 11)
+	active := catalogMetaLifecycleBuildPreparedV1(t, authority, &committer.index, identity, 0, 9)
+	_ = catalogMetaLifecycleApplyV1(t, authority, &committer.index, catalogMetaLifecycleTestCommandV1(active, VectorPartitionLifecycleActivateV1, func(command *VectorPartitionLifecycleCommandV1) {
+		command.MutationEpoch = 9
+	}))
+	op := "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	barrier, err := coordinator.BeginRelevantCollectionMutationV1(t.Context(), identity.Index.Collection, op)
+	if err != nil || barrier.Epoch != 10 {
+		t.Fatalf("barrier=%+v err=%v", barrier, err)
+	}
+	proof, err := coordinator.InvalidateBeforeRelevantMutationAtEpochV1(t.Context(), identity.Index, "vector update", barrier.Epoch)
+	if err != nil || proof.InvalidationEpoch != barrier.Epoch {
+		t.Fatalf("proof=%+v err=%v", proof, err)
+	}
+	if err := coordinator.ConfirmRelevantCollectionMutationV1(t.Context(), identity.Index.Collection, op); !errors.Is(err, ErrVectorPartitionLifecycleGuard) {
+		t.Fatalf("collection barrier cleared before index confirmation: %v", err)
+	}
+	if err := coordinator.ConfirmRelevantMutationV1(t.Context(), proof); err != nil {
+		t.Fatal(err)
+	}
+	if err := coordinator.ConfirmRelevantCollectionMutationV1(t.Context(), identity.Index.Collection, op); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestVectorPartitionCollectionMutationBarriersAreBoundedBeforePublicationV1(t *testing.T) {
+	authority, catalog := newCatalogMetaLifecycleTestAuthorityV1(t, true)
+	authority.collectionMutationBarriers = make(map[CollectionRefV1]vectorPartitionCollectionMutationBarrierStateV1, maxVectorPartitionCollectionMutationBarriersV1)
+	for i := 0; i < maxVectorPartitionCollectionMutationBarriersV1; i++ {
+		collection := CollectionRefV1{Database: DefaultDatabase, Catalog: DefaultCatalog, Collection: fmt.Sprintf("collection-%04d", i)}
+		authority.collectionMutationBarriers[collection] = vectorPartitionCollectionMutationBarrierStateV1{Epoch: 2, OperationDigest: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"}
+	}
+	committer := &lifecycleCoordinatorCommitterV1{authority: authority, index: 1}
+	coordinator := VectorPartitionLifecycleCoordinatorV1{Authority: authority, Committer: committer}
+	collection := catalogMetaLifecycleTestIdentityV1(catalog, 7, 11).Index.Collection
+	if _, err := coordinator.BeginRelevantCollectionMutationV1(t.Context(), collection, "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"); !errors.Is(err, ErrVectorPartitionLifecycleLimit) {
+		t.Fatalf("new barrier past cap err=%v", err)
 	}
 }
 

--- a/TreeDB/internal/raftplacement/vector_partition_lifecycle_v1.go
+++ b/TreeDB/internal/raftplacement/vector_partition_lifecycle_v1.go
@@ -1,0 +1,968 @@
+package raftplacement
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"sort"
+	"strings"
+	"unicode/utf8"
+
+	"github.com/snissn/gomap/TreeDB/internal/raftcluster"
+)
+
+const (
+	VectorPartitionLifecycleFormatV1          uint16 = 1
+	MaxVectorPartitionLifecycleCommandBytesV1        = 1 << 20
+	MaxVectorPartitionLifecycleRecordBytesV1         = 1 << 20
+	MaxVectorPartitionLifecycleGroupsV1              = MaxCatalogMetaGroupsV1
+	MaxVectorPartitionLifecycleReasonBytesV1         = 256
+)
+
+var (
+	ErrInvalidVectorPartitionLifecycle  = errors.New("raftplacement: invalid vector partition lifecycle")
+	ErrVectorPartitionLifecycleLimit    = errors.New("raftplacement: vector partition lifecycle limit")
+	ErrVectorPartitionLifecycleState    = errors.New("raftplacement: vector partition lifecycle state transition")
+	ErrVectorPartitionLifecycleIdentity = errors.New("raftplacement: vector partition lifecycle identity mismatch")
+	ErrVectorPartitionLifecycleStale    = errors.New("raftplacement: stale vector partition lifecycle command")
+	ErrVectorPartitionLifecycleConflict = errors.New("raftplacement: vector partition lifecycle conflict")
+	ErrVectorPartitionLifecycleGuard    = errors.New("raftplacement: vector partition lifecycle guard refused")
+)
+
+// VectorPartitionLifecycleStateV1 is the replicated state of one derived
+// generation. Absent is the zero state and the terminal state after cleanup.
+type VectorPartitionLifecycleStateV1 string
+
+const (
+	VectorPartitionLifecycleAbsentV1      VectorPartitionLifecycleStateV1 = "absent"
+	VectorPartitionLifecycleBuildingV1    VectorPartitionLifecycleStateV1 = "building"
+	VectorPartitionLifecycleStagedV1      VectorPartitionLifecycleStateV1 = "staged"
+	VectorPartitionLifecyclePreparedV1    VectorPartitionLifecycleStateV1 = "prepared"
+	VectorPartitionLifecycleActiveV1      VectorPartitionLifecycleStateV1 = "active"
+	VectorPartitionLifecycleInvalidatedV1 VectorPartitionLifecycleStateV1 = "invalidated"
+	VectorPartitionLifecycleRetiredV1     VectorPartitionLifecycleStateV1 = "retired"
+	VectorPartitionLifecycleCleanableV1   VectorPartitionLifecycleStateV1 = "cleanable"
+)
+
+type VectorPartitionLifecycleCommandKindV1 string
+
+const (
+	VectorPartitionLifecycleBeginBuildV1         VectorPartitionLifecycleCommandKindV1 = "begin_build"
+	VectorPartitionLifecycleRecordGroupReadyV1   VectorPartitionLifecycleCommandKindV1 = "record_group_ready"
+	VectorPartitionLifecyclePrepareV1            VectorPartitionLifecycleCommandKindV1 = "prepare"
+	VectorPartitionLifecycleActivateV1           VectorPartitionLifecycleCommandKindV1 = "activate"
+	VectorPartitionLifecycleAbortBuildV1         VectorPartitionLifecycleCommandKindV1 = "abort_build"
+	VectorPartitionLifecycleInvalidateV1         VectorPartitionLifecycleCommandKindV1 = "invalidate"
+	VectorPartitionLifecycleRetireV1             VectorPartitionLifecycleCommandKindV1 = "retire"
+	VectorPartitionLifecycleMarkCleanableV1      VectorPartitionLifecycleCommandKindV1 = "mark_cleanable"
+	VectorPartitionLifecycleRecordGroupCleanupV1 VectorPartitionLifecycleCommandKindV1 = "record_group_cleanup"
+	VectorPartitionLifecycleCompleteCleanupV1    VectorPartitionLifecycleCommandKindV1 = "complete_cleanup"
+)
+
+// VectorPartitionLifecycleIndexIdentityV1 distinguishes collection recreation,
+// index replacement, and catalog replacement. Every field participates in
+// equality; no name-only fallback is permitted.
+type VectorPartitionLifecycleIndexIdentityV1 struct {
+	Collection            CollectionRefV1 `json:"collection"`
+	CollectionIncarnation uint64          `json:"collection_incarnation"`
+	IndexName             string          `json:"index_name"`
+	IndexDefinitionDigest string          `json:"index_definition_digest"`
+	IndexEpoch            uint64          `json:"index_epoch"`
+	CatalogEpoch          uint64          `json:"catalog_epoch"`
+	CatalogDigest         string          `json:"catalog_digest"`
+}
+
+type VectorPartitionLifecycleSourceIdentityV1 struct {
+	Generation uint64 `json:"generation"`
+	Checksum   uint64 `json:"checksum"`
+	SchemaHash uint64 `json:"schema_hash"`
+	RowCount   uint64 `json:"row_count"`
+}
+
+// VectorPartitionLifecycleIdentityV1 is the exact identity of one derived
+// generation and its immutable source.
+type VectorPartitionLifecycleIdentityV1 struct {
+	Index      VectorPartitionLifecycleIndexIdentityV1  `json:"index"`
+	Source     VectorPartitionLifecycleSourceIdentityV1 `json:"source"`
+	Generation uint64                                   `json:"generation"`
+}
+
+// VectorPartitionLifecycleGroupReadyV1 is one bounded group-level aggregate.
+// AssetSetDigest binds all partition/router assets declared for that group;
+// the lifecycle record never carries an unbounded per-asset vector.
+type VectorPartitionLifecycleGroupReadyV1 struct {
+	GroupID        raftcluster.GroupID `json:"group_id"`
+	AppliedIndex   uint64              `json:"applied_index"`
+	AssetSetDigest string              `json:"asset_set_digest"`
+}
+
+// VectorPartitionLifecycleReferencesV1 is a point-in-time conservative
+// reachability observation used only to move a retired generation to cleanable.
+type VectorPartitionLifecycleReferencesV1 struct {
+	ReaderPins         uint64 `json:"reader_pins"`
+	SnapshotReferences uint64 `json:"snapshot_references"`
+	BackupReferences   uint64 `json:"backup_references"`
+	CatalogReferences  uint64 `json:"catalog_references"`
+}
+
+// VectorPartitionLifecycleSearchProofV1 is intentionally O(1): the local M5/M6
+// admission path validates selected assets, while this guard binds that local
+// evidence to the single replicated active ready-set.
+type VectorPartitionLifecycleSearchProofV1 struct {
+	Identity       VectorPartitionLifecycleIdentityV1 `json:"identity"`
+	ReadySetDigest string                             `json:"ready_set_digest"`
+}
+
+// VectorPartitionLifecycleMutationProofV1 proves either that no generation is
+// active or that the named active generation was durably invalidated first.
+type VectorPartitionLifecycleMutationProofV1 struct {
+	IndexIdentity     VectorPartitionLifecycleIndexIdentityV1 `json:"index_identity"`
+	ActiveGeneration  uint64                                  `json:"active_generation"`
+	InvalidationEpoch uint64                                  `json:"invalidation_epoch"`
+}
+
+// VectorPartitionLifecycleRecordV1 is a bounded, O(1)-friendly admission
+// record. RequiredGroups and ReadyGroups are scanned only on build/cleanup
+// transitions; steady-state guards compare fixed-size identity and digest data.
+type VectorPartitionLifecycleRecordV1 struct {
+	Format                   uint16                                 `json:"format"`
+	Revision                 uint64                                 `json:"revision"`
+	State                    VectorPartitionLifecycleStateV1        `json:"state"`
+	Identity                 VectorPartitionLifecycleIdentityV1     `json:"identity"`
+	PreviousActiveGeneration uint64                                 `json:"previous_active_generation"`
+	MutationEpoch            uint64                                 `json:"mutation_epoch"`
+	RequiredGroups           []raftcluster.GroupID                  `json:"required_groups"`
+	ReadyGroups              []VectorPartitionLifecycleGroupReadyV1 `json:"ready_groups"`
+	ReadySetDigest           string                                 `json:"ready_set_digest"`
+	InvalidationReason       string                                 `json:"invalidation_reason"`
+	InvalidationEpoch        uint64                                 `json:"invalidation_epoch"`
+	Aborted                  bool                                   `json:"aborted"`
+	RetirementReason         string                                 `json:"retirement_reason"`
+	SupersededByGeneration   uint64                                 `json:"superseded_by_generation"`
+	CleanedGroups            []raftcluster.GroupID                  `json:"cleaned_groups"`
+	CleanupComplete          bool                                   `json:"cleanup_complete"`
+	LastCommandDigest        string                                 `json:"last_command_digest"`
+}
+
+// VectorPartitionLifecycleCommandV1 is a single deterministic envelope. Fields
+// irrelevant to Kind must be zero, preventing ambiguous alternate encodings.
+type VectorPartitionLifecycleCommandV1 struct {
+	Format                   uint16                                `json:"format"`
+	Kind                     VectorPartitionLifecycleCommandKindV1 `json:"kind"`
+	ExpectedRevision         uint64                                `json:"expected_revision"`
+	ExpectedState            VectorPartitionLifecycleStateV1       `json:"expected_state"`
+	Identity                 VectorPartitionLifecycleIdentityV1    `json:"identity"`
+	RequiredGroups           []raftcluster.GroupID                 `json:"required_groups"`
+	PreviousActiveGeneration uint64                                `json:"previous_active_generation"`
+	PreviousActiveRevision   uint64                                `json:"previous_active_revision"`
+	MutationEpoch            uint64                                `json:"mutation_epoch"`
+	GroupReady               VectorPartitionLifecycleGroupReadyV1  `json:"group_ready"`
+	ReadySetDigest           string                                `json:"ready_set_digest"`
+	Reason                   string                                `json:"reason"`
+	InvalidationEpoch        uint64                                `json:"invalidation_epoch"`
+	References               VectorPartitionLifecycleReferencesV1  `json:"references"`
+	GroupID                  raftcluster.GroupID                   `json:"group_id"`
+}
+
+func EncodeVectorPartitionLifecycleCommandV1(command VectorPartitionLifecycleCommandV1) ([]byte, error) {
+	canonical, err := canonicalVectorPartitionLifecycleCommandV1(command)
+	if err != nil {
+		return nil, err
+	}
+	b, err := json.Marshal(canonical)
+	if err != nil {
+		return nil, errors.Join(ErrInvalidVectorPartitionLifecycle, err)
+	}
+	if len(b) > MaxVectorPartitionLifecycleCommandBytesV1 {
+		return nil, errors.Join(ErrVectorPartitionLifecycleLimit, fmt.Errorf("command is %d bytes", len(b)))
+	}
+	return b, nil
+}
+
+func DecodeVectorPartitionLifecycleCommandV1(raw []byte) (VectorPartitionLifecycleCommandV1, error) {
+	if len(raw) == 0 || len(raw) > MaxVectorPartitionLifecycleCommandBytesV1 {
+		return VectorPartitionLifecycleCommandV1{}, errors.Join(ErrVectorPartitionLifecycleLimit, fmt.Errorf("command is %d bytes", len(raw)))
+	}
+	var command VectorPartitionLifecycleCommandV1
+	if err := decodeVectorPartitionLifecycleJSONV1(raw, &command); err != nil {
+		return VectorPartitionLifecycleCommandV1{}, err
+	}
+	canonical, err := EncodeVectorPartitionLifecycleCommandV1(command)
+	if err != nil {
+		return VectorPartitionLifecycleCommandV1{}, err
+	}
+	if !bytes.Equal(raw, canonical) {
+		return VectorPartitionLifecycleCommandV1{}, errors.Join(ErrInvalidVectorPartitionLifecycle, fmt.Errorf("command is not canonical"))
+	}
+	return command, nil
+}
+
+func EncodeVectorPartitionLifecycleRecordV1(record VectorPartitionLifecycleRecordV1) ([]byte, error) {
+	canonical, err := canonicalVectorPartitionLifecycleRecordV1(record)
+	if err != nil {
+		return nil, err
+	}
+	b, err := json.Marshal(canonical)
+	if err != nil {
+		return nil, errors.Join(ErrInvalidVectorPartitionLifecycle, err)
+	}
+	if len(b) > MaxVectorPartitionLifecycleRecordBytesV1 {
+		return nil, errors.Join(ErrVectorPartitionLifecycleLimit, fmt.Errorf("record is %d bytes", len(b)))
+	}
+	return b, nil
+}
+
+func DecodeVectorPartitionLifecycleRecordV1(raw []byte) (VectorPartitionLifecycleRecordV1, error) {
+	if len(raw) == 0 || len(raw) > MaxVectorPartitionLifecycleRecordBytesV1 {
+		return VectorPartitionLifecycleRecordV1{}, errors.Join(ErrVectorPartitionLifecycleLimit, fmt.Errorf("record is %d bytes", len(raw)))
+	}
+	var record VectorPartitionLifecycleRecordV1
+	if err := decodeVectorPartitionLifecycleJSONV1(raw, &record); err != nil {
+		return VectorPartitionLifecycleRecordV1{}, err
+	}
+	canonical, err := EncodeVectorPartitionLifecycleRecordV1(record)
+	if err != nil {
+		return VectorPartitionLifecycleRecordV1{}, err
+	}
+	if !bytes.Equal(raw, canonical) {
+		return VectorPartitionLifecycleRecordV1{}, errors.Join(ErrInvalidVectorPartitionLifecycle, fmt.Errorf("record is not canonical"))
+	}
+	return record, nil
+}
+
+// ApplyVectorPartitionLifecycleCommandV1 is a deterministic pure reducer.
+// Exact retry of the last committed command is a no-op. Every other command is
+// revision-, state-, and identity-guarded before any state is changed.
+func ApplyVectorPartitionLifecycleCommandV1(record VectorPartitionLifecycleRecordV1, command VectorPartitionLifecycleCommandV1) (VectorPartitionLifecycleRecordV1, error) {
+	current, err := canonicalVectorPartitionLifecycleRecordV1(record)
+	if err != nil {
+		return VectorPartitionLifecycleRecordV1{}, err
+	}
+	commandBytes, err := EncodeVectorPartitionLifecycleCommandV1(command)
+	if err != nil {
+		return VectorPartitionLifecycleRecordV1{}, err
+	}
+	command, err = DecodeVectorPartitionLifecycleCommandV1(commandBytes)
+	if err != nil {
+		return VectorPartitionLifecycleRecordV1{}, err
+	}
+	commandDigest := sha256HexVectorPartitionLifecycleV1(commandBytes)
+	if current.LastCommandDigest != "" && current.LastCommandDigest == commandDigest {
+		return current, nil
+	}
+	if current.Revision != command.ExpectedRevision {
+		return VectorPartitionLifecycleRecordV1{}, errors.Join(ErrVectorPartitionLifecycleStale, fmt.Errorf("revision=%d want %d", command.ExpectedRevision, current.Revision))
+	}
+	if current.State != command.ExpectedState {
+		return VectorPartitionLifecycleRecordV1{}, errors.Join(ErrVectorPartitionLifecycleState, fmt.Errorf("state=%q want %q", current.State, command.ExpectedState))
+	}
+	if command.Kind != VectorPartitionLifecycleBeginBuildV1 && current.Identity != command.Identity {
+		return VectorPartitionLifecycleRecordV1{}, ErrVectorPartitionLifecycleIdentity
+	}
+
+	next := current
+	switch command.Kind {
+	case VectorPartitionLifecycleBeginBuildV1:
+		if !zeroVectorPartitionLifecycleIdentityV1(current.Identity) || current.Revision != 0 {
+			return VectorPartitionLifecycleRecordV1{}, errors.Join(ErrVectorPartitionLifecycleConflict, fmt.Errorf("build slot is not empty"))
+		}
+		next = VectorPartitionLifecycleRecordV1{
+			Format:                   VectorPartitionLifecycleFormatV1,
+			State:                    VectorPartitionLifecycleBuildingV1,
+			Identity:                 command.Identity,
+			PreviousActiveGeneration: command.PreviousActiveGeneration,
+			MutationEpoch:            command.MutationEpoch,
+			RequiredGroups:           append([]raftcluster.GroupID(nil), command.RequiredGroups...),
+			ReadyGroups:              []VectorPartitionLifecycleGroupReadyV1{},
+			CleanedGroups:            []raftcluster.GroupID{},
+		}
+	case VectorPartitionLifecycleRecordGroupReadyV1:
+		if !containsVectorPartitionLifecycleGroupV1(current.RequiredGroups, command.GroupReady.GroupID) {
+			return VectorPartitionLifecycleRecordV1{}, errors.Join(ErrVectorPartitionLifecycleIdentity, fmt.Errorf("group %q is not required", command.GroupReady.GroupID))
+		}
+		if i, ok := findVectorPartitionLifecycleReadyGroupV1(current.ReadyGroups, command.GroupReady.GroupID); ok {
+			if current.ReadyGroups[i] == command.GroupReady {
+				return current, nil
+			}
+			return VectorPartitionLifecycleRecordV1{}, errors.Join(ErrVectorPartitionLifecycleConflict, fmt.Errorf("group %q readiness changed", command.GroupReady.GroupID))
+		}
+		next.ReadyGroups = append(append([]VectorPartitionLifecycleGroupReadyV1(nil), current.ReadyGroups...), command.GroupReady)
+		sort.Slice(next.ReadyGroups, func(i, j int) bool { return next.ReadyGroups[i].GroupID < next.ReadyGroups[j].GroupID })
+		next.State = VectorPartitionLifecycleStagedV1
+	case VectorPartitionLifecyclePrepareV1:
+		if err := current.CanPrepare(command.Identity, command.ReadySetDigest); err != nil {
+			return VectorPartitionLifecycleRecordV1{}, err
+		}
+		next.State = VectorPartitionLifecyclePreparedV1
+		next.ReadySetDigest = command.ReadySetDigest
+	case VectorPartitionLifecycleActivateV1:
+		if command.PreviousActiveGeneration != 0 {
+			return VectorPartitionLifecycleRecordV1{}, errors.Join(ErrVectorPartitionLifecycleGuard, fmt.Errorf("activation with a previous active generation requires atomic cutover"))
+		}
+		if err := current.CanActivate(command.Identity, command.PreviousActiveGeneration, command.MutationEpoch); err != nil {
+			return VectorPartitionLifecycleRecordV1{}, err
+		}
+		next.State = VectorPartitionLifecycleActiveV1
+	case VectorPartitionLifecycleAbortBuildV1:
+		next.State = VectorPartitionLifecycleRetiredV1
+		next.Aborted = true
+		next.RetirementReason = command.Reason
+	case VectorPartitionLifecycleInvalidateV1:
+		if command.InvalidationEpoch <= current.MutationEpoch {
+			return VectorPartitionLifecycleRecordV1{}, errors.Join(ErrVectorPartitionLifecycleGuard, fmt.Errorf("invalidation epoch %d does not follow captured mutation epoch %d", command.InvalidationEpoch, current.MutationEpoch))
+		}
+		next.State = VectorPartitionLifecycleInvalidatedV1
+		next.InvalidationReason = command.Reason
+		next.InvalidationEpoch = command.InvalidationEpoch
+	case VectorPartitionLifecycleRetireV1:
+		next.State = VectorPartitionLifecycleRetiredV1
+	case VectorPartitionLifecycleMarkCleanableV1:
+		if err := current.CanClean(command.References); err != nil {
+			return VectorPartitionLifecycleRecordV1{}, err
+		}
+		next.State = VectorPartitionLifecycleCleanableV1
+	case VectorPartitionLifecycleRecordGroupCleanupV1:
+		if !containsVectorPartitionLifecycleGroupV1(current.RequiredGroups, command.GroupID) {
+			return VectorPartitionLifecycleRecordV1{}, errors.Join(ErrVectorPartitionLifecycleIdentity, fmt.Errorf("group %q is not required", command.GroupID))
+		}
+		if containsVectorPartitionLifecycleGroupV1(current.CleanedGroups, command.GroupID) {
+			return current, nil
+		}
+		next.CleanedGroups = append(append([]raftcluster.GroupID(nil), current.CleanedGroups...), command.GroupID)
+		sort.Slice(next.CleanedGroups, func(i, j int) bool { return next.CleanedGroups[i] < next.CleanedGroups[j] })
+	case VectorPartitionLifecycleCompleteCleanupV1:
+		if len(current.CleanedGroups) != len(current.RequiredGroups) {
+			return VectorPartitionLifecycleRecordV1{}, errors.Join(ErrVectorPartitionLifecycleGuard, fmt.Errorf("cleaned groups=%d required=%d", len(current.CleanedGroups), len(current.RequiredGroups)))
+		}
+		next.State = VectorPartitionLifecycleAbsentV1
+		next.RequiredGroups = []raftcluster.GroupID{}
+		next.ReadyGroups = []VectorPartitionLifecycleGroupReadyV1{}
+		next.ReadySetDigest = ""
+		next.CleanedGroups = []raftcluster.GroupID{}
+		next.CleanupComplete = true
+	default:
+		return VectorPartitionLifecycleRecordV1{}, errors.Join(ErrInvalidVectorPartitionLifecycle, fmt.Errorf("unknown command kind %q", command.Kind))
+	}
+	next.Revision = current.Revision + 1
+	next.LastCommandDigest = commandDigest
+	return canonicalVectorPartitionLifecycleRecordV1(next)
+}
+
+// ApplyVectorPartitionLifecycleCutoverV1 is the only activation path when a
+// previous generation is active. The authority must publish both returned
+// records in one meta-log replacement: the candidate becomes active exactly
+// when the previous record becomes retired. Supersession is not mutation
+// invalidation and cannot authorize a relevant mutation.
+func ApplyVectorPartitionLifecycleCutoverV1(previous, candidate VectorPartitionLifecycleRecordV1, command VectorPartitionLifecycleCommandV1) (VectorPartitionLifecycleRecordV1, VectorPartitionLifecycleRecordV1, error) {
+	oldRecord, err := canonicalVectorPartitionLifecycleRecordV1(previous)
+	if err != nil {
+		return VectorPartitionLifecycleRecordV1{}, VectorPartitionLifecycleRecordV1{}, err
+	}
+	newRecord, err := canonicalVectorPartitionLifecycleRecordV1(candidate)
+	if err != nil {
+		return VectorPartitionLifecycleRecordV1{}, VectorPartitionLifecycleRecordV1{}, err
+	}
+	commandBytes, err := EncodeVectorPartitionLifecycleCommandV1(command)
+	if err != nil {
+		return VectorPartitionLifecycleRecordV1{}, VectorPartitionLifecycleRecordV1{}, err
+	}
+	command, err = DecodeVectorPartitionLifecycleCommandV1(commandBytes)
+	if err != nil {
+		return VectorPartitionLifecycleRecordV1{}, VectorPartitionLifecycleRecordV1{}, err
+	}
+	if command.Kind != VectorPartitionLifecycleActivateV1 || command.PreviousActiveGeneration == 0 || command.PreviousActiveRevision == 0 {
+		return VectorPartitionLifecycleRecordV1{}, VectorPartitionLifecycleRecordV1{}, errors.Join(ErrInvalidVectorPartitionLifecycle, fmt.Errorf("cutover requires an activate command with a previous active guard"))
+	}
+	commandDigest := sha256HexVectorPartitionLifecycleV1(commandBytes)
+	if oldRecord.LastCommandDigest == commandDigest && newRecord.LastCommandDigest == commandDigest &&
+		oldRecord.State == VectorPartitionLifecycleRetiredV1 &&
+		oldRecord.SupersededByGeneration == newRecord.Identity.Generation &&
+		newRecord.State == VectorPartitionLifecycleActiveV1 {
+		return oldRecord, newRecord, nil
+	}
+	if newRecord.Revision != command.ExpectedRevision {
+		return VectorPartitionLifecycleRecordV1{}, VectorPartitionLifecycleRecordV1{}, errors.Join(ErrVectorPartitionLifecycleStale, fmt.Errorf("candidate revision=%d want %d", command.ExpectedRevision, newRecord.Revision))
+	}
+	if newRecord.State != command.ExpectedState {
+		return VectorPartitionLifecycleRecordV1{}, VectorPartitionLifecycleRecordV1{}, errors.Join(ErrVectorPartitionLifecycleState, fmt.Errorf("candidate state=%q want %q", newRecord.State, command.ExpectedState))
+	}
+	if newRecord.Identity != command.Identity || oldRecord.Identity.Index != newRecord.Identity.Index {
+		return VectorPartitionLifecycleRecordV1{}, VectorPartitionLifecycleRecordV1{}, ErrVectorPartitionLifecycleIdentity
+	}
+	if oldRecord.State != VectorPartitionLifecycleActiveV1 ||
+		oldRecord.Identity.Generation != command.PreviousActiveGeneration ||
+		oldRecord.Revision != command.PreviousActiveRevision {
+		return VectorPartitionLifecycleRecordV1{}, VectorPartitionLifecycleRecordV1{}, errors.Join(ErrVectorPartitionLifecycleStale, fmt.Errorf("previous active generation or revision changed"))
+	}
+	if err := newRecord.CanActivate(command.Identity, command.PreviousActiveGeneration, command.MutationEpoch); err != nil {
+		return VectorPartitionLifecycleRecordV1{}, VectorPartitionLifecycleRecordV1{}, err
+	}
+
+	nextOld := oldRecord
+	nextOld.State = VectorPartitionLifecycleRetiredV1
+	nextOld.SupersededByGeneration = newRecord.Identity.Generation
+	nextOld.Revision++
+	nextOld.LastCommandDigest = commandDigest
+	nextOld, err = canonicalVectorPartitionLifecycleRecordV1(nextOld)
+	if err != nil {
+		return VectorPartitionLifecycleRecordV1{}, VectorPartitionLifecycleRecordV1{}, err
+	}
+	nextNew := newRecord
+	nextNew.State = VectorPartitionLifecycleActiveV1
+	nextNew.Revision++
+	nextNew.LastCommandDigest = commandDigest
+	nextNew, err = canonicalVectorPartitionLifecycleRecordV1(nextNew)
+	if err != nil {
+		return VectorPartitionLifecycleRecordV1{}, VectorPartitionLifecycleRecordV1{}, err
+	}
+	return nextOld, nextNew, nil
+}
+
+func (r VectorPartitionLifecycleRecordV1) CanPrepare(identity VectorPartitionLifecycleIdentityV1, readySetDigest string) error {
+	if r.State != VectorPartitionLifecycleStagedV1 {
+		return errors.Join(ErrVectorPartitionLifecycleGuard, fmt.Errorf("prepare requires staged state"))
+	}
+	if r.Identity != identity {
+		return ErrVectorPartitionLifecycleIdentity
+	}
+	if len(r.ReadyGroups) != len(r.RequiredGroups) {
+		return errors.Join(ErrVectorPartitionLifecycleGuard, fmt.Errorf("ready groups=%d required=%d", len(r.ReadyGroups), len(r.RequiredGroups)))
+	}
+	digest, err := VectorPartitionLifecycleReadySetDigestV1(r.Identity, r.RequiredGroups, r.ReadyGroups)
+	if err != nil {
+		return err
+	}
+	if readySetDigest == "" || readySetDigest != digest {
+		return errors.Join(ErrVectorPartitionLifecycleGuard, fmt.Errorf("ready-set digest mismatch"))
+	}
+	return nil
+}
+
+func (r VectorPartitionLifecycleRecordV1) CanActivate(identity VectorPartitionLifecycleIdentityV1, previousActiveGeneration, mutationEpoch uint64) error {
+	if r.State != VectorPartitionLifecyclePreparedV1 {
+		return errors.Join(ErrVectorPartitionLifecycleGuard, fmt.Errorf("activate requires prepared state"))
+	}
+	if r.Identity != identity {
+		return ErrVectorPartitionLifecycleIdentity
+	}
+	if r.PreviousActiveGeneration != previousActiveGeneration || r.MutationEpoch != mutationEpoch {
+		return errors.Join(ErrVectorPartitionLifecycleGuard, fmt.Errorf("activation predecessor or mutation epoch changed"))
+	}
+	if r.ReadySetDigest == "" {
+		return errors.Join(ErrVectorPartitionLifecycleGuard, fmt.Errorf("prepared ready-set digest is missing"))
+	}
+	return nil
+}
+
+func (r VectorPartitionLifecycleRecordV1) CanSearch(proof VectorPartitionLifecycleSearchProofV1) error {
+	if r.State != VectorPartitionLifecycleActiveV1 || r.InvalidationEpoch != 0 {
+		return errors.Join(ErrVectorPartitionLifecycleGuard, fmt.Errorf("search requires non-invalidated active state"))
+	}
+	if r.Identity != proof.Identity {
+		return ErrVectorPartitionLifecycleIdentity
+	}
+	if r.ReadySetDigest == "" || r.ReadySetDigest != proof.ReadySetDigest {
+		return errors.Join(ErrVectorPartitionLifecycleGuard, fmt.Errorf("active ready-set digest mismatch"))
+	}
+	return nil
+}
+
+func (r VectorPartitionLifecycleRecordV1) CanCommitRelevantMutation(proof VectorPartitionLifecycleMutationProofV1) error {
+	if err := validateVectorPartitionLifecycleIndexIdentityV1(proof.IndexIdentity); err != nil {
+		return err
+	}
+	if r.State == VectorPartitionLifecycleAbsentV1 && zeroVectorPartitionLifecycleIdentityV1(r.Identity) {
+		if proof.ActiveGeneration == 0 && proof.InvalidationEpoch == 0 {
+			return nil
+		}
+		return errors.Join(ErrVectorPartitionLifecycleGuard, fmt.Errorf("absent lifecycle does not permit a named active generation"))
+	}
+	if indexIdentityVectorPartitionLifecycleV1(r.Identity) != proof.IndexIdentity {
+		return ErrVectorPartitionLifecycleIdentity
+	}
+	switch r.State {
+	case VectorPartitionLifecycleInvalidatedV1, VectorPartitionLifecycleRetiredV1, VectorPartitionLifecycleCleanableV1:
+		if r.Aborted || proof.ActiveGeneration != r.Identity.Generation || r.InvalidationEpoch == 0 || proof.InvalidationEpoch != r.InvalidationEpoch {
+			return errors.Join(ErrVectorPartitionLifecycleGuard, fmt.Errorf("active generation lacks exact durable invalidation"))
+		}
+		return nil
+	case VectorPartitionLifecycleAbsentV1:
+		if proof.ActiveGeneration == 0 && proof.InvalidationEpoch == 0 {
+			return nil
+		}
+	default:
+	}
+	return errors.Join(ErrVectorPartitionLifecycleGuard, fmt.Errorf("generation state %q does not prove invalidation-before-mutation", r.State))
+}
+
+func (r VectorPartitionLifecycleRecordV1) CanClean(references VectorPartitionLifecycleReferencesV1) error {
+	if r.State != VectorPartitionLifecycleRetiredV1 {
+		return errors.Join(ErrVectorPartitionLifecycleGuard, fmt.Errorf("cleanup requires retired state"))
+	}
+	if references.ReaderPins != 0 || references.SnapshotReferences != 0 ||
+		references.BackupReferences != 0 || references.CatalogReferences != 0 {
+		return errors.Join(ErrVectorPartitionLifecycleGuard, fmt.Errorf("generation remains referenced"))
+	}
+	return nil
+}
+
+// VectorPartitionLifecycleReadySetDigestV1 returns the SHA-256 of a canonical,
+// complete required-group/readiness payload. Inputs may be unordered; duplicate,
+// missing, extra, or invalid readiness fails closed.
+func VectorPartitionLifecycleReadySetDigestV1(identity VectorPartitionLifecycleIdentityV1, required []raftcluster.GroupID, ready []VectorPartitionLifecycleGroupReadyV1) (string, error) {
+	if err := validateVectorPartitionLifecycleIdentityV1(identity); err != nil {
+		return "", err
+	}
+	groups, err := canonicalVectorPartitionLifecycleGroupsV1(required)
+	if err != nil {
+		return "", err
+	}
+	readiness, err := canonicalVectorPartitionLifecycleReadyGroupsV1(ready)
+	if err != nil {
+		return "", err
+	}
+	if len(groups) != len(readiness) {
+		return "", errors.Join(ErrVectorPartitionLifecycleGuard, fmt.Errorf("ready groups=%d required=%d", len(readiness), len(groups)))
+	}
+	for i := range groups {
+		if readiness[i].GroupID != groups[i] {
+			return "", errors.Join(ErrVectorPartitionLifecycleIdentity, fmt.Errorf("ready group %q does not match required group %q", readiness[i].GroupID, groups[i]))
+		}
+	}
+	payload := struct {
+		Format         uint16                                 `json:"format"`
+		Identity       VectorPartitionLifecycleIdentityV1     `json:"identity"`
+		RequiredGroups []raftcluster.GroupID                  `json:"required_groups"`
+		ReadyGroups    []VectorPartitionLifecycleGroupReadyV1 `json:"ready_groups"`
+	}{
+		Format: VectorPartitionLifecycleFormatV1, Identity: identity,
+		RequiredGroups: groups, ReadyGroups: readiness,
+	}
+	b, err := json.Marshal(payload)
+	if err != nil {
+		return "", errors.Join(ErrInvalidVectorPartitionLifecycle, err)
+	}
+	return sha256HexVectorPartitionLifecycleV1(b), nil
+}
+
+func canonicalVectorPartitionLifecycleCommandV1(command VectorPartitionLifecycleCommandV1) (VectorPartitionLifecycleCommandV1, error) {
+	command.Format = VectorPartitionLifecycleFormatV1
+	if err := validateVectorPartitionLifecycleIdentityV1(command.Identity); err != nil {
+		return VectorPartitionLifecycleCommandV1{}, err
+	}
+	if !validVectorPartitionLifecycleStateV1(command.ExpectedState) {
+		return VectorPartitionLifecycleCommandV1{}, errors.Join(ErrInvalidVectorPartitionLifecycle, fmt.Errorf("invalid expected state %q", command.ExpectedState))
+	}
+	command.RequiredGroups = append([]raftcluster.GroupID(nil), command.RequiredGroups...)
+	if command.RequiredGroups == nil {
+		command.RequiredGroups = []raftcluster.GroupID{}
+	}
+	var err error
+	if len(command.RequiredGroups) != 0 {
+		command.RequiredGroups, err = canonicalVectorPartitionLifecycleGroupsV1(command.RequiredGroups)
+		if err != nil {
+			return VectorPartitionLifecycleCommandV1{}, err
+		}
+	}
+	if err := validateVectorPartitionLifecycleCommandShapeV1(command); err != nil {
+		return VectorPartitionLifecycleCommandV1{}, err
+	}
+	return command, nil
+}
+
+func validateVectorPartitionLifecycleCommandShapeV1(c VectorPartitionLifecycleCommandV1) error {
+	zeroReady := VectorPartitionLifecycleGroupReadyV1{}
+	zeroRefs := VectorPartitionLifecycleReferencesV1{}
+	if c.Kind != VectorPartitionLifecycleActivateV1 && c.PreviousActiveRevision != 0 {
+		return errors.Join(ErrInvalidVectorPartitionLifecycle, fmt.Errorf("previous active revision is only valid for activate"))
+	}
+	otherZero := func(previous, mutation uint64, ready VectorPartitionLifecycleGroupReadyV1, digest, reason string, invalidation uint64, refs VectorPartitionLifecycleReferencesV1, group raftcluster.GroupID) bool {
+		return len(c.RequiredGroups) == 0 && previous == 0 && mutation == 0 && ready == zeroReady &&
+			digest == "" && reason == "" && invalidation == 0 && refs == zeroRefs && group == ""
+	}
+	switch c.Kind {
+	case VectorPartitionLifecycleBeginBuildV1:
+		if c.ExpectedRevision != 0 || c.ExpectedState != VectorPartitionLifecycleAbsentV1 || len(c.RequiredGroups) == 0 ||
+			c.MutationEpoch == 0 || (c.PreviousActiveGeneration != 0 && c.Identity.Generation <= c.PreviousActiveGeneration) ||
+			c.GroupReady != zeroReady || c.ReadySetDigest != "" || c.Reason != "" || c.InvalidationEpoch != 0 || c.References != zeroRefs || c.GroupID != "" {
+			return errors.Join(ErrInvalidVectorPartitionLifecycle, fmt.Errorf("invalid begin-build command shape"))
+		}
+	case VectorPartitionLifecycleRecordGroupReadyV1:
+		if c.ExpectedState != VectorPartitionLifecycleBuildingV1 && c.ExpectedState != VectorPartitionLifecycleStagedV1 {
+			return errors.Join(ErrInvalidVectorPartitionLifecycle, fmt.Errorf("group readiness requires building or staged expected state"))
+		}
+		if err := validateVectorPartitionLifecycleGroupReadyV1(c.GroupReady); err != nil {
+			return err
+		}
+		if !otherZero(c.PreviousActiveGeneration, c.MutationEpoch, zeroReady, c.ReadySetDigest, c.Reason, c.InvalidationEpoch, c.References, c.GroupID) {
+			return errors.Join(ErrInvalidVectorPartitionLifecycle, fmt.Errorf("invalid group-ready command shape"))
+		}
+	case VectorPartitionLifecyclePrepareV1:
+		if c.ExpectedState != VectorPartitionLifecycleStagedV1 || !isSHA256HexVectorPartitionV1(c.ReadySetDigest) ||
+			!otherZero(c.PreviousActiveGeneration, c.MutationEpoch, c.GroupReady, "", c.Reason, c.InvalidationEpoch, c.References, c.GroupID) {
+			return errors.Join(ErrInvalidVectorPartitionLifecycle, fmt.Errorf("invalid prepare command shape"))
+		}
+	case VectorPartitionLifecycleActivateV1:
+		if c.ExpectedState != VectorPartitionLifecyclePreparedV1 || c.MutationEpoch == 0 ||
+			(c.PreviousActiveGeneration == 0) != (c.PreviousActiveRevision == 0) ||
+			c.GroupReady != zeroReady || c.ReadySetDigest != "" || c.Reason != "" || c.InvalidationEpoch != 0 || c.References != zeroRefs || c.GroupID != "" || len(c.RequiredGroups) != 0 {
+			return errors.Join(ErrInvalidVectorPartitionLifecycle, fmt.Errorf("invalid activate command shape"))
+		}
+	case VectorPartitionLifecycleAbortBuildV1:
+		if c.ExpectedState != VectorPartitionLifecycleBuildingV1 && c.ExpectedState != VectorPartitionLifecycleStagedV1 && c.ExpectedState != VectorPartitionLifecyclePreparedV1 {
+			return errors.Join(ErrInvalidVectorPartitionLifecycle, fmt.Errorf("abort requires building, staged, or prepared expected state"))
+		}
+		if err := validateVectorPartitionLifecycleReasonV1(c.Reason); err != nil ||
+			!otherZero(c.PreviousActiveGeneration, c.MutationEpoch, c.GroupReady, c.ReadySetDigest, "", c.InvalidationEpoch, c.References, c.GroupID) {
+			if err != nil {
+				return err
+			}
+			return errors.Join(ErrInvalidVectorPartitionLifecycle, fmt.Errorf("invalid abort command shape"))
+		}
+	case VectorPartitionLifecycleInvalidateV1:
+		if c.ExpectedState != VectorPartitionLifecycleActiveV1 || c.InvalidationEpoch == 0 {
+			return errors.Join(ErrInvalidVectorPartitionLifecycle, fmt.Errorf("invalidate requires active state and epoch"))
+		}
+		if err := validateVectorPartitionLifecycleReasonV1(c.Reason); err != nil ||
+			!otherZero(c.PreviousActiveGeneration, c.MutationEpoch, c.GroupReady, c.ReadySetDigest, "", 0, c.References, c.GroupID) {
+			if err != nil {
+				return err
+			}
+			return errors.Join(ErrInvalidVectorPartitionLifecycle, fmt.Errorf("invalid invalidate command shape"))
+		}
+	case VectorPartitionLifecycleRetireV1:
+		if c.ExpectedState != VectorPartitionLifecycleInvalidatedV1 ||
+			!otherZero(c.PreviousActiveGeneration, c.MutationEpoch, c.GroupReady, c.ReadySetDigest, c.Reason, c.InvalidationEpoch, c.References, c.GroupID) {
+			return errors.Join(ErrInvalidVectorPartitionLifecycle, fmt.Errorf("invalid retire command shape"))
+		}
+	case VectorPartitionLifecycleMarkCleanableV1:
+		if c.ExpectedState != VectorPartitionLifecycleRetiredV1 ||
+			len(c.RequiredGroups) != 0 || c.PreviousActiveGeneration != 0 || c.MutationEpoch != 0 || c.GroupReady != zeroReady ||
+			c.ReadySetDigest != "" || c.Reason != "" || c.InvalidationEpoch != 0 || c.GroupID != "" {
+			return errors.Join(ErrInvalidVectorPartitionLifecycle, fmt.Errorf("invalid mark-cleanable command shape"))
+		}
+	case VectorPartitionLifecycleRecordGroupCleanupV1:
+		if c.ExpectedState != VectorPartitionLifecycleCleanableV1 || c.GroupID == "" ||
+			!otherZero(c.PreviousActiveGeneration, c.MutationEpoch, c.GroupReady, c.ReadySetDigest, c.Reason, c.InvalidationEpoch, c.References, "") {
+			return errors.Join(ErrInvalidVectorPartitionLifecycle, fmt.Errorf("invalid group-cleanup command shape"))
+		}
+		if err := validateID("group id", string(c.GroupID)); err != nil {
+			return errors.Join(ErrInvalidVectorPartitionLifecycle, err)
+		}
+		if len(c.GroupID) > MaxCatalogMetaStringBytesV1 {
+			return errors.Join(ErrVectorPartitionLifecycleLimit, fmt.Errorf("group id is %d bytes", len(c.GroupID)))
+		}
+	case VectorPartitionLifecycleCompleteCleanupV1:
+		if c.ExpectedState != VectorPartitionLifecycleCleanableV1 ||
+			!otherZero(c.PreviousActiveGeneration, c.MutationEpoch, c.GroupReady, c.ReadySetDigest, c.Reason, c.InvalidationEpoch, c.References, c.GroupID) {
+			return errors.Join(ErrInvalidVectorPartitionLifecycle, fmt.Errorf("invalid complete-cleanup command shape"))
+		}
+	default:
+		return errors.Join(ErrInvalidVectorPartitionLifecycle, fmt.Errorf("unknown command kind %q", c.Kind))
+	}
+	return nil
+}
+
+func canonicalVectorPartitionLifecycleRecordV1(record VectorPartitionLifecycleRecordV1) (VectorPartitionLifecycleRecordV1, error) {
+	if record.Format == 0 && record.Revision == 0 && record.State == "" &&
+		zeroVectorPartitionLifecycleIdentityV1(record.Identity) &&
+		record.PreviousActiveGeneration == 0 && record.MutationEpoch == 0 &&
+		len(record.RequiredGroups) == 0 && len(record.ReadyGroups) == 0 &&
+		record.ReadySetDigest == "" && record.InvalidationReason == "" &&
+		record.InvalidationEpoch == 0 && !record.Aborted &&
+		record.RetirementReason == "" && record.SupersededByGeneration == 0 &&
+		len(record.CleanedGroups) == 0 &&
+		!record.CleanupComplete && record.LastCommandDigest == "" {
+		return VectorPartitionLifecycleRecordV1{
+			Format: VectorPartitionLifecycleFormatV1, State: VectorPartitionLifecycleAbsentV1,
+			RequiredGroups: []raftcluster.GroupID{}, ReadyGroups: []VectorPartitionLifecycleGroupReadyV1{},
+			CleanedGroups: []raftcluster.GroupID{},
+		}, nil
+	}
+	if record.Format != VectorPartitionLifecycleFormatV1 {
+		return VectorPartitionLifecycleRecordV1{}, errors.Join(ErrInvalidVectorPartitionLifecycle, fmt.Errorf("record format=%d", record.Format))
+	}
+	if err := validateVectorPartitionLifecycleIdentityV1(record.Identity); err != nil {
+		return VectorPartitionLifecycleRecordV1{}, err
+	}
+	var err error
+	record.RequiredGroups, err = canonicalVectorPartitionLifecycleGroupsAllowEmptyV1(record.RequiredGroups)
+	if err != nil {
+		return VectorPartitionLifecycleRecordV1{}, err
+	}
+	record.ReadyGroups, err = canonicalVectorPartitionLifecycleReadyGroupsAllowEmptyV1(record.ReadyGroups)
+	if err != nil {
+		return VectorPartitionLifecycleRecordV1{}, err
+	}
+	record.CleanedGroups, err = canonicalVectorPartitionLifecycleGroupsAllowEmptyV1(record.CleanedGroups)
+	if err != nil {
+		return VectorPartitionLifecycleRecordV1{}, err
+	}
+	if err := validateVectorPartitionLifecycleRecordV1(record); err != nil {
+		return VectorPartitionLifecycleRecordV1{}, err
+	}
+	return record, nil
+}
+
+func validateVectorPartitionLifecycleRecordV1(r VectorPartitionLifecycleRecordV1) error {
+	if r.Revision == 0 || !isSHA256HexVectorPartitionV1(r.LastCommandDigest) || r.MutationEpoch == 0 {
+		return errors.Join(ErrInvalidVectorPartitionLifecycle, fmt.Errorf("committed record revision, mutation epoch, or command digest is invalid"))
+	}
+	if !validVectorPartitionLifecycleStateV1(r.State) {
+		return errors.Join(ErrInvalidVectorPartitionLifecycle, fmt.Errorf("invalid state %q", r.State))
+	}
+	if r.PreviousActiveGeneration != 0 && r.Identity.Generation <= r.PreviousActiveGeneration {
+		return errors.Join(ErrInvalidVectorPartitionLifecycle, fmt.Errorf("generation does not follow previous active generation"))
+	}
+	if r.SupersededByGeneration != 0 {
+		if r.SupersededByGeneration <= r.Identity.Generation || r.Aborted ||
+			r.InvalidationEpoch != 0 || r.InvalidationReason != "" {
+			return errors.Join(ErrInvalidVectorPartitionLifecycle, fmt.Errorf("supersession identity or provenance is invalid"))
+		}
+		if r.State != VectorPartitionLifecycleRetiredV1 && r.State != VectorPartitionLifecycleCleanableV1 &&
+			r.State != VectorPartitionLifecycleAbsentV1 {
+			return errors.Join(ErrInvalidVectorPartitionLifecycle, fmt.Errorf("superseded generation has state %q", r.State))
+		}
+	}
+	if r.State == VectorPartitionLifecycleAbsentV1 {
+		if !r.CleanupComplete || len(r.RequiredGroups) != 0 || len(r.ReadyGroups) != 0 || len(r.CleanedGroups) != 0 || r.ReadySetDigest != "" {
+			return errors.Join(ErrInvalidVectorPartitionLifecycle, fmt.Errorf("terminal absent record is not cleaned"))
+		}
+		return nil
+	}
+	if r.CleanupComplete || len(r.RequiredGroups) == 0 {
+		return errors.Join(ErrInvalidVectorPartitionLifecycle, fmt.Errorf("live record has no required groups or is already cleaned"))
+	}
+	for _, ready := range r.ReadyGroups {
+		if !containsVectorPartitionLifecycleGroupV1(r.RequiredGroups, ready.GroupID) {
+			return errors.Join(ErrInvalidVectorPartitionLifecycle, fmt.Errorf("ready group %q is not required", ready.GroupID))
+		}
+	}
+	for _, group := range r.CleanedGroups {
+		if !containsVectorPartitionLifecycleGroupV1(r.RequiredGroups, group) {
+			return errors.Join(ErrInvalidVectorPartitionLifecycle, fmt.Errorf("cleaned group %q is not required", group))
+		}
+	}
+	switch r.State {
+	case VectorPartitionLifecycleBuildingV1:
+		if len(r.ReadyGroups) != 0 {
+			return errors.Join(ErrInvalidVectorPartitionLifecycle, fmt.Errorf("building record has ready groups"))
+		}
+	case VectorPartitionLifecycleStagedV1:
+		if len(r.ReadyGroups) == 0 || len(r.ReadyGroups) > len(r.RequiredGroups) {
+			return errors.Join(ErrInvalidVectorPartitionLifecycle, fmt.Errorf("staged readiness is invalid"))
+		}
+	case VectorPartitionLifecyclePreparedV1, VectorPartitionLifecycleActiveV1, VectorPartitionLifecycleInvalidatedV1:
+		if err := validateCompleteVectorPartitionLifecycleReadySetV1(r); err != nil {
+			return err
+		}
+	case VectorPartitionLifecycleRetiredV1, VectorPartitionLifecycleCleanableV1:
+		if !r.Aborted {
+			if err := validateCompleteVectorPartitionLifecycleReadySetV1(r); err != nil {
+				return err
+			}
+		}
+	}
+	needsInvalidation := r.State == VectorPartitionLifecycleInvalidatedV1 ||
+		((r.State == VectorPartitionLifecycleRetiredV1 || r.State == VectorPartitionLifecycleCleanableV1) &&
+			!r.Aborted && r.SupersededByGeneration == 0)
+	if needsInvalidation {
+		if r.InvalidationEpoch <= r.MutationEpoch || r.InvalidationReason == "" {
+			return errors.Join(ErrInvalidVectorPartitionLifecycle, fmt.Errorf("invalidated generation lacks durable invalidation"))
+		}
+	} else if r.SupersededByGeneration == 0 && (r.InvalidationEpoch != 0 || r.InvalidationReason != "") {
+		return errors.Join(ErrInvalidVectorPartitionLifecycle, fmt.Errorf("non-invalidated generation carries invalidation"))
+	}
+	if r.Aborted {
+		if r.State != VectorPartitionLifecycleRetiredV1 && r.State != VectorPartitionLifecycleCleanableV1 {
+			return errors.Join(ErrInvalidVectorPartitionLifecycle, fmt.Errorf("aborted generation has state %q", r.State))
+		}
+		if err := validateVectorPartitionLifecycleReasonV1(r.RetirementReason); err != nil {
+			return err
+		}
+	} else if r.RetirementReason != "" {
+		return errors.Join(ErrInvalidVectorPartitionLifecycle, fmt.Errorf("non-aborted generation has retirement reason"))
+	}
+	if r.State != VectorPartitionLifecycleCleanableV1 && len(r.CleanedGroups) != 0 {
+		return errors.Join(ErrInvalidVectorPartitionLifecycle, fmt.Errorf("non-cleanable generation has cleanup progress"))
+	}
+	return nil
+}
+
+func validateCompleteVectorPartitionLifecycleReadySetV1(r VectorPartitionLifecycleRecordV1) error {
+	digest, err := VectorPartitionLifecycleReadySetDigestV1(r.Identity, r.RequiredGroups, r.ReadyGroups)
+	if err != nil {
+		return err
+	}
+	if r.ReadySetDigest != digest {
+		return errors.Join(ErrInvalidVectorPartitionLifecycle, fmt.Errorf("record ready-set digest mismatch"))
+	}
+	return nil
+}
+
+func validateVectorPartitionLifecycleIdentityV1(identity VectorPartitionLifecycleIdentityV1) error {
+	if err := validateVectorPartitionLifecycleIndexIdentityV1(identity.Index); err != nil {
+		return err
+	}
+	if identity.Generation == 0 || identity.Source.Generation == 0 || identity.Source.Checksum == 0 ||
+		identity.Source.SchemaHash == 0 || identity.Source.RowCount == 0 {
+		return errors.Join(ErrInvalidVectorPartitionLifecycle, fmt.Errorf("identity contains zero generation or source field"))
+	}
+	return nil
+}
+
+func validateVectorPartitionLifecycleIndexIdentityV1(identity VectorPartitionLifecycleIndexIdentityV1) error {
+	if err := validateCollectionRef(identity.Collection); err != nil {
+		return errors.Join(ErrInvalidVectorPartitionLifecycle, err)
+	}
+	if identity.CollectionIncarnation == 0 || identity.IndexEpoch == 0 || identity.CatalogEpoch == 0 {
+		return errors.Join(ErrInvalidVectorPartitionLifecycle, fmt.Errorf("index identity contains zero incarnation or epoch"))
+	}
+	if err := validateVectorPartitionLifecycleNameV1("index name", identity.IndexName); err != nil {
+		return err
+	}
+	if !isSHA256HexVectorPartitionV1(identity.IndexDefinitionDigest) || !isSHA256HexVectorPartitionV1(identity.CatalogDigest) {
+		return errors.Join(ErrInvalidVectorPartitionLifecycle, fmt.Errorf("index or catalog digest is not canonical sha256"))
+	}
+	return nil
+}
+
+func validateVectorPartitionLifecycleGroupReadyV1(ready VectorPartitionLifecycleGroupReadyV1) error {
+	if err := validateID("group id", string(ready.GroupID)); err != nil {
+		return errors.Join(ErrInvalidVectorPartitionLifecycle, err)
+	}
+	if len(ready.GroupID) > MaxCatalogMetaStringBytesV1 {
+		return errors.Join(ErrVectorPartitionLifecycleLimit, fmt.Errorf("group id is %d bytes", len(ready.GroupID)))
+	}
+	if ready.AppliedIndex == 0 || !isSHA256HexVectorPartitionV1(ready.AssetSetDigest) {
+		return errors.Join(ErrInvalidVectorPartitionLifecycle, fmt.Errorf("group %q has invalid applied index or asset digest", ready.GroupID))
+	}
+	return nil
+}
+
+func canonicalVectorPartitionLifecycleGroupsV1(groups []raftcluster.GroupID) ([]raftcluster.GroupID, error) {
+	if len(groups) == 0 {
+		return nil, errors.Join(ErrInvalidVectorPartitionLifecycle, fmt.Errorf("at least one required group is required"))
+	}
+	return canonicalVectorPartitionLifecycleGroupsAllowEmptyV1(groups)
+}
+
+func canonicalVectorPartitionLifecycleGroupsAllowEmptyV1(groups []raftcluster.GroupID) ([]raftcluster.GroupID, error) {
+	if len(groups) > MaxVectorPartitionLifecycleGroupsV1 {
+		return nil, errors.Join(ErrVectorPartitionLifecycleLimit, fmt.Errorf("groups=%d", len(groups)))
+	}
+	out := append([]raftcluster.GroupID(nil), groups...)
+	if out == nil {
+		out = []raftcluster.GroupID{}
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i] < out[j] })
+	for i, group := range out {
+		if err := validateID("group id", string(group)); err != nil {
+			return nil, errors.Join(ErrInvalidVectorPartitionLifecycle, err)
+		}
+		if len(group) > MaxCatalogMetaStringBytesV1 {
+			return nil, errors.Join(ErrVectorPartitionLifecycleLimit, fmt.Errorf("group id is %d bytes", len(group)))
+		}
+		if i != 0 && out[i-1] == group {
+			return nil, errors.Join(ErrVectorPartitionLifecycleConflict, fmt.Errorf("duplicate group %q", group))
+		}
+	}
+	return out, nil
+}
+
+func canonicalVectorPartitionLifecycleReadyGroupsV1(groups []VectorPartitionLifecycleGroupReadyV1) ([]VectorPartitionLifecycleGroupReadyV1, error) {
+	if len(groups) == 0 {
+		return nil, errors.Join(ErrInvalidVectorPartitionLifecycle, fmt.Errorf("at least one ready group is required"))
+	}
+	return canonicalVectorPartitionLifecycleReadyGroupsAllowEmptyV1(groups)
+}
+
+func canonicalVectorPartitionLifecycleReadyGroupsAllowEmptyV1(groups []VectorPartitionLifecycleGroupReadyV1) ([]VectorPartitionLifecycleGroupReadyV1, error) {
+	if len(groups) > MaxVectorPartitionLifecycleGroupsV1 {
+		return nil, errors.Join(ErrVectorPartitionLifecycleLimit, fmt.Errorf("ready groups=%d", len(groups)))
+	}
+	out := append([]VectorPartitionLifecycleGroupReadyV1(nil), groups...)
+	if out == nil {
+		out = []VectorPartitionLifecycleGroupReadyV1{}
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].GroupID < out[j].GroupID })
+	for i, ready := range out {
+		if err := validateVectorPartitionLifecycleGroupReadyV1(ready); err != nil {
+			return nil, err
+		}
+		if i != 0 && out[i-1].GroupID == ready.GroupID {
+			return nil, errors.Join(ErrVectorPartitionLifecycleConflict, fmt.Errorf("duplicate ready group %q", ready.GroupID))
+		}
+	}
+	return out, nil
+}
+
+func validateVectorPartitionLifecycleReasonV1(reason string) error {
+	if reason == "" || len(reason) > MaxVectorPartitionLifecycleReasonBytesV1 || !utf8.ValidString(reason) || strings.TrimSpace(reason) != reason {
+		return errors.Join(ErrInvalidVectorPartitionLifecycle, fmt.Errorf("reason is empty, too long, non-canonical, or invalid utf-8"))
+	}
+	return nil
+}
+
+func validateVectorPartitionLifecycleNameV1(label, value string) error {
+	if value == "" || len(value) > MaxCatalogMetaStringBytesV1 || !utf8.ValidString(value) ||
+		strings.TrimSpace(value) != value || strings.ContainsRune(value, '\x00') {
+		return errors.Join(ErrInvalidVectorPartitionLifecycle, fmt.Errorf("%s is invalid", label))
+	}
+	return nil
+}
+
+func validVectorPartitionLifecycleStateV1(state VectorPartitionLifecycleStateV1) bool {
+	switch state {
+	case VectorPartitionLifecycleAbsentV1, VectorPartitionLifecycleBuildingV1, VectorPartitionLifecycleStagedV1,
+		VectorPartitionLifecyclePreparedV1, VectorPartitionLifecycleActiveV1, VectorPartitionLifecycleInvalidatedV1,
+		VectorPartitionLifecycleRetiredV1, VectorPartitionLifecycleCleanableV1:
+		return true
+	default:
+		return false
+	}
+}
+
+func indexIdentityVectorPartitionLifecycleV1(identity VectorPartitionLifecycleIdentityV1) VectorPartitionLifecycleIndexIdentityV1 {
+	return identity.Index
+}
+
+func zeroVectorPartitionLifecycleIdentityV1(identity VectorPartitionLifecycleIdentityV1) bool {
+	return identity == (VectorPartitionLifecycleIdentityV1{})
+}
+
+func containsVectorPartitionLifecycleGroupV1(groups []raftcluster.GroupID, group raftcluster.GroupID) bool {
+	i := sort.Search(len(groups), func(i int) bool { return groups[i] >= group })
+	return i < len(groups) && groups[i] == group
+}
+
+func findVectorPartitionLifecycleReadyGroupV1(groups []VectorPartitionLifecycleGroupReadyV1, group raftcluster.GroupID) (int, bool) {
+	i := sort.Search(len(groups), func(i int) bool { return groups[i].GroupID >= group })
+	return i, i < len(groups) && groups[i].GroupID == group
+}
+
+func isSHA256HexVectorPartitionLifecycleV1(value string) bool {
+	decoded, err := hex.DecodeString(value)
+	return err == nil && len(decoded) == sha256.Size && value == strings.ToLower(value)
+}
+
+func sha256HexVectorPartitionLifecycleV1(value []byte) string {
+	sum := sha256.Sum256(value)
+	return hex.EncodeToString(sum[:])
+}
+
+func decodeVectorPartitionLifecycleJSONV1(raw []byte, target any) error {
+	decoder := json.NewDecoder(bytes.NewReader(raw))
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(target); err != nil {
+		return errors.Join(ErrInvalidVectorPartitionLifecycle, err)
+	}
+	if err := decoder.Decode(&struct{}{}); !errors.Is(err, io.EOF) {
+		return errors.Join(ErrInvalidVectorPartitionLifecycle, fmt.Errorf("trailing json data"))
+	}
+	return nil
+}

--- a/TreeDB/internal/raftplacement/vector_partition_lifecycle_v1.go
+++ b/TreeDB/internal/raftplacement/vector_partition_lifecycle_v1.go
@@ -957,11 +957,6 @@ func findVectorPartitionLifecycleReadyGroupV1(groups []VectorPartitionLifecycleG
 	return i, i < len(groups) && groups[i].GroupID == group
 }
 
-func isSHA256HexVectorPartitionLifecycleV1(value string) bool {
-	decoded, err := hex.DecodeString(value)
-	return err == nil && len(decoded) == sha256.Size && value == strings.ToLower(value)
-}
-
 func sha256HexVectorPartitionLifecycleV1(value []byte) string {
 	sum := sha256.Sum256(value)
 	return hex.EncodeToString(sum[:])

--- a/TreeDB/internal/raftplacement/vector_partition_lifecycle_v1.go
+++ b/TreeDB/internal/raftplacement/vector_partition_lifecycle_v1.go
@@ -57,6 +57,7 @@ const (
 	VectorPartitionLifecycleActivateV1           VectorPartitionLifecycleCommandKindV1 = "activate"
 	VectorPartitionLifecycleAbortBuildV1         VectorPartitionLifecycleCommandKindV1 = "abort_build"
 	VectorPartitionLifecycleInvalidateV1         VectorPartitionLifecycleCommandKindV1 = "invalidate"
+	VectorPartitionLifecycleConfirmMutationV1    VectorPartitionLifecycleCommandKindV1 = "confirm_mutation"
 	VectorPartitionLifecycleRetireV1             VectorPartitionLifecycleCommandKindV1 = "retire"
 	VectorPartitionLifecycleMarkCleanableV1      VectorPartitionLifecycleCommandKindV1 = "mark_cleanable"
 	VectorPartitionLifecycleRecordGroupCleanupV1 VectorPartitionLifecycleCommandKindV1 = "record_group_cleanup"
@@ -140,6 +141,7 @@ type VectorPartitionLifecycleRecordV1 struct {
 	ReadySetDigest           string                                 `json:"ready_set_digest"`
 	InvalidationReason       string                                 `json:"invalidation_reason"`
 	InvalidationEpoch        uint64                                 `json:"invalidation_epoch"`
+	MutationConfirmed        bool                                   `json:"mutation_confirmed"`
 	Aborted                  bool                                   `json:"aborted"`
 	RetirementReason         string                                 `json:"retirement_reason"`
 	SupersededByGeneration   uint64                                 `json:"superseded_by_generation"`
@@ -318,6 +320,11 @@ func ApplyVectorPartitionLifecycleCommandV1(record VectorPartitionLifecycleRecor
 		next.State = VectorPartitionLifecycleInvalidatedV1
 		next.InvalidationReason = command.Reason
 		next.InvalidationEpoch = command.InvalidationEpoch
+	case VectorPartitionLifecycleConfirmMutationV1:
+		if current.InvalidationEpoch == 0 || current.InvalidationEpoch != command.MutationEpoch {
+			return VectorPartitionLifecycleRecordV1{}, errors.Join(ErrVectorPartitionLifecycleGuard, fmt.Errorf("mutation confirmation does not match invalidation fence"))
+		}
+		next.MutationConfirmed = true
 	case VectorPartitionLifecycleRetireV1:
 		next.State = VectorPartitionLifecycleRetiredV1
 	case VectorPartitionLifecycleMarkCleanableV1:
@@ -633,6 +640,11 @@ func validateVectorPartitionLifecycleCommandShapeV1(c VectorPartitionLifecycleCo
 				return err
 			}
 			return errors.Join(ErrInvalidVectorPartitionLifecycle, fmt.Errorf("invalid invalidate command shape"))
+		}
+	case VectorPartitionLifecycleConfirmMutationV1:
+		if c.ExpectedState != VectorPartitionLifecycleInvalidatedV1 || c.MutationEpoch == 0 ||
+			!otherZero(c.PreviousActiveGeneration, 0, c.GroupReady, c.ReadySetDigest, c.Reason, c.InvalidationEpoch, c.References, c.GroupID) {
+			return errors.Join(ErrInvalidVectorPartitionLifecycle, fmt.Errorf("invalid mutation-confirm command shape"))
 		}
 	case VectorPartitionLifecycleRetireV1:
 		if c.ExpectedState != VectorPartitionLifecycleInvalidatedV1 ||

--- a/TreeDB/internal/raftplacement/vector_partition_lifecycle_v1_test.go
+++ b/TreeDB/internal/raftplacement/vector_partition_lifecycle_v1_test.go
@@ -1,0 +1,641 @@
+package raftplacement
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/snissn/gomap/TreeDB/internal/raftcluster"
+)
+
+func TestVectorPartitionLifecycleV1FullTransitionAndGuards(t *testing.T) {
+	identity := vectorPartitionLifecycleTestIdentityV1()
+	record := VectorPartitionLifecycleRecordV1{}
+	begin := VectorPartitionLifecycleCommandV1{
+		Kind: VectorPartitionLifecycleBeginBuildV1, ExpectedState: VectorPartitionLifecycleAbsentV1,
+		Identity: identity, RequiredGroups: []raftcluster.GroupID{"group-b", "group-a"},
+		PreviousActiveGeneration: 0, MutationEpoch: 10,
+	}
+	record = applyVectorPartitionLifecycleTestCommandV1(t, record, begin)
+	assertVectorPartitionLifecycleStateV1(t, record, VectorPartitionLifecycleBuildingV1, 1)
+	if got := record.RequiredGroups; !reflect.DeepEqual(got, []raftcluster.GroupID{"group-a", "group-b"}) {
+		t.Fatalf("required groups=%v", got)
+	}
+
+	readyA := vectorPartitionLifecycleTestReadyV1("group-a", "b")
+	record = applyVectorPartitionLifecycleTestCommandV1(t, record, vectorPartitionLifecycleTestCommandV1(record, VectorPartitionLifecycleRecordGroupReadyV1, func(c *VectorPartitionLifecycleCommandV1) {
+		c.GroupReady = readyA
+	}))
+	assertVectorPartitionLifecycleStateV1(t, record, VectorPartitionLifecycleStagedV1, 2)
+
+	retry := vectorPartitionLifecycleTestCommandV1(record, VectorPartitionLifecycleRecordGroupReadyV1, func(c *VectorPartitionLifecycleCommandV1) {
+		c.ExpectedRevision--
+		c.ExpectedState = VectorPartitionLifecycleBuildingV1
+		c.GroupReady = readyA
+	})
+	retryBytes, err := EncodeVectorPartitionLifecycleCommandV1(retry)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Exact replay uses the originally committed bytes, including its revision.
+	replayed, err := ApplyVectorPartitionLifecycleCommandV1(record, mustDecodeVectorPartitionLifecycleCommandV1(t, retryBytes))
+	if err != nil {
+		t.Fatalf("exact ready retry: %v", err)
+	}
+	if !reflect.DeepEqual(replayed, record) {
+		t.Fatalf("exact retry changed record")
+	}
+
+	record = applyVectorPartitionLifecycleTestCommandV1(t, record, vectorPartitionLifecycleTestCommandV1(record, VectorPartitionLifecycleRecordGroupReadyV1, func(c *VectorPartitionLifecycleCommandV1) {
+		c.GroupReady = vectorPartitionLifecycleTestReadyV1("group-b", "c")
+	}))
+	digest, err := VectorPartitionLifecycleReadySetDigestV1(record.Identity, record.RequiredGroups, record.ReadyGroups)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := record.CanPrepare(identity, digest); err != nil {
+		t.Fatalf("CanPrepare: %v", err)
+	}
+	record = applyVectorPartitionLifecycleTestCommandV1(t, record, vectorPartitionLifecycleTestCommandV1(record, VectorPartitionLifecyclePrepareV1, func(c *VectorPartitionLifecycleCommandV1) {
+		c.ReadySetDigest = digest
+	}))
+	assertVectorPartitionLifecycleStateV1(t, record, VectorPartitionLifecyclePreparedV1, 4)
+
+	if err := record.CanActivate(identity, 0, 10); err != nil {
+		t.Fatalf("CanActivate: %v", err)
+	}
+	record = applyVectorPartitionLifecycleTestCommandV1(t, record, vectorPartitionLifecycleTestCommandV1(record, VectorPartitionLifecycleActivateV1, func(c *VectorPartitionLifecycleCommandV1) {
+		c.PreviousActiveGeneration, c.MutationEpoch = 0, 10
+	}))
+	assertVectorPartitionLifecycleStateV1(t, record, VectorPartitionLifecycleActiveV1, 5)
+
+	search := VectorPartitionLifecycleSearchProofV1{Identity: identity, ReadySetDigest: digest}
+	if err := record.CanSearch(search); err != nil {
+		t.Fatalf("CanSearch: %v", err)
+	}
+	mutation := VectorPartitionLifecycleMutationProofV1{
+		IndexIdentity: identity.Index, ActiveGeneration: identity.Generation, InvalidationEpoch: 11,
+	}
+	if err := record.CanCommitRelevantMutation(mutation); !errors.Is(err, ErrVectorPartitionLifecycleGuard) {
+		t.Fatalf("active mutation admission err=%v", err)
+	}
+
+	record = applyVectorPartitionLifecycleTestCommandV1(t, record, vectorPartitionLifecycleTestCommandV1(record, VectorPartitionLifecycleInvalidateV1, func(c *VectorPartitionLifecycleCommandV1) {
+		c.Reason, c.InvalidationEpoch = "vector field update", 11
+	}))
+	assertVectorPartitionLifecycleStateV1(t, record, VectorPartitionLifecycleInvalidatedV1, 6)
+	if err := record.CanSearch(search); !errors.Is(err, ErrVectorPartitionLifecycleGuard) {
+		t.Fatalf("invalidated search err=%v", err)
+	}
+	if err := record.CanCommitRelevantMutation(mutation); err != nil {
+		t.Fatalf("invalidated mutation admission: %v", err)
+	}
+
+	record = applyVectorPartitionLifecycleTestCommandV1(t, record, vectorPartitionLifecycleTestCommandV1(record, VectorPartitionLifecycleRetireV1, nil))
+	assertVectorPartitionLifecycleStateV1(t, record, VectorPartitionLifecycleRetiredV1, 7)
+	if err := record.CanClean(VectorPartitionLifecycleReferencesV1{ReaderPins: 1}); !errors.Is(err, ErrVectorPartitionLifecycleGuard) {
+		t.Fatalf("pinned CanClean err=%v", err)
+	}
+	record = applyVectorPartitionLifecycleTestCommandV1(t, record, vectorPartitionLifecycleTestCommandV1(record, VectorPartitionLifecycleMarkCleanableV1, nil))
+	assertVectorPartitionLifecycleStateV1(t, record, VectorPartitionLifecycleCleanableV1, 8)
+
+	record = applyVectorPartitionLifecycleTestCommandV1(t, record, vectorPartitionLifecycleTestCommandV1(record, VectorPartitionLifecycleRecordGroupCleanupV1, func(c *VectorPartitionLifecycleCommandV1) {
+		c.GroupID = "group-b"
+	}))
+	if _, err := ApplyVectorPartitionLifecycleCommandV1(record, vectorPartitionLifecycleTestCommandV1(record, VectorPartitionLifecycleCompleteCleanupV1, nil)); !errors.Is(err, ErrVectorPartitionLifecycleGuard) {
+		t.Fatalf("incomplete cleanup err=%v", err)
+	}
+	record = applyVectorPartitionLifecycleTestCommandV1(t, record, vectorPartitionLifecycleTestCommandV1(record, VectorPartitionLifecycleRecordGroupCleanupV1, func(c *VectorPartitionLifecycleCommandV1) {
+		c.GroupID = "group-a"
+	}))
+	complete := vectorPartitionLifecycleTestCommandV1(record, VectorPartitionLifecycleCompleteCleanupV1, nil)
+	record = applyVectorPartitionLifecycleTestCommandV1(t, record, complete)
+	assertVectorPartitionLifecycleStateV1(t, record, VectorPartitionLifecycleAbsentV1, 11)
+	if !record.CleanupComplete || len(record.RequiredGroups) != 0 || len(record.ReadyGroups) != 0 {
+		t.Fatalf("terminal record=%+v", record)
+	}
+	replayed, err = ApplyVectorPartitionLifecycleCommandV1(record, complete)
+	if err != nil {
+		t.Fatalf("complete cleanup retry: %v", err)
+	}
+	if !reflect.DeepEqual(replayed, record) {
+		t.Fatalf("complete cleanup retry changed record")
+	}
+}
+
+func TestVectorPartitionLifecycleV1AbortDoesNotRequireCompleteReadySet(t *testing.T) {
+	identity := vectorPartitionLifecycleTestIdentityV1()
+	record := applyVectorPartitionLifecycleTestCommandV1(t, VectorPartitionLifecycleRecordV1{}, VectorPartitionLifecycleCommandV1{
+		Kind: VectorPartitionLifecycleBeginBuildV1, ExpectedState: VectorPartitionLifecycleAbsentV1,
+		Identity: identity, RequiredGroups: []raftcluster.GroupID{"group-a", "group-b"},
+		PreviousActiveGeneration: 6, MutationEpoch: 10,
+	})
+	record = applyVectorPartitionLifecycleTestCommandV1(t, record, vectorPartitionLifecycleTestCommandV1(record, VectorPartitionLifecycleRecordGroupReadyV1, func(c *VectorPartitionLifecycleCommandV1) {
+		c.GroupReady = vectorPartitionLifecycleTestReadyV1("group-a", "d")
+	}))
+	record = applyVectorPartitionLifecycleTestCommandV1(t, record, vectorPartitionLifecycleTestCommandV1(record, VectorPartitionLifecycleAbortBuildV1, func(c *VectorPartitionLifecycleCommandV1) {
+		c.Reason = "operator cancelled build"
+	}))
+	if record.State != VectorPartitionLifecycleRetiredV1 || !record.Aborted || record.InvalidationEpoch != 0 {
+		t.Fatalf("aborted record=%+v", record)
+	}
+	if err := record.CanCommitRelevantMutation(VectorPartitionLifecycleMutationProofV1{
+		IndexIdentity: identity.Index, ActiveGeneration: identity.Generation, InvalidationEpoch: 0,
+	}); !errors.Is(err, ErrVectorPartitionLifecycleGuard) {
+		t.Fatalf("aborted build falsely proved active invalidation: %v", err)
+	}
+	record = applyVectorPartitionLifecycleTestCommandV1(t, record, vectorPartitionLifecycleTestCommandV1(record, VectorPartitionLifecycleMarkCleanableV1, nil))
+	if record.State != VectorPartitionLifecycleCleanableV1 {
+		t.Fatalf("aborted cleanable state=%q", record.State)
+	}
+}
+
+func TestVectorPartitionLifecycleV1AtomicCutoverRetiresPreviousActive(t *testing.T) {
+	oldIdentity := vectorPartitionLifecycleTestIdentityV1()
+	oldIdentity.Generation = 6
+	oldIdentity.Source.Generation = 10
+	previous := vectorPartitionLifecycleBuildPreparedV1(t, oldIdentity, 0, 9)
+	previous = applyVectorPartitionLifecycleTestCommandV1(t, previous, vectorPartitionLifecycleTestCommandV1(previous, VectorPartitionLifecycleActivateV1, func(c *VectorPartitionLifecycleCommandV1) {
+		c.MutationEpoch = 9
+	}))
+
+	newIdentity := vectorPartitionLifecycleTestIdentityV1()
+	candidate := vectorPartitionLifecycleBuildPreparedV1(t, newIdentity, oldIdentity.Generation, 10)
+	cutover := vectorPartitionLifecycleTestCommandV1(candidate, VectorPartitionLifecycleActivateV1, func(c *VectorPartitionLifecycleCommandV1) {
+		c.PreviousActiveGeneration = oldIdentity.Generation
+		c.PreviousActiveRevision = previous.Revision
+		c.MutationEpoch = 10
+	})
+	if _, err := ApplyVectorPartitionLifecycleCommandV1(candidate, cutover); !errors.Is(err, ErrVectorPartitionLifecycleGuard) {
+		t.Fatalf("non-atomic activation with previous generation err=%v", err)
+	}
+
+	stale := cutover
+	stale.PreviousActiveRevision--
+	if _, _, err := ApplyVectorPartitionLifecycleCutoverV1(previous, candidate, stale); !errors.Is(err, ErrVectorPartitionLifecycleStale) {
+		t.Fatalf("stale previous active revision err=%v", err)
+	}
+
+	retired, active, err := ApplyVectorPartitionLifecycleCutoverV1(previous, candidate, cutover)
+	if err != nil {
+		t.Fatalf("cutover: %v", err)
+	}
+	if retired.State != VectorPartitionLifecycleRetiredV1 ||
+		retired.SupersededByGeneration != newIdentity.Generation ||
+		retired.InvalidationEpoch != 0 || active.State != VectorPartitionLifecycleActiveV1 {
+		t.Fatalf("cutover old/new=%+v / %+v", retired, active)
+	}
+	if err := retired.CanSearch(VectorPartitionLifecycleSearchProofV1{
+		Identity: oldIdentity, ReadySetDigest: retired.ReadySetDigest,
+	}); !errors.Is(err, ErrVectorPartitionLifecycleGuard) {
+		t.Fatalf("superseded generation remained searchable: %v", err)
+	}
+	if err := active.CanSearch(VectorPartitionLifecycleSearchProofV1{
+		Identity: newIdentity, ReadySetDigest: active.ReadySetDigest,
+	}); err != nil {
+		t.Fatalf("new active generation is not searchable: %v", err)
+	}
+	if err := retired.CanClean(VectorPartitionLifecycleReferencesV1{}); err != nil {
+		t.Fatalf("superseded generation is not cleanup-eligible: %v", err)
+	}
+	if err := retired.CanCommitRelevantMutation(VectorPartitionLifecycleMutationProofV1{
+		IndexIdentity: oldIdentity.Index, ActiveGeneration: oldIdentity.Generation,
+	}); !errors.Is(err, ErrVectorPartitionLifecycleGuard) {
+		t.Fatalf("supersession falsely proved mutation invalidation: %v", err)
+	}
+
+	retryOld, retryNew, err := ApplyVectorPartitionLifecycleCutoverV1(retired, active, cutover)
+	if err != nil {
+		t.Fatalf("cutover retry: %v", err)
+	}
+	if !reflect.DeepEqual(retryOld, retired) || !reflect.DeepEqual(retryNew, active) {
+		t.Fatal("cutover retry changed records")
+	}
+}
+
+func TestVectorPartitionLifecycleV1RejectsStaleWrongIdentityAndConflicts(t *testing.T) {
+	identity := vectorPartitionLifecycleTestIdentityV1()
+	record := applyVectorPartitionLifecycleTestCommandV1(t, VectorPartitionLifecycleRecordV1{}, VectorPartitionLifecycleCommandV1{
+		Kind: VectorPartitionLifecycleBeginBuildV1, ExpectedState: VectorPartitionLifecycleAbsentV1,
+		Identity: identity, RequiredGroups: []raftcluster.GroupID{"group-a", "group-b"},
+		PreviousActiveGeneration: 6, MutationEpoch: 10,
+	})
+	ready := vectorPartitionLifecycleTestCommandV1(record, VectorPartitionLifecycleRecordGroupReadyV1, func(c *VectorPartitionLifecycleCommandV1) {
+		c.GroupReady = vectorPartitionLifecycleTestReadyV1("group-a", "a")
+	})
+	record = applyVectorPartitionLifecycleTestCommandV1(t, record, ready)
+
+	stale := vectorPartitionLifecycleTestCommandV1(record, VectorPartitionLifecycleRecordGroupReadyV1, func(c *VectorPartitionLifecycleCommandV1) {
+		c.ExpectedRevision--
+		c.GroupReady = vectorPartitionLifecycleTestReadyV1("group-b", "b")
+	})
+	if _, err := ApplyVectorPartitionLifecycleCommandV1(record, stale); !errors.Is(err, ErrVectorPartitionLifecycleStale) {
+		t.Fatalf("stale err=%v", err)
+	}
+
+	wrong := vectorPartitionLifecycleTestCommandV1(record, VectorPartitionLifecycleRecordGroupReadyV1, func(c *VectorPartitionLifecycleCommandV1) {
+		c.Identity.Index.CollectionIncarnation++
+		c.GroupReady = vectorPartitionLifecycleTestReadyV1("group-b", "b")
+	})
+	if _, err := ApplyVectorPartitionLifecycleCommandV1(record, wrong); !errors.Is(err, ErrVectorPartitionLifecycleIdentity) {
+		t.Fatalf("wrong identity err=%v", err)
+	}
+
+	conflict := vectorPartitionLifecycleTestCommandV1(record, VectorPartitionLifecycleRecordGroupReadyV1, func(c *VectorPartitionLifecycleCommandV1) {
+		c.GroupReady = vectorPartitionLifecycleTestReadyV1("group-a", "f")
+	})
+	if _, err := ApplyVectorPartitionLifecycleCommandV1(record, conflict); !errors.Is(err, ErrVectorPartitionLifecycleConflict) {
+		t.Fatalf("changed readiness err=%v", err)
+	}
+
+	extra := vectorPartitionLifecycleTestCommandV1(record, VectorPartitionLifecycleRecordGroupReadyV1, func(c *VectorPartitionLifecycleCommandV1) {
+		c.GroupReady = vectorPartitionLifecycleTestReadyV1("group-c", "c")
+	})
+	if _, err := ApplyVectorPartitionLifecycleCommandV1(record, extra); !errors.Is(err, ErrVectorPartitionLifecycleIdentity) {
+		t.Fatalf("extra readiness err=%v", err)
+	}
+
+	badDigest := strings.Repeat("f", 64)
+	if err := record.CanPrepare(identity, badDigest); !errors.Is(err, ErrVectorPartitionLifecycleGuard) {
+		t.Fatalf("incomplete/bad ready set err=%v", err)
+	}
+}
+
+func TestVectorPartitionLifecycleV1EveryIdentityFieldFailsClosed(t *testing.T) {
+	identity := vectorPartitionLifecycleTestIdentityV1()
+	record := applyVectorPartitionLifecycleTestCommandV1(t, VectorPartitionLifecycleRecordV1{}, VectorPartitionLifecycleCommandV1{
+		Kind: VectorPartitionLifecycleBeginBuildV1, ExpectedState: VectorPartitionLifecycleAbsentV1,
+		Identity: identity, RequiredGroups: []raftcluster.GroupID{"group-a"}, MutationEpoch: 10,
+	})
+	mutations := []struct {
+		name   string
+		mutate func(*VectorPartitionLifecycleIdentityV1)
+	}{
+		{"database", func(x *VectorPartitionLifecycleIdentityV1) { x.Index.Collection.Database = "other" }},
+		{"catalog name", func(x *VectorPartitionLifecycleIdentityV1) { x.Index.Collection.Catalog = "other" }},
+		{"collection", func(x *VectorPartitionLifecycleIdentityV1) { x.Index.Collection.Collection = "other" }},
+		{"collection incarnation", func(x *VectorPartitionLifecycleIdentityV1) { x.Index.CollectionIncarnation++ }},
+		{"index name", func(x *VectorPartitionLifecycleIdentityV1) { x.Index.IndexName = "other" }},
+		{"index digest", func(x *VectorPartitionLifecycleIdentityV1) { x.Index.IndexDefinitionDigest = strings.Repeat("b", 64) }},
+		{"index epoch", func(x *VectorPartitionLifecycleIdentityV1) { x.Index.IndexEpoch++ }},
+		{"catalog epoch", func(x *VectorPartitionLifecycleIdentityV1) { x.Index.CatalogEpoch++ }},
+		{"catalog digest", func(x *VectorPartitionLifecycleIdentityV1) { x.Index.CatalogDigest = strings.Repeat("8", 64) }},
+		{"source generation", func(x *VectorPartitionLifecycleIdentityV1) { x.Source.Generation++ }},
+		{"source checksum", func(x *VectorPartitionLifecycleIdentityV1) { x.Source.Checksum++ }},
+		{"source schema", func(x *VectorPartitionLifecycleIdentityV1) { x.Source.SchemaHash++ }},
+		{"source rows", func(x *VectorPartitionLifecycleIdentityV1) { x.Source.RowCount++ }},
+		{"generation", func(x *VectorPartitionLifecycleIdentityV1) { x.Generation++ }},
+	}
+	for _, test := range mutations {
+		t.Run(test.name, func(t *testing.T) {
+			command := vectorPartitionLifecycleTestCommandV1(record, VectorPartitionLifecycleRecordGroupReadyV1, func(c *VectorPartitionLifecycleCommandV1) {
+				test.mutate(&c.Identity)
+				c.GroupReady = vectorPartitionLifecycleTestReadyV1("group-a", "a")
+			})
+			if _, err := ApplyVectorPartitionLifecycleCommandV1(record, command); !errors.Is(err, ErrVectorPartitionLifecycleIdentity) {
+				t.Fatalf("changed identity err=%v", err)
+			}
+		})
+	}
+}
+
+func TestVectorPartitionLifecycleV1CommandStateMatrix(t *testing.T) {
+	states := []VectorPartitionLifecycleStateV1{
+		VectorPartitionLifecycleAbsentV1,
+		VectorPartitionLifecycleBuildingV1,
+		VectorPartitionLifecycleStagedV1,
+		VectorPartitionLifecyclePreparedV1,
+		VectorPartitionLifecycleActiveV1,
+		VectorPartitionLifecycleInvalidatedV1,
+		VectorPartitionLifecycleRetiredV1,
+		VectorPartitionLifecycleCleanableV1,
+	}
+	tests := []struct {
+		kind    VectorPartitionLifecycleCommandKindV1
+		allowed map[VectorPartitionLifecycleStateV1]bool
+	}{
+		{VectorPartitionLifecycleBeginBuildV1, map[VectorPartitionLifecycleStateV1]bool{VectorPartitionLifecycleAbsentV1: true}},
+		{VectorPartitionLifecycleRecordGroupReadyV1, map[VectorPartitionLifecycleStateV1]bool{VectorPartitionLifecycleBuildingV1: true, VectorPartitionLifecycleStagedV1: true}},
+		{VectorPartitionLifecyclePrepareV1, map[VectorPartitionLifecycleStateV1]bool{VectorPartitionLifecycleStagedV1: true}},
+		{VectorPartitionLifecycleActivateV1, map[VectorPartitionLifecycleStateV1]bool{VectorPartitionLifecyclePreparedV1: true}},
+		{VectorPartitionLifecycleAbortBuildV1, map[VectorPartitionLifecycleStateV1]bool{
+			VectorPartitionLifecycleBuildingV1: true, VectorPartitionLifecycleStagedV1: true, VectorPartitionLifecyclePreparedV1: true,
+		}},
+		{VectorPartitionLifecycleInvalidateV1, map[VectorPartitionLifecycleStateV1]bool{VectorPartitionLifecycleActiveV1: true}},
+		{VectorPartitionLifecycleRetireV1, map[VectorPartitionLifecycleStateV1]bool{VectorPartitionLifecycleInvalidatedV1: true}},
+		{VectorPartitionLifecycleMarkCleanableV1, map[VectorPartitionLifecycleStateV1]bool{VectorPartitionLifecycleRetiredV1: true}},
+		{VectorPartitionLifecycleRecordGroupCleanupV1, map[VectorPartitionLifecycleStateV1]bool{VectorPartitionLifecycleCleanableV1: true}},
+		{VectorPartitionLifecycleCompleteCleanupV1, map[VectorPartitionLifecycleStateV1]bool{VectorPartitionLifecycleCleanableV1: true}},
+	}
+	for _, test := range tests {
+		for _, state := range states {
+			t.Run(string(test.kind)+"/"+string(state), func(t *testing.T) {
+				command := VectorPartitionLifecycleCommandV1{
+					Kind: test.kind, ExpectedRevision: 1, ExpectedState: state,
+					Identity: vectorPartitionLifecycleTestIdentityV1(),
+				}
+				switch test.kind {
+				case VectorPartitionLifecycleBeginBuildV1:
+					command.ExpectedRevision = 0
+					command.RequiredGroups = []raftcluster.GroupID{"group-a"}
+					command.MutationEpoch = 10
+				case VectorPartitionLifecycleRecordGroupReadyV1:
+					command.GroupReady = vectorPartitionLifecycleTestReadyV1("group-a", "a")
+				case VectorPartitionLifecyclePrepareV1:
+					command.ReadySetDigest = strings.Repeat("a", 64)
+				case VectorPartitionLifecycleActivateV1:
+					command.MutationEpoch = 10
+				case VectorPartitionLifecycleAbortBuildV1:
+					command.Reason = "abort"
+				case VectorPartitionLifecycleInvalidateV1:
+					command.Reason, command.InvalidationEpoch = "mutation", 11
+				case VectorPartitionLifecycleRecordGroupCleanupV1:
+					command.GroupID = "group-a"
+				}
+				_, err := EncodeVectorPartitionLifecycleCommandV1(command)
+				if test.allowed[state] && err != nil {
+					t.Fatalf("allowed state rejected: %v", err)
+				}
+				if !test.allowed[state] && !errors.Is(err, ErrInvalidVectorPartitionLifecycle) {
+					t.Fatalf("forbidden state err=%v", err)
+				}
+			})
+		}
+	}
+}
+
+func TestVectorPartitionLifecycleV1ReadySetDigestIsCanonicalAndExact(t *testing.T) {
+	identity := vectorPartitionLifecycleTestIdentityV1()
+	required := []raftcluster.GroupID{"group-b", "group-a"}
+	ready := []VectorPartitionLifecycleGroupReadyV1{
+		vectorPartitionLifecycleTestReadyV1("group-b", "b"),
+		vectorPartitionLifecycleTestReadyV1("group-a", "a"),
+	}
+	left, err := VectorPartitionLifecycleReadySetDigestV1(identity, required, ready)
+	if err != nil {
+		t.Fatal(err)
+	}
+	right, err := VectorPartitionLifecycleReadySetDigestV1(identity,
+		[]raftcluster.GroupID{"group-a", "group-b"},
+		[]VectorPartitionLifecycleGroupReadyV1{ready[1], ready[0]})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if left != right {
+		t.Fatalf("unordered inputs produced %q and %q", left, right)
+	}
+	ready[0].AppliedIndex++
+	changed, err := VectorPartitionLifecycleReadySetDigestV1(identity, required, ready)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if changed == left {
+		t.Fatal("changed applied proof did not change ready-set digest")
+	}
+	if _, err := VectorPartitionLifecycleReadySetDigestV1(identity, required, ready[:1]); !errors.Is(err, ErrVectorPartitionLifecycleGuard) {
+		t.Fatalf("missing group err=%v", err)
+	}
+}
+
+func TestVectorPartitionLifecycleV1CanonicalCodecsAndLimits(t *testing.T) {
+	identity := vectorPartitionLifecycleTestIdentityV1()
+	command := VectorPartitionLifecycleCommandV1{
+		Kind: VectorPartitionLifecycleBeginBuildV1, ExpectedState: VectorPartitionLifecycleAbsentV1,
+		Identity: identity, RequiredGroups: []raftcluster.GroupID{"group-b", "group-a"},
+		PreviousActiveGeneration: 6, MutationEpoch: 10,
+	}
+	first, err := EncodeVectorPartitionLifecycleCommandV1(command)
+	if err != nil {
+		t.Fatal(err)
+	}
+	second, err := EncodeVectorPartitionLifecycleCommandV1(command)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(first, second) {
+		t.Fatal("command encoding is nondeterministic")
+	}
+	decoded := mustDecodeVectorPartitionLifecycleCommandV1(t, first)
+	if !reflect.DeepEqual(decoded.RequiredGroups, []raftcluster.GroupID{"group-a", "group-b"}) {
+		t.Fatalf("decoded required groups=%v", decoded.RequiredGroups)
+	}
+
+	rawNoncanonical, err := json.Marshal(command)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := DecodeVectorPartitionLifecycleCommandV1(rawNoncanonical); !errors.Is(err, ErrInvalidVectorPartitionLifecycle) {
+		t.Fatalf("noncanonical command err=%v", err)
+	}
+	withUnknown := append(append([]byte(nil), first[:len(first)-1]...), []byte(`,"unknown":1}`)...)
+	if _, err := DecodeVectorPartitionLifecycleCommandV1(withUnknown); !errors.Is(err, ErrInvalidVectorPartitionLifecycle) {
+		t.Fatalf("unknown field err=%v", err)
+	}
+
+	record := applyVectorPartitionLifecycleTestCommandV1(t, VectorPartitionLifecycleRecordV1{}, command)
+	recordBytes, err := EncodeVectorPartitionLifecycleRecordV1(record)
+	if err != nil {
+		t.Fatal(err)
+	}
+	decodedRecord, err := DecodeVectorPartitionLifecycleRecordV1(recordBytes)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(decodedRecord, record) {
+		t.Fatalf("record round trip mismatch\ngot:  %+v\nwant: %+v", decodedRecord, record)
+	}
+
+	tooMany := make([]raftcluster.GroupID, MaxVectorPartitionLifecycleGroupsV1+1)
+	for i := range tooMany {
+		tooMany[i] = raftcluster.GroupID("g" + strings.Repeat("x", i/26) + string(rune('a'+i%26)))
+	}
+	command.RequiredGroups = tooMany
+	if _, err := EncodeVectorPartitionLifecycleCommandV1(command); !errors.Is(err, ErrVectorPartitionLifecycleLimit) {
+		t.Fatalf("oversized group set err=%v", err)
+	}
+}
+
+func TestVectorPartitionLifecycleV1TransitionGuardsFailClosed(t *testing.T) {
+	identity := vectorPartitionLifecycleTestIdentityV1()
+	states := []VectorPartitionLifecycleStateV1{
+		VectorPartitionLifecycleAbsentV1,
+		VectorPartitionLifecycleBuildingV1,
+		VectorPartitionLifecycleStagedV1,
+		VectorPartitionLifecyclePreparedV1,
+		VectorPartitionLifecycleActiveV1,
+		VectorPartitionLifecycleInvalidatedV1,
+		VectorPartitionLifecycleRetiredV1,
+		VectorPartitionLifecycleCleanableV1,
+	}
+	for _, state := range states {
+		t.Run(string(state), func(t *testing.T) {
+			record := vectorPartitionLifecycleTestRecordAtStateV1(t, state)
+			search := VectorPartitionLifecycleSearchProofV1{Identity: identity, ReadySetDigest: record.ReadySetDigest}
+			err := record.CanSearch(search)
+			if state == VectorPartitionLifecycleActiveV1 {
+				if err != nil {
+					t.Fatalf("active CanSearch: %v", err)
+				}
+			} else if !errors.Is(err, ErrVectorPartitionLifecycleGuard) {
+				t.Fatalf("state %q CanSearch err=%v", state, err)
+			}
+			err = record.CanClean(VectorPartitionLifecycleReferencesV1{})
+			if state == VectorPartitionLifecycleRetiredV1 {
+				if err != nil {
+					t.Fatalf("retired CanClean: %v", err)
+				}
+			} else if !errors.Is(err, ErrVectorPartitionLifecycleGuard) {
+				t.Fatalf("state %q CanClean err=%v", state, err)
+			}
+		})
+	}
+}
+
+func TestVectorPartitionLifecycleV1NoActiveMutationProof(t *testing.T) {
+	record, err := canonicalVectorPartitionLifecycleRecordV1(VectorPartitionLifecycleRecordV1{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	proof := VectorPartitionLifecycleMutationProofV1{IndexIdentity: vectorPartitionLifecycleTestIdentityV1().Index}
+	if err := record.CanCommitRelevantMutation(proof); err != nil {
+		t.Fatalf("absent lifecycle rejected no-active proof: %v", err)
+	}
+	proof.ActiveGeneration = 7
+	if err := record.CanCommitRelevantMutation(proof); !errors.Is(err, ErrVectorPartitionLifecycleGuard) {
+		t.Fatalf("absent lifecycle accepted named active generation: %v", err)
+	}
+}
+
+func vectorPartitionLifecycleTestRecordAtStateV1(t *testing.T, state VectorPartitionLifecycleStateV1) VectorPartitionLifecycleRecordV1 {
+	t.Helper()
+	identity := vectorPartitionLifecycleTestIdentityV1()
+	if state == VectorPartitionLifecycleAbsentV1 {
+		record, err := canonicalVectorPartitionLifecycleRecordV1(VectorPartitionLifecycleRecordV1{})
+		if err != nil {
+			t.Fatal(err)
+		}
+		return record
+	}
+	record := applyVectorPartitionLifecycleTestCommandV1(t, VectorPartitionLifecycleRecordV1{}, VectorPartitionLifecycleCommandV1{
+		Kind: VectorPartitionLifecycleBeginBuildV1, ExpectedState: VectorPartitionLifecycleAbsentV1,
+		Identity: identity, RequiredGroups: []raftcluster.GroupID{"group-a"},
+		PreviousActiveGeneration: 0, MutationEpoch: 10,
+	})
+	if state == VectorPartitionLifecycleBuildingV1 {
+		return record
+	}
+	record = applyVectorPartitionLifecycleTestCommandV1(t, record, vectorPartitionLifecycleTestCommandV1(record, VectorPartitionLifecycleRecordGroupReadyV1, func(c *VectorPartitionLifecycleCommandV1) {
+		c.GroupReady = vectorPartitionLifecycleTestReadyV1("group-a", "a")
+	}))
+	if state == VectorPartitionLifecycleStagedV1 {
+		return record
+	}
+	digest, err := VectorPartitionLifecycleReadySetDigestV1(record.Identity, record.RequiredGroups, record.ReadyGroups)
+	if err != nil {
+		t.Fatal(err)
+	}
+	record = applyVectorPartitionLifecycleTestCommandV1(t, record, vectorPartitionLifecycleTestCommandV1(record, VectorPartitionLifecyclePrepareV1, func(c *VectorPartitionLifecycleCommandV1) {
+		c.ReadySetDigest = digest
+	}))
+	if state == VectorPartitionLifecyclePreparedV1 {
+		return record
+	}
+	record = applyVectorPartitionLifecycleTestCommandV1(t, record, vectorPartitionLifecycleTestCommandV1(record, VectorPartitionLifecycleActivateV1, func(c *VectorPartitionLifecycleCommandV1) {
+		c.PreviousActiveGeneration, c.MutationEpoch = 0, 10
+	}))
+	if state == VectorPartitionLifecycleActiveV1 {
+		return record
+	}
+	record = applyVectorPartitionLifecycleTestCommandV1(t, record, vectorPartitionLifecycleTestCommandV1(record, VectorPartitionLifecycleInvalidateV1, func(c *VectorPartitionLifecycleCommandV1) {
+		c.Reason, c.InvalidationEpoch = "test invalidation", 11
+	}))
+	if state == VectorPartitionLifecycleInvalidatedV1 {
+		return record
+	}
+	record = applyVectorPartitionLifecycleTestCommandV1(t, record, vectorPartitionLifecycleTestCommandV1(record, VectorPartitionLifecycleRetireV1, nil))
+	if state == VectorPartitionLifecycleRetiredV1 {
+		return record
+	}
+	return applyVectorPartitionLifecycleTestCommandV1(t, record, vectorPartitionLifecycleTestCommandV1(record, VectorPartitionLifecycleMarkCleanableV1, nil))
+}
+
+func vectorPartitionLifecycleTestCommandV1(record VectorPartitionLifecycleRecordV1, kind VectorPartitionLifecycleCommandKindV1, mutate func(*VectorPartitionLifecycleCommandV1)) VectorPartitionLifecycleCommandV1 {
+	command := VectorPartitionLifecycleCommandV1{
+		Kind: kind, ExpectedRevision: record.Revision, ExpectedState: record.State, Identity: record.Identity,
+	}
+	if mutate != nil {
+		mutate(&command)
+	}
+	return command
+}
+
+func vectorPartitionLifecycleBuildPreparedV1(t *testing.T, identity VectorPartitionLifecycleIdentityV1, previousGeneration, mutationEpoch uint64) VectorPartitionLifecycleRecordV1 {
+	t.Helper()
+	record := applyVectorPartitionLifecycleTestCommandV1(t, VectorPartitionLifecycleRecordV1{}, VectorPartitionLifecycleCommandV1{
+		Kind: VectorPartitionLifecycleBeginBuildV1, ExpectedState: VectorPartitionLifecycleAbsentV1,
+		Identity: identity, RequiredGroups: []raftcluster.GroupID{"group-a"},
+		PreviousActiveGeneration: previousGeneration, MutationEpoch: mutationEpoch,
+	})
+	record = applyVectorPartitionLifecycleTestCommandV1(t, record, vectorPartitionLifecycleTestCommandV1(record, VectorPartitionLifecycleRecordGroupReadyV1, func(c *VectorPartitionLifecycleCommandV1) {
+		c.GroupReady = vectorPartitionLifecycleTestReadyV1("group-a", "a")
+	}))
+	digest, err := VectorPartitionLifecycleReadySetDigestV1(record.Identity, record.RequiredGroups, record.ReadyGroups)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return applyVectorPartitionLifecycleTestCommandV1(t, record, vectorPartitionLifecycleTestCommandV1(record, VectorPartitionLifecyclePrepareV1, func(c *VectorPartitionLifecycleCommandV1) {
+		c.ReadySetDigest = digest
+	}))
+}
+
+func applyVectorPartitionLifecycleTestCommandV1(t *testing.T, record VectorPartitionLifecycleRecordV1, command VectorPartitionLifecycleCommandV1) VectorPartitionLifecycleRecordV1 {
+	t.Helper()
+	next, err := ApplyVectorPartitionLifecycleCommandV1(record, command)
+	if err != nil {
+		t.Fatalf("apply %q: %v", command.Kind, err)
+	}
+	return next
+}
+
+func mustDecodeVectorPartitionLifecycleCommandV1(t *testing.T, raw []byte) VectorPartitionLifecycleCommandV1 {
+	t.Helper()
+	command, err := DecodeVectorPartitionLifecycleCommandV1(raw)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return command
+}
+
+func vectorPartitionLifecycleTestReadyV1(group raftcluster.GroupID, digit string) VectorPartitionLifecycleGroupReadyV1 {
+	return VectorPartitionLifecycleGroupReadyV1{
+		GroupID: group, AppliedIndex: 100, AssetSetDigest: strings.Repeat(digit, 64),
+	}
+}
+
+func vectorPartitionLifecycleTestIdentityV1() VectorPartitionLifecycleIdentityV1 {
+	return VectorPartitionLifecycleIdentityV1{
+		Index: VectorPartitionLifecycleIndexIdentityV1{
+			Collection:            CollectionRefV1{Database: "default", Catalog: "default", Collection: "docs"},
+			CollectionIncarnation: 3,
+			IndexName:             "embedding",
+			IndexDefinitionDigest: strings.Repeat("a", 64),
+			IndexEpoch:            4,
+			CatalogEpoch:          5,
+			CatalogDigest:         strings.Repeat("9", 64),
+		},
+		Source: VectorPartitionLifecycleSourceIdentityV1{
+			Generation: 11, Checksum: 12, SchemaHash: 13, RowCount: 100,
+		},
+		Generation: 7,
+	}
+}
+
+func assertVectorPartitionLifecycleStateV1(t *testing.T, record VectorPartitionLifecycleRecordV1, state VectorPartitionLifecycleStateV1, revision uint64) {
+	t.Helper()
+	if record.State != state || record.Revision != revision {
+		t.Fatalf("record state/revision=%q/%d want %q/%d", record.State, record.Revision, state, revision)
+	}
+}

--- a/TreeDB/internal/raftplacement/vector_partition_lifecycle_workflow_v1.go
+++ b/TreeDB/internal/raftplacement/vector_partition_lifecycle_workflow_v1.go
@@ -20,6 +20,9 @@ type VectorPartitionLifecycleGroupBuilderV1 interface {
 // BeginBuildV1 records a source- and catalog-bound candidate before any group
 // assets can be accepted. Exact retry is handled by the catalog command digest.
 func (c VectorPartitionLifecycleCoordinatorV1) BeginBuildV1(ctx context.Context, identity VectorPartitionLifecycleIdentityV1, required []raftcluster.GroupID, previousGeneration, mutationEpoch uint64) (VectorPartitionLifecycleRecordV1, error) {
+	if err := c.validateConfiguredV1(); err != nil {
+		return VectorPartitionLifecycleRecordV1{}, err
+	}
 	if r, ok := c.Authority.VectorPartitionLifecycleRecordV1(identity); ok && r.State != VectorPartitionLifecycleAbsentV1 {
 		canonicalRequired, err := canonicalVectorPartitionLifecycleGroupsV1(required)
 		if err != nil {
@@ -34,6 +37,9 @@ func (c VectorPartitionLifecycleCoordinatorV1) BeginBuildV1(ctx context.Context,
 }
 
 func (c VectorPartitionLifecycleCoordinatorV1) RecordGroupReadyV1(ctx context.Context, identity VectorPartitionLifecycleIdentityV1, ready VectorPartitionLifecycleGroupReadyV1) (VectorPartitionLifecycleRecordV1, error) {
+	if err := c.validateConfiguredV1(); err != nil {
+		return VectorPartitionLifecycleRecordV1{}, err
+	}
 	record, ok := c.Authority.VectorPartitionLifecycleRecordV1(identity)
 	if !ok {
 		return VectorPartitionLifecycleRecordV1{}, ErrVectorPartitionLifecycleGuard
@@ -49,6 +55,9 @@ func (c VectorPartitionLifecycleCoordinatorV1) RecordGroupReadyV1(ctx context.Co
 // BuildAndRecordGroupReadyV1 invokes a caller-owned staging implementation and
 // commits only its bounded readiness proof.
 func (c VectorPartitionLifecycleCoordinatorV1) BuildAndRecordGroupReadyV1(ctx context.Context, builder VectorPartitionLifecycleGroupBuilderV1, identity VectorPartitionLifecycleIdentityV1, group raftcluster.GroupID) (VectorPartitionLifecycleRecordV1, error) {
+	if err := c.validateConfiguredV1(); err != nil {
+		return VectorPartitionLifecycleRecordV1{}, err
+	}
 	if builder == nil {
 		return VectorPartitionLifecycleRecordV1{}, errors.New("raftplacement: lifecycle group builder is required")
 	}
@@ -63,6 +72,9 @@ func (c VectorPartitionLifecycleCoordinatorV1) BuildAndRecordGroupReadyV1(ctx co
 }
 
 func (c VectorPartitionLifecycleCoordinatorV1) PrepareV1(ctx context.Context, identity VectorPartitionLifecycleIdentityV1) (VectorPartitionLifecycleRecordV1, error) {
+	if err := c.validateConfiguredV1(); err != nil {
+		return VectorPartitionLifecycleRecordV1{}, err
+	}
 	r, ok := c.Authority.VectorPartitionLifecycleRecordV1(identity)
 	if !ok {
 		return VectorPartitionLifecycleRecordV1{}, ErrVectorPartitionLifecycleGuard
@@ -78,6 +90,9 @@ func (c VectorPartitionLifecycleCoordinatorV1) PrepareV1(ctx context.Context, id
 }
 
 func (c VectorPartitionLifecycleCoordinatorV1) ActivateV1(ctx context.Context, identity VectorPartitionLifecycleIdentityV1) (VectorPartitionLifecycleRecordV1, error) {
+	if err := c.validateConfiguredV1(); err != nil {
+		return VectorPartitionLifecycleRecordV1{}, err
+	}
 	r, ok := c.Authority.VectorPartitionLifecycleRecordV1(identity)
 	if !ok {
 		return VectorPartitionLifecycleRecordV1{}, ErrVectorPartitionLifecycleGuard
@@ -95,6 +110,9 @@ func (c VectorPartitionLifecycleCoordinatorV1) ActivateV1(ctx context.Context, i
 }
 
 func (c VectorPartitionLifecycleCoordinatorV1) transitionV1(ctx context.Context, identity VectorPartitionLifecycleIdentityV1, kind VectorPartitionLifecycleCommandKindV1, mutate func(*VectorPartitionLifecycleCommandV1)) (VectorPartitionLifecycleRecordV1, error) {
+	if err := c.validateConfiguredV1(); err != nil {
+		return VectorPartitionLifecycleRecordV1{}, err
+	}
 	r, ok := c.Authority.VectorPartitionLifecycleRecordV1(identity)
 	if !ok {
 		return VectorPartitionLifecycleRecordV1{}, ErrVectorPartitionLifecycleGuard

--- a/TreeDB/internal/raftplacement/vector_partition_lifecycle_workflow_v1.go
+++ b/TreeDB/internal/raftplacement/vector_partition_lifecycle_workflow_v1.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"reflect"
 
 	"github.com/snissn/gomap/TreeDB/internal/raftcluster"
 )
@@ -20,7 +21,11 @@ type VectorPartitionLifecycleGroupBuilderV1 interface {
 // assets can be accepted. Exact retry is handled by the catalog command digest.
 func (c VectorPartitionLifecycleCoordinatorV1) BeginBuildV1(ctx context.Context, identity VectorPartitionLifecycleIdentityV1, required []raftcluster.GroupID, previousGeneration, mutationEpoch uint64) (VectorPartitionLifecycleRecordV1, error) {
 	if r, ok := c.Authority.VectorPartitionLifecycleRecordV1(identity); ok && r.State != VectorPartitionLifecycleAbsentV1 {
-		if r.PreviousActiveGeneration == previousGeneration && r.MutationEpoch == mutationEpoch {
+		canonicalRequired, err := canonicalVectorPartitionLifecycleGroupsV1(required)
+		if err != nil {
+			return VectorPartitionLifecycleRecordV1{}, err
+		}
+		if r.PreviousActiveGeneration == previousGeneration && r.MutationEpoch == mutationEpoch && reflect.DeepEqual(r.RequiredGroups, canonicalRequired) {
 			return r, nil
 		}
 		return VectorPartitionLifecycleRecordV1{}, ErrVectorPartitionLifecycleConflict

--- a/TreeDB/internal/raftplacement/vector_partition_lifecycle_workflow_v1.go
+++ b/TreeDB/internal/raftplacement/vector_partition_lifecycle_workflow_v1.go
@@ -1,0 +1,108 @@
+package raftplacement
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/snissn/gomap/TreeDB/internal/raftcluster"
+)
+
+// VectorPartitionLifecycleGroupBuilderV1 is the narrow integration seam for
+// a real asset builder/uploader. It returns only the bounded readiness proof;
+// transport, uploads, and local prepared-manifest staging remain owned by the
+// caller's group implementation.
+type VectorPartitionLifecycleGroupBuilderV1 interface {
+	BuildAndStageVectorPartitionGroupV1(context.Context, VectorPartitionLifecycleIdentityV1, raftcluster.GroupID) (VectorPartitionLifecycleGroupReadyV1, error)
+}
+
+// BeginBuildV1 records a source- and catalog-bound candidate before any group
+// assets can be accepted. Exact retry is handled by the catalog command digest.
+func (c VectorPartitionLifecycleCoordinatorV1) BeginBuildV1(ctx context.Context, identity VectorPartitionLifecycleIdentityV1, required []raftcluster.GroupID, previousGeneration, mutationEpoch uint64) (VectorPartitionLifecycleRecordV1, error) {
+	return c.Submit(ctx, VectorPartitionLifecycleCommandV1{Kind: VectorPartitionLifecycleBeginBuildV1, ExpectedState: VectorPartitionLifecycleAbsentV1, Identity: identity, RequiredGroups: required, PreviousActiveGeneration: previousGeneration, MutationEpoch: mutationEpoch})
+}
+
+func (c VectorPartitionLifecycleCoordinatorV1) RecordGroupReadyV1(ctx context.Context, identity VectorPartitionLifecycleIdentityV1, ready VectorPartitionLifecycleGroupReadyV1) (VectorPartitionLifecycleRecordV1, error) {
+	record, ok := c.Authority.VectorPartitionLifecycleRecordV1(identity)
+	if !ok {
+		return VectorPartitionLifecycleRecordV1{}, ErrVectorPartitionLifecycleGuard
+	}
+	return c.Submit(ctx, VectorPartitionLifecycleCommandV1{Kind: VectorPartitionLifecycleRecordGroupReadyV1, ExpectedRevision: record.Revision, ExpectedState: record.State, Identity: identity, GroupReady: ready})
+}
+
+// BuildAndRecordGroupReadyV1 invokes a caller-owned staging implementation and
+// commits only its bounded readiness proof.
+func (c VectorPartitionLifecycleCoordinatorV1) BuildAndRecordGroupReadyV1(ctx context.Context, builder VectorPartitionLifecycleGroupBuilderV1, identity VectorPartitionLifecycleIdentityV1, group raftcluster.GroupID) (VectorPartitionLifecycleRecordV1, error) {
+	if builder == nil {
+		return VectorPartitionLifecycleRecordV1{}, errors.New("raftplacement: lifecycle group builder is required")
+	}
+	ready, err := builder.BuildAndStageVectorPartitionGroupV1(ctx, identity, group)
+	if err != nil {
+		return VectorPartitionLifecycleRecordV1{}, err
+	}
+	if ready.GroupID != group {
+		return VectorPartitionLifecycleRecordV1{}, fmt.Errorf("raftplacement: group builder returned wrong group")
+	}
+	return c.RecordGroupReadyV1(ctx, identity, ready)
+}
+
+func (c VectorPartitionLifecycleCoordinatorV1) PrepareV1(ctx context.Context, identity VectorPartitionLifecycleIdentityV1) (VectorPartitionLifecycleRecordV1, error) {
+	r, ok := c.Authority.VectorPartitionLifecycleRecordV1(identity)
+	if !ok {
+		return VectorPartitionLifecycleRecordV1{}, ErrVectorPartitionLifecycleGuard
+	}
+	digest, err := VectorPartitionLifecycleReadySetDigestV1(r.Identity, r.RequiredGroups, r.ReadyGroups)
+	if err != nil {
+		return VectorPartitionLifecycleRecordV1{}, err
+	}
+	return c.Submit(ctx, VectorPartitionLifecycleCommandV1{Kind: VectorPartitionLifecyclePrepareV1, ExpectedRevision: r.Revision, ExpectedState: r.State, Identity: identity, ReadySetDigest: digest})
+}
+
+func (c VectorPartitionLifecycleCoordinatorV1) ActivateV1(ctx context.Context, identity VectorPartitionLifecycleIdentityV1) (VectorPartitionLifecycleRecordV1, error) {
+	r, ok := c.Authority.VectorPartitionLifecycleRecordV1(identity)
+	if !ok {
+		return VectorPartitionLifecycleRecordV1{}, ErrVectorPartitionLifecycleGuard
+	}
+	cmd := VectorPartitionLifecycleCommandV1{Kind: VectorPartitionLifecycleActivateV1, ExpectedRevision: r.Revision, ExpectedState: r.State, Identity: identity, PreviousActiveGeneration: r.PreviousActiveGeneration, MutationEpoch: r.MutationEpoch}
+	for _, status := range c.Authority.VectorPartitionLifecycleStatusesV1() {
+		if status.Active && status.Identity.Index == identity.Index {
+			cmd.PreviousActiveGeneration, cmd.PreviousActiveRevision = status.Identity.Generation, status.Revision
+		}
+	}
+	return c.Submit(ctx, cmd)
+}
+
+func (c VectorPartitionLifecycleCoordinatorV1) transitionV1(ctx context.Context, identity VectorPartitionLifecycleIdentityV1, kind VectorPartitionLifecycleCommandKindV1, mutate func(*VectorPartitionLifecycleCommandV1)) (VectorPartitionLifecycleRecordV1, error) {
+	r, ok := c.Authority.VectorPartitionLifecycleRecordV1(identity)
+	if !ok {
+		return VectorPartitionLifecycleRecordV1{}, ErrVectorPartitionLifecycleGuard
+	}
+	cmd := VectorPartitionLifecycleCommandV1{Kind: kind, ExpectedRevision: r.Revision, ExpectedState: r.State, Identity: identity}
+	if mutate != nil {
+		mutate(&cmd)
+	}
+	return c.Submit(ctx, cmd)
+}
+
+func (c VectorPartitionLifecycleCoordinatorV1) AbortV1(ctx context.Context, identity VectorPartitionLifecycleIdentityV1, reason string) (VectorPartitionLifecycleRecordV1, error) {
+	return c.transitionV1(ctx, identity, VectorPartitionLifecycleAbortBuildV1, func(x *VectorPartitionLifecycleCommandV1) { x.Reason = reason })
+}
+func (c VectorPartitionLifecycleCoordinatorV1) RetireV1(ctx context.Context, identity VectorPartitionLifecycleIdentityV1) (VectorPartitionLifecycleRecordV1, error) {
+	return c.transitionV1(ctx, identity, VectorPartitionLifecycleRetireV1, nil)
+}
+func (c VectorPartitionLifecycleCoordinatorV1) MarkCleanableV1(ctx context.Context, identity VectorPartitionLifecycleIdentityV1, refs VectorPartitionLifecycleReferencesV1) (VectorPartitionLifecycleRecordV1, error) {
+	return c.transitionV1(ctx, identity, VectorPartitionLifecycleMarkCleanableV1, func(x *VectorPartitionLifecycleCommandV1) { x.References = refs })
+}
+func (c VectorPartitionLifecycleCoordinatorV1) RecordGroupCleanupV1(ctx context.Context, identity VectorPartitionLifecycleIdentityV1, group raftcluster.GroupID) (VectorPartitionLifecycleRecordV1, error) {
+	return c.transitionV1(ctx, identity, VectorPartitionLifecycleRecordGroupCleanupV1, func(x *VectorPartitionLifecycleCommandV1) { x.GroupID = group })
+}
+func (c VectorPartitionLifecycleCoordinatorV1) CompleteCleanupV1(ctx context.Context, identity VectorPartitionLifecycleIdentityV1) (VectorPartitionLifecycleRecordV1, error) {
+	return c.transitionV1(ctx, identity, VectorPartitionLifecycleCompleteCleanupV1, nil)
+}
+
+func (c VectorPartitionLifecycleCoordinatorV1) RecoveryStatusV1() ([]VectorPartitionLifecycleAuthorityStatusV1, []VectorPartitionLifecycleMutationFenceStatusV1, error) {
+	if c.Authority == nil {
+		return nil, nil, ErrCatalogMetaUnavailable
+	}
+	return c.Authority.VectorPartitionLifecycleStatusesV1(), c.Authority.VectorPartitionLifecycleMutationFencesV1(), nil
+}

--- a/TreeDB/internal/raftplacement/vector_partition_lifecycle_workflow_v1.go
+++ b/TreeDB/internal/raftplacement/vector_partition_lifecycle_workflow_v1.go
@@ -151,3 +151,10 @@ func (c VectorPartitionLifecycleCoordinatorV1) RecoveryStatusV1() ([]VectorParti
 	}
 	return c.Authority.VectorPartitionLifecycleStatusesV1(), c.Authority.VectorPartitionLifecycleMutationFencesV1(), nil
 }
+
+func (c VectorPartitionLifecycleCoordinatorV1) RecoveryCollectionMutationBarriersV1() ([]VectorPartitionCollectionMutationBarrierStatusV1, error) {
+	if c.Authority == nil {
+		return nil, ErrCatalogMetaUnavailable
+	}
+	return c.Authority.VectorPartitionCollectionMutationBarriersV1(), nil
+}

--- a/TreeDB/internal/raftplacement/vector_partition_lifecycle_workflow_v1.go
+++ b/TreeDB/internal/raftplacement/vector_partition_lifecycle_workflow_v1.go
@@ -19,6 +19,12 @@ type VectorPartitionLifecycleGroupBuilderV1 interface {
 // BeginBuildV1 records a source- and catalog-bound candidate before any group
 // assets can be accepted. Exact retry is handled by the catalog command digest.
 func (c VectorPartitionLifecycleCoordinatorV1) BeginBuildV1(ctx context.Context, identity VectorPartitionLifecycleIdentityV1, required []raftcluster.GroupID, previousGeneration, mutationEpoch uint64) (VectorPartitionLifecycleRecordV1, error) {
+	if r, ok := c.Authority.VectorPartitionLifecycleRecordV1(identity); ok && r.State != VectorPartitionLifecycleAbsentV1 {
+		if r.PreviousActiveGeneration == previousGeneration && r.MutationEpoch == mutationEpoch {
+			return r, nil
+		}
+		return VectorPartitionLifecycleRecordV1{}, ErrVectorPartitionLifecycleConflict
+	}
 	return c.Submit(ctx, VectorPartitionLifecycleCommandV1{Kind: VectorPartitionLifecycleBeginBuildV1, ExpectedState: VectorPartitionLifecycleAbsentV1, Identity: identity, RequiredGroups: required, PreviousActiveGeneration: previousGeneration, MutationEpoch: mutationEpoch})
 }
 
@@ -26,6 +32,11 @@ func (c VectorPartitionLifecycleCoordinatorV1) RecordGroupReadyV1(ctx context.Co
 	record, ok := c.Authority.VectorPartitionLifecycleRecordV1(identity)
 	if !ok {
 		return VectorPartitionLifecycleRecordV1{}, ErrVectorPartitionLifecycleGuard
+	}
+	for _, existing := range record.ReadyGroups {
+		if existing.GroupID == ready.GroupID && existing == ready {
+			return record, nil
+		}
 	}
 	return c.Submit(ctx, VectorPartitionLifecycleCommandV1{Kind: VectorPartitionLifecycleRecordGroupReadyV1, ExpectedRevision: record.Revision, ExpectedState: record.State, Identity: identity, GroupReady: ready})
 }
@@ -51,6 +62,9 @@ func (c VectorPartitionLifecycleCoordinatorV1) PrepareV1(ctx context.Context, id
 	if !ok {
 		return VectorPartitionLifecycleRecordV1{}, ErrVectorPartitionLifecycleGuard
 	}
+	if r.State == VectorPartitionLifecyclePreparedV1 {
+		return r, nil
+	}
 	digest, err := VectorPartitionLifecycleReadySetDigestV1(r.Identity, r.RequiredGroups, r.ReadyGroups)
 	if err != nil {
 		return VectorPartitionLifecycleRecordV1{}, err
@@ -62,6 +76,9 @@ func (c VectorPartitionLifecycleCoordinatorV1) ActivateV1(ctx context.Context, i
 	r, ok := c.Authority.VectorPartitionLifecycleRecordV1(identity)
 	if !ok {
 		return VectorPartitionLifecycleRecordV1{}, ErrVectorPartitionLifecycleGuard
+	}
+	if r.State == VectorPartitionLifecycleActiveV1 {
+		return r, nil
 	}
 	cmd := VectorPartitionLifecycleCommandV1{Kind: VectorPartitionLifecycleActivateV1, ExpectedRevision: r.Revision, ExpectedState: r.State, Identity: identity, PreviousActiveGeneration: r.PreviousActiveGeneration, MutationEpoch: r.MutationEpoch}
 	for _, status := range c.Authority.VectorPartitionLifecycleStatusesV1() {
@@ -77,9 +94,32 @@ func (c VectorPartitionLifecycleCoordinatorV1) transitionV1(ctx context.Context,
 	if !ok {
 		return VectorPartitionLifecycleRecordV1{}, ErrVectorPartitionLifecycleGuard
 	}
+	switch kind {
+	case VectorPartitionLifecycleAbortBuildV1:
+		if r.State == VectorPartitionLifecycleRetiredV1 && r.Aborted {
+			return r, nil
+		}
+	case VectorPartitionLifecycleRetireV1:
+		if r.State == VectorPartitionLifecycleRetiredV1 {
+			return r, nil
+		}
+	case VectorPartitionLifecycleMarkCleanableV1:
+		if r.State == VectorPartitionLifecycleCleanableV1 {
+			return r, nil
+		}
+	case VectorPartitionLifecycleRecordGroupCleanupV1:
+		// handled below after the requested group is known.
+	case VectorPartitionLifecycleCompleteCleanupV1:
+		if r.State == VectorPartitionLifecycleAbsentV1 {
+			return r, nil
+		}
+	}
 	cmd := VectorPartitionLifecycleCommandV1{Kind: kind, ExpectedRevision: r.Revision, ExpectedState: r.State, Identity: identity}
 	if mutate != nil {
 		mutate(&cmd)
+	}
+	if kind == VectorPartitionLifecycleRecordGroupCleanupV1 && containsVectorPartitionLifecycleGroupV1(r.CleanedGroups, cmd.GroupID) {
+		return r, nil
 	}
 	return c.Submit(ctx, cmd)
 }

--- a/TreeDB/mongo_gateway/cluster_submitter.go
+++ b/TreeDB/mongo_gateway/cluster_submitter.go
@@ -529,6 +529,11 @@ func (s *Server) submitClusterMutation(ctx context.Context, command iwire.Comman
 	if err != nil {
 		return nil, err
 	}
+	if result.CommittedRecoverable {
+		if err := treenativewire.ConfirmVectorPartitionMutationV1(ctx, s.ClusterSubmitter, command, cmd.Known); err != nil {
+			return nil, err
+		}
+	}
 	if err := validateMongoClusterSubmitResult(ack, result); err != nil {
 		return nil, err
 	}

--- a/TreeDB/mongo_gateway/cluster_submitter.go
+++ b/TreeDB/mongo_gateway/cluster_submitter.go
@@ -505,9 +505,6 @@ func (s *Server) submitClusterMutation(ctx context.Context, command iwire.Comman
 	if err != nil {
 		return nil, err
 	}
-	if err := treenativewire.AdmitVectorPartitionMutationV1(ctx, s.ClusterSubmitter, command, cmd.Known); err != nil {
-		return nil, err
-	}
 	entry, err := iwire.AppendDeterministicEntry(nil, cmd)
 	if err != nil {
 		return nil, err
@@ -525,7 +522,7 @@ func (s *Server) submitClusterMutation(ctx context.Context, command iwire.Comman
 	if ctx == nil {
 		ctx = context.Background()
 	}
-	result, submitErr := s.ClusterSubmitter.SubmitCommandEntryV1(ctx, entry, metadata)
+	result, submitErr := treenativewire.SubmitCommandEntryWithVectorPartitionAdmissionV1(ctx, s.ClusterSubmitter, command, cmd.Known, entry, metadata)
 	if result.CommittedApplied {
 		if err := treenativewire.ConfirmCommittedVectorPartitionMutationV1(ctx, s.ClusterSubmitter, command, cmd.Known); err != nil {
 			return nil, errors.Join(submitErr, err)

--- a/TreeDB/mongo_gateway/cluster_submitter.go
+++ b/TreeDB/mongo_gateway/cluster_submitter.go
@@ -525,14 +525,14 @@ func (s *Server) submitClusterMutation(ctx context.Context, command iwire.Comman
 	if ctx == nil {
 		ctx = context.Background()
 	}
-	result, err := s.ClusterSubmitter.SubmitCommandEntryV1(ctx, entry, metadata)
-	if err != nil {
-		return nil, err
-	}
+	result, submitErr := s.ClusterSubmitter.SubmitCommandEntryV1(ctx, entry, metadata)
 	if result.CommittedApplied {
 		if err := treenativewire.ConfirmCommittedVectorPartitionMutationV1(ctx, s.ClusterSubmitter, command, cmd.Known); err != nil {
-			return nil, err
+			return nil, errors.Join(submitErr, err)
 		}
+	}
+	if submitErr != nil {
+		return nil, submitErr
 	}
 	if err := validateMongoClusterSubmitResult(ack, result); err != nil {
 		return nil, err

--- a/TreeDB/mongo_gateway/cluster_submitter.go
+++ b/TreeDB/mongo_gateway/cluster_submitter.go
@@ -505,6 +505,9 @@ func (s *Server) submitClusterMutation(ctx context.Context, command iwire.Comman
 	if err != nil {
 		return nil, err
 	}
+	if err := treenativewire.AdmitVectorPartitionMutationV1(ctx, s.ClusterSubmitter, command, cmd.Known); err != nil {
+		return nil, err
+	}
 	entry, err := iwire.AppendDeterministicEntry(nil, cmd)
 	if err != nil {
 		return nil, err

--- a/TreeDB/mongo_gateway/cluster_submitter.go
+++ b/TreeDB/mongo_gateway/cluster_submitter.go
@@ -529,7 +529,7 @@ func (s *Server) submitClusterMutation(ctx context.Context, command iwire.Comman
 	if err != nil {
 		return nil, err
 	}
-	if result.CommittedRecoverable {
+	if result.CommittedApplied {
 		if err := treenativewire.ConfirmVectorPartitionMutationV1(ctx, s.ClusterSubmitter, command, cmd.Known); err != nil {
 			return nil, err
 		}

--- a/TreeDB/mongo_gateway/cluster_submitter.go
+++ b/TreeDB/mongo_gateway/cluster_submitter.go
@@ -530,7 +530,7 @@ func (s *Server) submitClusterMutation(ctx context.Context, command iwire.Comman
 		return nil, err
 	}
 	if result.CommittedApplied {
-		if err := treenativewire.ConfirmVectorPartitionMutationV1(ctx, s.ClusterSubmitter, command, cmd.Known); err != nil {
+		if err := treenativewire.ConfirmCommittedVectorPartitionMutationV1(ctx, s.ClusterSubmitter, command, cmd.Known); err != nil {
 			return nil, err
 		}
 	}

--- a/TreeDB/mongo_gateway/cluster_submitter_test.go
+++ b/TreeDB/mongo_gateway/cluster_submitter_test.go
@@ -57,6 +57,13 @@ func (s *mongoConfirmingVectorPartitionSubmitterV1) RequiresVectorPartitionMutat
 	return true, nil
 }
 
+func (s *mongoConfirmingVectorPartitionSubmitterV1) SubmitCommandEntryWithPreCommitV1(ctx context.Context, entry []byte, metadata treenativewire.ClusterRequestMetadata, preCommit func(context.Context) error) (treenativewire.ClusterSubmitResult, error) {
+	if err := preCommit(ctx); err != nil {
+		return treenativewire.ClusterSubmitResult{}, err
+	}
+	return s.SubmitCommandEntryV1(ctx, entry, metadata)
+}
+
 func (s *mongoConfirmingVectorPartitionSubmitterV1) AdmitVectorPartitionMutationV1(context.Context, iwire.CommandID, []iwire.Section) error {
 	return nil
 }

--- a/TreeDB/mongo_gateway/cluster_submitter_test.go
+++ b/TreeDB/mongo_gateway/cluster_submitter_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/binary"
 	"errors"
 	"fmt"
+	"reflect"
 	"strings"
 	"sync"
 	"testing"
@@ -36,10 +37,32 @@ type mongoClusterFakeSubmitter struct {
 	calls                    []mongoClusterSubmitterCall
 	actualAck                iwire.AckPolicy
 	committedRecoverable     bool
+	committedApplied         bool
 	responseSections         []iwire.Section
 	overrideResponseSections bool
 	status                   treenativewire.ClusterAdmissionStatus
 	admissionErr             error
+}
+
+type mongoConfirmingVectorPartitionSubmitterV1 struct {
+	*mongoClusterFakeSubmitter
+	mu            sync.Mutex
+	confirmations []iwire.CommandID
+}
+
+func (s *mongoConfirmingVectorPartitionSubmitterV1) RequiresVectorPartitionMutationAdmissionV1(context.Context) (bool, error) {
+	return true, nil
+}
+
+func (s *mongoConfirmingVectorPartitionSubmitterV1) AdmitVectorPartitionMutationV1(context.Context, iwire.CommandID, []iwire.Section) error {
+	return nil
+}
+
+func (s *mongoConfirmingVectorPartitionSubmitterV1) ConfirmVectorPartitionMutationV1(_ context.Context, command iwire.CommandID, _ []iwire.Section) error {
+	s.mu.Lock()
+	s.confirmations = append(s.confirmations, command)
+	s.mu.Unlock()
+	return nil
 }
 
 type mongoClusterAdmissionSubmitter struct {
@@ -328,6 +351,7 @@ func (f *mongoClusterFakeSubmitter) SubmitCommandEntryV1(ctx context.Context, en
 	return treenativewire.ClusterSubmitResult{
 		ActualAck:            actualAck,
 		CommittedRecoverable: f.committedRecoverable,
+		CommittedApplied:     f.committedApplied,
 		ResponseSections:     responseSections,
 	}, nil
 }
@@ -2526,6 +2550,46 @@ func TestClusterSubmitterMajorityWriteConcernRejectsMissingCollectionNoops(t *te
 			t.Fatalf("submit calls=%d want 0", len(calls))
 		}
 	})
+}
+
+func TestClusterSubmitterVisibleAckConfirmsCommittedVectorMutationV1(t *testing.T) {
+	submitter := &mongoConfirmingVectorPartitionSubmitterV1{mongoClusterFakeSubmitter: &mongoClusterFakeSubmitter{committedApplied: true}}
+	server := NewServer()
+	server.DefaultCollectionOptions = collections.CollectionOptions{DocumentFormat: collections.DocumentFormatBSON}
+	server.ClusterSubmitter = submitter
+	server.ClusterCatalogVersion = mongoClusterStaticCatalogVersion(32)
+
+	response := serveCommand(t, server, 325834, bson.D{
+		{Key: "create", Value: "users"},
+		{Key: "$db", Value: "app"},
+	})
+	assertOK(t, response)
+	submitter.mu.Lock()
+	confirmations := append([]iwire.CommandID(nil), submitter.confirmations...)
+	submitter.mu.Unlock()
+	if !reflect.DeepEqual(confirmations, []iwire.CommandID{iwire.CommandCreateCollection}) {
+		t.Fatalf("confirmations=%v want create_collection", confirmations)
+	}
+}
+
+func TestClusterSubmitterRecoverableOnlyDoesNotConfirmVectorMutationV1(t *testing.T) {
+	submitter := &mongoConfirmingVectorPartitionSubmitterV1{mongoClusterFakeSubmitter: &mongoClusterFakeSubmitter{committedRecoverable: true}}
+	server := NewServer()
+	server.DefaultCollectionOptions = collections.CollectionOptions{DocumentFormat: collections.DocumentFormatBSON}
+	server.ClusterSubmitter = submitter
+	server.ClusterCatalogVersion = mongoClusterStaticCatalogVersion(32)
+
+	response := serveCommand(t, server, 325835, bson.D{
+		{Key: "create", Value: "users"},
+		{Key: "$db", Value: "app"},
+	})
+	assertOK(t, response)
+	submitter.mu.Lock()
+	confirmationCount := len(submitter.confirmations)
+	submitter.mu.Unlock()
+	if confirmationCount != 0 {
+		t.Fatalf("recoverable-only submission confirmations=%d want 0", confirmationCount)
+	}
 }
 
 func TestClusterSubmitterWriteConcernAccepted(t *testing.T) {

--- a/TreeDB/mongo_gateway/cluster_submitter_test.go
+++ b/TreeDB/mongo_gateway/cluster_submitter_test.go
@@ -1585,7 +1585,7 @@ func TestCatalogMetaMongoAndSharedSubmitProofMatrix(t *testing.T) {
 	if err != nil {
 		t.Fatalf("CurrentCatalogProof: %v", err)
 	}
-	provider, err := treenativewire.NewCatalogMetaClusterRouteProvider(authority, authority.CurrentCatalogProof)
+	provider, err := treenativewire.NewCatalogMetaClusterRouteProvider(authority, authority.CurrentCatalogProof, metaRaft)
 	if err != nil {
 		t.Fatalf("NewCatalogMetaClusterRouteProvider: %v", err)
 	}
@@ -1617,7 +1617,7 @@ func TestCatalogMetaMongoAndSharedSubmitProofMatrix(t *testing.T) {
 	}
 	staleProvider, err := treenativewire.NewCatalogMetaClusterRouteProvider(authority, func(context.Context) (raftplacement.CatalogProofV1, error) {
 		return proof, nil
-	})
+	}, metaRaft)
 	if err != nil {
 		t.Fatalf("NewCatalogMetaClusterRouteProvider stale: %v", err)
 	}
@@ -1668,8 +1668,8 @@ func TestMongoGroupRoutedDispatcherRejectsSingleTokenWriteWithoutOwnerBoundIndex
 }
 
 func BenchmarkCatalogMetaMongoMutationAdmission(b *testing.B) {
-	authority, _ := newMongoCatalogMetaAuthority(b)
-	provider, err := treenativewire.NewCatalogMetaClusterRouteProvider(authority, authority.CurrentCatalogProof)
+	authority, metaRaft := newMongoCatalogMetaAuthority(b)
+	provider, err := treenativewire.NewCatalogMetaClusterRouteProvider(authority, authority.CurrentCatalogProof, metaRaft)
 	if err != nil {
 		b.Fatalf("NewCatalogMetaClusterRouteProvider: %v", err)
 	}

--- a/TreeDB/mongo_gateway/cluster_submitter_test.go
+++ b/TreeDB/mongo_gateway/cluster_submitter_test.go
@@ -43,6 +43,7 @@ type mongoClusterFakeSubmitter struct {
 	status                   treenativewire.ClusterAdmissionStatus
 	admissionErr             error
 	submitHook               func()
+	submitErr                error
 }
 
 type mongoConfirmingVectorPartitionSubmitterV1 struct {
@@ -360,7 +361,7 @@ func (f *mongoClusterFakeSubmitter) SubmitCommandEntryV1(ctx context.Context, en
 		CommittedRecoverable: f.committedRecoverable,
 		CommittedApplied:     f.committedApplied,
 		ResponseSections:     responseSections,
-	}, nil
+	}, f.submitErr
 }
 
 func (f *mongoClusterFakeSubmitter) snapshotCalls() []mongoClusterSubmitterCall {
@@ -2571,6 +2572,30 @@ func TestClusterSubmitterVisibleAckConfirmsCommittedVectorMutationV1(t *testing.
 		{Key: "$db", Value: "app"},
 	})
 	assertOK(t, response)
+	submitter.mu.Lock()
+	confirmations := append([]iwire.CommandID(nil), submitter.confirmations...)
+	submitter.mu.Unlock()
+	if !reflect.DeepEqual(confirmations, []iwire.CommandID{iwire.CommandCreateCollection}) {
+		t.Fatalf("confirmations=%v want create_collection", confirmations)
+	}
+}
+
+func TestClusterSubmitterConfirmsCommittedVectorMutationBeforeReturningPostApplyErrorV1(t *testing.T) {
+	submitErr := errors.New("post-apply catalog refresh failed")
+	submitter := &mongoConfirmingVectorPartitionSubmitterV1{mongoClusterFakeSubmitter: &mongoClusterFakeSubmitter{committedApplied: true, submitErr: submitErr}}
+	server := NewServer()
+	server.DefaultCollectionOptions = collections.CollectionOptions{DocumentFormat: collections.DocumentFormatBSON}
+	server.ClusterSubmitter = submitter
+	server.ClusterCatalogVersion = mongoClusterStaticCatalogVersion(32)
+	raw, err := bson.Marshal(bson.D{{Key: "create", Value: "users"}, {Key: "$db", Value: "app"}})
+	if err != nil {
+		t.Fatalf("marshal command: %v", err)
+	}
+	response, err := server.clusterCreateCollectionResponse(context.Background(), wire.Document(raw))
+	if err != nil {
+		t.Fatalf("cluster create response: %v", err)
+	}
+	assertErrmsgContains(t, response, submitErr.Error())
 	submitter.mu.Lock()
 	confirmations := append([]iwire.CommandID(nil), submitter.confirmations...)
 	submitter.mu.Unlock()

--- a/TreeDB/mongo_gateway/cluster_submitter_test.go
+++ b/TreeDB/mongo_gateway/cluster_submitter_test.go
@@ -75,12 +75,13 @@ type mongoClusterAdmissionSubmitter struct {
 }
 
 type mongoRecordingRaftCommandSubmitter struct {
-	groupID raftcluster.GroupID
-	status  raftcluster.AdmissionStatus
-	err     error
-	discard bool
-	mu      sync.Mutex
-	calls   []mongoRecordingRaftCommandSubmitCall
+	groupID  raftcluster.GroupID
+	features raftcluster.FeatureSet
+	status   raftcluster.AdmissionStatus
+	err      error
+	discard  bool
+	mu       sync.Mutex
+	calls    []mongoRecordingRaftCommandSubmitCall
 }
 
 type mongoRecordingRaftCommandSubmitCall struct {
@@ -89,7 +90,7 @@ type mongoRecordingRaftCommandSubmitCall struct {
 }
 
 func (s *mongoRecordingRaftCommandSubmitter) Config() raftcluster.ResolvedConfig {
-	return raftcluster.ResolvedConfig{GroupID: s.groupID}
+	return raftcluster.ResolvedConfig{GroupID: s.groupID, Features: s.features}
 }
 
 func (s *mongoRecordingRaftCommandSubmitter) ClusterAdmissionStatus(context.Context) (raftcluster.AdmissionStatus, error) {
@@ -2575,6 +2576,29 @@ func TestClusterSubmitterVisibleAckConfirmsCommittedVectorMutationV1(t *testing.
 	submitter.mu.Unlock()
 	if !reflect.DeepEqual(confirmations, []iwire.CommandID{iwire.CommandCreateCollection}) {
 		t.Fatalf("confirmations=%v want create_collection", confirmations)
+	}
+}
+
+func TestLegacyRaftClusterSubmitterMongoRequiresVectorAdmissionFromClusterFeatureV1(t *testing.T) {
+	features := raftcluster.DefaultFeatureSet()
+	features.Required = append(features.Required, raftcluster.RequiredFeature{
+		Name:    raftcluster.FeatureVectorPartitionLifecycle,
+		Version: raftcluster.SupportedFeatureFloors[raftcluster.FeatureVectorPartitionLifecycle],
+	})
+	bridge := &mongoRecordingRaftCommandSubmitter{groupID: "group-a", features: features}
+	server := NewServer()
+	server.DefaultCollectionOptions = collections.CollectionOptions{DocumentFormat: collections.DocumentFormatBSON}
+	server.ClusterSubmitter = treenativewire.NewRaftClusterSubmitter(bridge)
+	server.ClusterCatalogVersion = mongoClusterStaticCatalogVersion(32)
+
+	response := serveCommand(t, server, 325836, bson.D{
+		{Key: "create", Value: "users"},
+		{Key: "$db", Value: "app"},
+	})
+	assertCommandError(t, response, "NotWritablePrimary")
+	assertErrmsgContains(t, response, "vector partition lifecycle admission is not configured")
+	if calls := bridge.snapshotCalls(); len(calls) != 0 {
+		t.Fatalf("legacy Mongo constructor submitted %d entries before required lifecycle admission", len(calls))
 	}
 }
 

--- a/TreeDB/mongo_gateway/cluster_submitter_test.go
+++ b/TreeDB/mongo_gateway/cluster_submitter_test.go
@@ -42,12 +42,14 @@ type mongoClusterFakeSubmitter struct {
 	overrideResponseSections bool
 	status                   treenativewire.ClusterAdmissionStatus
 	admissionErr             error
+	submitHook               func()
 }
 
 type mongoConfirmingVectorPartitionSubmitterV1 struct {
 	*mongoClusterFakeSubmitter
-	mu            sync.Mutex
-	confirmations []iwire.CommandID
+	mu                        sync.Mutex
+	confirmations             []iwire.CommandID
+	confirmationContextErrors []error
 }
 
 func (s *mongoConfirmingVectorPartitionSubmitterV1) RequiresVectorPartitionMutationAdmissionV1(context.Context) (bool, error) {
@@ -58,9 +60,10 @@ func (s *mongoConfirmingVectorPartitionSubmitterV1) AdmitVectorPartitionMutation
 	return nil
 }
 
-func (s *mongoConfirmingVectorPartitionSubmitterV1) ConfirmVectorPartitionMutationV1(_ context.Context, command iwire.CommandID, _ []iwire.Section) error {
+func (s *mongoConfirmingVectorPartitionSubmitterV1) ConfirmVectorPartitionMutationV1(ctx context.Context, command iwire.CommandID, _ []iwire.Section) error {
 	s.mu.Lock()
 	s.confirmations = append(s.confirmations, command)
+	s.confirmationContextErrors = append(s.confirmationContextErrors, ctx.Err())
 	s.mu.Unlock()
 	return nil
 }
@@ -339,6 +342,9 @@ func (f *mongoClusterFakeSubmitter) SubmitCommandEntryV1(ctx context.Context, en
 	f.mu.Unlock()
 	if ctxErr != nil {
 		return treenativewire.ClusterSubmitResult{}, ctxErr
+	}
+	if f.submitHook != nil {
+		f.submitHook()
 	}
 	actualAck := f.actualAck
 	if actualAck == 0 {
@@ -2569,6 +2575,32 @@ func TestClusterSubmitterVisibleAckConfirmsCommittedVectorMutationV1(t *testing.
 	submitter.mu.Unlock()
 	if !reflect.DeepEqual(confirmations, []iwire.CommandID{iwire.CommandCreateCollection}) {
 		t.Fatalf("confirmations=%v want create_collection", confirmations)
+	}
+}
+
+func TestClusterSubmitterCommittedVectorConfirmationOutlivesClientCancellationV1(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	submitter := &mongoConfirmingVectorPartitionSubmitterV1{mongoClusterFakeSubmitter: &mongoClusterFakeSubmitter{committedApplied: true, submitHook: cancel}}
+	server := NewServer()
+	server.DefaultCollectionOptions = collections.CollectionOptions{DocumentFormat: collections.DocumentFormatBSON}
+	server.ClusterSubmitter = submitter
+	server.ClusterCatalogVersion = mongoClusterStaticCatalogVersion(32)
+	raw, err := bson.Marshal(bson.D{{Key: "create", Value: "users"}, {Key: "$db", Value: "app"}})
+	if err != nil {
+		t.Fatalf("marshal command: %v", err)
+	}
+	response, err := server.clusterCreateCollectionResponse(ctx, wire.Document(raw))
+	if err != nil {
+		t.Fatalf("cluster create after client cancellation: %v", err)
+	}
+	assertOK(t, response)
+	if !errors.Is(ctx.Err(), context.Canceled) {
+		t.Fatalf("request context err=%v want canceled", ctx.Err())
+	}
+	submitter.mu.Lock()
+	defer submitter.mu.Unlock()
+	if len(submitter.confirmationContextErrors) != 1 || submitter.confirmationContextErrors[0] != nil {
+		t.Fatalf("confirmation context errors=%v want [nil]", submitter.confirmationContextErrors)
 	}
 }
 

--- a/TreeDB/nativewire/catalog_meta_vector_partition_lifecycle_v1.go
+++ b/TreeDB/nativewire/catalog_meta_vector_partition_lifecycle_v1.go
@@ -1,0 +1,68 @@
+package nativewire
+
+import (
+	"context"
+	"errors"
+
+	"github.com/snissn/gomap/TreeDB/internal/raftplacement"
+)
+
+// CatalogMetaLinearizableAppliedIndexProviderV1 performs the meta-Raft read
+// fence and returns the last catalog command installed in the fenced local
+// applied view.
+type CatalogMetaLinearizableAppliedIndexProviderV1 interface {
+	LinearizableCatalogMetaAppliedIndexV1(context.Context) (uint64, error)
+}
+
+// LinearizableCatalogVectorPartitionLifecycleAuthorityV1 is the only adapter
+// from the concrete catalog authority to the M7 serving interface. Every
+// validation first performs a fresh meta-Raft quorum read and then proves that
+// the local authority has caught up through the returned command index.
+type LinearizableCatalogVectorPartitionLifecycleAuthorityV1 struct {
+	authority *raftplacement.CatalogMetaAuthorityV1
+	readFence CatalogMetaLinearizableAppliedIndexProviderV1
+}
+
+func NewLinearizableCatalogVectorPartitionLifecycleAuthorityV1(
+	authority *raftplacement.CatalogMetaAuthorityV1,
+	readFence CatalogMetaLinearizableAppliedIndexProviderV1,
+) (*LinearizableCatalogVectorPartitionLifecycleAuthorityV1, error) {
+	if authority == nil || readFence == nil {
+		return nil, errors.New("nativewire: catalog lifecycle authority and linearizable read fence are required")
+	}
+	return &LinearizableCatalogVectorPartitionLifecycleAuthorityV1{authority: authority, readFence: readFence}, nil
+}
+
+func (a *LinearizableCatalogVectorPartitionLifecycleAuthorityV1) ValidateVectorPartitionGenerationSearchV1(
+	ctx context.Context,
+	collection raftplacement.CollectionRefV1,
+	index string,
+	generation uint64,
+	indexDefinitionDigest string,
+	sourceGeneration uint64,
+	sourceChecksum uint64,
+	sourceSchemaHash uint64,
+	sourceRowCount uint64,
+) (string, error) {
+	if a == nil || a.authority == nil || a.readFence == nil {
+		return "", ErrVectorPartitionShardSearchAssetsUnavailable
+	}
+	requiredAppliedIndex, err := a.readFence.LinearizableCatalogMetaAppliedIndexV1(ctx)
+	if err != nil {
+		return "", errors.Join(ErrVectorPartitionShardSearchAssetsUnavailable, err)
+	}
+	return a.authority.ValidateVectorPartitionGenerationSearchAtAppliedIndexV1(
+		ctx,
+		requiredAppliedIndex,
+		collection,
+		index,
+		generation,
+		indexDefinitionDigest,
+		sourceGeneration,
+		sourceChecksum,
+		sourceSchemaHash,
+		sourceRowCount,
+	)
+}
+
+var _ VectorPartitionReplicatedLifecycleAuthorityV1 = (*LinearizableCatalogVectorPartitionLifecycleAuthorityV1)(nil)

--- a/TreeDB/nativewire/catalog_meta_vector_partition_lifecycle_v1_test.go
+++ b/TreeDB/nativewire/catalog_meta_vector_partition_lifecycle_v1_test.go
@@ -1,0 +1,57 @@
+package nativewire
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/snissn/gomap/TreeDB/internal/raftcluster"
+	"github.com/snissn/gomap/TreeDB/internal/raftplacement"
+)
+
+type catalogMetaLinearizableAppliedIndexProviderTestV1 struct {
+	index uint64
+	err   error
+	calls int
+}
+
+func (p *catalogMetaLinearizableAppliedIndexProviderTestV1) LinearizableCatalogMetaAppliedIndexV1(context.Context) (uint64, error) {
+	p.calls++
+	return p.index, p.err
+}
+
+func TestLinearizableCatalogVectorPartitionLifecycleAuthorityFailsClosedBeforeLocalValidationV1(t *testing.T) {
+	authority := raftplacement.NewCatalogMetaAuthorityV1()
+	fence := &catalogMetaLinearizableAppliedIndexProviderTestV1{index: 7}
+	adapter, err := NewLinearizableCatalogVectorPartitionLifecycleAuthorityV1(authority, fence)
+	if err != nil {
+		t.Fatalf("NewLinearizableCatalogVectorPartitionLifecycleAuthorityV1: %v", err)
+	}
+	_, err = adapter.ValidateVectorPartitionGenerationSearchV1(
+		t.Context(),
+		raftplacement.CollectionRefV1{Database: "app", Catalog: "default", Collection: "users"},
+		"embedding", 1, "definition", 1, 2, 3, 4,
+	)
+	if !errors.Is(err, raftplacement.ErrCatalogMetaUnavailable) {
+		t.Fatalf("stale local catalog err=%v want ErrCatalogMetaUnavailable", err)
+	}
+	if fence.calls != 1 {
+		t.Fatalf("linearizable fence calls=%d want 1", fence.calls)
+	}
+}
+
+func TestLinearizableCatalogVectorPartitionLifecycleAuthorityPropagatesFenceFailureV1(t *testing.T) {
+	fence := &catalogMetaLinearizableAppliedIndexProviderTestV1{err: raftcluster.ErrNotLeader}
+	adapter, err := NewLinearizableCatalogVectorPartitionLifecycleAuthorityV1(raftplacement.NewCatalogMetaAuthorityV1(), fence)
+	if err != nil {
+		t.Fatalf("NewLinearizableCatalogVectorPartitionLifecycleAuthorityV1: %v", err)
+	}
+	_, err = adapter.ValidateVectorPartitionGenerationSearchV1(
+		t.Context(),
+		raftplacement.CollectionRefV1{Database: "app", Catalog: "default", Collection: "users"},
+		"embedding", 1, "definition", 1, 2, 3, 4,
+	)
+	if !errors.Is(err, ErrVectorPartitionShardSearchAssetsUnavailable) || !errors.Is(err, raftcluster.ErrNotLeader) {
+		t.Fatalf("fence failure err=%v want assets unavailable + not leader", err)
+	}
+}

--- a/TreeDB/nativewire/cluster_raft_submitter.go
+++ b/TreeDB/nativewire/cluster_raft_submitter.go
@@ -125,6 +125,7 @@ func (s *RaftClusterSubmitter) SubmitCommandEntryV1(ctx context.Context, entry [
 	return ClusterSubmitResult{
 		ActualAck:            AckPolicy(result.ActualAck),
 		CommittedRecoverable: result.CommittedRecoverable,
+		CommittedApplied:     result.CommittedApplied,
 		ResponseSections:     sections,
 		CatalogVersion:       result.CatalogVersion,
 		HasCatalogVersion:    result.HasCatalogVersion,

--- a/TreeDB/nativewire/cluster_raft_submitter.go
+++ b/TreeDB/nativewire/cluster_raft_submitter.go
@@ -18,7 +18,7 @@ import (
 type RaftClusterSubmitter struct {
 	Bridge                   raftcluster.CommandSubmitterV1
 	Collections              *collections.CollectionManager
-	VectorPartitionAdmission VectorPartitionMutationAdmissionProviderV1
+	VectorPartitionAdmission VectorPartitionMutationLifecycleProviderV1
 }
 
 // NewRaftClusterSubmitterWithVectorPartitionAdmissionV1 is the production M7
@@ -29,8 +29,12 @@ func NewRaftClusterSubmitterWithVectorPartitionAdmissionV1(bridge raftcluster.Co
 	if admission == nil {
 		return nil, errors.New("nativewire: vector partition admission provider is required")
 	}
+	lifecycle, ok := admission.(VectorPartitionMutationLifecycleProviderV1)
+	if !ok {
+		return nil, errors.New("nativewire: vector partition mutation confirmation provider is required")
+	}
 	submitter := NewRaftClusterSubmitter(bridge, managers...)
-	submitter.VectorPartitionAdmission = admission
+	submitter.VectorPartitionAdmission = lifecycle
 	return submitter, nil
 }
 
@@ -49,11 +53,7 @@ func (s *RaftClusterSubmitter) ConfirmVectorPartitionMutationV1(ctx context.Cont
 	if s == nil || s.VectorPartitionAdmission == nil {
 		return protocolError(iwire.ErrReadOnly, "vector partition lifecycle admission is not configured")
 	}
-	confirmer, ok := s.VectorPartitionAdmission.(VectorPartitionMutationCommitProviderV1)
-	if !ok {
-		return protocolError(iwire.ErrReadOnly, "vector partition lifecycle mutation confirmation is not configured")
-	}
-	return confirmer.ConfirmVectorPartitionMutationV1(ctx, command, sections)
+	return s.VectorPartitionAdmission.ConfirmVectorPartitionMutationV1(ctx, command, sections)
 }
 
 // RoutedRaftClusterSubmitter composes the concrete single-group Raft bridge

--- a/TreeDB/nativewire/cluster_raft_submitter.go
+++ b/TreeDB/nativewire/cluster_raft_submitter.go
@@ -39,7 +39,19 @@ func NewRaftClusterSubmitterWithVectorPartitionAdmissionV1(bridge raftcluster.Co
 }
 
 func (s *RaftClusterSubmitter) RequiresVectorPartitionMutationAdmissionV1(context.Context) (bool, error) {
-	return s != nil && s.VectorPartitionAdmission != nil, nil
+	if s == nil {
+		return false, raftcluster.ErrInvalidSubmitter
+	}
+	if s.VectorPartitionAdmission != nil {
+		return true, nil
+	}
+	if requirements, ok := s.Bridge.(raftcluster.FeatureRequirementProviderV1); ok {
+		return requirements.RequiresFeatureV1(raftcluster.FeatureVectorPartitionLifecycle)
+	}
+	if provider, ok := s.Bridge.(raftcluster.Provider); ok {
+		return raftcluster.FeatureSetRequiresV1(provider.Config().Features, raftcluster.FeatureVectorPartitionLifecycle), nil
+	}
+	return false, nil
 }
 
 func (s *RaftClusterSubmitter) AdmitVectorPartitionMutationV1(ctx context.Context, command iwire.CommandID, sections []iwire.Section) error {
@@ -63,6 +75,19 @@ func (s *RaftClusterSubmitter) ConfirmVectorPartitionMutationV1(ctx context.Cont
 type RoutedRaftClusterSubmitter struct {
 	*RaftClusterSubmitter
 	RouteProvider ClusterRouteProvider
+}
+
+func (s *RoutedRaftClusterSubmitter) RequiresVectorPartitionMutationAdmissionV1(ctx context.Context) (bool, error) {
+	if s == nil {
+		return false, raftcluster.ErrInvalidSubmitter
+	}
+	if requirements, ok := s.RouteProvider.(VectorPartitionMutationAdmissionRequiredV1); ok {
+		required, err := requirements.RequiresVectorPartitionMutationAdmissionV1(ctx)
+		if err != nil || required {
+			return required, err
+		}
+	}
+	return s.RaftClusterSubmitter.RequiresVectorPartitionMutationAdmissionV1(ctx)
 }
 
 func NewRaftClusterSubmitter(bridge raftcluster.CommandSubmitterV1, managers ...*collections.CollectionManager) *RaftClusterSubmitter {

--- a/TreeDB/nativewire/cluster_raft_submitter.go
+++ b/TreeDB/nativewire/cluster_raft_submitter.go
@@ -23,8 +23,8 @@ type RaftClusterSubmitter struct {
 
 // NewRaftClusterSubmitterWithVectorPartitionAdmissionV1 is the production M7
 // construction path. The supplied admission provider performs deterministic
-// schema classification and calls the replicated lifecycle coordinator before
-// this concrete shared submitter can encode a Raft command entry.
+// schema classification and calls the replicated lifecycle coordinator inside
+// the data preflight-to-commit boundary.
 func NewRaftClusterSubmitterWithVectorPartitionAdmissionV1(bridge raftcluster.CommandSubmitterV1, admission VectorPartitionMutationAdmissionProviderV1, managers ...*collections.CollectionManager) (*RaftClusterSubmitter, error) {
 	if admission == nil {
 		return nil, errors.New("nativewire: vector partition admission provider is required")
@@ -66,6 +66,13 @@ func (s *RaftClusterSubmitter) ConfirmVectorPartitionMutationV1(ctx context.Cont
 		return protocolError(iwire.ErrReadOnly, "vector partition lifecycle admission is not configured")
 	}
 	return s.VectorPartitionAdmission.ConfirmVectorPartitionMutationV1(ctx, command, sections)
+}
+
+func (s *RaftClusterSubmitter) ValidateVectorPartitionMutationLifecycleV1() error {
+	if s == nil || s.VectorPartitionAdmission == nil {
+		return protocolError(iwire.ErrReadOnly, "vector partition lifecycle admission is not configured")
+	}
+	return nil
 }
 
 // RoutedRaftClusterSubmitter composes the concrete single-group Raft bridge
@@ -133,13 +140,34 @@ func (s *RaftClusterSubmitter) ClusterAdmissionStatus(ctx context.Context) (Clus
 }
 
 func (s *RaftClusterSubmitter) SubmitCommandEntryV1(ctx context.Context, entry []byte, metadata ClusterRequestMetadata) (ClusterSubmitResult, error) {
+	return s.submitCommandEntryV1(ctx, entry, metadata, nil)
+}
+
+func (s *RaftClusterSubmitter) SubmitCommandEntryWithPreCommitV1(ctx context.Context, entry []byte, metadata ClusterRequestMetadata, preCommit func(context.Context) error) (ClusterSubmitResult, error) {
+	if preCommit == nil {
+		return ClusterSubmitResult{}, protocolError(iwire.ErrInvalidCommand, "raft cluster submitter pre-commit callback is required")
+	}
+	return s.submitCommandEntryV1(ctx, entry, metadata, preCommit)
+}
+
+func (s *RaftClusterSubmitter) submitCommandEntryV1(ctx context.Context, entry []byte, metadata ClusterRequestMetadata, preCommit func(context.Context) error) (ClusterSubmitResult, error) {
 	if s == nil || s.Bridge == nil {
 		return ClusterSubmitResult{}, protocolError(iwire.ErrInvalidCommand, "raft cluster submitter is not configured")
 	}
 	if s.Collections == nil {
 		return ClusterSubmitResult{}, protocolError(iwire.ErrInvalidCommand, "raft cluster submitter collection manager is not configured")
 	}
-	result, err := s.Bridge.SubmitCommandEntryV1(ctx, entry, metadata)
+	var result raftcluster.SubmitResultV1
+	var err error
+	if preCommit == nil {
+		result, err = s.Bridge.SubmitCommandEntryV1(ctx, entry, metadata)
+	} else {
+		atomicBridge, ok := s.Bridge.(raftcluster.CommandSubmitterWithPreCommitV1)
+		if !ok {
+			return ClusterSubmitResult{}, protocolError(iwire.ErrReadOnly, "raft bridge does not support serialized pre-commit callbacks")
+		}
+		result, err = atomicBridge.SubmitCommandEntryWithPreCommitV1(ctx, entry, metadata, preCommit)
+	}
 	clusterResult := ClusterSubmitResult{
 		ActualAck:            AckPolicy(result.ActualAck),
 		CommittedRecoverable: result.CommittedRecoverable,

--- a/TreeDB/nativewire/cluster_raft_submitter.go
+++ b/TreeDB/nativewire/cluster_raft_submitter.go
@@ -16,8 +16,33 @@ import (
 // RaftClusterSubmitter adapts the internal single-group raftcluster bridge to
 // the public nativewire ClusterSubmitter contract.
 type RaftClusterSubmitter struct {
-	Bridge      raftcluster.CommandSubmitterV1
-	Collections *collections.CollectionManager
+	Bridge                   raftcluster.CommandSubmitterV1
+	Collections              *collections.CollectionManager
+	VectorPartitionAdmission VectorPartitionMutationAdmissionProviderV1
+}
+
+// NewRaftClusterSubmitterWithVectorPartitionAdmissionV1 is the production M7
+// construction path. The supplied admission provider performs deterministic
+// schema classification and calls the replicated lifecycle coordinator before
+// this concrete shared submitter can encode a Raft command entry.
+func NewRaftClusterSubmitterWithVectorPartitionAdmissionV1(bridge raftcluster.CommandSubmitterV1, admission VectorPartitionMutationAdmissionProviderV1, managers ...*collections.CollectionManager) (*RaftClusterSubmitter, error) {
+	if admission == nil {
+		return nil, errors.New("nativewire: vector partition admission provider is required")
+	}
+	submitter := NewRaftClusterSubmitter(bridge, managers...)
+	submitter.VectorPartitionAdmission = admission
+	return submitter, nil
+}
+
+func (s *RaftClusterSubmitter) RequiresVectorPartitionMutationAdmissionV1(context.Context) (bool, error) {
+	return s != nil && s.VectorPartitionAdmission != nil, nil
+}
+
+func (s *RaftClusterSubmitter) AdmitVectorPartitionMutationV1(ctx context.Context, command iwire.CommandID, sections []iwire.Section) error {
+	if s == nil || s.VectorPartitionAdmission == nil {
+		return protocolError(iwire.ErrReadOnly, "vector partition lifecycle admission is not configured")
+	}
+	return s.VectorPartitionAdmission.AdmitVectorPartitionMutationV1(ctx, command, sections)
 }
 
 // RoutedRaftClusterSubmitter composes the concrete single-group Raft bridge

--- a/TreeDB/nativewire/cluster_raft_submitter.go
+++ b/TreeDB/nativewire/cluster_raft_submitter.go
@@ -45,6 +45,17 @@ func (s *RaftClusterSubmitter) AdmitVectorPartitionMutationV1(ctx context.Contex
 	return s.VectorPartitionAdmission.AdmitVectorPartitionMutationV1(ctx, command, sections)
 }
 
+func (s *RaftClusterSubmitter) ConfirmVectorPartitionMutationV1(ctx context.Context, command iwire.CommandID, sections []iwire.Section) error {
+	if s == nil || s.VectorPartitionAdmission == nil {
+		return protocolError(iwire.ErrReadOnly, "vector partition lifecycle admission is not configured")
+	}
+	confirmer, ok := s.VectorPartitionAdmission.(VectorPartitionMutationCommitProviderV1)
+	if !ok {
+		return protocolError(iwire.ErrReadOnly, "vector partition lifecycle mutation confirmation is not configured")
+	}
+	return confirmer.ConfirmVectorPartitionMutationV1(ctx, command, sections)
+}
+
 // RoutedRaftClusterSubmitter composes the concrete single-group Raft bridge
 // with a catalog-backed route provider. The base RaftClusterSubmitter does not
 // implement ClusterRouteProvider so existing no-provider behavior stays

--- a/TreeDB/nativewire/cluster_raft_submitter.go
+++ b/TreeDB/nativewire/cluster_raft_submitter.go
@@ -140,21 +140,22 @@ func (s *RaftClusterSubmitter) SubmitCommandEntryV1(ctx context.Context, entry [
 		return ClusterSubmitResult{}, protocolError(iwire.ErrInvalidCommand, "raft cluster submitter collection manager is not configured")
 	}
 	result, err := s.Bridge.SubmitCommandEntryV1(ctx, entry, metadata)
-	if err != nil {
-		return ClusterSubmitResult{}, nativeErrorForRaftClusterSubmit(err)
-	}
-	sections, err := raftClusterResponseSections(result.DecodedEntry, metadata, result, s.Collections)
-	if err != nil {
-		return ClusterSubmitResult{}, err
-	}
-	return ClusterSubmitResult{
+	clusterResult := ClusterSubmitResult{
 		ActualAck:            AckPolicy(result.ActualAck),
 		CommittedRecoverable: result.CommittedRecoverable,
 		CommittedApplied:     result.CommittedApplied,
-		ResponseSections:     sections,
 		CatalogVersion:       result.CatalogVersion,
 		HasCatalogVersion:    result.HasCatalogVersion,
-	}, nil
+	}
+	if err != nil {
+		return clusterResult, nativeErrorForRaftClusterSubmit(err)
+	}
+	sections, err := raftClusterResponseSections(result.DecodedEntry, metadata, result, s.Collections)
+	if err != nil {
+		return clusterResult, err
+	}
+	clusterResult.ResponseSections = sections
+	return clusterResult, nil
 }
 
 func raftClusterResponseSections(entry raftentry.CommandEntryV1, metadata ClusterRequestMetadata, result raftcluster.SubmitResultV1, manager *collections.CollectionManager) ([]iwire.Section, error) {

--- a/TreeDB/nativewire/cluster_route_provider.go
+++ b/TreeDB/nativewire/cluster_route_provider.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/snissn/gomap/TreeDB/internal/raftcluster"
 	"github.com/snissn/gomap/TreeDB/internal/raftplacement"
 )
 
@@ -14,6 +15,26 @@ import (
 // and activate routed ownership without a replicated proof.
 type CatalogRouteResolverV1 struct {
 	catalog raftplacement.ResolvedCatalogV1
+}
+
+// RequiresVectorPartitionMutationAdmissionV1 derives the shared mutation
+// requirement from replicated catalog configuration, independently of whether
+// an admission provider was installed on the submitter.
+func (p CatalogMetaClusterRouteProvider) RequiresVectorPartitionMutationAdmissionV1(ctx context.Context) (bool, error) {
+	if p.authority == nil {
+		return false, raftplacement.ErrCatalogMetaUnavailable
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if err := ctx.Err(); err != nil {
+		return false, err
+	}
+	status, ok := p.authority.Status()
+	if !ok {
+		return false, raftplacement.ErrCatalogMetaUnavailable
+	}
+	return raftcluster.FeatureSetRequiresV1(status.Features, raftcluster.FeatureVectorPartitionLifecycle), nil
 }
 
 // CatalogMetaProofProvider supplies a proof captured from the locally applied

--- a/TreeDB/nativewire/cluster_route_provider.go
+++ b/TreeDB/nativewire/cluster_route_provider.go
@@ -18,10 +18,11 @@ type CatalogRouteResolverV1 struct {
 }
 
 // RequiresVectorPartitionMutationAdmissionV1 derives the shared mutation
-// requirement from replicated catalog configuration, independently of whether
-// an admission provider was installed on the submitter.
+// requirement from a quorum-fenced replicated catalog view, independently of
+// whether an admission provider was installed on the submitter. A node whose
+// local authority has not caught up through the fence fails closed.
 func (p CatalogMetaClusterRouteProvider) RequiresVectorPartitionMutationAdmissionV1(ctx context.Context) (bool, error) {
-	if p.authority == nil {
+	if p.authority == nil || p.readFence == nil {
 		return false, raftplacement.ErrCatalogMetaUnavailable
 	}
 	if ctx == nil {
@@ -30,9 +31,19 @@ func (p CatalogMetaClusterRouteProvider) RequiresVectorPartitionMutationAdmissio
 	if err := ctx.Err(); err != nil {
 		return false, err
 	}
+	requiredAppliedIndex, err := p.readFence.LinearizableCatalogMetaAppliedIndexV1(ctx)
+	if err != nil {
+		return false, errors.Join(raftplacement.ErrCatalogMetaUnavailable, err)
+	}
 	status, ok := p.authority.Status()
 	if !ok {
 		return false, raftplacement.ErrCatalogMetaUnavailable
+	}
+	if requiredAppliedIndex == 0 || status.AppliedIndex < requiredAppliedIndex {
+		return false, errors.Join(
+			raftplacement.ErrCatalogMetaUnavailable,
+			fmt.Errorf("local catalog applied index %d is behind linearizable index %d", status.AppliedIndex, requiredAppliedIndex),
+		)
 	}
 	return raftcluster.FeatureSetRequiresV1(status.Features, raftcluster.FeatureVectorPartitionLifecycle), nil
 }
@@ -46,17 +57,23 @@ type CatalogMetaProofProvider func(context.Context) (raftplacement.CatalogProofV
 // CatalogMetaClusterRouteProvider is the production route provider. It never
 // activates a constructor-local catalog: every route is admitted by the
 // applied replicated CatalogMetaAuthorityV1 against an exact epoch and digest
-// proof.
+// proof. Mutation feature admission additionally requires a fresh linearizable
+// meta-Raft fence and local catch-up through that fence.
 type CatalogMetaClusterRouteProvider struct {
 	authority *raftplacement.CatalogMetaAuthorityV1
 	proof     CatalogMetaProofProvider
+	readFence CatalogMetaLinearizableAppliedIndexProviderV1
 }
 
-func NewCatalogMetaClusterRouteProvider(authority *raftplacement.CatalogMetaAuthorityV1, proof CatalogMetaProofProvider) (CatalogMetaClusterRouteProvider, error) {
-	if authority == nil || proof == nil {
-		return CatalogMetaClusterRouteProvider{}, errors.New("nativewire: replicated catalog meta authority and proof provider are required")
+func NewCatalogMetaClusterRouteProvider(
+	authority *raftplacement.CatalogMetaAuthorityV1,
+	proof CatalogMetaProofProvider,
+	readFence CatalogMetaLinearizableAppliedIndexProviderV1,
+) (CatalogMetaClusterRouteProvider, error) {
+	if authority == nil || proof == nil || readFence == nil {
+		return CatalogMetaClusterRouteProvider{}, errors.New("nativewire: replicated catalog meta authority, proof provider, and linearizable read fence are required")
 	}
-	return CatalogMetaClusterRouteProvider{authority: authority, proof: proof}, nil
+	return CatalogMetaClusterRouteProvider{authority: authority, proof: proof, readFence: readFence}, nil
 }
 
 func (p CatalogMetaClusterRouteProvider) ClusterRoute(ctx context.Context, request ClusterRouteRequest) (ClusterRouteTarget, error) {

--- a/TreeDB/nativewire/cluster_submitter.go
+++ b/TreeDB/nativewire/cluster_submitter.go
@@ -193,7 +193,11 @@ func ClusterUnavailableAdmission(reason string) ClusterAdmissionStatus {
 type ClusterSubmitResult struct {
 	ActualAck            AckPolicy
 	CommittedRecoverable bool
-	ResponseSections     []iwire.Section
+	// CommittedApplied is submitter-owned post-commit/apply evidence used only
+	// for lifecycle confirmation. Unlike CommittedRecoverable it does not
+	// depend on the acknowledgment policy selected by the client.
+	CommittedApplied bool
+	ResponseSections []iwire.Section
 	// CatalogVersion is internal post-apply evidence. It lets response shaping
 	// omit response_meta without hiding catalog-cache progress from the server.
 	CatalogVersion    uint64
@@ -271,7 +275,7 @@ func (s *Server) handleClusterMutation(ctx context.Context, header iwire.Header,
 	if err != nil {
 		return nil, err
 	}
-	if result.CommittedRecoverable {
+	if result.CommittedApplied {
 		if err := ConfirmVectorPartitionMutationV1(ctx, s.clusterSubmitter, cmd.Header.ID, cmd.Known); err != nil {
 			return nil, err
 		}

--- a/TreeDB/nativewire/cluster_submitter.go
+++ b/TreeDB/nativewire/cluster_submitter.go
@@ -89,6 +89,14 @@ type VectorPartitionMutationAdmissionProviderV1 interface {
 	AdmitVectorPartitionMutationV1(context.Context, iwire.CommandID, []iwire.Section) error
 }
 
+// VectorPartitionMutationCommitProviderV1 is called only after the data
+// command has a definitive committed-and-recoverable result.  It releases the
+// replicated lifecycle freeze installed by admission; ambiguous or failed
+// submissions deliberately do not call it.
+type VectorPartitionMutationCommitProviderV1 interface {
+	ConfirmVectorPartitionMutationV1(context.Context, iwire.CommandID, []iwire.Section) error
+}
+
 // VectorPartitionMutationAdmissionRequiredV1 marks an M7-enabled shared
 // submitter. It prevents a wiring error from degrading an active lifecycle to
 // the legacy optional path: a required submitter without an admission provider
@@ -122,6 +130,26 @@ func AdmitVectorPartitionMutationV1(ctx context.Context, submitter ClusterSubmit
 		return nil
 	}
 	return admitter.AdmitVectorPartitionMutationV1(ctx, command, cloneSections(sections))
+}
+
+func ConfirmVectorPartitionMutationV1(ctx context.Context, submitter ClusterSubmitter, command iwire.CommandID, sections []iwire.Section) error {
+	if required, ok := submitter.(VectorPartitionMutationAdmissionRequiredV1); ok {
+		enabled, err := required.RequiresVectorPartitionMutationAdmissionV1(ctx)
+		if err != nil {
+			return err
+		}
+		if !enabled {
+			return nil
+		}
+	}
+	confirmer, ok := submitter.(VectorPartitionMutationCommitProviderV1)
+	if !ok {
+		if _, required := submitter.(VectorPartitionMutationAdmissionRequiredV1); required {
+			return protocolError(iwire.ErrReadOnly, "vector partition lifecycle mutation confirmation is required but not configured")
+		}
+		return nil
+	}
+	return confirmer.ConfirmVectorPartitionMutationV1(ctx, command, cloneSections(sections))
 }
 
 // ClusterAdmissionStatus describes whether this node may accept cluster-owned
@@ -230,6 +258,11 @@ func (s *Server) handleClusterMutation(ctx context.Context, header iwire.Header,
 	result, err := s.clusterSubmitter.SubmitCommandEntryV1(ctx, entry, metadata)
 	if err != nil {
 		return nil, err
+	}
+	if result.CommittedRecoverable {
+		if err := ConfirmVectorPartitionMutationV1(ctx, s.clusterSubmitter, cmd.Header.ID, cmd.Known); err != nil {
+			return nil, err
+		}
 	}
 	if err := validateClusterSubmitResult(metadata, result); err != nil {
 		return nil, err

--- a/TreeDB/nativewire/cluster_submitter.go
+++ b/TreeDB/nativewire/cluster_submitter.go
@@ -222,9 +222,6 @@ func (s *Server) handleClusterMutation(ctx context.Context, header iwire.Header,
 	if err != nil {
 		return nil, err
 	}
-	if err := AdmitVectorPartitionMutationV1(ctx, s.clusterSubmitter, cmd.Header.ID, cmd.Known); err != nil {
-		return nil, err
-	}
 	entry, err := iwire.AppendDeterministicEntryWithLimits(nil, cmd, s.limits)
 	if err != nil {
 		return nil, err
@@ -254,6 +251,12 @@ func (s *Server) handleClusterMutation(ctx context.Context, header iwire.Header,
 			return nil, err
 		}
 		ApplyClusterRouteMetadata(&metadata, routeReq, route)
+	}
+	// Durable lifecycle admission is deliberately last: every fallible local
+	// encode/decode and route preflight has completed, so a refusal cannot
+	// strand a replicated pending mutation barrier without a data submission.
+	if err := AdmitVectorPartitionMutationV1(ctx, s.clusterSubmitter, cmd.Header.ID, cmd.Known); err != nil {
+		return nil, err
 	}
 	result, err := s.clusterSubmitter.SubmitCommandEntryV1(ctx, entry, metadata)
 	if err != nil {

--- a/TreeDB/nativewire/cluster_submitter.go
+++ b/TreeDB/nativewire/cluster_submitter.go
@@ -3,6 +3,7 @@ package nativewire
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"strconv"
 	"time"
@@ -288,14 +289,14 @@ func (s *Server) handleClusterMutation(ctx context.Context, header iwire.Header,
 	if err := AdmitVectorPartitionMutationV1(ctx, s.clusterSubmitter, cmd.Header.ID, cmd.Known); err != nil {
 		return nil, err
 	}
-	result, err := s.clusterSubmitter.SubmitCommandEntryV1(ctx, entry, metadata)
-	if err != nil {
-		return nil, err
-	}
+	result, submitErr := s.clusterSubmitter.SubmitCommandEntryV1(ctx, entry, metadata)
 	if result.CommittedApplied {
 		if err := ConfirmCommittedVectorPartitionMutationV1(ctx, s.clusterSubmitter, cmd.Header.ID, cmd.Known); err != nil {
-			return nil, err
+			return nil, errors.Join(submitErr, err)
 		}
+	}
+	if submitErr != nil {
+		return nil, submitErr
 	}
 	if err := validateClusterSubmitResult(metadata, result); err != nil {
 		return nil, err

--- a/TreeDB/nativewire/cluster_submitter.go
+++ b/TreeDB/nativewire/cluster_submitter.go
@@ -97,6 +97,15 @@ type VectorPartitionMutationCommitProviderV1 interface {
 	ConfirmVectorPartitionMutationV1(context.Context, iwire.CommandID, []iwire.Section) error
 }
 
+// VectorPartitionMutationLifecycleProviderV1 is the complete M7 mutation
+// lifecycle contract. Production wiring must provide both admission and
+// post-commit confirmation so a committed data mutation cannot strand its
+// replicated lifecycle fence in the pending state.
+type VectorPartitionMutationLifecycleProviderV1 interface {
+	VectorPartitionMutationAdmissionProviderV1
+	VectorPartitionMutationCommitProviderV1
+}
+
 // VectorPartitionMutationAdmissionRequiredV1 marks an M7-enabled shared
 // submitter. It prevents a wiring error from degrading an active lifecycle to
 // the legacy optional path: a required submitter without an admission provider

--- a/TreeDB/nativewire/cluster_submitter.go
+++ b/TreeDB/nativewire/cluster_submitter.go
@@ -105,16 +105,19 @@ func AdmitVectorPartitionMutationV1(ctx context.Context, submitter ClusterSubmit
 	if submitter == nil {
 		return protocolError(iwire.ErrInvalidCommand, "nativewire cluster submitter is not configured")
 	}
+	if required, ok := submitter.(VectorPartitionMutationAdmissionRequiredV1); ok {
+		enabled, err := required.RequiresVectorPartitionMutationAdmissionV1(ctx)
+		if err != nil {
+			return err
+		}
+		if !enabled {
+			return nil
+		}
+	}
 	admitter, ok := submitter.(VectorPartitionMutationAdmissionProviderV1)
 	if !ok {
-		if required, ok := submitter.(VectorPartitionMutationAdmissionRequiredV1); ok {
-			enabled, err := required.RequiresVectorPartitionMutationAdmissionV1(ctx)
-			if err != nil {
-				return err
-			}
-			if enabled {
-				return protocolError(iwire.ErrReadOnly, "vector partition lifecycle admission is required but not configured")
-			}
+		if _, required := submitter.(VectorPartitionMutationAdmissionRequiredV1); required {
+			return protocolError(iwire.ErrReadOnly, "vector partition lifecycle admission is required but not configured")
 		}
 		return nil
 	}

--- a/TreeDB/nativewire/cluster_submitter.go
+++ b/TreeDB/nativewire/cluster_submitter.go
@@ -23,6 +23,8 @@ type ClusterSubmitter interface {
 	SubmitCommandEntryV1(ctx context.Context, entry []byte, metadata ClusterRequestMetadata) (ClusterSubmitResult, error)
 }
 
+const committedVectorPartitionMutationConfirmationTimeoutV1 = 30 * time.Second
+
 // ClusterRouteProvider is an optional ClusterSubmitter extension for
 // collection-level route preflight. Providers should use catalog-derived route
 // decisions only; leader hints are metadata and are not live leadership proof.
@@ -161,6 +163,21 @@ func ConfirmVectorPartitionMutationV1(ctx context.Context, submitter ClusterSubm
 	return confirmer.ConfirmVectorPartitionMutationV1(ctx, command, cloneSections(sections))
 }
 
+// ConfirmCommittedVectorPartitionMutationV1 completes the lifecycle fence
+// after the data command is known committed and applied. At that point client
+// cancellation must not strand durable admission state, so confirmation uses
+// an internally bounded context detached from the request cancellation and
+// deadline while retaining request values for observability.
+func ConfirmCommittedVectorPartitionMutationV1(ctx context.Context, submitter ClusterSubmitter, command iwire.CommandID, sections []iwire.Section) error {
+	base := context.Background()
+	if ctx != nil {
+		base = context.WithoutCancel(ctx)
+	}
+	confirmCtx, cancel := context.WithTimeout(base, committedVectorPartitionMutationConfirmationTimeoutV1)
+	defer cancel()
+	return ConfirmVectorPartitionMutationV1(confirmCtx, submitter, command, sections)
+}
+
 // ClusterAdmissionStatus describes whether this node may accept cluster-owned
 // writes. A provider must set Leader for write admission; the zero value fails
 // closed as not-leader when returned by a configured provider.
@@ -276,7 +293,7 @@ func (s *Server) handleClusterMutation(ctx context.Context, header iwire.Header,
 		return nil, err
 	}
 	if result.CommittedApplied {
-		if err := ConfirmVectorPartitionMutationV1(ctx, s.clusterSubmitter, cmd.Header.ID, cmd.Known); err != nil {
+		if err := ConfirmCommittedVectorPartitionMutationV1(ctx, s.clusterSubmitter, cmd.Header.ID, cmd.Known); err != nil {
 			return nil, err
 		}
 	}

--- a/TreeDB/nativewire/cluster_submitter.go
+++ b/TreeDB/nativewire/cluster_submitter.go
@@ -89,6 +89,14 @@ type VectorPartitionMutationAdmissionProviderV1 interface {
 	AdmitVectorPartitionMutationV1(context.Context, iwire.CommandID, []iwire.Section) error
 }
 
+// VectorPartitionMutationAdmissionRequiredV1 marks an M7-enabled shared
+// submitter. It prevents a wiring error from degrading an active lifecycle to
+// the legacy optional path: a required submitter without an admission provider
+// is rejected before deterministic entry encoding.
+type VectorPartitionMutationAdmissionRequiredV1 interface {
+	RequiresVectorPartitionMutationAdmissionV1(context.Context) (bool, error)
+}
+
 // AdmitVectorPartitionMutationV1 invokes the optional M7 admission extension.
 // A plain cluster submitter remains valid for non-vector deployments; an M7
 // deployment installs this on its shared submitter so no frontend can bypass
@@ -99,6 +107,15 @@ func AdmitVectorPartitionMutationV1(ctx context.Context, submitter ClusterSubmit
 	}
 	admitter, ok := submitter.(VectorPartitionMutationAdmissionProviderV1)
 	if !ok {
+		if required, ok := submitter.(VectorPartitionMutationAdmissionRequiredV1); ok {
+			enabled, err := required.RequiresVectorPartitionMutationAdmissionV1(ctx)
+			if err != nil {
+				return err
+			}
+			if enabled {
+				return protocolError(iwire.ErrReadOnly, "vector partition lifecycle admission is required but not configured")
+			}
+		}
 		return nil
 	}
 	return admitter.AdmitVectorPartitionMutationV1(ctx, command, cloneSections(sections))

--- a/TreeDB/nativewire/cluster_submitter.go
+++ b/TreeDB/nativewire/cluster_submitter.go
@@ -90,9 +90,9 @@ type VectorPartitionMutationAdmissionProviderV1 interface {
 }
 
 // VectorPartitionMutationCommitProviderV1 is called only after the data
-// command has a definitive committed-and-recoverable result.  It releases the
-// replicated lifecycle freeze installed by admission; ambiguous or failed
-// submissions deliberately do not call it.
+// command has definitively committed and completed deterministic local apply.
+// It releases the replicated lifecycle freeze installed by admission;
+// ambiguous or failed submissions deliberately do not call it.
 type VectorPartitionMutationCommitProviderV1 interface {
 	ConfirmVectorPartitionMutationV1(context.Context, iwire.CommandID, []iwire.Section) error
 }

--- a/TreeDB/nativewire/cluster_submitter.go
+++ b/TreeDB/nativewire/cluster_submitter.go
@@ -24,6 +24,13 @@ type ClusterSubmitter interface {
 	SubmitCommandEntryV1(ctx context.Context, entry []byte, metadata ClusterRequestMetadata) (ClusterSubmitResult, error)
 }
 
+// ClusterSubmitterWithPreCommitV1 is the M7-safe submit extension. The callback
+// must run after the data layer's deterministic preflight succeeds and before
+// the command is offered to consensus, under the same serialization boundary.
+type ClusterSubmitterWithPreCommitV1 interface {
+	SubmitCommandEntryWithPreCommitV1(ctx context.Context, entry []byte, metadata ClusterRequestMetadata, preCommit func(context.Context) error) (ClusterSubmitResult, error)
+}
+
 const committedVectorPartitionMutationConfirmationTimeoutV1 = 30 * time.Second
 
 // ClusterRouteProvider is an optional ClusterSubmitter extension for
@@ -109,6 +116,13 @@ type VectorPartitionMutationLifecycleProviderV1 interface {
 	VectorPartitionMutationCommitProviderV1
 }
 
+// VectorPartitionMutationLifecycleReadinessV1 lets a concrete submitter fail
+// closed when it exposes lifecycle methods but their backing coordinator is
+// not configured.
+type VectorPartitionMutationLifecycleReadinessV1 interface {
+	ValidateVectorPartitionMutationLifecycleV1() error
+}
+
 // VectorPartitionMutationAdmissionRequiredV1 marks an M7-enabled shared
 // submitter. It prevents a wiring error from degrading an active lifecycle to
 // the legacy optional path: a required submitter without an admission provider
@@ -142,6 +156,46 @@ func AdmitVectorPartitionMutationV1(ctx context.Context, submitter ClusterSubmit
 		return nil
 	}
 	return admitter.AdmitVectorPartitionMutationV1(ctx, command, cloneSections(sections))
+}
+
+// SubmitCommandEntryWithVectorPartitionAdmissionV1 orders lifecycle admission
+// inside the data submitter's deterministic preflight-to-commit boundary for
+// an M7-required deployment. A definite data-preflight rejection therefore
+// cannot publish a pending lifecycle barrier. Legacy optional admission remains
+// supported for non-M7 test and integration submitters.
+func SubmitCommandEntryWithVectorPartitionAdmissionV1(ctx context.Context, submitter ClusterSubmitter, command iwire.CommandID, sections []iwire.Section, entry []byte, metadata ClusterRequestMetadata) (ClusterSubmitResult, error) {
+	if submitter == nil {
+		return ClusterSubmitResult{}, protocolError(iwire.ErrInvalidCommand, "nativewire cluster submitter is not configured")
+	}
+	required, hasRequirement := submitter.(VectorPartitionMutationAdmissionRequiredV1)
+	if !hasRequirement {
+		if err := AdmitVectorPartitionMutationV1(ctx, submitter, command, sections); err != nil {
+			return ClusterSubmitResult{}, err
+		}
+		return submitter.SubmitCommandEntryV1(ctx, entry, metadata)
+	}
+	enabled, err := required.RequiresVectorPartitionMutationAdmissionV1(ctx)
+	if err != nil {
+		return ClusterSubmitResult{}, err
+	}
+	if !enabled {
+		return submitter.SubmitCommandEntryV1(ctx, entry, metadata)
+	}
+	if readiness, ok := submitter.(VectorPartitionMutationLifecycleReadinessV1); ok {
+		if err := readiness.ValidateVectorPartitionMutationLifecycleV1(); err != nil {
+			return ClusterSubmitResult{}, err
+		}
+	}
+	if _, ok := submitter.(VectorPartitionMutationLifecycleProviderV1); !ok {
+		return ClusterSubmitResult{}, protocolError(iwire.ErrReadOnly, "vector partition lifecycle admission and confirmation are required but not configured")
+	}
+	atomicSubmitter, ok := submitter.(ClusterSubmitterWithPreCommitV1)
+	if !ok {
+		return ClusterSubmitResult{}, protocolError(iwire.ErrReadOnly, "vector partition lifecycle requires serialized data preflight and admission")
+	}
+	return atomicSubmitter.SubmitCommandEntryWithPreCommitV1(ctx, entry, metadata, func(callbackCtx context.Context) error {
+		return AdmitVectorPartitionMutationV1(callbackCtx, submitter, command, sections)
+	})
 }
 
 func ConfirmVectorPartitionMutationV1(ctx context.Context, submitter ClusterSubmitter, command iwire.CommandID, sections []iwire.Section) error {
@@ -283,13 +337,10 @@ func (s *Server) handleClusterMutation(ctx context.Context, header iwire.Header,
 		}
 		ApplyClusterRouteMetadata(&metadata, routeReq, route)
 	}
-	// Durable lifecycle admission is deliberately last: every fallible local
-	// encode/decode and route preflight has completed, so a refusal cannot
-	// strand a replicated pending mutation barrier without a data submission.
-	if err := AdmitVectorPartitionMutationV1(ctx, s.clusterSubmitter, cmd.Header.ID, cmd.Known); err != nil {
-		return nil, err
-	}
-	result, submitErr := s.clusterSubmitter.SubmitCommandEntryV1(ctx, entry, metadata)
+	// M7-required admission runs inside the submitter after deterministic data
+	// preflight and immediately before commit. This prevents a definite
+	// idempotency/schema rejection from stranding a replicated lifecycle fence.
+	result, submitErr := SubmitCommandEntryWithVectorPartitionAdmissionV1(ctx, s.clusterSubmitter, cmd.Header.ID, cmd.Known, entry, metadata)
 	if result.CommittedApplied {
 		if err := ConfirmCommittedVectorPartitionMutationV1(ctx, s.clusterSubmitter, cmd.Header.ID, cmd.Known); err != nil {
 			return nil, errors.Join(submitErr, err)

--- a/TreeDB/nativewire/cluster_submitter.go
+++ b/TreeDB/nativewire/cluster_submitter.go
@@ -74,6 +74,36 @@ type ClusterAdmissionProvider interface {
 	ClusterAdmissionStatus(ctx context.Context) (ClusterAdmissionStatus, error)
 }
 
+// VectorPartitionMutationAdmissionProviderV1 is the M7 extension point for
+// submitters that own both a catalog/meta lifecycle coordinator and collection
+// schema knowledge. It receives the already registry-validated, bounded
+// native-wire command before deterministic entry encoding or Raft submission.
+// Implementations classify vector-field and DDL effects conservatively and
+// must return only after invalidation-before-mutation is durably proven.
+//
+// The interface deliberately receives command sections instead of a decoded
+// document graph: classification remains at the shared submit boundary used by
+// nativewire, Mongo, retry, and replay callers, while the registry's existing
+// bounds remain the sole wire-size authority.
+type VectorPartitionMutationAdmissionProviderV1 interface {
+	AdmitVectorPartitionMutationV1(context.Context, iwire.CommandID, []iwire.Section) error
+}
+
+// AdmitVectorPartitionMutationV1 invokes the optional M7 admission extension.
+// A plain cluster submitter remains valid for non-vector deployments; an M7
+// deployment installs this on its shared submitter so no frontend can bypass
+// classification or durable invalidation.
+func AdmitVectorPartitionMutationV1(ctx context.Context, submitter ClusterSubmitter, command iwire.CommandID, sections []iwire.Section) error {
+	if submitter == nil {
+		return protocolError(iwire.ErrInvalidCommand, "nativewire cluster submitter is not configured")
+	}
+	admitter, ok := submitter.(VectorPartitionMutationAdmissionProviderV1)
+	if !ok {
+		return nil
+	}
+	return admitter.AdmitVectorPartitionMutationV1(ctx, command, cloneSections(sections))
+}
+
 // ClusterAdmissionStatus describes whether this node may accept cluster-owned
 // writes. A provider must set Leader for write admission; the zero value fails
 // closed as not-leader when returned by a configured provider.
@@ -142,6 +172,9 @@ func (s *Server) handleClusterMutation(ctx context.Context, header iwire.Header,
 	}
 	metadata, err := clusterRequestMetadata(header, cmd.Header, cmd.Known, ack)
 	if err != nil {
+		return nil, err
+	}
+	if err := AdmitVectorPartitionMutationV1(ctx, s.clusterSubmitter, cmd.Header.ID, cmd.Known); err != nil {
 		return nil, err
 	}
 	entry, err := iwire.AppendDeterministicEntryWithLimits(nil, cmd, s.limits)

--- a/TreeDB/nativewire/cluster_submitter_test.go
+++ b/TreeDB/nativewire/cluster_submitter_test.go
@@ -104,12 +104,13 @@ func (lifecycleRequiredNoAdmissionClusterSubmitter) RequiresVectorPartitionMutat
 }
 
 type recordingRaftCommandSubmitter struct {
-	groupID raftcluster.GroupID
-	manager *collections.CollectionManager
-	status  raftcluster.AdmissionStatus
-	err     error
-	mu      sync.Mutex
-	calls   []recordingRaftCommandSubmitCall
+	groupID  raftcluster.GroupID
+	features raftcluster.FeatureSet
+	manager  *collections.CollectionManager
+	status   raftcluster.AdmissionStatus
+	err      error
+	mu       sync.Mutex
+	calls    []recordingRaftCommandSubmitCall
 }
 
 type recordingRaftCommandSubmitCall struct {
@@ -118,7 +119,7 @@ type recordingRaftCommandSubmitCall struct {
 }
 
 func (s *recordingRaftCommandSubmitter) Config() raftcluster.ResolvedConfig {
-	return raftcluster.ResolvedConfig{GroupID: s.groupID}
+	return raftcluster.ResolvedConfig{GroupID: s.groupID, Features: s.features}
 }
 
 func (s *recordingRaftCommandSubmitter) ClusterAdmissionStatus(context.Context) (raftcluster.AdmissionStatus, error) {
@@ -802,6 +803,66 @@ func TestClusterSubmitterRequiredVectorAdmissionFailsClosedWhenMisconfiguredV1(t
 		[][]byte{[]byte("u1")}, [][]byte{[]byte(`{"embedding":[1,2]}`)}, AckVisible)
 	if err == nil {
 		t.Fatal("misconfigured M7 admission unexpectedly submitted mutation")
+	}
+}
+
+func TestLegacyRaftClusterSubmitterRequiresVectorAdmissionFromClusterFeatureV1(t *testing.T) {
+	features := raftcluster.DefaultFeatureSet()
+	features.Required = append(features.Required, raftcluster.RequiredFeature{
+		Name:    raftcluster.FeatureVectorPartitionLifecycle,
+		Version: raftcluster.SupportedFeatureFloors[raftcluster.FeatureVectorPartitionLifecycle],
+	})
+	bridge := &recordingRaftCommandSubmitter{groupID: "group-a", features: features}
+	submitter := NewRaftClusterSubmitter(bridge)
+	required, err := submitter.RequiresVectorPartitionMutationAdmissionV1(context.Background())
+	if err != nil {
+		t.Fatalf("RequiresVectorPartitionMutationAdmissionV1: %v", err)
+	}
+	if !required {
+		t.Fatal("vector partition admission requirement=false want true from bridge feature config")
+	}
+	client, _, _ := serveCollectionPipeWithOptions(t, ServerOptions{ClusterSubmitter: submitter})
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	if err := client.Hello(ctx); err != nil {
+		t.Fatalf("Hello: %v", err)
+	}
+	if _, err := client.InsertBatch(ctx, "users", collections.DocumentFormatJSON,
+		[][]byte{[]byte("u1")}, [][]byte{[]byte(`{"embedding":[1,2]}`)}, AckVisible); !isRemoteError(err, iwire.ErrReadOnly) {
+		t.Fatalf("InsertBatch err=%v want read-only missing lifecycle provider", err)
+	}
+	if calls := bridge.snapshotCalls(); len(calls) != 0 {
+		t.Fatalf("legacy constructor submitted %d entries before required lifecycle admission", len(calls))
+	}
+}
+
+func TestCatalogRoutedLegacySubmitterRequiresVectorAdmissionFromCatalogFeatureV1(t *testing.T) {
+	authority, _ := newNativewireCatalogMetaAuthorityWithLifecycle(t, true)
+	provider, err := NewCatalogMetaClusterRouteProvider(authority, authority.CurrentCatalogProof)
+	if err != nil {
+		t.Fatalf("NewCatalogMetaClusterRouteProvider: %v", err)
+	}
+	bridge := &recordingRaftCommandSubmitter{groupID: "group-a"}
+	submitter := NewRoutedRaftClusterSubmitter(bridge, provider)
+	required, err := submitter.RequiresVectorPartitionMutationAdmissionV1(context.Background())
+	if err != nil {
+		t.Fatalf("RequiresVectorPartitionMutationAdmissionV1: %v", err)
+	}
+	if !required {
+		t.Fatal("vector partition admission requirement=false want true from replicated catalog feature")
+	}
+	client, _, _ := serveCollectionPipeWithOptions(t, ServerOptions{ClusterSubmitter: submitter})
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	if err := client.Hello(ctx); err != nil {
+		t.Fatalf("Hello: %v", err)
+	}
+	if _, err := client.InsertBatch(ctx, "users", collections.DocumentFormatJSON,
+		[][]byte{[]byte("u1")}, [][]byte{[]byte(`{"embedding":[1,2]}`)}, AckVisible); !isRemoteError(err, iwire.ErrReadOnly) {
+		t.Fatalf("InsertBatch err=%v want read-only missing lifecycle provider", err)
+	}
+	if calls := bridge.snapshotCalls(); len(calls) != 0 {
+		t.Fatalf("routed legacy constructor submitted %d entries before required lifecycle admission", len(calls))
 	}
 }
 
@@ -3426,6 +3487,10 @@ func serveCatalogMetaGroupRoutedRaftClusterBridgePipe(t testing.TB, routeProvide
 }
 
 func newNativewireCatalogMetaAuthority(t testing.TB) (*raftplacement.CatalogMetaAuthorityV1, *raftcluster.CatalogMetaRaftProviderV1) {
+	return newNativewireCatalogMetaAuthorityWithLifecycle(t, false)
+}
+
+func newNativewireCatalogMetaAuthorityWithLifecycle(t testing.TB, lifecycle bool) (*raftplacement.CatalogMetaAuthorityV1, *raftcluster.CatalogMetaRaftProviderV1) {
 	t.Helper()
 	authority := raftplacement.NewCatalogMetaAuthorityV1()
 	_, transport := hraft.NewInmemTransport("meta-a")
@@ -3465,15 +3530,27 @@ func newNativewireCatalogMetaAuthority(t testing.TB) (*raftplacement.CatalogMeta
 		case <-time.After(time.Millisecond):
 		}
 	}
-	if _, _, err := provider.SubmitCatalogMetaCommandV1(ctx, nativewireCatalogMetaCommand(t, 0, 1)); err != nil {
+	if _, _, err := provider.SubmitCatalogMetaCommandV1(ctx, nativewireCatalogMetaCommandWithLifecycle(t, 0, 1, lifecycle)); err != nil {
 		t.Fatalf("submit initial catalog meta: %v", err)
 	}
 	return authority, provider
 }
 
 func nativewireCatalogMetaCommand(t testing.TB, expected, epoch uint64) []byte {
+	return nativewireCatalogMetaCommandWithLifecycle(t, expected, epoch, false)
+}
+
+func nativewireCatalogMetaCommandWithLifecycle(t testing.TB, expected, epoch uint64, lifecycle bool) []byte {
 	t.Helper()
+	features := raftplacement.DefaultFeatureSet()
+	if lifecycle {
+		features.Required = append(features.Required, raftcluster.RequiredFeature{
+			Name:    raftcluster.FeatureVectorPartitionLifecycle,
+			Version: raftcluster.SupportedFeatureFloors[raftcluster.FeatureVectorPartitionLifecycle],
+		})
+	}
 	record, err := raftplacement.NewCatalogMetaRecordV1(epoch, raftplacement.CatalogV1{
+		Features: features,
 		Groups: []raftplacement.GroupV1{
 			{ID: "group-a", Members: []raftcluster.NodeID{"node-a", "node-c"}, LeaderHint: "node-a"},
 			{ID: "group-b", Members: []raftcluster.NodeID{"node-b", "node-c"}, LeaderHint: "node-b"},

--- a/TreeDB/nativewire/cluster_submitter_test.go
+++ b/TreeDB/nativewire/cluster_submitter_test.go
@@ -37,17 +37,19 @@ type fakeClusterSubmitter struct {
 
 type confirmingVectorPartitionClusterSubmitterV1 struct {
 	*fakeClusterSubmitter
-	mu            sync.Mutex
-	confirmations []iwire.CommandID
+	mu                        sync.Mutex
+	confirmations             []iwire.CommandID
+	confirmationContextErrors []error
 }
 
 func (s *confirmingVectorPartitionClusterSubmitterV1) RequiresVectorPartitionMutationAdmissionV1(context.Context) (bool, error) {
 	return true, nil
 }
 
-func (s *confirmingVectorPartitionClusterSubmitterV1) ConfirmVectorPartitionMutationV1(_ context.Context, command iwire.CommandID, _ []iwire.Section) error {
+func (s *confirmingVectorPartitionClusterSubmitterV1) ConfirmVectorPartitionMutationV1(ctx context.Context, command iwire.CommandID, _ []iwire.Section) error {
 	s.mu.Lock()
 	s.confirmations = append(s.confirmations, command)
+	s.confirmationContextErrors = append(s.confirmationContextErrors, ctx.Err())
 	s.mu.Unlock()
 	return nil
 }
@@ -722,6 +724,44 @@ func TestClusterSubmitterVisibleAckConfirmsCommittedVectorMutationV1(t *testing.
 	submitter.mu.Unlock()
 	if !reflect.DeepEqual(confirmations, []iwire.CommandID{iwire.CommandInsertBatch}) {
 		t.Fatalf("confirmations=%v want insert_batch", confirmations)
+	}
+}
+
+func TestClusterSubmitterCommittedVectorConfirmationOutlivesClientCancellationV1(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	submitter := &confirmingVectorPartitionClusterSubmitterV1{fakeClusterSubmitter: &fakeClusterSubmitter{}}
+	submitter.resultHook = func(_ raftentry.CommandEntryV1, _ ClusterRequestMetadata, result ClusterSubmitResult) (ClusterSubmitResult, error) {
+		cancel()
+		return result, nil
+	}
+	client, server, _, _ := serveCollectionPipeWithServerAndOptions(t, ServerOptions{ClusterSubmitter: submitter})
+	setupCtx, setupCancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer setupCancel()
+	if err := client.Hello(setupCtx); err != nil {
+		t.Fatalf("Hello: %v", err)
+	}
+	body, err := appendCommandRequestBody(nil, iwire.CommandInsertBatch, clusterInsertBatchSections(t, client, setupCtx, AckVisible, "u1")...)
+	if err != nil {
+		t.Fatalf("append request body: %v", err)
+	}
+	sections, err := iwire.DecodeSections(body, server.limits)
+	if err != nil {
+		t.Fatalf("decode request body: %v", err)
+	}
+	cmd, err := server.registry.ValidateRequestSections(sections)
+	if err != nil {
+		t.Fatalf("validate request sections: %v", err)
+	}
+	if _, err := server.handleClusterMutation(ctx, iwire.Header{Type: iwire.FrameRequest, RequestID: 1}, cmd); err != nil {
+		t.Fatalf("handle committed mutation after client cancellation: %v", err)
+	}
+	if !errors.Is(ctx.Err(), context.Canceled) {
+		t.Fatalf("request context err=%v want canceled", ctx.Err())
+	}
+	submitter.mu.Lock()
+	defer submitter.mu.Unlock()
+	if len(submitter.confirmationContextErrors) != 1 || submitter.confirmationContextErrors[0] != nil {
+		t.Fatalf("confirmation context errors=%v want [nil]", submitter.confirmationContextErrors)
 	}
 }
 

--- a/TreeDB/nativewire/cluster_submitter_test.go
+++ b/TreeDB/nativewire/cluster_submitter_test.go
@@ -72,6 +72,18 @@ func (noAdmissionClusterSubmitter) SubmitCommandEntryV1(context.Context, []byte,
 	panic("unexpected submit")
 }
 
+type lifecycleRequiredNoAdmissionClusterSubmitter struct{}
+
+func (lifecycleRequiredNoAdmissionClusterSubmitter) SubmitCommandEntryV1(context.Context, []byte, ClusterRequestMetadata) (ClusterSubmitResult, error) {
+	panic("unexpected submit")
+}
+func (lifecycleRequiredNoAdmissionClusterSubmitter) ClusterAdmissionStatus(context.Context) (ClusterAdmissionStatus, error) {
+	return ClusterLeaderAdmission(), nil
+}
+func (lifecycleRequiredNoAdmissionClusterSubmitter) RequiresVectorPartitionMutationAdmissionV1(context.Context) (bool, error) {
+	return true, nil
+}
+
 type recordingRaftCommandSubmitter struct {
 	groupID raftcluster.GroupID
 	manager *collections.CollectionManager
@@ -671,6 +683,20 @@ func TestClusterSubmitterVectorPartitionAdmissionRunsBeforeRaftSubmitV1(t *testi
 	}
 	if calls := submitter.snapshot(); len(calls) != 1 {
 		t.Fatalf("successful admission submitted %d Raft entries", len(calls))
+	}
+}
+
+func TestClusterSubmitterRequiredVectorAdmissionFailsClosedWhenMisconfiguredV1(t *testing.T) {
+	client, _, _ := serveCollectionPipeWithOptions(t, ServerOptions{ClusterSubmitter: lifecycleRequiredNoAdmissionClusterSubmitter{}})
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	if err := client.Hello(ctx); err != nil {
+		t.Fatalf("Hello: %v", err)
+	}
+	_, err := client.InsertBatch(ctx, "users", collections.DocumentFormatJSON,
+		[][]byte{[]byte("u1")}, [][]byte{[]byte(`{"embedding":[1,2]}`)}, AckVisible)
+	if err == nil {
+		t.Fatal("misconfigured M7 admission unexpectedly submitted mutation")
 	}
 }
 

--- a/TreeDB/nativewire/cluster_submitter_test.go
+++ b/TreeDB/nativewire/cluster_submitter_test.go
@@ -113,6 +113,15 @@ type recordingRaftCommandSubmitter struct {
 	calls    []recordingRaftCommandSubmitCall
 }
 
+type fixedResultRaftCommandSubmitter struct {
+	result raftcluster.SubmitResultV1
+	err    error
+}
+
+func (s fixedResultRaftCommandSubmitter) SubmitCommandEntryV1(context.Context, []byte, raftentry.RequestMetadataV1) (raftcluster.SubmitResultV1, error) {
+	return s.result, s.err
+}
+
 type recordingRaftCommandSubmitCall struct {
 	entry    raftentry.CommandEntryV1
 	metadata raftentry.RequestMetadataV1
@@ -2847,6 +2856,38 @@ func TestRaftClusterSubmitterRequiresCollectionManagerBeforeSubmit(t *testing.T)
 	}
 	if preflightCalls != 0 || commitCalls != 0 || applier.calls != 0 {
 		t.Fatalf("bridge touched before collection-manager validation: preflight=%d commit=%d apply=%d", preflightCalls, commitCalls, applier.calls)
+	}
+}
+
+func TestRaftClusterSubmitterPreservesCommittedAppliedThroughErrorsV1(t *testing.T) {
+	db, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("Open DB: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+	manager := collections.NewCollectionManager(db)
+	base := raftcluster.SubmitResultV1{
+		ActualAck:        iwire.AckVisible,
+		CommittedApplied: true,
+		ApplyResult:      raftentry.ApplyResultV1{Status: raftentry.ApplyStatusApplied},
+	}
+	tests := []struct {
+		name   string
+		bridge fixedResultRaftCommandSubmitter
+	}{
+		{name: "bridge error", bridge: fixedResultRaftCommandSubmitter{result: base, err: raftcluster.ErrLocalApplyNotRecoverable}},
+		{name: "response shaping error", bridge: fixedResultRaftCommandSubmitter{result: base}},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			result, err := NewRaftClusterSubmitter(test.bridge, manager).SubmitCommandEntryV1(context.Background(), nil, ClusterRequestMetadata{})
+			if err == nil {
+				t.Fatal("SubmitCommandEntryV1 unexpectedly succeeded")
+			}
+			if !result.CommittedApplied {
+				t.Fatalf("error %v discarded committed-applied evidence", err)
+			}
+		})
 	}
 }
 

--- a/TreeDB/nativewire/cluster_submitter_test.go
+++ b/TreeDB/nativewire/cluster_submitter_test.go
@@ -46,6 +46,13 @@ func (s *confirmingVectorPartitionClusterSubmitterV1) RequiresVectorPartitionMut
 	return true, nil
 }
 
+func (s *confirmingVectorPartitionClusterSubmitterV1) SubmitCommandEntryWithPreCommitV1(ctx context.Context, entry []byte, metadata ClusterRequestMetadata, preCommit func(context.Context) error) (ClusterSubmitResult, error) {
+	if err := preCommit(ctx); err != nil {
+		return ClusterSubmitResult{}, err
+	}
+	return s.SubmitCommandEntryV1(ctx, entry, metadata)
+}
+
 func (s *confirmingVectorPartitionClusterSubmitterV1) ConfirmVectorPartitionMutationV1(ctx context.Context, command iwire.CommandID, _ []iwire.Section) error {
 	s.mu.Lock()
 	s.confirmations = append(s.confirmations, command)

--- a/TreeDB/nativewire/cluster_submitter_test.go
+++ b/TreeDB/nativewire/cluster_submitter_test.go
@@ -837,8 +837,8 @@ func TestLegacyRaftClusterSubmitterRequiresVectorAdmissionFromClusterFeatureV1(t
 }
 
 func TestCatalogRoutedLegacySubmitterRequiresVectorAdmissionFromCatalogFeatureV1(t *testing.T) {
-	authority, _ := newNativewireCatalogMetaAuthorityWithLifecycle(t, true)
-	provider, err := NewCatalogMetaClusterRouteProvider(authority, authority.CurrentCatalogProof)
+	authority, metaRaft := newNativewireCatalogMetaAuthorityWithLifecycle(t, true)
+	provider, err := NewCatalogMetaClusterRouteProvider(authority, authority.CurrentCatalogProof, metaRaft)
 	if err != nil {
 		t.Fatalf("NewCatalogMetaClusterRouteProvider: %v", err)
 	}
@@ -863,6 +863,37 @@ func TestCatalogRoutedLegacySubmitterRequiresVectorAdmissionFromCatalogFeatureV1
 	}
 	if calls := bridge.snapshotCalls(); len(calls) != 0 {
 		t.Fatalf("routed legacy constructor submitted %d entries before required lifecycle admission", len(calls))
+	}
+}
+
+func TestCatalogRoutedLegacySubmitterRejectsStaleFeatureViewV1(t *testing.T) {
+	authority, _ := newNativewireCatalogMetaAuthority(t)
+	status, ok := authority.Status()
+	if !ok {
+		t.Fatal("catalog authority status unavailable")
+	}
+	fence := &catalogMetaLinearizableAppliedIndexProviderTestV1{index: status.AppliedIndex + 1}
+	provider, err := NewCatalogMetaClusterRouteProvider(authority, authority.CurrentCatalogProof, fence)
+	if err != nil {
+		t.Fatalf("NewCatalogMetaClusterRouteProvider: %v", err)
+	}
+	bridge := &recordingRaftCommandSubmitter{groupID: "group-a"}
+	submitter := NewRoutedRaftClusterSubmitter(bridge, provider)
+	client, _, _ := serveCollectionPipeWithOptions(t, ServerOptions{ClusterSubmitter: submitter})
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	if err := client.Hello(ctx); err != nil {
+		t.Fatalf("Hello: %v", err)
+	}
+	if _, err := client.InsertBatch(ctx, "users", collections.DocumentFormatJSON,
+		[][]byte{[]byte("u1")}, [][]byte{[]byte(`{"embedding":[1,2]}`)}, AckVisible); err == nil {
+		t.Fatal("InsertBatch succeeded while local catalog feature view lagged the linearizable meta-Raft index")
+	}
+	if fence.calls != 1 {
+		t.Fatalf("linearizable fence calls=%d want 1", fence.calls)
+	}
+	if calls := bridge.snapshotCalls(); len(calls) != 0 {
+		t.Fatalf("stale catalog feature view submitted %d entries before lifecycle admission", len(calls))
 	}
 }
 
@@ -3035,7 +3066,7 @@ func TestCatalogMetaNativewireMutationAndReadProofMatrix(t *testing.T) {
 	if err != nil {
 		t.Fatalf("CurrentCatalogProof: %v", err)
 	}
-	provider, err := NewCatalogMetaClusterRouteProvider(authority, authority.CurrentCatalogProof)
+	provider, err := NewCatalogMetaClusterRouteProvider(authority, authority.CurrentCatalogProof, metaRaft)
 	if err != nil {
 		t.Fatalf("NewCatalogMetaClusterRouteProvider: %v", err)
 	}
@@ -3065,7 +3096,7 @@ func TestCatalogMetaNativewireMutationAndReadProofMatrix(t *testing.T) {
 
 	staleProvider, err := NewCatalogMetaClusterRouteProvider(authority, func(context.Context) (raftplacement.CatalogProofV1, error) {
 		return proof, nil
-	})
+	}, metaRaft)
 	if err != nil {
 		t.Fatalf("NewCatalogMetaClusterRouteProvider stale: %v", err)
 	}
@@ -3081,7 +3112,7 @@ func TestCatalogMetaNativewireMutationAndReadProofMatrix(t *testing.T) {
 	}
 	missingProvider, err := NewCatalogMetaClusterRouteProvider(authority, func(context.Context) (raftplacement.CatalogProofV1, error) {
 		return raftplacement.CatalogProofV1{}, nil
-	})
+	}, metaRaft)
 	if err != nil {
 		t.Fatalf("NewCatalogMetaClusterRouteProvider missing: %v", err)
 	}
@@ -3676,8 +3707,8 @@ func BenchmarkRaftClusterSubmitterConcreteBridgeUpdateBSONSet(b *testing.B) {
 }
 
 func BenchmarkCatalogMetaNativewireAdmission(b *testing.B) {
-	authority, _ := newNativewireCatalogMetaAuthority(b)
-	provider, err := NewCatalogMetaClusterRouteProvider(authority, authority.CurrentCatalogProof)
+	authority, metaRaft := newNativewireCatalogMetaAuthority(b)
+	provider, err := NewCatalogMetaClusterRouteProvider(authority, authority.CurrentCatalogProof, metaRaft)
 	if err != nil {
 		b.Fatalf("NewCatalogMetaClusterRouteProvider: %v", err)
 	}

--- a/TreeDB/nativewire/cluster_submitter_test.go
+++ b/TreeDB/nativewire/cluster_submitter_test.go
@@ -726,6 +726,13 @@ func TestClusterSubmitterRequiredVectorAdmissionFailsClosedWhenMisconfiguredV1(t
 	}
 }
 
+func TestNewRaftClusterSubmitterWithVectorPartitionAdmissionRequiresConfirmationV1(t *testing.T) {
+	_, err := NewRaftClusterSubmitterWithVectorPartitionAdmissionV1(nil, &fakeClusterSubmitter{})
+	if err == nil || !strings.Contains(err.Error(), "confirmation provider is required") {
+		t.Fatalf("constructor err=%v want missing confirmation provider", err)
+	}
+}
+
 func TestClusterAdmissionFollowerRejectsNativeMutationsBeforeLocalMutation(t *testing.T) {
 	submitter := &admissionClusterSubmitter{
 		fakeClusterSubmitter: &fakeClusterSubmitter{},

--- a/TreeDB/nativewire/cluster_submitter_test.go
+++ b/TreeDB/nativewire/cluster_submitter_test.go
@@ -686,6 +686,32 @@ func TestClusterSubmitterVectorPartitionAdmissionRunsBeforeRaftSubmitV1(t *testi
 	}
 }
 
+func TestClusterSubmitterRouteRefusalRunsBeforeVectorPartitionAdmissionV1(t *testing.T) {
+	submitter := &routingClusterSubmitter{
+		fakeClusterSubmitter: &fakeClusterSubmitter{},
+		err:                  errors.New("route lookup refused"),
+	}
+	client, _, _ := serveCollectionPipeWithOptions(t, ServerOptions{ClusterSubmitter: submitter})
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	if err := client.Hello(ctx); err != nil {
+		t.Fatalf("Hello: %v", err)
+	}
+	if _, err := client.InsertBatch(ctx, "users", collections.DocumentFormatJSON,
+		[][]byte{[]byte("u1")}, [][]byte{[]byte(`{"embedding":[1,2]}`)}, AckVisible); err == nil {
+		t.Fatal("InsertBatch succeeded despite route refusal")
+	}
+	if calls := submitter.snapshot(); len(calls) != 0 {
+		t.Fatalf("route refusal submitted %d Raft entries", len(calls))
+	}
+	submitter.mu.Lock()
+	admissions := append([]iwire.CommandID(nil), submitter.vectorAdmissionCalls...)
+	submitter.mu.Unlock()
+	if len(admissions) != 0 {
+		t.Fatalf("route refusal opened durable vector admission: %v", admissions)
+	}
+}
+
 func TestClusterSubmitterRequiredVectorAdmissionFailsClosedWhenMisconfiguredV1(t *testing.T) {
 	client, _, _ := serveCollectionPipeWithOptions(t, ServerOptions{ClusterSubmitter: lifecycleRequiredNoAdmissionClusterSubmitter{}})
 	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)

--- a/TreeDB/nativewire/cluster_submitter_test.go
+++ b/TreeDB/nativewire/cluster_submitter_test.go
@@ -35,6 +35,23 @@ type fakeClusterSubmitter struct {
 	resultHook           func(raftentry.CommandEntryV1, ClusterRequestMetadata, ClusterSubmitResult) (ClusterSubmitResult, error)
 }
 
+type confirmingVectorPartitionClusterSubmitterV1 struct {
+	*fakeClusterSubmitter
+	mu            sync.Mutex
+	confirmations []iwire.CommandID
+}
+
+func (s *confirmingVectorPartitionClusterSubmitterV1) RequiresVectorPartitionMutationAdmissionV1(context.Context) (bool, error) {
+	return true, nil
+}
+
+func (s *confirmingVectorPartitionClusterSubmitterV1) ConfirmVectorPartitionMutationV1(_ context.Context, command iwire.CommandID, _ []iwire.Section) error {
+	s.mu.Lock()
+	s.confirmations = append(s.confirmations, command)
+	s.mu.Unlock()
+	return nil
+}
+
 func (s *fakeClusterSubmitter) AdmitVectorPartitionMutationV1(_ context.Context, command iwire.CommandID, _ []iwire.Section) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -151,6 +168,7 @@ func (s *recordingRaftCommandSubmitter) SubmitCommandEntryV1(ctx context.Context
 	return raftcluster.SubmitResultV1{
 		ActualAck:            actualAck,
 		CommittedRecoverable: actualAck == iwire.AckRaftCommitted,
+		CommittedApplied:     true,
 		DecodedEntry:         decoded,
 		ApplyResult:          applyResult,
 		CommittedEntry:       committed,
@@ -420,6 +438,7 @@ func fakeClusterSubmitResponse(entry raftentry.CommandEntryV1, metadata ClusterR
 	}
 	return ClusterSubmitResult{
 		ActualAck:        actualAck,
+		CommittedApplied: true,
 		ResponseSections: sections,
 	}, nil
 }
@@ -683,6 +702,26 @@ func TestClusterSubmitterVectorPartitionAdmissionRunsBeforeRaftSubmitV1(t *testi
 	}
 	if calls := submitter.snapshot(); len(calls) != 1 {
 		t.Fatalf("successful admission submitted %d Raft entries", len(calls))
+	}
+}
+
+func TestClusterSubmitterVisibleAckConfirmsCommittedVectorMutationV1(t *testing.T) {
+	submitter := &confirmingVectorPartitionClusterSubmitterV1{fakeClusterSubmitter: &fakeClusterSubmitter{}}
+	client, _, _ := serveCollectionPipeWithOptions(t, ServerOptions{ClusterSubmitter: submitter})
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	if err := client.Hello(ctx); err != nil {
+		t.Fatalf("Hello: %v", err)
+	}
+	if _, err := client.InsertBatch(ctx, "users", collections.DocumentFormatJSON,
+		[][]byte{[]byte("u1")}, [][]byte{[]byte(`{"embedding":[1,2]}`)}, AckVisible); err != nil {
+		t.Fatalf("InsertBatch: %v", err)
+	}
+	submitter.mu.Lock()
+	confirmations := append([]iwire.CommandID(nil), submitter.confirmations...)
+	submitter.mu.Unlock()
+	if !reflect.DeepEqual(confirmations, []iwire.CommandID{iwire.CommandInsertBatch}) {
+		t.Fatalf("confirmations=%v want insert_batch", confirmations)
 	}
 }
 

--- a/TreeDB/nativewire/cluster_submitter_test.go
+++ b/TreeDB/nativewire/cluster_submitter_test.go
@@ -728,6 +728,41 @@ func TestClusterSubmitterVisibleAckConfirmsCommittedVectorMutationV1(t *testing.
 	}
 }
 
+func TestClusterSubmitterConfirmsCommittedVectorMutationBeforeReturningPostApplyErrorV1(t *testing.T) {
+	submitErr := errors.New("post-apply catalog refresh failed")
+	submitter := &confirmingVectorPartitionClusterSubmitterV1{fakeClusterSubmitter: &fakeClusterSubmitter{}}
+	submitter.resultHook = func(_ raftentry.CommandEntryV1, _ ClusterRequestMetadata, result ClusterSubmitResult) (ClusterSubmitResult, error) {
+		return result, submitErr
+	}
+	client, server, _, _ := serveCollectionPipeWithServerAndOptions(t, ServerOptions{ClusterSubmitter: submitter})
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	if err := client.Hello(ctx); err != nil {
+		t.Fatalf("Hello: %v", err)
+	}
+	body, err := appendCommandRequestBody(nil, iwire.CommandInsertBatch, clusterInsertBatchSections(t, client, ctx, AckVisible, "u1")...)
+	if err != nil {
+		t.Fatalf("append request body: %v", err)
+	}
+	sections, err := iwire.DecodeSections(body, server.limits)
+	if err != nil {
+		t.Fatalf("decode request body: %v", err)
+	}
+	cmd, err := server.registry.ValidateRequestSections(sections)
+	if err != nil {
+		t.Fatalf("validate request sections: %v", err)
+	}
+	if _, err := server.handleClusterMutation(ctx, iwire.Header{Type: iwire.FrameRequest, RequestID: 1}, cmd); !errors.Is(err, submitErr) {
+		t.Fatalf("post-apply error=%v want %v", err, submitErr)
+	}
+	submitter.mu.Lock()
+	confirmations := append([]iwire.CommandID(nil), submitter.confirmations...)
+	submitter.mu.Unlock()
+	if !reflect.DeepEqual(confirmations, []iwire.CommandID{iwire.CommandInsertBatch}) {
+		t.Fatalf("confirmations=%v want insert_batch", confirmations)
+	}
+}
+
 func TestClusterSubmitterCommittedVectorConfirmationOutlivesClientCancellationV1(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	submitter := &confirmingVectorPartitionClusterSubmitterV1{fakeClusterSubmitter: &fakeClusterSubmitter{}}

--- a/TreeDB/nativewire/cluster_submitter_test.go
+++ b/TreeDB/nativewire/cluster_submitter_test.go
@@ -26,11 +26,20 @@ import (
 )
 
 type fakeClusterSubmitter struct {
-	mu           sync.Mutex
-	calls        []fakeClusterSubmitCall
-	status       ClusterAdmissionStatus
-	admissionErr error
-	resultHook   func(raftentry.CommandEntryV1, ClusterRequestMetadata, ClusterSubmitResult) (ClusterSubmitResult, error)
+	mu                   sync.Mutex
+	calls                []fakeClusterSubmitCall
+	status               ClusterAdmissionStatus
+	admissionErr         error
+	vectorAdmissionErr   error
+	vectorAdmissionCalls []iwire.CommandID
+	resultHook           func(raftentry.CommandEntryV1, ClusterRequestMetadata, ClusterSubmitResult) (ClusterSubmitResult, error)
+}
+
+func (s *fakeClusterSubmitter) AdmitVectorPartitionMutationV1(_ context.Context, command iwire.CommandID, _ []iwire.Section) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.vectorAdmissionCalls = append(s.vectorAdmissionCalls, command)
+	return s.vectorAdmissionErr
 }
 
 type testSensitiveClusterRouteError struct {
@@ -630,6 +639,38 @@ func TestClusterAdmissionLeaderRoutesThroughSubmitter(t *testing.T) {
 	}
 	if got := calls[0].entry.Decoded.CommandID; got != iwire.CommandInsertBatch {
 		t.Fatalf("command=%d want insert_batch", got)
+	}
+}
+
+func TestClusterSubmitterVectorPartitionAdmissionRunsBeforeRaftSubmitV1(t *testing.T) {
+	submitter := &fakeClusterSubmitter{vectorAdmissionErr: errors.New("vector generation must be invalidated first")}
+	client, _, _ := serveCollectionPipeWithOptions(t, ServerOptions{ClusterSubmitter: submitter})
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	if err := client.Hello(ctx); err != nil {
+		t.Fatalf("Hello: %v", err)
+	}
+	_, err := client.InsertBatch(ctx, "users", collections.DocumentFormatJSON,
+		[][]byte{[]byte("u1")}, [][]byte{[]byte(`{"embedding":[1,2]}`)}, AckVisible)
+	if err == nil {
+		t.Fatal("InsertBatch succeeded despite vector admission refusal")
+	}
+	if calls := submitter.snapshot(); len(calls) != 0 {
+		t.Fatalf("admission refusal submitted %d Raft entries", len(calls))
+	}
+	submitter.mu.Lock()
+	admissions := append([]iwire.CommandID(nil), submitter.vectorAdmissionCalls...)
+	submitter.vectorAdmissionErr = nil
+	submitter.mu.Unlock()
+	if len(admissions) != 1 || admissions[0] != iwire.CommandInsertBatch {
+		t.Fatalf("admissions=%v", admissions)
+	}
+	if _, err := client.InsertBatch(ctx, "users", collections.DocumentFormatJSON,
+		[][]byte{[]byte("u1")}, [][]byte{[]byte(`{"embedding":[1,2]}`)}, AckVisible); err != nil {
+		t.Fatalf("InsertBatch after durable admission: %v", err)
+	}
+	if calls := submitter.snapshot(); len(calls) != 1 {
+		t.Fatalf("successful admission submitted %d Raft entries", len(calls))
 	}
 }
 

--- a/TreeDB/nativewire/vector_partition_coordinator_v1.go
+++ b/TreeDB/nativewire/vector_partition_coordinator_v1.go
@@ -151,11 +151,12 @@ func (f VectorPartitionShardSearchDispatcherFuncV1) DispatchVectorPartitionShard
 }
 
 type VectorPartitionCoordinatorOptionsV1 struct {
-	Catalog      raftplacement.ResolvedCatalogV1
-	Placement    raftplacement.VectorPartitionPlacementRecordV1
-	RouterSource VectorPartitionCoordinatorRouterSourceV1
-	Dispatcher   VectorPartitionShardSearchDispatcherV1
-	Limits       VectorPartitionCoordinatorLimitsV1
+	Catalog             raftplacement.ResolvedCatalogV1
+	Placement           raftplacement.VectorPartitionPlacementRecordV1
+	RouterSource        VectorPartitionCoordinatorRouterSourceV1
+	Dispatcher          VectorPartitionShardSearchDispatcherV1
+	ReplicatedLifecycle VectorPartitionReplicatedLifecycleAuthorityV1
+	Limits              VectorPartitionCoordinatorLimitsV1
 }
 
 // VectorPartitionCoordinatorTopologyV1 is the public, transport-neutral M1
@@ -256,12 +257,13 @@ type vectorPartitionCoordinatorStatsAccumulatorV1 struct {
 }
 
 type VectorPartitionCoordinatorV1 struct {
-	placement    raftplacement.VectorPartitionPlacementRecordV1
-	routerSource VectorPartitionCoordinatorRouterSourceV1
-	dispatcher   VectorPartitionShardSearchDispatcherV1
-	limits       VectorPartitionCoordinatorLimitsV1
-	groups       map[raftcluster.GroupID]raftplacement.ResolvedGroupV1
-	stats        vectorPartitionCoordinatorStatsAccumulatorV1
+	placement           raftplacement.VectorPartitionPlacementRecordV1
+	routerSource        VectorPartitionCoordinatorRouterSourceV1
+	dispatcher          VectorPartitionShardSearchDispatcherV1
+	replicatedLifecycle VectorPartitionReplicatedLifecycleAuthorityV1
+	limits              VectorPartitionCoordinatorLimitsV1
+	groups              map[raftcluster.GroupID]raftplacement.ResolvedGroupV1
+	stats               vectorPartitionCoordinatorStatsAccumulatorV1
 }
 
 func NewVectorPartitionCoordinatorV1(opts VectorPartitionCoordinatorOptionsV1) (*VectorPartitionCoordinatorV1, error) {
@@ -284,7 +286,8 @@ func NewVectorPartitionCoordinatorV1(opts VectorPartitionCoordinatorOptionsV1) (
 	placement.Partitions = slices.Clone(opts.Placement.Partitions)
 	return &VectorPartitionCoordinatorV1{
 		placement: placement, routerSource: opts.RouterSource,
-		dispatcher: opts.Dispatcher, limits: limits, groups: groups,
+		dispatcher: opts.Dispatcher, replicatedLifecycle: opts.ReplicatedLifecycle,
+		limits: limits, groups: groups,
 	}, nil
 }
 
@@ -446,6 +449,9 @@ func (c *VectorPartitionCoordinatorV1) Search(ctx context.Context, request Vecto
 	if err := c.validateRouterStatus(request, status); err != nil {
 		return response, c.wrapError(err, "")
 	}
+	if err := c.validateReplicatedLifecycle(requestCtx, status); err != nil {
+		return response, c.wrapError(err, "")
+	}
 
 	routerStarted := time.Now()
 	routed, err := router.SearchWithContextV1(requestCtx, request.Query, collections.VectorPartitionRouterSearchOptionsV1{
@@ -530,6 +536,25 @@ func (c *VectorPartitionCoordinatorV1) Search(ctx context.Context, request Vecto
 	response.ProbedGroups = selectedGroups
 	response.Counters = counters
 	return response, nil
+}
+
+// validateReplicatedLifecycle binds the coordinator's locally opened router to
+// the single active catalog generation on every request. It is deliberately
+// after local manifest validation and before router search/dispatch: prepared,
+// invalidated, or failover-stale state cannot select partitions or issue shard
+// RPCs. A nil authority preserves the standalone M6 test harness; M7 cluster
+// construction supplies the replicated authority and therefore fails closed
+// when it is unavailable.
+func (c *VectorPartitionCoordinatorV1) validateReplicatedLifecycle(ctx context.Context, status collections.VectorPartitionRouterRuntimeStatusV1) error {
+	if c == nil || c.replicatedLifecycle == nil {
+		return nil
+	}
+	m := status.Manifest
+	return c.replicatedLifecycle.ValidateVectorPartitionGenerationSearchV1(
+		ctx, c.placement.Collection, m.IndexName, m.Generation,
+		m.IndexDefinitionDigest, m.SourceGeneration, m.SourceChecksum,
+		m.SourceSchemaHash, m.SourceRowCount, m.ReadySetDigest,
+	)
 }
 
 func accumulateVectorPartitionCoordinatorResponseCountersV1(

--- a/TreeDB/nativewire/vector_partition_coordinator_v1.go
+++ b/TreeDB/nativewire/vector_partition_coordinator_v1.go
@@ -114,7 +114,7 @@ type VectorPartitionCoordinatorRouterV1 interface {
 }
 
 type VectorPartitionCoordinatorRouterSourceV1 interface {
-	OpenVectorPartitionCoordinatorRouterV1(context.Context, string) (VectorPartitionCoordinatorRouterV1, error)
+	OpenVectorPartitionCoordinatorRouterV1(context.Context, string, uint64) (VectorPartitionCoordinatorRouterV1, error)
 }
 
 // CollectionVectorPartitionCoordinatorRouterSourceV1 adapts the real M4
@@ -123,11 +123,11 @@ type CollectionVectorPartitionCoordinatorRouterSourceV1 struct {
 	Collection *collections.Collection
 }
 
-func (s CollectionVectorPartitionCoordinatorRouterSourceV1) OpenVectorPartitionCoordinatorRouterV1(ctx context.Context, index string) (VectorPartitionCoordinatorRouterV1, error) {
+func (s CollectionVectorPartitionCoordinatorRouterSourceV1) OpenVectorPartitionCoordinatorRouterV1(ctx context.Context, index string, generation uint64) (VectorPartitionCoordinatorRouterV1, error) {
 	if s.Collection == nil {
 		return nil, ErrVectorPartitionCoordinatorUnavailable
 	}
-	router, _, err := s.Collection.OpenVectorPartitionRouterWithContextV1(ctx, index)
+	router, _, err := s.Collection.OpenPreparedVectorPartitionRouterForGenerationWithContextV1(ctx, index, generation)
 	if err != nil {
 		return nil, err
 	}
@@ -436,7 +436,7 @@ func (c *VectorPartitionCoordinatorV1) Search(ctx context.Context, request Vecto
 	}
 
 	openStarted := time.Now()
-	router, err := c.routerSource.OpenVectorPartitionCoordinatorRouterV1(requestCtx, request.IndexName)
+	router, err := c.routerSource.OpenVectorPartitionCoordinatorRouterV1(requestCtx, request.IndexName, c.placement.PartitionGeneration)
 	response.Timing.RouterOpenNanos = elapsedNanosV1(openStarted)
 	if err != nil {
 		return response, c.wrapError(err, "")
@@ -453,7 +453,8 @@ func (c *VectorPartitionCoordinatorV1) Search(ctx context.Context, request Vecto
 	if err := c.validateRouterStatus(request, status); err != nil {
 		return response, c.wrapError(err, "")
 	}
-	if err := c.validateReplicatedLifecycle(requestCtx, status); err != nil {
+	replicatedReadySetDigest, err := c.validateReplicatedLifecycle(requestCtx, status)
+	if err != nil {
 		return response, c.wrapError(err, "")
 	}
 
@@ -471,7 +472,7 @@ func (c *VectorPartitionCoordinatorV1) Search(ctx context.Context, request Vecto
 	}
 
 	placementStarted := time.Now()
-	tasks, selectedPartitions, selectedGroups, budget, err := c.plan(requestCtx, request, status, routed.Partitions)
+	tasks, selectedPartitions, selectedGroups, budget, err := c.plan(requestCtx, request, status, replicatedReadySetDigest, routed.Partitions)
 	response.Timing.PlacementNanos = elapsedNanosV1(placementStarted)
 	if err != nil {
 		return response, c.wrapError(err, "")
@@ -533,7 +534,7 @@ func (c *VectorPartitionCoordinatorV1) Search(ctx context.Context, request Vecto
 	response.PartitionGeneration = status.Manifest.Generation
 	response.RouterGeneration = status.Manifest.RouterGeneration
 	response.RouterModelDigest = status.ModelDigest
-	response.ReadySetDigest = status.Manifest.ReadySetDigest
+	response.ReadySetDigest = replicatedReadySetDigest
 	response.Consistency = VectorPartitionShardSearchConsistencySnapshotV1
 	response.Neighbors = neighbors
 	response.ProbedPartitions = selectedPartitions
@@ -549,15 +550,15 @@ func (c *VectorPartitionCoordinatorV1) Search(ctx context.Context, request Vecto
 // RPCs. A nil authority preserves the standalone M6 test harness; M7 cluster
 // construction supplies the replicated authority and therefore fails closed
 // when it is unavailable.
-func (c *VectorPartitionCoordinatorV1) validateReplicatedLifecycle(ctx context.Context, status collections.VectorPartitionRouterRuntimeStatusV1) error {
+func (c *VectorPartitionCoordinatorV1) validateReplicatedLifecycle(ctx context.Context, status collections.VectorPartitionRouterRuntimeStatusV1) (string, error) {
 	if c == nil || c.replicatedLifecycle == nil {
-		return nil
+		return status.Manifest.ReadySetDigest, nil
 	}
 	m := status.Manifest
 	return c.replicatedLifecycle.ValidateVectorPartitionGenerationSearchV1(
 		ctx, c.placement.Collection, m.IndexName, m.Generation,
 		m.IndexDefinitionDigest, m.SourceGeneration, m.SourceChecksum,
-		m.SourceSchemaHash, m.SourceRowCount, m.ReadySetDigest,
+		m.SourceSchemaHash, m.SourceRowCount,
 	)
 }
 
@@ -755,7 +756,7 @@ type vectorPartitionCoordinatorTaskV1 struct {
 	queuedAt      time.Time
 }
 
-func (c *VectorPartitionCoordinatorV1) plan(ctx context.Context, request VectorPartitionCoordinatorRequestV1, status collections.VectorPartitionRouterRuntimeStatusV1, routed []collections.VectorPartitionRouterPartitionScoreV1) ([]vectorPartitionCoordinatorTaskV1, []uint32, []raftcluster.GroupID, vectorPartitionCoordinatorBudgetV1, error) {
+func (c *VectorPartitionCoordinatorV1) plan(ctx context.Context, request VectorPartitionCoordinatorRequestV1, status collections.VectorPartitionRouterRuntimeStatusV1, readySetDigest string, routed []collections.VectorPartitionRouterPartitionScoreV1) ([]vectorPartitionCoordinatorTaskV1, []uint32, []raftcluster.GroupID, vectorPartitionCoordinatorBudgetV1, error) {
 	var zero vectorPartitionCoordinatorBudgetV1
 	if ctx == nil {
 		ctx = context.Background()
@@ -765,6 +766,9 @@ func (c *VectorPartitionCoordinatorV1) plan(ctx context.Context, request VectorP
 	}
 	if len(routed) < 1 || len(routed) > c.limits.MaxSelectedPartitions {
 		return nil, nil, nil, zero, ErrVectorPartitionCoordinatorBudgetExceeded
+	}
+	if !isVectorPartitionShardSearchDigestV1(readySetDigest) {
+		return nil, nil, nil, zero, ErrVectorPartitionCoordinatorGenerationMismatch
 	}
 	selected := make([]uint32, len(routed))
 	byGroup := make(map[raftcluster.GroupID][]uint32)
@@ -855,7 +859,8 @@ func (c *VectorPartitionCoordinatorV1) plan(ctx context.Context, request VectorP
 				SourceGeneration: status.Manifest.SourceGeneration, SourceChecksum: status.Manifest.SourceChecksum,
 				SourceSchemaHash: status.Manifest.SourceSchemaHash, SourceRowCount: status.Manifest.SourceRowCount,
 				PartitionGeneration: status.Manifest.Generation, RouterGeneration: status.Manifest.RouterGeneration,
-				TargetGroupID: groupID, TargetNodeID: target, PartitionIDs: ids,
+				ReadySetDigest: readySetDigest,
+				TargetGroupID:  groupID, TargetNodeID: target, PartitionIDs: ids,
 				Query: request.Query, Metric: request.Metric, Mode: VectorPartitionShardSearchModeNoDocumentV1,
 				Consistency: request.Consistency, StatsMode: VectorPartitionShardSearchStatsBasicV1,
 				TopK: request.TopK, EfSearch: request.EfSearch, DeadlineUnixNano: request.DeadlineUnixNano,
@@ -1042,7 +1047,7 @@ func vectorPartitionCoordinatorShardRequestBytesV1(request VectorPartitionShardS
 	}
 	for _, identity := range []string{
 		request.RequestID, request.CancellationID, request.Database, request.Catalog,
-		request.Collection, request.IndexName, request.IndexDefinitionDigest,
+		request.Collection, request.IndexName, request.IndexDefinitionDigest, request.ReadySetDigest,
 		string(request.TargetGroupID), string(request.TargetNodeID),
 	} {
 		size, ok = addUint64V1(size, uint64(len(identity)))
@@ -1186,6 +1191,7 @@ func (c *VectorPartitionCoordinatorV1) validateShardResponse(ctx context.Context
 		proof.SourceGeneration != request.SourceGeneration || proof.SourceChecksum != request.SourceChecksum ||
 		proof.SourceSchemaHash != request.SourceSchemaHash || proof.SourceRowCount != request.SourceRowCount ||
 		proof.PartitionGeneration != request.PartitionGeneration || proof.RouterGeneration != request.RouterGeneration ||
+		proof.ReadySetDigest != request.ReadySetDigest ||
 		proof.ReadTerm == 0 || proof.ReadIndex == 0 || proof.AppliedTerm == 0 || proof.AppliedIndex < proof.ReadIndex ||
 		proof.ServingNode == "" || proof.LeaderNode == "" ||
 		proof.LeaderNode != proof.ServingNode ||

--- a/TreeDB/nativewire/vector_partition_coordinator_v1.go
+++ b/TreeDB/nativewire/vector_partition_coordinator_v1.go
@@ -151,12 +151,13 @@ func (f VectorPartitionShardSearchDispatcherFuncV1) DispatchVectorPartitionShard
 }
 
 type VectorPartitionCoordinatorOptionsV1 struct {
-	Catalog             raftplacement.ResolvedCatalogV1
-	Placement           raftplacement.VectorPartitionPlacementRecordV1
-	RouterSource        VectorPartitionCoordinatorRouterSourceV1
-	Dispatcher          VectorPartitionShardSearchDispatcherV1
-	ReplicatedLifecycle VectorPartitionReplicatedLifecycleAuthorityV1
-	Limits              VectorPartitionCoordinatorLimitsV1
+	Catalog                    raftplacement.ResolvedCatalogV1
+	Placement                  raftplacement.VectorPartitionPlacementRecordV1
+	RouterSource               VectorPartitionCoordinatorRouterSourceV1
+	Dispatcher                 VectorPartitionShardSearchDispatcherV1
+	ReplicatedLifecycle        VectorPartitionReplicatedLifecycleAuthorityV1
+	RequireReplicatedLifecycle bool
+	Limits                     VectorPartitionCoordinatorLimitsV1
 }
 
 // VectorPartitionCoordinatorTopologyV1 is the public, transport-neutral M1
@@ -273,6 +274,9 @@ func NewVectorPartitionCoordinatorV1(opts VectorPartitionCoordinatorOptionsV1) (
 	}
 	if opts.RouterSource == nil || opts.Dispatcher == nil {
 		return nil, fmt.Errorf("%w: incomplete coordinator dependencies", ErrVectorPartitionCoordinatorInvalidRequest)
+	}
+	if opts.RequireReplicatedLifecycle && opts.ReplicatedLifecycle == nil {
+		return nil, fmt.Errorf("%w: replicated lifecycle authority is required", ErrVectorPartitionCoordinatorUnavailable)
 	}
 	if err := opts.Catalog.ValidateVectorPartitionPlacementV1(opts.Placement); err != nil {
 		return nil, fmt.Errorf("%w: %v", ErrVectorPartitionCoordinatorRouteMismatch, err)

--- a/TreeDB/nativewire/vector_partition_coordinator_v1_test.go
+++ b/TreeDB/nativewire/vector_partition_coordinator_v1_test.go
@@ -8,6 +8,7 @@ import (
 	"reflect"
 	"slices"
 	"sort"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -50,12 +51,14 @@ func (r *testVectorPartitionCoordinatorRouterV1) Close() error {
 }
 
 type testVectorPartitionCoordinatorRouterSourceV1 struct {
-	router *testVectorPartitionCoordinatorRouterV1
-	opens  int
+	router      *testVectorPartitionCoordinatorRouterV1
+	opens       int
+	generations []uint64
 }
 
-func (s *testVectorPartitionCoordinatorRouterSourceV1) OpenVectorPartitionCoordinatorRouterV1(context.Context, string) (VectorPartitionCoordinatorRouterV1, error) {
+func (s *testVectorPartitionCoordinatorRouterSourceV1) OpenVectorPartitionCoordinatorRouterV1(_ context.Context, _ string, generation uint64) (VectorPartitionCoordinatorRouterV1, error) {
 	s.opens++
+	s.generations = append(s.generations, generation)
 	return s.router, nil
 }
 
@@ -143,7 +146,8 @@ func (d *testVectorPartitionCoordinatorDispatcherV1) DispatchVectorPartitionShar
 		Version: VectorPartitionShardSearchVersionV1, RequestID: request.RequestID,
 		Proof: VectorPartitionShardSearchProofV1{
 			ServingNode: request.TargetNodeID, LeaderNode: request.TargetNodeID, GroupID: request.TargetGroupID,
-			ReadTerm: 1, ReadIndex: 2, AppliedTerm: 1, AppliedIndex: 2,
+			ReadySetDigest: request.ReadySetDigest,
+			ReadTerm:       1, ReadIndex: 2, AppliedTerm: 1, AppliedIndex: 2,
 			SourceGeneration: request.SourceGeneration, SourceChecksum: request.SourceChecksum,
 			SourceSchemaHash: request.SourceSchemaHash, SourceRowCount: request.SourceRowCount,
 			PartitionGeneration: request.PartitionGeneration, RouterGeneration: request.RouterGeneration,
@@ -297,13 +301,15 @@ func TestVectorPartitionCoordinatorCoalescesChunksDedupesAndMergesV1(t *testing.
 
 func TestVectorPartitionCoordinatorUsesReplicatedLifecycleAdmissionV1(t *testing.T) {
 	owners := []raftcluster.GroupID{"group-a"}
-	coordinator, _, dispatcher := testVectorPartitionCoordinatorV1(t,
+	coordinator, source, dispatcher := testVectorPartitionCoordinatorV1(t,
 		[]raftplacement.GroupV1{{ID: "group-a", Members: []raftcluster.NodeID{"node-a"}, LeaderHint: "node-a"}},
 		owners, map[uint32][]VectorPartitionShardSearchNeighborV1{0: {{ID: "doc", Score: 1}}}, VectorPartitionCoordinatorLimitsV1{},
 	)
-	authority := &recordingVectorPartitionReplicatedLifecycleAuthorityV1{}
+	replicatedReadySetDigest := strings.Repeat("c", 64)
+	authority := &recordingVectorPartitionReplicatedLifecycleAuthorityV1{readySetDigest: replicatedReadySetDigest}
 	coordinator.replicatedLifecycle = authority
-	if _, err := coordinator.Search(t.Context(), testVectorPartitionCoordinatorRequestV1(len(owners))); err != nil {
+	response, err := coordinator.Search(t.Context(), testVectorPartitionCoordinatorRequestV1(len(owners)))
+	if err != nil {
 		t.Fatalf("Search: %v", err)
 	}
 	if authority.calls != 1 {
@@ -311,6 +317,12 @@ func TestVectorPartitionCoordinatorUsesReplicatedLifecycleAdmissionV1(t *testing
 	}
 	if len(dispatcher.calls) == 0 {
 		t.Fatal("admitted search did not dispatch shard request")
+	}
+	if !reflect.DeepEqual(source.generations, []uint64{coordinator.placement.PartitionGeneration}) {
+		t.Fatalf("router generations=%v want exact placement generation %d", source.generations, coordinator.placement.PartitionGeneration)
+	}
+	if response.ReadySetDigest != replicatedReadySetDigest || dispatcher.calls[0].ReadySetDigest != replicatedReadySetDigest {
+		t.Fatalf("replicated ready-set response/request=%q/%q want %q", response.ReadySetDigest, dispatcher.calls[0].ReadySetDigest, replicatedReadySetDigest)
 	}
 
 	authority.err = errors.New("generation invalidated")
@@ -681,6 +693,9 @@ func TestVectorPartitionCoordinatorRejectsCorruptShardProofsAndPartialsV1(t *tes
 		}},
 		{name: "applied_index_precedes_read", edit: func(_ VectorPartitionShardSearchRequestV1, response *VectorPartitionShardSearchResponseV1) {
 			response.Proof.ReadIndex = response.Proof.AppliedIndex + 1
+		}},
+		{name: "ready_set_digest", edit: func(_ VectorPartitionShardSearchRequestV1, response *VectorPartitionShardSearchResponseV1) {
+			response.Proof.ReadySetDigest = strings.Repeat("f", 64)
 		}},
 		{name: "underreported_candidates", edit: func(_ VectorPartitionShardSearchRequestV1, response *VectorPartitionShardSearchResponseV1) {
 			response.Partials[0].Candidates = 0

--- a/TreeDB/nativewire/vector_partition_coordinator_v1_test.go
+++ b/TreeDB/nativewire/vector_partition_coordinator_v1_test.go
@@ -323,6 +323,22 @@ func TestVectorPartitionCoordinatorUsesReplicatedLifecycleAdmissionV1(t *testing
 	}
 }
 
+func TestVectorPartitionCoordinatorRequiresReplicatedLifecycleV1(t *testing.T) {
+	_, source, dispatcher := testVectorPartitionCoordinatorV1(t,
+		[]raftplacement.GroupV1{{ID: "group-a", Members: []raftcluster.NodeID{"node-a"}, LeaderHint: "node-a"}},
+		[]raftcluster.GroupID{"group-a"}, map[uint32][]VectorPartitionShardSearchNeighborV1{0: nil}, VectorPartitionCoordinatorLimitsV1{},
+	)
+	ref := raftplacement.CollectionRefV1{Database: "db", Catalog: "default", Collection: "docs"}
+	catalog, err := raftplacement.Validate(raftplacement.CatalogV1{Groups: []raftplacement.GroupV1{{ID: "group-a", Members: []raftcluster.NodeID{"node-a"}, LeaderHint: "node-a"}}, Placements: []raftplacement.CollectionPlacementV1{{Collection: ref, GroupID: "group-a", Mode: raftplacement.PlacementModeCollectionV1}}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = NewVectorPartitionCoordinatorV1(VectorPartitionCoordinatorOptionsV1{Catalog: catalog, Placement: raftplacement.VectorPartitionPlacementRecordV1{Collection: ref, IndexName: "embedding", IndexDefinitionDigest: fmt.Sprintf("%064x", 17), SourceGeneration: 11, SourceChecksum: 12, SourceSchemaHash: 13, SourceRowCount: 100, PartitionGeneration: 7, PartitionCount: 1, Partitions: []raftplacement.VectorPartitionGroupV1{{GroupID: "group-a"}}}, RouterSource: source, Dispatcher: dispatcher, RequireReplicatedLifecycle: true})
+	if !errors.Is(err, ErrVectorPartitionCoordinatorUnavailable) {
+		t.Fatalf("missing M7 authority err=%v", err)
+	}
+}
+
 func TestVectorPartitionCoordinatorAllPartitionParityAndStableTiesV1(t *testing.T) {
 	owners := []raftcluster.GroupID{"group-b", "group-a", "group-b", "group-a"}
 	neighbors := map[uint32][]VectorPartitionShardSearchNeighborV1{

--- a/TreeDB/nativewire/vector_partition_coordinator_v1_test.go
+++ b/TreeDB/nativewire/vector_partition_coordinator_v1_test.go
@@ -295,6 +295,34 @@ func TestVectorPartitionCoordinatorCoalescesChunksDedupesAndMergesV1(t *testing.
 	}
 }
 
+func TestVectorPartitionCoordinatorUsesReplicatedLifecycleAdmissionV1(t *testing.T) {
+	owners := []raftcluster.GroupID{"group-a"}
+	coordinator, _, dispatcher := testVectorPartitionCoordinatorV1(t,
+		[]raftplacement.GroupV1{{ID: "group-a", Members: []raftcluster.NodeID{"node-a"}, LeaderHint: "node-a"}},
+		owners, map[uint32][]VectorPartitionShardSearchNeighborV1{0: {{ID: "doc", Score: 1}}}, VectorPartitionCoordinatorLimitsV1{},
+	)
+	authority := &recordingVectorPartitionReplicatedLifecycleAuthorityV1{}
+	coordinator.replicatedLifecycle = authority
+	if _, err := coordinator.Search(t.Context(), testVectorPartitionCoordinatorRequestV1(len(owners))); err != nil {
+		t.Fatalf("Search: %v", err)
+	}
+	if authority.calls != 1 {
+		t.Fatalf("replicated lifecycle calls=%d want 1", authority.calls)
+	}
+	if len(dispatcher.calls) == 0 {
+		t.Fatal("admitted search did not dispatch shard request")
+	}
+
+	authority.err = errors.New("generation invalidated")
+	before := len(dispatcher.calls)
+	if _, err := coordinator.Search(t.Context(), testVectorPartitionCoordinatorRequestV1(len(owners))); !errors.Is(err, authority.err) {
+		t.Fatalf("invalidated search err=%v", err)
+	}
+	if len(dispatcher.calls) != before {
+		t.Fatal("replicated lifecycle rejection dispatched shard request")
+	}
+}
+
 func TestVectorPartitionCoordinatorAllPartitionParityAndStableTiesV1(t *testing.T) {
 	owners := []raftcluster.GroupID{"group-b", "group-a", "group-b", "group-a"}
 	neighbors := map[uint32][]VectorPartitionShardSearchNeighborV1{

--- a/TreeDB/nativewire/vector_partition_generation_source_v1.go
+++ b/TreeDB/nativewire/vector_partition_generation_source_v1.go
@@ -8,6 +8,7 @@ import (
 	"sync"
 
 	"github.com/snissn/gomap/TreeDB/collections"
+	"github.com/snissn/gomap/TreeDB/internal/raftplacement"
 )
 
 const collectionVectorPartitionMaxAuthorityRefreshesV1 = 3
@@ -18,7 +19,7 @@ const collectionVectorPartitionMaxAuthorityRefreshesV1 = 3
 type VectorPartitionReplicatedLifecycleAuthorityV1 interface {
 	ValidateVectorPartitionGenerationSearchV1(
 		context.Context,
-		string,
+		raftplacement.CollectionRefV1,
 		string,
 		uint64,
 		string,
@@ -41,8 +42,9 @@ type VectorPartitionReplicatedLifecycleAuthorityV1 interface {
 // permanent for this source instance, so a stale service cannot reload the old
 // generation after the cutover.
 type CollectionVectorPartitionGenerationSourceV1 struct {
-	Collection          *collections.Collection
-	replicatedLifecycle VectorPartitionReplicatedLifecycleAuthorityV1
+	Collection           *collections.Collection
+	replicatedCollection raftplacement.CollectionRefV1
+	replicatedLifecycle  VectorPartitionReplicatedLifecycleAuthorityV1
 
 	mu          sync.Mutex
 	entries     map[collectionVectorPartitionGenerationKeyV1]*collectionVectorPartitionGenerationCacheV1
@@ -80,14 +82,16 @@ func NewCollectionVectorPartitionGenerationSourceV1(collection *collections.Coll
 // standalone LocalActivate pointer.
 func NewCollectionVectorPartitionGenerationSourceForReplicatedLifecycleV1(
 	collection *collections.Collection,
+	collectionRef raftplacement.CollectionRefV1,
 	authority VectorPartitionReplicatedLifecycleAuthorityV1,
 ) (*CollectionVectorPartitionGenerationSourceV1, error) {
-	if collection == nil || authority == nil {
+	if collection == nil || authority == nil || collectionRef.Database == "" || collectionRef.Catalog == "" || collectionRef.Collection == "" {
 		return nil, ErrVectorPartitionShardSearchAssetsUnavailable
 	}
 	return &CollectionVectorPartitionGenerationSourceV1{
-		Collection:          collection,
-		replicatedLifecycle: authority,
+		Collection:           collection,
+		replicatedCollection: collectionRef,
+		replicatedLifecycle:  authority,
 	}, nil
 }
 
@@ -298,7 +302,7 @@ func (s *CollectionVectorPartitionGenerationSourceV1) validateActive(ctx context
 	if s.replicatedLifecycle != nil {
 		return s.replicatedLifecycle.ValidateVectorPartitionGenerationSearchV1(
 			ctx,
-			entry.manifest.Collection,
+			s.replicatedCollection,
 			entry.manifest.IndexName,
 			entry.manifest.Generation,
 			entry.manifest.IndexDefinitionDigest,
@@ -316,9 +320,12 @@ func (s *CollectionVectorPartitionGenerationSourceV1) validateReplicatedLifecycl
 	if s.replicatedLifecycle == nil {
 		return nil
 	}
+	if manifest.Collection != s.replicatedCollection.Collection {
+		return ErrVectorPartitionShardSearchGenerationMismatch
+	}
 	return s.replicatedLifecycle.ValidateVectorPartitionGenerationSearchV1(
 		ctx,
-		manifest.Collection,
+		s.replicatedCollection,
 		key.index,
 		key.generation,
 		manifest.IndexDefinitionDigest,

--- a/TreeDB/nativewire/vector_partition_generation_source_v1.go
+++ b/TreeDB/nativewire/vector_partition_generation_source_v1.go
@@ -16,6 +16,8 @@ const collectionVectorPartitionMaxAuthorityRefreshesV1 = 3
 // VectorPartitionReplicatedLifecycleAuthorityV1 is the constant-time M7
 // serving guard. Local prepared assets are evidence, not activation authority;
 // every cold load and cache hit must match the single replicated active record.
+// Successful validation returns the replicated lifecycle ready-set digest,
+// which is distinct from the local manifest's asset/placement digest.
 type VectorPartitionReplicatedLifecycleAuthorityV1 interface {
 	ValidateVectorPartitionGenerationSearchV1(
 		context.Context,
@@ -27,8 +29,7 @@ type VectorPartitionReplicatedLifecycleAuthorityV1 interface {
 		uint64,
 		uint64,
 		uint64,
-		string,
-	) error
+	) (string, error)
 }
 
 // CollectionVectorPartitionGenerationSourceV1 binds M5 to one actual local
@@ -262,7 +263,8 @@ func (s *CollectionVectorPartitionGenerationSourceV1) loadGeneration(ctx context
 		}
 		return nil, fmt.Errorf("%w: generation status: %v", ErrVectorPartitionShardSearchGenerationMismatch, err)
 	}
-	if err := s.validateReplicatedLifecycle(ctx, key, manifest); err != nil {
+	replicatedReadySetDigest, err := s.validateReplicatedLifecycle(ctx, key, manifest)
+	if err != nil {
 		authorityToken.Release()
 		return nil, vectorPartitionReplicatedLifecycleValidationErrorV1(ctx, err)
 	}
@@ -279,11 +281,13 @@ func (s *CollectionVectorPartitionGenerationSourceV1) loadGeneration(ctx context
 		return nil, err
 	}
 	release = false
+	pinnedManifest := pinnedVectorPartitionManifestV1(manifest)
+	pinnedManifest.ReadySetDigest = replicatedReadySetDigest
 	return &collectionVectorPartitionGenerationCacheV1{
 		collection:     s.Collection,
 		index:          key.index,
 		generation:     key.generation,
-		manifest:       pinnedVectorPartitionManifestV1(manifest),
+		manifest:       pinnedManifest,
 		openPlan:       openPlan,
 		authorityToken: authorityToken,
 		pin:            pin,
@@ -310,7 +314,7 @@ func (s *CollectionVectorPartitionGenerationSourceV1) validateActive(ctx context
 		return ErrVectorPartitionShardSearchAssetsUnavailable
 	}
 	if s.replicatedLifecycle != nil {
-		return s.replicatedLifecycle.ValidateVectorPartitionGenerationSearchV1(
+		readySetDigest, err := s.replicatedLifecycle.ValidateVectorPartitionGenerationSearchV1(
 			ctx,
 			s.replicatedCollection,
 			entry.manifest.IndexName,
@@ -320,18 +324,24 @@ func (s *CollectionVectorPartitionGenerationSourceV1) validateActive(ctx context
 			entry.manifest.SourceChecksum,
 			entry.manifest.SourceSchemaHash,
 			entry.manifest.SourceRowCount,
-			entry.manifest.ReadySetDigest,
 		)
+		if err != nil {
+			return err
+		}
+		if readySetDigest != entry.manifest.ReadySetDigest {
+			return ErrVectorPartitionShardSearchGenerationMismatch
+		}
+		return nil
 	}
 	return s.Collection.ValidateActiveVectorPartitionAuthorityTokenWithContextV1(ctx, key.index, key.generation, entry.authorityToken)
 }
 
-func (s *CollectionVectorPartitionGenerationSourceV1) validateReplicatedLifecycle(ctx context.Context, key collectionVectorPartitionGenerationKeyV1, manifest collections.VectorPartitionManifestV1) error {
+func (s *CollectionVectorPartitionGenerationSourceV1) validateReplicatedLifecycle(ctx context.Context, key collectionVectorPartitionGenerationKeyV1, manifest collections.VectorPartitionManifestV1) (string, error) {
 	if s.replicatedLifecycle == nil {
-		return nil
+		return manifest.ReadySetDigest, nil
 	}
 	if manifest.Collection != s.replicatedCollection.Collection {
-		return ErrVectorPartitionShardSearchGenerationMismatch
+		return "", ErrVectorPartitionShardSearchGenerationMismatch
 	}
 	return s.replicatedLifecycle.ValidateVectorPartitionGenerationSearchV1(
 		ctx,
@@ -343,7 +353,6 @@ func (s *CollectionVectorPartitionGenerationSourceV1) validateReplicatedLifecycl
 		manifest.SourceChecksum,
 		manifest.SourceSchemaHash,
 		manifest.SourceRowCount,
-		manifest.ReadySetDigest,
 	)
 }
 

--- a/TreeDB/nativewire/vector_partition_generation_source_v1.go
+++ b/TreeDB/nativewire/vector_partition_generation_source_v1.go
@@ -264,7 +264,7 @@ func (s *CollectionVectorPartitionGenerationSourceV1) loadGeneration(ctx context
 	}
 	if err := s.validateReplicatedLifecycle(ctx, key, manifest); err != nil {
 		authorityToken.Release()
-		return nil, fmt.Errorf("%w: replicated lifecycle: %v", ErrVectorPartitionShardSearchGenerationMismatch, err)
+		return nil, vectorPartitionReplicatedLifecycleValidationErrorV1(ctx, err)
 	}
 	openPlan, err := collections.NewVectorPartitionGenerationSearchOpenPlanWithContextV1(ctx, manifest)
 	if err != nil {
@@ -290,6 +290,16 @@ func (s *CollectionVectorPartitionGenerationSourceV1) loadGeneration(ctx context
 		searchers:      make(map[uint32]*collections.VectorPartitionLocalSearcherV1),
 		opening:        make(map[uint32]*collectionVectorPartitionSearchLoadV1),
 	}, nil
+}
+
+func vectorPartitionReplicatedLifecycleValidationErrorV1(ctx context.Context, err error) error {
+	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) || ctx.Err() != nil {
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return ctxErr
+		}
+		return err
+	}
+	return fmt.Errorf("%w: replicated lifecycle: %v", ErrVectorPartitionShardSearchGenerationMismatch, err)
 }
 
 func (s *CollectionVectorPartitionGenerationSourceV1) validateActive(ctx context.Context, key collectionVectorPartitionGenerationKeyV1, entry *collectionVectorPartitionGenerationCacheV1) error {

--- a/TreeDB/nativewire/vector_partition_generation_source_v1.go
+++ b/TreeDB/nativewire/vector_partition_generation_source_v1.go
@@ -12,6 +12,24 @@ import (
 
 const collectionVectorPartitionMaxAuthorityRefreshesV1 = 3
 
+// VectorPartitionReplicatedLifecycleAuthorityV1 is the constant-time M7
+// serving guard. Local prepared assets are evidence, not activation authority;
+// every cold load and cache hit must match the single replicated active record.
+type VectorPartitionReplicatedLifecycleAuthorityV1 interface {
+	ValidateVectorPartitionGenerationSearchV1(
+		context.Context,
+		string,
+		string,
+		uint64,
+		string,
+		uint64,
+		uint64,
+		uint64,
+		uint64,
+		string,
+	) error
+}
+
 // CollectionVectorPartitionGenerationSourceV1 binds M5 to one actual local
 // collection store. It keeps immutable ready generations and their opened
 // partition packs cached until explicit invalidation or Close. A request lease
@@ -23,7 +41,8 @@ const collectionVectorPartitionMaxAuthorityRefreshesV1 = 3
 // permanent for this source instance, so a stale service cannot reload the old
 // generation after the cutover.
 type CollectionVectorPartitionGenerationSourceV1 struct {
-	Collection *collections.Collection
+	Collection          *collections.Collection
+	replicatedLifecycle VectorPartitionReplicatedLifecycleAuthorityV1
 
 	mu          sync.Mutex
 	entries     map[collectionVectorPartitionGenerationKeyV1]*collectionVectorPartitionGenerationCacheV1
@@ -53,6 +72,23 @@ func NewCollectionVectorPartitionGenerationSourceV1(collection *collections.Coll
 		return nil, ErrVectorPartitionShardSearchAssetsUnavailable
 	}
 	return &CollectionVectorPartitionGenerationSourceV1{Collection: collection}, nil
+}
+
+// NewCollectionVectorPartitionGenerationSourceForReplicatedLifecycleV1 opens
+// locally prepared generations and admits them only through replicated M7
+// lifecycle authority. It deliberately does not consult or mutate M1's
+// standalone LocalActivate pointer.
+func NewCollectionVectorPartitionGenerationSourceForReplicatedLifecycleV1(
+	collection *collections.Collection,
+	authority VectorPartitionReplicatedLifecycleAuthorityV1,
+) (*CollectionVectorPartitionGenerationSourceV1, error) {
+	if collection == nil || authority == nil {
+		return nil, ErrVectorPartitionShardSearchAssetsUnavailable
+	}
+	return &CollectionVectorPartitionGenerationSourceV1{
+		Collection:          collection,
+		replicatedLifecycle: authority,
+	}, nil
 }
 
 type collectionVectorPartitionGenerationKeyV1 struct {
@@ -94,7 +130,7 @@ func (s *CollectionVectorPartitionGenerationSourceV1) PinVectorPartitionGenerati
 		if entry := s.entries[key]; entry != nil {
 			entry.refs++
 			s.mu.Unlock()
-			if err := s.validateActive(ctx, key, entry.authorityToken); err != nil {
+			if err := s.validateActive(ctx, key, entry); err != nil {
 				if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
 					_ = s.release(entry)
 					return nil, err
@@ -209,12 +245,22 @@ func (s *CollectionVectorPartitionGenerationSourceV1) loadGeneration(ctx context
 			pin.Release()
 		}
 	}()
-	manifest, authorityToken, err := s.Collection.ActiveVectorPartitionManifestAndAuthorityTokenWithContextV1(ctx, key.index, key.generation)
+	var manifest collections.VectorPartitionManifestV1
+	var authorityToken collections.VectorPartitionActiveAuthorityTokenV1
+	if s.replicatedLifecycle != nil {
+		manifest, err = s.Collection.PreparedVectorPartitionManifestWithContextV1(ctx, key.index, key.generation)
+	} else {
+		manifest, authorityToken, err = s.Collection.ActiveVectorPartitionManifestAndAuthorityTokenWithContextV1(ctx, key.index, key.generation)
+	}
 	if err != nil {
 		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
 			return nil, err
 		}
 		return nil, fmt.Errorf("%w: generation status: %v", ErrVectorPartitionShardSearchGenerationMismatch, err)
+	}
+	if err := s.validateReplicatedLifecycle(ctx, key, manifest); err != nil {
+		authorityToken.Release()
+		return nil, fmt.Errorf("%w: replicated lifecycle: %v", ErrVectorPartitionShardSearchGenerationMismatch, err)
 	}
 	openPlan, err := collections.NewVectorPartitionGenerationSearchOpenPlanWithContextV1(ctx, manifest)
 	if err != nil {
@@ -242,11 +288,46 @@ func (s *CollectionVectorPartitionGenerationSourceV1) loadGeneration(ctx context
 	}, nil
 }
 
-func (s *CollectionVectorPartitionGenerationSourceV1) validateActive(ctx context.Context, key collectionVectorPartitionGenerationKeyV1, authorityToken collections.VectorPartitionActiveAuthorityTokenV1) error {
+func (s *CollectionVectorPartitionGenerationSourceV1) validateActive(ctx context.Context, key collectionVectorPartitionGenerationKeyV1, entry *collectionVectorPartitionGenerationCacheV1) error {
 	if s.testValidateActive != nil {
 		return s.testValidateActive(ctx, key)
 	}
-	return s.Collection.ValidateActiveVectorPartitionAuthorityTokenWithContextV1(ctx, key.index, key.generation, authorityToken)
+	if entry == nil {
+		return ErrVectorPartitionShardSearchAssetsUnavailable
+	}
+	if s.replicatedLifecycle != nil {
+		return s.replicatedLifecycle.ValidateVectorPartitionGenerationSearchV1(
+			ctx,
+			entry.manifest.Collection,
+			entry.manifest.IndexName,
+			entry.manifest.Generation,
+			entry.manifest.IndexDefinitionDigest,
+			entry.manifest.SourceGeneration,
+			entry.manifest.SourceChecksum,
+			entry.manifest.SourceSchemaHash,
+			entry.manifest.SourceRowCount,
+			entry.manifest.ReadySetDigest,
+		)
+	}
+	return s.Collection.ValidateActiveVectorPartitionAuthorityTokenWithContextV1(ctx, key.index, key.generation, entry.authorityToken)
+}
+
+func (s *CollectionVectorPartitionGenerationSourceV1) validateReplicatedLifecycle(ctx context.Context, key collectionVectorPartitionGenerationKeyV1, manifest collections.VectorPartitionManifestV1) error {
+	if s.replicatedLifecycle == nil {
+		return nil
+	}
+	return s.replicatedLifecycle.ValidateVectorPartitionGenerationSearchV1(
+		ctx,
+		manifest.Collection,
+		key.index,
+		key.generation,
+		manifest.IndexDefinitionDigest,
+		manifest.SourceGeneration,
+		manifest.SourceChecksum,
+		manifest.SourceSchemaHash,
+		manifest.SourceRowCount,
+		manifest.ReadySetDigest,
+	)
 }
 
 func (s *CollectionVectorPartitionGenerationSourceV1) isInvalidatedLocked(key collectionVectorPartitionGenerationKeyV1) bool {
@@ -568,6 +649,7 @@ func pinnedVectorPartitionManifestV1(m collections.VectorPartitionManifestV1) Ve
 		SourceRowCount:        m.SourceRowCount,
 		Generation:            m.Generation,
 		RouterGeneration:      m.RouterGeneration,
+		ReadySetDigest:        m.ReadySetDigest,
 		PartitionCount:        m.PartitionCount,
 		Placements:            slices.Clone(m.Placements),
 	}

--- a/TreeDB/nativewire/vector_partition_mutation_admission_v1.go
+++ b/TreeDB/nativewire/vector_partition_mutation_admission_v1.go
@@ -41,10 +41,53 @@ func (a CatalogVectorPartitionMutationAdmissionV1) AdmitVectorPartitionMutationV
 	}
 	for _, status := range a.Authority.VectorPartitionLifecycleStatusesV1() {
 		identity := status.Identity
-		if !status.Active || identity.Index.Collection.Database != database || identity.Index.Collection.Catalog != catalog || identity.Index.Collection.Collection != collection {
+		if identity.Index.Collection.Database != database || identity.Index.Collection.Catalog != catalog || identity.Index.Collection.Collection != collection {
+			continue
+		}
+		if status.State == raftplacement.VectorPartitionLifecycleInvalidatedV1 && !status.MutationConfirmed {
+			return errors.New("nativewire: a prior vector-relevant mutation is pending outcome recovery")
+		}
+		if !status.Active {
 			continue
 		}
 		if _, err := a.Coordinator.InvalidateBeforeRelevantMutationV1(ctx, identity.Index, "nativewire relevant mutation"); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// ConfirmVectorPartitionMutationV1 releases only the fences which this
+// request made pending.  The shared submitter calls this solely after the
+// data Raft bridge reports a committed and locally recoverable result; a
+// failed or ambiguous submit intentionally leaves the catalog frozen.
+func (a CatalogVectorPartitionMutationAdmissionV1) ConfirmVectorPartitionMutationV1(ctx context.Context, command iwire.CommandID, sections []iwire.Section) error {
+	if a.Authority == nil || a.Coordinator.Authority != a.Authority || a.Coordinator.Committer == nil {
+		return errors.New("nativewire: vector partition lifecycle admission is incompletely configured")
+	}
+	if !vectorPartitionRelevantMutationCommandV1(command) {
+		return fmt.Errorf("nativewire: unclassified cluster mutation command %d", command)
+	}
+	collection, err := vectorPartitionMutationCollectionV1(command, sections)
+	if err != nil {
+		return err
+	}
+	database, catalog := a.Database, a.Catalog
+	if database == "" {
+		database = raftplacement.DefaultDatabase
+	}
+	if catalog == "" {
+		catalog = raftplacement.DefaultCatalog
+	}
+	for _, status := range a.Authority.VectorPartitionLifecycleStatusesV1() {
+		identity := status.Identity
+		if identity.Index.Collection.Database != database || identity.Index.Collection.Catalog != catalog || identity.Index.Collection.Collection != collection ||
+			status.State != raftplacement.VectorPartitionLifecycleInvalidatedV1 || status.MutationConfirmed {
+			continue
+		}
+		if err := a.Coordinator.ConfirmRelevantMutationV1(ctx, raftplacement.VectorPartitionLifecycleMutationProofV1{
+			IndexIdentity: identity.Index, ActiveGeneration: identity.Generation, InvalidationEpoch: status.InvalidationEpoch,
+		}); err != nil {
 			return err
 		}
 	}

--- a/TreeDB/nativewire/vector_partition_mutation_admission_v1.go
+++ b/TreeDB/nativewire/vector_partition_mutation_admission_v1.go
@@ -1,0 +1,77 @@
+package nativewire
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	iwire "github.com/snissn/gomap/TreeDB/internal/nativewire"
+	"github.com/snissn/gomap/TreeDB/internal/raftplacement"
+)
+
+// CatalogVectorPartitionMutationAdmissionV1 is the concrete M7 provider for
+// RaftClusterSubmitter. It resolves the bounded active lifecycle set from the
+// replicated catalog authority, rather than trusting a frontend-local index
+// cache, then invalidates every active index for the affected collection before
+// the shared submitter encodes its deterministic mutation entry.
+type CatalogVectorPartitionMutationAdmissionV1 struct {
+	Authority   *raftplacement.CatalogMetaAuthorityV1
+	Coordinator raftplacement.VectorPartitionLifecycleCoordinatorV1
+	Database    string
+	Catalog     string
+}
+
+func (a CatalogVectorPartitionMutationAdmissionV1) AdmitVectorPartitionMutationV1(ctx context.Context, command iwire.CommandID, sections []iwire.Section) error {
+	if a.Authority == nil || a.Coordinator.Authority != a.Authority || a.Coordinator.Committer == nil {
+		return errors.New("nativewire: vector partition lifecycle admission is incompletely configured")
+	}
+	if !vectorPartitionRelevantMutationCommandV1(command) {
+		return fmt.Errorf("nativewire: unclassified cluster mutation command %d", command)
+	}
+	collection, err := vectorPartitionMutationCollectionV1(command, sections)
+	if err != nil {
+		return err
+	}
+	database, catalog := a.Database, a.Catalog
+	if database == "" {
+		database = raftplacement.DefaultDatabase
+	}
+	if catalog == "" {
+		catalog = raftplacement.DefaultCatalog
+	}
+	for _, status := range a.Authority.VectorPartitionLifecycleStatusesV1() {
+		identity := status.Identity
+		if !status.Active || identity.Index.Collection.Database != database || identity.Index.Collection.Catalog != catalog || identity.Index.Collection.Collection != collection {
+			continue
+		}
+		if _, err := a.Coordinator.InvalidateBeforeRelevantMutationV1(ctx, identity.Index, "nativewire relevant mutation"); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func vectorPartitionRelevantMutationCommandV1(command iwire.CommandID) bool {
+	switch command {
+	case iwire.CommandCreateCollection, iwire.CommandDropCollection, iwire.CommandCreateIndex, iwire.CommandDropIndex,
+		iwire.CommandInsertBatch, iwire.CommandReplaceBatch, iwire.CommandDeleteBatch, iwire.CommandUpdateBSONSet:
+		return true
+	default:
+		return false
+	}
+}
+
+func vectorPartitionMutationCollectionV1(command iwire.CommandID, sections []iwire.Section) (string, error) {
+	if command == iwire.CommandCreateCollection {
+		raw, err := metadataSection(sections, iwire.SectionCollectionMeta)
+		if err != nil {
+			return "", err
+		}
+		meta, err := decodeCollectionMeta(raw)
+		if err != nil {
+			return "", err
+		}
+		return meta.Name, nil
+	}
+	return collectionNameFromSections(sections)
+}

--- a/TreeDB/nativewire/vector_partition_mutation_admission_v1.go
+++ b/TreeDB/nativewire/vector_partition_mutation_admission_v1.go
@@ -16,7 +16,7 @@ import (
 // RaftClusterSubmitter. It resolves the bounded active lifecycle set from the
 // replicated catalog authority, rather than trusting a frontend-local index
 // cache, then invalidates every active index for the affected collection before
-// the shared submitter encodes its deterministic mutation entry.
+// the data command is offered to consensus.
 type CatalogVectorPartitionMutationAdmissionV1 struct {
 	Authority   *raftplacement.CatalogMetaAuthorityV1
 	Coordinator raftplacement.VectorPartitionLifecycleCoordinatorV1

--- a/TreeDB/nativewire/vector_partition_mutation_admission_v1.go
+++ b/TreeDB/nativewire/vector_partition_mutation_admission_v1.go
@@ -47,6 +47,10 @@ func (a CatalogVectorPartitionMutationAdmissionV1) AdmitVectorPartitionMutationV
 		if status.State == raftplacement.VectorPartitionLifecycleInvalidatedV1 && !status.MutationConfirmed {
 			return errors.New("nativewire: a prior vector-relevant mutation is pending outcome recovery")
 		}
+		switch status.State {
+		case raftplacement.VectorPartitionLifecycleBuildingV1, raftplacement.VectorPartitionLifecycleStagedV1, raftplacement.VectorPartitionLifecyclePreparedV1:
+			return errors.New("nativewire: vector generation source capture is in progress; relevant mutation is frozen")
+		}
 		if !status.Active {
 			continue
 		}
@@ -57,8 +61,8 @@ func (a CatalogVectorPartitionMutationAdmissionV1) AdmitVectorPartitionMutationV
 	return nil
 }
 
-// ConfirmVectorPartitionMutationV1 releases only the fences which this
-// request made pending.  The shared submitter calls this solely after the
+// ConfirmVectorPartitionMutationV1 releases pending fences for this affected
+// collection. The shared submitter calls this solely after the
 // data Raft bridge reports a committed and locally recoverable result; a
 // failed or ambiguous submit intentionally leaves the catalog frozen.
 func (a CatalogVectorPartitionMutationAdmissionV1) ConfirmVectorPartitionMutationV1(ctx context.Context, command iwire.CommandID, sections []iwire.Section) error {

--- a/TreeDB/nativewire/vector_partition_mutation_admission_v1.go
+++ b/TreeDB/nativewire/vector_partition_mutation_admission_v1.go
@@ -81,8 +81,8 @@ func (a CatalogVectorPartitionMutationAdmissionV1) AdmitVectorPartitionMutationV
 
 // ConfirmVectorPartitionMutationV1 releases pending fences for this affected
 // collection. The shared submitter calls this solely after the
-// data Raft bridge reports a committed and locally recoverable result; a
-// failed or ambiguous submit intentionally leaves the catalog frozen.
+// data Raft bridge proves commit plus deterministic local apply; a failed or
+// ambiguous submit intentionally leaves the catalog frozen.
 func (a CatalogVectorPartitionMutationAdmissionV1) ConfirmVectorPartitionMutationV1(ctx context.Context, command iwire.CommandID, sections []iwire.Section) error {
 	if a.Authority == nil || a.Coordinator.Authority != a.Authority || a.Coordinator.Committer == nil {
 		return errors.New("nativewire: vector partition lifecycle admission is incompletely configured")
@@ -106,7 +106,7 @@ func (a CatalogVectorPartitionMutationAdmissionV1) ConfirmVectorPartitionMutatio
 		return err
 	}
 	collectionRef := raftplacement.CollectionRefV1{Database: database, Catalog: catalog, Collection: collection}
-	barrier, exists, err := a.Authority.VectorPartitionCollectionMutationBarrierV1(collectionRef)
+	barrier, exists, err := a.Authority.VectorPartitionCollectionMutationOperationV1(collectionRef, operationDigest)
 	if err != nil {
 		return err
 	}

--- a/TreeDB/nativewire/vector_partition_mutation_admission_v1.go
+++ b/TreeDB/nativewire/vector_partition_mutation_admission_v1.go
@@ -2,6 +2,9 @@ package nativewire
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/binary"
+	"encoding/hex"
 	"errors"
 	"fmt"
 
@@ -39,12 +42,27 @@ func (a CatalogVectorPartitionMutationAdmissionV1) AdmitVectorPartitionMutationV
 	if catalog == "" {
 		catalog = raftplacement.DefaultCatalog
 	}
+	operationDigest, err := vectorPartitionMutationOperationDigestV1(command, sections)
+	if err != nil {
+		return err
+	}
+	collectionRef := raftplacement.CollectionRefV1{Database: database, Catalog: catalog, Collection: collection}
+	barrier, err := a.Coordinator.BeginRelevantCollectionMutationV1(ctx, collectionRef, operationDigest)
+	if err != nil {
+		return err
+	}
+	// A completed barrier with the same operation digest is an exact
+	// idempotency replay. The data Raft layer will return the already-applied
+	// result, so invalidating a generation built afterward would be spurious.
+	if !barrier.Pending {
+		return nil
+	}
 	for _, status := range a.Authority.VectorPartitionLifecycleStatusesV1() {
 		identity := status.Identity
 		if identity.Index.Collection.Database != database || identity.Index.Collection.Catalog != catalog || identity.Index.Collection.Collection != collection {
 			continue
 		}
-		if status.State == raftplacement.VectorPartitionLifecycleInvalidatedV1 && !status.MutationConfirmed {
+		if status.State == raftplacement.VectorPartitionLifecycleInvalidatedV1 && !status.MutationConfirmed && status.InvalidationEpoch != barrier.Epoch {
 			return errors.New("nativewire: a prior vector-relevant mutation is pending outcome recovery")
 		}
 		switch status.State {
@@ -54,7 +72,7 @@ func (a CatalogVectorPartitionMutationAdmissionV1) AdmitVectorPartitionMutationV
 		if !status.Active {
 			continue
 		}
-		if _, err := a.Coordinator.InvalidateBeforeRelevantMutationV1(ctx, identity.Index, "nativewire relevant mutation"); err != nil {
+		if _, err := a.Coordinator.InvalidateBeforeRelevantMutationAtEpochV1(ctx, identity.Index, "nativewire relevant mutation", barrier.Epoch); err != nil {
 			return err
 		}
 	}
@@ -83,11 +101,29 @@ func (a CatalogVectorPartitionMutationAdmissionV1) ConfirmVectorPartitionMutatio
 	if catalog == "" {
 		catalog = raftplacement.DefaultCatalog
 	}
+	operationDigest, err := vectorPartitionMutationOperationDigestV1(command, sections)
+	if err != nil {
+		return err
+	}
+	collectionRef := raftplacement.CollectionRefV1{Database: database, Catalog: catalog, Collection: collection}
+	barrier, exists, err := a.Authority.VectorPartitionCollectionMutationBarrierV1(collectionRef)
+	if err != nil {
+		return err
+	}
+	if !exists || barrier.OperationDigest != operationDigest {
+		return errors.New("nativewire: vector mutation confirmation has no matching collection barrier")
+	}
+	if !barrier.Pending {
+		return nil
+	}
 	for _, status := range a.Authority.VectorPartitionLifecycleStatusesV1() {
 		identity := status.Identity
 		if identity.Index.Collection.Database != database || identity.Index.Collection.Catalog != catalog || identity.Index.Collection.Collection != collection ||
 			status.State != raftplacement.VectorPartitionLifecycleInvalidatedV1 || status.MutationConfirmed {
 			continue
+		}
+		if status.InvalidationEpoch != barrier.Epoch {
+			return errors.New("nativewire: vector mutation confirmation found a mismatched index fence")
 		}
 		if err := a.Coordinator.ConfirmRelevantMutationV1(ctx, raftplacement.VectorPartitionLifecycleMutationProofV1{
 			IndexIdentity: identity.Index, ActiveGeneration: identity.Generation, InvalidationEpoch: status.InvalidationEpoch,
@@ -95,7 +131,23 @@ func (a CatalogVectorPartitionMutationAdmissionV1) ConfirmVectorPartitionMutatio
 			return err
 		}
 	}
-	return nil
+	return a.Coordinator.ConfirmRelevantCollectionMutationV1(ctx, collectionRef, operationDigest)
+}
+
+func vectorPartitionMutationOperationDigestV1(command iwire.CommandID, sections []iwire.Section) (string, error) {
+	idempotencyKey, ok, err := singletonSection(sections, iwire.SectionIdempotencyKey)
+	if err != nil {
+		return "", err
+	}
+	if !ok || len(idempotencyKey) == 0 {
+		return "", errors.New("nativewire: vector-relevant mutation requires an idempotency key")
+	}
+	h := sha256.New()
+	var commandBytes [8]byte
+	binary.BigEndian.PutUint64(commandBytes[:], uint64(command))
+	_, _ = h.Write(commandBytes[:])
+	_, _ = h.Write(idempotencyKey)
+	return hex.EncodeToString(h.Sum(nil)), nil
 }
 
 func vectorPartitionRelevantMutationCommandV1(command iwire.CommandID) bool {

--- a/TreeDB/nativewire/vector_partition_mutation_admission_v1_test.go
+++ b/TreeDB/nativewire/vector_partition_mutation_admission_v1_test.go
@@ -1,0 +1,40 @@
+package nativewire
+
+import (
+	"testing"
+
+	iwire "github.com/snissn/gomap/TreeDB/internal/nativewire"
+)
+
+func TestVectorPartitionMutationOperationDigestUsesCommandAndIdempotencyV1(t *testing.T) {
+	sections := []iwire.Section{{ID: iwire.SectionIdempotencyKey, Bytes: []byte("request-1")}}
+	first, err := vectorPartitionMutationOperationDigestV1(iwire.CommandInsertBatch, sections)
+	if err != nil {
+		t.Fatal(err)
+	}
+	retry, err := vectorPartitionMutationOperationDigestV1(iwire.CommandInsertBatch, append(sections, iwire.Section{ID: iwire.SectionDocuments, Bytes: []byte("same data-layer operation identity")}))
+	if err != nil || retry != first {
+		t.Fatalf("retry digest=%q first=%q err=%v", retry, first, err)
+	}
+	differentCommand, err := vectorPartitionMutationOperationDigestV1(iwire.CommandDeleteBatch, sections)
+	if err != nil || differentCommand == first {
+		t.Fatalf("different command digest=%q first=%q err=%v", differentCommand, first, err)
+	}
+	differentKey, err := vectorPartitionMutationOperationDigestV1(iwire.CommandInsertBatch, []iwire.Section{{ID: iwire.SectionIdempotencyKey, Bytes: []byte("request-2")}})
+	if err != nil || differentKey == first {
+		t.Fatalf("different key digest=%q first=%q err=%v", differentKey, first, err)
+	}
+}
+
+func TestVectorPartitionMutationOperationDigestRejectsMissingOrDuplicateKeyV1(t *testing.T) {
+	if _, err := vectorPartitionMutationOperationDigestV1(iwire.CommandInsertBatch, nil); err == nil {
+		t.Fatal("missing idempotency key was accepted")
+	}
+	duplicate := []iwire.Section{
+		{ID: iwire.SectionIdempotencyKey, Bytes: []byte("request-1")},
+		{ID: iwire.SectionIdempotencyKey, Bytes: []byte("request-1")},
+	}
+	if _, err := vectorPartitionMutationOperationDigestV1(iwire.CommandInsertBatch, duplicate); err == nil {
+		t.Fatal("duplicate idempotency key was accepted")
+	}
+}

--- a/TreeDB/nativewire/vector_partition_shard_search_v1.go
+++ b/TreeDB/nativewire/vector_partition_shard_search_v1.go
@@ -141,6 +141,7 @@ type VectorPartitionShardSearchRequestV1 struct {
 	RequestID, CancellationID        string
 	Database, Catalog, Collection    string
 	IndexName, IndexDefinitionDigest string
+	ReadySetDigest                   string
 
 	SourceGeneration, SourceChecksum, SourceSchemaHash, SourceRowCount uint64
 	PartitionGeneration, RouterGeneration                              uint64
@@ -182,6 +183,7 @@ type VectorPartitionShardSearchPartialV1 struct {
 type VectorPartitionShardSearchProofV1 struct {
 	ServingNode, LeaderNode                                            raftcluster.NodeID
 	GroupID                                                            raftcluster.GroupID
+	ReadySetDigest                                                     string
 	ReadTerm, ReadIndex                                                uint64
 	AppliedTerm, AppliedIndex                                          uint64
 	SourceGeneration, SourceChecksum, SourceSchemaHash, SourceRowCount uint64
@@ -623,6 +625,7 @@ func (s *VectorPartitionShardSearchServiceV1) Search(ctx context.Context, reques
 			ServingNode:         proof.NodeID,
 			LeaderNode:          proof.NodeID,
 			GroupID:             proof.GroupID,
+			ReadySetDigest:      request.ReadySetDigest,
 			ReadTerm:            proof.Term,
 			ReadIndex:           proof.Index,
 			AppliedTerm:         progress.Term,
@@ -707,6 +710,7 @@ func (s *VectorPartitionShardSearchServiceV1) validateRequest(r VectorPartitionS
 		r.RequestID == "" || r.CancellationID == "" ||
 		r.Database == "" || r.Catalog == "" || r.Collection == "" || r.IndexName == "" ||
 		!isVectorPartitionShardSearchDigestV1(r.IndexDefinitionDigest) ||
+		!isVectorPartitionShardSearchDigestV1(r.ReadySetDigest) ||
 		r.SourceGeneration == 0 || r.SourceRowCount == 0 || r.PartitionGeneration == 0 || r.RouterGeneration == 0 ||
 		len(r.PartitionIDs) < 1 || len(r.PartitionIDs) > l.MaxPartitions ||
 		len(r.Query) < 1 || len(r.Query) > l.MaxDimensions ||
@@ -716,7 +720,7 @@ func (s *VectorPartitionShardSearchServiceV1) validateRequest(r VectorPartitionS
 	if r.TargetGroupID == "" {
 		return errors.Join(ErrVectorPartitionShardSearchInvalidRequest, raftcluster.ErrRouteTargetMissing)
 	}
-	for _, identity := range []string{r.RequestID, r.CancellationID, r.Database, r.Catalog, r.Collection, r.IndexName, r.IndexDefinitionDigest, string(r.TargetGroupID), string(r.TargetNodeID)} {
+	for _, identity := range []string{r.RequestID, r.CancellationID, r.Database, r.Catalog, r.Collection, r.IndexName, r.IndexDefinitionDigest, r.ReadySetDigest, string(r.TargetGroupID), string(r.TargetNodeID)} {
 		if len(identity) > l.MaxIdentityBytes {
 			return fmt.Errorf("%w: identity bytes", ErrVectorPartitionShardSearchInvalidRequest)
 		}
@@ -756,7 +760,7 @@ func (s *VectorPartitionShardSearchServiceV1) validateRequest(r VectorPartitionS
 	if !ok {
 		return fmt.Errorf("%w: request byte overflow", ErrVectorPartitionShardSearchInvalidRequest)
 	}
-	for _, identity := range []string{r.RequestID, r.CancellationID, r.Database, r.Catalog, r.Collection, r.IndexName, r.IndexDefinitionDigest, string(r.TargetGroupID), string(r.TargetNodeID)} {
+	for _, identity := range []string{r.RequestID, r.CancellationID, r.Database, r.Catalog, r.Collection, r.IndexName, r.IndexDefinitionDigest, r.ReadySetDigest, string(r.TargetGroupID), string(r.TargetNodeID)} {
 		requestBytes, ok = addUint64V1(requestBytes, uint64(len(identity)))
 		if !ok {
 			return fmt.Errorf("%w: request byte overflow", ErrVectorPartitionShardSearchInvalidRequest)
@@ -829,7 +833,8 @@ func (s *VectorPartitionShardSearchServiceV1) validatePinnedManifest(r VectorPar
 		m.IndexDefinitionDigest != r.IndexDefinitionDigest ||
 		m.SourceGeneration != r.SourceGeneration || m.SourceChecksum != r.SourceChecksum ||
 		m.SourceSchemaHash != r.SourceSchemaHash || m.SourceRowCount != r.SourceRowCount ||
-		m.Generation != r.PartitionGeneration || m.RouterGeneration != r.RouterGeneration {
+		m.Generation != r.PartitionGeneration || m.RouterGeneration != r.RouterGeneration ||
+		m.ReadySetDigest != r.ReadySetDigest {
 		return ErrVectorPartitionShardSearchGenerationMismatch
 	}
 	for _, partitionID := range r.PartitionIDs {

--- a/TreeDB/nativewire/vector_partition_shard_search_v1.go
+++ b/TreeDB/nativewire/vector_partition_shard_search_v1.go
@@ -236,6 +236,7 @@ type VectorPartitionPinnedManifestV1 struct {
 	State, Collection, IndexName, IndexDefinitionDigest                string
 	SourceGeneration, SourceChecksum, SourceSchemaHash, SourceRowCount uint64
 	Generation, RouterGeneration                                       uint64
+	ReadySetDigest                                                     string
 	PartitionCount                                                     uint32
 	Placements                                                         []collections.VectorPartitionPlacementV1
 }

--- a/TreeDB/nativewire/vector_partition_shard_search_v1_test.go
+++ b/TreeDB/nativewire/vector_partition_shard_search_v1_test.go
@@ -298,7 +298,7 @@ type recordingVectorPartitionReplicatedLifecycleAuthorityV1 struct {
 
 func (a *recordingVectorPartitionReplicatedLifecycleAuthorityV1) ValidateVectorPartitionGenerationSearchV1(
 	_ context.Context,
-	collection string,
+	collection raftplacement.CollectionRefV1,
 	index string,
 	generation uint64,
 	indexDigest string,
@@ -331,9 +331,10 @@ func TestCollectionVectorPartitionGenerationCacheUsesReplicatedAuthorityOnWarmHi
 		opening:   make(map[uint32]*collectionVectorPartitionSearchLoadV1),
 	}
 	source := &CollectionVectorPartitionGenerationSourceV1{
-		Collection:          new(collections.Collection),
-		replicatedLifecycle: authority,
-		entries:             map[collectionVectorPartitionGenerationKeyV1]*collectionVectorPartitionGenerationCacheV1{key: entry},
+		Collection:           new(collections.Collection),
+		replicatedCollection: raftplacement.CollectionRefV1{Database: "default", Catalog: "default", Collection: "users"},
+		replicatedLifecycle:  authority,
+		entries:              map[collectionVectorPartitionGenerationKeyV1]*collectionVectorPartitionGenerationCacheV1{key: entry},
 	}
 
 	if _, err := source.PinVectorPartitionGenerationV1(t.Context(), key.index, key.generation); !errors.Is(err, ErrVectorPartitionShardSearchGenerationMismatch) {
@@ -342,7 +343,7 @@ func TestCollectionVectorPartitionGenerationCacheUsesReplicatedAuthorityOnWarmHi
 	if authority.calls != 1 {
 		t.Fatalf("replicated authority calls=%d want 1", authority.calls)
 	}
-	want := []any{"users", "embedding", uint64(7), strings.Repeat("a", 64), uint64(3), uint64(4), uint64(5), uint64(6), strings.Repeat("b", 64)}
+	want := []any{raftplacement.CollectionRefV1{Database: "default", Catalog: "default", Collection: "users"}, "embedding", uint64(7), strings.Repeat("a", 64), uint64(3), uint64(4), uint64(5), uint64(6), strings.Repeat("b", 64)}
 	if !reflect.DeepEqual(authority.args, want) {
 		t.Fatalf("replicated authority args=%#v want %#v", authority.args, want)
 	}

--- a/TreeDB/nativewire/vector_partition_shard_search_v1_test.go
+++ b/TreeDB/nativewire/vector_partition_shard_search_v1_test.go
@@ -291,9 +291,10 @@ func TestCollectionVectorPartitionGenerationCacheRevalidatesWarmHitV1(t *testing
 }
 
 type recordingVectorPartitionReplicatedLifecycleAuthorityV1 struct {
-	calls int
-	args  []any
-	err   error
+	calls          int
+	args           []any
+	readySetDigest string
+	err            error
 }
 
 func TestVectorPartitionReplicatedLifecycleValidationErrorPreservesCancellationV1(t *testing.T) {
@@ -337,11 +338,14 @@ func (a *recordingVectorPartitionReplicatedLifecycleAuthorityV1) ValidateVectorP
 	sourceChecksum uint64,
 	sourceSchemaHash uint64,
 	sourceRowCount uint64,
-	readySetDigest string,
-) error {
+) (string, error) {
 	a.calls++
-	a.args = []any{collection, index, generation, indexDigest, sourceGeneration, sourceChecksum, sourceSchemaHash, sourceRowCount, readySetDigest}
-	return a.err
+	a.args = []any{collection, index, generation, indexDigest, sourceGeneration, sourceChecksum, sourceSchemaHash, sourceRowCount}
+	readySetDigest := a.readySetDigest
+	if readySetDigest == "" {
+		readySetDigest = strings.Repeat("b", 64)
+	}
+	return readySetDigest, a.err
 }
 
 func TestCollectionVectorPartitionGenerationCacheUsesReplicatedAuthorityOnWarmHitV1(t *testing.T) {
@@ -374,12 +378,42 @@ func TestCollectionVectorPartitionGenerationCacheUsesReplicatedAuthorityOnWarmHi
 	if authority.calls != 1 {
 		t.Fatalf("replicated authority calls=%d want 1", authority.calls)
 	}
-	want := []any{raftplacement.CollectionRefV1{Database: "default", Catalog: "default", Collection: "users"}, "embedding", uint64(7), strings.Repeat("a", 64), uint64(3), uint64(4), uint64(5), uint64(6), strings.Repeat("b", 64)}
+	want := []any{raftplacement.CollectionRefV1{Database: "default", Catalog: "default", Collection: "users"}, "embedding", uint64(7), strings.Repeat("a", 64), uint64(3), uint64(4), uint64(5), uint64(6)}
 	if !reflect.DeepEqual(authority.args, want) {
 		t.Fatalf("replicated authority args=%#v want %#v", authority.args, want)
 	}
 	if _, ok := source.invalidated[key]; !ok {
 		t.Fatal("replicated invalidation did not permanently evict stale cache entry")
+	}
+}
+
+func TestCollectionVectorPartitionGenerationCacheRejectsChangedReplicatedReadySetV1(t *testing.T) {
+	key := collectionVectorPartitionGenerationKeyV1{index: "embedding", generation: 7}
+	manifest := VectorPartitionPinnedManifestV1{
+		Collection: "users", IndexName: key.index, Generation: key.generation,
+		IndexDefinitionDigest: strings.Repeat("a", 64),
+		SourceGeneration:      3,
+		SourceChecksum:        4,
+		SourceSchemaHash:      5,
+		SourceRowCount:        6,
+		ReadySetDigest:        strings.Repeat("b", 64),
+	}
+	entry := &collectionVectorPartitionGenerationCacheV1{
+		index: key.index, generation: key.generation, manifest: manifest,
+		searchers: make(map[uint32]*collections.VectorPartitionLocalSearcherV1),
+		opening:   make(map[uint32]*collectionVectorPartitionSearchLoadV1),
+	}
+	source := &CollectionVectorPartitionGenerationSourceV1{
+		Collection:           new(collections.Collection),
+		replicatedCollection: raftplacement.CollectionRefV1{Database: "default", Catalog: "default", Collection: "users"},
+		replicatedLifecycle:  &recordingVectorPartitionReplicatedLifecycleAuthorityV1{readySetDigest: strings.Repeat("c", 64)},
+		entries:              map[collectionVectorPartitionGenerationKeyV1]*collectionVectorPartitionGenerationCacheV1{key: entry},
+	}
+	if _, err := source.PinVectorPartitionGenerationV1(t.Context(), key.index, key.generation); !errors.Is(err, ErrVectorPartitionShardSearchGenerationMismatch) {
+		t.Fatalf("changed replicated ready-set err=%v", err)
+	}
+	if _, invalidated := source.invalidated[key]; !invalidated {
+		t.Fatal("changed replicated ready-set did not retire the cached generation")
 	}
 }
 
@@ -632,6 +666,7 @@ func TestVectorPartitionShardSearchLeaderGroupLocalReturnsOracleAndProofV1(t *te
 		t.Fatalf("response identity=%+v", response)
 	}
 	if got := response.Proof; got.ServingNode != "node-a" || got.LeaderNode != "node-a" || got.GroupID != "group-a" ||
+		got.ReadySetDigest != request.ReadySetDigest ||
 		got.ReadTerm != 3 || got.ReadIndex != 41 || got.AppliedTerm != 3 || got.AppliedIndex != 43 ||
 		got.PartitionGeneration != 7 || got.RouterGeneration != 7 || got.SourceGeneration != 11 {
 		t.Fatalf("proof=%+v", got)
@@ -1016,6 +1051,7 @@ func TestVectorPartitionShardSearchBoundsFailBeforeProofOrAllocationV1(t *testin
 		{name: "top_k", edit: func(r *VectorPartitionShardSearchRequestV1) { r.TopK = service.limits.MaxTopK + 1 }},
 		{name: "ef_search", edit: func(r *VectorPartitionShardSearchRequestV1) { r.EfSearch = service.limits.MaxEfSearch + 1 }},
 		{name: "partition_order", edit: func(r *VectorPartitionShardSearchRequestV1) { r.PartitionIDs = []uint32{0, 0} }},
+		{name: "ready_set_digest", edit: func(r *VectorPartitionShardSearchRequestV1) { r.ReadySetDigest = "" }},
 		{name: "request_bytes", edit: func(r *VectorPartitionShardSearchRequestV1) { r.RequestBytesLimit = 1 }},
 		{name: "candidate_bytes", edit: func(r *VectorPartitionShardSearchRequestV1) { r.CandidateBytesLimit = 1 }},
 		{name: "response_bytes", edit: func(r *VectorPartitionShardSearchRequestV1) { r.ResponseBytesLimit = 1 }, code: VectorPartitionShardSearchErrorResponseTooLargeV1},
@@ -1398,6 +1434,7 @@ func newVectorPartitionShardSearchTestServiceV1(tb testing.TB, parts []raftplace
 			SourceRowCount:        5,
 			Generation:            7,
 			RouterGeneration:      7,
+			ReadySetDigest:        vectorPartitionShardSearchDigestTestV1,
 			PartitionCount:        uint32(len(parts)),
 			Placements:            manifestParts,
 		},
@@ -1464,6 +1501,7 @@ func vectorPartitionShardSearchRequestTestV1(partitions []uint32) VectorPartitio
 		SourceRowCount:        5,
 		PartitionGeneration:   7,
 		RouterGeneration:      7,
+		ReadySetDigest:        vectorPartitionShardSearchDigestTestV1,
 		TargetGroupID:         "group-a",
 		TargetNodeID:          "node-a",
 		PartitionIDs:          append([]uint32(nil), partitions...),

--- a/TreeDB/nativewire/vector_partition_shard_search_v1_test.go
+++ b/TreeDB/nativewire/vector_partition_shard_search_v1_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"math"
+	"reflect"
 	"sort"
 	"strings"
 	"sync"
@@ -286,6 +287,67 @@ func TestCollectionVectorPartitionGenerationCacheRevalidatesWarmHitV1(t *testing
 	}
 	if _, ok := source.invalidated[key]; !ok {
 		t.Fatal("stale warm generation was not permanently invalidated")
+	}
+}
+
+type recordingVectorPartitionReplicatedLifecycleAuthorityV1 struct {
+	calls int
+	args  []any
+	err   error
+}
+
+func (a *recordingVectorPartitionReplicatedLifecycleAuthorityV1) ValidateVectorPartitionGenerationSearchV1(
+	_ context.Context,
+	collection string,
+	index string,
+	generation uint64,
+	indexDigest string,
+	sourceGeneration uint64,
+	sourceChecksum uint64,
+	sourceSchemaHash uint64,
+	sourceRowCount uint64,
+	readySetDigest string,
+) error {
+	a.calls++
+	a.args = []any{collection, index, generation, indexDigest, sourceGeneration, sourceChecksum, sourceSchemaHash, sourceRowCount, readySetDigest}
+	return a.err
+}
+
+func TestCollectionVectorPartitionGenerationCacheUsesReplicatedAuthorityOnWarmHitV1(t *testing.T) {
+	key := collectionVectorPartitionGenerationKeyV1{index: "embedding", generation: 7}
+	manifest := VectorPartitionPinnedManifestV1{
+		Collection: "users", IndexName: key.index, Generation: key.generation,
+		IndexDefinitionDigest: strings.Repeat("a", 64),
+		SourceGeneration:      3,
+		SourceChecksum:        4,
+		SourceSchemaHash:      5,
+		SourceRowCount:        6,
+		ReadySetDigest:        strings.Repeat("b", 64),
+	}
+	authority := &recordingVectorPartitionReplicatedLifecycleAuthorityV1{err: errors.New("generation invalidated")}
+	entry := &collectionVectorPartitionGenerationCacheV1{
+		index: key.index, generation: key.generation, manifest: manifest,
+		searchers: make(map[uint32]*collections.VectorPartitionLocalSearcherV1),
+		opening:   make(map[uint32]*collectionVectorPartitionSearchLoadV1),
+	}
+	source := &CollectionVectorPartitionGenerationSourceV1{
+		Collection:          new(collections.Collection),
+		replicatedLifecycle: authority,
+		entries:             map[collectionVectorPartitionGenerationKeyV1]*collectionVectorPartitionGenerationCacheV1{key: entry},
+	}
+
+	if _, err := source.PinVectorPartitionGenerationV1(t.Context(), key.index, key.generation); !errors.Is(err, ErrVectorPartitionShardSearchGenerationMismatch) {
+		t.Fatalf("warm invalidated generation err=%v", err)
+	}
+	if authority.calls != 1 {
+		t.Fatalf("replicated authority calls=%d want 1", authority.calls)
+	}
+	want := []any{"users", "embedding", uint64(7), strings.Repeat("a", 64), uint64(3), uint64(4), uint64(5), uint64(6), strings.Repeat("b", 64)}
+	if !reflect.DeepEqual(authority.args, want) {
+		t.Fatalf("replicated authority args=%#v want %#v", authority.args, want)
+	}
+	if _, ok := source.invalidated[key]; !ok {
+		t.Fatal("replicated invalidation did not permanently evict stale cache entry")
 	}
 }
 

--- a/TreeDB/nativewire/vector_partition_shard_search_v1_test.go
+++ b/TreeDB/nativewire/vector_partition_shard_search_v1_test.go
@@ -296,6 +296,37 @@ type recordingVectorPartitionReplicatedLifecycleAuthorityV1 struct {
 	err   error
 }
 
+func TestVectorPartitionReplicatedLifecycleValidationErrorPreservesCancellationV1(t *testing.T) {
+	tests := []struct {
+		name string
+		ctx  context.Context
+		err  error
+		want error
+	}{
+		{name: "authority canceled", ctx: context.Background(), err: context.Canceled, want: context.Canceled},
+		{name: "authority deadline", ctx: context.Background(), err: context.DeadlineExceeded, want: context.DeadlineExceeded},
+	}
+	canceled, cancel := context.WithCancel(context.Background())
+	cancel()
+	tests = append(tests, struct {
+		name string
+		ctx  context.Context
+		err  error
+		want error
+	}{name: "caller canceled", ctx: canceled, err: errors.New("authority unavailable"), want: context.Canceled})
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if got := vectorPartitionReplicatedLifecycleValidationErrorV1(test.ctx, test.err); !errors.Is(got, test.want) || errors.Is(got, ErrVectorPartitionShardSearchGenerationMismatch) {
+				t.Fatalf("validation error=%v want direct %v", got, test.want)
+			}
+		})
+	}
+	plain := errors.New("generation replaced")
+	if got := vectorPartitionReplicatedLifecycleValidationErrorV1(context.Background(), plain); !errors.Is(got, ErrVectorPartitionShardSearchGenerationMismatch) || errors.Is(got, plain) {
+		t.Fatalf("ordinary validation error=%v", got)
+	}
+}
+
 func (a *recordingVectorPartitionReplicatedLifecycleAuthorityV1) ValidateVectorPartitionGenerationSearchV1(
 	_ context.Context,
 	collection raftplacement.CollectionRefV1,

--- a/cmd/treedb_vector_partition_bench/m6_coordinator.go
+++ b/cmd/treedb_vector_partition_bench/m6_coordinator.go
@@ -268,7 +268,8 @@ func (d *m6LocalShardDispatcherV1) DispatchVectorPartitionShardSearchV1(ctx cont
 		Version: nativewire.VectorPartitionShardSearchVersionV1, RequestID: request.RequestID,
 		Proof: nativewire.VectorPartitionShardSearchProofV1{
 			ServingNode: request.TargetNodeID, LeaderNode: request.TargetNodeID, GroupID: request.TargetGroupID,
-			ReadTerm: 1, ReadIndex: 1, AppliedTerm: 1, AppliedIndex: 1,
+			ReadySetDigest: request.ReadySetDigest,
+			ReadTerm:       1, ReadIndex: 1, AppliedTerm: 1, AppliedIndex: 1,
 			SourceGeneration: request.SourceGeneration, SourceChecksum: request.SourceChecksum,
 			SourceSchemaHash: request.SourceSchemaHash, SourceRowCount: request.SourceRowCount,
 			PartitionGeneration: request.PartitionGeneration, RouterGeneration: request.RouterGeneration,


### PR DESCRIPTION
## Objective

Land M7 of #3908: a bounded, Raft-replicated vector-partition generation
lifecycle that admits M5/M6 search only for one complete active generation and
durably invalidates that generation before any relevant collection mutation can
commit.

Closes #3916.

## Context

M6 (#3915) merged the generation-pinned coordinator. M7 supplies the replicated
catalog authority, mutation ordering, manual rebuild/cutover workflow, recovery
state, and cleanup guards required before M8 can exercise repeated real-topology
failure and rebuild cycles.

## Non-goals

- No online HNSW repair, delta index, dual-write, live repartition, or automatic
  continuous rebuild scheduler.
- No production network transport or remote asset uploader; group construction
  is a narrow caller-owned bounded callback.
- No full-document distributed fetch.
- No claim that the lifecycle is production-ready; the feature remains
  experimental pending M8.

## Design

### Replicated state and transitions

`absent -> building -> staged -> prepared -> active -> invalidated -> retired
-> cleanable -> absent` is encoded by deterministic V1 commands and records in
the existing catalog/meta Raft owner. Commands bind collection incarnation,
index definition/epoch, catalog epoch/digest, source checksum/schema/row count,
generation, previous-active revision, mutation watermark, required groups,
ready-set digest, and bounded asset proofs.

The workflow coordinator exposes guarded begin, caller-owned build/stage,
group-ready, prepare, atomic activate/cutover, abort, retire, cleanability,
per-group cleanup, completion, and recovery-status operations. Exact achieved
states are idempotent on retry; stale or conflicting identities/revisions fail
closed.

### Invalidation-before-mutation

The concrete nativewire/Mongo Raft submitter integration resolves the bounded
active lifecycle set from replicated catalog authority. Relevant document and
DDL commands:

1. publish a bounded, collection-keyed barrier bound to the command and
   idempotency identity;
2. reject while a distinct mutation or source capture/build/prepare is in
   progress;
3. durably invalidate every active vector index at the barrier epoch;
4. hold snapshot-backed collection and per-index pending fences;
5. submit the deterministic data command;
6. clear per-index fences and then the collection barrier only after the data
   bridge proves commit plus deterministic local apply, independently of the
   client-selected acknowledgment policy.

Failure or ambiguity after barrier publication leaves conservative search/build
downtime. Pending barriers/fences survive snapshot/rejoin and block activation,
retirement, and cleanup. Build coordinators read the retained collection epoch
before source capture and `BeginBuildV1` revalidates it afterward; this closes
the first-generation scan/build race as well as delayed stale activation.
Distinct concurrent mutations cannot share a fence, while an exact idempotency
retry reuses the same operation safely. Each collection retains the 64 most
recent completed operation identities in the canonical catalog snapshot so a
delayed retained retry remains a no-op after newer mutations complete.

### Search and storage admission

- M5 generation pinning and M6 coordinator router admission validate the exact
  replicated active identity and lifecycle ready-set proof before
  search/fanout; this proof digest remains separate from the local manifest's
  placement/asset digest.
- Every validation performs a fresh quorum-verified meta-Raft leader fence and
  requires the local catalog view through the returned command index; the raw
  replica-local authority cannot implement the serving interface.
- The coordinator opens the exact locally prepared generation named by
  replicated placement without consulting the standalone active pointer.
- M7-enabled construction requires both mutation admission and replicated
  lifecycle authority; missing wiring fails closed.
- Local prepared manifests remain non-serving until replicated activation.
- Snapshot encoding retains lifecycle records, per-index fences, and bounded
  collection mutation barriers canonically under hard
  catalog/command/record byte limits.

## Scope

Includes:

- lifecycle model, codec, catalog authority, snapshot/recovery, status, and
  mutation-fence state;
- meta-Raft workflow coordinator and concrete Raft submitter admission;
- nativewire/Mongo shared mutation boundary;
- M5/M6 replicated active-generation admission;
- collections prepared-manifest lifecycle integration;
- model, crash/replay, cutover, cleanup, retry, and fail-closed tests;
- lifecycle specification and bounded microbenchmark evidence.

Excludes:

- production group-builder transport/upload and automatic orchestration;
- M8 production-topology acceptance and performance claim;
- compatibility migration scaffolding (TreeDB is pre-alpha).

## Correctness

Exact issue gates:

```sh
GOWORK=off go test ./TreeDB/internal/raftplacement ./TreeDB/internal/raftcluster ./TreeDB/internal/raftfsm ./TreeDB/collections ./TreeDB/nativewire ./TreeDB/mongo_gateway -run 'Test.*(VectorPartitionGeneration|Catalog|Snapshot|Mutation|Invalidate|Cutover).*' -count=1
GOWORK=off go test -race ./TreeDB/internal/raftcluster ./TreeDB/collections ./TreeDB/nativewire -run 'Test.*(VectorPartitionGeneration|Invalidate|Cutover).*' -count=1
```

Both pass on `da219c25e`. The full six-package affected suite, focused retained-
replay and cancellation race tests, and meta-Raft provider race test also pass
on that head. The final feature-derived admission, catalog-freshness, and
restore/confirmation and preflight-ordering corrections through `a924188c2` pass their full affected-package
suites, focused race regressions, vet, and diff hygiene:

```sh
GOWORK=off go test ./TreeDB/internal/raftcluster ./TreeDB/nativewire ./TreeDB/mongo_gateway -count=1
GOWORK=off go test -race ./TreeDB/internal/raftcluster ./TreeDB/nativewire ./TreeDB/mongo_gateway -run 'Test(GroupRoutedSubmitterRequiresFeatureWhenAnyGroupEnablesIt|LegacyRaftClusterSubmitterRequiresVectorAdmissionFromClusterFeatureV1|CatalogRoutedLegacySubmitterRequiresVectorAdmissionFromCatalogFeatureV1|LegacyRaftClusterSubmitterMongoRequiresVectorAdmissionFromClusterFeatureV1)$' -count=1
GOWORK=off go vet ./TreeDB/internal/raftcluster ./TreeDB/nativewire ./TreeDB/mongo_gateway
GOWORK=off go test ./TreeDB/internal/raftplacement -count=1
GOWORK=off go test -race ./TreeDB/internal/raftplacement -run 'Test(CatalogMetaLifecycleRecordReturnsDeepCopy|CatalogMetaLifecycleRefusesFenceMismatchBeforeReducerPublicationV1)$' -count=1
GOWORK=off go vet ./TreeDB/internal/raftplacement
GOWORK=off go test ./TreeDB/internal/raftplacement ./TreeDB/nativewire ./TreeDB/mongo_gateway -count=1
GOWORK=off go test -race ./TreeDB/internal/raftplacement ./TreeDB/nativewire ./TreeDB/mongo_gateway -run 'TestCatalogMetaLifecycleSnapshotRejectsInconsistentPendingFenceV1|TestClusterSubmitterConfirmsCommittedVectorMutationBeforeReturningPostApplyErrorV1' -count=1
GOWORK=off go test ./TreeDB/docs -count=1
GOWORK=off go vet ./TreeDB/internal/raftplacement ./TreeDB/nativewire ./TreeDB/mongo_gateway ./TreeDB/docs
GOWORK=off go test ./TreeDB/internal/raftcluster ./TreeDB/internal/raftplacement ./TreeDB/nativewire ./TreeDB/mongo_gateway ./TreeDB/docs -count=1
GOWORK=off go test -race ./TreeDB/internal/raftcluster ./TreeDB/nativewire -run 'TestSingleGroupSubmitterRejectsMissingPostApplyCatalogVersion|TestRaftClusterSubmitterPreservesCommittedAppliedThroughErrorsV1|TestClusterSubmitterConfirmsCommittedVectorMutationBeforeReturningPostApplyErrorV1' -count=1
GOWORK=off go test -race ./TreeDB/internal/raftcluster ./TreeDB/nativewire ./TreeDB/mongo_gateway -run 'TestSingleGroupSubmitterSerializesPreCommitAfterPreflightBeforeCommitV1|TestGroupRoutedSubmitterDelegatesSerializedPreCommitV1|TestGroupRoutedSubmitterRejectsMissingSerializedPreCommitV1|TestClusterSubmitterVisibleAckConfirmsCommittedVectorMutationV1|TestClusterSubmitterConfirmsCommittedVectorMutationBeforeReturningPostApplyErrorV1|TestClusterSubmitterCommittedVectorConfirmationOutlivesClientCancellationV1|TestLegacyRaftClusterSubmitterRequiresVectorAdmissionFromClusterFeatureV1|TestLegacyRaftClusterSubmitterMongoRequiresVectorAdmissionFromClusterFeatureV1' -count=1
git diff --check origin/main...HEAD
```

Coverage includes every legal/illegal reducer transition, deterministic
multi-generation proof selection, exact retry and stale/conflict refusal,
N-to-N+1 atomic cutover, build-time mutation freeze, equal-epoch activation
races, first-generation source-capture ordering, distinct concurrent-operation
refusal, completed idempotency replay, failed/ambiguous mutation recovery debt,
nativewire/Mongo no-submit refusal, snapshot/restore, bounded barrier capacity,
prospective full-snapshot and record-cap refusal with rollback, route refusal
before durable admission, production constructor refusal of admission-only
wiring, lower-ack mutation confirmation, distinct replicated/local ready-set
digests, exact prepared-generation router opening without a standalone active
pointer, unconfigured workflow fail-closed behavior, A/B/A retained operation
replay across snapshot restore, bounded completion-history eviction, Mongo
applied-versus-recoverable confirmation, cleanup reachability, cancellation
propagation, client cancellation between committed apply and lifecycle
confirmation in both protocol paths, stale catalog applied-index refusal,
meta-leader fence failure, and replicated search admission before router/shard
work. It also covers the legacy nativewire and Mongo constructors deriving the
M7 admission requirement from negotiated single-group, composite-group, or
quorum-fenced replicated-catalog feature state before any Raft submit, including
a local catalog view lagging the linearizable meta-Raft index. Public lifecycle
record reads also deep-clone every slice field so callers cannot mutate replicated
authority state outside a Raft command. Snapshot restore cross-checks pending
fences against exactly one matching invalidated generation, and both protocol
paths confirm committed-applied mutations before returning later post-apply
errors. M7-required lifecycle admission also runs only after deterministic data
preflight and immediately before commit under the selected group submitter's
serialization boundary, so a definitive preflight rejection cannot strand a
catalog lifecycle fence.

## Performance

Reproduction:

```sh
GOWORK=off go test ./TreeDB/internal/raftplacement \
  -run '^$' \
  -bench '^BenchmarkVectorPartitionLifecycle' \
  -benchtime=10000x \
  -count=3 \
  -benchmem
```

Linux/amd64, i5-11400F, 12 logical CPUs:

| Primitive | ns/op range | B/op | allocs/op |
| --- | ---: | ---: | ---: |
| canonical begin command encode | 1,974-2,085 | 1,401-1,405 | 7 |
| pure begin record apply | 15,628-15,810 | 6,416-6,417 | 49 |
| one-group ready-set verification | 2,413-2,476 | 1,201 | 11 |
| two-generation mutation-proof selection | 131.0-132.4 | 0 | 0 |

These are bounded in-process primitive measurements only. They exclude disk,
catalog quorum, production builder/upload, and multi-node failover latency; M8
owns those production-topology measurements. See
`TreeDB/docs/performance/vector-partition-m7.md`.

## Rollout / Toggle Plan

- Existing deployments remain unchanged unless the negotiated cluster or
  replicated catalog feature set enables M7.
- M7-enabled construction fails closed when required authority/admission is
  absent.
- Stop constructing the M7-enabled submitter/coordinator, or revert this PR, to
  disable the experimental path.
- Snapshot format changes are intentionally pre-alpha and require rebuilding old
  experimental DB directories rather than migration scaffolding.

## Follow-ups

- #3917: production multi-group correctness, failure, recall, and performance
  acceptance.
- Production group builder/uploader and automatic scheduling remain outside V1.

## Column Graph Native Workstream (#1646, if applicable)

Not applicable; this extends the native vector-partition/Raft path.

### AI Review Loop

- Codex review on `da219c25e` found one real P1: legacy constructors could
  derive the M7 admission requirement from provider installation instead of
  feature state. Fixed at `0c8721792`; the thread has a commit-linked reply and
  is resolved.
- Independent exact-head review then found that catalog-derived detection at
  `0c8721792` was replica-local and could return false during meta-catalog
  catch-up. Fixed at `88cda41f7` with a required linearizable meta-Raft fence
  and exact local applied-index catch-up gate; independent re-review found no
  blockers.
- A delayed Codex review on `0c8721792` found one P2: public lifecycle-record
  reads exposed mutable slice storage. Fixed at `06b919a12` by deep-cloning all
  lifecycle slice fields; the thread has a commit-linked reply and is resolved.
  Independent exact-head review of the repair found no blockers, and its focused
  race test passed.
- Codex review on `06b919a12` found two P2s: restore accepted inconsistent
  pending fences, and the canonical storage-format spec omitted the new catalog
  lifecycle snapshot. A delayed CodeRabbit review found that post-apply submit
  errors could bypass lifecycle confirmation. Fixed in `6d4002dab` for both
  nativewire and Mongo; all three threads have commit-linked dispositions and
  are resolved. Independent exact-head review of the combined repair found no
  blockers, and its focused tests passed.
- Codex review on `6d4002dab` found one deeper P1: the Raft layer and concrete
  bridge could discard committed-applied evidence before protocol confirmation.
  Fixed in `1a7b5f166`; the thread has a commit-linked disposition and is
  resolved. Independent exact-head review of this repair found no blockers,
  and its focused tests passed.
- Codex review on `1a7b5f166` found one P1: lifecycle admission preceded the
  data layer's idempotency/schema preflight, so a definite preflight rejection
  could strand a pending lifecycle fence. Fixed in `a924188c2` with a
  serialized post-preflight/pre-commit callback shared by single-group,
  routed, nativewire, and Mongo paths; the thread has a commit-linked
  disposition and is resolved. Independent exact-head review found no blocker,
  and the full affected suite plus focused race tests pass.
- Codex latest-head review: [re-requested on `a924188c2`](https://github.com/snissn/gomap/pull/3977#issuecomment-5081429943) after the first corrected trigger remained queued — pending; completion on the exact head remains a merge gate.
- CodeRabbit latest-head review: [requested on `a924188c2`](https://github.com/snissn/gomap/pull/3977#issuecomment-5081410418) — pending; it remains optional unless it produces a real finding/check.
- Every current inline thread is resolved.

---

## Optimization PR Checklist (TreeDB)

### Scope

- [x] Single lifecycle objective
- [x] Explicit include/exclude boundaries
- [x] No legacy slab/ValueIndex work

### Safety / Correctness

- [x] Deterministic bounded commands/records and canonical snapshots
- [x] No new mmap usage
- [x] Mutation/build/search state machine and invariants documented
- [x] Fail-closed ambiguity, replay, identity, and cleanup behavior

### Tests

- [x] Deterministic reducer/workflow regressions
- [x] Crash/replay/snapshot/cutover/corruption edge cases
- [x] Exact normal and race gates
- [x] Full affected-package suite

### Benchmarks / Measurements

- [x] Relevant bounded lifecycle microbenchmarks
- [x] Exact command, host, results, and claim boundary documented
- [x] Unimplemented production phases explicitly excluded

### Docs

- [x] M7 lifecycle/fence/recovery contract
- [x] Performance evidence and rollout limitations
- [x] Pre-alpha snapshot-format impact called out


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added replicated vector-partition lifecycle management, including build, staging, activation, invalidation, recovery, and cleanup workflows.
  * Added lifecycle-aware search validation to prevent stale or invalid generations from serving results.
  * Added mutation admission and confirmation safeguards for vector-relevant changes.
  * Added support for staging prepared manifests without changing the currently active generation.
  * Added lifecycle data to catalog snapshots and feature negotiation.

* **Documentation**
  * Added vector-partition lifecycle benchmark results and replicated mutation-fence specifications.

* **Tests**
  * Expanded coverage for lifecycle transitions, fail-closed behavior, recovery fences, snapshot validation, staging, and search admission.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
