### PR TITLE
fix(treedb): quiesce dictionary work before replay cut

### DIFF
--- a/TreeDB/caching/db.go
+++ b/TreeDB/caching/db.go
@@ -8884,6 +8884,8 @@ type DB struct {
 
 	valueLogDictTrainerMu      sync.RWMutex
 	valueLogDictApplyMu        sync.Mutex
+	valueLogDictQuiesceMu      sync.Mutex
+	valueLogDictQuiesced       atomic.Bool
 	valueLogDictTrainer        *compression.Trainer
 	valueLogDictTrainerByClass [vlogDictClassCount]*compression.Trainer
 	valueLogDictKickCh         chan struct{}
@@ -25212,6 +25214,9 @@ func (db *DB) Close() error {
 		}
 		closed[trainer] = struct{}{}
 		trainer.Close()
+	}
+	for trainer := range closed {
+		trainer.Wait()
 	}
 	if db.valueLogTemplateEngine != nil {
 		db.valueLogTemplateEngine.Close()

--- a/TreeDB/caching/vlog_dict.go
+++ b/TreeDB/caching/vlog_dict.go
@@ -880,11 +880,14 @@ func (db *DB) valueLogDictCollectSampleForClass(value []byte, class vlogDictClas
 }
 
 func (db *DB) ensureValueLogDictTrainer() {
-	if db == nil || !db.valueLogDictTrainingEnabled() {
+	if db == nil || db.valueLogDictQuiesced.Load() || !db.valueLogDictTrainingEnabled() {
 		return
 	}
 	db.valueLogDictTrainerMu.Lock()
 	defer db.valueLogDictTrainerMu.Unlock()
+	if db.valueLogDictQuiesced.Load() {
+		return
+	}
 	if db.valueLogDictTrainerByClass[vlogDictClassSingleValue] != nil {
 		return
 	}
@@ -955,6 +958,63 @@ func (db *DB) ensureValueLogDictTrainer() {
 	db.valueLogDictMetrics.SetSlab(1)
 	db.wg.Add(1)
 	go db.valueLogDictLoop()
+}
+
+// QuiesceValueLogDictTraining permanently stops dictionary training and
+// profile publication for this DB handle while keeping published dictionaries
+// available for reads and writes. It is a lifecycle boundary for callers that
+// require a live handle with no future asynchronous dictionary mutations.
+func (db *DB) QuiesceValueLogDictTraining() {
+	if db == nil {
+		return
+	}
+	db.valueLogDictQuiesceMu.Lock()
+	defer db.valueLogDictQuiesceMu.Unlock()
+	if db.valueLogDictQuiesced.Load() {
+		return
+	}
+
+	// Match checkpoint/close lock order. Holding both locks prevents a writer or
+	// flush from retaining a trainer pointer while its sample channel is closed.
+	db.flushMu.Lock()
+	db.writeMu.Lock()
+	db.valueLogDictQuiesced.Store(true)
+	db.valueLogDictTrainerMu.Lock()
+	trainers := make([]*compression.Trainer, 0, 1+vlogDictClassCount)
+	if db.valueLogDictTrainer != nil {
+		trainers = append(trainers, db.valueLogDictTrainer)
+		db.valueLogDictTrainer = nil
+	}
+	for i := range db.valueLogDictTrainerByClass {
+		if tr := db.valueLogDictTrainerByClass[i]; tr != nil {
+			trainers = append(trainers, tr)
+			db.valueLogDictTrainerByClass[i] = nil
+		}
+	}
+	db.valueLogDictTrainerMu.Unlock()
+
+	closed := make(map[*compression.Trainer]struct{}, len(trainers))
+	for _, trainer := range trainers {
+		if trainer == nil {
+			continue
+		}
+		if _, ok := closed[trainer]; ok {
+			continue
+		}
+		closed[trainer] = struct{}{}
+		trainer.Close()
+	}
+	db.writeMu.Unlock()
+	db.flushMu.Unlock()
+	for trainer := range closed {
+		trainer.Wait()
+	}
+
+	// A final accepted-profile callback may already be inside publication when
+	// the trainers are detached. Drain it before returning. Later periodic-loop
+	// attempts see no trainer and cannot mutate the dictionary store.
+	db.valueLogDictApplyMu.Lock()
+	db.valueLogDictApplyMu.Unlock()
 }
 
 func (db *DB) valueLogDictCandidateK() []int {

--- a/TreeDB/caching/vlog_dict_quiesce_test.go
+++ b/TreeDB/caching/vlog_dict_quiesce_test.go
@@ -1,0 +1,66 @@
+package caching
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	"github.com/snissn/compress/zstd"
+	"github.com/snissn/gomap/TreeDB/internal/compression"
+)
+
+type quiesceValueLogDictStore struct{}
+
+func (quiesceValueLogDictStore) GetCurrent(context.Context) (uint64, error) {
+	return 1, nil
+}
+
+func (quiesceValueLogDictStore) GetDictBytes(context.Context, uint64) ([]byte, error) {
+	return []byte("published-dictionary"), nil
+}
+
+func TestQuiesceValueLogDictTrainingDetachesAndPreventsRestart(t *testing.T) {
+	trainer := compression.NewTrainer(compression.TrainConfig{
+		TrainBytes:     1 << 20,
+		MinRecords:     100,
+		MaxRecordBytes: 1024,
+	}, compression.Config{Kind: compression.KindZSTD, Level: zstd.SpeedFastest}, false, false)
+	if trainer == nil {
+		t.Fatal("NewTrainer returned nil")
+	}
+	database := &DB{
+		dictStore:           quiesceValueLogDictStore{},
+		valueLogDictTrain:   compression.TrainConfig{TrainBytes: 1 << 20},
+		valueLogDictTrainer: trainer,
+	}
+	database.valueLogDictTrainerByClass[vlogDictClassSingleValue] = trainer
+	if !database.valueLogDictTrainingEnabled() {
+		t.Fatal("test DB did not enable dictionary training")
+	}
+
+	var callers sync.WaitGroup
+	for i := 0; i < 8; i++ {
+		callers.Add(1)
+		go func() {
+			defer callers.Done()
+			database.QuiesceValueLogDictTraining()
+		}()
+	}
+	callers.Wait()
+	if !database.valueLogDictQuiesced.Load() {
+		t.Fatal("dictionary training was not marked quiesced")
+	}
+	if database.valueLogDictTrainer != nil || database.valueLogDictTrainerByClass[vlogDictClassSingleValue] != nil {
+		t.Fatal("quiesced DB retained a dictionary trainer")
+	}
+	if trainer.ShouldCollect() {
+		t.Fatal("detached dictionary trainer still collects samples")
+	}
+
+	database.ensureValueLogDictTrainer()
+	if database.valueLogDictTrainer != nil || database.valueLogDictTrainerByClass[vlogDictClassSingleValue] != nil {
+		t.Fatal("quiesced DB recreated a dictionary trainer")
+	}
+	// The lifecycle boundary is idempotent.
+	database.QuiesceValueLogDictTraining()
+}

--- a/TreeDB/internal/compression/trainer.go
+++ b/TreeDB/internal/compression/trainer.go
@@ -77,6 +77,7 @@ type Trainer struct {
 	sampleStride        uint64
 	sampleStrideCounter atomic.Uint64
 	sampleCh            chan trainerSample
+	trainWG             sync.WaitGroup
 	doneCh              chan struct{}
 	closed              atomic.Bool
 	closeOnce           sync.Once
@@ -466,10 +467,13 @@ func (t *Trainer) Collect(value []byte) {
 }
 
 func (t *Trainer) run() {
-	defer close(t.doneCh)
 	for sample := range t.sampleCh {
 		t.appendSample(sample)
 	}
+	// appendSample is the only producer of asynchronous training jobs. Once the
+	// sample channel is closed and drained, no later Add can race this Wait.
+	t.trainWG.Wait()
+	close(t.doneCh)
 }
 
 func (t *Trainer) appendSample(sample trainerSample) {
@@ -523,7 +527,11 @@ func (t *Trainer) appendSample(sample trainerSample) {
 	if force {
 		t.forceNextTrain.Store(true)
 	}
-	go t.train(samples, dictBytes, level, slabID)
+	t.trainWG.Add(1)
+	go func() {
+		defer t.trainWG.Done()
+		t.train(samples, dictBytes, level, slabID)
+	}()
 }
 
 func (t *Trainer) train(samples [][]byte, dictBytes int, level zstd.EncoderLevel, slabID uint32) {

--- a/TreeDB/internal/compression/trainer.go
+++ b/TreeDB/internal/compression/trainer.go
@@ -77,6 +77,7 @@ type Trainer struct {
 	sampleStride        uint64
 	sampleStrideCounter atomic.Uint64
 	sampleCh            chan trainerSample
+	doneCh              chan struct{}
 	closed              atomic.Bool
 	closeOnce           sync.Once
 	measureCollect      bool
@@ -264,6 +265,7 @@ func NewTrainer(opts TrainConfig, cfg Config, readOnly bool, metricsEnabled bool
 		level:               cfg.Level,
 		sampleStride:        uint64(sampleStride),
 		sampleCh:            make(chan trainerSample, DefaultTrainQueue),
+		doneCh:              make(chan struct{}),
 		measureCollect:      metricsEnabled,
 		dictDedupWindow:     dedupWindow,
 		encodeNsPerRawByte:  opts.EncodeNsPerRawByte,
@@ -318,6 +320,15 @@ func (t *Trainer) Close() {
 		t.closed.Store(true)
 		close(t.sampleCh)
 	})
+}
+
+// Wait blocks until the trainer has drained every sample accepted before
+// Close and its background worker has stopped. Call Close before Wait.
+func (t *Trainer) Wait() {
+	if t == nil || t.doneCh == nil {
+		return
+	}
+	<-t.doneCh
 }
 
 func (t *Trainer) ShouldCollect() bool {
@@ -455,6 +466,7 @@ func (t *Trainer) Collect(value []byte) {
 }
 
 func (t *Trainer) run() {
+	defer close(t.doneCh)
 	for sample := range t.sampleCh {
 		t.appendSample(sample)
 	}

--- a/TreeDB/internal/compression/trainer_lifecycle_test.go
+++ b/TreeDB/internal/compression/trainer_lifecycle_test.go
@@ -1,0 +1,36 @@
+package compression
+
+import (
+	"testing"
+	"time"
+
+	"github.com/snissn/compress/zstd"
+)
+
+func TestTrainerWaitDrainsClosedWorker(t *testing.T) {
+	trainer := NewTrainer(TrainConfig{
+		TrainBytes:     1 << 20,
+		MinRecords:     100,
+		MaxRecordBytes: 1024,
+	}, Config{Kind: KindZSTD, Level: zstd.SpeedFastest}, false, false)
+	if trainer == nil {
+		t.Fatal("NewTrainer returned nil")
+	}
+	for i := 0; i < 32; i++ {
+		trainer.Collect([]byte("authoritative-resource-trainer-drain"))
+	}
+	trainer.Close()
+	done := make(chan struct{})
+	go func() {
+		trainer.Wait()
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("Trainer.Wait did not observe worker shutdown")
+	}
+	if trainer.ShouldCollect() {
+		t.Fatal("closed trainer still collects samples")
+	}
+}

--- a/TreeDB/internal/compression/trainer_lifecycle_test.go
+++ b/TreeDB/internal/compression/trainer_lifecycle_test.go
@@ -34,3 +34,42 @@ func TestTrainerWaitDrainsClosedWorker(t *testing.T) {
 		t.Fatal("closed trainer still collects samples")
 	}
 }
+
+func TestTrainerWaitIncludesSpawnedTrainingJobs(t *testing.T) {
+	trainer := NewTrainer(TrainConfig{
+		TrainBytes:     1 << 20,
+		MinRecords:     100,
+		MaxRecordBytes: 1024,
+	}, Config{Kind: KindZSTD, Level: zstd.SpeedFastest}, false, false)
+	if trainer == nil {
+		t.Fatal("NewTrainer returned nil")
+	}
+
+	// Model a job already spawned by appendSample. The queue worker owns Add,
+	// so closing and draining sampleCh guarantees there can be no later Add when
+	// run reaches its Wait.
+	jobRelease := make(chan struct{})
+	trainer.trainWG.Add(1)
+	go func() {
+		defer trainer.trainWG.Done()
+		<-jobRelease
+	}()
+	trainer.Close()
+
+	waitDone := make(chan struct{})
+	go func() {
+		trainer.Wait()
+		close(waitDone)
+	}()
+	select {
+	case <-waitDone:
+		t.Fatal("Trainer.Wait returned while a spawned training job was active")
+	case <-time.After(20 * time.Millisecond):
+	}
+	close(jobRelease)
+	select {
+	case <-waitDone:
+	case <-time.After(5 * time.Second):
+		t.Fatal("Trainer.Wait did not observe spawned training job completion")
+	}
+}

--- a/TreeDB/power_loss_certification_resources_backend_test.go
+++ b/TreeDB/power_loss_certification_resources_backend_test.go
@@ -12,3 +12,12 @@ func PowerLossCertificationBackendForTest(database *DB) *backenddb.DB {
 	}
 	return database.backend
 }
+
+// PowerLossCertificationQuiesceValueLogDictionaryForTest stops future
+// asynchronous dictionary mutations without closing the public DB handle.
+func PowerLossCertificationQuiesceValueLogDictionaryForTest(database *DB) {
+	if database == nil || database.cached == nil {
+		return
+	}
+	database.cached.QuiesceValueLogDictTraining()
+}

--- a/TreeDB/power_loss_certification_resources_test.go
+++ b/TreeDB/power_loss_certification_resources_test.go
@@ -127,6 +127,12 @@ func TestPowerLossCertificationAuthoritativeResourcesPublicReopen(t *testing.T) 
 	// persistence events rather than importing them as initially stable.
 	witness := prepareAuthoritativeResourceWitness(t, database, dir, backgroundErrors)
 	waitForAuthoritativeResourceObserverQuiescence(t, &observeMu, &observedEvents, backgroundErrors)
+	// Stop the trainer and drain its final accepted-profile callback before the
+	// replay window is armed. Published dictionaries remain live for the
+	// dictionary-encoded witness value, but no future asynchronous dictionary
+	// mutation can consume the selected terminal cut.
+	treedb.PowerLossCertificationQuiesceValueLogDictionaryForTest(database)
+	waitForAuthoritativeResourceObserverQuiescence(t, &observeMu, &observedEvents, backgroundErrors)
 	observeMu.Lock()
 	if err := model.BeginReplayWindow(authoritativeResourcesVariantID); err != nil {
 		observeMu.Unlock()
@@ -135,10 +141,10 @@ func TestPowerLossCertificationAuthoritativeResourcesPublicReopen(t *testing.T) 
 	metaSyncs = 0
 	armed = true
 	observeMu.Unlock()
-	// Publish one deterministic terminal marker after all asynchronous resource
-	// work is quiescent. The selected cut is the marker's real maindb metadata
-	// sync and its occurrence is relative to the explicit replay window. The
-	// complete pre-window persistence trace remains in the evidence artifact.
+	// Publish one deterministic terminal marker after asynchronous dictionary
+	// work has been lifecycle-fenced. The selected cut is the marker's real
+	// maindb metadata sync and its occurrence is relative to the explicit replay
+	// window. The complete pre-window persistence trace remains in the evidence.
 	boundaryKey := []byte("certification/authoritative-resource-boundary")
 	boundaryValue := []byte("stable")
 	if err := database.SetSync(boundaryKey, boundaryValue); err != nil {


### PR DESCRIPTION
Closes #3994

Parent execution: #3908  
Blocks re-gating: #3981 / #3993

## Objective

Make the authoritative-resource power-loss certificate structurally deterministic at its terminal replay window. Before the witness arms the selected checkpoint cut, explicitly detach and drain all value-log dictionary trainers on the live DB handle and permanently prevent their recreation.

## Context

Exact-head CI for #3993 at `95a0f4b3ca0391cd31a53d44786b94dd248ebc20` exposed two failures in `TestPowerLossCertificationAuthoritativeResourcesPublicReopen`:

- Windows `windows-core-1`: the terminal checkpoint returned `collectionwal: recovery required: root publication cannot safely progress; reopen required` before reaching the intended cut.
- Linux `race-check (linux)-2`: a late value-log health update collided on `maindb/vlog_health.json.tmp.*`.

The race failure reproduced locally. The certificate's prior 500 ms quiet period was only a timing observation; dictionary trainer work accepted before the replay window could wake later, consume the selected `AfterMetaSync` cut, or poison the DB before the intended checkpoint.

This PR is the no-waiver prerequisite for rebasing and re-gating #3993.

## Non-goals

- Weakening, retrying, or bypassing the power-loss witness.
- Hiding setup persistence events or replacing the public checkpoint/reopen path.
- Reopening the DB to manufacture quiescence; that would create a new leaf-generation manifest epoch at the cut.
- Changing dictionary compression policy, value-log format, public TreeDB options, or ordinary checkpoint behavior.
- Treating #3993's failures as unrelated and merging around them.

## Design

- `compression.Trainer` now exposes `Wait`, backed by a worker-completion channel. `Close` stops acceptance; the queue worker drains accepted samples, waits for every training goroutine it spawned (including its `onAccept` callback), and only then completes `Wait`.
- `caching.DB.QuiesceValueLogDictTraining` serializes concurrent quiesce callers, follows checkpoint/close lock ordering (`flushMu`, then `writeMu`), permanently marks the live handle quiesced, detaches and deduplicates every trainer, closes them, waits after releasing the write/flush locks, and drains the final accepted-profile callback under `valueLogDictApplyMu`.
- Trainer creation refuses to restart after quiescence. Already-published dictionaries remain readable; only future sampling/training is disabled for that handle.
- Ordinary `DB.Close` also waits for trainer workers after closing them.
- The external-package certificate reaches the lifecycle seam through a `_test.go` adapter and invokes it before opening the terminal replay window.

Invariants:

1. No writer or flush can retain a trainer pointer while trainers are detached.
2. No trainer worker or accepted publication callback remains when quiescence returns.
3. Concurrent quiesce calls are safe and idempotent.
4. Quiescence does not close or reopen the DB and does not replace its storage epoch.
5. Published dictionary-backed frames stay decodable.

No on-disk format, public option, durability semantic, allocation length, mmap, or checksum behavior changes.

## Scope

- Includes:
  - `TreeDB/internal/compression/trainer.go`
  - `TreeDB/internal/compression/trainer_lifecycle_test.go`
  - `TreeDB/caching/db.go`
  - `TreeDB/caching/vlog_dict.go`
  - `TreeDB/caching/vlog_dict_quiesce_test.go`
  - authoritative-resource certificate and test-only adapter
- Excludes:
  - vector routing changes in #3993
  - compression format/policy changes
  - production callers of the explicit quiesce seam
  - cloud or external-system certification

## Correctness

Red characterization retained:

```text
go test -race ./TreeDB -run '^TestPowerLossCertificationAuthoritativeResourcesPublicReopen$' -count=10
```

Before this change, repetition 9 failed with premature `recovery required` after 108.302s. A normal 20-run stress passed, demonstrating the race-sensitive nature of the lapse.

Green evidence through exact head `352309a2d`:

```text
go test ./TreeDB/internal/compression -run '^TestTrainerWaitDrainsClosedWorker$' -count=100
go test ./TreeDB/internal/compression -run '^TestTrainerWait' -count=100
go test -race ./TreeDB/internal/compression -run '^TestTrainerWait' -count=100
go test -race ./TreeDB/caching -run '^TestQuiesceValueLogDictTrainingDetachesAndPreventsRestart$' -count=50
go test -race ./TreeDB -run '^TestPowerLossCertificationAuthoritativeResourcesPublicReopen$' -count=10
go test -race ./TreeDB -run '^TestPowerLossCertificationAuthoritativeResourcesPublicReopen$' -count=3
GOWORK=off go vet ./TreeDB/internal/compression ./TreeDB/caching ./TreeDB
GOWORK=off go test ./TreeDB/internal/compression ./TreeDB/caching ./TreeDB -count=1
git diff --check HEAD^
```

Results:

- trainer queue and spawned-job lifecycle: pass (100x normal and 100x race after the review fix)
- concurrent quiescence under race: pass (50x, 1.101s)
- authoritative-resource certificate under race: pass (10x, 111.816s), then pass again after final concurrency hardening (3x, 34.534s)
- affected-package vet: pass
- affected-package tests: pass (`compression` 0.061s, `caching` 90.327s, `TreeDB` 397.489s)
- diff check: clean

The trainer regression holds a modeled spawned training job open and proves `Wait` cannot return early. The direct quiescence test verifies detachment, completed worker shutdown, retained published dictionary state, no trainer restart, and eight concurrent callers.

## Performance

Not performance-relevant. The new synchronization is on explicit trainer quiescence and ordinary DB close; no read, write, checkpoint, value-log encode/decode, or query hot path gains per-operation work. The certificate is the only caller of the explicit lifecycle seam. No benchmark is claimed or required for this lifecycle correctness fix.

## Rollout / Toggle Plan

- No new option or default changes.
- No format migration.
- The certificate opts into quiescence through a test-only adapter.
- Revert this PR to remove the behavior; ordinary runtime operation otherwise remains unchanged apart from `Close` waiting for trainer shutdown.

## Follow-ups

- After merge, rebase #3993 onto the resulting `main`, rerun focused evidence, obtain a fresh exact-head Codex review, and require latest-head CI green.
- Continue #3908 with #3982 only after #3981 merges.

### AI Review Loop

- Codex latest-head review: clean for `352309a2d` ([result](https://github.com/snissn/gomap/pull/3995#issuecomment-5086681582)); retry also delivered clean
- Copilot latest-head review: pending if delivered
- CodeRabbit latest-head review: rate-limited after the final push; its earlier DRY-only thread was answered as intentionally distinct lock sequencing
- Review comments/threads resolved: yes; zero unresolved threads
- Re-requested after final meaningful push: yes (`@codex review` literal prompt)

---

## Optimization PR Checklist (TreeDB)

### Scope

- [x] Single, clear objective
- [x] Explicit include and exclude lists
- [x] No unrelated feature reintroduction

### Safety / Correctness

- [x] Concurrency state and invariants are defined
- [x] No written-vs-durable `*Sync`, mmap, allocation-length, or checksum behavior changed
- [x] Deterministic lifecycle regressions added without sleep-based synchronization

### Tests

- [x] Focused regression and race tests pass repeatedly
- [x] Affected-package vet and package tests pass
- [x] Repository-wide platform/shard coverage completed through latest-head required CI

### Benchmarks / Measurements

- [x] Classified not performance-relevant with rationale; no hot-path benchmark applies

### Docs / Rollout

- [x] No format, config, or milestone documentation change applies
- [x] No production toggle is introduced

### Merge Gates

- [x] Exact-head mature Codex review clean
- [x] Latest-head required CI green (33/33)
- [x] Zero unresolved review threads
