### PR TITLE
ci: isolate unified bigkeys guard timeout budget

### DIFF
--- a/.github/scripts/test_unified_bench_suites_headroom.py
+++ b/.github/scripts/test_unified_bench_suites_headroom.py
@@ -21,26 +21,37 @@ class UnifiedBenchSuitesHeadroomContractTests(unittest.TestCase):
 
     def test_bigkeys_has_an_independent_bounded_job(self) -> None:
         self.assertIn("name: bigkeys_guard (linux)", self.bigkeys)
-        self.assertIn("timeout-minutes: 20", self.bigkeys)
+        self.assertRegex(self.bigkeys, r"(?m)^    timeout-minutes: 20$")
+        self.assertRegex(self.suites, r"(?m)^    timeout-minutes: 20$")
         self.assertNotIn("Suite: bigkeys_guard", self.suites)
+        self.assertNotIn(
+            "run: ./bin/unified-bench -suite bigkeys_guard",
+            self.suites,
+        )
 
     def test_suite_gates_and_fail_closed_limits_are_preserved(self) -> None:
         self.assertIn(
-            "./bin/unified-bench -suite flushthrash -keys 200000 -seed 1 -progress=false",
+            "run: ./bin/unified-bench -suite flushthrash -keys 200000 -seed 1 -progress=false",
             self.suites,
         )
         self.assertIn(
-            "./bin/unified-bench -suite longmix -keys 100001 -seed 1 -progress=false",
+            "run: ./bin/unified-bench -suite longmix -keys 100001 -seed 1 -progress=false",
             self.suites,
         )
         self.assertIn(
-            "./bin/unified-bench -suite bigkeys_guard -keys 1000000 -seed 1 -progress=false -max-wall 15m -max-rss-mb 4096",
+            "run: ./bin/unified-bench -suite bigkeys_guard -keys 1000000 -seed 1 -progress=false -max-wall 15m -max-rss-mb 4096",
             self.bigkeys,
         )
 
     def test_profile_gates_remain_enabled(self) -> None:
-        self.assertIn("timeout-minutes: 20", self.profiles)
+        self.assertRegex(self.profiles, r"(?m)^    timeout-minutes: 20$")
         self.assertIn("profile: [balanced, fast, durable]", self.profiles)
+        self.assertIn(
+            "run: ./bin/unified-bench -dbs treedb -profile ${{ matrix.profile }} "
+            "-test write_rand,read_rand -keys 20000 -seed 1 -progress=false "
+            "-checkpoint-between-tests",
+            self.profiles,
+        )
 
 
 if __name__ == "__main__":

--- a/.github/scripts/test_unified_bench_suites_headroom.py
+++ b/.github/scripts/test_unified_bench_suites_headroom.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python3
+"""Contract tests for bounded unified-suite workflow headroom."""
+
+from __future__ import annotations
+
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+WORKFLOW = ROOT / ".github" / "workflows" / "unified-bench-suites.yml"
+
+
+class UnifiedBenchSuitesHeadroomContractTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.source = WORKFLOW.read_text(encoding="utf-8")
+        cls.suites = cls.source.split("  suites:\n", 1)[1].split("\n  bigkeys_guard:\n", 1)[0]
+        cls.bigkeys = cls.source.split("  bigkeys_guard:\n", 1)[1].split("\n  profiles:\n", 1)[0]
+        cls.profiles = cls.source.split("  profiles:\n", 1)[1]
+
+    def test_bigkeys_has_an_independent_bounded_job(self) -> None:
+        self.assertIn("name: bigkeys_guard (linux)", self.bigkeys)
+        self.assertIn("timeout-minutes: 20", self.bigkeys)
+        self.assertNotIn("Suite: bigkeys_guard", self.suites)
+
+    def test_suite_gates_and_fail_closed_limits_are_preserved(self) -> None:
+        self.assertIn(
+            "./bin/unified-bench -suite flushthrash -keys 200000 -seed 1 -progress=false",
+            self.suites,
+        )
+        self.assertIn(
+            "./bin/unified-bench -suite longmix -keys 100001 -seed 1 -progress=false",
+            self.suites,
+        )
+        self.assertIn(
+            "./bin/unified-bench -suite bigkeys_guard -keys 1000000 -seed 1 -progress=false -max-wall 15m -max-rss-mb 4096",
+            self.bigkeys,
+        )
+
+    def test_profile_gates_remain_enabled(self) -> None:
+        self.assertIn("timeout-minutes: 20", self.profiles)
+        self.assertIn("profile: [balanced, fast, durable]", self.profiles)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/workflows/unified-bench-suites.yml
+++ b/.github/workflows/unified-bench-suites.yml
@@ -45,10 +45,12 @@ jobs:
     # build/flushthrash/longmix orchestration budget.
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          persist-credentials: false
 
       - name: Setup Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
           go-version-file: go.mod
           cache: true

--- a/.github/workflows/unified-bench-suites.yml
+++ b/.github/workflows/unified-bench-suites.yml
@@ -23,6 +23,11 @@ jobs:
           cache-dependency-path: |
             go.sum
 
+      - name: Unified suite headroom contract
+        env:
+          PYTHONDONTWRITEBYTECODE: "1"
+        run: python3 .github/scripts/test_unified_bench_suites_headroom.py
+
       - name: Build unified-bench
         run: make unified-bench
 
@@ -31,6 +36,32 @@ jobs:
 
       - name: "Suite: longmix"
         run: ./bin/unified-bench -suite longmix -keys 100001 -seed 1 -progress=false
+
+  bigkeys_guard:
+    name: bigkeys_guard (linux)
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    # Keep this job's 15-minute fail-closed suite cap independent from the
+    # build/flushthrash/longmix orchestration budget.
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+          cache-dependency-path: |
+            go.sum
+
+      - name: Unified suite headroom contract
+        env:
+          PYTHONDONTWRITEBYTECODE: "1"
+        run: python3 .github/scripts/test_unified_bench_suites_headroom.py
+
+      - name: Build unified-bench
+        run: make unified-bench
 
       - name: "Suite: bigkeys_guard"
         run: ./bin/unified-bench -suite bigkeys_guard -keys 1000000 -seed 1 -progress=false -max-wall 15m -max-rss-mb 4096


### PR DESCRIPTION
Closes #4002

Parent: #4004

## Objective

Give `bigkeys_guard` an independent outer timeout envelope so variable earlier
suite stages cannot consume its headroom, while preserving the suite-owned
15-minute wall limit, 4096 MiB RSS limit, and every existing gate.

## Scope

- Split `bigkeys_guard` into its own Linux job while retaining `flushthrash`,
  `longmix`, and all three profile jobs.
- Preserve the exact
  `bigkeys_guard -max-wall 15m -max-rss-mb 4096` command and every existing
  suite/profile input.
- Add a workflow contract that rejects returning bigkeys to the shared suite
  job and checks both job-level bounds, active run commands, fail-closed limits,
  and the profile matrix.
- Use repository-approved immutable action SHAs and disable checkout credential
  persistence in the new job.

## Hosted timing evidence

The outer 20-minute `suites (linux)` job, not a suite-owned assertion or
RSS/wall guard, cancelled twice:

- run 30268381148 attempt 1: build 64s, flushthrash 200s, longmix 195s, then
  bigkeys cancelled after 744s;
- run 30291217563: build 60s, flushthrash 311s, longmix 331s, then bigkeys
  cancelled after 501s.

Recent successful shared-job runs also showed variable stage duration:
30288218432 (59s / 49s / 52s / 278s), 30293851360
(43s / 104s / 101s / 515s), and 30295916094
(62s / 49s / 54s / 275s).

A larger shared outer timeout would still couple the maximum 15-minute bigkeys
guard to unrelated prior stages. The split gives bigkeys a fresh 20-minute job
envelope while keeping the 15-minute fail-closed cap authoritative.

## Validation

Exact head: `235ca7c8eefb22b15eb978bbf7faba32ef1aae7e`

- Failing first:
  `PYTHONDONTWRITEBYTECODE=1 python3 .github/scripts/test_unified_bench_suites_headroom.py`
  failed against the original shared job because `bigkeys_guard` had no
  independent job.
- Passing: the strengthened workflow contract passes all three tests.
- `git diff --check` passes.
- Exact-head suites proof 1: run 30318178058, all five jobs green;
  `bigkeys_guard` job 7m31s.
- Independent exact-SHA suites proof 2: run 30318983499, all five jobs green;
  `bigkeys_guard` job 11m39s.
- Independent exact-SHA suites proof 3: run 30319778318, all five jobs green;
  `bigkeys_guard` job 7m17s.
- Exact-head push workflows are green. Third-proof TreeDB matrix run
  30319788640 also completed green across both race shards, all Windows shards,
  macOS, Linux, performance gates, and the required-gate aggregator.

The three bigkeys executions all remain below the independent 20-minute job
bound and preserve the command's internal 15-minute wall cap.

## Non-goals / performance

No TreeDB product, storage, WAL, value-log, vector, or benchmark behavior
changes. This is CI orchestration reliability work; product performance is not
applicable. Hosted duration/headroom is the required evidence.

## Review and merge gates

- CodeRabbit's three valid workflow-contract/security findings were fixed at
  the exact head; all threads are resolved.
- Exact-head Codex review on `235ca7c8ee` reports no major issues.
- Zero unresolved review threads.
- Required `TreeDB required gate` is green.
- Third-proof TreeDB run 30319788640: green.
- The five same-SHA proof-2 workflows previously cancelled by the coordinator
  were rerun in place and all completed green: Format 30318983571, redis
  30318983486, Root 30318983514, HashDB Windows 30318983500, and unified vet
  30318983492.
