### PR TITLE
test(treedb): scope authoritative replay cut to checkpoint

### DIFF
--- a/TreeDB/power_loss_certification_resources_test.go
+++ b/TreeDB/power_loss_certification_resources_test.go
@@ -35,10 +35,14 @@ func TestPowerLossCertificationAuthoritativeResourcesPublicReopen(t *testing.T) 
 	opts.DisableSideStores = false
 	opts.DisableBackgroundPrune = true
 	opts.BackgroundCheckpointInterval = -1
+	opts.BackgroundCheckpointIdleDuration = -1
+	opts.MaxWALBytes = -1
+	opts.BackgroundIndexVacuumInterval = -1
 	opts.IndexOuterLeavesInValueLog = true
 	opts.FlushThreshold = 1 << 20
 	opts.ValueLog.ForcePointers = true
 	opts.ValueLog.PointerThreshold = 1
+	opts.ValueLog.Generational.Policy = treedb.ValueLogGenerationOff
 	opts.ValueLog.Compression = treedb.ValueLogCompressionDict
 	opts.ValueLog.CompressionAutotune = treedb.AutotuneOptions{Mode: treedb.AutotuneOff}
 	opts.ValueLog.DictAdaptiveRatio = -1
@@ -61,6 +65,7 @@ func TestPowerLossCertificationAuthoritativeResourcesPublicReopen(t *testing.T) 
 	if err != nil {
 		t.Fatal(err)
 	}
+	requireAuthoritativeResourceAutonomousPublishersDisabled(t, database)
 	backend := treedb.PowerLossCertificationBackendForTest(database)
 	if backend == nil {
 		_ = database.Close()
@@ -86,6 +91,8 @@ func TestPowerLossCertificationAuthoritativeResourcesPublicReopen(t *testing.T) 
 	dictDBPersistenceEvents := 0
 	authoritativeAssetPersistenceEvents := 0
 	armed := false
+	phase := "witness"
+	armedTerminalCuts := 0
 	var observeMu sync.Mutex
 	restore := durabilitycut.Install(func(event durabilitycut.Event) error {
 		observeMu.Lock()
@@ -113,6 +120,10 @@ func TestPowerLossCertificationAuthoritativeResourcesPublicReopen(t *testing.T) 
 			occurrence := metaSyncs
 			metaSyncs++
 			if armed && filepath.Clean(event.Root) == mainDir {
+				if phase != "terminal-checkpoint" {
+					return fmt.Errorf("armed authoritative-resource meta sync during %s, want terminal-checkpoint", phase)
+				}
+				armedTerminalCuts++
 				selectedOccurrence = occurrence
 				return cutErr
 			}
@@ -127,30 +138,62 @@ func TestPowerLossCertificationAuthoritativeResourcesPublicReopen(t *testing.T) 
 	// persistence events rather than importing them as initially stable.
 	witness := prepareAuthoritativeResourceWitness(t, database, dir, backgroundErrors)
 	waitForAuthoritativeResourceObserverQuiescence(t, &observeMu, &observedEvents, backgroundErrors)
-	// Stop the trainer and drain its final accepted-profile callback before the
-	// replay window is armed. Published dictionaries remain live for the
-	// dictionary-encoded witness value, but no future asynchronous dictionary
-	// mutation can consume the selected terminal cut.
+	// Stop the trainer and drain its final accepted-profile callback. Published
+	// dictionaries remain live for the dictionary-encoded witness value, but no
+	// future asynchronous dictionary mutation can consume the terminal cut.
 	treedb.PowerLossCertificationQuiesceValueLogDictionaryForTest(database)
-	waitForAuthoritativeResourceObserverQuiescence(t, &observeMu, &observedEvents, backgroundErrors)
+	// Drain every pre-window cached/root-publication obligation through the
+	// public checkpoint before the marker is written. This is the operation
+	// boundary; the preceding quiet observation only lets the witness finish
+	// materializing its dictionary resource and is not used to claim ownership
+	// of a later durability event.
+	observeMu.Lock()
+	phase = "pre-window-drain"
+	if armed {
+		observeMu.Unlock()
+		t.Fatal("authoritative-resource replay cut armed before pre-window drain")
+	}
+	observeMu.Unlock()
+	if err := database.Checkpoint(); err != nil {
+		restoreObserver()
+		t.Fatalf("drain authoritative resource witness before replay window: %v", err)
+	}
+	select {
+	case err := <-backgroundErrors:
+		restoreObserver()
+		t.Fatalf("authoritative resource background error after pre-window drain: %v", err)
+	default:
+	}
+	// The marker is a durable command-WAL write, but is deliberately placed
+	// before arming. With autonomous checkpoint, vacuum, prune, value-log
+	// generation, and dictionary-training publishers disabled or quiesced above,
+	// the explicit Checkpoint below owns the marker's cached frontier and its
+	// main-root metadata publication.
+	boundaryKey := []byte("certification/authoritative-resource-boundary")
+	boundaryValue := []byte("stable")
+	observeMu.Lock()
+	phase = "boundary-set"
+	if armed {
+		observeMu.Unlock()
+		t.Fatal("authoritative-resource replay cut armed during boundary SetSync")
+	}
+	observeMu.Unlock()
+	if err := database.SetSync(boundaryKey, boundaryValue); err != nil {
+		restoreObserver()
+		t.Fatalf("write authoritative resource boundary: %v", err)
+	}
 	observeMu.Lock()
 	if err := model.BeginReplayWindow(authoritativeResourcesVariantID); err != nil {
 		observeMu.Unlock()
 		t.Fatal(err)
 	}
 	metaSyncs = 0
+	phase = "terminal-checkpoint"
 	armed = true
 	observeMu.Unlock()
-	// Publish one deterministic terminal marker after asynchronous dictionary
-	// work has been lifecycle-fenced. The selected cut is the marker's real
-	// maindb metadata sync and its occurrence is relative to the explicit replay
-	// window. The complete pre-window persistence trace remains in the evidence.
-	boundaryKey := []byte("certification/authoritative-resource-boundary")
-	boundaryValue := []byte("stable")
-	if err := database.SetSync(boundaryKey, boundaryValue); err != nil {
-		restoreObserver()
-		t.Fatalf("write authoritative resource boundary: %v", err)
-	}
+	// The selected cut is the marker's real maindb metadata sync in this explicit
+	// terminal checkpoint. The complete pre-window persistence trace remains in
+	// the evidence.
 	err = database.Checkpoint()
 	restoreObserver()
 	if !errors.Is(err, cutErr) {
@@ -158,6 +201,9 @@ func TestPowerLossCertificationAuthoritativeResourcesPublicReopen(t *testing.T) 
 	}
 	if selectedOccurrence < 0 {
 		t.Fatal("authoritative-resource checkpoint did not select a maindb meta-sync occurrence")
+	}
+	if armedTerminalCuts != 1 {
+		t.Fatalf("armed terminal checkpoint cuts=%d want=1", armedTerminalCuts)
 	}
 	wantCutID := "cut/" + authoritativeResourcesVariantID + "/after-meta-sync/" + fmt.Sprintf("%03d", selectedOccurrence)
 	if selector != (powerlossoracle.ReplaySelector{}) {
@@ -191,6 +237,21 @@ func TestPowerLossCertificationAuthoritativeResourcesPublicReopen(t *testing.T) 
 	}
 	if err := closeReopened(); err != nil {
 		t.Fatal(err)
+	}
+}
+
+func requireAuthoritativeResourceAutonomousPublishersDisabled(t *testing.T, database *treedb.DB) {
+	t.Helper()
+	stats := database.Stats()
+	for key, want := range map[string]string{
+		"treedb.cache.auto_checkpoint.count":   "0",
+		"treedb.cache.vlog_generation.enabled": "false",
+		"treedb.bg_vacuum.enabled":             "false",
+		"treedb.prune.enabled":                 "false",
+	} {
+		if got := stats[key]; got != want {
+			t.Fatalf("authoritative resource autonomous publisher %s=%q want=%q", key, got, want)
+		}
 	}
 }
 

--- a/TreeDB/testdata/power_loss_witness_contracts.json
+++ b/TreeDB/testdata/power_loss_witness_contracts.json
@@ -499,17 +499,17 @@
       "failure_classes": [
         "dependency_closed_reopen"
       ],
-      "expected_durable_horizon": "behaviorally queried collection and side-store resources select commit 13 and applied command LSN 19",
+      "expected_durable_horizon": "behaviorally queried collection and side-store resources select commit 14 and applied command LSN 19",
       "expected_outcome": "accepted:stable-root",
       "expected_typed_error": "none",
       "state": {
-        "root_meta_generation": "selected_commit_seq=13 fallback_commit_seq=12",
+        "root_meta_generation": "selected_commit_seq=14 fallback_commit_seq=13",
         "freelist_generation": "generation=persisted",
         "external_resource_ids_frontiers": "stable_image_tree_artifact=stable_image_tree.json manifest_entries=9",
         "namespace_generations": "stable_image_tree_artifact=stable_image_tree.json",
         "wal_lineage": "profile=command_wal_durable applied_lsn=19",
-        "durable_lsn": "durable_wal_lsn=0 durable_root_commit_seq=13",
-        "cleanup_maintenance_pins": "selected_commit_seq=13 fallback_commit_seq=12"
+        "durable_lsn": "durable_wal_lsn=0 durable_root_commit_seq=14",
+        "cleanup_maintenance_pins": "selected_commit_seq=14 fallback_commit_seq=13"
       },
       "state_comparison": "logical_horizon",
       "seed": 3674,
@@ -521,7 +521,7 @@
       "expected_recovery": {
         "rejected": false,
         "error_type": "",
-        "commit_seq": 13,
+        "commit_seq": 14,
         "applied_lsn": 19
       },
       "claim_boundary": "normal public read-only reopen behaviorally queries primary, secondary, text, physical column, vector, TemplateV1, and maindb dictionary-compressed value-log resources; live templatedb value-log compression is not claimed"


### PR DESCRIPTION
Closes #3994

Parent execution: #4004  
Blocks re-gating and merge: #4003 / #4006

## Objective

Make the authoritative-resource certificate's selected replay cut belong structurally to one explicit public checkpoint. The witness now disables every autonomous publisher, drains pre-window work while unarmed, writes its boundary marker while unarmed, and permits a main-root metadata cut only during the terminal checkpoint.

## Recurrence

The original dictionary lifecycle repair merged in #3995, but current exact-tree race stress on #4006 head `43ad48b21` still reproduced the same premature recovery-required family:

```text
checkpoint cut error=collectionwal: recovery required: root publication cannot safely progress; reopen required
want=power-loss-certification: stop after authoritative-resource checkpoint meta sync
```

The observer was armed before `SetSync` and the terminal `Checkpoint`. That interval still allowed a publisher outside the intended checkpoint to consume the cut and poison the live handle. A clean rerun did not waive the exact recurrence.

## Test-first invariant

Once the replay window is armed, exactly one selected main-DB metadata cut may occur, and it must be owned by the terminal public checkpoint. No setup write, autonomous checkpoint, vacuum, prune, value-log generation, or dictionary callback may publish inside the armed interval.

## Design

- Disable interval, idle, and WAL-size autonomous checkpoints for the certificate.
- Disable background index vacuum, background prune, and value-log generation; assert their runtime stats are disabled before installing the witness.
- Keep the full authoritative-resource creation trace and quiesce dictionary training.
- Drain cached/root-publication obligations through a public checkpoint while the observer is unarmed.
- Write the durable command-WAL boundary marker while still unarmed.
- Begin the replay window, arm the observer, and immediately execute the terminal public checkpoint.
- Reject any armed main-root metadata sync outside the `terminal-checkpoint` phase and assert exactly one terminal cut.

The existing quiet observer helper remains only a witness-materialization aid. It is no longer used to claim ownership of a later durability event.

## Scope

Includes:

- `TreeDB/power_loss_certification_resources_test.go`
- `TreeDB/testdata/power_loss_witness_contracts.json`
- deterministic certificate setup, phase contract, and autonomous-publisher assertions
- refreshed frozen logical horizon for the added pre-window checkpoint

Excludes:

- production checkpoint, value-log, WAL, compression, or recovery behavior
- retrying or waiving recovery-required results
- sleeps as correctness proof
- on-disk format or public API changes
- #4003 power-loss oracle implementation

## Correctness evidence

Implementation head: `7ad3004d73cb05175d3346c69c9fc83a3a512439`  
Current exact head: `63a609d8e13f6bd6950f8b92d61dddb2ffed3d59`

```text
GOWORK=off go test ./TreeDB -run '^TestPowerLossCertificationAuthoritativeResourcesPublicReopen$' -count=1
GOWORK=off GOMEMLIMIT=4GiB GOMAXPROCS=2 go test -race -p 1 ./TreeDB -run '^TestPowerLossCertificationAuthoritativeResourcesPublicReopen$' -count=1
GOWORK=off GOMEMLIMIT=4GiB GOMAXPROCS=2 go test -race -p 1 ./TreeDB -run '^TestPowerLossCertificationAuthoritativeResourcesPublicReopen$' -count=10
GOWORK=off go test ./TreeDB -run '^TestQuiesceValueLogDictTrainingDetachesAndPreventsRestart$' -count=1
GOWORK=off go test ./TreeDB/internal/powerlosscert -count=1
GOWORK=off go vet ./TreeDB/...
jq empty TreeDB/testdata/power_loss_witness_contracts.json
git diff --check HEAD^
```

Results: pass / clean. The coordinator-owned constrained `-race -count=10`
execution passed in 110.687s on the implementation head. After the frozen
contract repair, the focused authoritative-resource test passed three
repetitions in 7.732s and the complete `powerlosscert` package passed.

The first exact `8dcb4b066` hosted matrix passed all 33 checks, including both
race shards, all Windows shards, suites, and the required TreeDB aggregator.
Because #4005 merged while that matrix ran, the strict branch rule correctly
reported the PR behind `main`. Current `main` was merged without rebasing into
`63a609d8e`; on that combined head the focused test passed three repetitions,
the focused race test passed ten repetitions in 111.875s, the complete
`powerlosscert` package and TreeDB vet passed, the new unified-suite workflow
contract passed, the witness JSON parsed, and the diff check was clean. Fresh
hosted CI and exact-head review are required and the prior green matrix is
retained only as diagnostic evidence.

Exact-head Codex review found that the added pre-window checkpoint advances the
logical durable horizon. The captured execution reports selected/fallback
commits 14/13 (formerly 13/12), with applied command LSN 19 unchanged. The
frozen authoritative-resource contract now records commit 14, fallback 13,
and matching logical-state strings so the certification runner validates the
new structural boundary instead of rejecting it as stale.

The retained red characterization is the exact #4006 recurrence recorded on #3994; this patch does not turn a subsequent green rerun into a waiver.

## Performance

Not performance-relevant. This is test-only certification structure with no production hot-path or runtime changes, so no benchmark is required.

## Merge gates

- [x] Coordinator `-race -count=10` stress green on the implementation head
- [x] Frozen recovery/state horizon refreshed for the added checkpoint
- [x] Latest-head required CI green
- [x] Exact-head mature Codex review clean
- [x] Zero unresolved review threads
- [ ] Merge #3994 before merging current `main` into #4006 and re-gating #4003
