### PR TITLE
treedb: establish vector exactness and recall attribution

### DIFF
--- a/TreeDB/collections/vector_partition_router_v1.go
+++ b/TreeDB/collections/vector_partition_router_v1.go
@@ -31,6 +31,10 @@ const (
 	VectorPartitionRouterModeApproxV1    = "approximate"
 )
 
+// ErrVectorPartitionRouterCandidateCoverageV1 marks a bounded candidate set
+// that is valid but collapses to fewer distinct partitions than requested.
+var ErrVectorPartitionRouterCandidateCoverageV1 = errors.New("collections: vector partition router candidate coverage shortfall")
+
 type VectorPartitionRouterBuildOptionsV1 struct {
 	Config         internalrouter.RouterConfigV1
 	AssetFileID    uint32
@@ -1390,7 +1394,7 @@ func rankVectorPartitionRouterCandidatesWithContextV1(ctx context.Context, repre
 		}
 	}
 	if len(best) < probes {
-		return nil, fmt.Errorf("collections: vector partition router candidate budget reached only %d unique partitions for %d probes", len(best), probes)
+		return nil, fmt.Errorf("%w: candidate budget reached only %d unique partitions for %d probes", ErrVectorPartitionRouterCandidateCoverageV1, len(best), probes)
 	}
 	result := make([]VectorPartitionRouterPartitionScoreV1, 0, len(best))
 	for _, score := range best {

--- a/TreeDB/collections/vector_partition_router_v1_test.go
+++ b/TreeDB/collections/vector_partition_router_v1_test.go
@@ -29,6 +29,18 @@ func TestVectorPartitionRouterContextEntryPointsRejectCanceledWorkV1(t *testing.
 	}
 }
 
+func TestRankVectorPartitionRouterCandidatesReportsUniqueCoverageShortfallV1(t *testing.T) {
+	representatives := []internalrouter.RouterRepresentativeV1{
+		{PartitionID: 0}, {PartitionID: 0}, {PartitionID: 1},
+	}
+	_, err := rankVectorPartitionRouterCandidatesWithContextV1(context.Background(), representatives, []vectorPartitionRouterCandidateV1{
+		{ordinal: 0, score: 1}, {ordinal: 1, score: .9},
+	}, 2)
+	if !errors.Is(err, ErrVectorPartitionRouterCandidateCoverageV1) {
+		t.Fatalf("coverage shortfall err=%v", err)
+	}
+}
+
 func TestVectorPartitionRouterActiveLoadCancellationReleasesBarrierV1(t *testing.T) {
 	requireVectorPartitionPersistenceV1(t)
 	database := openCollectionCommandWALDB(t, t.TempDir())

--- a/TreeDB/collections/vector_partition_searcher_v1.go
+++ b/TreeDB/collections/vector_partition_searcher_v1.go
@@ -29,22 +29,15 @@ func CanonicalVectorPartitionCosineScoreV1(query, vector []float32) (float32, er
 	if len(query) == 0 || len(query) != len(vector) {
 		return 0, fmt.Errorf("%w: canonical score dimensions", ErrVectorPartitionSearchUnavailable)
 	}
-	queryInvNorm, err := columnVectorGraphInvNorm(query)
+	normalizedQuery, err := canonicalVectorPartitionNormalizeV1(query)
 	if err != nil {
 		return 0, fmt.Errorf("%w: canonical query norm: %v", ErrVectorPartitionSearchUnavailable, err)
 	}
-	vectorInvNorm, err := columnVectorGraphInvNorm(vector)
+	normalizedVector, err := canonicalVectorPartitionNormalizeV1(vector)
 	if err != nil {
 		return 0, fmt.Errorf("%w: canonical vector norm: %v", ErrVectorPartitionSearchUnavailable, err)
 	}
-	var dot float64
-	for i := range query {
-		dot += float64(query[i]*queryInvNorm) * float64(vector[i]*vectorInvNorm)
-	}
-	if math.IsNaN(dot) || math.IsInf(dot, 0) {
-		return 0, fmt.Errorf("%w: canonical score nonfinite", ErrVectorPartitionSearchUnavailable)
-	}
-	return float32(dot), nil
+	return canonicalVectorPartitionNormalizedScoreV1(normalizedQuery, normalizedVector)
 }
 
 func canonicalVectorPartitionNormalizeV1(vector []float32) ([]float32, error) {
@@ -401,7 +394,7 @@ func checkedVectorPartitionScratchProductV1(left, right uint64) (uint64, error) 
 type VectorPartitionLocalSearcherV1 struct {
 	mu                                  sync.Mutex
 	asset                               VectorPartitionSearchAssetV1
-	norms                               []float32
+	normalizedVectors                   [][]float32
 	digest                              string
 	pins                                uint64
 	retired                             bool
@@ -460,16 +453,13 @@ func OpenVectorPartitionLocalSearcherV1(asset VectorPartitionSearchAssetV1) (*Ve
 	if err := validateVectorPartitionSearchAssetV1(asset); err != nil {
 		return nil, fmt.Errorf("%w: %v", ErrVectorPartitionSearchUnavailable, err)
 	}
-	norms := make([]float32, len(asset.Vectors))
+	normalizedVectors := make([][]float32, len(asset.Vectors))
 	for i, v := range asset.Vectors {
-		var sum float64
-		for _, x := range v {
-			sum += float64(x) * float64(x)
+		normalized, err := canonicalVectorPartitionNormalizeV1(v)
+		if err != nil {
+			return nil, fmt.Errorf("%w: vector[%d] norm: %v", ErrVectorPartitionSearchUnavailable, i, err)
 		}
-		norms[i] = float32(math.Sqrt(sum))
-		if norms[i] == 0 {
-			return nil, fmt.Errorf("%w: zero vector", ErrVectorPartitionSearchUnavailable)
-		}
+		normalizedVectors[i] = normalized
 	}
 	h := sha256.New()
 	h.Write([]byte(asset.ManifestChecksum))
@@ -480,12 +470,12 @@ func OpenVectorPartitionLocalSearcherV1(asset VectorPartitionSearchAssetV1) (*Ve
 		}
 	}
 	return &VectorPartitionLocalSearcherV1{
-		asset:            clonePartitionSearchAsset(asset),
-		norms:            norms,
-		digest:           hex.EncodeToString(h.Sum(nil)),
-		opened:           1,
-		searchRoute:      VectorPartitionSearchRouteExactFP32ScanV1,
-		maxStableIDBytes: vectorPartitionMaxStableIDBytesV1(asset.IDs),
+		asset:             clonePartitionSearchAsset(asset),
+		normalizedVectors: normalizedVectors,
+		digest:            hex.EncodeToString(h.Sum(nil)),
+		opened:            1,
+		searchRoute:       VectorPartitionSearchRouteExactFP32ScanV1,
+		maxStableIDBytes:  vectorPartitionMaxStableIDBytesV1(asset.IDs),
 	}, nil
 }
 
@@ -661,15 +651,15 @@ func (s *VectorPartitionLocalSearcherV1) SearchWithOptionsV1(ctx context.Context
 		s.recordFailure()
 		return nil, VectorPartitionSearchMetricsV1{}, fmt.Errorf("%w: stable ID bytes=%d exceeds limit=%d", ErrVectorPartitionSearchUnavailable, s.maxStableIDBytes, opts.MaxStableIDBytes)
 	}
-	var qn float64
+	var queryNormSquared float64
 	for _, x := range query {
 		if math.IsNaN(float64(x)) || math.IsInf(float64(x), 0) {
 			s.recordFailure()
 			return nil, VectorPartitionSearchMetricsV1{}, fmt.Errorf("%w: query nonfinite", ErrVectorPartitionSearchUnavailable)
 		}
-		qn += float64(x) * float64(x)
+		queryNormSquared += float64(x) * float64(x)
 	}
-	if qn == 0 {
+	if queryNormSquared == 0 {
 		s.recordFailure()
 		return nil, VectorPartitionSearchMetricsV1{}, fmt.Errorf("%w: zero query", ErrVectorPartitionSearchUnavailable)
 	}
@@ -699,23 +689,29 @@ func (s *VectorPartitionLocalSearcherV1) SearchWithOptionsV1(ctx context.Context
 		s.mu.Unlock()
 		return out, metrics, nil
 	}
+	normalizedQuery, err := canonicalVectorPartitionNormalizeV1(query)
+	if err != nil {
+		s.recordFailure()
+		return nil, VectorPartitionSearchMetricsV1{}, err
+	}
 	limit := min(opts.TopK, len(s.asset.IDs))
 	top := make(vectorPartitionSearchResultMaxHeapV1, 0, limit)
 	var edges uint64
-	for i, v := range s.asset.Vectors {
+	for i := range s.asset.Vectors {
 		if i&255 == 0 {
 			if err := ctx.Err(); err != nil {
 				s.recordFailure()
 				return nil, VectorPartitionSearchMetricsV1{}, err
 			}
 		}
-		var d float64
-		for j, x := range v {
-			d += float64(x) * float64(query[j])
+		score, err := canonicalVectorPartitionNormalizedScoreV1(normalizedQuery, s.normalizedVectors[i])
+		if err != nil {
+			s.recordFailure()
+			return nil, VectorPartitionSearchMetricsV1{}, err
 		}
 		top.pushBounded(limit, VectorPartitionSearchResultV1{
 			ID:    s.asset.IDs[i],
-			Score: float32(d / (math.Sqrt(qn) * float64(s.norms[i]))),
+			Score: score,
 		})
 		if len(s.asset.Adjacency) > i {
 			edges += uint64(len(s.asset.Adjacency[i]))

--- a/TreeDB/collections/vector_partition_searcher_v1.go
+++ b/TreeDB/collections/vector_partition_searcher_v1.go
@@ -29,15 +29,50 @@ func CanonicalVectorPartitionCosineScoreV1(query, vector []float32) (float32, er
 	if len(query) == 0 || len(query) != len(vector) {
 		return 0, fmt.Errorf("%w: canonical score dimensions", ErrVectorPartitionSearchUnavailable)
 	}
+	scorer, err := NewCanonicalVectorPartitionCosineScorerV1(query)
+	if err != nil {
+		return 0, err
+	}
+	return scorer.ScoreV1(vector)
+}
+
+// CanonicalVectorPartitionCosineScorerV1 retains one normalized query so a
+// full-source exact oracle can score many caller-owned vectors without
+// allocating a normalized query and vector for every source row.
+type CanonicalVectorPartitionCosineScorerV1 struct {
+	normalizedQuery []float32
+}
+
+// NewCanonicalVectorPartitionCosineScorerV1 prepares one query for repeated
+// execution of VectorPartitionCanonicalScoreContractV1.
+func NewCanonicalVectorPartitionCosineScorerV1(query []float32) (*CanonicalVectorPartitionCosineScorerV1, error) {
 	normalizedQuery, err := canonicalVectorPartitionNormalizeV1(query)
 	if err != nil {
-		return 0, fmt.Errorf("%w: canonical query norm: %v", ErrVectorPartitionSearchUnavailable, err)
+		return nil, fmt.Errorf("%w: canonical query norm: %v", ErrVectorPartitionSearchUnavailable, err)
 	}
-	normalizedVector, err := canonicalVectorPartitionNormalizeV1(vector)
+	return &CanonicalVectorPartitionCosineScorerV1{normalizedQuery: normalizedQuery}, nil
+}
+
+// ScoreV1 scores one source vector without allocating. Multiplication by the
+// FP32 inverse norm is rounded to FP32 before the binary64 dot accumulation,
+// preserving the public score bits produced by the one-shot helper.
+func (s *CanonicalVectorPartitionCosineScorerV1) ScoreV1(vector []float32) (float32, error) {
+	if s == nil || len(s.normalizedQuery) == 0 || len(s.normalizedQuery) != len(vector) {
+		return 0, fmt.Errorf("%w: canonical score dimensions", ErrVectorPartitionSearchUnavailable)
+	}
+	invNorm, err := columnVectorGraphInvNorm(vector)
 	if err != nil {
 		return 0, fmt.Errorf("%w: canonical vector norm: %v", ErrVectorPartitionSearchUnavailable, err)
 	}
-	return canonicalVectorPartitionNormalizedScoreV1(normalizedQuery, normalizedVector)
+	var dot float64
+	for i := range vector {
+		normalized := vector[i] * invNorm
+		dot += float64(s.normalizedQuery[i]) * float64(normalized)
+	}
+	if math.IsNaN(dot) || math.IsInf(dot, 0) {
+		return 0, fmt.Errorf("%w: canonical score nonfinite", ErrVectorPartitionSearchUnavailable)
+	}
+	return float32(dot), nil
 }
 
 func canonicalVectorPartitionNormalizeV1(vector []float32) ([]float32, error) {
@@ -103,6 +138,81 @@ type VectorPartitionSearchResultV1 struct {
 // score-descending, stable-ID-ascending result order without one uninterruptible
 // full-partition sort.
 type vectorPartitionSearchResultMaxHeapV1 []VectorPartitionSearchResultV1
+
+type vectorPartitionSearchRefResultV1 struct {
+	ID    []byte
+	Score float32
+}
+
+type vectorPartitionSearchRefResultMaxHeapV1 []vectorPartitionSearchRefResultV1
+
+func vectorPartitionSearchRefResultBetterV1(left, right vectorPartitionSearchRefResultV1) bool {
+	if left.Score != right.Score {
+		return left.Score > right.Score
+	}
+	return bytes.Compare(left.ID, right.ID) < 0
+}
+
+func vectorPartitionSearchRefResultWorseV1(left, right vectorPartitionSearchRefResultV1) bool {
+	return vectorPartitionSearchRefResultBetterV1(right, left)
+}
+
+func (h *vectorPartitionSearchRefResultMaxHeapV1) pushBounded(limit int, candidate vectorPartitionSearchRefResultV1) {
+	if limit <= 0 {
+		return
+	}
+	if len(*h) < limit {
+		*h = append(*h, candidate)
+		h.up(len(*h) - 1)
+		return
+	}
+	if !vectorPartitionSearchRefResultBetterV1(candidate, (*h)[0]) {
+		return
+	}
+	(*h)[0] = candidate
+	h.down(0)
+}
+
+func (h *vectorPartitionSearchRefResultMaxHeapV1) popWorst() vectorPartitionSearchRefResultV1 {
+	out := (*h)[0]
+	last := len(*h) - 1
+	(*h)[0] = (*h)[last]
+	*h = (*h)[:last]
+	if len(*h) > 0 {
+		h.down(0)
+	}
+	return out
+}
+
+func (h *vectorPartitionSearchRefResultMaxHeapV1) up(child int) {
+	for child > 0 {
+		parent := (child - 1) / 2
+		if !vectorPartitionSearchRefResultWorseV1((*h)[child], (*h)[parent]) {
+			return
+		}
+		(*h)[child], (*h)[parent] = (*h)[parent], (*h)[child]
+		child = parent
+	}
+}
+
+func (h *vectorPartitionSearchRefResultMaxHeapV1) down(parent int) {
+	for {
+		left := parent*2 + 1
+		if left >= len(*h) {
+			return
+		}
+		child := left
+		right := left + 1
+		if right < len(*h) && vectorPartitionSearchRefResultWorseV1((*h)[right], (*h)[left]) {
+			child = right
+		}
+		if !vectorPartitionSearchRefResultWorseV1((*h)[child], (*h)[parent]) {
+			return
+		}
+		(*h)[parent], (*h)[child] = (*h)[child], (*h)[parent]
+		parent = child
+	}
+}
 
 func vectorPartitionSearchResultBetterV1(left, right VectorPartitionSearchResultV1) bool {
 	if left.Score != right.Score {
@@ -779,7 +889,8 @@ func (s *VectorPartitionLocalSearcherV1) SearchExactWithOptionsV1(ctx context.Co
 		return nil, VectorPartitionSearchMetricsV1{}, err
 	}
 	rows, dims, stride := int(s.prepared.Header.Rows), s.asset.Dimensions, int(s.prepared.Header.VectorStride)
-	top := make(vectorPartitionSearchResultMaxHeapV1, 0, min(opts.TopK, rows))
+	limit := min(opts.TopK, rows)
+	top := make(vectorPartitionSearchRefResultMaxHeapV1, 0, limit)
 	for row := 0; row < rows; row++ {
 		if row&255 == 0 {
 			if err := ctx.Err(); err != nil {
@@ -793,7 +904,7 @@ func (s *VectorPartitionLocalSearcherV1) SearchExactWithOptionsV1(ctx context.Co
 			return nil, VectorPartitionSearchMetricsV1{}, err
 		}
 		start, end := s.prepared.DocumentIDOffsets[row], s.prepared.DocumentIDOffsets[row+1]
-		top.pushBounded(min(opts.TopK, rows), VectorPartitionSearchResultV1{ID: string(append([]byte(nil), s.prepared.DocumentIDBytes[start:end]...)), Score: score})
+		top.pushBounded(limit, vectorPartitionSearchRefResultV1{ID: s.prepared.DocumentIDBytes[start:end], Score: score})
 	}
 	out := make([]VectorPartitionSearchResultV1, len(top))
 	for target := len(out) - 1; target >= 0; target-- {
@@ -803,7 +914,8 @@ func (s *VectorPartitionLocalSearcherV1) SearchExactWithOptionsV1(ctx context.Co
 				return nil, VectorPartitionSearchMetricsV1{}, err
 			}
 		}
-		out[target] = top.popWorst()
+		candidate := top.popWorst()
+		out[target] = VectorPartitionSearchResultV1{ID: string(candidate.ID), Score: candidate.Score}
 	}
 	if err := ctx.Err(); err != nil {
 		s.recordFailure()

--- a/TreeDB/collections/vector_partition_searcher_v1.go
+++ b/TreeDB/collections/vector_partition_searcher_v1.go
@@ -895,7 +895,7 @@ func (s *VectorPartitionLocalSearcherV1) statusLockedV1() VectorPartitionSearchS
 		} else {
 			st.OverlapMemberships++
 		}
-		st.HeapBytes += uint64(4*len(s.asset.Vectors[i]) + len(s.asset.IDs[i]))
+		st.HeapBytes += uint64(4*len(s.asset.Vectors[i]) + 4*len(s.normalizedVectors[i]) + len(s.asset.IDs[i]))
 	}
 	st.PackBytes = st.HeapBytes
 	return st

--- a/TreeDB/collections/vector_partition_searcher_v1.go
+++ b/TreeDB/collections/vector_partition_searcher_v1.go
@@ -77,7 +77,7 @@ func canonicalVectorPartitionScoreWithInvNormV1(normalizedQuery, vector []float3
 	var dot float64
 	for i := range vector {
 		normalized := vector[i] * invNorm
-		dot += float64(normalizedQuery[i]) * float64(normalized)
+		dot = canonicalVectorPartitionAccumulateV1(dot, normalizedQuery[i], normalized)
 	}
 	if math.IsNaN(dot) || math.IsInf(dot, 0) {
 		return 0, fmt.Errorf("%w: canonical score nonfinite", ErrVectorPartitionSearchUnavailable)
@@ -103,12 +103,21 @@ func canonicalVectorPartitionNormalizedScoreV1(left, right []float32) (float32, 
 	}
 	var dot float64
 	for i := range left {
-		dot += float64(left[i]) * float64(right[i])
+		dot = canonicalVectorPartitionAccumulateV1(dot, left[i], right[i])
 	}
 	if math.IsNaN(dot) || math.IsInf(dot, 0) {
 		return 0, fmt.Errorf("%w: canonical score nonfinite", ErrVectorPartitionSearchUnavailable)
 	}
 	return float32(dot), nil
+}
+
+// canonicalVectorPartitionAccumulateV1 makes the public binary64 product and
+// left-to-right addition rounding points explicit. Float64bits/Float64frombits
+// are allocation-free compiler intrinsics and prevent a future compiler or
+// operand-type change from contracting the two public contract operations.
+func canonicalVectorPartitionAccumulateV1(sum float64, left, right float32) float64 {
+	product := math.Float64frombits(math.Float64bits(float64(left) * float64(right)))
+	return math.Float64frombits(math.Float64bits(sum + product))
 }
 
 type VectorPartitionMembershipKindV1 string

--- a/TreeDB/collections/vector_partition_searcher_v1.go
+++ b/TreeDB/collections/vector_partition_searcher_v1.go
@@ -699,17 +699,23 @@ func (s *VectorPartitionLocalSearcherV1) SearchExactWithOptionsV1(ctx context.Co
 		return nil, VectorPartitionSearchMetricsV1{}, err
 	}
 	defer s.Release()
-	if s.prepared == nil || opts.TopK < 1 || len(query) != s.asset.Dimensions {
+	if s.prepared == nil || opts.TopK < 1 || opts.MaxStableIDBytes < 0 || len(query) != s.asset.Dimensions {
+		return nil, VectorPartitionSearchMetricsV1{}, ErrVectorPartitionSearchUnavailable
+	}
+	if opts.MaxStableIDBytes > 0 && s.maxStableIDBytes > opts.MaxStableIDBytes {
 		return nil, VectorPartitionSearchMetricsV1{}, ErrVectorPartitionSearchUnavailable
 	}
 	var qn float64
 	for _, x := range query {
+		if math.IsNaN(float64(x)) || math.IsInf(float64(x), 0) {
+			return nil, VectorPartitionSearchMetricsV1{}, ErrVectorPartitionSearchUnavailable
+		}
 		qn += float64(x) * float64(x)
 	}
 	if qn == 0 {
 		return nil, VectorPartitionSearchMetricsV1{}, ErrVectorPartitionSearchUnavailable
 	}
-	rows, dims := int(s.prepared.Header.Rows), s.asset.Dimensions
+	rows, dims, stride := int(s.prepared.Header.Rows), s.asset.Dimensions, int(s.prepared.Header.VectorStride)
 	top := make(vectorPartitionSearchResultMaxHeapV1, 0, min(opts.TopK, rows))
 	for row := 0; row < rows; row++ {
 		if row&255 == 0 {
@@ -719,13 +725,18 @@ func (s *VectorPartitionLocalSearcherV1) SearchExactWithOptionsV1(ctx context.Co
 		}
 		var dot float64
 		for col := 0; col < dims; col++ {
-			dot += float64(query[col]) * float64(s.prepared.NormalizedVectors[row*dims+col])
+			dot += float64(query[col]) * float64(s.prepared.NormalizedVectors[row*stride+col])
 		}
 		start, end := s.prepared.DocumentIDOffsets[row], s.prepared.DocumentIDOffsets[row+1]
-		top.pushBounded(min(opts.TopK, rows), VectorPartitionSearchResultV1{ID: string(s.prepared.DocumentIDBytes[start:end]), Score: float32(dot / math.Sqrt(qn))})
+		top.pushBounded(min(opts.TopK, rows), VectorPartitionSearchResultV1{ID: string(append([]byte(nil), s.prepared.DocumentIDBytes[start:end]...)), Score: float32(dot / math.Sqrt(qn))})
 	}
 	out := make([]VectorPartitionSearchResultV1, len(top))
 	for target := len(out) - 1; target >= 0; target-- {
+		if target&255 == 0 {
+			if err := ctx.Err(); err != nil {
+				return nil, VectorPartitionSearchMetricsV1{}, err
+			}
+		}
 		out[target] = top.popWorst()
 	}
 	return out, VectorPartitionSearchMetricsV1{Candidates: uint64(rows), Route: VectorPartitionSearchRouteExactFP32ScanV1}, nil

--- a/TreeDB/collections/vector_partition_searcher_v1.go
+++ b/TreeDB/collections/vector_partition_searcher_v1.go
@@ -64,10 +64,20 @@ func (s *CanonicalVectorPartitionCosineScorerV1) ScoreV1(vector []float32) (floa
 	if err != nil {
 		return 0, fmt.Errorf("%w: canonical vector norm: %v", ErrVectorPartitionSearchUnavailable, err)
 	}
+	return canonicalVectorPartitionScoreWithInvNormV1(s.normalizedQuery, vector, invNorm)
+}
+
+func canonicalVectorPartitionScoreWithInvNormV1(normalizedQuery, vector []float32, invNorm float32) (float32, error) {
+	if len(normalizedQuery) == 0 || len(normalizedQuery) != len(vector) {
+		return 0, fmt.Errorf("%w: canonical score dimensions", ErrVectorPartitionSearchUnavailable)
+	}
+	if invNorm <= 0 || math.IsNaN(float64(invNorm)) || math.IsInf(float64(invNorm), 0) {
+		return 0, fmt.Errorf("%w: canonical vector inverse norm", ErrVectorPartitionSearchUnavailable)
+	}
 	var dot float64
 	for i := range vector {
 		normalized := vector[i] * invNorm
-		dot += float64(s.normalizedQuery[i]) * float64(normalized)
+		dot += float64(normalizedQuery[i]) * float64(normalized)
 	}
 	if math.IsNaN(dot) || math.IsInf(dot, 0) {
 		return 0, fmt.Errorf("%w: canonical score nonfinite", ErrVectorPartitionSearchUnavailable)
@@ -517,7 +527,7 @@ func checkedVectorPartitionScratchProductV1(left, right uint64) (uint64, error) 
 type VectorPartitionLocalSearcherV1 struct {
 	mu                                  sync.Mutex
 	asset                               VectorPartitionSearchAssetV1
-	normalizedVectors                   [][]float32
+	vectorInvNorms                      []float32
 	digest                              string
 	pins                                uint64
 	retired                             bool
@@ -576,13 +586,13 @@ func OpenVectorPartitionLocalSearcherV1(asset VectorPartitionSearchAssetV1) (*Ve
 	if err := validateVectorPartitionSearchAssetV1(asset); err != nil {
 		return nil, fmt.Errorf("%w: %v", ErrVectorPartitionSearchUnavailable, err)
 	}
-	normalizedVectors := make([][]float32, len(asset.Vectors))
+	vectorInvNorms := make([]float32, len(asset.Vectors))
 	for i, v := range asset.Vectors {
-		normalized, err := canonicalVectorPartitionNormalizeV1(v)
+		invNorm, err := columnVectorGraphInvNorm(v)
 		if err != nil {
 			return nil, fmt.Errorf("%w: vector[%d] norm: %v", ErrVectorPartitionSearchUnavailable, i, err)
 		}
-		normalizedVectors[i] = normalized
+		vectorInvNorms[i] = invNorm
 	}
 	h := sha256.New()
 	h.Write([]byte(asset.ManifestChecksum))
@@ -593,12 +603,12 @@ func OpenVectorPartitionLocalSearcherV1(asset VectorPartitionSearchAssetV1) (*Ve
 		}
 	}
 	return &VectorPartitionLocalSearcherV1{
-		asset:             clonePartitionSearchAsset(asset),
-		normalizedVectors: normalizedVectors,
-		digest:            hex.EncodeToString(h.Sum(nil)),
-		opened:            1,
-		searchRoute:       VectorPartitionSearchRouteExactFP32ScanV1,
-		maxStableIDBytes:  vectorPartitionMaxStableIDBytesV1(asset.IDs),
+		asset:            clonePartitionSearchAsset(asset),
+		vectorInvNorms:   vectorInvNorms,
+		digest:           hex.EncodeToString(h.Sum(nil)),
+		opened:           1,
+		searchRoute:      VectorPartitionSearchRouteExactFP32ScanV1,
+		maxStableIDBytes: vectorPartitionMaxStableIDBytesV1(asset.IDs),
 	}, nil
 }
 
@@ -827,7 +837,7 @@ func (s *VectorPartitionLocalSearcherV1) SearchWithOptionsV1(ctx context.Context
 				return nil, VectorPartitionSearchMetricsV1{}, err
 			}
 		}
-		score, err := canonicalVectorPartitionNormalizedScoreV1(normalizedQuery, s.normalizedVectors[i])
+		score, err := canonicalVectorPartitionScoreWithInvNormV1(normalizedQuery, s.asset.Vectors[i], s.vectorInvNorms[i])
 		if err != nil {
 			s.recordFailure()
 			return nil, VectorPartitionSearchMetricsV1{}, err
@@ -1020,8 +1030,9 @@ func (s *VectorPartitionLocalSearcherV1) statusLockedV1() VectorPartitionSearchS
 		} else {
 			st.OverlapMemberships++
 		}
-		st.HeapBytes += uint64(4*len(s.asset.Vectors[i]) + 4*len(s.normalizedVectors[i]) + len(s.asset.IDs[i]))
+		st.HeapBytes += uint64(4*len(s.asset.Vectors[i]) + len(s.asset.IDs[i]))
 	}
+	st.HeapBytes += uint64(4 * len(s.vectorInvNorms))
 	st.PackBytes = st.HeapBytes
 	return st
 }

--- a/TreeDB/collections/vector_partition_searcher_v1.go
+++ b/TreeDB/collections/vector_partition_searcher_v1.go
@@ -407,7 +407,9 @@ func vectorPartitionSearchScratchBytesV1(opts VectorPartitionSearchOptionsV1, pr
 		// index definition has a much larger M.
 		degree = rowCount
 	}
-	return vectorPartitionHNSWSearchScratchBytesV1(rowCount, header.Dimensions, header.VectorStride, degree, topK, efSearch)
+	// Native traversal must materialize every retained ef_search candidate so
+	// the public stable-ID tie-break runs before final top-k truncation.
+	return vectorPartitionHNSWSearchScratchBytesV1(rowCount, header.Dimensions, header.VectorStride, degree, efSearch, topK, efSearch)
 }
 
 func vectorPartitionExactSearchScratchBytesV1(rows, dimensions, topK int) (uint64, error) {
@@ -461,18 +463,18 @@ func VectorPartitionConservativeSearchScratchBytesV1(rows, dimensions int, opts 
 	}
 	// Search caps the doubled HNSW degree at row count. Using row count here
 	// therefore covers every persisted M without requiring shard-local headers.
-	hnswBytes, err := vectorPartitionHNSWSearchScratchBytesV1(rows, dimensions, vectorStride, rows, topK, efSearch)
+	hnswBytes, err := vectorPartitionHNSWSearchScratchBytesV1(rows, dimensions, vectorStride, rows, efSearch, topK, efSearch)
 	if err != nil {
 		return 0, err
 	}
 	return max(exactBytes, hnswBytes), nil
 }
 
-func vectorPartitionHNSWSearchScratchBytesV1(rowCount, dimensions, vectorStride, degree, topK, efSearch int) (uint64, error) {
-	if rowCount < 0 || dimensions <= 0 || vectorStride < 0 || degree < 0 || topK < 0 || efSearch < 0 {
+func vectorPartitionHNSWSearchScratchBytesV1(rowCount, dimensions, vectorStride, degree, nativeTopK, publicTopK, efSearch int) (uint64, error) {
+	if rowCount < 0 || dimensions <= 0 || vectorStride < 0 || degree < 0 || nativeTopK < 0 || publicTopK < 0 || efSearch < 0 {
 		return 0, ErrVectorPartitionSearchUnavailable
 	}
-	frontier := columnVectorGraphNativeSearchFrontierCapacity(rowCount, degree, topK, efSearch)
+	frontier := columnVectorGraphNativeSearchFrontierCapacity(rowCount, degree, nativeTopK, efSearch)
 
 	var total uint64
 	add := func(count int, width uintptr) error {
@@ -493,15 +495,16 @@ func vectorPartitionHNSWSearchScratchBytesV1(rowCount, dimensions, vectorStride,
 		{rowCount, unsafe.Sizeof(uint64(0))},
 		{frontier, unsafe.Sizeof(columnVectorGraphSearchCandidate{})},
 		{efSearch, unsafe.Sizeof(columnVectorGraphSearchCandidate{})},
-		{topK, unsafe.Sizeof(columnVectorGraphNativeSearchResult{})},
-		// Native results remain live while the public FP32/stable-ID buffer is
-		// built and canonically reordered.
-		{topK, unsafe.Sizeof(VectorPartitionSearchResultV1{})},
-		{topK, unsafe.Sizeof([]byte(nil))},
-		{topK, unsafe.Sizeof(int(0))},
-		{topK, unsafe.Sizeof(int(0))},
-		{topK, unsafe.Sizeof(DocumentRowRef{})},
-		{topK, unsafe.Sizeof(bool(false))},
+		{nativeTopK, unsafe.Sizeof(columnVectorGraphNativeSearchResult{})},
+		// Native results remain live while a bounded borrowed-ID heap applies the
+		// public FP32/stable-ID order and materializes the final owned results.
+		{publicTopK, unsafe.Sizeof(vectorPartitionSearchRefResultV1{})},
+		{publicTopK, unsafe.Sizeof(VectorPartitionSearchResultV1{})},
+		{nativeTopK, unsafe.Sizeof([]byte(nil))},
+		{nativeTopK, unsafe.Sizeof(int(0))},
+		{nativeTopK, unsafe.Sizeof(int(0))},
+		{nativeTopK, unsafe.Sizeof(DocumentRowRef{})},
+		{nativeTopK, unsafe.Sizeof(bool(false))},
 		{degree, unsafe.Sizeof(float64(0))},
 		{degree, unsafe.Sizeof(uint32(0))},
 		{degree, unsafe.Sizeof(float32(0))},
@@ -797,7 +800,17 @@ func (s *VectorPartitionLocalSearcherV1) SearchWithOptionsV1(ctx context.Context
 		return nil, VectorPartitionSearchMetricsV1{}, fmt.Errorf("%w: zero query", ErrVectorPartitionSearchUnavailable)
 	}
 	if s.prepared != nil {
-		results, stats, err := s.prepared.searchCosineWithContext(ctx, query, columnVectorGraphNativeSearchOptions{TopK: opts.TopK, EfSearch: opts.EfSearch}, &columnVectorGraphNativeSearchScratch{})
+		nativeTopK := opts.EfSearch
+		if nativeTopK == 0 {
+			nativeTopK = s.prepared.Header.EfSearch
+		}
+		if nativeTopK < opts.TopK {
+			nativeTopK = opts.TopK
+		}
+		if nativeTopK > s.prepared.Header.Rows {
+			nativeTopK = s.prepared.Header.Rows
+		}
+		results, stats, err := s.prepared.searchCosineWithContext(ctx, query, columnVectorGraphNativeSearchOptions{TopK: nativeTopK, EfSearch: opts.EfSearch}, &columnVectorGraphNativeSearchScratch{})
 		if err != nil {
 			s.recordFailure()
 			if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
@@ -809,7 +822,7 @@ func (s *VectorPartitionLocalSearcherV1) SearchWithOptionsV1(ctx context.Context
 			s.recordFailure()
 			return nil, VectorPartitionSearchMetricsV1{}, err
 		}
-		out, err := canonicalizeVectorPartitionNativeResultsV1(ctx, s.prepared, query, results)
+		out, err := canonicalizeVectorPartitionNativeResultsV1(ctx, s.prepared, query, results, opts.TopK)
 		if err != nil {
 			s.recordFailure()
 			return nil, VectorPartitionSearchMetricsV1{}, err
@@ -951,21 +964,22 @@ func (s *VectorPartitionLocalSearcherV1) SearchExactWithOptionsV1(ctx context.Co
 	return out, VectorPartitionSearchMetricsV1{Candidates: uint64(rows), Route: VectorPartitionSearchRouteExactFP32ScanV1}, nil
 }
 
-func canonicalizeVectorPartitionNativeResultsV1(ctx context.Context, prepared *columnHNSWSearchPackPreparedView, query []float32, results []columnVectorGraphNativeSearchResult) ([]VectorPartitionSearchResultV1, error) {
+func canonicalizeVectorPartitionNativeResultsV1(ctx context.Context, prepared *columnHNSWSearchPackPreparedView, query []float32, results []columnVectorGraphNativeSearchResult, topK int) ([]VectorPartitionSearchResultV1, error) {
 	if ctx == nil {
 		ctx = context.Background()
 	}
 	// Native HNSW traversal may use platform-optimized FP32 kernels. Recompute
 	// the returned candidate scores with the deterministic public contract, then
 	// rebuild and drain the bounded heap before M5 publishes owned results.
-	if prepared == nil || len(query) != prepared.Header.Dimensions {
+	if prepared == nil || len(query) != prepared.Header.Dimensions || topK < 1 {
 		return nil, ErrVectorPartitionSearchUnavailable
 	}
 	normalizedQuery, err := canonicalVectorPartitionNormalizeV1(query)
 	if err != nil {
 		return nil, err
 	}
-	top := make(vectorPartitionSearchResultMaxHeapV1, 0, len(results))
+	limit := min(topK, len(results))
+	top := make(vectorPartitionSearchRefResultMaxHeapV1, 0, limit)
 	for i, result := range results {
 		if i&255 == 0 {
 			if err := ctx.Err(); err != nil {
@@ -984,16 +998,17 @@ func canonicalizeVectorPartitionNativeResultsV1(ctx context.Context, prepared *c
 		if err != nil {
 			return nil, err
 		}
-		top.pushBounded(len(results), VectorPartitionSearchResultV1{ID: string(result.ID), Score: score})
+		top.pushBounded(limit, vectorPartitionSearchRefResultV1{ID: prepared.DocumentIDBytes[idStart:idEnd], Score: score})
 	}
-	out := []VectorPartitionSearchResultV1(top)
+	out := make([]VectorPartitionSearchResultV1, len(top))
 	for completed, target := 0, len(out)-1; target >= 0; completed, target = completed+1, target-1 {
 		if completed&255 == 0 {
 			if err := ctx.Err(); err != nil {
 				return nil, err
 			}
 		}
-		out[target] = top.popWorst()
+		candidate := top.popWorst()
+		out[target] = VectorPartitionSearchResultV1{ID: string(candidate.ID), Score: candidate.Score}
 	}
 	if err := ctx.Err(); err != nil {
 		return nil, err

--- a/TreeDB/collections/vector_partition_searcher_v1.go
+++ b/TreeDB/collections/vector_partition_searcher_v1.go
@@ -883,16 +883,17 @@ func (s *VectorPartitionLocalSearcherV1) SearchExactWithOptionsV1(ctx context.Co
 		s.recordFailure()
 		return nil, VectorPartitionSearchMetricsV1{}, fmt.Errorf("%w: stable ID bytes=%d exceeds limit=%d", ErrVectorPartitionSearchUnavailable, s.maxStableIDBytes, opts.MaxStableIDBytes)
 	}
-	expectedStride, err := columnHNSWSearchPackVectorStrideForDimensions(s.asset.Dimensions)
-	if err != nil || s.prepared.Header.Dimensions != s.asset.Dimensions || s.prepared.Header.VectorStride != expectedStride {
+	preparedStride := s.prepared.Header.VectorStride
+	alignmentFloats := int(columnHNSWSearchPackVectorSectionAlignment) / 4
+	if s.prepared.Header.Dimensions != s.asset.Dimensions || preparedStride < s.asset.Dimensions ||
+		alignmentFloats <= 0 || preparedStride%alignmentFloats != 0 {
 		s.recordFailure()
 		return nil, VectorPartitionSearchMetricsV1{}, fmt.Errorf(
-			"%w: prepared dimensions/stride=(%d,%d) want (%d,%d)",
+			"%w: prepared dimensions/stride=(%d,%d) want dimensions=%d and aligned stride>=dimensions",
 			ErrVectorPartitionSearchUnavailable,
 			s.prepared.Header.Dimensions,
-			s.prepared.Header.VectorStride,
+			preparedStride,
 			s.asset.Dimensions,
-			expectedStride,
 		)
 	}
 	normalizedQuery, err := canonicalVectorPartitionNormalizeV1(query)

--- a/TreeDB/collections/vector_partition_searcher_v1.go
+++ b/TreeDB/collections/vector_partition_searcher_v1.go
@@ -236,6 +236,7 @@ func (s *VectorPartitionLocalSearcherV1) SearchPreflightV1(opts VectorPartitionS
 	status := s.statusLockedV1()
 	prepared := s.prepared
 	exactRows := len(s.asset.IDs)
+	dimensions := s.asset.Dimensions
 	maxStableIDBytes := s.maxStableIDBytes
 	var header columnHNSWSearchPackHeader
 	if prepared != nil {
@@ -243,16 +244,16 @@ func (s *VectorPartitionLocalSearcherV1) SearchPreflightV1(opts VectorPartitionS
 	}
 	s.mu.Unlock()
 
-	scratchBytes, err := vectorPartitionSearchScratchBytesV1(opts, prepared, exactRows, maxStableIDBytes, header)
+	scratchBytes, err := vectorPartitionSearchScratchBytesV1(opts, prepared, exactRows, dimensions, maxStableIDBytes, header)
 	return status, scratchBytes, err
 }
 
-func vectorPartitionSearchScratchBytesV1(opts VectorPartitionSearchOptionsV1, prepared *columnHNSWSearchPackPreparedView, exactRows, maxStableIDBytes int, header columnHNSWSearchPackHeader) (uint64, error) {
+func vectorPartitionSearchScratchBytesV1(opts VectorPartitionSearchOptionsV1, prepared *columnHNSWSearchPackPreparedView, exactRows, dimensions, maxStableIDBytes int, header columnHNSWSearchPackHeader) (uint64, error) {
 	if opts.MaxStableIDBytes > 0 && maxStableIDBytes > opts.MaxStableIDBytes {
 		return 0, fmt.Errorf("%w: stable ID bytes=%d exceeds limit=%d", ErrVectorPartitionSearchUnavailable, maxStableIDBytes, opts.MaxStableIDBytes)
 	}
 	if prepared == nil {
-		return vectorPartitionExactSearchScratchBytesV1(exactRows, opts.TopK)
+		return vectorPartitionExactSearchScratchBytesV1(exactRows, dimensions, opts.TopK)
 	}
 	rowCount := header.Rows
 	if rowCount < 0 || header.VectorStride < 0 || header.M < 0 {
@@ -286,11 +287,11 @@ func vectorPartitionSearchScratchBytesV1(opts VectorPartitionSearchOptionsV1, pr
 		// index definition has a much larger M.
 		degree = rowCount
 	}
-	return vectorPartitionHNSWSearchScratchBytesV1(rowCount, header.VectorStride, degree, topK, efSearch)
+	return vectorPartitionHNSWSearchScratchBytesV1(rowCount, header.Dimensions, header.VectorStride, degree, topK, efSearch)
 }
 
-func vectorPartitionExactSearchScratchBytesV1(rows, topK int) (uint64, error) {
-	if rows < 0 || topK < 1 {
+func vectorPartitionExactSearchScratchBytesV1(rows, dimensions, topK int) (uint64, error) {
+	if rows < 0 || dimensions <= 0 || topK < 1 {
 		return 0, ErrVectorPartitionSearchUnavailable
 	}
 	width := uint64(unsafe.Sizeof(VectorPartitionSearchResultV1{}))
@@ -302,9 +303,18 @@ func vectorPartitionExactSearchScratchBytesV1(rows, topK int) (uint64, error) {
 	if err != nil || math.MaxUint64-selectedBytes < selectedBytes {
 		return 0, ErrVectorPartitionSearchUnavailable
 	}
+	queryBytes, err := checkedVectorPartitionScratchProductV1(uint64(dimensions), uint64(unsafe.Sizeof(float32(0))))
+	if err != nil {
+		return 0, err
+	}
 	// Preserve the original row-sized conservative floor while covering the
 	// bounded heap and final output slice, which coexist during heap draining.
-	return max(rowBytes, selectedBytes+selectedBytes), nil
+	// The canonical FP32 query copy remains live through the complete scan.
+	resultBytes := max(rowBytes, selectedBytes+selectedBytes)
+	if math.MaxUint64-resultBytes < queryBytes {
+		return 0, ErrVectorPartitionSearchUnavailable
+	}
+	return resultBytes + queryBytes, nil
 }
 
 // VectorPartitionConservativeSearchScratchBytesV1 returns a transport-neutral
@@ -316,7 +326,7 @@ func VectorPartitionConservativeSearchScratchBytesV1(rows, dimensions int, opts 
 	if rows < 0 || dimensions <= 0 || opts.TopK < 1 || opts.EfSearch < opts.TopK || opts.MaxStableIDBytes < 0 {
 		return 0, ErrVectorPartitionSearchUnavailable
 	}
-	exactBytes, err := vectorPartitionExactSearchScratchBytesV1(rows, opts.TopK)
+	exactBytes, err := vectorPartitionExactSearchScratchBytesV1(rows, dimensions, opts.TopK)
 	if err != nil {
 		return 0, err
 	}
@@ -331,15 +341,15 @@ func VectorPartitionConservativeSearchScratchBytesV1(rows, dimensions int, opts 
 	}
 	// Search caps the doubled HNSW degree at row count. Using row count here
 	// therefore covers every persisted M without requiring shard-local headers.
-	hnswBytes, err := vectorPartitionHNSWSearchScratchBytesV1(rows, vectorStride, rows, topK, efSearch)
+	hnswBytes, err := vectorPartitionHNSWSearchScratchBytesV1(rows, dimensions, vectorStride, rows, topK, efSearch)
 	if err != nil {
 		return 0, err
 	}
 	return max(exactBytes, hnswBytes), nil
 }
 
-func vectorPartitionHNSWSearchScratchBytesV1(rowCount, vectorStride, degree, topK, efSearch int) (uint64, error) {
-	if rowCount < 0 || vectorStride < 0 || degree < 0 || topK < 0 || efSearch < 0 {
+func vectorPartitionHNSWSearchScratchBytesV1(rowCount, dimensions, vectorStride, degree, topK, efSearch int) (uint64, error) {
+	if rowCount < 0 || dimensions <= 0 || vectorStride < 0 || degree < 0 || topK < 0 || efSearch < 0 {
 		return 0, ErrVectorPartitionSearchUnavailable
 	}
 	frontier := columnVectorGraphNativeSearchFrontierCapacity(rowCount, degree, topK, efSearch)
@@ -376,6 +386,9 @@ func vectorPartitionHNSWSearchScratchBytesV1(rowCount, vectorStride, degree, top
 		{degree, unsafe.Sizeof(uint32(0))},
 		{degree, unsafe.Sizeof(float32(0))},
 		{vectorStride, unsafe.Sizeof(float32(0))},
+		// Canonical result scoring normalizes the request query into its own
+		// FP32 buffer after native traversal; it does not reuse native scratch.
+		{dimensions, unsafe.Sizeof(float32(0))},
 	} {
 		if err := add(item.count, item.width); err != nil {
 			return 0, err

--- a/TreeDB/collections/vector_partition_searcher_v1.go
+++ b/TreeDB/collections/vector_partition_searcher_v1.go
@@ -4,6 +4,7 @@ package collections
 // can be carried by a serving group without claiming canonical-row ownership.
 
 import (
+	"bytes"
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
@@ -15,6 +16,62 @@ import (
 )
 
 var ErrVectorPartitionSearchUnavailable = errors.New("collections: vector partition search unavailable")
+
+// VectorPartitionCanonicalScoreContractV1 names the score bits published by
+// vector-partition search. Both operands are normalized in FP32, their dot
+// product is accumulated left-to-right in binary64, and the result is rounded
+// once to FP32.
+const VectorPartitionCanonicalScoreContractV1 = "fp32_normalized_cosine_binary64_accum_score_desc_stable_id_asc_best_duplicate_v1"
+
+// CanonicalVectorPartitionCosineScoreV1 executes the public V1 score contract
+// over caller-owned source vectors.
+func CanonicalVectorPartitionCosineScoreV1(query, vector []float32) (float32, error) {
+	if len(query) == 0 || len(query) != len(vector) {
+		return 0, fmt.Errorf("%w: canonical score dimensions", ErrVectorPartitionSearchUnavailable)
+	}
+	queryInvNorm, err := columnVectorGraphInvNorm(query)
+	if err != nil {
+		return 0, fmt.Errorf("%w: canonical query norm: %v", ErrVectorPartitionSearchUnavailable, err)
+	}
+	vectorInvNorm, err := columnVectorGraphInvNorm(vector)
+	if err != nil {
+		return 0, fmt.Errorf("%w: canonical vector norm: %v", ErrVectorPartitionSearchUnavailable, err)
+	}
+	var dot float64
+	for i := range query {
+		dot += float64(query[i]*queryInvNorm) * float64(vector[i]*vectorInvNorm)
+	}
+	if math.IsNaN(dot) || math.IsInf(dot, 0) {
+		return 0, fmt.Errorf("%w: canonical score nonfinite", ErrVectorPartitionSearchUnavailable)
+	}
+	return float32(dot), nil
+}
+
+func canonicalVectorPartitionNormalizeV1(vector []float32) ([]float32, error) {
+	invNorm, err := columnVectorGraphInvNorm(vector)
+	if err != nil {
+		return nil, fmt.Errorf("%w: canonical score norm: %v", ErrVectorPartitionSearchUnavailable, err)
+	}
+	normalized := make([]float32, len(vector))
+	for i := range vector {
+		normalized[i] = vector[i] * invNorm
+	}
+	return normalized, nil
+}
+
+func canonicalVectorPartitionNormalizedScoreV1(left, right []float32) (float32, error) {
+	if len(left) == 0 || len(left) != len(right) {
+		return 0, fmt.Errorf("%w: canonical normalized score dimensions", ErrVectorPartitionSearchUnavailable)
+	}
+	var dot float64
+	for i := range left {
+		dot += float64(left[i]) * float64(right[i])
+	}
+	if math.IsNaN(dot) || math.IsInf(dot, 0) {
+		return 0, fmt.Errorf("%w: canonical score nonfinite", ErrVectorPartitionSearchUnavailable)
+	}
+	return float32(dot), nil
+}
 
 type VectorPartitionMembershipKindV1 string
 
@@ -629,7 +686,7 @@ func (s *VectorPartitionLocalSearcherV1) SearchWithOptionsV1(ctx context.Context
 			s.recordFailure()
 			return nil, VectorPartitionSearchMetricsV1{}, err
 		}
-		out, err := canonicalizeVectorPartitionNativeResultsV1(ctx, results)
+		out, err := canonicalizeVectorPartitionNativeResultsV1(ctx, s.prepared, query, results)
 		if err != nil {
 			s.recordFailure()
 			return nil, VectorPartitionSearchMetricsV1{}, err
@@ -699,57 +756,71 @@ func (s *VectorPartitionLocalSearcherV1) SearchExactWithOptionsV1(ctx context.Co
 		return nil, VectorPartitionSearchMetricsV1{}, err
 	}
 	defer s.Release()
-	if s.prepared == nil || opts.TopK < 1 || opts.MaxStableIDBytes < 0 || len(query) != s.asset.Dimensions {
-		return nil, VectorPartitionSearchMetricsV1{}, ErrVectorPartitionSearchUnavailable
+	if s.prepared == nil || opts.TopK < 1 || opts.EfSearch < 0 || opts.MaxStableIDBytes < 0 || len(query) != s.asset.Dimensions {
+		s.recordFailure()
+		return nil, VectorPartitionSearchMetricsV1{}, fmt.Errorf("%w: query bounds", ErrVectorPartitionSearchUnavailable)
 	}
 	if opts.MaxStableIDBytes > 0 && s.maxStableIDBytes > opts.MaxStableIDBytes {
-		return nil, VectorPartitionSearchMetricsV1{}, ErrVectorPartitionSearchUnavailable
+		s.recordFailure()
+		return nil, VectorPartitionSearchMetricsV1{}, fmt.Errorf("%w: stable ID bytes=%d exceeds limit=%d", ErrVectorPartitionSearchUnavailable, s.maxStableIDBytes, opts.MaxStableIDBytes)
 	}
-	var qn float64
-	for _, x := range query {
-		if math.IsNaN(float64(x)) || math.IsInf(float64(x), 0) {
-			return nil, VectorPartitionSearchMetricsV1{}, ErrVectorPartitionSearchUnavailable
-		}
-		qn += float64(x) * float64(x)
-	}
-	if qn == 0 {
-		return nil, VectorPartitionSearchMetricsV1{}, ErrVectorPartitionSearchUnavailable
+	normalizedQuery, err := canonicalVectorPartitionNormalizeV1(query)
+	if err != nil {
+		s.recordFailure()
+		return nil, VectorPartitionSearchMetricsV1{}, err
 	}
 	rows, dims, stride := int(s.prepared.Header.Rows), s.asset.Dimensions, int(s.prepared.Header.VectorStride)
 	top := make(vectorPartitionSearchResultMaxHeapV1, 0, min(opts.TopK, rows))
 	for row := 0; row < rows; row++ {
 		if row&255 == 0 {
 			if err := ctx.Err(); err != nil {
+				s.recordFailure()
 				return nil, VectorPartitionSearchMetricsV1{}, err
 			}
 		}
-		var dot float64
-		for col := 0; col < dims; col++ {
-			dot += float64(query[col]) * float64(s.prepared.NormalizedVectors[row*stride+col])
+		score, err := canonicalVectorPartitionNormalizedScoreV1(normalizedQuery, s.prepared.NormalizedVectors[row*stride:row*stride+dims])
+		if err != nil {
+			s.recordFailure()
+			return nil, VectorPartitionSearchMetricsV1{}, err
 		}
 		start, end := s.prepared.DocumentIDOffsets[row], s.prepared.DocumentIDOffsets[row+1]
-		top.pushBounded(min(opts.TopK, rows), VectorPartitionSearchResultV1{ID: string(append([]byte(nil), s.prepared.DocumentIDBytes[start:end]...)), Score: float32(dot / math.Sqrt(qn))})
+		top.pushBounded(min(opts.TopK, rows), VectorPartitionSearchResultV1{ID: string(append([]byte(nil), s.prepared.DocumentIDBytes[start:end]...)), Score: score})
 	}
 	out := make([]VectorPartitionSearchResultV1, len(top))
 	for target := len(out) - 1; target >= 0; target-- {
 		if target&255 == 0 {
 			if err := ctx.Err(); err != nil {
+				s.recordFailure()
 				return nil, VectorPartitionSearchMetricsV1{}, err
 			}
 		}
 		out[target] = top.popWorst()
 	}
+	if err := ctx.Err(); err != nil {
+		s.recordFailure()
+		return nil, VectorPartitionSearchMetricsV1{}, err
+	}
+	s.mu.Lock()
+	s.searches++
+	s.candidates += uint64(rows)
+	s.mu.Unlock()
 	return out, VectorPartitionSearchMetricsV1{Candidates: uint64(rows), Route: VectorPartitionSearchRouteExactFP32ScanV1}, nil
 }
 
-func canonicalizeVectorPartitionNativeResultsV1(ctx context.Context, results []columnVectorGraphNativeSearchResult) ([]VectorPartitionSearchResultV1, error) {
+func canonicalizeVectorPartitionNativeResultsV1(ctx context.Context, prepared *columnHNSWSearchPackPreparedView, query []float32, results []columnVectorGraphNativeSearchResult) ([]VectorPartitionSearchResultV1, error) {
 	if ctx == nil {
 		ctx = context.Background()
 	}
-	// Native HNSW ranks its float64 scores by row ordinal. The wire contract
-	// exposes float32 scores with stable-ID tie order, so two distinct native
-	// scores may collapse into a public tie. Rebuild the bounded result heap
-	// after conversion and drain it canonically before M5 publishes it.
+	// Native HNSW traversal may use platform-optimized FP32 kernels. Recompute
+	// the returned candidate scores with the deterministic public contract, then
+	// rebuild and drain the bounded heap before M5 publishes owned results.
+	if prepared == nil || len(query) != prepared.Header.Dimensions {
+		return nil, ErrVectorPartitionSearchUnavailable
+	}
+	normalizedQuery, err := canonicalVectorPartitionNormalizeV1(query)
+	if err != nil {
+		return nil, err
+	}
 	top := make(vectorPartitionSearchResultMaxHeapV1, 0, len(results))
 	for i, result := range results {
 		if i&255 == 0 {
@@ -757,7 +828,19 @@ func canonicalizeVectorPartitionNativeResultsV1(ctx context.Context, results []c
 				return nil, err
 			}
 		}
-		top.pushBounded(len(results), VectorPartitionSearchResultV1{ID: string(result.ID), Score: float32(result.Score)})
+		if result.Ordinal < 0 || result.Ordinal >= prepared.Header.Rows {
+			return nil, ErrVectorPartitionSearchUnavailable
+		}
+		base := result.Ordinal * prepared.Header.VectorStride
+		idStart, idEnd := prepared.DocumentIDOffsets[result.Ordinal], prepared.DocumentIDOffsets[result.Ordinal+1]
+		if !bytes.Equal(result.ID, prepared.DocumentIDBytes[idStart:idEnd]) {
+			return nil, ErrVectorPartitionSearchUnavailable
+		}
+		score, err := canonicalVectorPartitionNormalizedScoreV1(normalizedQuery, prepared.NormalizedVectors[base:base+prepared.Header.Dimensions])
+		if err != nil {
+			return nil, err
+		}
+		top.pushBounded(len(results), VectorPartitionSearchResultV1{ID: string(result.ID), Score: score})
 	}
 	out := []VectorPartitionSearchResultV1(top)
 	for completed, target := 0, len(out)-1; target >= 0; completed, target = completed+1, target-1 {

--- a/TreeDB/collections/vector_partition_searcher_v1.go
+++ b/TreeDB/collections/vector_partition_searcher_v1.go
@@ -686,6 +686,51 @@ func (s *VectorPartitionLocalSearcherV1) SearchWithOptionsV1(ctx context.Context
 	return out, VectorPartitionSearchMetricsV1{Candidates: uint64(len(s.asset.IDs)), Edges: edges, Route: VectorPartitionSearchRouteExactFP32ScanV1}, nil
 }
 
+// SearchExactWithOptionsV1 scans the already generation-pinned prepared pack.
+// It is diagnostic attribution only; it never reopens mutable source state.
+func (s *VectorPartitionLocalSearcherV1) SearchExactWithOptionsV1(ctx context.Context, query []float32, opts VectorPartitionSearchOptionsV1) ([]VectorPartitionSearchResultV1, VectorPartitionSearchMetricsV1, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if err := ctx.Err(); err != nil {
+		return nil, VectorPartitionSearchMetricsV1{}, err
+	}
+	if err := s.Acquire(); err != nil {
+		return nil, VectorPartitionSearchMetricsV1{}, err
+	}
+	defer s.Release()
+	if s.prepared == nil || opts.TopK < 1 || len(query) != s.asset.Dimensions {
+		return nil, VectorPartitionSearchMetricsV1{}, ErrVectorPartitionSearchUnavailable
+	}
+	var qn float64
+	for _, x := range query {
+		qn += float64(x) * float64(x)
+	}
+	if qn == 0 {
+		return nil, VectorPartitionSearchMetricsV1{}, ErrVectorPartitionSearchUnavailable
+	}
+	rows, dims := int(s.prepared.Header.Rows), s.asset.Dimensions
+	top := make(vectorPartitionSearchResultMaxHeapV1, 0, min(opts.TopK, rows))
+	for row := 0; row < rows; row++ {
+		if row&255 == 0 {
+			if err := ctx.Err(); err != nil {
+				return nil, VectorPartitionSearchMetricsV1{}, err
+			}
+		}
+		var dot float64
+		for col := 0; col < dims; col++ {
+			dot += float64(query[col]) * float64(s.prepared.NormalizedVectors[row*dims+col])
+		}
+		start, end := s.prepared.DocumentIDOffsets[row], s.prepared.DocumentIDOffsets[row+1]
+		top.pushBounded(min(opts.TopK, rows), VectorPartitionSearchResultV1{ID: string(s.prepared.DocumentIDBytes[start:end]), Score: float32(dot / math.Sqrt(qn))})
+	}
+	out := make([]VectorPartitionSearchResultV1, len(top))
+	for target := len(out) - 1; target >= 0; target-- {
+		out[target] = top.popWorst()
+	}
+	return out, VectorPartitionSearchMetricsV1{Candidates: uint64(rows), Route: VectorPartitionSearchRouteExactFP32ScanV1}, nil
+}
+
 func canonicalizeVectorPartitionNativeResultsV1(ctx context.Context, results []columnVectorGraphNativeSearchResult) ([]VectorPartitionSearchResultV1, error) {
 	if ctx == nil {
 		ctx = context.Background()

--- a/TreeDB/collections/vector_partition_searcher_v1.go
+++ b/TreeDB/collections/vector_partition_searcher_v1.go
@@ -883,6 +883,18 @@ func (s *VectorPartitionLocalSearcherV1) SearchExactWithOptionsV1(ctx context.Co
 		s.recordFailure()
 		return nil, VectorPartitionSearchMetricsV1{}, fmt.Errorf("%w: stable ID bytes=%d exceeds limit=%d", ErrVectorPartitionSearchUnavailable, s.maxStableIDBytes, opts.MaxStableIDBytes)
 	}
+	expectedStride, err := columnHNSWSearchPackVectorStrideForDimensions(s.asset.Dimensions)
+	if err != nil || s.prepared.Header.Dimensions != s.asset.Dimensions || s.prepared.Header.VectorStride != expectedStride {
+		s.recordFailure()
+		return nil, VectorPartitionSearchMetricsV1{}, fmt.Errorf(
+			"%w: prepared dimensions/stride=(%d,%d) want (%d,%d)",
+			ErrVectorPartitionSearchUnavailable,
+			s.prepared.Header.Dimensions,
+			s.prepared.Header.VectorStride,
+			s.asset.Dimensions,
+			expectedStride,
+		)
+	}
 	normalizedQuery, err := canonicalVectorPartitionNormalizeV1(query)
 	if err != nil {
 		s.recordFailure()

--- a/TreeDB/collections/vector_partition_searcher_v1_test.go
+++ b/TreeDB/collections/vector_partition_searcher_v1_test.go
@@ -136,6 +136,32 @@ func TestVectorPartitionLocalSearcherV1HNSWCanonicalizesFP32TieOrder(t *testing.
 	}
 }
 
+func TestVectorPartitionLocalSearcherV1PinnedExactPackScanV1(t *testing.T) {
+	input := testColumnHNSWSearchPackInput2312()
+	input.NormalizedVectors = []float32{1, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0}
+	input.DocumentIDOffsets = []uint64{0, 1, 2, 3}
+	input.DocumentIDBytes = []byte("zac")
+	raw, err := encodeColumnHNSWSearchPack(input)
+	if err != nil {
+		t.Fatal(err)
+	}
+	view, handle := testColumnHNSWSearchPackPreparedViewFromBytes2314(t, raw, mappedresource.SourceHeapCopy, input.BaseIdentity)
+	searcher := &VectorPartitionLocalSearcherV1{asset: VectorPartitionSearchAssetV1{Generation: 11, PartitionID: 2, Dimensions: 3}, prepared: view, opened: 1, maxStableIDBytes: 1}
+	results, metrics, err := searcher.SearchExactWithOptionsV1(context.Background(), []float32{1, 0, 0}, VectorPartitionSearchOptionsV1{TopK: 2})
+	if err != nil || len(results) != 2 || results[0].ID != "a" || results[1].ID != "z" || metrics.Route != VectorPartitionSearchRouteExactFP32ScanV1 {
+		t.Fatalf("results=%+v metrics=%+v err=%v", results, metrics, err)
+	}
+	if _, _, err := searcher.SearchExactWithOptionsV1(context.Background(), []float32{1, 0, 0}, VectorPartitionSearchOptionsV1{TopK: 1, MaxStableIDBytes: 0}); err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := searcher.SearchExactWithOptionsV1(context.Background(), []float32{1, 0, 0}, VectorPartitionSearchOptionsV1{TopK: 1, MaxStableIDBytes: 0}); err != nil {
+		t.Fatal(err)
+	}
+	if err := searcher.Close(); err != nil || !handle.Released() {
+		t.Fatalf("close=%v released=%v", err, handle.Released())
+	}
+}
+
 func TestVectorPartitionNativeResultsCanonicalizeCollapsedFP32TieV1(t *testing.T) {
 	higherFloat64 := math.Nextafter(1, 2)
 	if float32(higherFloat64) != float32(1) {

--- a/TreeDB/collections/vector_partition_searcher_v1_test.go
+++ b/TreeDB/collections/vector_partition_searcher_v1_test.go
@@ -139,26 +139,37 @@ func TestVectorPartitionLocalSearcherV1HNSWCanonicalizesFP32TieOrder(t *testing.
 func TestVectorPartitionLocalSearcherV1PinnedExactPackScanV1(t *testing.T) {
 	input := testColumnHNSWSearchPackInput2312()
 	input.NormalizedVectors = []float32{1, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0}
-	input.DocumentIDOffsets = []uint64{0, 1, 2, 3}
-	input.DocumentIDBytes = []byte("zac")
+	input.DocumentIDOffsets = []uint64{0, 4, 5, 6}
+	input.DocumentIDBytes = []byte("longac")
 	raw, err := encodeColumnHNSWSearchPack(input)
 	if err != nil {
 		t.Fatal(err)
 	}
 	view, handle := testColumnHNSWSearchPackPreparedViewFromBytes2314(t, raw, mappedresource.SourceHeapCopy, input.BaseIdentity)
-	searcher := &VectorPartitionLocalSearcherV1{asset: VectorPartitionSearchAssetV1{Generation: 11, PartitionID: 2, Dimensions: 3}, prepared: view, opened: 1, maxStableIDBytes: 1}
+	searcher := &VectorPartitionLocalSearcherV1{asset: VectorPartitionSearchAssetV1{Generation: 11, PartitionID: 2, Dimensions: 3}, prepared: view, opened: 1, maxStableIDBytes: 4}
 	results, metrics, err := searcher.SearchExactWithOptionsV1(context.Background(), []float32{1, 0, 0}, VectorPartitionSearchOptionsV1{TopK: 2})
-	if err != nil || len(results) != 2 || results[0].ID != "a" || results[1].ID != "z" || metrics.Route != VectorPartitionSearchRouteExactFP32ScanV1 {
+	if err != nil || len(results) != 2 || results[0].ID != "a" || results[1].ID != "long" || metrics.Route != VectorPartitionSearchRouteExactFP32ScanV1 {
 		t.Fatalf("results=%+v metrics=%+v err=%v", results, metrics, err)
 	}
-	if _, _, err := searcher.SearchExactWithOptionsV1(context.Background(), []float32{1, 0, 0}, VectorPartitionSearchOptionsV1{TopK: 1, MaxStableIDBytes: 0}); err != nil {
-		t.Fatal(err)
+	if _, _, err := searcher.SearchExactWithOptionsV1(context.Background(), []float32{1, 0, 0}, VectorPartitionSearchOptionsV1{TopK: 1, MaxStableIDBytes: 3}); !errors.Is(err, ErrVectorPartitionSearchUnavailable) {
+		t.Fatalf("stable-ID cap err=%v", err)
 	}
-	if _, _, err := searcher.SearchExactWithOptionsV1(context.Background(), []float32{1, 0, 0}, VectorPartitionSearchOptionsV1{TopK: 1, MaxStableIDBytes: 0}); err != nil {
-		t.Fatal(err)
+	if _, _, err := searcher.SearchExactWithOptionsV1(context.Background(), []float32{1, 0, 0}, VectorPartitionSearchOptionsV1{TopK: 1, EfSearch: -1}); !errors.Is(err, ErrVectorPartitionSearchUnavailable) {
+		t.Fatalf("negative ef_search err=%v", err)
+	}
+	canceled, cancel := context.WithCancel(context.Background())
+	cancel()
+	if _, _, err := searcher.SearchExactWithOptionsV1(canceled, []float32{1, 0, 0}, VectorPartitionSearchOptionsV1{TopK: 1}); !errors.Is(err, context.Canceled) {
+		t.Fatalf("canceled context err=%v", err)
+	}
+	if status := searcher.Status(); status.Searches != 1 || status.Candidates != 3 || status.Failures != 2 || status.ActivePins != 0 {
+		t.Fatalf("exact diagnostic status=%+v", status)
 	}
 	if err := searcher.Close(); err != nil || !handle.Released() {
 		t.Fatalf("close=%v released=%v", err, handle.Released())
+	}
+	if len(results) != 2 || results[0].ID != "a" || results[1].ID != "long" {
+		t.Fatalf("caller-owned results changed after close: %+v", results)
 	}
 }
 
@@ -167,9 +178,15 @@ func TestVectorPartitionNativeResultsCanonicalizeCollapsedFP32TieV1(t *testing.T
 	if float32(higherFloat64) != float32(1) {
 		t.Fatal("test scores do not collapse to one float32 value")
 	}
-	results, err := canonicalizeVectorPartitionNativeResultsV1(context.Background(), []columnVectorGraphNativeSearchResult{
+	prepared := &columnHNSWSearchPackPreparedView{
+		Header:            columnHNSWSearchPackHeader{Rows: 2, Dimensions: 2, VectorStride: 2},
+		NormalizedVectors: []float32{1, 0, 1, 0},
+		DocumentIDOffsets: []uint64{0, 1, 2},
+		DocumentIDBytes:   []byte("za"),
+	}
+	results, err := canonicalizeVectorPartitionNativeResultsV1(context.Background(), prepared, []float32{1, 0}, []columnVectorGraphNativeSearchResult{
 		{Ordinal: 0, ID: []byte("z"), Score: higherFloat64},
-		{Ordinal: 1, ID: []byte("a"), Score: 1},
+		{Ordinal: 1, ID: []byte("a"), Score: -1},
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -177,6 +194,18 @@ func TestVectorPartitionNativeResultsCanonicalizeCollapsedFP32TieV1(t *testing.T
 	if len(results) != 2 || results[0].ID != "a" || results[1].ID != "z" ||
 		results[0].Score != results[1].Score {
 		t.Fatalf("collapsed FP32 tie results=%+v want a,z", results)
+	}
+}
+
+func TestCanonicalVectorPartitionCosineScoreV1NormalizesInFP32V1(t *testing.T) {
+	query := []float32{3, 4}
+	vector := []float32{6, 8}
+	got, err := CanonicalVectorPartitionCosineScoreV1(query, vector)
+	if err != nil || got != 1 {
+		t.Fatalf("score=%v err=%v want 1", got, err)
+	}
+	if _, err := CanonicalVectorPartitionCosineScoreV1(query, []float32{0, 0}); !errors.Is(err, ErrVectorPartitionSearchUnavailable) {
+		t.Fatalf("zero-vector err=%v", err)
 	}
 }
 

--- a/TreeDB/collections/vector_partition_searcher_v1_test.go
+++ b/TreeDB/collections/vector_partition_searcher_v1_test.go
@@ -116,14 +116,13 @@ func TestVectorPartitionLocalSearcherV1HNSWCanonicalizesFP32TieOrder(t *testing.
 	}
 
 	results, metrics, err := searcher.SearchWithOptionsV1(
-		context.Background(), []float32{1, 0, 0}, VectorPartitionSearchOptionsV1{TopK: 2, EfSearch: 3},
+		context.Background(), []float32{1, 0, 0}, VectorPartitionSearchOptionsV1{TopK: 1, EfSearch: 3},
 	)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(results) != 2 || results[0].ID != "a" || results[1].ID != "z" ||
-		results[0].Score != results[1].Score {
-		t.Fatalf("HNSW tie results=%+v want a,z in public FP32/stable-ID order", results)
+	if len(results) != 1 || results[0].ID != "a" {
+		t.Fatalf("HNSW cutoff-tie results=%+v want stable-ID winner a", results)
 	}
 	if metrics.Route != VectorPartitionSearchRouteHNSWSearchPackV1 {
 		t.Fatalf("metrics=%+v", metrics)
@@ -187,7 +186,7 @@ func TestVectorPartitionNativeResultsCanonicalizeCollapsedFP32TieV1(t *testing.T
 	results, err := canonicalizeVectorPartitionNativeResultsV1(context.Background(), prepared, []float32{1, 0}, []columnVectorGraphNativeSearchResult{
 		{Ordinal: 0, ID: []byte("z"), Score: higherFloat64},
 		{Ordinal: 1, ID: []byte("a"), Score: -1},
-	})
+	}, 2)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -263,6 +262,41 @@ func TestVectorPartitionLocalSearcherV1ExactScanAllocationsBoundedByTopKV1(t *te
 	}
 	if allocs >= 32 {
 		t.Fatalf("exact scan allocs/run=%.1f want O(topK), not O(rows=%d)", allocs, rows)
+	}
+}
+
+func TestCanonicalizeVectorPartitionNativeResultsAllocationsBoundedByTopKV1(t *testing.T) {
+	const (
+		rows = 512
+		topK = 5
+	)
+	vectors := make([]float32, rows*2)
+	offsets := make([]uint64, rows+1)
+	ids := make([]byte, 0, rows*8)
+	results := make([]columnVectorGraphNativeSearchResult, rows)
+	for row := 0; row < rows; row++ {
+		vectors[row*2] = 1
+		start := len(ids)
+		ids = fmt.Appendf(ids, "%08d", rows-row-1)
+		offsets[row+1] = uint64(len(ids))
+		results[row] = columnVectorGraphNativeSearchResult{Ordinal: row, ID: ids[start:len(ids)]}
+	}
+	prepared := &columnHNSWSearchPackPreparedView{
+		Header:            columnHNSWSearchPackHeader{Rows: rows, Dimensions: 2, VectorStride: 2},
+		NormalizedVectors: vectors,
+		DocumentIDOffsets: offsets,
+		DocumentIDBytes:   ids,
+	}
+	var canonicalErr error
+	allocs := testing.AllocsPerRun(10, func() {
+		var got []VectorPartitionSearchResultV1
+		got, canonicalErr = canonicalizeVectorPartitionNativeResultsV1(context.Background(), prepared, []float32{1, 0}, results, topK)
+		if len(got) != topK || got[0].ID != "00000000" {
+			canonicalErr = fmt.Errorf("canonical results=%+v", got)
+		}
+	})
+	if canonicalErr != nil || allocs >= 32 {
+		t.Fatalf("canonical native results err=%v allocs/run=%.1f want O(topK), not O(rows=%d)", canonicalErr, allocs, rows)
 	}
 }
 
@@ -369,7 +403,7 @@ func TestCanonicalizeVectorPartitionNativeResultsRejectsUntrustedIdentityV1(t *t
 		{name: "ID mismatch", result: columnVectorGraphNativeSearchResult{Ordinal: 0, ID: []byte("b")}},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			if _, err := canonicalizeVectorPartitionNativeResultsV1(context.Background(), prepared, []float32{1, 0}, []columnVectorGraphNativeSearchResult{tc.result}); !errors.Is(err, ErrVectorPartitionSearchUnavailable) {
+			if _, err := canonicalizeVectorPartitionNativeResultsV1(context.Background(), prepared, []float32{1, 0}, []columnVectorGraphNativeSearchResult{tc.result}, 1); !errors.Is(err, ErrVectorPartitionSearchUnavailable) {
 				t.Fatalf("err=%v want unavailable", err)
 			}
 		})
@@ -415,20 +449,20 @@ func TestVectorPartitionHNSWSearchScratchIncludesConvertedResultsV1(t *testing.T
 	if err != nil {
 		t.Fatal(err)
 	}
-	frontier := columnVectorGraphNativeSearchFrontierCapacity(rows, degree, topK, efSearch)
+	frontier := columnVectorGraphNativeSearchFrontierCapacity(rows, degree, efSearch, efSearch)
 	withoutConverted := uint64(rows)*uint64(unsafe.Sizeof(uint64(0))) +
 		uint64(frontier)*uint64(unsafe.Sizeof(columnVectorGraphSearchCandidate{})) +
 		uint64(efSearch)*uint64(unsafe.Sizeof(columnVectorGraphSearchCandidate{})) +
-		uint64(topK)*uint64(unsafe.Sizeof(columnVectorGraphNativeSearchResult{})) +
-		uint64(topK)*uint64(unsafe.Sizeof([]byte(nil))) +
-		uint64(topK)*uint64(unsafe.Sizeof(int(0)))*2 +
-		uint64(topK)*uint64(unsafe.Sizeof(DocumentRowRef{})) +
-		uint64(topK)*uint64(unsafe.Sizeof(bool(false))) +
+		uint64(efSearch)*uint64(unsafe.Sizeof(columnVectorGraphNativeSearchResult{})) +
+		uint64(efSearch)*uint64(unsafe.Sizeof([]byte(nil))) +
+		uint64(efSearch)*uint64(unsafe.Sizeof(int(0)))*2 +
+		uint64(efSearch)*uint64(unsafe.Sizeof(DocumentRowRef{})) +
+		uint64(efSearch)*uint64(unsafe.Sizeof(bool(false))) +
 		uint64(degree)*uint64(unsafe.Sizeof(float64(0))) +
 		uint64(degree)*uint64(unsafe.Sizeof(uint32(0))) +
 		uint64(degree)*uint64(unsafe.Sizeof(float32(0))) +
 		uint64(vectorStride)*uint64(unsafe.Sizeof(float32(0)))
-	wantConverted := uint64(topK) * uint64(unsafe.Sizeof(VectorPartitionSearchResultV1{}))
+	wantConverted := uint64(topK) * uint64(unsafe.Sizeof(vectorPartitionSearchRefResultV1{})+unsafe.Sizeof(VectorPartitionSearchResultV1{}))
 	wantCanonicalQuery := uint64(dimensions) * uint64(unsafe.Sizeof(float32(0)))
 	if got-withoutConverted != wantConverted+wantCanonicalQuery {
 		t.Fatalf("converted result and canonical query scratch=%d want=%d (total=%d)", got-withoutConverted, wantConverted+wantCanonicalQuery, got)

--- a/TreeDB/collections/vector_partition_searcher_v1_test.go
+++ b/TreeDB/collections/vector_partition_searcher_v1_test.go
@@ -290,12 +290,16 @@ func TestVectorPartitionLocalSearcherV1ScratchBoundIncludesRowSizedHNSWState(t *
 func TestVectorPartitionHNSWSearchScratchIncludesConvertedResultsV1(t *testing.T) {
 	const (
 		rows         = 17
+		dimensions   = 29
 		vectorStride = 32
 		degree       = 8
 		topK         = 7
 		efSearch     = 11
 	)
-	got, err := vectorPartitionHNSWSearchScratchBytesV1(rows, vectorStride, degree, topK, efSearch)
+	prepared := &columnHNSWSearchPackPreparedView{Header: columnHNSWSearchPackHeader{
+		Rows: rows, Dimensions: dimensions, VectorStride: vectorStride, M: degree / 2, EfSearch: efSearch,
+	}}
+	got, err := vectorPartitionSearchScratchBytesV1(VectorPartitionSearchOptionsV1{TopK: topK, EfSearch: efSearch}, prepared, 0, dimensions, 0, prepared.Header)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -313,8 +317,26 @@ func TestVectorPartitionHNSWSearchScratchIncludesConvertedResultsV1(t *testing.T
 		uint64(degree)*uint64(unsafe.Sizeof(float32(0))) +
 		uint64(vectorStride)*uint64(unsafe.Sizeof(float32(0)))
 	wantConverted := uint64(topK) * uint64(unsafe.Sizeof(VectorPartitionSearchResultV1{}))
-	if got-withoutConverted != wantConverted {
-		t.Fatalf("converted result scratch=%d want=%d (total=%d)", got-withoutConverted, wantConverted, got)
+	wantCanonicalQuery := uint64(dimensions) * uint64(unsafe.Sizeof(float32(0)))
+	if got-withoutConverted != wantConverted+wantCanonicalQuery {
+		t.Fatalf("converted result and canonical query scratch=%d want=%d (total=%d)", got-withoutConverted, wantConverted+wantCanonicalQuery, got)
+	}
+}
+
+func TestVectorPartitionExactSearchScratchIncludesCanonicalQueryV1(t *testing.T) {
+	const (
+		rows       = 3
+		dimensions = 29
+		topK       = 3
+	)
+	got, err := vectorPartitionSearchScratchBytesV1(VectorPartitionSearchOptionsV1{TopK: topK}, nil, rows, dimensions, 0, columnHNSWSearchPackHeader{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	withoutCanonicalQuery := uint64(topK*2) * uint64(unsafe.Sizeof(VectorPartitionSearchResultV1{}))
+	wantCanonicalQuery := uint64(dimensions) * uint64(unsafe.Sizeof(float32(0)))
+	if got-withoutCanonicalQuery != wantCanonicalQuery {
+		t.Fatalf("canonical query scratch=%d want=%d (total=%d)", got-withoutCanonicalQuery, wantCanonicalQuery, got)
 	}
 }
 
@@ -327,11 +349,11 @@ func TestVectorPartitionConservativeSearchScratchCoversActualRoutesV1(t *testing
 	prepared := &columnHNSWSearchPackPreparedView{Header: columnHNSWSearchPackHeader{
 		Rows: 17, Dimensions: 4096, VectorStride: 4096, M: 256, EfSearch: 128,
 	}}
-	actualHNSW, err := vectorPartitionSearchScratchBytesV1(opts, prepared, 0, 0, prepared.Header)
+	actualHNSW, err := vectorPartitionSearchScratchBytesV1(opts, prepared, 0, 4096, 0, prepared.Header)
 	if err != nil {
 		t.Fatal(err)
 	}
-	actualExact, err := vectorPartitionSearchScratchBytesV1(opts, nil, 17, 0, columnHNSWSearchPackHeader{})
+	actualExact, err := vectorPartitionSearchScratchBytesV1(opts, nil, 17, 4096, 0, columnHNSWSearchPackHeader{})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/TreeDB/collections/vector_partition_searcher_v1_test.go
+++ b/TreeDB/collections/vector_partition_searcher_v1_test.go
@@ -207,6 +207,63 @@ func TestCanonicalVectorPartitionCosineScoreV1NormalizesInFP32V1(t *testing.T) {
 	if _, err := CanonicalVectorPartitionCosineScoreV1(query, []float32{0, 0}); !errors.Is(err, ErrVectorPartitionSearchUnavailable) {
 		t.Fatalf("zero-vector err=%v", err)
 	}
+	scorer, err := NewCanonicalVectorPartitionCosineScorerV1(query)
+	if err != nil {
+		t.Fatal(err)
+	}
+	prepared, err := scorer.ScoreV1(vector)
+	if err != nil || math.Float32bits(prepared) != math.Float32bits(got) {
+		t.Fatalf("prepared score=%v bits=%#x err=%v want=%v bits=%#x", prepared, math.Float32bits(prepared), err, got, math.Float32bits(got))
+	}
+	var scoreErr error
+	allocs := testing.AllocsPerRun(100, func() {
+		_, scoreErr = scorer.ScoreV1(vector)
+	})
+	if scoreErr != nil || allocs != 0 {
+		t.Fatalf("prepared score err=%v allocs/run=%.1f want zero", scoreErr, allocs)
+	}
+}
+
+func TestVectorPartitionLocalSearcherV1ExactScanAllocationsBoundedByTopKV1(t *testing.T) {
+	const (
+		rows = 512
+		topK = 5
+	)
+	vectors := make([]float32, rows*2)
+	offsets := make([]uint64, rows+1)
+	ids := make([]byte, 0, rows*8)
+	for row := 0; row < rows; row++ {
+		vectors[row*2] = 1
+		ids = fmt.Appendf(ids, "%08d", row)
+		offsets[row+1] = uint64(len(ids))
+	}
+	searcher := &VectorPartitionLocalSearcherV1{
+		asset: VectorPartitionSearchAssetV1{Generation: 11, PartitionID: 2, Dimensions: 2},
+		prepared: &columnHNSWSearchPackPreparedView{
+			Header:            columnHNSWSearchPackHeader{Rows: rows, Dimensions: 2, VectorStride: 2},
+			NormalizedVectors: vectors,
+			DocumentIDOffsets: offsets,
+			DocumentIDBytes:   ids,
+		},
+		opened:           1,
+		maxStableIDBytes: 8,
+	}
+	var searchErr error
+	allocs := testing.AllocsPerRun(10, func() {
+		var results []VectorPartitionSearchResultV1
+		results, _, searchErr = searcher.SearchExactWithOptionsV1(
+			context.Background(), []float32{1, 0}, VectorPartitionSearchOptionsV1{TopK: topK},
+		)
+		if len(results) != topK {
+			searchErr = fmt.Errorf("results=%d want=%d", len(results), topK)
+		}
+	})
+	if searchErr != nil {
+		t.Fatal(searchErr)
+	}
+	if allocs >= 32 {
+		t.Fatalf("exact scan allocs/run=%.1f want O(topK), not O(rows=%d)", allocs, rows)
+	}
 }
 
 func TestVectorPartitionLocalSearcherV1ExactScanUsesCanonicalScoreBitsV1(t *testing.T) {

--- a/TreeDB/collections/vector_partition_searcher_v1_test.go
+++ b/TreeDB/collections/vector_partition_searcher_v1_test.go
@@ -209,6 +209,61 @@ func TestCanonicalVectorPartitionCosineScoreV1NormalizesInFP32V1(t *testing.T) {
 	}
 }
 
+func TestVectorPartitionLocalSearcherV1ExactScanUsesCanonicalScoreBitsV1(t *testing.T) {
+	query := []float32{-17132608, 10416778, -5245998.5}
+	vector := []float32{40529192, 32163242, -2387782.25}
+	want, err := CanonicalVectorPartitionCosineScoreV1(query, vector)
+	if err != nil {
+		t.Fatal(err)
+	}
+	searcher, err := OpenVectorPartitionLocalSearcherV1(VectorPartitionSearchAssetV1{
+		ManifestChecksum: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+		Generation:       1,
+		PartitionID:      2,
+		Dimensions:       len(query),
+		IDs:              []string{"a"},
+		Vectors:          [][]float32{vector},
+		Kinds:            []VectorPartitionMembershipKindV1{VectorPartitionMembershipHomeV1},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = searcher.Close() })
+	// The searcher owns its normalized snapshot; caller mutation after Open
+	// cannot change the generation-pinned score bits.
+	vector[0] = 0
+	got, _, err := searcher.SearchWithOptionsV1(context.Background(), query, VectorPartitionSearchOptionsV1{TopK: 1})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 1 || math.Float32bits(got[0].Score) != math.Float32bits(want) {
+		t.Fatalf("exact score=%v bits=%#x want=%v bits=%#x", got, math.Float32bits(got[0].Score), want, math.Float32bits(want))
+	}
+}
+
+func TestCanonicalizeVectorPartitionNativeResultsRejectsUntrustedIdentityV1(t *testing.T) {
+	prepared := &columnHNSWSearchPackPreparedView{
+		Header:            columnHNSWSearchPackHeader{Rows: 2, Dimensions: 2, VectorStride: 2},
+		NormalizedVectors: []float32{1, 0, 0, 1},
+		DocumentIDOffsets: []uint64{0, 1, 2},
+		DocumentIDBytes:   []byte("ab"),
+	}
+	for _, tc := range []struct {
+		name   string
+		result columnVectorGraphNativeSearchResult
+	}{
+		{name: "negative ordinal", result: columnVectorGraphNativeSearchResult{Ordinal: -1, ID: []byte("a")}},
+		{name: "out of range ordinal", result: columnVectorGraphNativeSearchResult{Ordinal: 2, ID: []byte("a")}},
+		{name: "ID mismatch", result: columnVectorGraphNativeSearchResult{Ordinal: 0, ID: []byte("b")}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if _, err := canonicalizeVectorPartitionNativeResultsV1(context.Background(), prepared, []float32{1, 0}, []columnVectorGraphNativeSearchResult{tc.result}); !errors.Is(err, ErrVectorPartitionSearchUnavailable) {
+				t.Fatalf("err=%v want unavailable", err)
+			}
+		})
+	}
+}
+
 func TestVectorPartitionLocalSearcherV1ScratchBoundIncludesRowSizedHNSWState(t *testing.T) {
 	searcher := &VectorPartitionLocalSearcherV1{
 		asset: VectorPartitionSearchAssetV1{Generation: 1, PartitionID: 2, Dimensions: 128},

--- a/TreeDB/collections/vector_partition_searcher_v1_test.go
+++ b/TreeDB/collections/vector_partition_searcher_v1_test.go
@@ -223,6 +223,18 @@ func TestCanonicalVectorPartitionCosineScoreV1NormalizesInFP32V1(t *testing.T) {
 	}
 }
 
+func TestCanonicalVectorPartitionAccumulateV1RoundsProductAndSumV1(t *testing.T) {
+	sum := math.Float64frombits(0x3ff0000000000001)
+	left := math.Float32frombits(0x3f7fffff)
+	right := math.Float32frombits(0x3f000001)
+	product := math.Float64frombits(math.Float64bits(float64(left) * float64(right)))
+	want := math.Float64frombits(math.Float64bits(sum + product))
+	got := canonicalVectorPartitionAccumulateV1(sum, left, right)
+	if math.Float64bits(got) != math.Float64bits(want) {
+		t.Fatalf("canonical accumulation bits=%#x want=%#x", math.Float64bits(got), math.Float64bits(want))
+	}
+}
+
 func TestVectorPartitionLocalSearcherV1ExactScanAllocationsBoundedByTopKV1(t *testing.T) {
 	const (
 		rows = 512

--- a/TreeDB/collections/vector_partition_searcher_v1_test.go
+++ b/TreeDB/collections/vector_partition_searcher_v1_test.go
@@ -25,8 +25,8 @@ func TestVectorPartitionLocalSearcherV1ExactStableIDsAndPins(t *testing.T) {
 	if got[0].ID != "bb" || got[0].Score <= got[1].Score {
 		t.Fatalf("%+v", got)
 	}
-	if status := s.Status(); status.MaxStableIDBytes != 2 {
-		t.Fatalf("max stable ID bytes=%d want 2", status.MaxStableIDBytes)
+	if status := s.Status(); status.MaxStableIDBytes != 2 || status.HeapBytes != 35 || status.PackBytes != 35 {
+		t.Fatalf("exact in-memory status=%+v want max ID 2 and 35-byte cloned+normalized payload", status)
 	}
 	if _, _, err := s.SearchWithOptionsV1(context.Background(), []float32{1, 0}, VectorPartitionSearchOptionsV1{TopK: 1, MaxStableIDBytes: 0}); err != nil {
 		t.Fatalf("uncapped stable ID search: %v", err)

--- a/TreeDB/collections/vector_partition_searcher_v1_test.go
+++ b/TreeDB/collections/vector_partition_searcher_v1_test.go
@@ -300,6 +300,27 @@ func TestVectorPartitionLocalSearcherV1ExactScanRejectsPreparedShapeMismatchV1(t
 	}
 }
 
+func TestVectorPartitionLocalSearcherV1ExactScanAcceptsAlignedOverpaddedStrideV1(t *testing.T) {
+	searcher := &VectorPartitionLocalSearcherV1{
+		asset: VectorPartitionSearchAssetV1{Generation: 11, PartitionID: 2, Dimensions: 3},
+		prepared: &columnHNSWSearchPackPreparedView{
+			Header:            columnHNSWSearchPackHeader{Rows: 1, Dimensions: 3, VectorStride: 8},
+			NormalizedVectors: []float32{1, 0, 0, 0, 0, 0, 0, 0},
+			DocumentIDOffsets: []uint64{0, 1},
+			DocumentIDBytes:   []byte("a"),
+		},
+		opened:           1,
+		maxStableIDBytes: 1,
+	}
+	results, metrics, err := searcher.SearchExactWithOptionsV1(
+		context.Background(), []float32{1, 0, 0}, VectorPartitionSearchOptionsV1{TopK: 1},
+	)
+	if err != nil || len(results) != 1 || results[0].ID != "a" || results[0].Score != 1 ||
+		metrics.Route != VectorPartitionSearchRouteExactFP32ScanV1 {
+		t.Fatalf("results=%+v metrics=%+v err=%v want valid overpadded exact result", results, metrics, err)
+	}
+}
+
 func TestVectorPartitionLocalSearcherV1ExactScanUsesCanonicalScoreBitsV1(t *testing.T) {
 	query := []float32{-17132608, 10416778, -5245998.5}
 	vector := []float32{40529192, 32163242, -2387782.25}

--- a/TreeDB/collections/vector_partition_searcher_v1_test.go
+++ b/TreeDB/collections/vector_partition_searcher_v1_test.go
@@ -229,18 +229,18 @@ func TestVectorPartitionLocalSearcherV1ExactScanAllocationsBoundedByTopKV1(t *te
 		rows = 512
 		topK = 5
 	)
-	vectors := make([]float32, rows*2)
+	vectors := make([]float32, rows*4)
 	offsets := make([]uint64, rows+1)
 	ids := make([]byte, 0, rows*8)
 	for row := 0; row < rows; row++ {
-		vectors[row*2] = 1
+		vectors[row*4] = 1
 		ids = fmt.Appendf(ids, "%08d", row)
 		offsets[row+1] = uint64(len(ids))
 	}
 	searcher := &VectorPartitionLocalSearcherV1{
 		asset: VectorPartitionSearchAssetV1{Generation: 11, PartitionID: 2, Dimensions: 2},
 		prepared: &columnHNSWSearchPackPreparedView{
-			Header:            columnHNSWSearchPackHeader{Rows: rows, Dimensions: 2, VectorStride: 2},
+			Header:            columnHNSWSearchPackHeader{Rows: rows, Dimensions: 2, VectorStride: 4},
 			NormalizedVectors: vectors,
 			DocumentIDOffsets: offsets,
 			DocumentIDBytes:   ids,
@@ -263,6 +263,40 @@ func TestVectorPartitionLocalSearcherV1ExactScanAllocationsBoundedByTopKV1(t *te
 	}
 	if allocs >= 32 {
 		t.Fatalf("exact scan allocs/run=%.1f want O(topK), not O(rows=%d)", allocs, rows)
+	}
+}
+
+func TestVectorPartitionLocalSearcherV1ExactScanRejectsPreparedShapeMismatchV1(t *testing.T) {
+	for _, tc := range []struct {
+		name       string
+		dimensions int
+		stride     int
+	}{
+		{name: "dimensions", dimensions: 2, stride: 4},
+		{name: "stride", dimensions: 3, stride: 3},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			searcher := &VectorPartitionLocalSearcherV1{
+				asset: VectorPartitionSearchAssetV1{Generation: 11, PartitionID: 2, Dimensions: 3},
+				prepared: &columnHNSWSearchPackPreparedView{
+					Header:            columnHNSWSearchPackHeader{Rows: 1, Dimensions: tc.dimensions, VectorStride: tc.stride},
+					NormalizedVectors: make([]float32, tc.stride),
+					DocumentIDOffsets: []uint64{0, 1},
+					DocumentIDBytes:   []byte("a"),
+				},
+				opened:           1,
+				maxStableIDBytes: 1,
+			}
+			results, metrics, err := searcher.SearchExactWithOptionsV1(
+				context.Background(), []float32{1, 0, 0}, VectorPartitionSearchOptionsV1{TopK: 1},
+			)
+			if !errors.Is(err, ErrVectorPartitionSearchUnavailable) || results != nil || metrics != (VectorPartitionSearchMetricsV1{}) {
+				t.Fatalf("results=%+v metrics=%+v err=%v want unavailable and no partial result", results, metrics, err)
+			}
+			if status := searcher.Status(); status.Failures != 1 || status.Searches != 0 || status.ActivePins != 0 {
+				t.Fatalf("status=%+v want one failure, no search, released pin", status)
+			}
+		})
 	}
 }
 

--- a/TreeDB/collections/vector_partition_searcher_v1_test.go
+++ b/TreeDB/collections/vector_partition_searcher_v1_test.go
@@ -25,8 +25,8 @@ func TestVectorPartitionLocalSearcherV1ExactStableIDsAndPins(t *testing.T) {
 	if got[0].ID != "bb" || got[0].Score <= got[1].Score {
 		t.Fatalf("%+v", got)
 	}
-	if status := s.Status(); status.MaxStableIDBytes != 2 || status.HeapBytes != 35 || status.PackBytes != 35 {
-		t.Fatalf("exact in-memory status=%+v want max ID 2 and 35-byte cloned+normalized payload", status)
+	if status := s.Status(); status.MaxStableIDBytes != 2 || status.HeapBytes != 27 || status.PackBytes != 27 {
+		t.Fatalf("exact in-memory status=%+v want max ID 2 and 27-byte cloned+inverse-norm payload", status)
 	}
 	if _, _, err := s.SearchWithOptionsV1(context.Background(), []float32{1, 0}, VectorPartitionSearchOptionsV1{TopK: 1, MaxStableIDBytes: 0}); err != nil {
 		t.Fatalf("uncapped stable ID search: %v", err)
@@ -341,7 +341,7 @@ func TestVectorPartitionLocalSearcherV1ExactScanUsesCanonicalScoreBitsV1(t *test
 		t.Fatal(err)
 	}
 	t.Cleanup(func() { _ = searcher.Close() })
-	// The searcher owns its normalized snapshot; caller mutation after Open
+	// The searcher owns its vector snapshot and cached inverse norms; caller mutation after Open
 	// cannot change the generation-pinned score bits.
 	vector[0] = 0
 	got, _, err := searcher.SearchWithOptionsV1(context.Background(), query, VectorPartitionSearchOptionsV1{TopK: 1})

--- a/TreeDB/docs/performance/vector-partition-m8-evidence.json
+++ b/TreeDB/docs/performance/vector-partition-m8-evidence.json
@@ -72,6 +72,44 @@
     "cpu_profile_sha256": "46a106805b3795267bd50c868bec5a7c2d4023f445ca03254c857445ca62c963",
     "trace_sha256": "13470d84b203738c49f7bba87c8fa52b80e0da0453d17b871e13a9347e54fe1e"
   },
+  "continuation_attribution": {
+    "status": "diagnosed_experimental_off",
+    "schema_version": 2,
+    "result_kind": "m8_production_multi_group_evidence_v2",
+    "measured_code_head": "3b52711665297c7396f1f86238840dee1ea2897b",
+    "canonical_contract": "fp32_normalized_cosine_binary64_accum_score_desc_stable_id_asc_best_duplicate_v1",
+    "checked_in_10k": {
+      "artifact_sha256": "c9d37aba290284b742f9e8189b429031146226a8cf9801370bd15754b80c81dc",
+      "artifact_retained_path": "/mnt/fast4tb/tmp/treedb_vector_partition_3980_10k_clean_fvQhPj/vector_partition_m8_3b5271166529_0f33a1583ce3.json",
+      "dirty": false,
+      "queries": 128,
+      "exhaustive_partition_union_recall_at_10": 1,
+      "exhaustive_partition_union_id_parity": true,
+      "exhaustive_partition_union_score_parity": true,
+      "all_partition_ef4096_local_hnsw_recall_at_10": 0.9695312500000001,
+      "all_partition_loss_owner": "partition_local_hnsw",
+      "coordinator_merge_id_parity": true,
+      "coordinator_merge_score_parity": true
+    },
+    "retained_1m": {
+      "artifact_sha256": "9afad07fb8daf374076fe9fa630106ffdf6241ae746344349eb1885d37cdfbd1",
+      "artifact_retained_path": "/mnt/fast4tb/tmp/treedb_vector_partition_3980_1m_clean_Wadji9/vector_partition_m8_3b5271166529_55786c770e98.json",
+      "dirty": false,
+      "queries": 1,
+      "exhaustive_partition_union_recall_at_10": 1,
+      "exhaustive_partition_union_id_parity": true,
+      "exhaustive_partition_union_score_parity": true,
+      "all_partition_exact_representative_recall_at_10": 1,
+      "all_partition_approximate_representative_recall_at_10": 1,
+      "all_partition_local_hnsw_recall_at_10": 0,
+      "all_partition_end_to_end_recall_at_10": 0,
+      "all_partition_loss_owner": "partition_local_hnsw",
+      "coordinator_merge_id_parity": true,
+      "coordinator_merge_score_parity": true
+    },
+    "disposition": "diagnosis_only_enablement_remains_off",
+    "next_owners": ["3981_generation_pinned_session_cache", "3982_local_hnsw_and_final_gate"]
+  },
   "unsupported": [
     "overlap_0.20_assets",
     "stable_id_hash_attribution",

--- a/TreeDB/docs/performance/vector-partition-m8.md
+++ b/TreeDB/docs/performance/vector-partition-m8.md
@@ -226,6 +226,15 @@ merge; its all-partition owner is partition-local HNSW.
 | clean 10k attribution JSON | `/mnt/fast4tb/tmp/treedb_vector_partition_3980_10k_clean_fvQhPj/vector_partition_m8_3b5271166529_0f33a1583ce3.json` | `c9d37aba290284b742f9e8189b429031146226a8cf9801370bd15754b80c81dc` |
 | clean retained 1M attribution JSON | `/mnt/fast4tb/tmp/treedb_vector_partition_3980_1m_clean_Wadji9/vector_partition_m8_3b5271166529_55786c770e98.json` | `9afad07fb8daf374076fe9fa630106ffdf6241ae746344349eb1885d37cdfbd1` |
 
+These two diagnostic records predate the runner-ordering repair and performed
+their exhaustive mmap-backed attribution scans before the timed sweep. They
+remain valid for exactness and recall-loss ownership, but their QPS, latency,
+profile, and peak-RSS fields are not clean performance evidence. The current
+runner completes the measured query/fault profile and snapshots peak RSS before
+opening the attribution harness. The peak-RSS scope still includes the bounded
+top-k coordinator results retained from measured cells for later parity checks;
+performance acceptance requires a new capture.
+
 These runs diagnose ownership; they do not pass the original exhaustive-HNSW,
 representative-recall, overlap, resource-bound, or matched-QPS enablement gates.
 Issue #3981 owns generation-pinned request-session caching. Issue #3982 owns

--- a/TreeDB/docs/performance/vector-partition-m8.md
+++ b/TreeDB/docs/performance/vector-partition-m8.md
@@ -228,8 +228,9 @@ merge; its all-partition owner is partition-local HNSW.
 
 These runs diagnose ownership; they do not pass the original exhaustive-HNSW,
 representative-recall, overlap, resource-bound, or matched-QPS enablement gates.
-#3981 owns generation-pinned request-session caching. #3982 owns remediation or
-explicit disposition of the local-HNSW loss plus the sole final local gate.
+Issue #3981 owns generation-pinned request-session caching. Issue #3982 owns
+remediation or explicit disposition of the local-HNSW loss plus the sole final
+local gate.
 
 The retained M3 record separately reports 188,427,800 mapped bytes,
 200,546,033 derived physical bytes, and 1,023,827,968 resident bytes after the

--- a/TreeDB/docs/performance/vector-partition-m8.md
+++ b/TreeDB/docs/performance/vector-partition-m8.md
@@ -185,6 +185,52 @@ performance owner. They do not justify bypassing integrity checks; remediation
 must retain snapshot/generation identity, cancellation, and fail-closed reader
 pin semantics.
 
+## #3980 exactness and recall-attribution continuation
+
+Measured production-code head: `3b52711665297c7396f1f86238840dee1ea2897b`
+(the documentation commit is subsequent). Status remains **experimental/off**.
+The continuation emits schema `2`, result kind
+`m8_production_multi_group_evidence_v2`, and persists zero recall explicitly.
+
+The executable score contract is
+`fp32_normalized_cosine_binary64_accum_score_desc_stable_id_asc_best_duplicate_v1`:
+query and source vectors are normalized in FP32, their dot product is
+accumulated left-to-right in binary64, the result is rounded once to FP32,
+duplicate stable IDs retain their best score, and results sort by descending
+score then ascending stable ID. The full-source oracle, generation-pinned exact
+partition scan, and published HNSW candidate rescoring share this contract.
+
+The clean 10k diagnostic used two data groups, four partitions, probes `1,4`,
+`ef_search=64,4096`, one measured concurrency, and 128 queries. The canonical
+source oracle and exhaustive exact partition union matched with recall `1.0`
+and exact ID/score parity in every row. Coordinator merge/transport also had
+exact ID/score parity. At four probes, exact and approximate representative
+routing both retained recall `1.0`; remaining recall was `0.25625` at
+`ef_search=64` and `0.96953125` at `ef_search=4096`, wholly owned by
+partition-local HNSW. At one probe, exact representative routing retained
+`0.25234375`; local HNSW reduced it further to `0.07109375` or `0.24375`.
+
+The retained 1M diagnostic used four data groups, 16 partitions, probes `1,16`,
+`ef_search=64,4096`, and the declared single smoke query. Its canonical source
+oracle and exhaustive exact union again matched at recall `1.0` with exact
+ID/score parity. At 16 probes, both representative-routing stages retained
+recall `1.0`, but partition-local HNSW and end-to-end recall were explicitly
+`0` at both search budgets. Coordinator ID/score parity remained exact. At one
+probe, representative routing itself retained no truth IDs. The former 1M zero
+is therefore explained: it is not caused by source identity, partition
+membership, the score contract, Raft/TCP transport, dedupe, or coordinator
+merge; its all-partition owner is partition-local HNSW.
+
+| Continuation record | Path | SHA-256 |
+| --- | --- | --- |
+| clean 10k attribution JSON | `/mnt/fast4tb/tmp/treedb_vector_partition_3980_10k_clean_fvQhPj/vector_partition_m8_3b5271166529_0f33a1583ce3.json` | `c9d37aba290284b742f9e8189b429031146226a8cf9801370bd15754b80c81dc` |
+| clean retained 1M attribution JSON | `/mnt/fast4tb/tmp/treedb_vector_partition_3980_1m_clean_Wadji9/vector_partition_m8_3b5271166529_55786c770e98.json` | `9afad07fb8daf374076fe9fa630106ffdf6241ae746344349eb1885d37cdfbd1` |
+
+These runs diagnose ownership; they do not pass the original exhaustive-HNSW,
+representative-recall, overlap, resource-bound, or matched-QPS enablement gates.
+#3981 owns generation-pinned request-session caching. #3982 owns remediation or
+explicit disposition of the local-HNSW loss plus the sole final local gate.
+
 The retained M3 record separately reports 188,427,800 mapped bytes,
 200,546,033 derived physical bytes, and 1,023,827,968 resident bytes after the
 build. Its build peak RSS was 2,793,459,712 bytes. The M8 process measured peak

--- a/TreeDB/docs/performance/vector-partition-m8.md
+++ b/TreeDB/docs/performance/vector-partition-m8.md
@@ -195,7 +195,8 @@ The continuation emits schema `2`, result kind
 The executable score contract is
 `fp32_normalized_cosine_binary64_accum_score_desc_stable_id_asc_best_duplicate_v1`:
 query and source vectors are normalized in FP32, their dot product is
-accumulated left-to-right in binary64, the result is rounded once to FP32,
+accumulated left-to-right with explicit separately rounded binary64 products
+and additions, the result is rounded once to FP32,
 duplicate stable IDs retain their best score, and results sort by descending
 score then ascending stable ID. The full-source oracle, generation-pinned exact
 partition scan, and published HNSW candidate rescoring share this contract.

--- a/TreeDB/docs/spec/vector-partition-raft-v1.md
+++ b/TreeDB/docs/spec/vector-partition-raft-v1.md
@@ -235,6 +235,30 @@ consistency, or shard failure is an explicit error with no incomplete result.
 
 ## M0 oracle and evidence boundary
 
+### Canonical V1 partition-result contract
+
+`collections.VectorPartitionCanonicalScoreContractV1` is the executable
+production result contract. It normalizes both query and source vector in
+FP32, accumulates their normalized dot product left-to-right in binary64, and
+rounds the final cosine score once to FP32. Across partition responses,
+duplicate stable IDs retain the highest canonical score. Final top-k order is
+descending score with bytewise ascending stable ID as the exact tie break.
+
+Generation-pinned exact scans operate only on the already validated persistent
+search pack and hold the same reader pin as HNSW search. Native HNSW traversal
+may use an optimized score kernel to discover candidates, but every published
+candidate is rescored with the canonical contract before shard and coordinator
+ordering. Empty IDs, non-finite scores, duplicate response IDs, noncanonical
+wire order, incomplete partition/group coverage, source-generation mismatch,
+or partial top-k fail closed.
+
+Production evidence schema 2 reports recall independently for the full-source
+oracle, exhaustive exact partition union, exact representative routing,
+approximate representative routing, partition-local HNSW, and end-to-end
+output. It also records exact coordinator ID/score parity and names every
+remaining loss owner. These attribution fields diagnose a red enablement gate;
+they do not turn approximate all-partition HNSW into an exact oracle.
+
 By default, `cmd/treedb_vector_partition_bench` is a sequential **simulation**. It emits
 `result_kind=simulation_only` and `production_evidence=false`; its Markdown
 artifacts repeat that it is not production Raft evidence. It records exact

--- a/TreeDB/docs/spec/vector-partition-raft-v1.md
+++ b/TreeDB/docs/spec/vector-partition-raft-v1.md
@@ -239,7 +239,8 @@ consistency, or shard failure is an explicit error with no incomplete result.
 
 `collections.VectorPartitionCanonicalScoreContractV1` is the executable
 production result contract. It normalizes both query and source vector in
-FP32, accumulates their normalized dot product left-to-right in binary64, and
+FP32, accumulates their normalized dot product left-to-right with explicit
+separately rounded binary64 products and additions, and
 rounds the final cosine score once to FP32. Across partition responses,
 duplicate stable IDs retain the highest canonical score. Final top-k order is
 descending score with bytewise ascending stable ID as the exact tie break.

--- a/TreeDB/docs/vector_partition_raft_v1_test.go
+++ b/TreeDB/docs/vector_partition_raft_v1_test.go
@@ -152,6 +152,19 @@ func TestDocsVectorPartitionM8ProductionContract(t *testing.T) {
 				"unavailable endpoint returned error, zero neighbors, zero groups",
 				"no configured process-resource limit was compared",
 				"Enablement stays off",
+				"3b52711665297c7396f1f86238840dee1ea2897b",
+				"fp32_normalized_cosine_binary64_accum_score_desc_stable_id_asc_best_duplicate_v1",
+				"9afad07fb8daf374076fe9fa630106ffdf6241ae746344349eb1885d37cdfbd1",
+				"its all-partition owner is partition-local HNSW",
+			},
+		},
+		{
+			path: filepath.Join(root, "docs", "spec", "vector-partition-raft-v1.md"),
+			needles: []string{
+				"Canonical V1 partition-result contract",
+				"VectorPartitionCanonicalScoreContractV1",
+				"candidate is rescored with the canonical contract",
+				"Production evidence schema 2",
 			},
 		},
 	}
@@ -189,6 +202,24 @@ func TestDocsVectorPartitionM8ProductionContract(t *testing.T) {
 			ResourceBounds     string `json:"resource_bounds"`
 			ResourceBoundsNote string `json:"resource_bounds_note"`
 		} `json:"gate_ledger"`
+		Continuation struct {
+			Status           string `json:"status"`
+			SchemaVersion    int    `json:"schema_version"`
+			ResultKind       string `json:"result_kind"`
+			MeasuredCodeHead string `json:"measured_code_head"`
+			Contract         string `json:"canonical_contract"`
+			CheckedIn10K     struct {
+				ExhaustiveRecall float64 `json:"exhaustive_partition_union_recall_at_10"`
+				IDParity         bool    `json:"exhaustive_partition_union_id_parity"`
+				ScoreParity      bool    `json:"exhaustive_partition_union_score_parity"`
+			} `json:"checked_in_10k"`
+			Retained1M struct {
+				ExhaustiveRecall  float64 `json:"exhaustive_partition_union_recall_at_10"`
+				ExactRouterRecall float64 `json:"all_partition_exact_representative_recall_at_10"`
+				LocalHNSWRecall   float64 `json:"all_partition_local_hnsw_recall_at_10"`
+				LossOwner         string  `json:"all_partition_loss_owner"`
+			} `json:"retained_1m"`
+		} `json:"continuation_attribution"`
 	}
 	if err := json.Unmarshal(raw, &evidence); err != nil {
 		t.Fatal(err)
@@ -200,7 +231,14 @@ func TestDocsVectorPartitionM8ProductionContract(t *testing.T) {
 		evidence.Retained1M.Vectors != 1_000_000 || evidence.Retained1M.Groups != 4 ||
 		evidence.Retained1M.MeasuredRows != 60 || evidence.Retained1M.UnsupportedOverlapRows != 1 ||
 		evidence.GateLedger.ResourceBounds != "measured_not_bounded" ||
-		!strings.Contains(evidence.GateLedger.ResourceBoundsNote, "no configured resource limit was compared") {
+		!strings.Contains(evidence.GateLedger.ResourceBoundsNote, "no configured resource limit was compared") ||
+		evidence.Continuation.Status != "diagnosed_experimental_off" || evidence.Continuation.SchemaVersion != 2 ||
+		evidence.Continuation.ResultKind != "m8_production_multi_group_evidence_v2" ||
+		evidence.Continuation.MeasuredCodeHead != "3b52711665297c7396f1f86238840dee1ea2897b" ||
+		evidence.Continuation.Contract != "fp32_normalized_cosine_binary64_accum_score_desc_stable_id_asc_best_duplicate_v1" ||
+		evidence.Continuation.CheckedIn10K.ExhaustiveRecall != 1 || !evidence.Continuation.CheckedIn10K.IDParity || !evidence.Continuation.CheckedIn10K.ScoreParity ||
+		evidence.Continuation.Retained1M.ExhaustiveRecall != 1 || evidence.Continuation.Retained1M.ExactRouterRecall != 1 ||
+		evidence.Continuation.Retained1M.LocalHNSWRecall != 0 || evidence.Continuation.Retained1M.LossOwner != "partition_local_hnsw" {
 		t.Fatalf("M8 evidence boundary changed: %+v", evidence)
 	}
 }

--- a/cmd/treedb_vector_partition_bench/m8_production_assets_test.go
+++ b/cmd/treedb_vector_partition_bench/m8_production_assets_test.go
@@ -58,12 +58,18 @@ func TestM8ProductionReportRejectsUnexercisedDataGroupV1(t *testing.T) {
 		}
 	}
 	report := m8ProductionReportV1{
-		SchemaVersion: 1, ResultKind: "m8_production_multi_group_evidence_v1", Mode: m8ProductionMultiGroupModeV1, ProductionEvidence: true,
+		SchemaVersion: 2, ResultKind: "m8_production_multi_group_evidence_v2", Mode: m8ProductionMultiGroupModeV1, ProductionEvidence: true,
 		GeneratedAt: time.Now(), Command: []string{"m8-test"}, BaseSHA: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", HeadSHA: "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
-		Dataset: fixture, Config: m8ProductionConfigEvidenceV1{RaftGroups: 2, RaftNodesPerGroup: 3, Partitions: 4, TopK: 10}, BuildNanos: 1,
+		Dataset: fixture, Config: m8ProductionConfigEvidenceV1{RaftGroups: 2, RaftNodesPerGroup: 3, Partitions: 4, TopK: 10, RouterCandidates: 1}, BuildNanos: 1,
 		Topology: nativewire.VectorPartitionM8ProductionMultiGroupEvidenceV1{Network: "tcp_loopback_serialized_m5_v1", LifecycleState: "active", ReadySetDigest: "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc", MetaNodes: []string{"meta-a", "meta-b", "meta-c"}, Groups: []nativewire.VectorPartitionM8ProductionGroupEvidenceV1{group("group-a", 1), group("group-b", 1)}},
-		Rows:     []m8ProductionRowV1{{Status: "pass", Probes: 4, EfSearch: 10, Concurrency: 1, Samples: fixture.Queries, QPS: 1, RouterMode: "exact", RouterCandidates: 1, ExactParityChecked: true}},
-		Failure:  m8ProductionFailureEvidenceV1{Passed: true, Error: "unavailable group rejected"}, GateLedger: m8ProductionGateLedgerV1{FailureHonesty: "pass"},
+		Rows: []m8ProductionRowV1{{Status: "pass", Probes: 4, EfSearch: 10, Concurrency: 1, Samples: fixture.Queries, RecallAtK: 1, QPS: 1, RouterMode: "exact", RouterCandidates: 1, ExactParityChecked: true, ExactParityPassed: true, NoPartialResults: true, Attribution: m8ProductionAttributionV1{
+			Contract: m8CanonicalResultContractV1, GlobalExactRecallAtK: 1, ExhaustivePartitionRecallAtK: 1,
+			ExhaustivePartitionIDParity: true, ExhaustivePartitionScoreParity: true,
+			ExactRepresentativeRecallAtK: 1, ApproximateRepresentativeRecallAtK: 1, LocalHNSWRecallAtK: 1, EndToEndRecallAtK: 1,
+			CoordinatorMergeIDParity: true, CoordinatorMergeScoreParity: true,
+			ApproximateRouterCandidateBudget: 1, ResidualLossOwners: []string{"none_observed"},
+		}}},
+		Failure: m8ProductionFailureEvidenceV1{Passed: true, Error: "unavailable group rejected"}, GateLedger: m8ProductionGateLedgerV1{FailureHonesty: "pass"},
 		Resources: m8ProductionResourceEvidenceV1{PersistentAssetBytes: 1}, TimedBoundary: "measured", Limitations: []string{"test"},
 	}
 	if err := validateM8ProductionReportV1(report); err != nil {
@@ -224,8 +230,8 @@ func TestM8ProductionMultiGroupTopology10kTCPV1(t *testing.T) {
 	if len(response.Neighbors) != 10 || len(response.ProbedGroups) != 2 {
 		t.Fatalf("response=%+v", response)
 	}
-	// The exhaustive collection scan is the independent ID/tie oracle; the
-	// persisted local packs are the score-bit oracle for the TCP coordinator.
+	// Compare the raw TCP result with independently opened partition searchers;
+	// m8ExactTruthV1 below owns the full-source canonical oracle.
 	direct := make([]neighbor, 0, 40)
 	directScores := make(map[string]float32, 40)
 	for partition := 0; partition < 4; partition++ {
@@ -249,6 +255,37 @@ func TestM8ProductionMultiGroupTopology10kTCPV1(t *testing.T) {
 		if got.ID != direct[i].ID || math.Float32bits(got.Score) != math.Float32bits(directScores[direct[i].ID]) {
 			t.Fatalf("tcp parity rank=%d got=%+v direct=%+v", i, got, direct[i])
 		}
+	}
+	attributionQueries := [][]float64{vectors[17], vectors[18], vectors[19], vectors[20]}
+	staleManifest := assets.manifest
+	staleManifest.SourceGeneration++
+	if _, err := m8ExactTruthV1(assets.collection, staleManifest, attributionQueries[:1], 10); err == nil {
+		t.Fatal("canonical source oracle accepted a mismatched source generation")
+	}
+	truth, err := m8ExactTruthV1(assets.collection, assets.manifest, attributionQueries, 10)
+	if err != nil {
+		t.Fatal(err)
+	}
+	harness, err := newM8AttributionHarnessV1(assets)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer harness.Close()
+	candidates := int(assets.status.Representatives)
+	attribution, err := m8BuildAttributionV1(ctx, assets, attributionQueries, truth, 4, 4096, 10, candidates, make([][]m8CanonicalResultV1, len(attributionQueries)), harness)
+	if err != nil {
+		t.Fatal(err)
+	}
+	row, err := m8RunProductionCellV1(ctx, topology.Coordinator(), assets, attributionQueries, truth, attribution, 4, 4096, 4, 10)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if row.Attribution.Contract != m8CanonicalResultContractV1 || row.Attribution.ExhaustivePartitionRecallAtK != 1 ||
+		row.Attribution.ExactRepresentativeRecallAtK != 1 || row.Attribution.ApproximateRepresentativeRecallAtK != 1 ||
+		row.Attribution.LocalHNSWRecallAtK != 1 || row.Attribution.EndToEndRecallAtK != 1 ||
+		!row.Attribution.ExhaustivePartitionIDParity || !row.Attribution.ExhaustivePartitionScoreParity ||
+		!row.Attribution.CoordinatorMergeIDParity || !row.Attribution.CoordinatorMergeScoreParity || !row.NoPartialResults {
+		t.Fatalf("attribution=%+v", row.Attribution)
 	}
 	evidence := topology.Evidence()
 	if evidence.LifecycleState != "active" || len(evidence.Groups) != 2 {

--- a/cmd/treedb_vector_partition_bench/m8_production_assets_test.go
+++ b/cmd/treedb_vector_partition_bench/m8_production_assets_test.go
@@ -147,9 +147,7 @@ func TestM8ProductionMultiGroupAssetsCheckedIn10kCISmokeV1(t *testing.T) {
 			merged = append(merged, neighbor{ID: result.ID, Distance: 1 - float64(result.Score)})
 		}
 	}
-	sortNeighbors(merged)
-	merged = dedupeSortedNeighbors(merged)
-	merged = merged[:10]
+	merged = canonicalExactNeighborsV1(merged, 10)
 	want, err := assets.collection.SearchVectorsExact(query, collections.VectorSearchOptions{Field: "embedding", Metric: collections.VectorMetricCosine, TopK: 10})
 	if err != nil {
 		t.Fatal(err)

--- a/cmd/treedb_vector_partition_bench/m8_production_assets_test.go
+++ b/cmd/treedb_vector_partition_bench/m8_production_assets_test.go
@@ -75,6 +75,15 @@ func TestM8ProductionReportRejectsUnexercisedDataGroupV1(t *testing.T) {
 	if err := validateM8ProductionReportV1(report); err != nil {
 		t.Fatalf("valid endpoint coverage rejected: %v", err)
 	}
+	report.Resources.PeakRSSMeasured = true
+	if err := validateM8ProductionReportV1(report); err == nil {
+		t.Fatal("accepted measured peak RSS without an explicit scope")
+	}
+	report.Resources.PeakRSSScope = "forged measured boundary"
+	if err := validateM8ProductionReportV1(report); err == nil {
+		t.Fatal("accepted measured peak RSS with a forged scope")
+	}
+	report.Resources.PeakRSSScope = m8PeakRSSScopeV1
 	report.Topology.Groups[1].EndpointHits = 0
 	if err := validateM8ProductionReportV1(report); err == nil {
 		t.Fatal("accepted report with an unexercised data-group endpoint")
@@ -276,8 +285,11 @@ func TestM8ProductionMultiGroupTopology10kTCPV1(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	row, err := m8RunProductionCellV1(ctx, topology.Coordinator(), assets, attributionQueries, truth, attribution, 4, 4096, 4, 10)
+	row, coordinatorResults, err := m8RunProductionCellV1(ctx, topology.Coordinator(), assets, attributionQueries, truth, 4, 4096, 4, 10)
 	if err != nil {
+		t.Fatal(err)
+	}
+	if err := m8AttachAttributionV1(&row, attribution, coordinatorResults); err != nil {
 		t.Fatal(err)
 	}
 	if row.Attribution.Contract != m8CanonicalResultContractV1 || row.Attribution.ExhaustivePartitionRecallAtK != 1 ||

--- a/cmd/treedb_vector_partition_bench/m8_production_assets_test.go
+++ b/cmd/treedb_vector_partition_bench/m8_production_assets_test.go
@@ -129,6 +129,10 @@ func TestM8ProductionMultiGroupAssetsCheckedIn10kCISmokeV1(t *testing.T) {
 	for i, value := range vectors[17] {
 		query[i] = float32(value)
 	}
+	exactUnion, err := m8ExactPartitionUnionV1(context.Background(), assets, vectors[17], 10)
+	if err != nil {
+		t.Fatal(err)
+	}
 	merged := make([]neighbor, 0, 40)
 	for partition := 0; partition < 4; partition++ {
 		searcher, err := assets.collection.OpenVectorPartitionLocalSearcherForGenerationV1(partitionHNSWIndex, assets.manifest.Generation, uint32(partition))
@@ -153,6 +157,9 @@ func TestM8ProductionMultiGroupAssetsCheckedIn10kCISmokeV1(t *testing.T) {
 		t.Fatal(err)
 	}
 	for i := range want {
+		if exactUnion[i].ID != string(want[i].DocumentID) {
+			t.Fatalf("exact union rank=%d got=%s want=%s", i, exactUnion[i].ID, want[i].DocumentID)
+		}
 		if merged[i].ID != string(want[i].DocumentID) {
 			t.Fatalf("parity rank=%d got=%s want=%s got_all=%s", i, merged[i].ID, want[i].DocumentID, fmt.Sprint(merged))
 		}

--- a/cmd/treedb_vector_partition_bench/m8_production_assets_test.go
+++ b/cmd/treedb_vector_partition_bench/m8_production_assets_test.go
@@ -67,7 +67,7 @@ func TestM8ProductionReportRejectsUnexercisedDataGroupV1(t *testing.T) {
 			ExhaustivePartitionIDParity: true, ExhaustivePartitionScoreParity: true,
 			ExactRepresentativeRecallAtK: 1, ApproximateRepresentativeRecallAtK: 1, LocalHNSWRecallAtK: 1, EndToEndRecallAtK: 1,
 			CoordinatorMergeIDParity: true, CoordinatorMergeScoreParity: true,
-			ApproximateRouterCandidateBudget: 1, ResidualLossOwners: []string{"none_observed"},
+			ApproximateRouterCandidateBudget: 1, ApproximateRouterPartitionCoverageComplete: true, ResidualLossOwners: []string{"none_observed"},
 		}}},
 		Failure: m8ProductionFailureEvidenceV1{Passed: true, Error: "unavailable group rejected"}, GateLedger: m8ProductionGateLedgerV1{FailureHonesty: "pass"},
 		Resources: m8ProductionResourceEvidenceV1{PersistentAssetBytes: 1}, TimedBoundary: "measured", Limitations: []string{"test"},

--- a/cmd/treedb_vector_partition_bench/m8_production_assets_test.go
+++ b/cmd/treedb_vector_partition_bench/m8_production_assets_test.go
@@ -166,6 +166,19 @@ func TestM8ProductionMultiGroupAssetsCheckedIn10kCISmokeV1(t *testing.T) {
 	}
 }
 
+func TestM8ExactPartitionUnionRejectsDuplicateOrMissingPlacementsV1(t *testing.T) {
+	assets := &m8ProductionMultiGroupAssetsV1{}
+	assets.manifest.PartitionCount = 2
+	assets.manifest.Placements = []collections.VectorPartitionPlacementV1{{PartitionID: 0}, {PartitionID: 0}}
+	if _, err := m8ExactPartitionUnionV1(context.Background(), assets, []float64{1}, 1); err == nil {
+		t.Fatal("accepted duplicate placement")
+	}
+	assets.manifest.Placements = []collections.VectorPartitionPlacementV1{{PartitionID: 0}}
+	if _, err := m8ExactPartitionUnionV1(context.Background(), assets, []float64{1}, 1); err == nil {
+		t.Fatal("accepted missing placement")
+	}
+}
+
 func TestM8ProductionMultiGroupTopology10kTCPV1(t *testing.T) {
 	requireM8PersistentAssetSupportV1(t)
 	fixture, err := loadFixture(fixturePath(t))

--- a/cmd/treedb_vector_partition_bench/m8_production_runner.go
+++ b/cmd/treedb_vector_partition_bench/m8_production_runner.go
@@ -26,7 +26,10 @@ import (
 	"github.com/snissn/gomap/TreeDB/nativewire"
 )
 
-const m8ProductionMultiGroupModeV1 = "production_multi_group"
+const (
+	m8ProductionMultiGroupModeV1 = "production_multi_group"
+	m8PeakRSSScopeV1             = "process lifetime through measured query and endpoint-loss fault boundary; includes retained top-k coordinator results; excludes post-measurement attribution"
+)
 
 type m8ProductionReportV1 struct {
 	SchemaVersion      int                                                        `json:"schema_version"`
@@ -159,6 +162,7 @@ type m8ProductionResourceEvidenceV1 struct {
 	PersistentAssetBytes uint64 `json:"persistent_asset_bytes"`
 	PeakRSSBytes         int64  `json:"peak_rss_bytes,omitempty"`
 	PeakRSSMeasured      bool   `json:"peak_rss_measured"`
+	PeakRSSScope         string `json:"peak_rss_scope,omitempty"`
 	OverlapMemberships   int    `json:"overlap_memberships"`
 	MaxPartitionLoad     uint64 `json:"max_partition_load"`
 	BalanceHardCap       uint64 `json:"balance_hard_cap"`
@@ -198,35 +202,9 @@ func runM8ProductionMultiGroupV1(cfg config, fixture fixtureManifest, vectors, q
 	if err != nil {
 		return err
 	}
-	attributionHarness, err := newM8AttributionHarnessV1(assets)
-	if err != nil {
-		return fmt.Errorf("open M8 attribution harness: %w", err)
-	}
-	attributionHarnessClosed := false
-	defer func() {
-		if !attributionHarnessClosed {
-			runErr = errors.Join(runErr, attributionHarness.Close())
-		}
-	}()
 	approximateCandidates := min(cfg.routerCandidates, int(assets.status.Representatives))
 	if approximateCandidates < 1 {
 		return errors.New("M8 attribution requires an approximate router candidate budget")
-	}
-	attribution := make(map[string]m8AttributionCellV1, len(cfg.probes)*len(cfg.efSearch))
-	exhaustive := make([][]m8CanonicalResultV1, len(queries))
-	for _, probes := range cfg.probes {
-		for _, efSearch := range cfg.efSearch {
-			cell, buildErr := m8BuildAttributionV1(context.Background(), assets, queries, truth, probes, efSearch, cfg.topK, approximateCandidates, exhaustive, attributionHarness)
-			if buildErr != nil {
-				return fmt.Errorf("build M8 attribution probes=%d ef=%d: %w", probes, efSearch, buildErr)
-			}
-			attribution[m8AttributionKeyV1(probes, efSearch)] = cell
-		}
-	}
-	attributionHarnessCloseErr := attributionHarness.Close()
-	attributionHarnessClosed = true
-	if attributionHarnessCloseErr != nil {
-		return fmt.Errorf("close M8 attribution harness: %w", attributionHarnessCloseErr)
 	}
 	report := m8ProductionReportV1{
 		SchemaVersion: 2, ResultKind: "m8_production_multi_group_evidence_v2", Status: "incomplete",
@@ -236,8 +214,7 @@ func runM8ProductionMultiGroupV1(cfg config, fixture fixtureManifest, vectors, q
 		Config:        m8ProductionConfigEvidenceV1{RaftGroups: cfg.raftGroups, RaftNodesPerGroup: cfg.raftNodes, Partitions: cfg.partitions, Probes: append([]int(nil), cfg.probes...), Overlap: append([]float64(nil), cfg.overlaps...), TopK: cfg.topK, RecallTarget: cfg.recallTarget, Concurrency: append([]int(nil), cfg.concurrency...), Warmup: cfg.warmup, EfSearch: append([]int(nil), cfg.efSearch...), RouterCandidates: cfg.routerCandidates, Seed: cfg.seed},
 		BuildNanos:    buildNanos,
 		Profiles:      m8ProductionProfileEvidenceV1{Directory: cfg.profiles, Status: "not_captured", Scope: "CPU, block, mutex, and trace cover measured query cells plus the endpoint-loss fault; heap is an end snapshot; allocs requires the captured baseline for differential analysis"},
-		Resources:     m8ProductionResourcesV1(assets),
-		TimedBoundary: "wall-clock query cells after topology, exhaustive endpoint preflight, and generation warmup; includes router, coordinator, TCP M5 serialization, Raft read-index/apply, persistent HNSW search, response merge, and caller scheduling; excludes topology construction, exact truth, preflight, warmup, artifact encoding, and shutdown",
+		TimedBoundary: "wall-clock query cells after topology, exhaustive endpoint preflight, and generation warmup; includes router, coordinator, TCP M5 serialization, Raft read-index/apply, persistent HNSW search, response merge, and caller scheduling; excludes topology construction, exact truth, preflight, warmup, post-measurement attribution, artifact encoding, and shutdown",
 		Limitations: []string{
 			"loopback TCP with real serialized M5 messages and real in-memory HashiCorp Raft consensus; not a multi-host deployment",
 			"the checked-in 10k path materializes disjoint round-robin packs; -m8-existing-db reuses the retained graph-built M3 packs read-only",
@@ -262,6 +239,12 @@ func runM8ProductionMultiGroupV1(cfg config, fixture fixtureManifest, vectors, q
 			runErr = errors.Join(runErr, closeErr)
 		}
 	}()
+	type measuredCellV1 struct {
+		rowIndex         int
+		probes, efSearch int
+		results          [][]m8CanonicalResultV1
+	}
+	measuredCells := make([]measuredCellV1, 0, len(cfg.overlaps)*len(cfg.probes)*len(cfg.efSearch)*len(cfg.concurrency))
 	for _, overlap := range cfg.overlaps {
 		if overlap != 0 {
 			report.Rows = append(report.Rows, m8ProductionRowV1{Status: "unsupported", UnsupportedReason: "overlap assets are not materialized by the initial M8 production topology checkpoint", Overlap: overlap})
@@ -270,12 +253,13 @@ func runM8ProductionMultiGroupV1(cfg config, fixture fixtureManifest, vectors, q
 		for _, probes := range cfg.probes {
 			for _, ef := range cfg.efSearch {
 				for _, concurrency := range cfg.concurrency {
-					row, rowErr := m8RunProductionCellV1(context.Background(), topology.Coordinator(), assets, queries, truth, attribution[m8AttributionKeyV1(probes, ef)], probes, ef, concurrency, cfg.topK)
+					row, results, rowErr := m8RunProductionCellV1(context.Background(), topology.Coordinator(), assets, queries, truth, probes, ef, concurrency, cfg.topK)
 					if rowErr != nil {
 						return fmt.Errorf("M8 production cell probes=%d ef=%d concurrency=%d: %w", probes, ef, concurrency, rowErr)
 					}
 					row.Overlap = overlap
 					report.Rows = append(report.Rows, row)
+					measuredCells = append(measuredCells, measuredCellV1{rowIndex: len(report.Rows) - 1, probes: probes, efSearch: ef, results: results})
 				}
 			}
 		}
@@ -290,6 +274,47 @@ func runM8ProductionMultiGroupV1(cfg config, fixture fixtureManifest, vectors, q
 		report.Profiles = m8ProductionProfileEvidenceV1{Directory: cfg.profiles, Captured: captured, Status: "captured_production_query_and_fault_boundary", Scope: "CPU, block, mutex, and trace cover measured query cells plus the endpoint-loss fault; heap is an end snapshot; allocs.pprof is cumulative and must be compared with allocs_baseline.pprof"}
 	}
 	report.Resources = m8ProductionResourcesV1(assets)
+
+	// Attribution deliberately runs after the timed query/fault boundary,
+	// profile capture, and peak-RSS snapshot. Its exhaustive mmap scans must not
+	// pre-fault the corpus or contaminate measured process-resource evidence.
+	// The snapshot does include the bounded top-k coordinator results retained
+	// from measured cells so post-measurement attribution can verify parity.
+	attributionHarness, err := newM8AttributionHarnessV1(assets)
+	if err != nil {
+		return fmt.Errorf("open M8 attribution harness: %w", err)
+	}
+	attributionHarnessClosed := false
+	defer func() {
+		if !attributionHarnessClosed {
+			runErr = errors.Join(runErr, attributionHarness.Close())
+		}
+	}()
+	attribution := make(map[string]m8AttributionCellV1, len(cfg.probes)*len(cfg.efSearch))
+	exhaustive := make([][]m8CanonicalResultV1, len(queries))
+	for _, probes := range cfg.probes {
+		for _, efSearch := range cfg.efSearch {
+			cell, buildErr := m8BuildAttributionV1(context.Background(), assets, queries, truth, probes, efSearch, cfg.topK, approximateCandidates, exhaustive, attributionHarness)
+			if buildErr != nil {
+				return fmt.Errorf("build M8 attribution probes=%d ef=%d: %w", probes, efSearch, buildErr)
+			}
+			attribution[m8AttributionKeyV1(probes, efSearch)] = cell
+		}
+	}
+	closeErr := attributionHarness.Close()
+	attributionHarnessClosed = true
+	if closeErr != nil {
+		return fmt.Errorf("close M8 attribution harness: %w", closeErr)
+	}
+	for _, measured := range measuredCells {
+		cell, ok := attribution[m8AttributionKeyV1(measured.probes, measured.efSearch)]
+		if !ok {
+			return fmt.Errorf("missing M8 attribution probes=%d ef=%d", measured.probes, measured.efSearch)
+		}
+		if err := m8AttachAttributionV1(&report.Rows[measured.rowIndex], cell, measured.results); err != nil {
+			return fmt.Errorf("attach M8 attribution probes=%d ef=%d: %w", measured.probes, measured.efSearch, err)
+		}
+	}
 	report.GateLedger = m8ProductionGateLedgerForReportV1(report)
 	if m8ProductionAllGatesPassV1(report.GateLedger) {
 		report.Status = "pass"
@@ -892,13 +917,14 @@ func m8ProductionResourcesV1(assets *m8ProductionMultiGroupAssetsV1) m8Productio
 	rows, partitions := assets.manifest.SourceRowCount, uint64(assets.manifest.PartitionCount)
 	out.BalanceHardCap = (rows*105 + partitions*100 - 1) / (partitions * 100)
 	out.MmapStatus = "not_captured_by_m8_runner; retained M3/M5 artifacts own mapped-pack evidence"
+	out.PeakRSSScope = m8PeakRSSScopeV1
 	if peak, ok := vectorPartitionBenchmarkPeakRSS(); ok {
 		out.PeakRSSBytes, out.PeakRSSMeasured = peak, true
 	}
 	return out
 }
 
-func m8RunProductionCellV1(ctx context.Context, coordinator *nativewire.VectorPartitionCoordinatorV1, assets *m8ProductionMultiGroupAssetsV1, queries [][]float64, truth [][]m8CanonicalResultV1, attribution m8AttributionCellV1, probes, efSearch, concurrency, topK int) (m8ProductionRowV1, error) {
+func m8RunProductionCellV1(ctx context.Context, coordinator *nativewire.VectorPartitionCoordinatorV1, assets *m8ProductionMultiGroupAssetsV1, queries [][]float64, truth [][]m8CanonicalResultV1, probes, efSearch, concurrency, topK int) (m8ProductionRowV1, [][]m8CanonicalResultV1, error) {
 	type outcome struct {
 		response nativewire.VectorPartitionCoordinatorResponseV1
 		err      error
@@ -918,21 +944,20 @@ func m8RunProductionCellV1(ctx context.Context, coordinator *nativewire.VectorPa
 		outcomes[index].response, outcomes[index].err = coordinator.Search(requestCtx, m8ProductionRequestV1(assets, query, fmt.Sprintf("m8-q-%06d-p-%04d-ef-%06d-c-%03d", index, probes, efSearch, concurrency), probes, efSearch, topK))
 	})
 	elapsed := time.Since(started)
-	row := m8ProductionRowV1{Status: "pass", Probes: probes, EfSearch: efSearch, Concurrency: concurrency, RouterMode: collections.VectorPartitionRouterModeExactV1, RouterCandidates: max(1, int(assets.status.Representatives)), Samples: len(queries), ExactParityChecked: probes == len(assets.manifest.Placements), ExactParityPassed: probes == len(assets.manifest.Placements), Attribution: attribution.Evidence}
+	row := m8ProductionRowV1{Status: "pass", Probes: probes, EfSearch: efSearch, Concurrency: concurrency, RouterMode: collections.VectorPartitionRouterModeExactV1, RouterCandidates: max(1, int(assets.status.Representatives)), Samples: len(queries), ExactParityChecked: probes == len(assets.manifest.Placements), ExactParityPassed: probes == len(assets.manifest.Placements)}
+	canonicalResults := make([][]m8CanonicalResultV1, len(outcomes))
 	durations := make([]uint64, 0, len(outcomes))
 	var recallSum float64
 	for index, outcome := range outcomes {
 		if outcome.err != nil {
-			return row, fmt.Errorf("query %d: %w", index, outcome.err)
+			return row, nil, fmt.Errorf("query %d: %w", index, outcome.err)
 		}
 		got, shapeErr := m8ValidateCoordinatorResponseV1(outcome.response, assets.manifest, probes, topK)
 		if shapeErr != nil {
-			return row, fmt.Errorf("query %d response shape: %w", index, shapeErr)
+			return row, nil, fmt.Errorf("query %d response shape: %w", index, shapeErr)
 		}
+		canonicalResults[index] = got
 		recallSum += m8CanonicalRecallV1(truth[index], got)
-		idParity, scoreParity := m8CanonicalParityV1(attribution.Local[index], got)
-		row.Attribution.CoordinatorMergeIDParity = row.Attribution.CoordinatorMergeIDParity && idParity
-		row.Attribution.CoordinatorMergeScoreParity = row.Attribution.CoordinatorMergeScoreParity && scoreParity
 		globalIDParity, globalScoreParity := m8CanonicalParityV1(truth[index], got)
 		if row.ExactParityChecked && (!globalIDParity || !globalScoreParity) {
 			row.ExactParityPassed = false
@@ -946,11 +971,24 @@ func m8RunProductionCellV1(ctx context.Context, coordinator *nativewire.VectorPa
 	}
 	row.NoPartialResults = true
 	row.RecallAtK = recallSum / float64(len(outcomes))
-	row.Attribution.EndToEndRecallAtK = row.RecallAtK
-	row.Attribution.ResidualLossOwners = m8AttributionLossOwnersV1(row.Attribution)
 	row.QPS = float64(len(outcomes)) / elapsed.Seconds()
 	row.P50Nanos, row.P95Nanos, row.P99Nanos = m8PercentileV1(durations, 50), m8PercentileV1(durations, 95), m8PercentileV1(durations, 99)
-	return row, nil
+	return row, canonicalResults, nil
+}
+
+func m8AttachAttributionV1(row *m8ProductionRowV1, attribution m8AttributionCellV1, coordinatorResults [][]m8CanonicalResultV1) error {
+	if row == nil || row.Samples < 1 || len(attribution.Local) != row.Samples || len(coordinatorResults) != row.Samples {
+		return errors.New("M8 attribution result cardinality mismatch")
+	}
+	row.Attribution = attribution.Evidence
+	for i := range coordinatorResults {
+		idParity, scoreParity := m8CanonicalParityV1(attribution.Local[i], coordinatorResults[i])
+		row.Attribution.CoordinatorMergeIDParity = row.Attribution.CoordinatorMergeIDParity && idParity
+		row.Attribution.CoordinatorMergeScoreParity = row.Attribution.CoordinatorMergeScoreParity && scoreParity
+	}
+	row.Attribution.EndToEndRecallAtK = row.RecallAtK
+	row.Attribution.ResidualLossOwners = m8AttributionLossOwnersV1(row.Attribution)
+	return nil
 }
 
 func m8ValidateCoordinatorResponseV1(response nativewire.VectorPartitionCoordinatorResponseV1, manifest collections.VectorPartitionManifestV1, probes, topK int) ([]m8CanonicalResultV1, error) {
@@ -1285,7 +1323,8 @@ func validateM8ProductionReportV1(report m8ProductionReportV1) error {
 		}
 	}
 	if !report.Failure.Passed || report.Failure.Error == "" || report.Failure.ReturnedNeighbors != 0 || report.Failure.ReturnedGroups != 0 ||
-		report.GateLedger.FailureHonesty != "pass" || report.Resources.PersistentAssetBytes == 0 {
+		report.GateLedger.FailureHonesty != "pass" || report.Resources.PersistentAssetBytes == 0 ||
+		report.Resources.PeakRSSMeasured && report.Resources.PeakRSSScope != m8PeakRSSScopeV1 {
 		return errors.New("incomplete M8 failure or resource evidence")
 	}
 	if report.Profiles.Status == "captured_production_query_and_fault_boundary" {

--- a/cmd/treedb_vector_partition_bench/m8_production_runner.go
+++ b/cmd/treedb_vector_partition_bench/m8_production_runner.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bytes"
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
@@ -452,6 +453,11 @@ type m8CanonicalResultV1 struct {
 	Score float32
 }
 
+type m8CanonicalRefResultV1 struct {
+	ID    []byte
+	Score float32
+}
+
 const m8CanonicalResultContractV1 = collections.VectorPartitionCanonicalScoreContractV1
 
 func m8CanonicalResultsV1(in []m8CanonicalResultV1, topK int) []m8CanonicalResultV1 {
@@ -505,7 +511,57 @@ func m8AppendBoundedCanonicalV1(results []m8CanonicalResultV1, candidate m8Canon
 	return m8CanonicalResultsV1(append(results, candidate), topK)
 }
 
+func m8CanonicalRefResultsV1(results []m8CanonicalRefResultV1, topK int) []m8CanonicalRefResultV1 {
+	slices.SortFunc(results, func(a, b m8CanonicalRefResultV1) int {
+		if a.Score > b.Score {
+			return -1
+		}
+		if a.Score < b.Score {
+			return 1
+		}
+		return bytes.Compare(a.ID, b.ID)
+	})
+	if len(results) > topK {
+		results = results[:topK]
+	}
+	return results
+}
+
+func m8AppendBoundedCanonicalRefV1(results []m8CanonicalRefResultV1, candidate m8CanonicalRefResultV1, topK int) []m8CanonicalRefResultV1 {
+	if topK <= 0 || len(candidate.ID) == 0 || math.IsNaN(float64(candidate.Score)) || math.IsInf(float64(candidate.Score), 0) {
+		return nil
+	}
+	for i := range results {
+		if bytes.Equal(results[i].ID, candidate.ID) {
+			if candidate.Score > results[i].Score {
+				results[i] = candidate
+			}
+			return m8CanonicalRefResultsV1(results, topK)
+		}
+	}
+	if len(results) == topK {
+		worst := results[len(results)-1]
+		if candidate.Score < worst.Score || candidate.Score == worst.Score && bytes.Compare(candidate.ID, worst.ID) >= 0 {
+			return results
+		}
+		results[len(results)-1] = candidate
+		return m8CanonicalRefResultsV1(results, topK)
+	}
+	return m8CanonicalRefResultsV1(append(results, candidate), topK)
+}
+
+func m8MaterializeCanonicalRefsV1(refs []m8CanonicalRefResultV1) []m8CanonicalResultV1 {
+	out := make([]m8CanonicalResultV1, len(refs))
+	for i := range refs {
+		out[i] = m8CanonicalResultV1{ID: string(refs[i].ID), Score: refs[i].Score}
+	}
+	return out
+}
+
 func m8ExactTruthV1(collection *collections.Collection, manifest collections.VectorPartitionManifestV1, queries [][]float64, topK int) ([][]m8CanonicalResultV1, error) {
+	if topK < 1 {
+		return nil, errors.New("M8 canonical source oracle requires positive top_k")
+	}
 	source, rows, err := collection.ReadVectorPartitionRouterSourceRowsV1(partitionHNSWIndex)
 	if err != nil {
 		return nil, fmt.Errorf("M8 canonical source oracle: %w", err)
@@ -516,13 +572,19 @@ func m8ExactTruthV1(collection *collections.Collection, manifest collections.Vec
 	truth := make([][]m8CanonicalResultV1, len(queries))
 	for i, query64 := range queries {
 		query := m8Query32V1(query64)
+		scorer, scoreErr := collections.NewCanonicalVectorPartitionCosineScorerV1(query)
+		if scoreErr != nil {
+			return nil, fmt.Errorf("M8 canonical source oracle query=%d: %w", i, scoreErr)
+		}
+		refs := make([]m8CanonicalRefResultV1, 0, min(topK, len(rows)))
 		for ordinal, row := range rows {
-			score, scoreErr := collections.CanonicalVectorPartitionCosineScoreV1(query, row.Values)
+			score, scoreErr := scorer.ScoreV1(row.Values)
 			if scoreErr != nil {
 				return nil, fmt.Errorf("M8 canonical source oracle query=%d ordinal=%d: %w", i, ordinal, scoreErr)
 			}
-			truth[i] = m8AppendBoundedCanonicalV1(truth[i], m8CanonicalResultV1{ID: string(row.DocumentID), Score: score}, topK)
+			refs = m8AppendBoundedCanonicalRefV1(refs, m8CanonicalRefResultV1{ID: row.DocumentID, Score: score}, topK)
 		}
+		truth[i] = m8MaterializeCanonicalRefsV1(refs)
 		if len(truth[i]) != min(topK, len(rows)) {
 			return nil, fmt.Errorf("M8 canonical source oracle query=%d results=%d", i, len(truth[i]))
 		}

--- a/cmd/treedb_vector_partition_bench/m8_production_runner.go
+++ b/cmd/treedb_vector_partition_bench/m8_production_runner.go
@@ -919,6 +919,21 @@ func m8ValidateCoordinatorResponseV1(response nativewire.VectorPartitionCoordina
 		}
 		seenGroups[string(group)] = struct{}{}
 	}
+	selectedOrdinals := make(map[uint64]struct{})
+	for _, memberships := range [][]collections.VectorPartitionMembershipV1{manifest.Memberships, manifest.OverlapMemberships} {
+		for _, membership := range memberships {
+			if membership.PartitionID >= manifest.PartitionCount || membership.VectorOrdinal >= manifest.SourceRowCount {
+				return nil, errors.New("manifest contains an invalid coordinator membership")
+			}
+			if _, selected := seenPartitions[membership.PartitionID]; selected {
+				selectedOrdinals[membership.VectorOrdinal] = struct{}{}
+			}
+		}
+	}
+	expectedNeighbors := min(topK, len(selectedOrdinals))
+	if len(response.Neighbors) != expectedNeighbors {
+		return nil, fmt.Errorf("truncated coordinator response: neighbors=%d want=%d", len(response.Neighbors), expectedNeighbors)
+	}
 	return raw, nil
 }
 

--- a/cmd/treedb_vector_partition_bench/m8_production_runner.go
+++ b/cmd/treedb_vector_partition_bench/m8_production_runner.go
@@ -200,7 +200,12 @@ func runM8ProductionMultiGroupV1(cfg config, fixture fixtureManifest, vectors, q
 	if err != nil {
 		return fmt.Errorf("open M8 attribution harness: %w", err)
 	}
-	defer func() { runErr = errors.Join(runErr, attributionHarness.Close()) }()
+	attributionHarnessClosed := false
+	defer func() {
+		if !attributionHarnessClosed {
+			runErr = errors.Join(runErr, attributionHarness.Close())
+		}
+	}()
 	approximateCandidates := min(cfg.routerCandidates, int(assets.status.Representatives))
 	if approximateCandidates < 1 {
 		return errors.New("M8 attribution requires an approximate router candidate budget")
@@ -215,6 +220,11 @@ func runM8ProductionMultiGroupV1(cfg config, fixture fixtureManifest, vectors, q
 			}
 			attribution[m8AttributionKeyV1(probes, efSearch)] = cell
 		}
+	}
+	attributionHarnessCloseErr := attributionHarness.Close()
+	attributionHarnessClosed = true
+	if attributionHarnessCloseErr != nil {
+		return fmt.Errorf("close M8 attribution harness: %w", attributionHarnessCloseErr)
 	}
 	report := m8ProductionReportV1{
 		SchemaVersion: 2, ResultKind: "m8_production_multi_group_evidence_v2", Status: "incomplete",
@@ -857,7 +867,7 @@ func m8RunProductionCellV1(ctx context.Context, coordinator *nativewire.VectorPa
 
 func m8ValidateCoordinatorResponseV1(response nativewire.VectorPartitionCoordinatorResponseV1, manifest collections.VectorPartitionManifestV1, probes, topK int) ([]m8CanonicalResultV1, error) {
 	partitionCount := int(manifest.PartitionCount)
-	if probes < 1 || partitionCount < probes || len(manifest.Placements) != partitionCount || topK < 1 || len(response.Neighbors) != topK || len(response.ProbedPartitions) != probes || len(response.ProbedGroups) == 0 || len(response.ProbedGroups) > probes {
+	if probes < 1 || partitionCount < probes || len(manifest.Placements) != partitionCount || topK < 1 || len(response.Neighbors) > topK || len(response.ProbedPartitions) != probes || len(response.ProbedGroups) == 0 || len(response.ProbedGroups) > probes {
 		return nil, errors.New("truncated or dimensionally invalid coordinator response")
 	}
 	raw := make([]m8CanonicalResultV1, len(response.Neighbors))
@@ -1191,8 +1201,7 @@ func validateM8ProductionReportV1(report m8ProductionReportV1) error {
 
 func validM8AttributionV1(attribution m8ProductionAttributionV1) bool {
 	if attribution.Contract != m8CanonicalResultContractV1 || attribution.GlobalExactRecallAtK != 1 ||
-		attribution.ExhaustivePartitionRecallAtK != 1 || !attribution.ExhaustivePartitionIDParity ||
-		!attribution.ExhaustivePartitionScoreParity || attribution.ApproximateRouterCandidateBudget < 1 ||
+		attribution.ApproximateRouterCandidateBudget < 1 ||
 		!slices.Equal(attribution.ResidualLossOwners, m8AttributionLossOwnersV1(attribution)) {
 		return false
 	}

--- a/cmd/treedb_vector_partition_bench/m8_production_runner.go
+++ b/cmd/treedb_vector_partition_bench/m8_production_runner.go
@@ -1022,12 +1022,13 @@ func m8ProductionResourcesV1(assets *m8ProductionMultiGroupAssetsV1) m8Productio
 	return out
 }
 
+type m8ProductionCellOutcomeV1 struct {
+	response nativewire.VectorPartitionCoordinatorResponseV1
+	err      error
+}
+
 func m8RunProductionCellV1(ctx context.Context, coordinator *nativewire.VectorPartitionCoordinatorV1, assets *m8ProductionMultiGroupAssetsV1, queries [][]float64, truth [][]m8CanonicalResultV1, probes, efSearch, concurrency, topK int) (m8ProductionRowV1, [][]m8CanonicalResultV1, error) {
-	type outcome struct {
-		response nativewire.VectorPartitionCoordinatorResponseV1
-		err      error
-	}
-	outcomes := make([]outcome, len(queries))
+	outcomes := make([]m8ProductionCellOutcomeV1, len(queries))
 	started := time.Now()
 	m8RunBoundedWorkV1(len(queries), concurrency, func(index int) {
 		query := m8Query32V1(queries[index])

--- a/cmd/treedb_vector_partition_bench/m8_production_runner.go
+++ b/cmd/treedb_vector_partition_bench/m8_production_runner.go
@@ -416,6 +416,16 @@ func m8ExactPartitionUnionV1(ctx context.Context, assets *m8ProductionMultiGroup
 	if assets == nil || len(assets.manifest.Placements) != int(assets.manifest.PartitionCount) {
 		return nil, errors.New("incomplete M8 partition manifest")
 	}
+	seen := make(map[uint32]struct{}, assets.manifest.PartitionCount)
+	for _, placement := range assets.manifest.Placements {
+		if placement.PartitionID >= assets.manifest.PartitionCount {
+			return nil, errors.New("invalid M8 partition placement")
+		}
+		if _, duplicate := seen[placement.PartitionID]; duplicate {
+			return nil, errors.New("duplicate M8 partition placement")
+		}
+		seen[placement.PartitionID] = struct{}{}
+	}
 	merged := make([]neighbor, 0, len(assets.manifest.Placements)*topK)
 	for partition := 0; partition < len(assets.manifest.Placements); partition++ {
 		searcher, err := assets.collection.OpenVectorPartitionLocalSearcherForGenerationV1(partitionHNSWIndex, assets.manifest.Generation, uint32(partition))

--- a/cmd/treedb_vector_partition_bench/m8_production_runner.go
+++ b/cmd/treedb_vector_partition_bench/m8_production_runner.go
@@ -538,8 +538,8 @@ func m8CanonicalResultsV1(in []m8CanonicalResultV1, topK int) []m8CanonicalResul
 	sort.Slice(ordered, func(i, j int) bool {
 		return ordered[i].Score > ordered[j].Score || ordered[i].Score == ordered[j].Score && ordered[i].ID < ordered[j].ID
 	})
-	seen := make(map[string]struct{}, len(ordered))
-	out := ordered[:0]
+	seen := make(map[string]struct{}, min(topK, len(ordered)))
+	out := make([]m8CanonicalResultV1, 0, min(topK, len(ordered)))
 	for _, result := range ordered {
 		if _, ok := seen[result.ID]; ok {
 			continue

--- a/cmd/treedb_vector_partition_bench/m8_production_runner.go
+++ b/cmd/treedb_vector_partition_bench/m8_production_runner.go
@@ -169,6 +169,12 @@ type m8ProductionResourceEvidenceV1 struct {
 	MmapStatus           string `json:"mmap_status"`
 }
 
+type m8MeasuredCellV1 struct {
+	rowIndex         int
+	probes, efSearch int
+	results          [][]m8CanonicalResultV1
+}
+
 func runM8ProductionMultiGroupV1(cfg config, fixture fixtureManifest, vectors, queries [][]float64, stdout io.Writer) (runErr error) {
 	groups := make([]string, cfg.raftGroups)
 	for i := range groups {
@@ -239,12 +245,7 @@ func runM8ProductionMultiGroupV1(cfg config, fixture fixtureManifest, vectors, q
 			runErr = errors.Join(runErr, closeErr)
 		}
 	}()
-	type measuredCellV1 struct {
-		rowIndex         int
-		probes, efSearch int
-		results          [][]m8CanonicalResultV1
-	}
-	measuredCells := make([]measuredCellV1, 0, len(cfg.overlaps)*len(cfg.probes)*len(cfg.efSearch)*len(cfg.concurrency))
+	measuredCells := make([]m8MeasuredCellV1, 0, len(cfg.overlaps)*len(cfg.probes)*len(cfg.efSearch)*len(cfg.concurrency))
 	for _, overlap := range cfg.overlaps {
 		if overlap != 0 {
 			report.Rows = append(report.Rows, m8ProductionRowV1{Status: "unsupported", UnsupportedReason: "overlap assets are not materialized by the initial M8 production topology checkpoint", Overlap: overlap})
@@ -259,7 +260,7 @@ func runM8ProductionMultiGroupV1(cfg config, fixture fixtureManifest, vectors, q
 					}
 					row.Overlap = overlap
 					report.Rows = append(report.Rows, row)
-					measuredCells = append(measuredCells, measuredCellV1{rowIndex: len(report.Rows) - 1, probes: probes, efSearch: ef, results: results})
+					measuredCells = append(measuredCells, m8MeasuredCellV1{rowIndex: len(report.Rows) - 1, probes: probes, efSearch: ef, results: results})
 				}
 			}
 		}

--- a/cmd/treedb_vector_partition_bench/m8_production_runner.go
+++ b/cmd/treedb_vector_partition_bench/m8_production_runner.go
@@ -209,10 +209,6 @@ func runM8ProductionMultiGroupV1(cfg config, fixture fixtureManifest, vectors, q
 	if err != nil {
 		return err
 	}
-	approximateCandidates := min(cfg.routerCandidates, int(assets.status.Representatives))
-	if approximateCandidates < 1 {
-		return errors.New("M8 attribution requires an approximate router candidate budget")
-	}
 	report := m8ProductionReportV1{
 		SchemaVersion: 2, ResultKind: "m8_production_multi_group_evidence_v2", Status: "incomplete",
 		Mode: m8ProductionMultiGroupModeV1, ProductionEvidence: true, GeneratedAt: time.Now().UTC(),
@@ -282,39 +278,45 @@ func runM8ProductionMultiGroupV1(cfg config, fixture fixtureManifest, vectors, q
 	// pre-fault the corpus or contaminate measured process-resource evidence.
 	// The snapshot does include the bounded top-k coordinator results retained
 	// from measured cells so post-measurement attribution can verify parity.
-	attributionHarness, err := newM8AttributionHarnessV1(assets)
-	if err != nil {
-		return fmt.Errorf("open M8 attribution harness: %w", err)
-	}
-	attributionHarnessClosed := false
-	defer func() {
-		if !attributionHarnessClosed {
-			runErr = errors.Join(runErr, attributionHarness.Close())
+	if len(measuredCells) > 0 {
+		approximateCandidates := min(cfg.routerCandidates, int(assets.status.Representatives))
+		if approximateCandidates < 1 {
+			return errors.New("M8 attribution requires an approximate router candidate budget")
 		}
-	}()
-	attribution := make(map[string]m8AttributionCellV1, len(cfg.probes)*len(cfg.efSearch))
-	exhaustive := make([][]m8CanonicalResultV1, len(queries))
-	for _, probes := range cfg.probes {
-		for _, efSearch := range cfg.efSearch {
-			cell, buildErr := m8BuildAttributionV1(context.Background(), assets, queries, truth, probes, efSearch, cfg.topK, approximateCandidates, exhaustive, attributionHarness)
-			if buildErr != nil {
-				return fmt.Errorf("build M8 attribution probes=%d ef=%d: %w", probes, efSearch, buildErr)
+		attributionHarness, err := newM8AttributionHarnessV1(assets)
+		if err != nil {
+			return fmt.Errorf("open M8 attribution harness: %w", err)
+		}
+		attributionHarnessClosed := false
+		defer func() {
+			if !attributionHarnessClosed {
+				runErr = errors.Join(runErr, attributionHarness.Close())
 			}
-			attribution[m8AttributionKeyV1(probes, efSearch)] = cell
+		}()
+		attribution := make(map[string]m8AttributionCellV1, len(cfg.probes)*len(cfg.efSearch))
+		exhaustive := make([][]m8CanonicalResultV1, len(queries))
+		for _, probes := range cfg.probes {
+			for _, efSearch := range cfg.efSearch {
+				cell, buildErr := m8BuildAttributionV1(context.Background(), assets, queries, truth, probes, efSearch, cfg.topK, approximateCandidates, exhaustive, attributionHarness)
+				if buildErr != nil {
+					return fmt.Errorf("build M8 attribution probes=%d ef=%d: %w", probes, efSearch, buildErr)
+				}
+				attribution[m8AttributionKeyV1(probes, efSearch)] = cell
+			}
 		}
-	}
-	closeErr := attributionHarness.Close()
-	attributionHarnessClosed = true
-	if closeErr != nil {
-		return fmt.Errorf("close M8 attribution harness: %w", closeErr)
-	}
-	for _, measured := range measuredCells {
-		cell, ok := attribution[m8AttributionKeyV1(measured.probes, measured.efSearch)]
-		if !ok {
-			return fmt.Errorf("missing M8 attribution probes=%d ef=%d", measured.probes, measured.efSearch)
+		closeErr := attributionHarness.Close()
+		attributionHarnessClosed = true
+		if closeErr != nil {
+			return fmt.Errorf("close M8 attribution harness: %w", closeErr)
 		}
-		if err := m8AttachAttributionV1(&report.Rows[measured.rowIndex], cell, measured.results); err != nil {
-			return fmt.Errorf("attach M8 attribution probes=%d ef=%d: %w", measured.probes, measured.efSearch, err)
+		for _, measured := range measuredCells {
+			cell, ok := attribution[m8AttributionKeyV1(measured.probes, measured.efSearch)]
+			if !ok {
+				return fmt.Errorf("missing M8 attribution probes=%d ef=%d", measured.probes, measured.efSearch)
+			}
+			if err := m8AttachAttributionV1(&report.Rows[measured.rowIndex], cell, measured.results); err != nil {
+				return fmt.Errorf("attach M8 attribution probes=%d ef=%d: %w", measured.probes, measured.efSearch, err)
+			}
 		}
 	}
 	report.GateLedger = m8ProductionGateLedgerForReportV1(report)

--- a/cmd/treedb_vector_partition_bench/m8_production_runner.go
+++ b/cmd/treedb_vector_partition_bench/m8_production_runner.go
@@ -74,19 +74,20 @@ type m8ProductionConfigEvidenceV1 struct {
 // m8ProductionAttributionV1 keeps each lossy boundary visible. Recall is
 // always measured against the same canonical global FP32-score oracle.
 type m8ProductionAttributionV1 struct {
-	Contract                           string   `json:"contract"`
-	GlobalExactRecallAtK               float64  `json:"global_exact_recall_at_k"`
-	ExhaustivePartitionRecallAtK       float64  `json:"exhaustive_partition_union_recall_at_k"`
-	ExhaustivePartitionIDParity        bool     `json:"exhaustive_partition_union_id_parity"`
-	ExhaustivePartitionScoreParity     bool     `json:"exhaustive_partition_union_score_parity"`
-	ExactRepresentativeRecallAtK       float64  `json:"exact_representative_routing_recall_at_k"`
-	ApproximateRepresentativeRecallAtK float64  `json:"approximate_representative_routing_recall_at_k"`
-	LocalHNSWRecallAtK                 float64  `json:"partition_local_hnsw_recall_at_k"`
-	EndToEndRecallAtK                  float64  `json:"end_to_end_recall_at_k"`
-	CoordinatorMergeIDParity           bool     `json:"coordinator_merge_id_parity"`
-	CoordinatorMergeScoreParity        bool     `json:"coordinator_merge_score_parity"`
-	ApproximateRouterCandidateBudget   int      `json:"approximate_router_candidate_budget"`
-	ResidualLossOwners                 []string `json:"residual_loss_owners"`
+	Contract                                   string   `json:"contract"`
+	GlobalExactRecallAtK                       float64  `json:"global_exact_recall_at_k"`
+	ExhaustivePartitionRecallAtK               float64  `json:"exhaustive_partition_union_recall_at_k"`
+	ExhaustivePartitionIDParity                bool     `json:"exhaustive_partition_union_id_parity"`
+	ExhaustivePartitionScoreParity             bool     `json:"exhaustive_partition_union_score_parity"`
+	ExactRepresentativeRecallAtK               float64  `json:"exact_representative_routing_recall_at_k"`
+	ApproximateRepresentativeRecallAtK         float64  `json:"approximate_representative_routing_recall_at_k"`
+	LocalHNSWRecallAtK                         float64  `json:"partition_local_hnsw_recall_at_k"`
+	EndToEndRecallAtK                          float64  `json:"end_to_end_recall_at_k"`
+	CoordinatorMergeIDParity                   bool     `json:"coordinator_merge_id_parity"`
+	CoordinatorMergeScoreParity                bool     `json:"coordinator_merge_score_parity"`
+	ApproximateRouterCandidateBudget           int      `json:"approximate_router_candidate_budget"`
+	ApproximateRouterPartitionCoverageComplete bool     `json:"approximate_router_partition_coverage_complete"`
+	ResidualLossOwners                         []string `json:"residual_loss_owners"`
 }
 
 type m8ProductionRowV1 struct {
@@ -626,6 +627,19 @@ func (h *m8AttributionHarnessV1) route(ctx context.Context, query []float32, pro
 	return partitions, nil
 }
 
+// m8ApproximateRouterCoverageV1 converts only the typed bounded-candidate
+// shortfall into an attributable approximate-routing loss. Every other router
+// error remains fail-closed evidence construction failure.
+func m8ApproximateRouterCoverageV1(err error) (bool, error) {
+	if err == nil {
+		return true, nil
+	}
+	if errors.Is(err, collections.ErrVectorPartitionRouterCandidateCoverageV1) {
+		return false, nil
+	}
+	return false, err
+}
+
 func (h *m8AttributionHarnessV1) search(ctx context.Context, query []float32, partitions []uint32, topK, efSearch int, exact bool) ([]m8CanonicalResultV1, error) {
 	merged := make([]m8CanonicalResultV1, 0, len(partitions)*topK)
 	for _, partition := range partitions {
@@ -664,7 +678,8 @@ func m8BuildAttributionV1(ctx context.Context, assets *m8ProductionMultiGroupAss
 		Contract: m8CanonicalResultContractV1, GlobalExactRecallAtK: 1,
 		ExhaustivePartitionIDParity: true, ExhaustivePartitionScoreParity: true,
 		CoordinatorMergeIDParity: true, CoordinatorMergeScoreParity: true,
-		ApproximateRouterCandidateBudget: approximateCandidates,
+		ApproximateRouterCandidateBudget:           approximateCandidates,
+		ApproximateRouterPartitionCoverageComplete: true,
 	}, Local: make([][]m8CanonicalResultV1, len(queries))}
 	allPartitions := make([]uint32, len(harness.searchers))
 	for i := range allPartitions {
@@ -692,17 +707,22 @@ func m8BuildAttributionV1(ctx context.Context, assets *m8ProductionMultiGroupAss
 		if err != nil {
 			return cell, err
 		}
-		approximatePartitions, err := harness.route(ctx, query, probes, collections.VectorPartitionRouterModeApproxV1, approximateCandidates)
+		approximatePartitions, approximateRouteErr := harness.route(ctx, query, probes, collections.VectorPartitionRouterModeApproxV1, approximateCandidates)
+		approximateCoverageComplete, err := m8ApproximateRouterCoverageV1(approximateRouteErr)
 		if err != nil {
 			return cell, err
 		}
+		cell.Evidence.ApproximateRouterPartitionCoverageComplete = cell.Evidence.ApproximateRouterPartitionCoverageComplete && approximateCoverageComplete
 		exactResults, err := harness.search(ctx, query, exactPartitions, topK, efSearch, true)
 		if err != nil {
 			return cell, err
 		}
-		approximateResults, err := harness.search(ctx, query, approximatePartitions, topK, efSearch, true)
-		if err != nil {
-			return cell, err
+		var approximateResults []m8CanonicalResultV1
+		if approximateCoverageComplete {
+			approximateResults, err = harness.search(ctx, query, approximatePartitions, topK, efSearch, true)
+			if err != nil {
+				return cell, err
+			}
 		}
 		cell.Local[i], err = harness.search(ctx, query, exactPartitions, topK, efSearch, false)
 		if err != nil {
@@ -713,6 +733,12 @@ func m8BuildAttributionV1(ctx context.Context, assets *m8ProductionMultiGroupAss
 		localRecall += m8CanonicalRecallV1(truth[i], cell.Local[i])
 	}
 	n := float64(len(queries))
+	if !cell.Evidence.ApproximateRouterPartitionCoverageComplete {
+		// A shortfall means this approximate attribution cell did not evaluate
+		// its requested partition coverage. Do not average successful partial
+		// queries into a deceptively nonzero approximate-routing recall.
+		approximateRecall = 0
+	}
 	cell.Evidence.ExhaustivePartitionRecallAtK = exhaustiveRecall / n
 	cell.Evidence.ExactRepresentativeRecallAtK = exactRecall / n
 	cell.Evidence.ApproximateRepresentativeRecallAtK = approximateRecall / n
@@ -946,7 +972,7 @@ func m8AttributionLossOwnersV1(attribution m8ProductionAttributionV1) []string {
 	if attribution.ExactRepresentativeRecallAtK+epsilon < attribution.ExhaustivePartitionRecallAtK {
 		owners = append(owners, "exact_representative_routing")
 	}
-	if attribution.ApproximateRepresentativeRecallAtK+epsilon < attribution.ExactRepresentativeRecallAtK {
+	if !attribution.ApproximateRouterPartitionCoverageComplete || attribution.ApproximateRepresentativeRecallAtK+epsilon < attribution.ExactRepresentativeRecallAtK {
 		owners = append(owners, "approximate_representative_routing")
 	}
 	if attribution.LocalHNSWRecallAtK+epsilon < attribution.ExactRepresentativeRecallAtK {
@@ -1217,6 +1243,7 @@ func validateM8ProductionReportV1(report m8ProductionReportV1) error {
 func validM8AttributionV1(attribution m8ProductionAttributionV1) bool {
 	if attribution.Contract != m8CanonicalResultContractV1 || attribution.GlobalExactRecallAtK != 1 ||
 		attribution.ApproximateRouterCandidateBudget < 1 ||
+		(!attribution.ApproximateRouterPartitionCoverageComplete && attribution.ApproximateRepresentativeRecallAtK != 0) ||
 		!slices.Equal(attribution.ResidualLossOwners, m8AttributionLossOwnersV1(attribution)) {
 		return false
 	}

--- a/cmd/treedb_vector_partition_bench/m8_production_runner.go
+++ b/cmd/treedb_vector_partition_bench/m8_production_runner.go
@@ -410,6 +410,30 @@ func m8ExactTruthV1(collection *collections.Collection, queries [][]float64, top
 	return truth, nil
 }
 
+// m8ExactPartitionUnionV1 scans every generation-pinned partition pack and
+// fails closed unless the caller supplies the complete manifest partition set.
+func m8ExactPartitionUnionV1(ctx context.Context, assets *m8ProductionMultiGroupAssetsV1, query []float64, topK int) ([]neighbor, error) {
+	if assets == nil || len(assets.manifest.Placements) != int(assets.manifest.PartitionCount) {
+		return nil, errors.New("incomplete M8 partition manifest")
+	}
+	merged := make([]neighbor, 0, len(assets.manifest.Placements)*topK)
+	for partition := 0; partition < len(assets.manifest.Placements); partition++ {
+		searcher, err := assets.collection.OpenVectorPartitionLocalSearcherForGenerationV1(partitionHNSWIndex, assets.manifest.Generation, uint32(partition))
+		if err != nil {
+			return nil, err
+		}
+		results, _, searchErr := searcher.SearchExactWithOptionsV1(ctx, m8Query32V1(query), collections.VectorPartitionSearchOptionsV1{TopK: topK})
+		closeErr := searcher.Close()
+		if searchErr != nil || closeErr != nil {
+			return nil, errors.Join(searchErr, closeErr)
+		}
+		for _, result := range results {
+			merged = append(merged, neighbor{ID: result.ID, Distance: 1 - float64(result.Score)})
+		}
+	}
+	return canonicalExactNeighborsV1(merged, topK), nil
+}
+
 func m8WarmProductionTopologyV1(ctx context.Context, coordinator *nativewire.VectorPartitionCoordinatorV1, assets *m8ProductionMultiGroupAssetsV1, queries [][]float64, cfg config) error {
 	if len(queries) == 0 {
 		return errors.New("M8 warmup requires a query")

--- a/cmd/treedb_vector_partition_bench/m8_production_runner.go
+++ b/cmd/treedb_vector_partition_bench/m8_production_runner.go
@@ -8,12 +8,14 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"math"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"runtime"
 	"runtime/pprof"
 	"runtime/trace"
+	"slices"
 	"sort"
 	"strings"
 	"sync"
@@ -65,31 +67,51 @@ type m8ProductionConfigEvidenceV1 struct {
 	Concurrency       []int     `json:"concurrency"`
 	Warmup            int       `json:"warmup_requests"`
 	EfSearch          []int     `json:"ef_search"`
+	RouterCandidates  int       `json:"approximate_router_candidate_budget"`
 	Seed              int64     `json:"seed"`
 }
 
+// m8ProductionAttributionV1 keeps each lossy boundary visible. Recall is
+// always measured against the same canonical global FP32-score oracle.
+type m8ProductionAttributionV1 struct {
+	Contract                           string   `json:"contract"`
+	GlobalExactRecallAtK               float64  `json:"global_exact_recall_at_k"`
+	ExhaustivePartitionRecallAtK       float64  `json:"exhaustive_partition_union_recall_at_k"`
+	ExhaustivePartitionIDParity        bool     `json:"exhaustive_partition_union_id_parity"`
+	ExhaustivePartitionScoreParity     bool     `json:"exhaustive_partition_union_score_parity"`
+	ExactRepresentativeRecallAtK       float64  `json:"exact_representative_routing_recall_at_k"`
+	ApproximateRepresentativeRecallAtK float64  `json:"approximate_representative_routing_recall_at_k"`
+	LocalHNSWRecallAtK                 float64  `json:"partition_local_hnsw_recall_at_k"`
+	EndToEndRecallAtK                  float64  `json:"end_to_end_recall_at_k"`
+	CoordinatorMergeIDParity           bool     `json:"coordinator_merge_id_parity"`
+	CoordinatorMergeScoreParity        bool     `json:"coordinator_merge_score_parity"`
+	ApproximateRouterCandidateBudget   int      `json:"approximate_router_candidate_budget"`
+	ResidualLossOwners                 []string `json:"residual_loss_owners"`
+}
+
 type m8ProductionRowV1 struct {
-	Status             string  `json:"status"`
-	UnsupportedReason  string  `json:"unsupported_reason,omitempty"`
-	Overlap            float64 `json:"overlap"`
-	Probes             int     `json:"probes,omitempty"`
-	EfSearch           int     `json:"ef_search,omitempty"`
-	Concurrency        int     `json:"concurrency,omitempty"`
-	RouterMode         string  `json:"router_mode,omitempty"`
-	RouterCandidates   int     `json:"router_candidate_budget,omitempty"`
-	Samples            int     `json:"samples,omitempty"`
-	RecallAtK          float64 `json:"recall_at_k,omitempty"`
-	QPS                float64 `json:"qps,omitempty"`
-	P50Nanos           uint64  `json:"p50_nanos,omitempty"`
-	P95Nanos           uint64  `json:"p95_nanos,omitempty"`
-	P99Nanos           uint64  `json:"p99_nanos,omitempty"`
-	RequestBytes       uint64  `json:"request_bytes,omitempty"`
-	ResponseBytes      uint64  `json:"response_bytes,omitempty"`
-	CandidateBytes     uint64  `json:"candidate_bytes,omitempty"`
-	RPCs               uint64  `json:"rpcs,omitempty"`
-	ExactParityChecked bool    `json:"exact_all_partition_parity_checked"`
-	ExactParityPassed  bool    `json:"exact_all_partition_parity_passed"`
-	NoPartialResults   bool    `json:"no_partial_results"`
+	Status             string                    `json:"status"`
+	UnsupportedReason  string                    `json:"unsupported_reason,omitempty"`
+	Overlap            float64                   `json:"overlap"`
+	Probes             int                       `json:"probes,omitempty"`
+	EfSearch           int                       `json:"ef_search,omitempty"`
+	Concurrency        int                       `json:"concurrency,omitempty"`
+	RouterMode         string                    `json:"router_mode,omitempty"`
+	RouterCandidates   int                       `json:"router_candidate_budget,omitempty"`
+	Samples            int                       `json:"samples,omitempty"`
+	RecallAtK          float64                   `json:"recall_at_k"`
+	QPS                float64                   `json:"qps,omitempty"`
+	P50Nanos           uint64                    `json:"p50_nanos,omitempty"`
+	P95Nanos           uint64                    `json:"p95_nanos,omitempty"`
+	P99Nanos           uint64                    `json:"p99_nanos,omitempty"`
+	RequestBytes       uint64                    `json:"request_bytes,omitempty"`
+	ResponseBytes      uint64                    `json:"response_bytes,omitempty"`
+	CandidateBytes     uint64                    `json:"candidate_bytes,omitempty"`
+	RPCs               uint64                    `json:"rpcs,omitempty"`
+	ExactParityChecked bool                      `json:"exact_all_partition_parity_checked"`
+	ExactParityPassed  bool                      `json:"exact_all_partition_parity_passed"`
+	NoPartialResults   bool                      `json:"no_partial_results"`
+	Attribution        m8ProductionAttributionV1 `json:"recall_attribution"`
 }
 
 type m8ProductionFailureEvidenceV1 struct {
@@ -170,16 +192,36 @@ func runM8ProductionMultiGroupV1(cfg config, fixture fixtureManifest, vectors, q
 	defer func() { runErr = errors.Join(runErr, topology.Close()) }()
 	buildNanos := time.Since(started).Nanoseconds()
 
-	truth, err := m8ExactTruthV1(assets.collection, queries, cfg.topK)
+	truth, err := m8ExactTruthV1(assets.collection, assets.manifest, queries, cfg.topK)
 	if err != nil {
 		return err
 	}
+	attributionHarness, err := newM8AttributionHarnessV1(assets)
+	if err != nil {
+		return fmt.Errorf("open M8 attribution harness: %w", err)
+	}
+	defer func() { runErr = errors.Join(runErr, attributionHarness.Close()) }()
+	approximateCandidates := min(cfg.routerCandidates, int(assets.status.Representatives))
+	if approximateCandidates < 1 {
+		return errors.New("M8 attribution requires an approximate router candidate budget")
+	}
+	attribution := make(map[string]m8AttributionCellV1, len(cfg.probes)*len(cfg.efSearch))
+	exhaustive := make([][]m8CanonicalResultV1, len(queries))
+	for _, probes := range cfg.probes {
+		for _, efSearch := range cfg.efSearch {
+			cell, buildErr := m8BuildAttributionV1(context.Background(), assets, queries, truth, probes, efSearch, cfg.topK, approximateCandidates, exhaustive, attributionHarness)
+			if buildErr != nil {
+				return fmt.Errorf("build M8 attribution probes=%d ef=%d: %w", probes, efSearch, buildErr)
+			}
+			attribution[m8AttributionKeyV1(probes, efSearch)] = cell
+		}
+	}
 	report := m8ProductionReportV1{
-		SchemaVersion: 1, ResultKind: "m8_production_multi_group_evidence_v1", Status: "incomplete",
+		SchemaVersion: 2, ResultKind: "m8_production_multi_group_evidence_v2", Status: "incomplete",
 		Mode: m8ProductionMultiGroupModeV1, ProductionEvidence: true, GeneratedAt: time.Now().UTC(),
 		Command: cfg.command, BaseSHA: cfg.baseSHA, HeadSHA: cfg.headSHA, Dirty: m8GitDirtyV1(),
 		GoVersion: runtime.Version(), GOOS: runtime.GOOS, GOARCH: runtime.GOARCH, LogicalCPUs: runtime.NumCPU(), Host: m8ProductionHostV1(cfg, assets.dir), Dataset: fixture,
-		Config:        m8ProductionConfigEvidenceV1{RaftGroups: cfg.raftGroups, RaftNodesPerGroup: cfg.raftNodes, Partitions: cfg.partitions, Probes: append([]int(nil), cfg.probes...), Overlap: append([]float64(nil), cfg.overlaps...), TopK: cfg.topK, RecallTarget: cfg.recallTarget, Concurrency: append([]int(nil), cfg.concurrency...), Warmup: cfg.warmup, EfSearch: append([]int(nil), cfg.efSearch...), Seed: cfg.seed},
+		Config:        m8ProductionConfigEvidenceV1{RaftGroups: cfg.raftGroups, RaftNodesPerGroup: cfg.raftNodes, Partitions: cfg.partitions, Probes: append([]int(nil), cfg.probes...), Overlap: append([]float64(nil), cfg.overlaps...), TopK: cfg.topK, RecallTarget: cfg.recallTarget, Concurrency: append([]int(nil), cfg.concurrency...), Warmup: cfg.warmup, EfSearch: append([]int(nil), cfg.efSearch...), RouterCandidates: cfg.routerCandidates, Seed: cfg.seed},
 		BuildNanos:    buildNanos,
 		Profiles:      m8ProductionProfileEvidenceV1{Directory: cfg.profiles, Status: "not_captured", Scope: "CPU, block, mutex, and trace cover measured query cells plus the endpoint-loss fault; heap is an end snapshot; allocs requires the captured baseline for differential analysis"},
 		Resources:     m8ProductionResourcesV1(assets),
@@ -216,7 +258,7 @@ func runM8ProductionMultiGroupV1(cfg config, fixture fixtureManifest, vectors, q
 		for _, probes := range cfg.probes {
 			for _, ef := range cfg.efSearch {
 				for _, concurrency := range cfg.concurrency {
-					row, rowErr := m8RunProductionCellV1(context.Background(), topology.Coordinator(), assets, queries, truth, probes, ef, concurrency, cfg.topK)
+					row, rowErr := m8RunProductionCellV1(context.Background(), topology.Coordinator(), assets, queries, truth, attribution[m8AttributionKeyV1(probes, ef)], probes, ef, concurrency, cfg.topK)
 					if rowErr != nil {
 						return fmt.Errorf("M8 production cell probes=%d ef=%d concurrency=%d: %w", probes, ef, concurrency, rowErr)
 					}
@@ -283,7 +325,7 @@ func m8ArtifactNameV1(cfg config, fixture fixtureManifest, manifest collections.
 		Assets  m8ArtifactAssetIdentityV1
 	}{
 		Fixture: fixture,
-		Config:  m8ProductionConfigEvidenceV1{RaftGroups: cfg.raftGroups, RaftNodesPerGroup: cfg.raftNodes, Partitions: cfg.partitions, Probes: cfg.probes, Overlap: cfg.overlaps, TopK: cfg.topK, RecallTarget: cfg.recallTarget, Concurrency: cfg.concurrency, Warmup: cfg.warmup, EfSearch: cfg.efSearch, Seed: cfg.seed},
+		Config:  m8ProductionConfigEvidenceV1{RaftGroups: cfg.raftGroups, RaftNodesPerGroup: cfg.raftNodes, Partitions: cfg.partitions, Probes: cfg.probes, Overlap: cfg.overlaps, TopK: cfg.topK, RecallTarget: cfg.recallTarget, Concurrency: cfg.concurrency, Warmup: cfg.warmup, EfSearch: cfg.efSearch, RouterCandidates: cfg.routerCandidates, Seed: cfg.seed},
 		Assets: m8ArtifactAssetIdentityV1{
 			IntegrityDigest:  manifest.IntegrityDigest,
 			ReadySetDigest:   manifest.ReadySetDigest,
@@ -394,20 +436,278 @@ func writeM8RuntimeProfileV1(name, path string) error {
 	return errors.Join(err, file.Close())
 }
 
-func m8ExactTruthV1(collection *collections.Collection, queries [][]float64, topK int) ([][]string, error) {
-	truth := make([][]string, len(queries))
+type m8CanonicalResultV1 struct {
+	ID    string
+	Score float32
+}
+
+const m8CanonicalResultContractV1 = collections.VectorPartitionCanonicalScoreContractV1
+
+func m8CanonicalResultsV1(in []m8CanonicalResultV1, topK int) []m8CanonicalResultV1 {
+	if topK <= 0 {
+		return nil
+	}
+	for _, result := range in {
+		if result.ID == "" || math.IsNaN(float64(result.Score)) || math.IsInf(float64(result.Score), 0) {
+			return nil
+		}
+	}
+	ordered := append([]m8CanonicalResultV1(nil), in...)
+	sort.Slice(ordered, func(i, j int) bool {
+		return ordered[i].Score > ordered[j].Score || ordered[i].Score == ordered[j].Score && ordered[i].ID < ordered[j].ID
+	})
+	seen := make(map[string]struct{}, len(ordered))
+	out := ordered[:0]
+	for _, result := range ordered {
+		if _, ok := seen[result.ID]; ok {
+			continue
+		}
+		seen[result.ID] = struct{}{}
+		out = append(out, result)
+		if len(out) == topK {
+			break
+		}
+	}
+	return out
+}
+
+func m8AppendBoundedCanonicalV1(results []m8CanonicalResultV1, candidate m8CanonicalResultV1, topK int) []m8CanonicalResultV1 {
+	if topK <= 0 || candidate.ID == "" || math.IsNaN(float64(candidate.Score)) || math.IsInf(float64(candidate.Score), 0) {
+		return nil
+	}
+	for i := range results {
+		if results[i].ID == candidate.ID {
+			if candidate.Score > results[i].Score {
+				results[i] = candidate
+			}
+			return m8CanonicalResultsV1(results, topK)
+		}
+	}
+	if len(results) == topK {
+		worst := results[len(results)-1]
+		if candidate.Score < worst.Score || candidate.Score == worst.Score && candidate.ID >= worst.ID {
+			return results
+		}
+		results[len(results)-1] = candidate
+		return m8CanonicalResultsV1(results, topK)
+	}
+	return m8CanonicalResultsV1(append(results, candidate), topK)
+}
+
+func m8ExactTruthV1(collection *collections.Collection, manifest collections.VectorPartitionManifestV1, queries [][]float64, topK int) ([][]m8CanonicalResultV1, error) {
+	source, rows, err := collection.ReadVectorPartitionRouterSourceRowsV1(partitionHNSWIndex)
+	if err != nil {
+		return nil, fmt.Errorf("M8 canonical source oracle: %w", err)
+	}
+	if source.Generation != manifest.SourceGeneration || source.Checksum != manifest.SourceChecksum || source.SchemaHash != manifest.SourceSchemaHash || source.RowCount != manifest.SourceRowCount || len(rows) != int(source.RowCount) {
+		return nil, errors.New("M8 canonical source oracle identity does not match the pinned partition generation")
+	}
+	truth := make([][]m8CanonicalResultV1, len(queries))
 	for i, query64 := range queries {
 		query := m8Query32V1(query64)
-		results, err := collection.SearchVectorsExact(query, collections.VectorSearchOptions{Field: "embedding", Metric: collections.VectorMetricCosine, TopK: topK})
-		if err != nil {
-			return nil, fmt.Errorf("M8 exact truth query %d: %w", i, err)
+		for ordinal, row := range rows {
+			score, scoreErr := collections.CanonicalVectorPartitionCosineScoreV1(query, row.Values)
+			if scoreErr != nil {
+				return nil, fmt.Errorf("M8 canonical source oracle query=%d ordinal=%d: %w", i, ordinal, scoreErr)
+			}
+			truth[i] = m8AppendBoundedCanonicalV1(truth[i], m8CanonicalResultV1{ID: string(row.DocumentID), Score: score}, topK)
 		}
-		truth[i] = make([]string, len(results))
-		for rank := range results {
-			truth[i][rank] = string(results[rank].DocumentID)
+		if len(truth[i]) != min(topK, len(rows)) {
+			return nil, fmt.Errorf("M8 canonical source oracle query=%d results=%d", i, len(truth[i]))
 		}
 	}
 	return truth, nil
+}
+
+func m8CanonicalIDsV1(results []m8CanonicalResultV1) []string {
+	ids := make([]string, len(results))
+	for i := range results {
+		ids[i] = results[i].ID
+	}
+	return ids
+}
+
+func m8CanonicalParityV1(want, got []m8CanonicalResultV1) (idParity, scoreParity bool) {
+	if len(want) != len(got) {
+		return false, false
+	}
+	idParity, scoreParity = true, true
+	for i := range want {
+		if want[i].ID != got[i].ID {
+			idParity = false
+		}
+		if math.Float32bits(want[i].Score) != math.Float32bits(got[i].Score) {
+			scoreParity = false
+		}
+	}
+	return idParity, scoreParity
+}
+
+func m8CanonicalRecallV1(want, got []m8CanonicalResultV1) float64 {
+	return m8IDRecallV1(m8CanonicalIDsV1(want), m8CanonicalIDsV1(got))
+}
+
+type m8AttributionHarnessV1 struct {
+	assets    *m8ProductionMultiGroupAssetsV1
+	searchers []*collections.VectorPartitionLocalSearcherV1
+}
+
+func newM8AttributionHarnessV1(assets *m8ProductionMultiGroupAssetsV1) (_ *m8AttributionHarnessV1, resultErr error) {
+	if assets == nil || assets.collection == nil || assets.router == nil || assets.manifest.PartitionCount == 0 || len(assets.manifest.Placements) != int(assets.manifest.PartitionCount) {
+		return nil, errors.New("incomplete M8 attribution assets")
+	}
+	seen := make([]bool, assets.manifest.PartitionCount)
+	for _, placement := range assets.manifest.Placements {
+		if placement.PartitionID >= assets.manifest.PartitionCount || seen[placement.PartitionID] {
+			return nil, errors.New("incomplete or duplicate M8 attribution placement")
+		}
+		seen[placement.PartitionID] = true
+	}
+	h := &m8AttributionHarnessV1{assets: assets, searchers: make([]*collections.VectorPartitionLocalSearcherV1, assets.manifest.PartitionCount)}
+	defer func() {
+		if resultErr != nil {
+			resultErr = errors.Join(resultErr, h.Close())
+		}
+	}()
+	for partition := range h.searchers {
+		searcher, err := assets.collection.OpenVectorPartitionLocalSearcherForGenerationV1(partitionHNSWIndex, assets.manifest.Generation, uint32(partition))
+		if err != nil {
+			return nil, fmt.Errorf("open M8 attribution partition %d: %w", partition, err)
+		}
+		h.searchers[partition] = searcher
+	}
+	return h, nil
+}
+
+func (h *m8AttributionHarnessV1) Close() error {
+	if h == nil {
+		return nil
+	}
+	var err error
+	for i, searcher := range h.searchers {
+		if searcher != nil {
+			err = errors.Join(err, searcher.Close())
+			h.searchers[i] = nil
+		}
+	}
+	return err
+}
+
+func (h *m8AttributionHarnessV1) route(ctx context.Context, query []float32, probes int, mode string, candidates int) ([]uint32, error) {
+	result, err := h.assets.router.SearchWithContextV1(ctx, query, collections.VectorPartitionRouterSearchOptionsV1{Mode: mode, CandidateBudget: candidates, PartitionProbes: probes})
+	if err != nil {
+		return nil, err
+	}
+	partitions := make([]uint32, len(result.Partitions))
+	seen := make(map[uint32]struct{}, len(result.Partitions))
+	for i, partition := range result.Partitions {
+		if partition.PartitionID >= uint32(len(h.searchers)) {
+			return nil, errors.New("M8 attribution router returned out-of-range partition")
+		}
+		if _, ok := seen[partition.PartitionID]; ok {
+			return nil, errors.New("M8 attribution router returned duplicate partition")
+		}
+		seen[partition.PartitionID] = struct{}{}
+		partitions[i] = partition.PartitionID
+	}
+	if len(partitions) != probes {
+		return nil, fmt.Errorf("M8 attribution router selected %d partitions, want %d", len(partitions), probes)
+	}
+	return partitions, nil
+}
+
+func (h *m8AttributionHarnessV1) search(ctx context.Context, query []float32, partitions []uint32, topK, efSearch int, exact bool) ([]m8CanonicalResultV1, error) {
+	merged := make([]m8CanonicalResultV1, 0, len(partitions)*topK)
+	for _, partition := range partitions {
+		if partition >= uint32(len(h.searchers)) || h.searchers[partition] == nil {
+			return nil, errors.New("M8 attribution partition coverage is incomplete")
+		}
+		opts := collections.VectorPartitionSearchOptionsV1{TopK: topK, EfSearch: efSearch}
+		var results []collections.VectorPartitionSearchResultV1
+		var err error
+		if exact {
+			results, _, err = h.searchers[partition].SearchExactWithOptionsV1(ctx, query, opts)
+		} else {
+			results, _, err = h.searchers[partition].SearchWithOptionsV1(ctx, query, opts)
+		}
+		if err != nil {
+			return nil, fmt.Errorf("M8 attribution partition %d: %w", partition, err)
+		}
+		for _, result := range results {
+			merged = append(merged, m8CanonicalResultV1{ID: result.ID, Score: result.Score})
+		}
+	}
+	return m8CanonicalResultsV1(merged, topK), nil
+}
+
+type m8AttributionCellV1 struct {
+	Evidence m8ProductionAttributionV1
+	Local    [][]m8CanonicalResultV1
+}
+
+func m8AttributionKeyV1(probes, efSearch int) string {
+	return fmt.Sprintf("%d/%d", probes, efSearch)
+}
+
+func m8BuildAttributionV1(ctx context.Context, assets *m8ProductionMultiGroupAssetsV1, queries [][]float64, truth [][]m8CanonicalResultV1, probes, efSearch, topK, approximateCandidates int, exhaustive [][]m8CanonicalResultV1, harness *m8AttributionHarnessV1) (m8AttributionCellV1, error) {
+	cell := m8AttributionCellV1{Evidence: m8ProductionAttributionV1{
+		Contract: m8CanonicalResultContractV1, GlobalExactRecallAtK: 1,
+		ExhaustivePartitionIDParity: true, ExhaustivePartitionScoreParity: true,
+		CoordinatorMergeIDParity: true, CoordinatorMergeScoreParity: true,
+		ApproximateRouterCandidateBudget: approximateCandidates,
+	}, Local: make([][]m8CanonicalResultV1, len(queries))}
+	allPartitions := make([]uint32, len(harness.searchers))
+	for i := range allPartitions {
+		allPartitions[i] = uint32(i)
+	}
+	var exhaustiveRecall, exactRecall, approximateRecall, localRecall float64
+	for i, query64 := range queries {
+		if err := ctx.Err(); err != nil {
+			return cell, err
+		}
+		query := m8Query32V1(query64)
+		if exhaustive[i] == nil {
+			var err error
+			exhaustive[i], err = harness.search(ctx, query, allPartitions, topK, efSearch, true)
+			if err != nil {
+				return cell, err
+			}
+		}
+		idParity, scoreParity := m8CanonicalParityV1(truth[i], exhaustive[i])
+		cell.Evidence.ExhaustivePartitionIDParity = cell.Evidence.ExhaustivePartitionIDParity && idParity
+		cell.Evidence.ExhaustivePartitionScoreParity = cell.Evidence.ExhaustivePartitionScoreParity && scoreParity
+		exhaustiveRecall += m8CanonicalRecallV1(truth[i], exhaustive[i])
+
+		exactPartitions, err := harness.route(ctx, query, probes, collections.VectorPartitionRouterModeExactV1, int(assets.status.Representatives))
+		if err != nil {
+			return cell, err
+		}
+		approximatePartitions, err := harness.route(ctx, query, probes, collections.VectorPartitionRouterModeApproxV1, approximateCandidates)
+		if err != nil {
+			return cell, err
+		}
+		exactResults, err := harness.search(ctx, query, exactPartitions, topK, efSearch, true)
+		if err != nil {
+			return cell, err
+		}
+		approximateResults, err := harness.search(ctx, query, approximatePartitions, topK, efSearch, true)
+		if err != nil {
+			return cell, err
+		}
+		cell.Local[i], err = harness.search(ctx, query, exactPartitions, topK, efSearch, false)
+		if err != nil {
+			return cell, err
+		}
+		exactRecall += m8CanonicalRecallV1(truth[i], exactResults)
+		approximateRecall += m8CanonicalRecallV1(truth[i], approximateResults)
+		localRecall += m8CanonicalRecallV1(truth[i], cell.Local[i])
+	}
+	n := float64(len(queries))
+	cell.Evidence.ExhaustivePartitionRecallAtK = exhaustiveRecall / n
+	cell.Evidence.ExactRepresentativeRecallAtK = exactRecall / n
+	cell.Evidence.ApproximateRepresentativeRecallAtK = approximateRecall / n
+	cell.Evidence.LocalHNSWRecallAtK = localRecall / n
+	return cell, nil
 }
 
 // m8ExactPartitionUnionV1 scans every generation-pinned partition pack and
@@ -500,7 +800,7 @@ func m8ProductionResourcesV1(assets *m8ProductionMultiGroupAssetsV1) m8Productio
 	return out
 }
 
-func m8RunProductionCellV1(ctx context.Context, coordinator *nativewire.VectorPartitionCoordinatorV1, assets *m8ProductionMultiGroupAssetsV1, queries [][]float64, truth [][]string, probes, efSearch, concurrency, topK int) (m8ProductionRowV1, error) {
+func m8RunProductionCellV1(ctx context.Context, coordinator *nativewire.VectorPartitionCoordinatorV1, assets *m8ProductionMultiGroupAssetsV1, queries [][]float64, truth [][]m8CanonicalResultV1, attribution m8AttributionCellV1, probes, efSearch, concurrency, topK int) (m8ProductionRowV1, error) {
 	type outcome struct {
 		response nativewire.VectorPartitionCoordinatorResponseV1
 		err      error
@@ -520,19 +820,23 @@ func m8RunProductionCellV1(ctx context.Context, coordinator *nativewire.VectorPa
 		outcomes[index].response, outcomes[index].err = coordinator.Search(requestCtx, m8ProductionRequestV1(assets, query, fmt.Sprintf("m8-q-%06d-p-%04d-ef-%06d-c-%03d", index, probes, efSearch, concurrency), probes, efSearch, topK))
 	})
 	elapsed := time.Since(started)
-	row := m8ProductionRowV1{Status: "pass", Probes: probes, EfSearch: efSearch, Concurrency: concurrency, RouterMode: collections.VectorPartitionRouterModeExactV1, RouterCandidates: max(1, int(assets.status.Representatives)), Samples: len(queries), ExactParityChecked: probes == len(assets.manifest.Placements), ExactParityPassed: probes == len(assets.manifest.Placements), NoPartialResults: true}
+	row := m8ProductionRowV1{Status: "pass", Probes: probes, EfSearch: efSearch, Concurrency: concurrency, RouterMode: collections.VectorPartitionRouterModeExactV1, RouterCandidates: max(1, int(assets.status.Representatives)), Samples: len(queries), ExactParityChecked: probes == len(assets.manifest.Placements), ExactParityPassed: probes == len(assets.manifest.Placements), Attribution: attribution.Evidence}
 	durations := make([]uint64, 0, len(outcomes))
 	var recallSum float64
 	for index, outcome := range outcomes {
 		if outcome.err != nil {
 			return row, fmt.Errorf("query %d: %w", index, outcome.err)
 		}
-		got := make([]string, len(outcome.response.Neighbors))
-		for rank := range outcome.response.Neighbors {
-			got[rank] = outcome.response.Neighbors[rank].ID
+		got, shapeErr := m8ValidateCoordinatorResponseV1(outcome.response, assets.manifest, probes, topK)
+		if shapeErr != nil {
+			return row, fmt.Errorf("query %d response shape: %w", index, shapeErr)
 		}
-		recallSum += m8IDRecallV1(truth[index], got)
-		if row.ExactParityChecked && !m8EqualIDsV1(truth[index], got) {
+		recallSum += m8CanonicalRecallV1(truth[index], got)
+		idParity, scoreParity := m8CanonicalParityV1(attribution.Local[index], got)
+		row.Attribution.CoordinatorMergeIDParity = row.Attribution.CoordinatorMergeIDParity && idParity
+		row.Attribution.CoordinatorMergeScoreParity = row.Attribution.CoordinatorMergeScoreParity && scoreParity
+		globalIDParity, globalScoreParity := m8CanonicalParityV1(truth[index], got)
+		if row.ExactParityChecked && (!globalIDParity || !globalScoreParity) {
 			row.ExactParityPassed = false
 			row.Status = "fail"
 		}
@@ -542,10 +846,94 @@ func m8RunProductionCellV1(ctx context.Context, coordinator *nativewire.VectorPa
 		row.CandidateBytes += outcome.response.Counters.CandidateBytes
 		row.RPCs += outcome.response.Counters.RPCs
 	}
+	row.NoPartialResults = true
 	row.RecallAtK = recallSum / float64(len(outcomes))
+	row.Attribution.EndToEndRecallAtK = row.RecallAtK
+	row.Attribution.ResidualLossOwners = m8AttributionLossOwnersV1(row.Attribution)
 	row.QPS = float64(len(outcomes)) / elapsed.Seconds()
 	row.P50Nanos, row.P95Nanos, row.P99Nanos = m8PercentileV1(durations, 50), m8PercentileV1(durations, 95), m8PercentileV1(durations, 99)
 	return row, nil
+}
+
+func m8ValidateCoordinatorResponseV1(response nativewire.VectorPartitionCoordinatorResponseV1, manifest collections.VectorPartitionManifestV1, probes, topK int) ([]m8CanonicalResultV1, error) {
+	partitionCount := int(manifest.PartitionCount)
+	if probes < 1 || partitionCount < probes || len(manifest.Placements) != partitionCount || topK < 1 || len(response.Neighbors) != topK || len(response.ProbedPartitions) != probes || len(response.ProbedGroups) == 0 || len(response.ProbedGroups) > probes {
+		return nil, errors.New("truncated or dimensionally invalid coordinator response")
+	}
+	raw := make([]m8CanonicalResultV1, len(response.Neighbors))
+	for i := range response.Neighbors {
+		raw[i] = m8CanonicalResultV1{ID: response.Neighbors[i].ID, Score: response.Neighbors[i].Score}
+	}
+	canonical := m8CanonicalResultsV1(raw, topK)
+	if len(canonical) != len(raw) {
+		return nil, errors.New("coordinator response contains empty, nonfinite, or duplicate neighbors")
+	}
+	if idParity, scoreParity := m8CanonicalParityV1(canonical, raw); !idParity || !scoreParity {
+		return nil, errors.New("coordinator response violates canonical score/stable-ID order")
+	}
+	seenPartitions := make(map[uint32]struct{}, probes)
+	owners := make(map[uint32]string, len(manifest.Placements))
+	for _, placement := range manifest.Placements {
+		if placement.PartitionID >= manifest.PartitionCount || placement.GroupID == "" {
+			return nil, errors.New("manifest contains invalid coordinator ownership")
+		}
+		if _, duplicate := owners[placement.PartitionID]; duplicate {
+			return nil, errors.New("manifest contains duplicate coordinator ownership")
+		}
+		owners[placement.PartitionID] = placement.GroupID
+	}
+	expectedGroups := make(map[string]struct{}, probes)
+	for _, partition := range response.ProbedPartitions {
+		if partition >= uint32(partitionCount) {
+			return nil, errors.New("coordinator response contains an out-of-range partition")
+		}
+		if _, duplicate := seenPartitions[partition]; duplicate {
+			return nil, errors.New("coordinator response contains a duplicate partition")
+		}
+		seenPartitions[partition] = struct{}{}
+		expectedGroups[owners[partition]] = struct{}{}
+	}
+	if len(expectedGroups) != len(response.ProbedGroups) {
+		return nil, errors.New("coordinator response group coverage is incomplete")
+	}
+	seenGroups := make(map[string]struct{}, len(response.ProbedGroups))
+	for _, group := range response.ProbedGroups {
+		if group == "" {
+			return nil, errors.New("coordinator response contains an empty group")
+		}
+		if _, duplicate := seenGroups[string(group)]; duplicate {
+			return nil, errors.New("coordinator response contains a duplicate group")
+		}
+		if _, expected := expectedGroups[string(group)]; !expected {
+			return nil, errors.New("coordinator response contains a non-owner group")
+		}
+		seenGroups[string(group)] = struct{}{}
+	}
+	return raw, nil
+}
+
+func m8AttributionLossOwnersV1(attribution m8ProductionAttributionV1) []string {
+	const epsilon = 1e-12
+	owners := make([]string, 0, 5)
+	if !attribution.ExhaustivePartitionIDParity || !attribution.ExhaustivePartitionScoreParity || attribution.ExhaustivePartitionRecallAtK < 1-epsilon {
+		owners = append(owners, "partition_membership_or_score_contract")
+	}
+	if attribution.ExactRepresentativeRecallAtK+epsilon < attribution.ExhaustivePartitionRecallAtK {
+		owners = append(owners, "exact_representative_routing")
+	}
+	if attribution.ApproximateRepresentativeRecallAtK+epsilon < attribution.ExactRepresentativeRecallAtK {
+		owners = append(owners, "approximate_representative_routing")
+	}
+	if attribution.LocalHNSWRecallAtK+epsilon < attribution.ExactRepresentativeRecallAtK {
+		owners = append(owners, "partition_local_hnsw")
+	}
+	if !attribution.CoordinatorMergeIDParity || !attribution.CoordinatorMergeScoreParity || attribution.EndToEndRecallAtK+epsilon < attribution.LocalHNSWRecallAtK {
+		owners = append(owners, "coordinator_merge_or_transport")
+	}
+	if len(owners) == 0 {
+		return []string{"none_observed"}
+	}
+	return owners
 }
 
 // m8RunBoundedWorkV1 starts no more than concurrency workers, rather than one
@@ -738,11 +1126,11 @@ func m8GitDirtyV1() bool {
 }
 
 func validateM8ProductionReportV1(report m8ProductionReportV1) error {
-	if report.SchemaVersion != 1 || report.ResultKind != "m8_production_multi_group_evidence_v1" ||
+	if report.SchemaVersion != 2 || report.ResultKind != "m8_production_multi_group_evidence_v2" ||
 		report.Mode != m8ProductionMultiGroupModeV1 || !report.ProductionEvidence ||
 		report.GeneratedAt.IsZero() || len(report.Command) == 0 || !validSHA(report.BaseSHA) || !validSHA(report.HeadSHA) ||
 		report.Config.RaftGroups < 2 || report.Config.RaftNodesPerGroup != 3 || report.Config.Partitions < 4 ||
-		report.Config.Warmup < 0 || report.BuildNanos <= 0 || report.TimedBoundary == "" || len(report.Limitations) == 0 {
+		report.Config.Warmup < 0 || report.Config.RouterCandidates < 1 || report.BuildNanos <= 0 || report.TimedBoundary == "" || len(report.Limitations) == 0 {
 		return errors.New("missing or invalid M8 identity, topology, or timing metadata")
 	}
 	if err := validateM3FixtureWithCaps(report.Dataset, maxVectors, maxFixtureBytes); err != nil {
@@ -776,7 +1164,10 @@ func validateM8ProductionReportV1(report m8ProductionReportV1) error {
 		}
 		if row.Status != "pass" && row.Status != "fail" || row.Probes < 1 || row.Probes > report.Config.Partitions ||
 			row.EfSearch < report.Config.TopK || row.Concurrency < 1 || row.Samples != report.Dataset.Queries || row.QPS <= 0 ||
-			row.RouterMode == "" || row.RouterCandidates < 1 || row.ExactParityChecked != (row.Probes == report.Config.Partitions) {
+			row.RouterMode == "" || row.RouterCandidates < 1 || row.ExactParityChecked != (row.Probes == report.Config.Partitions) ||
+			(!row.ExactParityChecked && row.ExactParityPassed) || !row.NoPartialResults ||
+			math.Float64bits(row.RecallAtK) != math.Float64bits(row.Attribution.EndToEndRecallAtK) ||
+			!validM8AttributionV1(row.Attribution) {
 			return errors.New("malformed measured M8 row")
 		}
 	}
@@ -796,6 +1187,27 @@ func validateM8ProductionReportV1(report m8ProductionReportV1) error {
 		}
 	}
 	return nil
+}
+
+func validM8AttributionV1(attribution m8ProductionAttributionV1) bool {
+	if attribution.Contract != m8CanonicalResultContractV1 || attribution.GlobalExactRecallAtK != 1 ||
+		attribution.ExhaustivePartitionRecallAtK != 1 || !attribution.ExhaustivePartitionIDParity ||
+		!attribution.ExhaustivePartitionScoreParity || attribution.ApproximateRouterCandidateBudget < 1 ||
+		!slices.Equal(attribution.ResidualLossOwners, m8AttributionLossOwnersV1(attribution)) {
+		return false
+	}
+	for _, recall := range []float64{
+		attribution.ExhaustivePartitionRecallAtK,
+		attribution.ExactRepresentativeRecallAtK,
+		attribution.ApproximateRepresentativeRecallAtK,
+		attribution.LocalHNSWRecallAtK,
+		attribution.EndToEndRecallAtK,
+	} {
+		if math.IsNaN(recall) || math.IsInf(recall, 0) || recall < 0 || recall > 1 {
+			return false
+		}
+	}
+	return true
 }
 
 func m8SHA256V1(value string) bool {

--- a/cmd/treedb_vector_partition_bench/m8_production_runner.go
+++ b/cmd/treedb_vector_partition_bench/m8_production_runner.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bytes"
+	"container/heap"
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
@@ -484,6 +485,44 @@ type m8CanonicalRefResultV1 struct {
 	Score float32
 }
 
+type m8CanonicalRefHeapEntryV1 struct {
+	result m8CanonicalRefResultV1
+	hash   uint64
+	index  int
+	next   *m8CanonicalRefHeapEntryV1
+}
+
+type m8CanonicalRefHeapV1 []*m8CanonicalRefHeapEntryV1
+
+func (h m8CanonicalRefHeapV1) Len() int { return len(h) }
+func (h m8CanonicalRefHeapV1) Less(i, j int) bool {
+	return m8CanonicalRefBetterV1(h[j].result, h[i].result)
+}
+func (h m8CanonicalRefHeapV1) Swap(i, j int) {
+	h[i], h[j] = h[j], h[i]
+	h[i].index, h[j].index = i, j
+}
+func (h *m8CanonicalRefHeapV1) Push(value any) {
+	entry := value.(*m8CanonicalRefHeapEntryV1)
+	entry.index = len(*h)
+	*h = append(*h, entry)
+}
+func (h *m8CanonicalRefHeapV1) Pop() any {
+	old := *h
+	entry := old[len(old)-1]
+	old[len(old)-1] = nil
+	entry.index = -1
+	*h = old[:len(old)-1]
+	return entry
+}
+
+type m8CanonicalRefTopKV1 struct {
+	topK          int
+	heap          m8CanonicalRefHeapV1
+	byHash        map[uint64]*m8CanonicalRefHeapEntryV1
+	idComparisons uint64
+}
+
 const m8CanonicalResultContractV1 = collections.VectorPartitionCanonicalScoreContractV1
 
 func m8CanonicalResultsV1(in []m8CanonicalResultV1, topK int) []m8CanonicalResultV1 {
@@ -553,27 +592,83 @@ func m8CanonicalRefResultsV1(results []m8CanonicalRefResultV1, topK int) []m8Can
 	return results
 }
 
-func m8AppendBoundedCanonicalRefV1(results []m8CanonicalRefResultV1, candidate m8CanonicalRefResultV1, topK int) []m8CanonicalRefResultV1 {
-	if topK <= 0 || len(candidate.ID) == 0 || math.IsNaN(float64(candidate.Score)) || math.IsInf(float64(candidate.Score), 0) {
+func m8CanonicalRefBetterV1(a, b m8CanonicalRefResultV1) bool {
+	return a.Score > b.Score || a.Score == b.Score && bytes.Compare(a.ID, b.ID) < 0
+}
+
+func m8CanonicalRefIDHashV1(id []byte) uint64 {
+	const (
+		offset = uint64(14695981039346656037)
+		prime  = uint64(1099511628211)
+	)
+	hash := offset
+	for _, value := range id {
+		hash ^= uint64(value)
+		hash *= prime
+	}
+	return hash
+}
+
+func newM8CanonicalRefTopKV1(topK int) *m8CanonicalRefTopKV1 {
+	return &m8CanonicalRefTopKV1{topK: topK, heap: make(m8CanonicalRefHeapV1, 0, max(0, topK)), byHash: make(map[uint64]*m8CanonicalRefHeapEntryV1, max(0, topK))}
+}
+
+func (top *m8CanonicalRefTopKV1) add(candidate m8CanonicalRefResultV1) bool {
+	if top == nil || top.topK <= 0 || len(candidate.ID) == 0 || math.IsNaN(float64(candidate.Score)) || math.IsInf(float64(candidate.Score), 0) {
+		return false
+	}
+	hash := m8CanonicalRefIDHashV1(candidate.ID)
+	for entry := top.byHash[hash]; entry != nil; entry = entry.next {
+		top.idComparisons++
+		if bytes.Equal(entry.result.ID, candidate.ID) {
+			if candidate.Score > entry.result.Score {
+				entry.result.Score = candidate.Score
+				heap.Fix(&top.heap, entry.index)
+			}
+			return true
+		}
+	}
+	if len(top.heap) < top.topK {
+		entry := &m8CanonicalRefHeapEntryV1{result: candidate, hash: hash, index: -1, next: top.byHash[hash]}
+		top.byHash[hash] = entry
+		heap.Push(&top.heap, entry)
+		return true
+	}
+	worst := top.heap[0]
+	if !m8CanonicalRefBetterV1(candidate, worst.result) {
+		return true
+	}
+	chain := top.byHash[worst.hash]
+	if chain == worst {
+		if worst.next == nil {
+			delete(top.byHash, worst.hash)
+		} else {
+			top.byHash[worst.hash] = worst.next
+		}
+	} else {
+		for chain != nil && chain.next != worst {
+			chain = chain.next
+		}
+		if chain == nil {
+			return false
+		}
+		chain.next = worst.next
+	}
+	worst.result, worst.hash, worst.next = candidate, hash, top.byHash[hash]
+	top.byHash[hash] = worst
+	heap.Fix(&top.heap, worst.index)
+	return true
+}
+
+func (top *m8CanonicalRefTopKV1) results() []m8CanonicalRefResultV1 {
+	if top == nil || top.topK <= 0 {
 		return nil
 	}
-	for i := range results {
-		if bytes.Equal(results[i].ID, candidate.ID) {
-			if candidate.Score > results[i].Score {
-				results[i] = candidate
-			}
-			return m8CanonicalRefResultsV1(results, topK)
-		}
+	results := make([]m8CanonicalRefResultV1, len(top.heap))
+	for i := range top.heap {
+		results[i] = top.heap[i].result
 	}
-	if len(results) == topK {
-		worst := results[len(results)-1]
-		if candidate.Score < worst.Score || candidate.Score == worst.Score && bytes.Compare(candidate.ID, worst.ID) >= 0 {
-			return results
-		}
-		results[len(results)-1] = candidate
-		return m8CanonicalRefResultsV1(results, topK)
-	}
-	return m8CanonicalRefResultsV1(append(results, candidate), topK)
+	return m8CanonicalRefResultsV1(results, top.topK)
 }
 
 func m8MaterializeCanonicalRefsV1(refs []m8CanonicalRefResultV1) []m8CanonicalResultV1 {
@@ -602,15 +697,17 @@ func m8ExactTruthV1(collection *collections.Collection, manifest collections.Vec
 		if scoreErr != nil {
 			return nil, fmt.Errorf("M8 canonical source oracle query=%d: %w", i, scoreErr)
 		}
-		refs := make([]m8CanonicalRefResultV1, 0, min(topK, len(rows)))
+		refs := newM8CanonicalRefTopKV1(min(topK, len(rows)))
 		for ordinal, row := range rows {
 			score, scoreErr := scorer.ScoreV1(row.Values)
 			if scoreErr != nil {
 				return nil, fmt.Errorf("M8 canonical source oracle query=%d ordinal=%d: %w", i, ordinal, scoreErr)
 			}
-			refs = m8AppendBoundedCanonicalRefV1(refs, m8CanonicalRefResultV1{ID: row.DocumentID, Score: score}, topK)
+			if !refs.add(m8CanonicalRefResultV1{ID: row.DocumentID, Score: score}) {
+				return nil, fmt.Errorf("M8 canonical source oracle query=%d ordinal=%d: retain canonical result", i, ordinal)
+			}
 		}
-		truth[i] = m8MaterializeCanonicalRefsV1(refs)
+		truth[i] = m8MaterializeCanonicalRefsV1(refs.results())
 		if len(truth[i]) != min(topK, len(rows)) {
 			return nil, fmt.Errorf("M8 canonical source oracle query=%d results=%d", i, len(truth[i]))
 		}

--- a/cmd/treedb_vector_partition_bench/main.go
+++ b/cmd/treedb_vector_partition_bench/main.go
@@ -1083,7 +1083,7 @@ func validateM8BenchmarkWork(cfg config, m fixtureManifest, capUnits int64) (m8B
 	if err != nil {
 		return m8BenchmarkWorkPlan{}, err
 	}
-	// Attribution runs once before measured overlap/concurrency rows. For every
+	// Attribution runs once after measured overlap/concurrency rows. For every
 	// query/probe/ef cell it executes exact, approximate, and local-HNSW passes;
 	// the exhaustive partition-union pass is cached once per query.
 	attributionStages, err := memoryMul(3, int64(len(cfg.probes)), int64(len(cfg.efSearch)), int64(m.Queries))

--- a/cmd/treedb_vector_partition_bench/main.go
+++ b/cmd/treedb_vector_partition_bench/main.go
@@ -1070,6 +1070,7 @@ type m8BenchmarkWorkPlan struct {
 	RetainedCoordinatorCells        int64
 	RetainedCoordinatorResults      int64
 	FixtureResidentBytes            int64
+	SourceSnapshotBytes             int64
 	ExactTruthBytes                 int64
 	RetainedCoordinatorBytes        int64
 	ModeledPeakBytes                int64
@@ -1125,6 +1126,18 @@ func validateM8BenchmarkWork(cfg config, m fixtureManifest, capUnits, capBytes i
 	if err != nil {
 		return plan, err
 	}
+	sourceRowBytes, err := memoryAdd(
+		int64(unsafe.Sizeof(collections.VectorPartitionRouterSourceRowV1{})),
+		documentIDStorageBytes,
+		int64(m.Dimensions)*4,
+	)
+	if err != nil {
+		return plan, err
+	}
+	plan.SourceSnapshotBytes, err = memoryMul(int64(m.Vectors), sourceRowBytes)
+	if err != nil {
+		return plan, err
+	}
 
 	// M8 owns the deterministic doc-%06d corpus even when reopening retained
 	// assets, so documentIDStorageBytes bounds its result string storage. The
@@ -1172,16 +1185,23 @@ func validateM8BenchmarkWork(cfg config, m fixtureManifest, capUnits, capBytes i
 	if err != nil {
 		return plan, err
 	}
-	peak, err := memoryAdd(plan.FixtureResidentBytes, plan.ExactTruthBytes, plan.RetainedCoordinatorBytes)
+	// The owned FP32 source snapshot remains live while exact truth accumulates;
+	// it is released before measured coordinator results begin accumulating.
+	sourceOraclePeak, err := memoryAdd(plan.FixtureResidentBytes, plan.SourceSnapshotBytes, plan.ExactTruthBytes)
 	if err != nil {
 		return plan, err
 	}
+	measurementPeak, err := memoryAdd(plan.FixtureResidentBytes, plan.ExactTruthBytes, plan.RetainedCoordinatorBytes)
+	if err != nil {
+		return plan, err
+	}
+	peak := max(sourceOraclePeak, measurementPeak)
 	plan.ModeledPeakBytes, err = memoryScaleCeil(peak, memorySlackNumerator, memorySlackDenominator)
 	if err != nil {
 		return plan, err
 	}
 	if plan.ModeledPeakBytes > capBytes {
-		return plan, fmt.Errorf("modeled M8 benchmark-owned memory %d exceeds -max-fixture-bytes %d: fixture_resident_bytes=%d exact_truth_bytes=%d retained_coordinator_cells=%d retained_coordinator_results=%d retained_coordinator_bytes=%d", plan.ModeledPeakBytes, capBytes, plan.FixtureResidentBytes, plan.ExactTruthBytes, plan.RetainedCoordinatorCells, plan.RetainedCoordinatorResults, plan.RetainedCoordinatorBytes)
+		return plan, fmt.Errorf("modeled M8 benchmark-owned memory %d exceeds -max-fixture-bytes %d: fixture_resident_bytes=%d source_snapshot_bytes=%d exact_truth_bytes=%d retained_coordinator_cells=%d retained_coordinator_results=%d retained_coordinator_bytes=%d", plan.ModeledPeakBytes, capBytes, plan.FixtureResidentBytes, plan.SourceSnapshotBytes, plan.ExactTruthBytes, plan.RetainedCoordinatorCells, plan.RetainedCoordinatorResults, plan.RetainedCoordinatorBytes)
 	}
 	return plan, nil
 }

--- a/cmd/treedb_vector_partition_bench/main.go
+++ b/cmd/treedb_vector_partition_bench/main.go
@@ -2144,11 +2144,14 @@ func dedupeSortedNeighbors(in []neighbor) []neighbor {
 	return out
 }
 
-// canonicalExactNeighborsV1 freezes the benchmark's exact result contract:
-// FP32-derived distances sort ascending, equal scores break by stable ID, and
+// canonicalExactNeighborsV1 freezes the benchmark's production-score contract:
+// distances are rounded through the FP32 search representation, then sort ascending, equal scores break by stable ID, and
 // duplicate IDs retain their best-scoring occurrence before top-k truncation.
 func canonicalExactNeighborsV1(in []neighbor, topK int) []neighbor {
 	ordered := append([]neighbor(nil), in...)
+	for i := range ordered {
+		ordered[i].Distance = float64(float32(ordered[i].Distance))
+	}
 	sortNeighbors(ordered)
 	ordered = dedupeSortedNeighbors(ordered)
 	if topK < len(ordered) {

--- a/cmd/treedb_vector_partition_bench/main.go
+++ b/cmd/treedb_vector_partition_bench/main.go
@@ -466,7 +466,7 @@ func runWithRuntimeCapabilities(args []string, stdout io.Writer, capabilities be
 		if cfg.topK > nativewire.DefaultVectorPartitionShardSearchLimitsV1().MaxTopK {
 			return fmt.Errorf("top-k cannot exceed M8 shard limit %d", nativewire.DefaultVectorPartitionShardSearchLimitsV1().MaxTopK)
 		}
-		if _, err := validateM8BenchmarkWork(cfg, fixture, maxBenchmarkWorkUnits); err != nil {
+		if _, err := validateM8BenchmarkWork(cfg, fixture, maxBenchmarkWorkUnits, cfg.maxBytes); err != nil {
 			return err
 		}
 		vectors, queries := deterministicFixture(fixture)
@@ -1067,11 +1067,17 @@ type m8BenchmarkWorkPlan struct {
 	WarmupAndPreflightQueryRequests int64
 	AttributionQueryPasses          int64
 	QueryRequests                   int64
+	RetainedCoordinatorCells        int64
+	RetainedCoordinatorResults      int64
+	FixtureResidentBytes            int64
+	ExactTruthBytes                 int64
+	RetainedCoordinatorBytes        int64
+	ModeledPeakBytes                int64
 }
 
-func validateM8BenchmarkWork(cfg config, m fixtureManifest, capUnits int64) (m8BenchmarkWorkPlan, error) {
-	if capUnits < 1 || len(cfg.overlaps) == 0 || len(cfg.probes) == 0 || len(cfg.efSearch) == 0 || len(cfg.concurrency) == 0 {
-		return m8BenchmarkWorkPlan{}, errors.New("cannot plan M8 benchmark work without a positive cap and complete sweeps")
+func validateM8BenchmarkWork(cfg config, m fixtureManifest, capUnits, capBytes int64) (m8BenchmarkWorkPlan, error) {
+	if capUnits < 1 || capBytes < 1 || cfg.topK < 1 || m.Vectors < 1 || m.Queries < 1 || m.Dimensions < 1 || len(cfg.overlaps) == 0 || len(cfg.probes) == 0 || len(cfg.efSearch) == 0 || len(cfg.concurrency) == 0 {
+		return m8BenchmarkWorkPlan{}, errors.New("cannot plan M8 benchmark work without positive caps, a valid fixture/top-k, and complete sweeps")
 	}
 	measured, err := memoryMul(int64(len(cfg.overlaps)), int64(len(cfg.probes)), int64(len(cfg.efSearch)), int64(len(cfg.concurrency)), int64(m.Queries))
 	if err != nil {
@@ -1101,6 +1107,81 @@ func validateM8BenchmarkWork(cfg config, m fixtureManifest, capUnits int64) (m8B
 	plan := m8BenchmarkWorkPlan{MeasuredQueryRequests: measured, WarmupAndPreflightQueryRequests: warmupAndPreflight, AttributionQueryPasses: attribution, QueryRequests: requests}
 	if requests > capUnits {
 		return plan, fmt.Errorf("modeled M8 benchmark work exceeds %d-unit cap (%s): measured_query_requests=%d warmup_and_preflight_query_requests=%d attribution_query_passes=%d query_requests=%d", capUnits, m8BenchmarkWorkScope, measured, warmupAndPreflight, attribution, requests)
+	}
+
+	rows, err := memoryAdd(int64(m.Vectors), int64(m.Queries))
+	if err != nil {
+		return plan, err
+	}
+	fixtureValues, err := memoryMul(rows, int64(m.Dimensions), 8)
+	if err != nil {
+		return plan, err
+	}
+	fixtureRows, err := memoryMul(rows, int64(unsafe.Sizeof([]float64{})))
+	if err != nil {
+		return plan, err
+	}
+	plan.FixtureResidentBytes, err = memoryAdd(fixtureValues, fixtureRows)
+	if err != nil {
+		return plan, err
+	}
+
+	// M8 owns the deterministic doc-%06d corpus even when reopening retained
+	// assets, so documentIDStorageBytes bounds its result string storage. The
+	// much larger transport stable-ID limit is not reachable by this harness.
+	resultBytes, err := memoryAdd(int64(unsafe.Sizeof(m8CanonicalResultV1{})), documentIDStorageBytes)
+	if err != nil {
+		return plan, err
+	}
+	perQueryResults, err := memoryMul(int64(cfg.topK), resultBytes)
+	if err != nil {
+		return plan, err
+	}
+	perQueryResults, err = memoryAdd(int64(unsafe.Sizeof([]m8CanonicalResultV1{})), perQueryResults)
+	if err != nil {
+		return plan, err
+	}
+	plan.ExactTruthBytes, err = memoryMul(int64(m.Queries), perQueryResults)
+	if err != nil {
+		return plan, err
+	}
+
+	var supportedOverlaps int64
+	for _, overlap := range cfg.overlaps {
+		if overlap == 0 {
+			supportedOverlaps++
+		}
+	}
+	plan.RetainedCoordinatorCells, err = memoryMul(supportedOverlaps, int64(len(cfg.probes)), int64(len(cfg.efSearch)), int64(len(cfg.concurrency)))
+	if err != nil {
+		return plan, err
+	}
+	plan.RetainedCoordinatorResults, err = memoryMul(plan.RetainedCoordinatorCells, int64(m.Queries), int64(cfg.topK))
+	if err != nil {
+		return plan, err
+	}
+	perCellResults, err := memoryMul(int64(m.Queries), perQueryResults)
+	if err != nil {
+		return plan, err
+	}
+	perCellResults, err = memoryAdd(int64(unsafe.Sizeof(m8MeasuredCellV1{})), perCellResults)
+	if err != nil {
+		return plan, err
+	}
+	plan.RetainedCoordinatorBytes, err = memoryMul(plan.RetainedCoordinatorCells, perCellResults)
+	if err != nil {
+		return plan, err
+	}
+	peak, err := memoryAdd(plan.FixtureResidentBytes, plan.ExactTruthBytes, plan.RetainedCoordinatorBytes)
+	if err != nil {
+		return plan, err
+	}
+	plan.ModeledPeakBytes, err = memoryScaleCeil(peak, memorySlackNumerator, memorySlackDenominator)
+	if err != nil {
+		return plan, err
+	}
+	if plan.ModeledPeakBytes > capBytes {
+		return plan, fmt.Errorf("modeled M8 benchmark-owned memory %d exceeds -max-fixture-bytes %d: fixture_resident_bytes=%d exact_truth_bytes=%d retained_coordinator_cells=%d retained_coordinator_results=%d retained_coordinator_bytes=%d", plan.ModeledPeakBytes, capBytes, plan.FixtureResidentBytes, plan.ExactTruthBytes, plan.RetainedCoordinatorCells, plan.RetainedCoordinatorResults, plan.RetainedCoordinatorBytes)
 	}
 	return plan, nil
 }

--- a/cmd/treedb_vector_partition_bench/main.go
+++ b/cmd/treedb_vector_partition_bench/main.go
@@ -1073,6 +1073,9 @@ type m8BenchmarkWorkPlan struct {
 	SourceSnapshotBytes             int64
 	ExactTruthBytes                 int64
 	RetainedCoordinatorBytes        int64
+	RetainedAttributionMatrices     int64
+	RetainedAttributionResults      int64
+	RetainedAttributionBytes        int64
 	ModeledPeakBytes                int64
 }
 
@@ -1173,15 +1176,39 @@ func validateM8BenchmarkWork(cfg config, m fixtureManifest, capUnits, capBytes i
 	if err != nil {
 		return plan, err
 	}
-	perCellResults, err := memoryMul(int64(m.Queries), perQueryResults)
+	perResultMatrix, err := memoryMul(int64(m.Queries), perQueryResults)
 	if err != nil {
 		return plan, err
 	}
-	perCellResults, err = memoryAdd(int64(unsafe.Sizeof(m8MeasuredCellV1{})), perCellResults)
+	perCellResults, err := memoryAdd(int64(unsafe.Sizeof(m8MeasuredCellV1{})), perResultMatrix)
 	if err != nil {
 		return plan, err
 	}
 	plan.RetainedCoordinatorBytes, err = memoryMul(plan.RetainedCoordinatorCells, perCellResults)
+	if err != nil {
+		return plan, err
+	}
+	attributionCells, err := memoryMul(int64(len(cfg.probes)), int64(len(cfg.efSearch)))
+	if err != nil {
+		return plan, err
+	}
+	plan.RetainedAttributionMatrices, err = memoryAdd(attributionCells, 1) // local matrices plus cached exhaustive union
+	if err != nil {
+		return plan, err
+	}
+	plan.RetainedAttributionResults, err = memoryMul(plan.RetainedAttributionMatrices, int64(m.Queries), int64(cfg.topK))
+	if err != nil {
+		return plan, err
+	}
+	plan.RetainedAttributionBytes, err = memoryMul(plan.RetainedAttributionMatrices, perResultMatrix)
+	if err != nil {
+		return plan, err
+	}
+	attributionMetadata, err := memoryMul(attributionCells, int64(unsafe.Sizeof(m8AttributionCellV1{}))+memoryMapEntryBytes+32)
+	if err != nil {
+		return plan, err
+	}
+	plan.RetainedAttributionBytes, err = memoryAdd(plan.RetainedAttributionBytes, attributionMetadata)
 	if err != nil {
 		return plan, err
 	}
@@ -1195,13 +1222,17 @@ func validateM8BenchmarkWork(cfg config, m fixtureManifest, capUnits, capBytes i
 	if err != nil {
 		return plan, err
 	}
-	peak := max(sourceOraclePeak, measurementPeak)
+	attributionPeak, err := memoryAdd(measurementPeak, plan.RetainedAttributionBytes)
+	if err != nil {
+		return plan, err
+	}
+	peak := max(sourceOraclePeak, attributionPeak)
 	plan.ModeledPeakBytes, err = memoryScaleCeil(peak, memorySlackNumerator, memorySlackDenominator)
 	if err != nil {
 		return plan, err
 	}
 	if plan.ModeledPeakBytes > capBytes {
-		return plan, fmt.Errorf("modeled M8 benchmark-owned memory %d exceeds -max-fixture-bytes %d: fixture_resident_bytes=%d source_snapshot_bytes=%d exact_truth_bytes=%d retained_coordinator_cells=%d retained_coordinator_results=%d retained_coordinator_bytes=%d", plan.ModeledPeakBytes, capBytes, plan.FixtureResidentBytes, plan.SourceSnapshotBytes, plan.ExactTruthBytes, plan.RetainedCoordinatorCells, plan.RetainedCoordinatorResults, plan.RetainedCoordinatorBytes)
+		return plan, fmt.Errorf("modeled M8 benchmark-owned memory %d exceeds -max-fixture-bytes %d: fixture_resident_bytes=%d source_snapshot_bytes=%d exact_truth_bytes=%d retained_coordinator_cells=%d retained_coordinator_results=%d retained_coordinator_bytes=%d retained_attribution_matrices=%d retained_attribution_results=%d retained_attribution_bytes=%d", plan.ModeledPeakBytes, capBytes, plan.FixtureResidentBytes, plan.SourceSnapshotBytes, plan.ExactTruthBytes, plan.RetainedCoordinatorCells, plan.RetainedCoordinatorResults, plan.RetainedCoordinatorBytes, plan.RetainedAttributionMatrices, plan.RetainedAttributionResults, plan.RetainedAttributionBytes)
 	}
 	return plan, nil
 }

--- a/cmd/treedb_vector_partition_bench/main.go
+++ b/cmd/treedb_vector_partition_bench/main.go
@@ -1076,11 +1076,13 @@ type m8BenchmarkWorkPlan struct {
 	RetainedAttributionMatrices     int64
 	RetainedAttributionResults      int64
 	RetainedAttributionBytes        int64
+	AttributionMergeScratchResults  int64
+	AttributionMergeScratchBytes    int64
 	ModeledPeakBytes                int64
 }
 
 func validateM8BenchmarkWork(cfg config, m fixtureManifest, capUnits, capBytes int64) (m8BenchmarkWorkPlan, error) {
-	if capUnits < 1 || capBytes < 1 || cfg.topK < 1 || m.Vectors < 1 || m.Queries < 1 || m.Dimensions < 1 || len(cfg.overlaps) == 0 || len(cfg.probes) == 0 || len(cfg.efSearch) == 0 || len(cfg.concurrency) == 0 {
+	if capUnits < 1 || capBytes < 1 || cfg.partitions < 1 || cfg.topK < 1 || m.Vectors < 1 || m.Queries < 1 || m.Dimensions < 1 || len(cfg.overlaps) == 0 || len(cfg.probes) == 0 || len(cfg.efSearch) == 0 || len(cfg.concurrency) == 0 {
 		return m8BenchmarkWorkPlan{}, errors.New("cannot plan M8 benchmark work without positive caps, a valid fixture/top-k, and complete sweeps")
 	}
 	measured, err := memoryMul(int64(len(cfg.overlaps)), int64(len(cfg.probes)), int64(len(cfg.efSearch)), int64(len(cfg.concurrency)), int64(m.Queries))
@@ -1212,6 +1214,26 @@ func validateM8BenchmarkWork(cfg config, m fixtureManifest, capUnits, capBytes i
 	if err != nil {
 		return plan, err
 	}
+	// The exhaustive attribution search is the largest merge. It reserves one
+	// partition-count by top-k input buffer, canonicalization copies that full
+	// buffer, and duplicate suppression holds at most top-k map entries. The
+	// returned top-k is copied into a right-sized retained matrix above.
+	plan.AttributionMergeScratchResults, err = memoryMul(2, int64(cfg.partitions), int64(cfg.topK))
+	if err != nil {
+		return plan, err
+	}
+	plan.AttributionMergeScratchBytes, err = memoryMul(plan.AttributionMergeScratchResults, int64(unsafe.Sizeof(m8CanonicalResultV1{})))
+	if err != nil {
+		return plan, err
+	}
+	attributionMergeMapBytes, err := memoryMul(int64(cfg.topK), memoryMapEntryBytes)
+	if err != nil {
+		return plan, err
+	}
+	plan.AttributionMergeScratchBytes, err = memoryAdd(plan.AttributionMergeScratchBytes, attributionMergeMapBytes)
+	if err != nil {
+		return plan, err
+	}
 	// The owned FP32 source snapshot remains live while exact truth accumulates;
 	// it is released before measured coordinator results begin accumulating.
 	sourceOraclePeak, err := memoryAdd(plan.FixtureResidentBytes, plan.SourceSnapshotBytes, plan.ExactTruthBytes)
@@ -1222,7 +1244,7 @@ func validateM8BenchmarkWork(cfg config, m fixtureManifest, capUnits, capBytes i
 	if err != nil {
 		return plan, err
 	}
-	attributionPeak, err := memoryAdd(measurementPeak, plan.RetainedAttributionBytes)
+	attributionPeak, err := memoryAdd(measurementPeak, plan.RetainedAttributionBytes, plan.AttributionMergeScratchBytes)
 	if err != nil {
 		return plan, err
 	}
@@ -1232,7 +1254,7 @@ func validateM8BenchmarkWork(cfg config, m fixtureManifest, capUnits, capBytes i
 		return plan, err
 	}
 	if plan.ModeledPeakBytes > capBytes {
-		return plan, fmt.Errorf("modeled M8 benchmark-owned memory %d exceeds -max-fixture-bytes %d: fixture_resident_bytes=%d source_snapshot_bytes=%d exact_truth_bytes=%d retained_coordinator_cells=%d retained_coordinator_results=%d retained_coordinator_bytes=%d retained_attribution_matrices=%d retained_attribution_results=%d retained_attribution_bytes=%d", plan.ModeledPeakBytes, capBytes, plan.FixtureResidentBytes, plan.SourceSnapshotBytes, plan.ExactTruthBytes, plan.RetainedCoordinatorCells, plan.RetainedCoordinatorResults, plan.RetainedCoordinatorBytes, plan.RetainedAttributionMatrices, plan.RetainedAttributionResults, plan.RetainedAttributionBytes)
+		return plan, fmt.Errorf("modeled M8 benchmark-owned memory %d exceeds -max-fixture-bytes %d: fixture_resident_bytes=%d source_snapshot_bytes=%d exact_truth_bytes=%d retained_coordinator_cells=%d retained_coordinator_results=%d retained_coordinator_bytes=%d retained_attribution_matrices=%d retained_attribution_results=%d retained_attribution_bytes=%d attribution_merge_scratch_results=%d attribution_merge_scratch_bytes=%d", plan.ModeledPeakBytes, capBytes, plan.FixtureResidentBytes, plan.SourceSnapshotBytes, plan.ExactTruthBytes, plan.RetainedCoordinatorCells, plan.RetainedCoordinatorResults, plan.RetainedCoordinatorBytes, plan.RetainedAttributionMatrices, plan.RetainedAttributionResults, plan.RetainedAttributionBytes, plan.AttributionMergeScratchResults, plan.AttributionMergeScratchBytes)
 	}
 	return plan, nil
 }

--- a/cmd/treedb_vector_partition_bench/main.go
+++ b/cmd/treedb_vector_partition_bench/main.go
@@ -1069,6 +1069,8 @@ type m8BenchmarkWorkPlan struct {
 	QueryRequests                   int64
 	RetainedCoordinatorCells        int64
 	RetainedCoordinatorResults      int64
+	CurrentCellOutcomes             int64
+	CurrentCellOutcomeBytes         int64
 	FixtureResidentBytes            int64
 	SourceSnapshotBytes             int64
 	ExactTruthBytes                 int64
@@ -1190,6 +1192,55 @@ func validateM8BenchmarkWork(cfg config, m fixtureManifest, capUnits, capBytes i
 	if err != nil {
 		return plan, err
 	}
+	maxProbes, maxEFSearch, maxConcurrency := 0, 0, 0
+	for _, probes := range cfg.probes {
+		maxProbes = max(maxProbes, probes)
+	}
+	for _, efSearch := range cfg.efSearch {
+		maxEFSearch = max(maxEFSearch, efSearch)
+	}
+	for _, concurrency := range cfg.concurrency {
+		maxConcurrency = max(maxConcurrency, concurrency)
+	}
+	// m8RunProductionCellV1 retains every raw response until the full cell has
+	// completed. Bound the largest response shape, including the backing arrays
+	// and harness-owned identity strings that are not included in the response
+	// struct or the retained canonical top-k matrices.
+	neighborBytes, err := memoryMul(int64(cfg.topK), int64(unsafe.Sizeof(nativewire.VectorPartitionCoordinatorNeighborV1{}))+documentIDStorageBytes)
+	if err != nil {
+		return plan, err
+	}
+	partitionBytes, err := memoryMul(int64(maxProbes), int64(unsafe.Sizeof(uint32(0))))
+	if err != nil {
+		return plan, err
+	}
+	// Group IDs and the response digests reference generation-pinned topology
+	// storage; each response owns the group string headers, not duplicate backing
+	// strings. RequestID is formatted per query and remains owned by the outcome.
+	maxGroups := min(maxProbes, cfg.raftGroups)
+	if maxGroups < 1 {
+		maxGroups = maxProbes // conservative for direct planner callers without parsed defaults
+	}
+	groupBytes, err := memoryMul(int64(maxGroups), int64(unsafe.Sizeof("")))
+	if err != nil {
+		return plan, err
+	}
+	requestIDStorageBytes := int64(len(fmt.Sprintf("m8-q-%06d-p-%04d-ef-%06d-c-%03d", max(0, m.Queries-1), maxProbes, maxEFSearch, maxConcurrency)))
+	perOutcomeBytes, err := memoryAdd(
+		int64(unsafe.Sizeof(m8ProductionCellOutcomeV1{})),
+		neighborBytes,
+		partitionBytes,
+		groupBytes,
+		requestIDStorageBytes,
+	)
+	if err != nil {
+		return plan, err
+	}
+	plan.CurrentCellOutcomes = int64(m.Queries)
+	plan.CurrentCellOutcomeBytes, err = memoryMul(plan.CurrentCellOutcomes, perOutcomeBytes)
+	if err != nil {
+		return plan, err
+	}
 	attributionCells, err := memoryMul(int64(len(cfg.probes)), int64(len(cfg.efSearch)))
 	if err != nil {
 		return plan, err
@@ -1245,21 +1296,25 @@ func validateM8BenchmarkWork(cfg config, m fixtureManifest, capUnits, capBytes i
 	if err != nil {
 		return plan, err
 	}
-	measurementPeak, err := memoryAdd(plan.FixtureResidentBytes, plan.ExactTruthBytes, plan.RetainedCoordinatorBytes)
+	measurementBase, err := memoryAdd(plan.FixtureResidentBytes, plan.ExactTruthBytes, plan.RetainedCoordinatorBytes)
 	if err != nil {
 		return plan, err
 	}
-	attributionPeak, err := memoryAdd(measurementPeak, plan.RetainedAttributionBytes, plan.AttributionMergeScratchBytes)
+	measurementPeak, err := memoryAdd(measurementBase, plan.CurrentCellOutcomeBytes)
 	if err != nil {
 		return plan, err
 	}
-	peak := max(sourceOraclePeak, attributionPeak)
+	attributionPeak, err := memoryAdd(measurementBase, plan.RetainedAttributionBytes, plan.AttributionMergeScratchBytes)
+	if err != nil {
+		return plan, err
+	}
+	peak := max(sourceOraclePeak, measurementPeak, attributionPeak)
 	plan.ModeledPeakBytes, err = memoryScaleCeil(peak, memorySlackNumerator, memorySlackDenominator)
 	if err != nil {
 		return plan, err
 	}
 	if plan.ModeledPeakBytes > capBytes {
-		return plan, fmt.Errorf("modeled M8 benchmark-owned memory %d exceeds -max-fixture-bytes %d: fixture_resident_bytes=%d source_snapshot_bytes=%d exact_truth_bytes=%d retained_coordinator_cells=%d retained_coordinator_results=%d retained_coordinator_bytes=%d retained_attribution_matrices=%d retained_attribution_results=%d retained_attribution_bytes=%d attribution_merge_scratch_results=%d attribution_merge_scratch_bytes=%d", plan.ModeledPeakBytes, capBytes, plan.FixtureResidentBytes, plan.SourceSnapshotBytes, plan.ExactTruthBytes, plan.RetainedCoordinatorCells, plan.RetainedCoordinatorResults, plan.RetainedCoordinatorBytes, plan.RetainedAttributionMatrices, plan.RetainedAttributionResults, plan.RetainedAttributionBytes, plan.AttributionMergeScratchResults, plan.AttributionMergeScratchBytes)
+		return plan, fmt.Errorf("modeled M8 benchmark-owned memory %d exceeds -max-fixture-bytes %d: fixture_resident_bytes=%d source_snapshot_bytes=%d exact_truth_bytes=%d retained_coordinator_cells=%d retained_coordinator_results=%d retained_coordinator_bytes=%d current_cell_outcomes=%d current_cell_outcome_bytes=%d retained_attribution_matrices=%d retained_attribution_results=%d retained_attribution_bytes=%d attribution_merge_scratch_results=%d attribution_merge_scratch_bytes=%d", plan.ModeledPeakBytes, capBytes, plan.FixtureResidentBytes, plan.SourceSnapshotBytes, plan.ExactTruthBytes, plan.RetainedCoordinatorCells, plan.RetainedCoordinatorResults, plan.RetainedCoordinatorBytes, plan.CurrentCellOutcomes, plan.CurrentCellOutcomeBytes, plan.RetainedAttributionMatrices, plan.RetainedAttributionResults, plan.RetainedAttributionBytes, plan.AttributionMergeScratchResults, plan.AttributionMergeScratchBytes)
 	}
 	return plan, nil
 }

--- a/cmd/treedb_vector_partition_bench/main.go
+++ b/cmd/treedb_vector_partition_bench/main.go
@@ -694,6 +694,11 @@ func parseConfig(args []string) (config, error) {
 				return config{}, fmt.Errorf("each ef-search must be in [%d,%d]", cfg.topK, shardLimits.MaxEfSearch)
 			}
 		}
+		for _, probes := range cfg.probes {
+			if probes > cfg.routerCandidates {
+				return config{}, errors.New("production_multi_group requires router-candidates >= every probe count")
+			}
+		}
 	}
 	if cfg.m3PersistDir != "" && (cfg.stage != "overlap,partition_index" || len(cfg.overlaps) != 1) {
 		return config{}, errors.New("-m3-persist-db requires stage overlap,partition_index with exactly one overlap ratio")

--- a/cmd/treedb_vector_partition_bench/main.go
+++ b/cmd/treedb_vector_partition_bench/main.go
@@ -1087,7 +1087,13 @@ func validateM8BenchmarkWork(cfg config, m fixtureManifest, capUnits, capBytes i
 	if capUnits < 1 || capBytes < 1 || cfg.partitions < 1 || cfg.topK < 1 || m.Vectors < 1 || m.Queries < 1 || m.Dimensions < 1 || len(cfg.overlaps) == 0 || len(cfg.probes) == 0 || len(cfg.efSearch) == 0 || len(cfg.concurrency) == 0 {
 		return m8BenchmarkWorkPlan{}, errors.New("cannot plan M8 benchmark work without positive caps, a valid fixture/top-k, and complete sweeps")
 	}
-	measured, err := memoryMul(int64(len(cfg.overlaps)), int64(len(cfg.probes)), int64(len(cfg.efSearch)), int64(len(cfg.concurrency)), int64(m.Queries))
+	var supportedOverlaps int64
+	for _, overlap := range cfg.overlaps {
+		if overlap == 0 {
+			supportedOverlaps++
+		}
+	}
+	measured, err := memoryMul(supportedOverlaps, int64(len(cfg.probes)), int64(len(cfg.efSearch)), int64(len(cfg.concurrency)), int64(m.Queries))
 	if err != nil {
 		return m8BenchmarkWorkPlan{}, err
 	}
@@ -1100,13 +1106,16 @@ func validateM8BenchmarkWork(cfg config, m fixtureManifest, capUnits, capBytes i
 	// Attribution runs once after measured overlap/concurrency rows. For every
 	// query/probe/ef cell it executes exact, approximate, and local-HNSW passes;
 	// the exhaustive partition-union pass is cached once per query.
-	attributionStages, err := memoryMul(3, int64(len(cfg.probes)), int64(len(cfg.efSearch)), int64(m.Queries))
-	if err != nil {
-		return m8BenchmarkWorkPlan{}, err
-	}
-	attribution, err := memoryAdd(int64(m.Queries), attributionStages)
-	if err != nil {
-		return m8BenchmarkWorkPlan{}, err
+	var attribution int64
+	if supportedOverlaps > 0 {
+		attributionStages, stageErr := memoryMul(3, int64(len(cfg.probes)), int64(len(cfg.efSearch)), int64(m.Queries))
+		if stageErr != nil {
+			return m8BenchmarkWorkPlan{}, stageErr
+		}
+		attribution, err = memoryAdd(int64(m.Queries), attributionStages)
+		if err != nil {
+			return m8BenchmarkWorkPlan{}, err
+		}
 	}
 	requests, err := memoryAdd(measured, warmupAndPreflight, attribution)
 	if err != nil {
@@ -1166,12 +1175,6 @@ func validateM8BenchmarkWork(cfg config, m fixtureManifest, capUnits, capBytes i
 		return plan, err
 	}
 
-	var supportedOverlaps int64
-	for _, overlap := range cfg.overlaps {
-		if overlap == 0 {
-			supportedOverlaps++
-		}
-	}
 	plan.RetainedCoordinatorCells, err = memoryMul(supportedOverlaps, int64(len(cfg.probes)), int64(len(cfg.efSearch)), int64(len(cfg.concurrency)))
 	if err != nil {
 		return plan, err
@@ -1192,103 +1195,107 @@ func validateM8BenchmarkWork(cfg config, m fixtureManifest, capUnits, capBytes i
 	if err != nil {
 		return plan, err
 	}
-	maxProbes, maxEFSearch, maxConcurrency := 0, 0, 0
-	for _, probes := range cfg.probes {
-		maxProbes = max(maxProbes, probes)
+	if supportedOverlaps > 0 {
+		maxProbes, maxEFSearch, maxConcurrency := 0, 0, 0
+		for _, probes := range cfg.probes {
+			maxProbes = max(maxProbes, probes)
+		}
+		for _, efSearch := range cfg.efSearch {
+			maxEFSearch = max(maxEFSearch, efSearch)
+		}
+		for _, concurrency := range cfg.concurrency {
+			maxConcurrency = max(maxConcurrency, concurrency)
+		}
+		// m8RunProductionCellV1 retains every raw response until the full cell has
+		// completed. Bound the largest response shape, including the backing arrays
+		// and harness-owned identity strings that are not included in the response
+		// struct or the retained canonical top-k matrices.
+		neighborBytes, err := memoryMul(int64(cfg.topK), int64(unsafe.Sizeof(nativewire.VectorPartitionCoordinatorNeighborV1{}))+documentIDStorageBytes)
+		if err != nil {
+			return plan, err
+		}
+		partitionBytes, err := memoryMul(int64(maxProbes), int64(unsafe.Sizeof(uint32(0))))
+		if err != nil {
+			return plan, err
+		}
+		// Group IDs and the response digests reference generation-pinned topology
+		// storage; each response owns the group string headers, not duplicate backing
+		// strings. RequestID is formatted per query and remains owned by the outcome.
+		maxGroups := min(maxProbes, cfg.raftGroups)
+		if maxGroups < 1 {
+			maxGroups = maxProbes // conservative for direct planner callers without parsed defaults
+		}
+		groupBytes, err := memoryMul(int64(maxGroups), int64(unsafe.Sizeof("")))
+		if err != nil {
+			return plan, err
+		}
+		requestIDStorageBytes := int64(len(fmt.Sprintf("m8-q-%06d-p-%04d-ef-%06d-c-%03d", max(0, m.Queries-1), maxProbes, maxEFSearch, maxConcurrency)))
+		perOutcomeBytes, err := memoryAdd(
+			int64(unsafe.Sizeof(m8ProductionCellOutcomeV1{})),
+			neighborBytes,
+			partitionBytes,
+			groupBytes,
+			requestIDStorageBytes,
+		)
+		if err != nil {
+			return plan, err
+		}
+		plan.CurrentCellOutcomes = int64(m.Queries)
+		plan.CurrentCellOutcomeBytes, err = memoryMul(plan.CurrentCellOutcomes, perOutcomeBytes)
+		if err != nil {
+			return plan, err
+		}
 	}
-	for _, efSearch := range cfg.efSearch {
-		maxEFSearch = max(maxEFSearch, efSearch)
-	}
-	for _, concurrency := range cfg.concurrency {
-		maxConcurrency = max(maxConcurrency, concurrency)
-	}
-	// m8RunProductionCellV1 retains every raw response until the full cell has
-	// completed. Bound the largest response shape, including the backing arrays
-	// and harness-owned identity strings that are not included in the response
-	// struct or the retained canonical top-k matrices.
-	neighborBytes, err := memoryMul(int64(cfg.topK), int64(unsafe.Sizeof(nativewire.VectorPartitionCoordinatorNeighborV1{}))+documentIDStorageBytes)
-	if err != nil {
-		return plan, err
-	}
-	partitionBytes, err := memoryMul(int64(maxProbes), int64(unsafe.Sizeof(uint32(0))))
-	if err != nil {
-		return plan, err
-	}
-	// Group IDs and the response digests reference generation-pinned topology
-	// storage; each response owns the group string headers, not duplicate backing
-	// strings. RequestID is formatted per query and remains owned by the outcome.
-	maxGroups := min(maxProbes, cfg.raftGroups)
-	if maxGroups < 1 {
-		maxGroups = maxProbes // conservative for direct planner callers without parsed defaults
-	}
-	groupBytes, err := memoryMul(int64(maxGroups), int64(unsafe.Sizeof("")))
-	if err != nil {
-		return plan, err
-	}
-	requestIDStorageBytes := int64(len(fmt.Sprintf("m8-q-%06d-p-%04d-ef-%06d-c-%03d", max(0, m.Queries-1), maxProbes, maxEFSearch, maxConcurrency)))
-	perOutcomeBytes, err := memoryAdd(
-		int64(unsafe.Sizeof(m8ProductionCellOutcomeV1{})),
-		neighborBytes,
-		partitionBytes,
-		groupBytes,
-		requestIDStorageBytes,
-	)
-	if err != nil {
-		return plan, err
-	}
-	plan.CurrentCellOutcomes = int64(m.Queries)
-	plan.CurrentCellOutcomeBytes, err = memoryMul(plan.CurrentCellOutcomes, perOutcomeBytes)
-	if err != nil {
-		return plan, err
-	}
-	attributionCells, err := memoryMul(int64(len(cfg.probes)), int64(len(cfg.efSearch)))
-	if err != nil {
-		return plan, err
-	}
-	plan.RetainedAttributionMatrices, err = memoryAdd(attributionCells, 1) // local matrices plus cached exhaustive union
-	if err != nil {
-		return plan, err
-	}
-	plan.RetainedAttributionResults, err = memoryMul(plan.RetainedAttributionMatrices, int64(m.Queries), int64(cfg.topK))
-	if err != nil {
-		return plan, err
-	}
-	plan.RetainedAttributionBytes, err = memoryMul(plan.RetainedAttributionMatrices, perResultMatrix)
-	if err != nil {
-		return plan, err
-	}
-	attributionMetadata, err := memoryMul(attributionCells, int64(unsafe.Sizeof(m8AttributionCellV1{}))+memoryMapEntryBytes+32)
-	if err != nil {
-		return plan, err
-	}
-	plan.RetainedAttributionBytes, err = memoryAdd(plan.RetainedAttributionBytes, attributionMetadata)
-	if err != nil {
-		return plan, err
-	}
-	// The exhaustive attribution search is the largest merge. It reserves one
-	// partition-count by top-k input buffer, canonicalization copies that full
-	// buffer, and the input retains one owned document-ID allocation per
-	// candidate. Duplicate suppression holds at most top-k map entries. The
-	// returned top-k is copied into a right-sized retained matrix above.
-	plan.AttributionMergeScratchResults, err = memoryMul(2, int64(cfg.partitions), int64(cfg.topK))
-	if err != nil {
-		return plan, err
-	}
-	plan.AttributionMergeScratchBytes, err = memoryMul(plan.AttributionMergeScratchResults, int64(unsafe.Sizeof(m8CanonicalResultV1{})))
-	if err != nil {
-		return plan, err
-	}
-	attributionMergeIDBytes, err := memoryMul(int64(cfg.partitions), int64(cfg.topK), documentIDStorageBytes)
-	if err != nil {
-		return plan, err
-	}
-	attributionMergeMapBytes, err := memoryMul(int64(cfg.topK), memoryMapEntryBytes)
-	if err != nil {
-		return plan, err
-	}
-	plan.AttributionMergeScratchBytes, err = memoryAdd(plan.AttributionMergeScratchBytes, attributionMergeIDBytes, attributionMergeMapBytes)
-	if err != nil {
-		return plan, err
+	if supportedOverlaps > 0 {
+		attributionCells, attributionErr := memoryMul(int64(len(cfg.probes)), int64(len(cfg.efSearch)))
+		if attributionErr != nil {
+			return plan, attributionErr
+		}
+		plan.RetainedAttributionMatrices, err = memoryAdd(attributionCells, 1) // local matrices plus cached exhaustive union
+		if err != nil {
+			return plan, err
+		}
+		plan.RetainedAttributionResults, err = memoryMul(plan.RetainedAttributionMatrices, int64(m.Queries), int64(cfg.topK))
+		if err != nil {
+			return plan, err
+		}
+		plan.RetainedAttributionBytes, err = memoryMul(plan.RetainedAttributionMatrices, perResultMatrix)
+		if err != nil {
+			return plan, err
+		}
+		attributionMetadata, err := memoryMul(attributionCells, int64(unsafe.Sizeof(m8AttributionCellV1{}))+memoryMapEntryBytes+32)
+		if err != nil {
+			return plan, err
+		}
+		plan.RetainedAttributionBytes, err = memoryAdd(plan.RetainedAttributionBytes, attributionMetadata)
+		if err != nil {
+			return plan, err
+		}
+		// The exhaustive attribution search is the largest merge. It reserves one
+		// partition-count by top-k input buffer, canonicalization copies that full
+		// buffer, and the input retains one owned document-ID allocation per
+		// candidate. Duplicate suppression holds at most top-k map entries. The
+		// returned top-k is copied into a right-sized retained matrix above.
+		plan.AttributionMergeScratchResults, err = memoryMul(2, int64(cfg.partitions), int64(cfg.topK))
+		if err != nil {
+			return plan, err
+		}
+		plan.AttributionMergeScratchBytes, err = memoryMul(plan.AttributionMergeScratchResults, int64(unsafe.Sizeof(m8CanonicalResultV1{})))
+		if err != nil {
+			return plan, err
+		}
+		attributionMergeIDBytes, err := memoryMul(int64(cfg.partitions), int64(cfg.topK), documentIDStorageBytes)
+		if err != nil {
+			return plan, err
+		}
+		attributionMergeMapBytes, err := memoryMul(int64(cfg.topK), memoryMapEntryBytes)
+		if err != nil {
+			return plan, err
+		}
+		plan.AttributionMergeScratchBytes, err = memoryAdd(plan.AttributionMergeScratchBytes, attributionMergeIDBytes, attributionMergeMapBytes)
+		if err != nil {
+			return plan, err
+		}
 	}
 	// The owned FP32 source snapshot remains live while exact truth accumulates;
 	// it is released before measured coordinator results begin accumulating.

--- a/cmd/treedb_vector_partition_bench/main.go
+++ b/cmd/treedb_vector_partition_bench/main.go
@@ -56,6 +56,7 @@ const (
 	memorySlackDenominator               = 4
 	memoryBudgetScope                    = "modeled_peak_live_bytes_v1: contiguous generated float64 fixture/query matrices and row headers; exact/selected top-k candidates; representative routing; persisted router ingest JSON/IDs/slices and source-row capture; HNSW partition JSON plus decoded JSON/vector batch; HNSW query merge and cache; 25% allocation slack; excludes TreeDB engine/index internals, Go runtime/GC metadata, and artifact/CLI encoding"
 	benchmarkWorkScope                   = "benchmark_owned_vector_query_corpus_visits_v1: checksum exact truth once; mandatory truth plus enabled exhaustive/routing corpus passes for every probe/overlap row; excludes TreeDB HNSW engine-internal search work"
+	m8BenchmarkWorkScope                 = "m8_query_passes_v1: measured coordinator requests, warmup/endpoint preflight, cached exhaustive attribution, and exact/approximate/local-HNSW attribution passes; excludes the pre-existing canonical source oracle and engine-internal HNSW work"
 )
 
 type config struct {
@@ -1061,25 +1062,45 @@ type m3BenchmarkWorkPlan struct {
 	VectorQueryVisits           int64
 }
 
-type m8BenchmarkWorkPlan struct{ QueryRequests int64 }
+type m8BenchmarkWorkPlan struct {
+	MeasuredQueryRequests           int64
+	WarmupAndPreflightQueryRequests int64
+	AttributionQueryPasses          int64
+	QueryRequests                   int64
+}
 
 func validateM8BenchmarkWork(cfg config, m fixtureManifest, capUnits int64) (m8BenchmarkWorkPlan, error) {
 	if capUnits < 1 || len(cfg.overlaps) == 0 || len(cfg.probes) == 0 || len(cfg.efSearch) == 0 || len(cfg.concurrency) == 0 {
 		return m8BenchmarkWorkPlan{}, errors.New("cannot plan M8 benchmark work without a positive cap and complete sweeps")
 	}
-	requests, err := memoryMul(int64(len(cfg.overlaps)), int64(len(cfg.probes)), int64(len(cfg.efSearch)), int64(len(cfg.concurrency)), int64(m.Queries))
+	measured, err := memoryMul(int64(len(cfg.overlaps)), int64(len(cfg.probes)), int64(len(cfg.efSearch)), int64(len(cfg.concurrency)), int64(m.Queries))
 	if err != nil {
 		return m8BenchmarkWorkPlan{}, err
 	}
 	// Production M8 also performs one exhaustive endpoint preflight and the
 	// configured untimed warmup requests outside the measured cell sweep.
-	requests, err = memoryAdd(requests, int64(cfg.warmup), 1)
+	warmupAndPreflight, err := memoryAdd(int64(cfg.warmup), 1)
 	if err != nil {
 		return m8BenchmarkWorkPlan{}, err
 	}
-	plan := m8BenchmarkWorkPlan{QueryRequests: requests}
+	// Attribution runs once before measured overlap/concurrency rows. For every
+	// query/probe/ef cell it executes exact, approximate, and local-HNSW passes;
+	// the exhaustive partition-union pass is cached once per query.
+	attributionStages, err := memoryMul(3, int64(len(cfg.probes)), int64(len(cfg.efSearch)), int64(m.Queries))
+	if err != nil {
+		return m8BenchmarkWorkPlan{}, err
+	}
+	attribution, err := memoryAdd(int64(m.Queries), attributionStages)
+	if err != nil {
+		return m8BenchmarkWorkPlan{}, err
+	}
+	requests, err := memoryAdd(measured, warmupAndPreflight, attribution)
+	if err != nil {
+		return m8BenchmarkWorkPlan{}, err
+	}
+	plan := m8BenchmarkWorkPlan{MeasuredQueryRequests: measured, WarmupAndPreflightQueryRequests: warmupAndPreflight, AttributionQueryPasses: attribution, QueryRequests: requests}
 	if requests > capUnits {
-		return plan, fmt.Errorf("modeled M8 benchmark work exceeds %d-unit cap (%s): query_requests=%d", capUnits, benchmarkWorkScope, requests)
+		return plan, fmt.Errorf("modeled M8 benchmark work exceeds %d-unit cap (%s): measured_query_requests=%d warmup_and_preflight_query_requests=%d attribution_query_passes=%d query_requests=%d", capUnits, m8BenchmarkWorkScope, measured, warmupAndPreflight, attribution, requests)
 	}
 	return plan, nil
 }

--- a/cmd/treedb_vector_partition_bench/main.go
+++ b/cmd/treedb_vector_partition_bench/main.go
@@ -2144,6 +2144,19 @@ func dedupeSortedNeighbors(in []neighbor) []neighbor {
 	return out
 }
 
+// canonicalExactNeighborsV1 freezes the benchmark's exact result contract:
+// FP32-derived distances sort ascending, equal scores break by stable ID, and
+// duplicate IDs retain their best-scoring occurrence before top-k truncation.
+func canonicalExactNeighborsV1(in []neighbor, topK int) []neighbor {
+	ordered := append([]neighbor(nil), in...)
+	sortNeighbors(ordered)
+	ordered = dedupeSortedNeighbors(ordered)
+	if topK < len(ordered) {
+		ordered = ordered[:topK]
+	}
+	return ordered
+}
+
 func recall(want, got []neighbor) float64 {
 	found := map[string]bool{}
 	for _, x := range got {

--- a/cmd/treedb_vector_partition_bench/main.go
+++ b/cmd/treedb_vector_partition_bench/main.go
@@ -2144,12 +2144,18 @@ func dedupeSortedNeighbors(in []neighbor) []neighbor {
 	return out
 }
 
-// canonicalExactNeighborsV1 freezes the benchmark's production-score contract:
-// distances are rounded through the FP32 search representation, then sort ascending, equal scores break by stable ID, and
-// duplicate IDs retain their best-scoring occurrence before top-k truncation.
+// canonicalExactNeighborsV1 keeps the legacy simulation distance representation
+// deterministic. Production M8 evidence uses m8CanonicalResultsV1 and the
+// executable collections.VectorPartitionCanonicalScoreContractV1 instead.
 func canonicalExactNeighborsV1(in []neighbor, topK int) []neighbor {
+	if topK <= 0 {
+		return nil
+	}
 	ordered := append([]neighbor(nil), in...)
 	for i := range ordered {
+		if ordered[i].ID == "" || math.IsNaN(ordered[i].Distance) || math.IsInf(ordered[i].Distance, 0) {
+			return nil
+		}
 		ordered[i].Distance = float64(float32(ordered[i].Distance))
 	}
 	sortNeighbors(ordered)

--- a/cmd/treedb_vector_partition_bench/main.go
+++ b/cmd/treedb_vector_partition_bench/main.go
@@ -1216,7 +1216,8 @@ func validateM8BenchmarkWork(cfg config, m fixtureManifest, capUnits, capBytes i
 	}
 	// The exhaustive attribution search is the largest merge. It reserves one
 	// partition-count by top-k input buffer, canonicalization copies that full
-	// buffer, and duplicate suppression holds at most top-k map entries. The
+	// buffer, and the input retains one owned document-ID allocation per
+	// candidate. Duplicate suppression holds at most top-k map entries. The
 	// returned top-k is copied into a right-sized retained matrix above.
 	plan.AttributionMergeScratchResults, err = memoryMul(2, int64(cfg.partitions), int64(cfg.topK))
 	if err != nil {
@@ -1226,11 +1227,15 @@ func validateM8BenchmarkWork(cfg config, m fixtureManifest, capUnits, capBytes i
 	if err != nil {
 		return plan, err
 	}
+	attributionMergeIDBytes, err := memoryMul(int64(cfg.partitions), int64(cfg.topK), documentIDStorageBytes)
+	if err != nil {
+		return plan, err
+	}
 	attributionMergeMapBytes, err := memoryMul(int64(cfg.topK), memoryMapEntryBytes)
 	if err != nil {
 		return plan, err
 	}
-	plan.AttributionMergeScratchBytes, err = memoryAdd(plan.AttributionMergeScratchBytes, attributionMergeMapBytes)
+	plan.AttributionMergeScratchBytes, err = memoryAdd(plan.AttributionMergeScratchBytes, attributionMergeIDBytes, attributionMergeMapBytes)
 	if err != nil {
 		return plan, err
 	}

--- a/cmd/treedb_vector_partition_bench/main_test.go
+++ b/cmd/treedb_vector_partition_bench/main_test.go
@@ -1106,14 +1106,14 @@ func TestM8ProductionModeParsesCanonicalTopologyAndSweepsV1(t *testing.T) {
 func TestM8BenchmarkWorkCapAndOverflowV1(t *testing.T) {
 	cfg := config{partitions: 4, overlaps: []float64{0, .2}, probes: []int{1, 4}, efSearch: []int{64, 128}, concurrency: []int{1, 2}, warmup: 3, topK: 2}
 	manifest := fixtureManifest{Vectors: 10, Queries: 5, Dimensions: 8}
-	plan, err := validateM8BenchmarkWork(cfg, manifest, 149, math.MaxInt64)
-	if err != nil || plan.QueryRequests != 149 || plan.MeasuredQueryRequests != 80 || plan.WarmupAndPreflightQueryRequests != 4 || plan.AttributionQueryPasses != 65 {
+	plan, err := validateM8BenchmarkWork(cfg, manifest, 109, math.MaxInt64)
+	if err != nil || plan.QueryRequests != 109 || plan.MeasuredQueryRequests != 40 || plan.WarmupAndPreflightQueryRequests != 4 || plan.AttributionQueryPasses != 65 {
 		t.Fatalf("M8 work plan=%+v err=%v", plan, err)
 	}
 	if plan.RetainedCoordinatorCells != 8 || plan.RetainedCoordinatorResults != 80 || plan.CurrentCellOutcomes != 5 || plan.CurrentCellOutcomeBytes == 0 || plan.FixtureResidentBytes == 0 || plan.SourceSnapshotBytes == 0 || plan.ExactTruthBytes == 0 || plan.RetainedCoordinatorBytes == 0 || plan.RetainedAttributionMatrices != 5 || plan.RetainedAttributionResults != 50 || plan.RetainedAttributionBytes == 0 || plan.AttributionMergeScratchResults != 16 || plan.AttributionMergeScratchBytes == 0 || plan.ModeledPeakBytes == 0 {
 		t.Fatalf("incomplete M8 memory plan=%+v", plan)
 	}
-	if _, err := validateM8BenchmarkWork(cfg, manifest, 148, math.MaxInt64); err == nil {
+	if _, err := validateM8BenchmarkWork(cfg, manifest, 108, math.MaxInt64); err == nil {
 		t.Fatal("accepted oversized M8 sweep")
 	}
 	if _, err := validateM8BenchmarkWork(cfg, fixtureManifest{Vectors: 1, Queries: math.MaxInt, Dimensions: 1}, maxBenchmarkWorkUnits, math.MaxInt64); err == nil {
@@ -1121,6 +1121,18 @@ func TestM8BenchmarkWorkCapAndOverflowV1(t *testing.T) {
 	}
 	if _, err := validateM8BenchmarkWork(config{partitions: 1, overlaps: []float64{0}, probes: []int{1}, efSearch: []int{64}, concurrency: []int{1}, topK: 1}, fixtureManifest{Vectors: 1, Queries: math.MaxInt, Dimensions: 1}, maxBenchmarkWorkUnits, math.MaxInt64); err == nil {
 		t.Fatal("accepted overflowing M8 preflight accounting")
+	}
+}
+
+func TestM8UnsupportedOverlapSkipsMeasuredAndAttributionWorkV1(t *testing.T) {
+	cfg := config{partitions: 4, overlaps: []float64{.2}, probes: []int{1, 4}, efSearch: []int{64, 128}, concurrency: []int{1, 2}, warmup: 3, topK: 2}
+	manifest := fixtureManifest{Vectors: 10, Queries: 5, Dimensions: 8}
+	plan, err := validateM8BenchmarkWork(cfg, manifest, 4, math.MaxInt64)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if plan.QueryRequests != 4 || plan.MeasuredQueryRequests != 0 || plan.WarmupAndPreflightQueryRequests != 4 || plan.AttributionQueryPasses != 0 || plan.RetainedCoordinatorCells != 0 || plan.RetainedCoordinatorResults != 0 || plan.CurrentCellOutcomes != 0 || plan.CurrentCellOutcomeBytes != 0 || plan.RetainedAttributionMatrices != 0 || plan.RetainedAttributionResults != 0 || plan.RetainedAttributionBytes != 0 || plan.AttributionMergeScratchResults != 0 || plan.AttributionMergeScratchBytes != 0 {
+		t.Fatalf("unsupported-only M8 work plan=%+v", plan)
 	}
 }
 

--- a/cmd/treedb_vector_partition_bench/main_test.go
+++ b/cmd/treedb_vector_partition_bench/main_test.go
@@ -1207,6 +1207,43 @@ func TestM8CanonicalFP32ScoreContractTiePrecisionAndDedupeV1(t *testing.T) {
 	}
 }
 
+func TestM8CanonicalRefPathMatchesOwnedTieDedupeAndLifetimeV1(t *testing.T) {
+	candidates := []m8CanonicalResultV1{
+		{ID: "duplicate", Score: 0.1},
+		{ID: "z", Score: 0.9},
+		{ID: "a", Score: 0.9},
+		{ID: "duplicate", Score: 0.95},
+		{ID: "lower", Score: math.Float32frombits(math.Float32bits(0.9) - 1)},
+	}
+	var owned []m8CanonicalResultV1
+	var refs []m8CanonicalRefResultV1
+	refIDs := make([][]byte, len(candidates))
+	for i, candidate := range candidates {
+		owned = m8AppendBoundedCanonicalV1(owned, candidate, 4)
+		refIDs[i] = []byte(candidate.ID)
+		refs = m8AppendBoundedCanonicalRefV1(refs, m8CanonicalRefResultV1{ID: refIDs[i], Score: candidate.Score}, 4)
+	}
+	got := m8MaterializeCanonicalRefsV1(refs)
+	if len(got) != len(owned) {
+		t.Fatalf("ref results=%+v owned=%+v", got, owned)
+	}
+	for i := range owned {
+		if got[i] != owned[i] {
+			t.Fatalf("rank=%d ref=%+v owned=%+v", i, got, owned)
+		}
+	}
+	for i := range refIDs {
+		for j := range refIDs[i] {
+			refIDs[i][j] = 'x'
+		}
+	}
+	for i := range owned {
+		if got[i] != owned[i] {
+			t.Fatalf("materialized result changed after source mutation rank=%d ref=%+v owned=%+v", i, got, owned)
+		}
+	}
+}
+
 func TestM8CanonicalContractRejectsInvalidBoundsAndScoresV1(t *testing.T) {
 	if got := m8CanonicalResultsV1([]m8CanonicalResultV1{{ID: "a", Score: 1}}, -1); got != nil {
 		t.Fatalf("negative top-k result=%+v", got)

--- a/cmd/treedb_vector_partition_bench/main_test.go
+++ b/cmd/treedb_vector_partition_bench/main_test.go
@@ -1094,6 +1094,7 @@ func TestM8ProductionModeParsesCanonicalTopologyAndSweepsV1(t *testing.T) {
 		{"-stage", "router", "-m8-existing-db", "/retained/m8-assets", "-dataset", fixturePath(t), "-out", t.TempDir(), "-partitions", "16", "-probes", "1"},
 		{"-mode", m8ProductionMultiGroupModeV1, "-dataset", fixturePath(t), "-out", t.TempDir(), "-partitions", "16", "-raft-groups", "4", "-warmup", "-1"},
 		{"-mode", m8ProductionMultiGroupModeV1, "-dataset", fixturePath(t), "-out", t.TempDir(), "-partitions", strconv.Itoa(limit + 1), "-raft-groups", "2"},
+		{"-mode", m8ProductionMultiGroupModeV1, "-dataset", fixturePath(t), "-out", t.TempDir(), "-partitions", "16", "-raft-groups", "4", "-probes", "1,4", "-router-candidates", "2"},
 	} {
 		if _, err := parseConfig(args); err == nil {
 			t.Fatalf("accepted malformed M8 config %#v", args)

--- a/cmd/treedb_vector_partition_bench/main_test.go
+++ b/cmd/treedb_vector_partition_bench/main_test.go
@@ -1104,11 +1104,11 @@ func TestM8ProductionModeParsesCanonicalTopologyAndSweepsV1(t *testing.T) {
 
 func TestM8BenchmarkWorkCapAndOverflowV1(t *testing.T) {
 	cfg := config{overlaps: []float64{0, .2}, probes: []int{1, 4}, efSearch: []int{64, 128}, concurrency: []int{1, 2}, warmup: 3}
-	plan, err := validateM8BenchmarkWork(cfg, fixtureManifest{Queries: 5}, 84)
-	if err != nil || plan.QueryRequests != 84 {
+	plan, err := validateM8BenchmarkWork(cfg, fixtureManifest{Queries: 5}, 149)
+	if err != nil || plan.QueryRequests != 149 || plan.MeasuredQueryRequests != 80 || plan.WarmupAndPreflightQueryRequests != 4 || plan.AttributionQueryPasses != 65 {
 		t.Fatalf("M8 work plan=%+v err=%v", plan, err)
 	}
-	if _, err := validateM8BenchmarkWork(cfg, fixtureManifest{Queries: 5}, 83); err == nil {
+	if _, err := validateM8BenchmarkWork(cfg, fixtureManifest{Queries: 5}, 148); err == nil {
 		t.Fatal("accepted oversized M8 sweep")
 	}
 	if _, err := validateM8BenchmarkWork(cfg, fixtureManifest{Queries: math.MaxInt}, maxBenchmarkWorkUnits); err == nil {
@@ -1128,13 +1128,13 @@ func TestM8ProductionEvidenceJSONKeepsEveryTopologyDimensionV1(t *testing.T) {
 			ExactRepresentativeRecallAtK: .9, ApproximateRepresentativeRecallAtK: .8,
 			LocalHNSWRecallAtK: .7, EndToEndRecallAtK: 0,
 			CoordinatorMergeIDParity: true, CoordinatorMergeScoreParity: true,
-			ApproximateRouterCandidateBudget: 256, ResidualLossOwners: []string{"partition_local_hnsw"},
+			ApproximateRouterCandidateBudget: 256, ApproximateRouterPartitionCoverageComplete: true, ResidualLossOwners: []string{"partition_local_hnsw"},
 		}}},
 	})
 	if err != nil {
 		t.Fatal(err)
 	}
-	for _, field := range []string{`"raft_groups":4`, `"raft_nodes_per_group":3`, `"partitions":16`, `"approximate_router_candidate_budget":256`, `"probes":4`, `"ef_search":128`, `"concurrency":16`, `"samples":32`, `"recall_at_k":0`, `"contract":"` + m8CanonicalResultContractV1 + `"`, `"global_exact_recall_at_k":1`, `"exhaustive_partition_union_score_parity":true`, `"residual_loss_owners":["partition_local_hnsw"]`} {
+	for _, field := range []string{`"raft_groups":4`, `"raft_nodes_per_group":3`, `"partitions":16`, `"approximate_router_candidate_budget":256`, `"approximate_router_partition_coverage_complete":true`, `"probes":4`, `"ef_search":128`, `"concurrency":16`, `"samples":32`, `"recall_at_k":0`, `"contract":"` + m8CanonicalResultContractV1 + `"`, `"global_exact_recall_at_k":1`, `"exhaustive_partition_union_score_parity":true`, `"residual_loss_owners":["partition_local_hnsw"]`} {
 		if !bytes.Contains(raw, []byte(field)) {
 			t.Fatalf("missing %s in %s", field, raw)
 		}
@@ -1218,18 +1218,19 @@ func TestM8CanonicalContractRejectsInvalidBoundsAndScoresV1(t *testing.T) {
 
 func TestValidM8AttributionPersistsExhaustiveUnionFailureV1(t *testing.T) {
 	attribution := m8ProductionAttributionV1{
-		Contract:                           m8CanonicalResultContractV1,
-		GlobalExactRecallAtK:               1,
-		ExhaustivePartitionRecallAtK:       .5,
-		ExhaustivePartitionIDParity:        false,
-		ExhaustivePartitionScoreParity:     false,
-		ExactRepresentativeRecallAtK:       .5,
-		ApproximateRepresentativeRecallAtK: .5,
-		LocalHNSWRecallAtK:                 .5,
-		EndToEndRecallAtK:                  .5,
-		CoordinatorMergeIDParity:           true,
-		CoordinatorMergeScoreParity:        true,
-		ApproximateRouterCandidateBudget:   1,
+		Contract:                                   m8CanonicalResultContractV1,
+		GlobalExactRecallAtK:                       1,
+		ExhaustivePartitionRecallAtK:               .5,
+		ExhaustivePartitionIDParity:                false,
+		ExhaustivePartitionScoreParity:             false,
+		ExactRepresentativeRecallAtK:               .5,
+		ApproximateRepresentativeRecallAtK:         .5,
+		LocalHNSWRecallAtK:                         .5,
+		EndToEndRecallAtK:                          .5,
+		CoordinatorMergeIDParity:                   true,
+		CoordinatorMergeScoreParity:                true,
+		ApproximateRouterCandidateBudget:           1,
+		ApproximateRouterPartitionCoverageComplete: true,
 	}
 	attribution.ResidualLossOwners = m8AttributionLossOwnersV1(attribution)
 	if !validM8AttributionV1(attribution) {
@@ -1241,6 +1242,32 @@ func TestValidM8AttributionPersistsExhaustiveUnionFailureV1(t *testing.T) {
 	attribution.ResidualLossOwners = nil
 	if validM8AttributionV1(attribution) {
 		t.Fatal("accepted exhaustive-union failure without its loss owner")
+	}
+}
+
+func TestM8AttributionApproximateCoverageShortfallIsOwnedV1(t *testing.T) {
+	attribution := m8ProductionAttributionV1{
+		Contract: m8CanonicalResultContractV1, GlobalExactRecallAtK: 1,
+		ExhaustivePartitionRecallAtK: 1, ExhaustivePartitionIDParity: true, ExhaustivePartitionScoreParity: true,
+		ExactRepresentativeRecallAtK: 1, ApproximateRepresentativeRecallAtK: 0, LocalHNSWRecallAtK: 1, EndToEndRecallAtK: 1,
+		CoordinatorMergeIDParity: true, CoordinatorMergeScoreParity: true,
+		ApproximateRouterCandidateBudget: 2, ApproximateRouterPartitionCoverageComplete: false,
+	}
+	attribution.ResidualLossOwners = m8AttributionLossOwnersV1(attribution)
+	if !validM8AttributionV1(attribution) || !slices.Equal(attribution.ResidualLossOwners, []string{"approximate_representative_routing"}) {
+		t.Fatalf("coverage-shortfall attribution=%+v", attribution)
+	}
+	if complete, err := m8ApproximateRouterCoverageV1(fmt.Errorf("wrapped: %w", collections.ErrVectorPartitionRouterCandidateCoverageV1)); err != nil || complete {
+		t.Fatalf("typed coverage result complete=%t err=%v", complete, err)
+	}
+	invalid := attribution
+	invalid.ApproximateRepresentativeRecallAtK = .5
+	invalid.ResidualLossOwners = m8AttributionLossOwnersV1(invalid)
+	if validM8AttributionV1(invalid) {
+		t.Fatalf("accepted nonzero approximate recall with incomplete coverage: %+v", invalid)
+	}
+	if _, err := m8ApproximateRouterCoverageV1(errors.New("router corruption")); err == nil {
+		t.Fatal("accepted non-coverage router error")
 	}
 }
 

--- a/cmd/treedb_vector_partition_bench/main_test.go
+++ b/cmd/treedb_vector_partition_bench/main_test.go
@@ -1110,7 +1110,7 @@ func TestM8BenchmarkWorkCapAndOverflowV1(t *testing.T) {
 	if err != nil || plan.QueryRequests != 149 || plan.MeasuredQueryRequests != 80 || plan.WarmupAndPreflightQueryRequests != 4 || plan.AttributionQueryPasses != 65 {
 		t.Fatalf("M8 work plan=%+v err=%v", plan, err)
 	}
-	if plan.RetainedCoordinatorCells != 8 || plan.RetainedCoordinatorResults != 80 || plan.FixtureResidentBytes == 0 || plan.SourceSnapshotBytes == 0 || plan.ExactTruthBytes == 0 || plan.RetainedCoordinatorBytes == 0 || plan.RetainedAttributionMatrices != 5 || plan.RetainedAttributionResults != 50 || plan.RetainedAttributionBytes == 0 || plan.AttributionMergeScratchResults != 16 || plan.AttributionMergeScratchBytes == 0 || plan.ModeledPeakBytes == 0 {
+	if plan.RetainedCoordinatorCells != 8 || plan.RetainedCoordinatorResults != 80 || plan.CurrentCellOutcomes != 5 || plan.CurrentCellOutcomeBytes == 0 || plan.FixtureResidentBytes == 0 || plan.SourceSnapshotBytes == 0 || plan.ExactTruthBytes == 0 || plan.RetainedCoordinatorBytes == 0 || plan.RetainedAttributionMatrices != 5 || plan.RetainedAttributionResults != 50 || plan.RetainedAttributionBytes == 0 || plan.AttributionMergeScratchResults != 16 || plan.AttributionMergeScratchBytes == 0 || plan.ModeledPeakBytes == 0 {
 		t.Fatalf("incomplete M8 memory plan=%+v", plan)
 	}
 	if _, err := validateM8BenchmarkWork(cfg, manifest, 148, math.MaxInt64); err == nil {
@@ -1187,6 +1187,37 @@ func TestM8AttributionMergeScratchRespectsMemoryCapV1(t *testing.T) {
 	}
 	if _, err := validateM8BenchmarkWork(cfg, manifest, maxBenchmarkWorkUnits, withoutScratch); err == nil || !strings.Contains(err.Error(), "attribution_merge_scratch_results=131072") {
 		t.Fatalf("accepted unmodeled attribution merge scratch: %v", err)
+	}
+}
+
+func TestM8CurrentCellOutcomesRespectMemoryCapV1(t *testing.T) {
+	cfg := config{partitions: 256, raftGroups: 4, overlaps: []float64{0}, probes: []int{256}, efSearch: []int{64}, concurrency: []int{64}, topK: 1}
+	manifest := fixtureManifest{Vectors: 256, Queries: 1_000_000, Dimensions: 1}
+	plan, err := validateM8BenchmarkWork(cfg, manifest, maxBenchmarkWorkUnits, math.MaxInt64)
+	if err != nil {
+		t.Fatal(err)
+	}
+	withoutOutcomes, err := memoryAdd(plan.FixtureResidentBytes, plan.ExactTruthBytes, plan.RetainedCoordinatorBytes)
+	if err != nil {
+		t.Fatal(err)
+	}
+	attributionWithoutOutcomes, err := memoryAdd(withoutOutcomes, plan.RetainedAttributionBytes, plan.AttributionMergeScratchBytes)
+	if err != nil {
+		t.Fatal(err)
+	}
+	sourceOracle, err := memoryAdd(plan.FixtureResidentBytes, plan.SourceSnapshotBytes, plan.ExactTruthBytes)
+	if err != nil {
+		t.Fatal(err)
+	}
+	withoutOutcomes, err = memoryScaleCeil(max(sourceOracle, withoutOutcomes, attributionWithoutOutcomes), memorySlackNumerator, memorySlackDenominator)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if plan.CurrentCellOutcomes != 1_000_000 || plan.CurrentCellOutcomeBytes <= 1_500_000_000 || plan.ModeledPeakBytes <= withoutOutcomes {
+		t.Fatalf("M8 current-cell outcome plan=%+v without_outcomes=%d", plan, withoutOutcomes)
+	}
+	if _, err := validateM8BenchmarkWork(cfg, manifest, maxBenchmarkWorkUnits, withoutOutcomes); err == nil || !strings.Contains(err.Error(), "current_cell_outcomes=1000000") {
+		t.Fatalf("accepted unmodeled current-cell outcomes: %v", err)
 	}
 }
 

--- a/cmd/treedb_vector_partition_bench/main_test.go
+++ b/cmd/treedb_vector_partition_bench/main_test.go
@@ -1119,13 +1119,20 @@ func TestM8BenchmarkWorkCapAndOverflowV1(t *testing.T) {
 
 func TestM8ProductionEvidenceJSONKeepsEveryTopologyDimensionV1(t *testing.T) {
 	raw, err := json.Marshal(m8ProductionReportV1{
-		Config: m8ProductionConfigEvidenceV1{RaftGroups: 4, RaftNodesPerGroup: 3, Partitions: 16},
-		Rows:   []m8ProductionRowV1{{Probes: 4, EfSearch: 128, Concurrency: 16, Samples: 32}},
+		Config: m8ProductionConfigEvidenceV1{RaftGroups: 4, RaftNodesPerGroup: 3, Partitions: 16, RouterCandidates: 256},
+		Rows: []m8ProductionRowV1{{Probes: 4, EfSearch: 128, Concurrency: 16, Samples: 32, RecallAtK: 0, Attribution: m8ProductionAttributionV1{
+			Contract: m8CanonicalResultContractV1, GlobalExactRecallAtK: 1, ExhaustivePartitionRecallAtK: 1,
+			ExhaustivePartitionIDParity: true, ExhaustivePartitionScoreParity: true,
+			ExactRepresentativeRecallAtK: .9, ApproximateRepresentativeRecallAtK: .8,
+			LocalHNSWRecallAtK: .7, EndToEndRecallAtK: 0,
+			CoordinatorMergeIDParity: true, CoordinatorMergeScoreParity: true,
+			ApproximateRouterCandidateBudget: 256, ResidualLossOwners: []string{"partition_local_hnsw"},
+		}}},
 	})
 	if err != nil {
 		t.Fatal(err)
 	}
-	for _, field := range []string{`"raft_groups":4`, `"raft_nodes_per_group":3`, `"partitions":16`, `"probes":4`, `"ef_search":128`, `"concurrency":16`, `"samples":32`} {
+	for _, field := range []string{`"raft_groups":4`, `"raft_nodes_per_group":3`, `"partitions":16`, `"approximate_router_candidate_budget":256`, `"probes":4`, `"ef_search":128`, `"concurrency":16`, `"samples":32`, `"recall_at_k":0`, `"contract":"` + m8CanonicalResultContractV1 + `"`, `"global_exact_recall_at_k":1`, `"exhaustive_partition_union_score_parity":true`, `"residual_loss_owners":["partition_local_hnsw"]`} {
 		if !bytes.Contains(raw, []byte(field)) {
 			t.Fatalf("missing %s in %s", field, raw)
 		}
@@ -1134,7 +1141,7 @@ func TestM8ProductionEvidenceJSONKeepsEveryTopologyDimensionV1(t *testing.T) {
 
 func TestM8ArtifactNameIncludesConfigurationV1(t *testing.T) {
 	fixture := fixtureManifest{Fixture: "x", Checksum: "y"}
-	base := config{headSHA: strings.Repeat("a", 40), raftGroups: 2, raftNodes: 3, partitions: 4, probes: []int{4}, overlaps: []float64{0}, topK: 10, concurrency: []int{1}, efSearch: []int{64}}
+	base := config{headSHA: strings.Repeat("a", 40), raftGroups: 2, raftNodes: 3, partitions: 4, probes: []int{4}, overlaps: []float64{0}, topK: 10, concurrency: []int{1}, efSearch: []int{64}, routerCandidates: 64}
 	first, err := m8ArtifactNameV1(base, fixture, collections.VectorPartitionManifestV1{ReadySetDigest: "a"})
 	if err != nil {
 		t.Fatal(err)
@@ -1148,6 +1155,11 @@ func TestM8ArtifactNameIncludesConfigurationV1(t *testing.T) {
 	third, err := m8ArtifactNameV1(base, fixture, collections.VectorPartitionManifestV1{ReadySetDigest: "different"})
 	if err != nil || first == third {
 		t.Fatalf("asset identities collided %q %q err=%v", first, third, err)
+	}
+	base.routerCandidates = 32
+	fourth, err := m8ArtifactNameV1(base, fixture, collections.VectorPartitionManifestV1{ReadySetDigest: "a"})
+	if err != nil || first == fourth {
+		t.Fatalf("router candidate budgets collided %q %q err=%v", first, fourth, err)
 	}
 }
 
@@ -1167,6 +1179,61 @@ func TestCanonicalExactNeighborsContractTiePrecisionAndDedupeV1(t *testing.T) {
 	}
 	if got[0].Distance != float64(float32(0.05)) {
 		t.Fatalf("duplicate retained wrong score: %+v", got[0])
+	}
+}
+
+func TestM8CanonicalFP32ScoreContractTiePrecisionAndDedupeV1(t *testing.T) {
+	near := math.Float32frombits(math.Float32bits(0.9))
+	got := m8CanonicalResultsV1([]m8CanonicalResultV1{
+		{ID: "duplicate", Score: 0.1},
+		{ID: "z", Score: near},
+		{ID: "a", Score: near},
+		{ID: "duplicate", Score: 0.95},
+		{ID: "lower", Score: math.Float32frombits(math.Float32bits(near) - 1)},
+	}, 4)
+	want := []string{"duplicate", "a", "z", "lower"}
+	if len(got) != len(want) {
+		t.Fatalf("got=%+v", got)
+	}
+	for i := range want {
+		if got[i].ID != want[i] {
+			t.Fatalf("rank %d got=%+v want=%s", i, got, want[i])
+		}
+	}
+	if got[0].Score != float32(0.95) {
+		t.Fatalf("duplicate retained wrong score: %+v", got[0])
+	}
+}
+
+func TestM8CanonicalContractRejectsInvalidBoundsAndScoresV1(t *testing.T) {
+	if got := m8CanonicalResultsV1([]m8CanonicalResultV1{{ID: "a", Score: 1}}, -1); got != nil {
+		t.Fatalf("negative top-k result=%+v", got)
+	}
+	if got := m8CanonicalResultsV1([]m8CanonicalResultV1{{ID: "a", Score: float32(math.NaN())}}, 1); got != nil {
+		t.Fatalf("nonfinite result=%+v", got)
+	}
+}
+
+func TestM8CoordinatorResponseCanonicalShapeFailsClosedV1(t *testing.T) {
+	response := nativewire.VectorPartitionCoordinatorResponseV1{
+		Neighbors:        []nativewire.VectorPartitionCoordinatorNeighborV1{{ID: "a", Score: .9}, {ID: "b", Score: .8}},
+		ProbedPartitions: []uint32{0, 1},
+	}
+	response.ProbedGroups = append(response.ProbedGroups, "group-a")
+	manifest := collections.VectorPartitionManifestV1{PartitionCount: 4, Placements: []collections.VectorPartitionPlacementV1{
+		{PartitionID: 0, GroupID: "group-a"}, {PartitionID: 1, GroupID: "group-a"},
+		{PartitionID: 2, GroupID: "group-b"}, {PartitionID: 3, GroupID: "group-b"},
+	}}
+	if got, err := m8ValidateCoordinatorResponseV1(response, manifest, 2, 2); err != nil || len(got) != 2 {
+		t.Fatalf("valid response got=%+v err=%v", got, err)
+	}
+	response.Neighbors[0], response.Neighbors[1] = response.Neighbors[1], response.Neighbors[0]
+	if _, err := m8ValidateCoordinatorResponseV1(response, manifest, 2, 2); err == nil {
+		t.Fatal("accepted noncanonical response order")
+	}
+	response.Neighbors = []nativewire.VectorPartitionCoordinatorNeighborV1{{ID: "a", Score: .9}, {ID: "a", Score: .8}}
+	if _, err := m8ValidateCoordinatorResponseV1(response, manifest, 2, 2); err == nil {
+		t.Fatal("accepted duplicate response neighbor")
 	}
 }
 

--- a/cmd/treedb_vector_partition_bench/main_test.go
+++ b/cmd/treedb_vector_partition_bench/main_test.go
@@ -1103,19 +1103,38 @@ func TestM8ProductionModeParsesCanonicalTopologyAndSweepsV1(t *testing.T) {
 }
 
 func TestM8BenchmarkWorkCapAndOverflowV1(t *testing.T) {
-	cfg := config{overlaps: []float64{0, .2}, probes: []int{1, 4}, efSearch: []int{64, 128}, concurrency: []int{1, 2}, warmup: 3}
-	plan, err := validateM8BenchmarkWork(cfg, fixtureManifest{Queries: 5}, 149)
+	cfg := config{overlaps: []float64{0, .2}, probes: []int{1, 4}, efSearch: []int{64, 128}, concurrency: []int{1, 2}, warmup: 3, topK: 2}
+	manifest := fixtureManifest{Vectors: 10, Queries: 5, Dimensions: 8}
+	plan, err := validateM8BenchmarkWork(cfg, manifest, 149, math.MaxInt64)
 	if err != nil || plan.QueryRequests != 149 || plan.MeasuredQueryRequests != 80 || plan.WarmupAndPreflightQueryRequests != 4 || plan.AttributionQueryPasses != 65 {
 		t.Fatalf("M8 work plan=%+v err=%v", plan, err)
 	}
-	if _, err := validateM8BenchmarkWork(cfg, fixtureManifest{Queries: 5}, 148); err == nil {
+	if plan.RetainedCoordinatorCells != 8 || plan.RetainedCoordinatorResults != 80 || plan.FixtureResidentBytes == 0 || plan.ExactTruthBytes == 0 || plan.RetainedCoordinatorBytes == 0 || plan.ModeledPeakBytes == 0 {
+		t.Fatalf("incomplete M8 memory plan=%+v", plan)
+	}
+	if _, err := validateM8BenchmarkWork(cfg, manifest, 148, math.MaxInt64); err == nil {
 		t.Fatal("accepted oversized M8 sweep")
 	}
-	if _, err := validateM8BenchmarkWork(cfg, fixtureManifest{Queries: math.MaxInt}, maxBenchmarkWorkUnits); err == nil {
+	if _, err := validateM8BenchmarkWork(cfg, fixtureManifest{Vectors: 1, Queries: math.MaxInt, Dimensions: 1}, maxBenchmarkWorkUnits, math.MaxInt64); err == nil {
 		t.Fatal("accepted overflowing M8 sweep")
 	}
-	if _, err := validateM8BenchmarkWork(config{overlaps: []float64{0}, probes: []int{1}, efSearch: []int{64}, concurrency: []int{1}}, fixtureManifest{Queries: math.MaxInt}, maxBenchmarkWorkUnits); err == nil {
+	if _, err := validateM8BenchmarkWork(config{overlaps: []float64{0}, probes: []int{1}, efSearch: []int{64}, concurrency: []int{1}, topK: 1}, fixtureManifest{Vectors: 1, Queries: math.MaxInt, Dimensions: 1}, maxBenchmarkWorkUnits, math.MaxInt64); err == nil {
 		t.Fatal("accepted overflowing M8 preflight accounting")
+	}
+}
+
+func TestM8RetainedCoordinatorResultsRespectMemoryCapV1(t *testing.T) {
+	cfg := config{overlaps: []float64{0}, probes: []int{1, 4}, efSearch: []int{64, 128}, concurrency: []int{1, 2}, topK: 256}
+	manifest := fixtureManifest{Vectors: 10_000, Queries: 50_000, Dimensions: 8}
+	plan, err := validateM8BenchmarkWork(cfg, manifest, maxBenchmarkWorkUnits, math.MaxInt64)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if plan.RetainedCoordinatorResults != 102_400_000 || plan.RetainedCoordinatorBytes < 4_000_000_000 {
+		t.Fatalf("M8 retained-result plan=%+v", plan)
+	}
+	if _, err := validateM8BenchmarkWork(cfg, manifest, maxBenchmarkWorkUnits, maxFixtureBytes); err == nil || !strings.Contains(err.Error(), "retained_coordinator_results=102400000") {
+		t.Fatalf("accepted oversized retained result sweep: %v", err)
 	}
 }
 

--- a/cmd/treedb_vector_partition_bench/main_test.go
+++ b/cmd/treedb_vector_partition_bench/main_test.go
@@ -1109,7 +1109,7 @@ func TestM8BenchmarkWorkCapAndOverflowV1(t *testing.T) {
 	if err != nil || plan.QueryRequests != 149 || plan.MeasuredQueryRequests != 80 || plan.WarmupAndPreflightQueryRequests != 4 || plan.AttributionQueryPasses != 65 {
 		t.Fatalf("M8 work plan=%+v err=%v", plan, err)
 	}
-	if plan.RetainedCoordinatorCells != 8 || plan.RetainedCoordinatorResults != 80 || plan.FixtureResidentBytes == 0 || plan.ExactTruthBytes == 0 || plan.RetainedCoordinatorBytes == 0 || plan.ModeledPeakBytes == 0 {
+	if plan.RetainedCoordinatorCells != 8 || plan.RetainedCoordinatorResults != 80 || plan.FixtureResidentBytes == 0 || plan.SourceSnapshotBytes == 0 || plan.ExactTruthBytes == 0 || plan.RetainedCoordinatorBytes == 0 || plan.ModeledPeakBytes == 0 {
 		t.Fatalf("incomplete M8 memory plan=%+v", plan)
 	}
 	if _, err := validateM8BenchmarkWork(cfg, manifest, 148, math.MaxInt64); err == nil {
@@ -1120,6 +1120,21 @@ func TestM8BenchmarkWorkCapAndOverflowV1(t *testing.T) {
 	}
 	if _, err := validateM8BenchmarkWork(config{overlaps: []float64{0}, probes: []int{1}, efSearch: []int{64}, concurrency: []int{1}, topK: 1}, fixtureManifest{Vectors: 1, Queries: math.MaxInt, Dimensions: 1}, maxBenchmarkWorkUnits, math.MaxInt64); err == nil {
 		t.Fatal("accepted overflowing M8 preflight accounting")
+	}
+}
+
+func TestM8SourceOracleSnapshotRespectsMemoryCapV1(t *testing.T) {
+	cfg := config{overlaps: []float64{0}, probes: []int{1}, efSearch: []int{64}, concurrency: []int{1}, topK: 1}
+	manifest := fixtureManifest{Vectors: 1_000_000, Queries: 1, Dimensions: 512}
+	plan, err := validateM8BenchmarkWork(cfg, manifest, maxBenchmarkWorkUnits, math.MaxInt64)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if plan.FixtureResidentBytes >= maxFixtureBytes || plan.SourceSnapshotBytes < 2_000_000_000 {
+		t.Fatalf("M8 source snapshot plan=%+v", plan)
+	}
+	if _, err := validateM8BenchmarkWork(cfg, manifest, maxBenchmarkWorkUnits, maxFixtureBytes); err == nil || !strings.Contains(err.Error(), "source_snapshot_bytes=") {
+		t.Fatalf("accepted oversized source snapshot: %v", err)
 	}
 }
 

--- a/cmd/treedb_vector_partition_bench/main_test.go
+++ b/cmd/treedb_vector_partition_bench/main_test.go
@@ -1109,7 +1109,7 @@ func TestM8BenchmarkWorkCapAndOverflowV1(t *testing.T) {
 	if err != nil || plan.QueryRequests != 149 || plan.MeasuredQueryRequests != 80 || plan.WarmupAndPreflightQueryRequests != 4 || plan.AttributionQueryPasses != 65 {
 		t.Fatalf("M8 work plan=%+v err=%v", plan, err)
 	}
-	if plan.RetainedCoordinatorCells != 8 || plan.RetainedCoordinatorResults != 80 || plan.FixtureResidentBytes == 0 || plan.SourceSnapshotBytes == 0 || plan.ExactTruthBytes == 0 || plan.RetainedCoordinatorBytes == 0 || plan.ModeledPeakBytes == 0 {
+	if plan.RetainedCoordinatorCells != 8 || plan.RetainedCoordinatorResults != 80 || plan.FixtureResidentBytes == 0 || plan.SourceSnapshotBytes == 0 || plan.ExactTruthBytes == 0 || plan.RetainedCoordinatorBytes == 0 || plan.RetainedAttributionMatrices != 5 || plan.RetainedAttributionResults != 50 || plan.RetainedAttributionBytes == 0 || plan.ModeledPeakBytes == 0 {
 		t.Fatalf("incomplete M8 memory plan=%+v", plan)
 	}
 	if _, err := validateM8BenchmarkWork(cfg, manifest, 148, math.MaxInt64); err == nil {
@@ -1120,6 +1120,29 @@ func TestM8BenchmarkWorkCapAndOverflowV1(t *testing.T) {
 	}
 	if _, err := validateM8BenchmarkWork(config{overlaps: []float64{0}, probes: []int{1}, efSearch: []int{64}, concurrency: []int{1}, topK: 1}, fixtureManifest{Vectors: 1, Queries: math.MaxInt, Dimensions: 1}, maxBenchmarkWorkUnits, math.MaxInt64); err == nil {
 		t.Fatal("accepted overflowing M8 preflight accounting")
+	}
+}
+
+func TestM8RetainedAttributionResultsRespectMemoryCapV1(t *testing.T) {
+	cfg := config{overlaps: []float64{0}, probes: []int{1, 4}, efSearch: []int{64, 128}, concurrency: []int{1}, topK: 256}
+	manifest := fixtureManifest{Vectors: 10_000, Queries: 50_000, Dimensions: 8}
+	plan, err := validateM8BenchmarkWork(cfg, manifest, maxBenchmarkWorkUnits, math.MaxInt64)
+	if err != nil {
+		t.Fatal(err)
+	}
+	measurementBytes, err := memoryAdd(plan.FixtureResidentBytes, plan.ExactTruthBytes, plan.RetainedCoordinatorBytes)
+	if err != nil {
+		t.Fatal(err)
+	}
+	measurementPeak, err := memoryScaleCeil(measurementBytes, memorySlackNumerator, memorySlackDenominator)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if measurementPeak >= maxFixtureBytes || plan.RetainedAttributionMatrices != 5 || plan.RetainedAttributionResults != 64_000_000 || plan.RetainedAttributionBytes < 2_500_000_000 || plan.ModeledPeakBytes <= maxFixtureBytes {
+		t.Fatalf("M8 attribution retention plan=%+v measurement_peak=%d", plan, measurementPeak)
+	}
+	if _, err := validateM8BenchmarkWork(cfg, manifest, maxBenchmarkWorkUnits, maxFixtureBytes); err == nil || !strings.Contains(err.Error(), "retained_attribution_results=64000000") {
+		t.Fatalf("accepted oversized retained attribution sweep: %v", err)
 	}
 }
 
@@ -1250,14 +1273,16 @@ func TestM8CanonicalRefPathMatchesOwnedTieDedupeAndLifetimeV1(t *testing.T) {
 		{ID: "lower", Score: math.Float32frombits(math.Float32bits(0.9) - 1)},
 	}
 	var owned []m8CanonicalResultV1
-	var refs []m8CanonicalRefResultV1
+	refs := newM8CanonicalRefTopKV1(4)
 	refIDs := make([][]byte, len(candidates))
 	for i, candidate := range candidates {
 		owned = m8AppendBoundedCanonicalV1(owned, candidate, 4)
 		refIDs[i] = []byte(candidate.ID)
-		refs = m8AppendBoundedCanonicalRefV1(refs, m8CanonicalRefResultV1{ID: refIDs[i], Score: candidate.Score}, 4)
+		if !refs.add(m8CanonicalRefResultV1{ID: refIDs[i], Score: candidate.Score}) {
+			t.Fatalf("rejected ref candidate %+v", candidate)
+		}
 	}
-	got := m8MaterializeCanonicalRefsV1(refs)
+	got := m8MaterializeCanonicalRefsV1(refs.results())
 	if len(got) != len(owned) {
 		t.Fatalf("ref results=%+v owned=%+v", got, owned)
 	}
@@ -1275,6 +1300,46 @@ func TestM8CanonicalRefPathMatchesOwnedTieDedupeAndLifetimeV1(t *testing.T) {
 		if got[i] != owned[i] {
 			t.Fatalf("materialized result changed after source mutation rank=%d ref=%+v owned=%+v", i, got, owned)
 		}
+	}
+}
+
+func TestM8CanonicalRefTopKUsesKeyedBoundedHeapV1(t *testing.T) {
+	const candidates = 10_000
+	top := newM8CanonicalRefTopKV1(256)
+	for i := 0; i < candidates; i++ {
+		id := []byte(fmt.Sprintf("doc-%06d", i))
+		if !top.add(m8CanonicalRefResultV1{ID: id, Score: float32(i)}) {
+			t.Fatalf("rejected candidate %d", i)
+		}
+	}
+	if len(top.heap) != 256 || len(top.results()) != 256 {
+		t.Fatalf("unbounded or short ref heap len=%d results=%d", len(top.heap), len(top.results()))
+	}
+	if top.idComparisons >= candidates {
+		t.Fatalf("ref duplicate comparisons=%d candidates=%d", top.idComparisons, candidates)
+	}
+}
+
+func TestM8CanonicalRefTopKMatchesCanonicalOrderWithDuplicatesV1(t *testing.T) {
+	const (
+		candidates = 10_000
+		topK       = 256
+	)
+	var want []m8CanonicalResultV1
+	top := newM8CanonicalRefTopKV1(topK)
+	for i := 0; i < candidates; i++ {
+		candidate := m8CanonicalResultV1{
+			ID:    fmt.Sprintf("doc-%06d", (i*37)%777),
+			Score: float32((i * 41) % 997),
+		}
+		want = m8AppendBoundedCanonicalV1(want, candidate, topK)
+		if !top.add(m8CanonicalRefResultV1{ID: []byte(candidate.ID), Score: candidate.Score}) {
+			t.Fatalf("rejected candidate %d", i)
+		}
+	}
+	got := m8MaterializeCanonicalRefsV1(top.results())
+	if !slices.Equal(got, want) {
+		t.Fatalf("ref top-k differs from canonical order\ngot=%+v\nwant=%+v", got, want)
 	}
 }
 

--- a/cmd/treedb_vector_partition_bench/main_test.go
+++ b/cmd/treedb_vector_partition_bench/main_test.go
@@ -1156,7 +1156,7 @@ func TestCanonicalExactNeighborsContractTiePrecisionAndDedupeV1(t *testing.T) {
 		{ID: "duplicate", Distance: 0.2}, {ID: "z", Distance: 0.1}, {ID: "a", Distance: 0.1},
 		{ID: "duplicate", Distance: 0.05}, {ID: "near", Distance: 0.100000001},
 	}, 4)
-	want := []string{"duplicate", "a", "z", "near"}
+	want := []string{"duplicate", "a", "near", "z"}
 	if len(got) != len(want) {
 		t.Fatalf("got=%+v", got)
 	}
@@ -1165,7 +1165,7 @@ func TestCanonicalExactNeighborsContractTiePrecisionAndDedupeV1(t *testing.T) {
 			t.Fatalf("rank %d got=%+v want=%s", i, got, want[i])
 		}
 	}
-	if got[0].Distance != 0.05 {
+	if got[0].Distance != float64(float32(0.05)) {
 		t.Fatalf("duplicate retained wrong score: %+v", got[0])
 	}
 }

--- a/cmd/treedb_vector_partition_bench/main_test.go
+++ b/cmd/treedb_vector_partition_bench/main_test.go
@@ -1250,9 +1250,12 @@ func TestM8CoordinatorResponseCanonicalShapeFailsClosedV1(t *testing.T) {
 		ProbedPartitions: []uint32{0, 1},
 	}
 	response.ProbedGroups = append(response.ProbedGroups, "group-a")
-	manifest := collections.VectorPartitionManifestV1{PartitionCount: 4, Placements: []collections.VectorPartitionPlacementV1{
+	manifest := collections.VectorPartitionManifestV1{SourceRowCount: 3, PartitionCount: 4, Placements: []collections.VectorPartitionPlacementV1{
 		{PartitionID: 0, GroupID: "group-a"}, {PartitionID: 1, GroupID: "group-a"},
 		{PartitionID: 2, GroupID: "group-b"}, {PartitionID: 3, GroupID: "group-b"},
+	}, Memberships: []collections.VectorPartitionMembershipV1{
+		{VectorOrdinal: 0, PartitionID: 0}, {VectorOrdinal: 1, PartitionID: 1},
+		{VectorOrdinal: 2, PartitionID: 2},
 	}}
 	if got, err := m8ValidateCoordinatorResponseV1(response, manifest, 2, 2); err != nil || len(got) != 2 {
 		t.Fatalf("valid response got=%+v err=%v", got, err)
@@ -1277,8 +1280,15 @@ func TestM8CoordinatorResponseCanonicalShapeFailsClosedV1(t *testing.T) {
 	}
 	response.ProbedGroups = append(response.ProbedGroups[:0], "group-a")
 	response.Neighbors = response.Neighbors[:1]
-	if got, err := m8ValidateCoordinatorResponseV1(response, manifest, 2, 2); err != nil || len(got) != 1 {
-		t.Fatalf("valid short response got=%+v err=%v", got, err)
+	if _, err := m8ValidateCoordinatorResponseV1(response, manifest, 2, 2); err == nil {
+		t.Fatal("accepted truncated response for two unique selected rows")
+	}
+	sparseManifest := manifest
+	sparseManifest.SourceRowCount = 1
+	sparseManifest.Memberships = []collections.VectorPartitionMembershipV1{{VectorOrdinal: 0, PartitionID: 0}}
+	sparseManifest.OverlapMemberships = []collections.VectorPartitionMembershipV1{{VectorOrdinal: 0, PartitionID: 1}}
+	if got, err := m8ValidateCoordinatorResponseV1(response, sparseManifest, 2, 2); err != nil || len(got) != 1 {
+		t.Fatalf("valid sparse response got=%+v err=%v", got, err)
 	}
 	response.Neighbors = append(response.Neighbors,
 		nativewire.VectorPartitionCoordinatorNeighborV1{ID: "b", Score: .8},

--- a/cmd/treedb_vector_partition_bench/main_test.go
+++ b/cmd/treedb_vector_partition_bench/main_test.go
@@ -1151,6 +1151,25 @@ func TestM8ArtifactNameIncludesConfigurationV1(t *testing.T) {
 	}
 }
 
+func TestCanonicalExactNeighborsContractTiePrecisionAndDedupeV1(t *testing.T) {
+	got := canonicalExactNeighborsV1([]neighbor{
+		{ID: "duplicate", Distance: 0.2}, {ID: "z", Distance: 0.1}, {ID: "a", Distance: 0.1},
+		{ID: "duplicate", Distance: 0.05}, {ID: "near", Distance: 0.100000001},
+	}, 4)
+	want := []string{"duplicate", "a", "z", "near"}
+	if len(got) != len(want) {
+		t.Fatalf("got=%+v", got)
+	}
+	for i := range want {
+		if got[i].ID != want[i] {
+			t.Fatalf("rank %d got=%+v want=%s", i, got, want[i])
+		}
+	}
+	if got[0].Distance != 0.05 {
+		t.Fatalf("duplicate retained wrong score: %+v", got[0])
+	}
+}
+
 func TestM8ProfileCaptureWritesRequiredRuntimeArtifactsV1(t *testing.T) {
 	dir := t.TempDir()
 	capture, err := startM8ProfileCaptureV1(dir)

--- a/cmd/treedb_vector_partition_bench/main_test.go
+++ b/cmd/treedb_vector_partition_bench/main_test.go
@@ -16,6 +16,7 @@ import (
 	"strconv"
 	"strings"
 	"testing"
+	"unsafe"
 
 	"github.com/snissn/gomap/TreeDB/collections"
 	"github.com/snissn/gomap/TreeDB/nativewire"
@@ -1165,7 +1166,23 @@ func TestM8AttributionMergeScratchRespectsMemoryCapV1(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if plan.AttributionMergeScratchResults != 131_072 || plan.AttributionMergeScratchBytes < 3_000_000 || plan.ModeledPeakBytes <= withoutScratch {
+	resultStructBytes, err := memoryMul(plan.AttributionMergeScratchResults, int64(unsafe.Sizeof(m8CanonicalResultV1{})))
+	if err != nil {
+		t.Fatal(err)
+	}
+	ownedIDBytes, err := memoryMul(int64(cfg.partitions), int64(cfg.topK), documentIDStorageBytes)
+	if err != nil {
+		t.Fatal(err)
+	}
+	mapBytes, err := memoryMul(int64(cfg.topK), memoryMapEntryBytes)
+	if err != nil {
+		t.Fatal(err)
+	}
+	wantScratchBytes, err := memoryAdd(resultStructBytes, ownedIDBytes, mapBytes)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if plan.AttributionMergeScratchResults != 131_072 || plan.AttributionMergeScratchBytes != wantScratchBytes || ownedIDBytes != 1_048_576 || plan.ModeledPeakBytes <= withoutScratch {
 		t.Fatalf("M8 attribution scratch plan=%+v without_scratch=%d", plan, withoutScratch)
 	}
 	if _, err := validateM8BenchmarkWork(cfg, manifest, maxBenchmarkWorkUnits, withoutScratch); err == nil || !strings.Contains(err.Error(), "attribution_merge_scratch_results=131072") {

--- a/cmd/treedb_vector_partition_bench/main_test.go
+++ b/cmd/treedb_vector_partition_bench/main_test.go
@@ -12,6 +12,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"runtime"
+	"slices"
 	"strconv"
 	"strings"
 	"testing"
@@ -1214,6 +1215,34 @@ func TestM8CanonicalContractRejectsInvalidBoundsAndScoresV1(t *testing.T) {
 	}
 }
 
+func TestValidM8AttributionPersistsExhaustiveUnionFailureV1(t *testing.T) {
+	attribution := m8ProductionAttributionV1{
+		Contract:                           m8CanonicalResultContractV1,
+		GlobalExactRecallAtK:               1,
+		ExhaustivePartitionRecallAtK:       .5,
+		ExhaustivePartitionIDParity:        false,
+		ExhaustivePartitionScoreParity:     false,
+		ExactRepresentativeRecallAtK:       .5,
+		ApproximateRepresentativeRecallAtK: .5,
+		LocalHNSWRecallAtK:                 .5,
+		EndToEndRecallAtK:                  .5,
+		CoordinatorMergeIDParity:           true,
+		CoordinatorMergeScoreParity:        true,
+		ApproximateRouterCandidateBudget:   1,
+	}
+	attribution.ResidualLossOwners = m8AttributionLossOwnersV1(attribution)
+	if !validM8AttributionV1(attribution) {
+		t.Fatalf("rejected attributable exhaustive-union failure: %+v", attribution)
+	}
+	if !slices.Equal(attribution.ResidualLossOwners, []string{"partition_membership_or_score_contract"}) {
+		t.Fatalf("loss owners=%v", attribution.ResidualLossOwners)
+	}
+	attribution.ResidualLossOwners = nil
+	if validM8AttributionV1(attribution) {
+		t.Fatal("accepted exhaustive-union failure without its loss owner")
+	}
+}
+
 func TestM8CoordinatorResponseCanonicalShapeFailsClosedV1(t *testing.T) {
 	response := nativewire.VectorPartitionCoordinatorResponseV1{
 		Neighbors:        []nativewire.VectorPartitionCoordinatorNeighborV1{{ID: "a", Score: .9}, {ID: "b", Score: .8}},
@@ -1234,6 +1263,28 @@ func TestM8CoordinatorResponseCanonicalShapeFailsClosedV1(t *testing.T) {
 	response.Neighbors = []nativewire.VectorPartitionCoordinatorNeighborV1{{ID: "a", Score: .9}, {ID: "a", Score: .8}}
 	if _, err := m8ValidateCoordinatorResponseV1(response, manifest, 2, 2); err == nil {
 		t.Fatal("accepted duplicate response neighbor")
+	}
+	response.Neighbors = []nativewire.VectorPartitionCoordinatorNeighborV1{{ID: "a", Score: .9}, {ID: "b", Score: .8}}
+	response.ProbedPartitions = []uint32{0, 2}
+	if _, err := m8ValidateCoordinatorResponseV1(response, manifest, 2, 2); err == nil {
+		t.Fatal("accepted response missing an owning group")
+	}
+	response.ProbedPartitions = []uint32{0, 1}
+	response.ProbedGroups = append(response.ProbedGroups[:0], "group-b")
+	if _, err := m8ValidateCoordinatorResponseV1(response, manifest, 2, 2); err == nil {
+		t.Fatal("accepted a non-owner group")
+	}
+	response.ProbedGroups = append(response.ProbedGroups[:0], "group-a")
+	response.Neighbors = response.Neighbors[:1]
+	if got, err := m8ValidateCoordinatorResponseV1(response, manifest, 2, 2); err != nil || len(got) != 1 {
+		t.Fatalf("valid short response got=%+v err=%v", got, err)
+	}
+	response.Neighbors = append(response.Neighbors,
+		nativewire.VectorPartitionCoordinatorNeighborV1{ID: "b", Score: .8},
+		nativewire.VectorPartitionCoordinatorNeighborV1{ID: "c", Score: .7},
+	)
+	if _, err := m8ValidateCoordinatorResponseV1(response, manifest, 2, 2); err == nil {
+		t.Fatal("accepted response longer than top-k")
 	}
 }
 

--- a/cmd/treedb_vector_partition_bench/main_test.go
+++ b/cmd/treedb_vector_partition_bench/main_test.go
@@ -1282,6 +1282,31 @@ func TestValidM8AttributionPersistsExhaustiveUnionFailureV1(t *testing.T) {
 	}
 }
 
+func TestM8AttachAttributionAfterMeasurementV1(t *testing.T) {
+	row := m8ProductionRowV1{Samples: 2, RecallAtK: .5}
+	cell := m8AttributionCellV1{
+		Evidence: m8ProductionAttributionV1{
+			Contract: m8CanonicalResultContractV1, GlobalExactRecallAtK: 1,
+			ExhaustivePartitionRecallAtK: 1, ExhaustivePartitionIDParity: true, ExhaustivePartitionScoreParity: true,
+			ExactRepresentativeRecallAtK: 1, ApproximateRepresentativeRecallAtK: 1, LocalHNSWRecallAtK: .5,
+			CoordinatorMergeIDParity: true, CoordinatorMergeScoreParity: true,
+			ApproximateRouterCandidateBudget: 2, ApproximateRouterPartitionCoverageComplete: true,
+		},
+		Local: [][]m8CanonicalResultV1{{{ID: "a", Score: 1}}, {{ID: "b", Score: 1}}},
+	}
+	coordinator := [][]m8CanonicalResultV1{{{ID: "a", Score: 1}}, {{ID: "z", Score: 1}}}
+	if err := m8AttachAttributionV1(&row, cell, coordinator); err != nil {
+		t.Fatal(err)
+	}
+	if row.Attribution.EndToEndRecallAtK != row.RecallAtK || row.Attribution.CoordinatorMergeIDParity || !row.Attribution.CoordinatorMergeScoreParity ||
+		!slices.Contains(row.Attribution.ResidualLossOwners, "coordinator_merge_or_transport") {
+		t.Fatalf("post-measurement attribution=%+v", row.Attribution)
+	}
+	if err := m8AttachAttributionV1(&m8ProductionRowV1{Samples: 1}, cell, coordinator); err == nil {
+		t.Fatal("accepted post-measurement attribution cardinality mismatch")
+	}
+}
+
 func TestM8AttributionApproximateCoverageShortfallIsOwnedV1(t *testing.T) {
 	attribution := m8ProductionAttributionV1{
 		Contract: m8CanonicalResultContractV1, GlobalExactRecallAtK: 1,

--- a/cmd/treedb_vector_partition_bench/main_test.go
+++ b/cmd/treedb_vector_partition_bench/main_test.go
@@ -1103,13 +1103,13 @@ func TestM8ProductionModeParsesCanonicalTopologyAndSweepsV1(t *testing.T) {
 }
 
 func TestM8BenchmarkWorkCapAndOverflowV1(t *testing.T) {
-	cfg := config{overlaps: []float64{0, .2}, probes: []int{1, 4}, efSearch: []int{64, 128}, concurrency: []int{1, 2}, warmup: 3, topK: 2}
+	cfg := config{partitions: 4, overlaps: []float64{0, .2}, probes: []int{1, 4}, efSearch: []int{64, 128}, concurrency: []int{1, 2}, warmup: 3, topK: 2}
 	manifest := fixtureManifest{Vectors: 10, Queries: 5, Dimensions: 8}
 	plan, err := validateM8BenchmarkWork(cfg, manifest, 149, math.MaxInt64)
 	if err != nil || plan.QueryRequests != 149 || plan.MeasuredQueryRequests != 80 || plan.WarmupAndPreflightQueryRequests != 4 || plan.AttributionQueryPasses != 65 {
 		t.Fatalf("M8 work plan=%+v err=%v", plan, err)
 	}
-	if plan.RetainedCoordinatorCells != 8 || plan.RetainedCoordinatorResults != 80 || plan.FixtureResidentBytes == 0 || plan.SourceSnapshotBytes == 0 || plan.ExactTruthBytes == 0 || plan.RetainedCoordinatorBytes == 0 || plan.RetainedAttributionMatrices != 5 || plan.RetainedAttributionResults != 50 || plan.RetainedAttributionBytes == 0 || plan.ModeledPeakBytes == 0 {
+	if plan.RetainedCoordinatorCells != 8 || plan.RetainedCoordinatorResults != 80 || plan.FixtureResidentBytes == 0 || plan.SourceSnapshotBytes == 0 || plan.ExactTruthBytes == 0 || plan.RetainedCoordinatorBytes == 0 || plan.RetainedAttributionMatrices != 5 || plan.RetainedAttributionResults != 50 || plan.RetainedAttributionBytes == 0 || plan.AttributionMergeScratchResults != 16 || plan.AttributionMergeScratchBytes == 0 || plan.ModeledPeakBytes == 0 {
 		t.Fatalf("incomplete M8 memory plan=%+v", plan)
 	}
 	if _, err := validateM8BenchmarkWork(cfg, manifest, 148, math.MaxInt64); err == nil {
@@ -1118,13 +1118,13 @@ func TestM8BenchmarkWorkCapAndOverflowV1(t *testing.T) {
 	if _, err := validateM8BenchmarkWork(cfg, fixtureManifest{Vectors: 1, Queries: math.MaxInt, Dimensions: 1}, maxBenchmarkWorkUnits, math.MaxInt64); err == nil {
 		t.Fatal("accepted overflowing M8 sweep")
 	}
-	if _, err := validateM8BenchmarkWork(config{overlaps: []float64{0}, probes: []int{1}, efSearch: []int{64}, concurrency: []int{1}, topK: 1}, fixtureManifest{Vectors: 1, Queries: math.MaxInt, Dimensions: 1}, maxBenchmarkWorkUnits, math.MaxInt64); err == nil {
+	if _, err := validateM8BenchmarkWork(config{partitions: 1, overlaps: []float64{0}, probes: []int{1}, efSearch: []int{64}, concurrency: []int{1}, topK: 1}, fixtureManifest{Vectors: 1, Queries: math.MaxInt, Dimensions: 1}, maxBenchmarkWorkUnits, math.MaxInt64); err == nil {
 		t.Fatal("accepted overflowing M8 preflight accounting")
 	}
 }
 
 func TestM8RetainedAttributionResultsRespectMemoryCapV1(t *testing.T) {
-	cfg := config{overlaps: []float64{0}, probes: []int{1, 4}, efSearch: []int{64, 128}, concurrency: []int{1}, topK: 256}
+	cfg := config{partitions: 16, overlaps: []float64{0}, probes: []int{1, 4}, efSearch: []int{64, 128}, concurrency: []int{1}, topK: 256}
 	manifest := fixtureManifest{Vectors: 10_000, Queries: 50_000, Dimensions: 8}
 	plan, err := validateM8BenchmarkWork(cfg, manifest, maxBenchmarkWorkUnits, math.MaxInt64)
 	if err != nil {
@@ -1146,8 +1146,35 @@ func TestM8RetainedAttributionResultsRespectMemoryCapV1(t *testing.T) {
 	}
 }
 
+func TestM8AttributionMergeScratchRespectsMemoryCapV1(t *testing.T) {
+	cfg := config{partitions: 256, overlaps: []float64{0}, probes: []int{1}, efSearch: []int{64}, concurrency: []int{1}, topK: 256}
+	manifest := fixtureManifest{Vectors: 256, Queries: 1, Dimensions: 8}
+	plan, err := validateM8BenchmarkWork(cfg, manifest, maxBenchmarkWorkUnits, math.MaxInt64)
+	if err != nil {
+		t.Fatal(err)
+	}
+	withoutScratch, err := memoryAdd(plan.FixtureResidentBytes, plan.ExactTruthBytes, plan.RetainedCoordinatorBytes, plan.RetainedAttributionBytes)
+	if err != nil {
+		t.Fatal(err)
+	}
+	sourceOracle, err := memoryAdd(plan.FixtureResidentBytes, plan.SourceSnapshotBytes, plan.ExactTruthBytes)
+	if err != nil {
+		t.Fatal(err)
+	}
+	withoutScratch, err = memoryScaleCeil(max(sourceOracle, withoutScratch), memorySlackNumerator, memorySlackDenominator)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if plan.AttributionMergeScratchResults != 131_072 || plan.AttributionMergeScratchBytes < 3_000_000 || plan.ModeledPeakBytes <= withoutScratch {
+		t.Fatalf("M8 attribution scratch plan=%+v without_scratch=%d", plan, withoutScratch)
+	}
+	if _, err := validateM8BenchmarkWork(cfg, manifest, maxBenchmarkWorkUnits, withoutScratch); err == nil || !strings.Contains(err.Error(), "attribution_merge_scratch_results=131072") {
+		t.Fatalf("accepted unmodeled attribution merge scratch: %v", err)
+	}
+}
+
 func TestM8SourceOracleSnapshotRespectsMemoryCapV1(t *testing.T) {
-	cfg := config{overlaps: []float64{0}, probes: []int{1}, efSearch: []int{64}, concurrency: []int{1}, topK: 1}
+	cfg := config{partitions: 1, overlaps: []float64{0}, probes: []int{1}, efSearch: []int{64}, concurrency: []int{1}, topK: 1}
 	manifest := fixtureManifest{Vectors: 1_000_000, Queries: 1, Dimensions: 512}
 	plan, err := validateM8BenchmarkWork(cfg, manifest, maxBenchmarkWorkUnits, math.MaxInt64)
 	if err != nil {
@@ -1162,7 +1189,7 @@ func TestM8SourceOracleSnapshotRespectsMemoryCapV1(t *testing.T) {
 }
 
 func TestM8RetainedCoordinatorResultsRespectMemoryCapV1(t *testing.T) {
-	cfg := config{overlaps: []float64{0}, probes: []int{1, 4}, efSearch: []int{64, 128}, concurrency: []int{1, 2}, topK: 256}
+	cfg := config{partitions: 16, overlaps: []float64{0}, probes: []int{1, 4}, efSearch: []int{64, 128}, concurrency: []int{1, 2}, topK: 256}
 	manifest := fixtureManifest{Vectors: 10_000, Queries: 50_000, Dimensions: 8}
 	plan, err := validateM8BenchmarkWork(cfg, manifest, maxBenchmarkWorkUnits, math.MaxInt64)
 	if err != nil {
@@ -1349,6 +1376,13 @@ func TestM8CanonicalContractRejectsInvalidBoundsAndScoresV1(t *testing.T) {
 	}
 	if got := m8CanonicalResultsV1([]m8CanonicalResultV1{{ID: "a", Score: float32(math.NaN())}}, 1); got != nil {
 		t.Fatalf("nonfinite result=%+v", got)
+	}
+	oversized := make([]m8CanonicalResultV1, 256*256)
+	for i := range oversized {
+		oversized[i] = m8CanonicalResultV1{ID: fmt.Sprintf("doc-%06d", i), Score: float32(i)}
+	}
+	if got := m8CanonicalResultsV1(oversized, 256); len(got) != 256 || cap(got) != 256 {
+		t.Fatalf("canonical top-k retained oversized merge backing len=%d cap=%d", len(got), cap(got))
 	}
 }
 


### PR DESCRIPTION
Closes #3980

## Objective

Freeze one executable vector-partition result contract, prove the exact union of generation-pinned partitions against the full source, and separate recall loss across representative routing, local HNSW, and the Raft/TCP coordinator boundary.

## Design

- Defines `VectorPartitionCanonicalScoreContractV1`: normalize query/source vectors in FP32, accumulate the normalized dot product left-to-right with explicit separately rounded binary64 products and additions, round once to FP32, retain the best duplicate stable ID, then order by score descending and stable ID ascending.
- Uses that contract for the full-source oracle, exact scans of pinned persistent packs, and canonical publication of retained HNSW frontiers.
- Adds fail-closed source-generation identity, pack-shape, complete/unique partition coverage, raw coordinator order/duplicate/top-k, and owner-group coverage checks.
- Adds schema-v2 attribution for source oracle, exhaustive partition union, exact/approximate representative routing, partition-local HNSW, end-to-end result, and coordinator ID/score parity.
- Bounds benchmark-owned memory for the fixture, source snapshot, exact truth, retained canonical matrices, current-cell raw coordinator responses, exhaustive attribution result structs, owned stable-ID backing storage, and duplicate-map scratch; unsupported-only overlap sweeps bypass measured and attribution work.
- Keeps the feature experimental/off; #3981 owns generation-pinned request-session caching and #3982 owns local-HNSW remediation/disposition plus the final local enablement gate.

## Diagnostic evidence

The retained 10k and 1M artifacts were captured at measured code head `3b52711665297c7396f1f86238840dee1ea2897b` before later measurement-ordering and memory-accounting repairs. They are valid only for exactness and recall-loss attribution, not QPS, latency, profile, or peak-RSS acceptance.

10k / 128-query diagnostic:

- artifact: `/mnt/fast4tb/tmp/treedb_vector_partition_3980_10k_clean_fvQhPj/vector_partition_m8_3b5271166529_0f33a1583ce3.json`
- SHA-256: `c9d37aba290284b742f9e8189b429031146226a8cf9801370bd15754b80c81dc`
- exact source-to-partition union recall `1.0`; ID and score parity true
- all four partitions: exact/approx representative recall `1.0`; local/end-to-end recall `0.25625` at ef=64 and `0.96953125` at ef=4096
- coordinator merge ID/score parity true

1M / one-query diagnostic:

- artifact: `/mnt/fast4tb/tmp/treedb_vector_partition_3980_1m_clean_Wadji9/vector_partition_m8_3b5271166529_55786c770e98.json`
- SHA-256: `9afad07fb8daf374076fe9fa630106ffdf6241ae746344349eb1885d37cdfbd1`
- exact source-to-partition union recall `1.0`; ID and score parity true
- all 16 partitions: exact/approx representative recall `1.0`; local/end-to-end recall `0` at ef=64 and ef=4096
- coordinator merge ID/score parity true
- diagnosis: all-partition zero recall is owned by partition-local HNSW, not source identity, membership, score semantics, Raft/TCP transport, dedupe, or coordinator merge

These are diagnostic attribution runs, not a matched-recall performance matrix. Approximate-HNSW, overlap, resource-bound, and matched-QPS gates remain red or deferred to #3982/#3983.

## Current-head validation

Current PR head: `8a1b1636c68db9074243c6c796553c9072223fbe`.

- focused canonical-score and unsupported-overlap planner regressions — pass
- `GOWORK=off go test ./cmd/treedb_vector_partition_bench -count=1` — pass, 41.028s
- focused canonical collection race set — pass, 1.157s
- `GOWORK=off go test ./TreeDB/docs -count=1` — pass, 1.633s
- exact-head hosted CI passed, including the required aggregate gate and the same-head rerun of the initially failed `windows-core-1` shard
- both findings from the `784d29397` exact-head Codex review are fixed and resolved; Codex completed an exact-head re-review with no major issues

The retained diagnostic limitations above remain authoritative even though the implementation and validation head is newer.
