### PR TITLE
test(treedb): reconcile captured power-loss oracle creates

### DIFF
--- a/TreeDB/internal/powerlossoracle/model.go
+++ b/TreeDB/internal/powerlossoracle/model.go
@@ -475,11 +475,23 @@ func (m *Model) observeNamespace(root string, event durabilitycut.Event) error {
 			return fmt.Errorf("powerlossoracle: read created file %q: %w", event.NewPath, err)
 		}
 		if id, exists := m.volatile[path]; exists {
+			node := m.inodes[id]
 			if _, stable := m.stable[path]; stable {
+				// Capture can race a background CreateTemp between the real
+				// namespace mutation and its synchronous observer callback. If
+				// both observations name the same physical file, reconcile the
+				// delayed callback with the captured baseline. A different inode
+				// remains a genuine duplicate-create error.
+				if validStableIdentity(node.stableIdentity) && validStableIdentity(identity) &&
+					rootpublication.SamePhysicalIdentity(node.stableIdentity, identity) {
+					node.volatile = clone(data)
+					m.trace = append(m.trace, "create-captured:"+path)
+					return nil
+				}
 				return fmt.Errorf("powerlossoracle: file already exists %q", path)
 			}
-			m.inodes[id].volatile = clone(data)
-			m.inodes[id].stableIdentity = physicalStableIdentity(identity)
+			node.volatile = clone(data)
+			node.stableIdentity = physicalStableIdentity(identity)
 			m.trace = append(m.trace, "create-observed:"+path)
 			return nil
 		}

--- a/TreeDB/internal/powerlossoracle/model.go
+++ b/TreeDB/internal/powerlossoracle/model.go
@@ -476,13 +476,16 @@ func (m *Model) observeNamespace(root string, event durabilitycut.Event) error {
 		}
 		if id, exists := m.volatile[path]; exists {
 			node := m.inodes[id]
-			if _, stable := m.stable[path]; stable {
+			if stableID, stable := m.stable[path]; stable {
 				// Capture can race a background CreateTemp between the real
 				// namespace mutation and its synchronous observer callback. If
-				// both observations name the same physical file, reconcile the
-				// delayed callback with the captured baseline. A different inode
-				// remains a genuine duplicate-create error.
-				if validStableIdentity(node.stableIdentity) && validStableIdentity(identity) &&
+				// the volatile and stable names still reference the same model
+				// inode and both observations name the same physical file,
+				// reconcile the delayed callback with the captured baseline. A
+				// replacement overlay or different physical inode remains a
+				// genuine duplicate-create error.
+				if id == stableID &&
+					validStableIdentity(node.stableIdentity) && validStableIdentity(identity) &&
 					rootpublication.SamePhysicalIdentity(node.stableIdentity, identity) {
 					node.volatile = clone(data)
 					m.trace = append(m.trace, "create-captured:"+path)

--- a/TreeDB/internal/powerlossoracle/model.go
+++ b/TreeDB/internal/powerlossoracle/model.go
@@ -470,14 +470,16 @@ func (m *Model) observeNamespace(root string, event durabilitycut.Event) error {
 				// the volatile and stable names still reference the same model
 				// inode and both observations name the same physical file,
 				// reconcile the delayed callback with the captured baseline.
-				// The callback precedes parent-directory sync, so demote the
-				// name that Capture initially imported as stable; SyncDir can
-				// promote it again. A replacement overlay or different physical
-				// inode remains a genuine duplicate-create error.
+				// The callback precedes both file and parent-directory sync, so
+				// demote the bytes and name that Capture initially imported as
+				// stable; SyncFile and SyncDir can promote them independently.
+				// A replacement overlay or different physical inode remains a
+				// genuine duplicate-create error.
 				if id == stableID &&
 					validStableIdentity(node.stableIdentity) && validStableIdentity(identity) &&
 					rootpublication.SamePhysicalIdentity(node.stableIdentity, identity) {
 					node.volatile = clone(data)
+					node.stable = nil
 					delete(m.stable, path)
 					m.trace = append(m.trace, "create-captured:"+path)
 					return nil

--- a/TreeDB/internal/powerlossoracle/model.go
+++ b/TreeDB/internal/powerlossoracle/model.go
@@ -469,13 +469,16 @@ func (m *Model) observeNamespace(root string, event durabilitycut.Event) error {
 				// namespace mutation and its synchronous observer callback. If
 				// the volatile and stable names still reference the same model
 				// inode and both observations name the same physical file,
-				// reconcile the delayed callback with the captured baseline. A
-				// replacement overlay or different physical inode remains a
-				// genuine duplicate-create error.
+				// reconcile the delayed callback with the captured baseline.
+				// The callback precedes parent-directory sync, so demote the
+				// name that Capture initially imported as stable; SyncDir can
+				// promote it again. A replacement overlay or different physical
+				// inode remains a genuine duplicate-create error.
 				if id == stableID &&
 					validStableIdentity(node.stableIdentity) && validStableIdentity(identity) &&
 					rootpublication.SamePhysicalIdentity(node.stableIdentity, identity) {
 					node.volatile = clone(data)
+					delete(m.stable, path)
 					m.trace = append(m.trace, "create-captured:"+path)
 					return nil
 				}

--- a/TreeDB/internal/powerlossoracle/model.go
+++ b/TreeDB/internal/powerlossoracle/model.go
@@ -8,6 +8,7 @@ import (
 	"encoding/binary"
 	"errors"
 	"fmt"
+	"io"
 	"io/fs"
 	"os"
 	pathpkg "path"
@@ -153,9 +154,12 @@ func capture(root string, excludeLockFiles bool, excluded []string) (*Model, err
 			return nil
 		}
 		if entry.IsDir() {
-			identity, err := captureStableIdentity(path)
+			info, _, identity, err := capturePathSnapshot(path)
 			if err != nil {
 				return err
+			}
+			if !info.IsDir() {
+				return fmt.Errorf("powerlossoracle: captured directory %q rebound to %s", rel, info.Mode())
 			}
 			m.volatileDirs[rel] = identity
 			m.stableDirs[rel] = identity
@@ -164,11 +168,7 @@ func capture(root string, excludeLockFiles bool, excluded []string) (*Model, err
 		if !entry.Type().IsRegular() {
 			return fmt.Errorf("powerlossoracle: unsupported entry %q (%s)", rel, entry.Type())
 		}
-		data, err := os.ReadFile(path)
-		if err != nil {
-			return err
-		}
-		identity, err := captureStableIdentity(path)
+		_, data, identity, err := capturePathSnapshot(path)
 		if err != nil {
 			return err
 		}
@@ -288,9 +288,12 @@ func (m *Model) Overlay(root string) error {
 			return nil
 		}
 		if entry.IsDir() {
-			identity, err := captureStableIdentity(path)
+			info, _, identity, err := capturePathSnapshot(path)
 			if err != nil {
 				return err
+			}
+			if !info.IsDir() {
+				return fmt.Errorf("powerlossoracle: overlaid directory %q rebound to %s", rel, info.Mode())
 			}
 			seenDirs[rel] = identity
 			return nil
@@ -298,11 +301,7 @@ func (m *Model) Overlay(root string) error {
 		if !entry.Type().IsRegular() {
 			return fmt.Errorf("powerlossoracle: unsupported entry %q (%s)", rel, entry.Type())
 		}
-		data, err := os.ReadFile(path)
-		if err != nil {
-			return err
-		}
-		identity, err := captureStableIdentity(path)
+		_, data, identity, err := capturePathSnapshot(path)
 		if err != nil {
 			return err
 		}
@@ -453,26 +452,15 @@ func (m *Model) observeNamespace(root string, event durabilitycut.Event) error {
 		if err != nil {
 			return err
 		}
-		info, err := os.Stat(event.NewPath)
+		info, data, identity, err := capturePathSnapshot(event.NewPath)
 		if err != nil {
-			return fmt.Errorf("powerlossoracle: stat created path %q: %w", event.NewPath, err)
-		}
-		identity, err := captureStableIdentity(event.NewPath)
-		if err != nil {
-			return err
+			return fmt.Errorf("powerlossoracle: capture created path %q: %w", event.NewPath, err)
 		}
 		if info.IsDir() {
 			m.ensureVolatileParents(path)
 			m.volatileDirs[path] = identity
 			m.trace = append(m.trace, "create-dir:"+path)
 			return nil
-		}
-		if !info.Mode().IsRegular() {
-			return fmt.Errorf("powerlossoracle: created path %q is unsupported type %s", event.NewPath, info.Mode())
-		}
-		data, err := os.ReadFile(event.NewPath)
-		if err != nil {
-			return fmt.Errorf("powerlossoracle: read created file %q: %w", event.NewPath, err)
 		}
 		if id, exists := m.volatile[path]; exists {
 			node := m.inodes[id]
@@ -1036,12 +1024,44 @@ func syntheticDirectoryIdentity(id uint64) rootpublication.StableIdentity {
 	return rootpublication.StableIdentity{Platform: "powerlossoracle", ObjectID: objectID}
 }
 
-func captureStableIdentity(path string) (rootpublication.StableIdentity, error) {
+func capturePathSnapshot(path string) (fs.FileInfo, []byte, rootpublication.StableIdentity, error) {
 	file, err := os.Open(path)
 	if err != nil {
-		return rootpublication.StableIdentity{}, err
+		return nil, nil, rootpublication.StableIdentity{}, err
 	}
 	defer file.Close()
+	return captureOpenFileSnapshot(file)
+}
+
+func captureOpenFileSnapshot(file *os.File) (fs.FileInfo, []byte, rootpublication.StableIdentity, error) {
+	if file == nil {
+		return nil, nil, rootpublication.StableIdentity{}, os.ErrInvalid
+	}
+	info, err := file.Stat()
+	if err != nil {
+		return nil, nil, rootpublication.StableIdentity{}, err
+	}
+	identity, err := captureStableIdentityFromFile(file)
+	if err != nil {
+		return nil, nil, rootpublication.StableIdentity{}, err
+	}
+	if info.IsDir() {
+		return info, nil, identity, nil
+	}
+	if !info.Mode().IsRegular() {
+		return nil, nil, rootpublication.StableIdentity{}, fmt.Errorf("powerlossoracle: path %q is unsupported type %s", file.Name(), info.Mode())
+	}
+	if _, err := file.Seek(0, io.SeekStart); err != nil {
+		return nil, nil, rootpublication.StableIdentity{}, err
+	}
+	data, err := io.ReadAll(file)
+	if err != nil {
+		return nil, nil, rootpublication.StableIdentity{}, err
+	}
+	return info, data, identity, nil
+}
+
+func captureStableIdentityFromFile(file *os.File) (rootpublication.StableIdentity, error) {
 	identity, err := rootpublication.StableIdentityFromFile(file)
 	if errors.Is(err, rootpublication.ErrStableIdentityUnsupported) {
 		return rootpublication.StableIdentity{}, nil

--- a/TreeDB/internal/powerlossoracle/model.go
+++ b/TreeDB/internal/powerlossoracle/model.go
@@ -91,6 +91,11 @@ type Model struct {
 	inodes    map[uint64]*inode
 	volatile  map[string]uint64
 	stable    map[string]uint64
+	// Sync callbacks that have been serialized after Capture. A delayed
+	// same-inode create callback may invalidate Capture's provisional stable
+	// baseline, but it must not roll back these later completed promotions.
+	syncedFiles map[uint64]struct{}
+	syncedDirs  map[string]struct{}
 	// overlayDetached retains the inode behind a process-visible name that a
 	// post-operation scan no longer sees. Concurrent producers can complete a
 	// rename before their synchronous observation callbacks acquire the test's
@@ -190,6 +195,8 @@ func newModel() *Model {
 		inodes:          make(map[uint64]*inode),
 		volatile:        make(map[string]uint64),
 		stable:          make(map[string]uint64),
+		syncedFiles:     make(map[uint64]struct{}),
+		syncedDirs:      make(map[string]struct{}),
 		overlayDetached: make(map[string]uint64),
 		volatileDirs:    map[string]rootpublication.StableIdentity{".": rootIdentity},
 		stableDirs:      map[string]rootpublication.StableIdentity{".": rootIdentity},
@@ -228,6 +235,12 @@ func (m *Model) Clone() *Model {
 	}
 	for path, id := range m.stable {
 		out.stable[path] = id
+	}
+	for id := range m.syncedFiles {
+		out.syncedFiles[id] = struct{}{}
+	}
+	for dir := range m.syncedDirs {
+		out.syncedDirs[dir] = struct{}{}
 	}
 	for path, id := range m.overlayDetached {
 		out.overlayDetached[path] = id
@@ -470,17 +483,22 @@ func (m *Model) observeNamespace(root string, event durabilitycut.Event) error {
 				// the volatile and stable names still reference the same model
 				// inode and both observations name the same physical file,
 				// reconcile the delayed callback with the captured baseline.
-				// The callback precedes both file and parent-directory sync, so
-				// demote the bytes and name that Capture initially imported as
-				// stable; SyncFile and SyncDir can promote them independently.
+				// The captured stable baseline is provisional. Demote only the
+				// portions that no later serialized sync has promoted: a file
+				// sync preserves bytes and a parent-directory sync preserves the
+				// name independently.
 				// A replacement overlay or different physical inode remains a
 				// genuine duplicate-create error.
 				if id == stableID &&
 					validStableIdentity(node.stableIdentity) && validStableIdentity(identity) &&
 					rootpublication.SamePhysicalIdentity(node.stableIdentity, identity) {
 					node.volatile = clone(data)
-					node.stable = nil
-					delete(m.stable, path)
+					if _, synced := m.syncedFiles[id]; !synced {
+						node.stable = nil
+					}
+					if _, synced := m.syncedDirs[cleanInternal(pathpkg.Dir(path))]; !synced {
+						delete(m.stable, path)
+					}
 					m.trace = append(m.trace, "create-captured:"+path)
 					return nil
 				}
@@ -717,6 +735,7 @@ func (m *Model) SyncFile(path string) error {
 		return fmt.Errorf("powerlossoracle: sync missing file %q", path)
 	}
 	m.inodes[id].stable = clone(m.inodes[id].volatile)
+	m.syncedFiles[id] = struct{}{}
 	m.trace = append(m.trace, "sync-file:"+path)
 	return nil
 }
@@ -731,6 +750,7 @@ func (m *Model) SyncDir(dir string) error {
 	if _, ok := m.volatileDirs[dir]; !ok {
 		return fmt.Errorf("powerlossoracle: sync missing directory %q", dir)
 	}
+	m.syncedDirs[dir] = struct{}{}
 	for path := range m.stable {
 		if cleanInternal(pathpkg.Dir(path)) == dir {
 			delete(m.stable, path)

--- a/TreeDB/internal/powerlossoracle/model.go
+++ b/TreeDB/internal/powerlossoracle/model.go
@@ -168,7 +168,7 @@ func capture(root string, excludeLockFiles bool, excluded []string) (*Model, err
 		if !entry.Type().IsRegular() {
 			return fmt.Errorf("powerlossoracle: unsupported entry %q (%s)", rel, entry.Type())
 		}
-		_, data, identity, err := capturePathSnapshot(path)
+		data, identity, err := captureRegularPathSnapshot(path)
 		if err != nil {
 			return err
 		}
@@ -301,7 +301,7 @@ func (m *Model) Overlay(root string) error {
 		if !entry.Type().IsRegular() {
 			return fmt.Errorf("powerlossoracle: unsupported entry %q (%s)", rel, entry.Type())
 		}
-		_, data, identity, err := capturePathSnapshot(path)
+		data, identity, err := captureRegularPathSnapshot(path)
 		if err != nil {
 			return err
 		}
@@ -1031,6 +1031,17 @@ func capturePathSnapshot(path string) (fs.FileInfo, []byte, rootpublication.Stab
 	}
 	defer file.Close()
 	return captureOpenFileSnapshot(file)
+}
+
+func captureRegularPathSnapshot(path string) ([]byte, rootpublication.StableIdentity, error) {
+	info, data, identity, err := capturePathSnapshot(path)
+	if err != nil {
+		return nil, rootpublication.StableIdentity{}, err
+	}
+	if !info.Mode().IsRegular() {
+		return nil, rootpublication.StableIdentity{}, fmt.Errorf("powerlossoracle: regular file %q rebound to %s", path, info.Mode())
+	}
+	return data, identity, nil
 }
 
 func captureOpenFileSnapshot(file *os.File) (fs.FileInfo, []byte, rootpublication.StableIdentity, error) {

--- a/TreeDB/internal/powerlossoracle/model_path_rebind_unix_test.go
+++ b/TreeDB/internal/powerlossoracle/model_path_rebind_unix_test.go
@@ -1,0 +1,60 @@
+//go:build !windows
+
+package powerlossoracle
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/snissn/gomap/TreeDB/internal/rootpublication"
+)
+
+func TestCaptureOpenFileSnapshotKeepsBytesAndIdentityCoupledAcrossPathRebind(t *testing.T) {
+	root := t.TempDir()
+	path := filepath.Join(root, "resource")
+	if err := os.WriteFile(path, []byte("captured"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	captured, err := os.Open(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer captured.Close()
+	capturedIdentity, err := rootpublication.StableIdentityFromFile(captured)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := os.Rename(path, filepath.Join(root, "captured-inode")); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte("replacement"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	replacement, err := os.Open(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	replacementIdentity, err := rootpublication.StableIdentityFromFile(replacement)
+	if closeErr := replacement.Close(); err == nil {
+		err = closeErr
+	}
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	info, data, identity, err := captureOpenFileSnapshot(captured)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !info.Mode().IsRegular() || string(data) != "captured" {
+		t.Fatalf("snapshot mode=%s data=%q want retained regular file bytes", info.Mode(), data)
+	}
+	if !rootpublication.SamePhysicalIdentity(identity, capturedIdentity) {
+		t.Fatalf("snapshot identity=%+v want captured identity=%+v", identity, capturedIdentity)
+	}
+	if rootpublication.SamePhysicalIdentity(identity, replacementIdentity) {
+		t.Fatalf("snapshot identity=%+v unexpectedly followed replacement=%+v", identity, replacementIdentity)
+	}
+}

--- a/TreeDB/internal/powerlossoracle/model_path_rebind_unix_test.go
+++ b/TreeDB/internal/powerlossoracle/model_path_rebind_unix_test.go
@@ -1,4 +1,4 @@
-//go:build !windows
+//go:build darwin || linux || freebsd || netbsd || openbsd
 
 package powerlossoracle
 

--- a/TreeDB/internal/powerlossoracle/model_path_rebind_windows_test.go
+++ b/TreeDB/internal/powerlossoracle/model_path_rebind_windows_test.go
@@ -1,0 +1,46 @@
+//go:build windows
+
+package powerlossoracle
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/snissn/gomap/TreeDB/internal/rootpublication"
+)
+
+func TestCaptureOpenFileSnapshotWindowsRetainedHandleBlocksPathRebind(t *testing.T) {
+	root := t.TempDir()
+	path := filepath.Join(root, "resource")
+	if err := os.WriteFile(path, []byte("captured"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	captured, err := os.Open(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer captured.Close()
+	capturedIdentity, err := rootpublication.StableIdentityFromFile(captured)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// os.Open does not grant delete sharing on Windows. The retained handle
+	// therefore prevents the pathname from being rebound while the snapshot is
+	// captured, which is the platform's equivalent safety property.
+	if err := os.Rename(path, filepath.Join(root, "captured-inode")); err == nil {
+		t.Fatal("rename unexpectedly rebound a path while its snapshot handle was retained")
+	}
+
+	info, data, identity, err := captureOpenFileSnapshot(captured)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !info.Mode().IsRegular() || string(data) != "captured" {
+		t.Fatalf("snapshot mode=%s data=%q want retained regular file bytes", info.Mode(), data)
+	}
+	if !rootpublication.SamePhysicalIdentity(identity, capturedIdentity) {
+		t.Fatalf("snapshot identity=%+v want captured identity=%+v", identity, capturedIdentity)
+	}
+}

--- a/TreeDB/internal/powerlossoracle/model_test.go
+++ b/TreeDB/internal/powerlossoracle/model_test.go
@@ -92,6 +92,16 @@ func TestCaptureExcludingKeepsNonExcludedNestedLock(t *testing.T) {
 	}
 }
 
+func TestCaptureRegularPathSnapshotRejectsDirectoryRebind(t *testing.T) {
+	_, _, err := captureRegularPathSnapshot(t.TempDir())
+	if err == nil {
+		t.Fatal("regular-file snapshot accepted a directory rebound")
+	}
+	if !strings.Contains(err.Error(), "rebound to") {
+		t.Fatalf("regular-file snapshot err=%v, want rebound diagnostic", err)
+	}
+}
+
 func TestCapturedModelObserveContinuesToOmitNestedLocks(t *testing.T) {
 	root := t.TempDir()
 	dictDir := filepath.Join(root, "dictdb")

--- a/TreeDB/internal/powerlossoracle/model_test.go
+++ b/TreeDB/internal/powerlossoracle/model_test.go
@@ -40,55 +40,6 @@ func TestCaptureOmitsProcessLocalLock(t *testing.T) {
 	}
 }
 
-func TestCaptureOpenFileSnapshotKeepsBytesAndIdentityCoupledAcrossPathRebind(t *testing.T) {
-	root := t.TempDir()
-	path := filepath.Join(root, "resource")
-	if err := os.WriteFile(path, []byte("captured"), 0o600); err != nil {
-		t.Fatal(err)
-	}
-	captured, err := os.Open(path)
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer captured.Close()
-	capturedIdentity, err := rootpublication.StableIdentityFromFile(captured)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	if err := os.Rename(path, filepath.Join(root, "captured-inode")); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.WriteFile(path, []byte("replacement"), 0o600); err != nil {
-		t.Fatal(err)
-	}
-	replacement, err := os.Open(path)
-	if err != nil {
-		t.Fatal(err)
-	}
-	replacementIdentity, err := rootpublication.StableIdentityFromFile(replacement)
-	if closeErr := replacement.Close(); err == nil {
-		err = closeErr
-	}
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	info, data, identity, err := captureOpenFileSnapshot(captured)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if !info.Mode().IsRegular() || string(data) != "captured" {
-		t.Fatalf("snapshot mode=%s data=%q want retained regular file bytes", info.Mode(), data)
-	}
-	if !rootpublication.SamePhysicalIdentity(identity, capturedIdentity) {
-		t.Fatalf("snapshot identity=%+v want captured identity=%+v", identity, capturedIdentity)
-	}
-	if rootpublication.SamePhysicalIdentity(identity, replacementIdentity) {
-		t.Fatalf("snapshot identity=%+v unexpectedly followed replacement=%+v", identity, replacementIdentity)
-	}
-}
-
 func TestCaptureOmitsNestedProcessLocalLocks(t *testing.T) {
 	root := t.TempDir()
 	for _, dir := range []string{"maindb", "dictdb", "nested/leafdb"} {

--- a/TreeDB/internal/powerlossoracle/model_test.go
+++ b/TreeDB/internal/powerlossoracle/model_test.go
@@ -697,6 +697,39 @@ func TestObservedCreateRejectsDifferentFileAtCapturedPath(t *testing.T) {
 	}
 }
 
+func TestObservedCreateRejectsReplacementOverlaidAtCapturedPath(t *testing.T) {
+	root := t.TempDir()
+	tmp := filepath.Join(root, "health.json.tmp.1")
+	if err := os.WriteFile(tmp, []byte("captured"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	model, err := Capture(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Simulate another serialized callback overlaying the filesystem after the
+	// captured path was rebound but before the delayed create callback arrives.
+	// The volatile name now points at the replacement while the stable name
+	// still points at the captured inode.
+	if err := os.Rename(tmp, filepath.Join(root, "captured-inode")); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(tmp, []byte("replacement"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := model.Overlay(root); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := model.Observe(root, durabilitycut.Event{
+		Namespace: durabilitycut.NamespaceCreate,
+		NewPath:   tmp,
+	}); err == nil || !strings.Contains(err.Error(), "file already exists") {
+		t.Fatalf("observe delayed create after replacement overlay err=%v want duplicate-create error", err)
+	}
+}
+
 func TestCrossDirectoryRenameNeedsBothDirectorySyncs(t *testing.T) {
 	model := newModel()
 	if err := model.Create("from/value", []byte("payload")); err != nil {

--- a/TreeDB/internal/powerlossoracle/model_test.go
+++ b/TreeDB/internal/powerlossoracle/model_test.go
@@ -660,7 +660,7 @@ func TestObservedRenameRecoversSourceDetachedByEarlierOverlay(t *testing.T) {
 func TestObservedCreateAcceptsSameFileCapturedBeforeCallback(t *testing.T) {
 	root := t.TempDir()
 	tmp := filepath.Join(root, "health.json.tmp.1")
-	if err := os.WriteFile(tmp, nil, 0o600); err != nil {
+	if err := os.WriteFile(tmp, []byte("captured"), 0o600); err != nil {
 		t.Fatal(err)
 	}
 	model, err := Capture(root)
@@ -677,6 +677,23 @@ func TestObservedCreateAcceptsSameFileCapturedBeforeCallback(t *testing.T) {
 		NewPath:   tmp,
 	}); err != nil {
 		t.Fatalf("observe delayed create for captured file: %v", err)
+	}
+	beforeSync := t.TempDir()
+	if err := model.MaterializeStable(beforeSync); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(filepath.Join(beforeSync, "health.json.tmp.1")); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("captured create became durable before directory sync: %v", err)
+	}
+	if err := model.SyncDir("."); err != nil {
+		t.Fatal(err)
+	}
+	afterSync := t.TempDir()
+	if err := model.MaterializeStable(afterSync); err != nil {
+		t.Fatal(err)
+	}
+	if got, err := os.ReadFile(filepath.Join(afterSync, "health.json.tmp.1")); err != nil || string(got) != "captured" {
+		t.Fatalf("captured create after directory sync=%q err=%v want captured", got, err)
 	}
 }
 

--- a/TreeDB/internal/powerlossoracle/model_test.go
+++ b/TreeDB/internal/powerlossoracle/model_test.go
@@ -647,6 +647,56 @@ func TestObservedRenameRecoversSourceDetachedByEarlierOverlay(t *testing.T) {
 	}
 }
 
+func TestObservedCreateAcceptsSameFileCapturedBeforeCallback(t *testing.T) {
+	root := t.TempDir()
+	tmp := filepath.Join(root, "health.json.tmp.1")
+	if err := os.WriteFile(tmp, nil, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	model, err := Capture(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// A background producer can complete CreateTemp while Capture is walking
+	// the directory, then deliver that create's synchronous observer callback
+	// after Capture returns. The callback describes the same physical file and
+	// must reconcile with the captured baseline instead of reporting EEXIST.
+	if err := model.Observe(root, durabilitycut.Event{
+		Namespace: durabilitycut.NamespaceCreate,
+		NewPath:   tmp,
+	}); err != nil {
+		t.Fatalf("observe delayed create for captured file: %v", err)
+	}
+}
+
+func TestObservedCreateRejectsDifferentFileAtCapturedPath(t *testing.T) {
+	root := t.TempDir()
+	tmp := filepath.Join(root, "health.json.tmp.1")
+	if err := os.WriteFile(tmp, nil, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	model, err := Capture(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Keep the captured inode alive under another name so recreating tmp cannot
+	// reuse its physical identity.
+	if err := os.Rename(tmp, filepath.Join(root, "captured-inode")); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(tmp, nil, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := model.Observe(root, durabilitycut.Event{
+		Namespace: durabilitycut.NamespaceCreate,
+		NewPath:   tmp,
+	}); err == nil || !strings.Contains(err.Error(), "file already exists") {
+		t.Fatalf("observe different file at captured path err=%v want duplicate-create error", err)
+	}
+}
+
 func TestCrossDirectoryRenameNeedsBothDirectorySyncs(t *testing.T) {
 	model := newModel()
 	if err := model.Create("from/value", []byte("payload")); err != nil {

--- a/TreeDB/internal/powerlossoracle/model_test.go
+++ b/TreeDB/internal/powerlossoracle/model_test.go
@@ -707,6 +707,96 @@ func TestObservedCreateAcceptsSameFileCapturedBeforeCallback(t *testing.T) {
 	}
 }
 
+func TestObservedCreatePreservesSyncsSerializedBeforeDelayedCallback(t *testing.T) {
+	for _, tc := range []struct {
+		name            string
+		beforeCallback  func(t *testing.T, model *Model)
+		afterCallback   func(t *testing.T, model *Model)
+		wantStableName  bool
+		wantStableBytes string
+	}{
+		{
+			name: "file-sync",
+			beforeCallback: func(t *testing.T, model *Model) {
+				t.Helper()
+				if err := model.SyncFile("health.json.tmp.1"); err != nil {
+					t.Fatal(err)
+				}
+			},
+			afterCallback: func(t *testing.T, model *Model) {
+				t.Helper()
+				if err := model.SyncDir("."); err != nil {
+					t.Fatal(err)
+				}
+			},
+			wantStableName:  true,
+			wantStableBytes: "captured",
+		},
+		{
+			name: "parent-directory-sync",
+			beforeCallback: func(t *testing.T, model *Model) {
+				t.Helper()
+				if err := model.SyncDir("."); err != nil {
+					t.Fatal(err)
+				}
+			},
+			wantStableName:  true,
+			wantStableBytes: "",
+		},
+		{
+			name: "file-and-parent-directory-sync",
+			beforeCallback: func(t *testing.T, model *Model) {
+				t.Helper()
+				if err := model.SyncFile("health.json.tmp.1"); err != nil {
+					t.Fatal(err)
+				}
+				if err := model.SyncDir("."); err != nil {
+					t.Fatal(err)
+				}
+			},
+			wantStableName:  true,
+			wantStableBytes: "captured",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			root := t.TempDir()
+			tmp := filepath.Join(root, "health.json.tmp.1")
+			if err := os.WriteFile(tmp, []byte("captured"), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			model, err := Capture(root)
+			if err != nil {
+				t.Fatal(err)
+			}
+			tc.beforeCallback(t, model)
+			if err := model.Observe(root, durabilitycut.Event{
+				Namespace: durabilitycut.NamespaceCreate,
+				NewPath:   tmp,
+			}); err != nil {
+				t.Fatalf("observe delayed create: %v", err)
+			}
+			if tc.afterCallback != nil {
+				tc.afterCallback(t, model)
+			}
+
+			stable := t.TempDir()
+			if err := model.MaterializeStable(stable); err != nil {
+				t.Fatal(err)
+			}
+			path := filepath.Join(stable, "health.json.tmp.1")
+			if !tc.wantStableName {
+				if _, err := os.Stat(path); !errors.Is(err, os.ErrNotExist) {
+					t.Fatalf("stable file after delayed create stat err=%v want not exist", err)
+				}
+				return
+			}
+			if got, err := os.ReadFile(path); err != nil || string(got) != tc.wantStableBytes {
+				t.Fatalf("stable file after delayed create=%q err=%v want=%q", got, err, tc.wantStableBytes)
+			}
+		})
+	}
+}
+
 func TestObservedCreateRejectsDifferentFileAtCapturedPath(t *testing.T) {
 	root := t.TempDir()
 	tmp := filepath.Join(root, "health.json.tmp.1")

--- a/TreeDB/internal/powerlossoracle/model_test.go
+++ b/TreeDB/internal/powerlossoracle/model_test.go
@@ -692,8 +692,18 @@ func TestObservedCreateAcceptsSameFileCapturedBeforeCallback(t *testing.T) {
 	if err := model.MaterializeStable(afterSync); err != nil {
 		t.Fatal(err)
 	}
-	if got, err := os.ReadFile(filepath.Join(afterSync, "health.json.tmp.1")); err != nil || string(got) != "captured" {
-		t.Fatalf("captured create after directory sync=%q err=%v want captured", got, err)
+	if got, err := os.ReadFile(filepath.Join(afterSync, "health.json.tmp.1")); err != nil || len(got) != 0 {
+		t.Fatalf("captured create after directory-only sync=%q err=%v want empty unsynced bytes", got, err)
+	}
+	if err := model.SyncFile("health.json.tmp.1"); err != nil {
+		t.Fatal(err)
+	}
+	afterFileSync := t.TempDir()
+	if err := model.MaterializeStable(afterFileSync); err != nil {
+		t.Fatal(err)
+	}
+	if got, err := os.ReadFile(filepath.Join(afterFileSync, "health.json.tmp.1")); err != nil || string(got) != "captured" {
+		t.Fatalf("captured create after file sync=%q err=%v want captured", got, err)
 	}
 }
 

--- a/TreeDB/internal/powerlossoracle/model_test.go
+++ b/TreeDB/internal/powerlossoracle/model_test.go
@@ -40,6 +40,55 @@ func TestCaptureOmitsProcessLocalLock(t *testing.T) {
 	}
 }
 
+func TestCaptureOpenFileSnapshotKeepsBytesAndIdentityCoupledAcrossPathRebind(t *testing.T) {
+	root := t.TempDir()
+	path := filepath.Join(root, "resource")
+	if err := os.WriteFile(path, []byte("captured"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	captured, err := os.Open(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer captured.Close()
+	capturedIdentity, err := rootpublication.StableIdentityFromFile(captured)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := os.Rename(path, filepath.Join(root, "captured-inode")); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte("replacement"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	replacement, err := os.Open(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	replacementIdentity, err := rootpublication.StableIdentityFromFile(replacement)
+	if closeErr := replacement.Close(); err == nil {
+		err = closeErr
+	}
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	info, data, identity, err := captureOpenFileSnapshot(captured)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !info.Mode().IsRegular() || string(data) != "captured" {
+		t.Fatalf("snapshot mode=%s data=%q want retained regular file bytes", info.Mode(), data)
+	}
+	if !rootpublication.SamePhysicalIdentity(identity, capturedIdentity) {
+		t.Fatalf("snapshot identity=%+v want captured identity=%+v", identity, capturedIdentity)
+	}
+	if rootpublication.SamePhysicalIdentity(identity, replacementIdentity) {
+		t.Fatalf("snapshot identity=%+v unexpectedly followed replacement=%+v", identity, replacementIdentity)
+	}
+}
+
 func TestCaptureOmitsNestedProcessLocalLocks(t *testing.T) {
 	root := t.TempDir()
 	for _, dir := range []string{"maindb", "dictdb", "nested/leafdb"} {


### PR DESCRIPTION
Closes #4003

Parent: #4004

## Objective

Make the deterministic TreeDB power-loss oracle reconcile a delayed
namespace-create callback when `Capture` already observed the same physical
file, while preserving fail-closed rejection for a different or unresolved
identity.

This is a focused extraction of commit `84d14c400` from PR #4000 onto current
`main`. PR #4000 remains an unrelated vector-feature PR and is not merged or
broadened by this change.

## Scope

- Update `TreeDB/internal/powerlossoracle/model.go` to compare stable physical
  identities before reconciling a captured create, and require the volatile
  and stable names to still reference the same model inode.
- Capture bytes, file kind, and stable physical identity through one retained
  open handle in `Capture`, `Overlay`, and namespace-create handling so a path
  rebind cannot couple bytes from one file with identity from another.
- Add deterministic same-file acceptance, different-file rejection, and
  intervening-replacement-overlay rejection regressions, plus a retained-handle
  path-rebind regression.
- Make retained-handle coverage platform-specific: Unix exercises a real
  rename/recreate rebind, while Windows asserts that its non-delete-shared
  `os.Open` handle rejects the rebind and still yields one coherent snapshot.
- Require the snapshots used by `Capture` and `Overlay` file branches to remain
  regular after opening, so a file-to-directory rebind fails closed instead of
  importing an empty regular inode.
- When a delayed create callback reconciles a file that `Capture` saw during
  creation, demote the imported stable name until the parent directory is
  explicitly synced.

## Non-goals

- No TreeDB value-log health persistence change.
- No production storage, WAL, value-log, GC, public API, Raft, vector, or
  benchmark behavior change.
- No acceptance of duplicate creates when identity is invalid or different.
- No waiver based on the earlier passing rerun.

## Correctness

- Failing-first evidence is recorded in #4003: before the patch,
  `TestObservedCreateAcceptsSameFileCapturedBeforeCallback` returned
  `powerlossoracle: file already exists`.
- Review red/green: before the model-ID guard,
  `TestObservedCreateRejectsReplacementOverlaidAtCapturedPath` accepted the
  rebound path; after the guard, all three create-ordering tests passed 20
  repetitions.
- Review red/green: the retained-handle regression initially failed to compile
  because `captureOpenFileSnapshot` did not exist. After the fix,
  `TestCaptureOpenFileSnapshotKeepsBytesAndIdentityCoupledAcrossPathRebind`
  passed 20 repetitions and proved the snapshot retains file A's bytes and
  identity after the captured pathname is rebound to file B.
- Review red/green: the regular-file snapshot regression initially failed to
  compile because no checked file helper existed. At exact head
  `f22b58d55`, `TestCaptureRegularPathSnapshotRejectsDirectoryRebind` passes 20
  repetitions, and both file-walk callers now reject an opened directory.
- Review red/green: before the stable-name demotion,
  `TestObservedCreateAcceptsSameFileCapturedBeforeCallback` materialized the
  captured name before any parent-directory sync. At head `64f0cb32e`, the name
  is absent before `SyncDir(".")`, present with the
  captured bytes afterward, and all three create-ordering tests pass 20
  repetitions.
- Review red/green: before stable-byte demotion, the same regression showed
  that `SyncDir` alone materialized `"captured"` even though no file sync had
  occurred. At implementation head `1c647c92a`, directory-only sync materializes
  no captured bytes, and only `SyncFile` promotes them.
- `cd TreeDB && GOWORK=off go test ./internal/powerlossoracle -count=1`
  — PASS.
- `cd TreeDB && GOWORK=off go test . -run '^TestPowerLossCertificationAuthoritativeResourcesPublicReopen$' -count=3`
  — PASS.
- Prior reviewed head `f36cafd11233`: `cd TreeDB && GOWORK=off GOMEMLIMIT=4GiB
  GOMAXPROCS=2 go test -race -p 1 . -run
  '^TestPowerLossCertificationAuthoritativeResourcesPublicReopen$' -count=10`
  — PASS in 274.417s.
- `cd TreeDB && GOWORK=off go vet ./internal/powerlossoracle`
  — PASS.
- `cd TreeDB && GOWORK=off go test -race ./internal/powerlossoracle -count=1`
  — PASS.
- `cd TreeDB && GOWORK=off go test ./internal/powerlossoracle -run
  'TestCaptureOpenFileSnapshotKeepsBytesAndIdentityCoupledAcrossPathRebind' -count=20`
  — PASS.
- `GOOS=windows GOARCH=amd64 GOWORK=off go test -c
  ./internal/powerlossoracle` — PASS.
- `git diff --check origin/main...HEAD`
  — PASS.

Exact-head hosted run 30319182704 exposed that the original retained-handle
regression attempted a Unix rename/recreate while the file remained open.
Windows correctly rejected the rename with a sharing violation. Commit
`80ea31f34` splits the regression by platform; after that repair, the Unix test
passed 20 repetitions, the full package and package race run passed, vet
passed, and the Windows test binary cross-compiled.

Exact-head Codex review on `80ea31f34` then found that the two file-walk
branches still discarded the opened file kind. Commit `f22b58d55` adds a
checked regular-file snapshot helper used by both `Capture` and `Overlay`.
Focused 20x, full package, package race, vet, Windows cross-compile, and diff
checks pass. Fresh exact-head hosted CI and Codex review are in flight.

Exact-head Codex review on `f22b58d55` found that captured-create
reconciliation retained the name in the stable namespace even though the
delayed create callback precedes parent-directory sync. Commit `64f0cb32e`
deletes only that stable name during same-inode reconciliation; the volatile
name and stable inode bytes remain available, and `SyncDir` promotes the name
normally. Focused 20x, all create-ordering tests 20x, full package, package
race, vet, Windows cross-compile, and diff checks pass. Fresh exact-head hosted
CI and review are in flight.

Exact-head Codex review on `64f0cb32e` found that demoting only the name left
the captured inode's unsynced bytes stable, allowing a later directory sync to
expose them. Commit `1c647c92a` also clears the stable bytes during
reconciliation. The regression failed before the fix with `"captured"` after
directory-only sync, then passed 20x by proving empty unsynced bytes until
`SyncFile`; the full create-ordering set, package, race, vet, Windows
cross-compile, and diff checks pass. Fresh exact-head hosted CI and review are
in flight.

During the review repair, one ten-repetition race invocation reproduced the
premature `collectionwal: recovery required: root publication cannot safely
progress; reopen required` signature previously owned by #3994. An untouched
`f3b14fae` control then passed ten repetitions, and the repaired tree passed a
second ten-repetition race invocation in 111.244s. The red occurrence is not
waived: #3994 is the separate lifecycle owner.

The pre-integration hosted TreeDB matrix at `1c647c92a` later failed only
race-check-2 (run/job 30321771916/90159178373) in the broader
authoritative-resource certificate:

```text
sync durable-root index: powerlossoracle: sync missing file "maindb/index.db.new"
```

The uploaded JSON artifact identifies that failure after 36.04s. It is the
#3994 terminal-cut lifecycle interaction, not a duplicate-create reconciliation
failure. PR #4007 subsequently merged the structural #3994 repair as
`4a0946a275928f07fe37fdf6cf4f82fc7010441b`.

Combined base head `45b438fb5281125cc7c0cbd78da312207d84318b` merges that
predecessor into this focused PR without rebasing. On that combined head:

- the exact authoritative-resource race test passed ten repetitions in
  289.368s (295.954s wall time), with no retry;
- all `TestObservedCreate*` regressions passed 20 repetitions;
- the complete power-loss oracle package passed normally and under race;
- oracle vet, Windows/amd64 compile, and `git diff --check origin/main...HEAD`
  passed.

Exact-head Codex review then found one additional ordering hole: unconditional
same-inode demotion could reverse file or parent-directory sync promotions
serialized after Capture but before the delayed create callback. Commit
`501340bb6da3b58a5ff69d3df72b53a61767ace8` tracks those completed
promotions independently by inode and normalized parent directory. The delayed
callback now demotes only an unpromoted component.

The new deterministic table regression failed in all three pre-fix cases:
file sync lost its bytes after a later directory sync, directory sync lost its
name, and combined sync lost both. After the repair, those cases and the
original pre-sync demotion case pass 20 repetitions. On current exact head
`501340bb6da3b58a5ff69d3df72b53a61767ace8`:

- the authoritative-resource race proof passed ten repetitions in 283.842s
  (289.871s wall time), with no retry;
- the complete oracle package passed normally and under race;
- oracle vet, Windows/amd64 compile, and diff checks passed.

Fresh exact-head hosted CI and Codex review are required on this repaired head;
all earlier matrices remain diagnostic only.

Exact-head review on `501340bb6` found one test-portability issue: the retained
handle regression used `!windows`, but native stable identity is supported only
on Darwin, Linux, FreeBSD, NetBSD, and OpenBSD. Commit
`7ae95e8682cd5a2171fce3bd2a3ce83bf02e1a44` gives the regression the
same build constraint as `rootpublication/resource_identity_unix.go`.
Windows and Solaris cross-compiles exclude the test and pass; the native
retained-handle regression passes 20 repetitions. On this current exact head,
the authoritative-resource race proof also passed ten repetitions in 295.001s
(295.848s wall time) without retry, and the diff check is clean.

Fresh hosted CI and exact-head Codex review are required on `7ae95e868`.

## Performance

Not performance-relevant. `internal/powerlossoracle` is deterministic test
infrastructure and is not imported by production packages; no benchmark is
required. The production dependency graph for TreeDB, db, and caching contains
no `powerlossoracle` import.

The first exact-head MVCC raw-path job in TreeDB run 30326237087 nevertheless
measured one fsync-heavy row at +17.60% paired; allocations were unchanged,
bytes decreased by 1.5 B/op, and all four other paired rows passed. The raw
samples ranged roughly 0.49-1.13 ms on both revisions. An independent execution
of the repository's exact eight-pair AB/BA gate against the same base/head
passed every row and measured that fsync row at -2.69% paired. The single hosted
failed-job rerun then passed it at +0.81% paired with unchanged allocations and
lower bytes; the required TreeDB aggregator passed. The original red artifact
is retained as timing-variance evidence rather than silently waived.

## Risk and review

The reconciliation path requires the volatile and stable names to retain the
same model inode, both physical identities to be valid, and
`SamePhysicalIdentity` to succeed. Each accepted physical snapshot now derives
bytes, file kind, and identity from one retained handle, and file-walk snapshots
must still be regular after opening. A replacement overlay, directory rebound,
or different inode fails closed. A captured create does not gain a durable name
until parent-directory sync and does not gain durable bytes until file sync.
If either sync is serialized after Capture but before the delayed callback, its
promotion is preserved rather than rolled back.
Latest-head hosted race CI and mature exact-head Codex review remain mandatory
before merge.

## Merge gates

- [x] #3994 predecessor merged and incorporated without rebasing
- [x] Combined-head authoritative-resource race proof passed ten repetitions
- [x] Focused normal/race/vet/Windows/diff gates passed
- [x] Latest-head required CI green
- [x] Exact-head mature Codex review clean
- [x] Zero unresolved review threads
