### PR TITLE
test(raftplacement): harden catalog Raft readiness

### DIFF
--- a/TreeDB/internal/raftplacement/catalog_meta_lifecycle_harness_v1.go
+++ b/TreeDB/internal/raftplacement/catalog_meta_lifecycle_harness_v1.go
@@ -39,7 +39,13 @@ type catalogMetaLeaderDwellV1 struct {
 
 func (d *catalogMetaLeaderDwellV1) Observe(now time.Time, complete bool, leader raftcluster.NodeID, dwell, maxGap time.Duration) bool {
 	gapTooLarge := !d.lastObservation.IsZero() && now.Sub(d.lastObservation) > maxGap
-	if !complete || leader == "" || leader != d.leader || gapTooLarge {
+	if !complete || leader == "" {
+		d.leader = ""
+		d.since = time.Time{}
+		d.lastObservation = now
+		return false
+	}
+	if leader != d.leader || gapTooLarge {
 		d.leader = leader
 		d.since = now
 		d.lastObservation = now

--- a/TreeDB/internal/raftplacement/catalog_meta_lifecycle_harness_v1.go
+++ b/TreeDB/internal/raftplacement/catalog_meta_lifecycle_harness_v1.go
@@ -37,9 +37,9 @@ type catalogMetaLeaderDwellV1 struct {
 	lastObservation time.Time
 }
 
-func (d *catalogMetaLeaderDwellV1) Observe(now time.Time, leader raftcluster.NodeID, dwell, maxGap time.Duration) bool {
+func (d *catalogMetaLeaderDwellV1) Observe(now time.Time, complete bool, leader raftcluster.NodeID, dwell, maxGap time.Duration) bool {
 	gapTooLarge := !d.lastObservation.IsZero() && now.Sub(d.lastObservation) > maxGap
-	if leader == "" || leader != d.leader || gapTooLarge {
+	if !complete || leader == "" || leader != d.leader || gapTooLarge {
 		d.leader = leader
 		d.since = now
 		d.lastObservation = now
@@ -153,10 +153,12 @@ func (h *CatalogMetaLifecycleHarnessV1) waitLeader(ctx context.Context) error {
 	defer tick.Stop()
 	for {
 		var leader raftcluster.NodeID
+		complete := true
 		for id, p := range h.providers {
 			status, err := p.ClusterAdmissionStatus(ctx)
 			if err != nil {
-				continue
+				complete = false
+				break
 			}
 			if status.Leader {
 				if leader != "" {
@@ -166,7 +168,7 @@ func (h *CatalogMetaLifecycleHarnessV1) waitLeader(ctx context.Context) error {
 				leader = id
 			}
 		}
-		if dwell.Observe(time.Now(), leader, catalogMetaLifecycleHarnessLeaderDwellV1, catalogMetaLeaderObservationMaxGapV1) {
+		if dwell.Observe(time.Now(), complete, leader, catalogMetaLifecycleHarnessLeaderDwellV1, catalogMetaLeaderObservationMaxGapV1) {
 			h.leader = leader
 			return nil
 		}

--- a/TreeDB/internal/raftplacement/catalog_meta_lifecycle_harness_v1.go
+++ b/TreeDB/internal/raftplacement/catalog_meta_lifecycle_harness_v1.go
@@ -22,6 +22,9 @@ import (
 
 var catalogMetaLifecycleHarnessSequenceV1 atomic.Uint64
 
+const catalogMetaLifecycleHarnessCoordinationTimeoutV1 = 5 * time.Second
+const catalogMetaLifecycleHarnessLeaderDwellV1 = time.Second
+
 type CatalogMetaLifecycleHarnessOptionsV1 struct {
 	Catalog CatalogV1
 	Prefix  string
@@ -108,9 +111,9 @@ func catalogMetaLifecycleHarnessFeaturesV1() raftcluster.FeatureSet {
 }
 func catalogMetaLifecycleHarnessRaftConfigV1() *hraft.Config {
 	cfg := hraft.DefaultConfig()
-	cfg.HeartbeatTimeout = 300 * time.Millisecond
-	cfg.ElectionTimeout = 300 * time.Millisecond
-	cfg.LeaderLeaseTimeout = 300 * time.Millisecond
+	cfg.HeartbeatTimeout = catalogMetaLifecycleHarnessCoordinationTimeoutV1
+	cfg.ElectionTimeout = catalogMetaLifecycleHarnessCoordinationTimeoutV1
+	cfg.LeaderLeaseTimeout = catalogMetaLifecycleHarnessCoordinationTimeoutV1
 	cfg.CommitTimeout = 5 * time.Millisecond
 	cfg.SnapshotInterval = time.Hour
 	cfg.SnapshotThreshold = ^uint64(0)
@@ -121,7 +124,9 @@ func catalogMetaLifecycleHarnessRaftConfigV1() *hraft.Config {
 	return cfg
 }
 func (h *CatalogMetaLifecycleHarnessV1) waitLeader(ctx context.Context) error {
-	tick := time.NewTicker(10 * time.Millisecond)
+	var prior raftcluster.NodeID
+	var since time.Time
+	tick := time.NewTicker(20 * time.Millisecond)
 	defer tick.Stop()
 	for {
 		var leader raftcluster.NodeID
@@ -138,7 +143,12 @@ func (h *CatalogMetaLifecycleHarnessV1) waitLeader(ctx context.Context) error {
 				leader = id
 			}
 		}
-		if leader != "" {
+		now := time.Now()
+		if leader == "" {
+			prior = ""
+		} else if prior != leader {
+			prior, since = leader, now
+		} else if now.Sub(since) >= catalogMetaLifecycleHarnessLeaderDwellV1 {
 			h.leader = leader
 			return nil
 		}

--- a/TreeDB/internal/raftplacement/catalog_meta_lifecycle_harness_v1.go
+++ b/TreeDB/internal/raftplacement/catalog_meta_lifecycle_harness_v1.go
@@ -23,7 +23,7 @@ import (
 var catalogMetaLifecycleHarnessSequenceV1 atomic.Uint64
 
 const catalogMetaLifecycleHarnessCoordinationTimeoutV1 = 5 * time.Second
-const catalogMetaLifecycleHarnessLeaderDwellV1 = time.Second
+const catalogMetaLifecycleHarnessLeaderDwellV1 = catalogMetaLifecycleHarnessCoordinationTimeoutV1
 
 type CatalogMetaLifecycleHarnessOptionsV1 struct {
 	Catalog CatalogV1
@@ -67,7 +67,7 @@ func OpenCatalogMetaLifecycleHarnessV1(ctx context.Context, opts CatalogMetaLife
 	for _, suffix := range []string{"a", "b", "c"} {
 		id := raftcluster.NodeID(prefix + "-" + suffix)
 		h.peers = append(h.peers, raftcluster.Peer{ID: id, Address: string(id), Capabilities: features})
-		_, tr := hraft.NewInmemTransportWithTimeout(hraft.ServerAddress(id), 2*time.Second)
+		_, tr := hraft.NewInmemTransportWithTimeout(hraft.ServerAddress(id), catalogMetaLifecycleHarnessCoordinationTimeoutV1)
 		h.transports[id] = tr
 	}
 	for _, from := range h.peers {

--- a/TreeDB/internal/raftplacement/catalog_meta_lifecycle_harness_v1.go
+++ b/TreeDB/internal/raftplacement/catalog_meta_lifecycle_harness_v1.go
@@ -24,6 +24,30 @@ var catalogMetaLifecycleHarnessSequenceV1 atomic.Uint64
 
 const catalogMetaLifecycleHarnessCoordinationTimeoutV1 = 5 * time.Second
 const catalogMetaLifecycleHarnessLeaderDwellV1 = catalogMetaLifecycleHarnessCoordinationTimeoutV1
+const catalogMetaLeaderObservationMaxGapV1 = time.Second
+
+// catalogMetaLeaderDwellV1 records continuous observation of one unique
+// leader. A long scheduling gap cannot prove that the same node retained
+// leadership: it could have stepped down and been re-elected while no probe
+// ran. Reset the dwell in that case instead of carrying wall-clock time
+// through the gap.
+type catalogMetaLeaderDwellV1 struct {
+	leader          raftcluster.NodeID
+	since           time.Time
+	lastObservation time.Time
+}
+
+func (d *catalogMetaLeaderDwellV1) Observe(now time.Time, leader raftcluster.NodeID, dwell, maxGap time.Duration) bool {
+	gapTooLarge := !d.lastObservation.IsZero() && now.Sub(d.lastObservation) > maxGap
+	if leader == "" || leader != d.leader || gapTooLarge {
+		d.leader = leader
+		d.since = now
+		d.lastObservation = now
+		return false
+	}
+	d.lastObservation = now
+	return !d.since.IsZero() && now.Sub(d.since) >= dwell
+}
 
 type CatalogMetaLifecycleHarnessOptionsV1 struct {
 	Catalog CatalogV1
@@ -124,8 +148,7 @@ func catalogMetaLifecycleHarnessRaftConfigV1() *hraft.Config {
 	return cfg
 }
 func (h *CatalogMetaLifecycleHarnessV1) waitLeader(ctx context.Context) error {
-	var prior raftcluster.NodeID
-	var since time.Time
+	var dwell catalogMetaLeaderDwellV1
 	tick := time.NewTicker(20 * time.Millisecond)
 	defer tick.Stop()
 	for {
@@ -143,12 +166,7 @@ func (h *CatalogMetaLifecycleHarnessV1) waitLeader(ctx context.Context) error {
 				leader = id
 			}
 		}
-		now := time.Now()
-		if leader == "" {
-			prior = ""
-		} else if prior != leader {
-			prior, since = leader, now
-		} else if now.Sub(since) >= catalogMetaLifecycleHarnessLeaderDwellV1 {
+		if dwell.Observe(time.Now(), leader, catalogMetaLifecycleHarnessLeaderDwellV1, catalogMetaLeaderObservationMaxGapV1) {
 			h.leader = leader
 			return nil
 		}

--- a/TreeDB/internal/raftplacement/catalog_meta_lifecycle_harness_v1_test.go
+++ b/TreeDB/internal/raftplacement/catalog_meta_lifecycle_harness_v1_test.go
@@ -65,7 +65,7 @@ func TestCatalogMetaLifecycleHarnessRaftConfigProvidesSchedulingHeadroomV1(t *te
 	if config.HeartbeatTimeout < minimum || config.ElectionTimeout < minimum || config.LeaderLeaseTimeout < minimum {
 		t.Fatalf("coordination timeouts heartbeat=%s election=%s lease=%s want each at least %s", config.HeartbeatTimeout, config.ElectionTimeout, config.LeaderLeaseTimeout, minimum)
 	}
-	if catalogMetaLifecycleHarnessLeaderDwellV1 < time.Second {
-		t.Fatalf("leader dwell=%s want at least 1s", catalogMetaLifecycleHarnessLeaderDwellV1)
+	if catalogMetaLifecycleHarnessLeaderDwellV1 < config.LeaderLeaseTimeout {
+		t.Fatalf("leader dwell=%s want at least leader lease=%s", catalogMetaLifecycleHarnessLeaderDwellV1, config.LeaderLeaseTimeout)
 	}
 }

--- a/TreeDB/internal/raftplacement/catalog_meta_lifecycle_harness_v1_test.go
+++ b/TreeDB/internal/raftplacement/catalog_meta_lifecycle_harness_v1_test.go
@@ -13,7 +13,7 @@ func TestCatalogMetaLifecycleHarnessActivatesAndConvergesV1(t *testing.T) {
 	catalog := validCatalog()
 	catalog.Features = DefaultFeatureSet()
 	catalog.Features.Required = append(catalog.Features.Required, raftcluster.RequiredFeature{Name: raftcluster.FeatureVectorPartitionLifecycle, Version: raftcluster.SupportedFeatureFloors[raftcluster.FeatureVectorPartitionLifecycle]})
-	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), realCatalogMetaIntegrationTestTimeoutV1)
 	defer cancel()
 	harness, err := OpenCatalogMetaLifecycleHarnessV1(ctx, CatalogMetaLifecycleHarnessOptionsV1{Catalog: catalog, Prefix: "m8-meta-test"})
 	if err != nil {

--- a/TreeDB/internal/raftplacement/catalog_meta_lifecycle_harness_v1_test.go
+++ b/TreeDB/internal/raftplacement/catalog_meta_lifecycle_harness_v1_test.go
@@ -117,12 +117,19 @@ func TestCatalogMetaLeaderDwellRestartsAfterProbeFailureV1(t *testing.T) {
 	if dwell.Observe(failureAt, false, "node-a", lease, maxGap) {
 		t.Fatal("failed probe unexpectedly satisfies dwell")
 	}
-	for elapsed := 500 * time.Millisecond; elapsed < lease; elapsed += 500 * time.Millisecond {
+	firstComplete := failureAt.Add(500 * time.Millisecond)
+	if dwell.Observe(firstComplete, true, "node-a", lease, maxGap) {
+		t.Fatal("first complete post-failure observation unexpectedly satisfies dwell")
+	}
+	for elapsed := time.Second; elapsed < lease; elapsed += 500 * time.Millisecond {
 		if dwell.Observe(failureAt.Add(elapsed), true, "node-a", lease, maxGap) {
 			t.Fatal("same node inherited dwell from before the probe failure")
 		}
 	}
-	if !dwell.Observe(failureAt.Add(lease), true, "node-a", lease, maxGap) {
+	if dwell.Observe(failureAt.Add(lease), true, "node-a", lease, maxGap) {
+		t.Fatal("same node inherited the failed-probe timestamp")
+	}
+	if !dwell.Observe(firstComplete.Add(lease), true, "node-a", lease, maxGap) {
 		t.Fatal("continuous post-failure observation did not satisfy a full dwell")
 	}
 }

--- a/TreeDB/internal/raftplacement/catalog_meta_lifecycle_harness_v1_test.go
+++ b/TreeDB/internal/raftplacement/catalog_meta_lifecycle_harness_v1_test.go
@@ -68,4 +68,34 @@ func TestCatalogMetaLifecycleHarnessRaftConfigProvidesSchedulingHeadroomV1(t *te
 	if catalogMetaLifecycleHarnessLeaderDwellV1 < config.LeaderLeaseTimeout {
 		t.Fatalf("leader dwell=%s want at least leader lease=%s", catalogMetaLifecycleHarnessLeaderDwellV1, config.LeaderLeaseTimeout)
 	}
+	if catalogMetaLeaderObservationMaxGapV1 >= config.ElectionTimeout || catalogMetaLeaderObservationMaxGapV1 >= config.LeaderLeaseTimeout {
+		t.Fatalf("leader observation max gap=%s want below election=%s and lease=%s", catalogMetaLeaderObservationMaxGapV1, config.ElectionTimeout, config.LeaderLeaseTimeout)
+	}
+}
+
+func TestCatalogMetaLeaderDwellRestartsAfterObservationGapV1(t *testing.T) {
+	const lease = 5 * time.Second
+	const maxGap = time.Second
+	start := time.Unix(0, 0)
+	var dwell catalogMetaLeaderDwellV1
+	if dwell.Observe(start, "node-a", lease, maxGap) {
+		t.Fatal("initial observation unexpectedly satisfies dwell")
+	}
+	if dwell.Observe(start.Add(500*time.Millisecond), "node-a", lease, maxGap) {
+		t.Fatal("pre-lease observation unexpectedly satisfies dwell")
+	}
+	// This same node could have stepped down and been re-elected while the
+	// polling goroutine was stalled, so its former wall-clock dwell is invalid.
+	afterGap := start.Add(2 * time.Second)
+	if dwell.Observe(afterGap, "node-a", lease, maxGap) {
+		t.Fatal("same node after an observation gap unexpectedly satisfies dwell")
+	}
+	for elapsed := 500 * time.Millisecond; elapsed < lease; elapsed += 500 * time.Millisecond {
+		if dwell.Observe(afterGap.Add(elapsed), "node-a", lease, maxGap) {
+			t.Fatal("same node inherited dwell from before the observation gap")
+		}
+	}
+	if !dwell.Observe(afterGap.Add(lease), "node-a", lease, maxGap) {
+		t.Fatal("continuous post-gap observation did not satisfy a full dwell")
+	}
 }

--- a/TreeDB/internal/raftplacement/catalog_meta_lifecycle_harness_v1_test.go
+++ b/TreeDB/internal/raftplacement/catalog_meta_lifecycle_harness_v1_test.go
@@ -58,3 +58,14 @@ func TestCatalogMetaLifecycleHarnessActivatesAndConvergesV1(t *testing.T) {
 		t.Fatal(err)
 	}
 }
+
+func TestCatalogMetaLifecycleHarnessRaftConfigProvidesSchedulingHeadroomV1(t *testing.T) {
+	config := catalogMetaLifecycleHarnessRaftConfigV1()
+	minimum := 5 * time.Second
+	if config.HeartbeatTimeout < minimum || config.ElectionTimeout < minimum || config.LeaderLeaseTimeout < minimum {
+		t.Fatalf("coordination timeouts heartbeat=%s election=%s lease=%s want each at least %s", config.HeartbeatTimeout, config.ElectionTimeout, config.LeaderLeaseTimeout, minimum)
+	}
+	if catalogMetaLifecycleHarnessLeaderDwellV1 < time.Second {
+		t.Fatalf("leader dwell=%s want at least 1s", catalogMetaLifecycleHarnessLeaderDwellV1)
+	}
+}

--- a/TreeDB/internal/raftplacement/catalog_meta_lifecycle_harness_v1_test.go
+++ b/TreeDB/internal/raftplacement/catalog_meta_lifecycle_harness_v1_test.go
@@ -78,24 +78,51 @@ func TestCatalogMetaLeaderDwellRestartsAfterObservationGapV1(t *testing.T) {
 	const maxGap = time.Second
 	start := time.Unix(0, 0)
 	var dwell catalogMetaLeaderDwellV1
-	if dwell.Observe(start, "node-a", lease, maxGap) {
+	if dwell.Observe(start, true, "node-a", lease, maxGap) {
 		t.Fatal("initial observation unexpectedly satisfies dwell")
 	}
-	if dwell.Observe(start.Add(500*time.Millisecond), "node-a", lease, maxGap) {
+	if dwell.Observe(start.Add(500*time.Millisecond), true, "node-a", lease, maxGap) {
 		t.Fatal("pre-lease observation unexpectedly satisfies dwell")
 	}
 	// This same node could have stepped down and been re-elected while the
 	// polling goroutine was stalled, so its former wall-clock dwell is invalid.
 	afterGap := start.Add(2 * time.Second)
-	if dwell.Observe(afterGap, "node-a", lease, maxGap) {
+	if dwell.Observe(afterGap, true, "node-a", lease, maxGap) {
 		t.Fatal("same node after an observation gap unexpectedly satisfies dwell")
 	}
 	for elapsed := 500 * time.Millisecond; elapsed < lease; elapsed += 500 * time.Millisecond {
-		if dwell.Observe(afterGap.Add(elapsed), "node-a", lease, maxGap) {
+		if dwell.Observe(afterGap.Add(elapsed), true, "node-a", lease, maxGap) {
 			t.Fatal("same node inherited dwell from before the observation gap")
 		}
 	}
-	if !dwell.Observe(afterGap.Add(lease), "node-a", lease, maxGap) {
+	if !dwell.Observe(afterGap.Add(lease), true, "node-a", lease, maxGap) {
 		t.Fatal("continuous post-gap observation did not satisfy a full dwell")
+	}
+}
+
+func TestCatalogMetaLeaderDwellRestartsAfterProbeFailureV1(t *testing.T) {
+	const lease = 5 * time.Second
+	const maxGap = time.Second
+	start := time.Unix(0, 0)
+	var dwell catalogMetaLeaderDwellV1
+	if dwell.Observe(start, true, "node-a", lease, maxGap) {
+		t.Fatal("initial observation unexpectedly satisfies dwell")
+	}
+	if dwell.Observe(start.Add(500*time.Millisecond), true, "node-a", lease, maxGap) {
+		t.Fatal("pre-lease observation unexpectedly satisfies dwell")
+	}
+	// A probe error makes the cluster sample incomplete: the apparently same
+	// leader cannot carry any earlier dwell through that unknown interval.
+	failureAt := start.Add(time.Second)
+	if dwell.Observe(failureAt, false, "node-a", lease, maxGap) {
+		t.Fatal("failed probe unexpectedly satisfies dwell")
+	}
+	for elapsed := 500 * time.Millisecond; elapsed < lease; elapsed += 500 * time.Millisecond {
+		if dwell.Observe(failureAt.Add(elapsed), true, "node-a", lease, maxGap) {
+			t.Fatal("same node inherited dwell from before the probe failure")
+		}
+	}
+	if !dwell.Observe(failureAt.Add(lease), true, "node-a", lease, maxGap) {
+		t.Fatal("continuous post-failure observation did not satisfy a full dwell")
 	}
 }

--- a/TreeDB/internal/raftplacement/catalog_meta_raft_integration_test.go
+++ b/TreeDB/internal/raftplacement/catalog_meta_raft_integration_test.go
@@ -248,8 +248,7 @@ func (c *realCatalogMetaClusterV1) connectAll() {
 
 func (c *realCatalogMetaClusterV1) waitLeader(t *testing.T, ctx context.Context) raftcluster.NodeID {
 	t.Helper()
-	var stableLeader raftcluster.NodeID
-	var stableSince time.Time
+	var dwell catalogMetaLeaderDwellV1
 	tick := time.NewTicker(20 * time.Millisecond)
 	defer tick.Stop()
 	for {
@@ -264,15 +263,7 @@ func (c *realCatalogMetaClusterV1) waitLeader(t *testing.T, ctx context.Context)
 				leader = id
 			}
 		}
-		now := time.Now()
-		switch {
-		case leader == "":
-			stableLeader = ""
-			stableSince = time.Time{}
-		case leader != stableLeader:
-			stableLeader = leader
-			stableSince = now
-		case now.Sub(stableSince) >= realCatalogMetaIntegrationLeaderDwellV1:
+		if dwell.Observe(time.Now(), leader, realCatalogMetaIntegrationLeaderDwellV1, catalogMetaLeaderObservationMaxGapV1) {
 			return leader
 		}
 		select {
@@ -397,6 +388,9 @@ func TestRealCatalogMetaRaftConfigAddsSchedulingHeadroom(t *testing.T) {
 	}
 	if realCatalogMetaIntegrationLeaderDwellV1 < config.LeaderLeaseTimeout {
 		t.Fatalf("leader dwell=%s want at least leader lease=%s", realCatalogMetaIntegrationLeaderDwellV1, config.LeaderLeaseTimeout)
+	}
+	if catalogMetaLeaderObservationMaxGapV1 >= config.ElectionTimeout || catalogMetaLeaderObservationMaxGapV1 >= config.LeaderLeaseTimeout {
+		t.Fatalf("leader observation max gap=%s want below election=%s and lease=%s", catalogMetaLeaderObservationMaxGapV1, config.ElectionTimeout, config.LeaderLeaseTimeout)
 	}
 }
 

--- a/TreeDB/internal/raftplacement/catalog_meta_raft_integration_test.go
+++ b/TreeDB/internal/raftplacement/catalog_meta_raft_integration_test.go
@@ -15,13 +15,15 @@ import (
 )
 
 func TestCatalogMetaBackupRestoresFreshThreeAuthorityClusterAndSurvivesReopenFailoverRejoin(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), realCatalogMetaIntegrationTestTimeoutV1)
+	defer cancel()
 	source := newRealCatalogMetaClusterV1(t, "source")
-	sourceLeader := source.waitLeader(t)
+	sourceLeader := source.waitLeader(t, ctx)
 	command1 := mustCatalogMetaCommand(t, 0, 1, realCatalogMetaIntegrationCatalogV1("group-a"))
-	if _, _, err := source.providers[sourceLeader].SubmitCatalogMetaCommandV1(context.Background(), command1); err != nil {
+	if _, _, err := source.providers[sourceLeader].SubmitCatalogMetaCommandV1(ctx, command1); err != nil {
 		t.Fatalf("source epoch 1: %v", err)
 	}
-	source.waitEpoch(t, 1)
+	source.waitEpoch(t, ctx, 1)
 	firstStatus, ok := source.authorities[sourceLeader].Status()
 	if !ok {
 		t.Fatal("source leader status unavailable")
@@ -29,23 +31,20 @@ func TestCatalogMetaBackupRestoresFreshThreeAuthorityClusterAndSurvivesReopenFai
 
 	// An exact command retry is idempotent even though Raft commits another
 	// entry; the catalog's original applied index remains authoritative.
-	if _, _, err := source.providers[sourceLeader].SubmitCatalogMetaCommandV1(context.Background(), command1); err != nil {
+	if _, _, err := source.providers[sourceLeader].SubmitCatalogMetaCommandV1(ctx, command1); err != nil {
 		t.Fatalf("source exact retry: %v", err)
 	}
-	source.waitEpoch(t, 1)
+	source.waitEpoch(t, ctx, 1)
 	retryStatus, _ := source.authorities[sourceLeader].Status()
 	if retryStatus.AppliedIndex != firstStatus.AppliedIndex {
 		t.Fatalf("exact retry applied index=%d want original %d", retryStatus.AppliedIndex, firstStatus.AppliedIndex)
 	}
 
 	stale := mustCatalogMetaCommand(t, 0, 2, realCatalogMetaIntegrationCatalogV1("group-b"))
-	if _, _, err := source.providers[sourceLeader].SubmitCatalogMetaCommandV1(context.Background(), stale); !errors.Is(err, ErrCatalogMetaStaleEpoch) {
+	if _, _, err := source.providers[sourceLeader].SubmitCatalogMetaCommandV1(ctx, stale); !errors.Is(err, ErrCatalogMetaStaleEpoch) {
 		t.Fatalf("stale source transition error=%v want ErrCatalogMetaStaleEpoch", err)
 	}
-	source.assertEpochAndRoute(t, 1, "group-a")
-
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-	defer cancel()
+	source.assertEpochAndRoute(t, ctx, 1, "group-a")
 	backup, err := source.providers[sourceLeader].ExportCatalogMetaBackupV1(ctx)
 	if err != nil {
 		t.Fatalf("export source backup: %v", err)
@@ -55,9 +54,9 @@ func TestCatalogMetaBackupRestoresFreshThreeAuthorityClusterAndSurvivesReopenFai
 	}
 
 	target := newRealCatalogMetaClusterV1(t, "target")
-	targetLeader := target.waitLeader(t)
+	targetLeader := target.waitLeader(t, ctx)
 	follower := target.anyFollower(targetLeader)
-	target.waitFollower(t, follower)
+	target.waitFollower(t, ctx, follower)
 	if err := target.providers[follower].RestoreCatalogMetaBackupV1(ctx, backup); !errors.Is(err, raftcluster.ErrNotLeader) {
 		t.Fatalf("follower restore error=%v want ErrNotLeader", err)
 	}
@@ -75,14 +74,14 @@ func TestCatalogMetaBackupRestoresFreshThreeAuthorityClusterAndSurvivesReopenFai
 	// stable admission-ready leader before exercising the valid restore so a
 	// hosted-runner scheduling stall cannot turn harness readiness into the
 	// production ErrAdmissionUnavailable path under test.
-	targetLeader = target.waitLeader(t)
+	targetLeader = target.waitLeader(t, ctx)
 	follower = target.anyFollower(targetLeader)
-	target.waitFollower(t, follower)
+	target.waitFollower(t, ctx, follower)
 	if err := target.providers[targetLeader].RestoreCatalogMetaBackupV1(ctx, backup); err != nil {
 		t.Fatalf("restore fresh target leader: %v", err)
 	}
-	target.waitEpoch(t, 1)
-	target.assertEpochAndRoute(t, 1, "group-a")
+	target.waitEpoch(t, ctx, 1)
+	target.assertEpochAndRoute(t, ctx, 1, "group-a")
 
 	// The restored last command retains exact-retry semantics in the new
 	// cluster, including its original applied-index identity.
@@ -90,7 +89,7 @@ func TestCatalogMetaBackupRestoresFreshThreeAuthorityClusterAndSurvivesReopenFai
 	if _, _, err := target.providers[targetLeader].SubmitCatalogMetaCommandV1(ctx, command1); err != nil {
 		t.Fatalf("restored exact retry: %v", err)
 	}
-	target.waitEpoch(t, 1)
+	target.waitEpoch(t, ctx, 1)
 	afterRetry, _ := target.authorities[targetLeader].Status()
 	if afterRetry.AppliedIndex != restoredStatus.AppliedIndex {
 		t.Fatalf("restored exact retry applied index=%d want %d", afterRetry.AppliedIndex, restoredStatus.AppliedIndex)
@@ -100,19 +99,19 @@ func TestCatalogMetaBackupRestoresFreshThreeAuthorityClusterAndSurvivesReopenFai
 	target.closeNode(t, follower)
 	target.reopenNode(t, follower)
 	target.connectAll()
-	target.waitEpochOn(t, follower, 1)
-	target.assertAuthorityIdentityAndRoute(t, follower, 1, "group-a")
+	target.waitEpochOn(t, ctx, follower, 1)
+	target.assertAuthorityIdentityAndRoute(t, ctx, follower, 1, "group-a")
 
 	// Fail over and prove that an epoch-valid owner move still fails closed:
 	// M4A has no migration workflow that could transfer the collection data,
 	// apply progress, and idempotency state before publishing the new route.
 	target.closeNode(t, targetLeader)
-	newLeader := target.waitLeader(t)
+	newLeader := target.waitLeader(t, ctx)
 	unsafeCommand2 := mustCatalogMetaCommand(t, 1, 2, realCatalogMetaIntegrationCatalogV1("group-b"))
 	if _, _, err := target.providers[newLeader].SubmitCatalogMetaCommandV1(ctx, unsafeCommand2); !errors.Is(err, ErrCatalogMetaTopologyChange) {
 		t.Fatalf("target owner move error=%v want ErrCatalogMetaTopologyChange", err)
 	}
-	target.assertEpochAndRoute(t, 1, "group-a")
+	target.assertEpochAndRoute(t, ctx, 1, "group-a")
 
 	// The refused log entry does not prevent a safe metadata generation from
 	// advancing monotonically, and the old backup still cannot roll it back.
@@ -120,20 +119,24 @@ func TestCatalogMetaBackupRestoresFreshThreeAuthorityClusterAndSurvivesReopenFai
 	if _, _, err := target.providers[newLeader].SubmitCatalogMetaCommandV1(ctx, command2); err != nil {
 		t.Fatalf("target epoch 2 after failover: %v", err)
 	}
-	target.waitEpoch(t, 2)
-	target.assertEpochAndRoute(t, 2, "group-a")
+	target.waitEpoch(t, ctx, 2)
+	target.assertEpochAndRoute(t, ctx, 2, "group-a")
 	if err := target.providers[newLeader].RestoreCatalogMetaBackupV1(ctx, backup); !errors.Is(err, raftcluster.ErrCatalogMetaBackupRestoreTarget) || !errors.Is(err, ErrCatalogMetaConflict) {
 		t.Fatalf("live rollback restore error=%v want restore-target conflict", err)
 	}
-	target.assertEpochAndRoute(t, 2, "group-a")
+	target.assertEpochAndRoute(t, ctx, 2, "group-a")
 
 	// Rejoin the former leader with a new real authority and prove it receives
 	// the newer snapshot/log state and exact identity.
 	target.reopenNode(t, targetLeader)
 	target.connectAll()
-	target.waitEpochOn(t, targetLeader, 2)
-	target.assertEpochAndRoute(t, 2, "group-a")
+	target.waitEpochOn(t, ctx, targetLeader, 2)
+	target.assertEpochAndRoute(t, ctx, 2, "group-a")
 }
+
+const realCatalogMetaIntegrationCoordinationTimeoutV1 = 5 * time.Second
+const realCatalogMetaIntegrationLeaderDwellV1 = realCatalogMetaIntegrationCoordinationTimeoutV1
+const realCatalogMetaIntegrationTestTimeoutV1 = 4*realCatalogMetaIntegrationCoordinationTimeoutV1 + 60*time.Second
 
 type realCatalogMetaClusterV1 struct {
 	peers       []raftcluster.Peer
@@ -166,7 +169,7 @@ func newRealCatalogMetaClusterV1(t *testing.T, prefix string) *realCatalogMetaCl
 			Address:      string(id),
 			Capabilities: features,
 		})
-		_, transport := hraft.NewInmemTransportWithTimeout(hraft.ServerAddress(id), 2*time.Second)
+		_, transport := hraft.NewInmemTransportWithTimeout(hraft.ServerAddress(id), realCatalogMetaIntegrationCoordinationTimeoutV1)
 		cluster.transports[id] = transport
 	}
 	cluster.connectAll()
@@ -243,15 +246,16 @@ func (c *realCatalogMetaClusterV1) connectAll() {
 	}
 }
 
-func (c *realCatalogMetaClusterV1) waitLeader(t *testing.T) raftcluster.NodeID {
+func (c *realCatalogMetaClusterV1) waitLeader(t *testing.T, ctx context.Context) raftcluster.NodeID {
 	t.Helper()
-	deadline := time.Now().Add(30 * time.Second)
 	var stableLeader raftcluster.NodeID
 	var stableSince time.Time
-	for time.Now().Before(deadline) {
+	tick := time.NewTicker(20 * time.Millisecond)
+	defer tick.Stop()
+	for {
 		var leader raftcluster.NodeID
 		for id, provider := range c.providers {
-			status, err := provider.ClusterAdmissionStatus(context.Background())
+			status, err := provider.ClusterAdmissionStatus(ctx)
 			if err == nil && status.Leader {
 				if leader != "" {
 					leader = ""
@@ -268,13 +272,15 @@ func (c *realCatalogMetaClusterV1) waitLeader(t *testing.T) raftcluster.NodeID {
 		case leader != stableLeader:
 			stableLeader = leader
 			stableSince = now
-		case now.Sub(stableSince) >= time.Second:
+		case now.Sub(stableSince) >= realCatalogMetaIntegrationLeaderDwellV1:
 			return leader
 		}
-		time.Sleep(20 * time.Millisecond)
+		select {
+		case <-ctx.Done():
+			t.Fatalf("catalog meta cluster has no admission-ready leader stable for %s: %v", realCatalogMetaIntegrationLeaderDwellV1, ctx.Err())
+		case <-tick.C:
+		}
 	}
-	t.Fatalf("catalog meta cluster has no admission-ready leader stable for 1s")
-	return ""
 }
 
 func (c *realCatalogMetaClusterV1) anyFollower(leader raftcluster.NodeID) raftcluster.NodeID {
@@ -286,17 +292,17 @@ func (c *realCatalogMetaClusterV1) anyFollower(leader raftcluster.NodeID) raftcl
 	return ""
 }
 
-func (c *realCatalogMetaClusterV1) waitFollower(t *testing.T, id raftcluster.NodeID) {
+func (c *realCatalogMetaClusterV1) waitFollower(t *testing.T, ctx context.Context, id raftcluster.NodeID) {
 	t.Helper()
-	waitRealCatalogMetaConditionV1(t, func() bool {
-		status, err := c.providers[id].ClusterAdmissionStatus(context.Background())
+	waitRealCatalogMetaConditionV1(t, ctx, func() bool {
+		status, err := c.providers[id].ClusterAdmissionStatus(ctx)
 		return err == nil && !status.Leader && !status.Unavailable && status.LeaderHint != ""
 	}, fmt.Sprintf("%s did not observe the catalog leader", id))
 }
 
-func (c *realCatalogMetaClusterV1) waitEpoch(t *testing.T, epoch uint64) {
+func (c *realCatalogMetaClusterV1) waitEpoch(t *testing.T, ctx context.Context, epoch uint64) {
 	t.Helper()
-	waitRealCatalogMetaConditionV1(t, func() bool {
+	waitRealCatalogMetaConditionV1(t, ctx, func() bool {
 		for id := range c.providers {
 			status, ok := c.authorities[id].Status()
 			if !ok || status.Epoch != epoch {
@@ -307,22 +313,22 @@ func (c *realCatalogMetaClusterV1) waitEpoch(t *testing.T, epoch uint64) {
 	}, fmt.Sprintf("catalog authorities did not converge to epoch %d", epoch))
 }
 
-func (c *realCatalogMetaClusterV1) waitEpochOn(t *testing.T, id raftcluster.NodeID, epoch uint64) {
+func (c *realCatalogMetaClusterV1) waitEpochOn(t *testing.T, ctx context.Context, id raftcluster.NodeID, epoch uint64) {
 	t.Helper()
-	waitRealCatalogMetaConditionV1(t, func() bool {
+	waitRealCatalogMetaConditionV1(t, ctx, func() bool {
 		status, ok := c.authorities[id].Status()
 		return ok && status.Epoch == epoch
 	}, fmt.Sprintf("%s did not converge to epoch %d", id, epoch))
 }
 
-func (c *realCatalogMetaClusterV1) assertEpochAndRoute(t *testing.T, epoch uint64, groupID raftcluster.GroupID) {
+func (c *realCatalogMetaClusterV1) assertEpochAndRoute(t *testing.T, ctx context.Context, epoch uint64, groupID raftcluster.GroupID) {
 	t.Helper()
 	for id := range c.providers {
-		c.assertAuthorityIdentityAndRoute(t, id, epoch, groupID)
+		c.assertAuthorityIdentityAndRoute(t, ctx, id, epoch, groupID)
 	}
 }
 
-func (c *realCatalogMetaClusterV1) assertAuthorityIdentityAndRoute(t *testing.T, id raftcluster.NodeID, epoch uint64, groupID raftcluster.GroupID) {
+func (c *realCatalogMetaClusterV1) assertAuthorityIdentityAndRoute(t *testing.T, ctx context.Context, id raftcluster.NodeID, epoch uint64, groupID raftcluster.GroupID) {
 	t.Helper()
 	authority := c.authorities[id]
 	status, ok := authority.Status()
@@ -336,7 +342,7 @@ func (c *realCatalogMetaClusterV1) assertAuthorityIdentityAndRoute(t *testing.T,
 		t.Fatalf("%s catalog features=%+v want collection-groups v1", id, status.Features)
 	}
 	proof := CatalogProofV1{Epoch: status.Epoch, Digest: status.Digest}
-	decision, err := authority.Route(context.Background(), proof, RouteRequestV1{
+	decision, err := authority.Route(ctx, proof, RouteRequestV1{
 		Collection: CollectionRefV1{Database: DefaultDatabase, Catalog: DefaultCatalog, Collection: "users"},
 		Shape:      RouteShapeCollectionV1,
 	})
@@ -370,9 +376,9 @@ func realCatalogMetaRaftConfigV1() *hraft.Config {
 	// These are scheduling headroom for contended hosted Windows runners, not
 	// a production semantic change. The readiness barrier above still proves a
 	// continuously stable leader before an operation under test is attempted.
-	config.HeartbeatTimeout = 5 * time.Second
-	config.ElectionTimeout = 5 * time.Second
-	config.LeaderLeaseTimeout = 5 * time.Second
+	config.HeartbeatTimeout = realCatalogMetaIntegrationCoordinationTimeoutV1
+	config.ElectionTimeout = realCatalogMetaIntegrationCoordinationTimeoutV1
+	config.LeaderLeaseTimeout = realCatalogMetaIntegrationCoordinationTimeoutV1
 	config.CommitTimeout = 5 * time.Millisecond
 	config.SnapshotInterval = time.Hour
 	config.SnapshotThreshold = ^uint64(0)
@@ -389,16 +395,23 @@ func TestRealCatalogMetaRaftConfigAddsSchedulingHeadroom(t *testing.T) {
 	if config.HeartbeatTimeout < minimum || config.ElectionTimeout < minimum || config.LeaderLeaseTimeout < minimum {
 		t.Fatalf("coordination timeouts heartbeat=%s election=%s lease=%s want each at least %s", config.HeartbeatTimeout, config.ElectionTimeout, config.LeaderLeaseTimeout, minimum)
 	}
+	if realCatalogMetaIntegrationLeaderDwellV1 < config.LeaderLeaseTimeout {
+		t.Fatalf("leader dwell=%s want at least leader lease=%s", realCatalogMetaIntegrationLeaderDwellV1, config.LeaderLeaseTimeout)
+	}
 }
 
-func waitRealCatalogMetaConditionV1(t *testing.T, ready func() bool, message string) {
+func waitRealCatalogMetaConditionV1(t *testing.T, ctx context.Context, ready func() bool, message string) {
 	t.Helper()
-	deadline := time.Now().Add(12 * time.Second)
-	for time.Now().Before(deadline) {
+	tick := time.NewTicker(5 * time.Millisecond)
+	defer tick.Stop()
+	for {
 		if ready() {
 			return
 		}
-		time.Sleep(5 * time.Millisecond)
+		select {
+		case <-ctx.Done():
+			t.Fatalf("%s: %v", message, ctx.Err())
+		case <-tick.C:
+		}
 	}
-	t.Fatal(message)
 }

--- a/TreeDB/internal/raftplacement/catalog_meta_raft_integration_test.go
+++ b/TreeDB/internal/raftplacement/catalog_meta_raft_integration_test.go
@@ -253,9 +253,14 @@ func (c *realCatalogMetaClusterV1) waitLeader(t *testing.T, ctx context.Context)
 	defer tick.Stop()
 	for {
 		var leader raftcluster.NodeID
+		complete := true
 		for id, provider := range c.providers {
 			status, err := provider.ClusterAdmissionStatus(ctx)
-			if err == nil && status.Leader {
+			if err != nil {
+				complete = false
+				break
+			}
+			if status.Leader {
 				if leader != "" {
 					leader = ""
 					break
@@ -263,7 +268,7 @@ func (c *realCatalogMetaClusterV1) waitLeader(t *testing.T, ctx context.Context)
 				leader = id
 			}
 		}
-		if dwell.Observe(time.Now(), leader, realCatalogMetaIntegrationLeaderDwellV1, catalogMetaLeaderObservationMaxGapV1) {
+		if dwell.Observe(time.Now(), complete, leader, realCatalogMetaIntegrationLeaderDwellV1, catalogMetaLeaderObservationMaxGapV1) {
 			return leader
 		}
 		select {

--- a/TreeDB/internal/raftplacement/catalog_meta_raft_integration_test.go
+++ b/TreeDB/internal/raftplacement/catalog_meta_raft_integration_test.go
@@ -44,7 +44,7 @@ func TestCatalogMetaBackupRestoresFreshThreeAuthorityClusterAndSurvivesReopenFai
 	}
 	source.assertEpochAndRoute(t, 1, "group-a")
 
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 	backup, err := source.providers[sourceLeader].ExportCatalogMetaBackupV1(ctx)
 	if err != nil {
@@ -71,6 +71,13 @@ func TestCatalogMetaBackupRestoresFreshThreeAuthorityClusterAndSurvivesReopenFai
 	if err := target.providers[targetLeader].RestoreCatalogMetaBackupV1(ctx, corrupt); !errors.Is(err, raftcluster.ErrInvalidCatalogMetaBackup) {
 		t.Fatalf("corrupt restore error=%v want ErrInvalidCatalogMetaBackup", err)
 	}
+	// The invalid archive is rejected before Raft admission. Reacquire a
+	// stable admission-ready leader before exercising the valid restore so a
+	// hosted-runner scheduling stall cannot turn harness readiness into the
+	// production ErrAdmissionUnavailable path under test.
+	targetLeader = target.waitLeader(t)
+	follower = target.anyFollower(targetLeader)
+	target.waitFollower(t, follower)
 	if err := target.providers[targetLeader].RestoreCatalogMetaBackupV1(ctx, backup); err != nil {
 		t.Fatalf("restore fresh target leader: %v", err)
 	}
@@ -238,21 +245,36 @@ func (c *realCatalogMetaClusterV1) connectAll() {
 
 func (c *realCatalogMetaClusterV1) waitLeader(t *testing.T) raftcluster.NodeID {
 	t.Helper()
-	var leader raftcluster.NodeID
-	waitRealCatalogMetaConditionV1(t, func() bool {
-		leader = ""
+	deadline := time.Now().Add(30 * time.Second)
+	var stableLeader raftcluster.NodeID
+	var stableSince time.Time
+	for time.Now().Before(deadline) {
+		var leader raftcluster.NodeID
 		for id, provider := range c.providers {
 			status, err := provider.ClusterAdmissionStatus(context.Background())
 			if err == nil && status.Leader {
 				if leader != "" {
-					return false
+					leader = ""
+					break
 				}
 				leader = id
 			}
 		}
-		return leader != ""
-	}, "catalog meta cluster has no unique leader")
-	return leader
+		now := time.Now()
+		switch {
+		case leader == "":
+			stableLeader = ""
+			stableSince = time.Time{}
+		case leader != stableLeader:
+			stableLeader = leader
+			stableSince = now
+		case now.Sub(stableSince) >= time.Second:
+			return leader
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	t.Fatalf("catalog meta cluster has no admission-ready leader stable for 1s")
+	return ""
 }
 
 func (c *realCatalogMetaClusterV1) anyFollower(leader raftcluster.NodeID) raftcluster.NodeID {
@@ -345,9 +367,12 @@ func realCatalogMetaIntegrationCatalogV1(usersGroup raftcluster.GroupID) Catalog
 
 func realCatalogMetaRaftConfigV1() *hraft.Config {
 	config := hraft.DefaultConfig()
-	config.HeartbeatTimeout = 300 * time.Millisecond
-	config.ElectionTimeout = 300 * time.Millisecond
-	config.LeaderLeaseTimeout = 300 * time.Millisecond
+	// These are scheduling headroom for contended hosted Windows runners, not
+	// a production semantic change. The readiness barrier above still proves a
+	// continuously stable leader before an operation under test is attempted.
+	config.HeartbeatTimeout = 5 * time.Second
+	config.ElectionTimeout = 5 * time.Second
+	config.LeaderLeaseTimeout = 5 * time.Second
 	config.CommitTimeout = 5 * time.Millisecond
 	config.SnapshotInterval = time.Hour
 	config.SnapshotThreshold = ^uint64(0)
@@ -356,6 +381,14 @@ func realCatalogMetaRaftConfigV1() *hraft.Config {
 	config.LogLevel = "ERROR"
 	config.NoLegacyTelemetry = true
 	return config
+}
+
+func TestRealCatalogMetaRaftConfigAddsSchedulingHeadroom(t *testing.T) {
+	config := realCatalogMetaRaftConfigV1()
+	const minimum = 5 * time.Second
+	if config.HeartbeatTimeout < minimum || config.ElectionTimeout < minimum || config.LeaderLeaseTimeout < minimum {
+		t.Fatalf("coordination timeouts heartbeat=%s election=%s lease=%s want each at least %s", config.HeartbeatTimeout, config.ElectionTimeout, config.LeaderLeaseTimeout, minimum)
+	}
 }
 
 func waitRealCatalogMetaConditionV1(t *testing.T, ready func() bool, message string) {

--- a/cmd/treedb_vector_partition_bench/m8_production_assets_test.go
+++ b/cmd/treedb_vector_partition_bench/m8_production_assets_test.go
@@ -46,6 +46,8 @@ func requireM8PersistentAssetSupportV1(t testing.TB) {
 	}
 }
 
+const m8ProductionTopologyTestTimeoutV1 = 80 * time.Second
+
 func TestM8ProductionReportRejectsUnexercisedDataGroupV1(t *testing.T) {
 	fixture, err := loadFixture(fixturePath(t))
 	if err != nil {
@@ -283,7 +285,7 @@ func TestM8ProductionMultiGroupTopology10kTCPV1(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer assets.Close()
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), m8ProductionTopologyTestTimeoutV1)
 	defer cancel()
 	topology, err := nativewire.NewVectorPartitionM8ProductionMultiGroupV1(ctx, nativewire.VectorPartitionM8ProductionMultiGroupOptionsV1{Collection: assets.collection, Manifest: assets.manifest, RouterSource: assets.RouterSource(), GroupAssetSetDigests: assets.assetSetDigests, Database: "default", Catalog: "default"})
 	if err != nil {
@@ -440,7 +442,7 @@ func TestM8ExistingAssetsRelabelsTopologyWithoutMutatingLocalPacksV1(t *testing.
 			t.Fatalf("relabeled placement=%+v original=%+v", placement, original.Placements[i])
 		}
 	}
-	ctx, cancel := context.WithTimeout(context.Background(), 45*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), m8ProductionTopologyTestTimeoutV1)
 	defer cancel()
 	topology, err := nativewire.NewVectorPartitionM8ProductionMultiGroupV1(ctx, nativewire.VectorPartitionM8ProductionMultiGroupOptionsV1{Collection: assets.collection, Manifest: assets.manifest, RouterSource: assets.RouterSource(), GroupAssetSetDigests: assets.assetSetDigests, Database: "default", Catalog: "default"})
 	if err != nil {


### PR DESCRIPTION
Closes #3665

Parent: #4004

## Objective

Make the catalog-meta Raft integration harness require a continuously stable,
unique leader before the first restore or lifecycle operation, while preserving
production fail-closed admission, ambiguity, and leadership-loss semantics.

## Scope

- Give the in-memory catalog-meta integration/benchmark harnesses bounded five-second
  heartbeat/election/lease headroom for hosted Windows scheduling stalls.
- Require continuously sampled unique-leader admission for a full five-second
  leader lease before the first restore or lifecycle mutation.
- Reset the dwell after any observation gap longer than one second, which is
  strictly shorter than the configured election and lease windows.
- Reacquire a stable leader immediately before the valid restore.
- Keep a bounded 80-second whole-test context and add timing regressions.
- Do not retry restore/lifecycle operations or accept ambiguous commits.

## Test-first and local validation

The two repairs were first developed and exercised on PR #4000 after exact
hosted Windows recurrences, then cherry-picked onto current `main` for this
issue-owned PR:

- `2b38bf944534b841737409466fa04221b3610343`
  (`TestCatalogMetaBackupRestoresFreshThreeAuthorityClusterAndSurvivesReopenFailoverRejoin`)
- `1254374a4060dd4f681516a8d4088daacdbf7ed5`
  (`TestCatalogMetaLifecycleHarnessActivatesAndConvergesV1`)

Exact issue branch:

- base: `7a7c060738f95d7ee132820a9d2be61abd24f4ba`
- head: `4b32da5222c5fd101d13ee03e16b6ef8e3542a90`
- local commits: `c2660df0ecebedbe56966518c2a48211114510f6`,
  `24c52c6dfe791515f797a31b2649fd5145113143`,
  `b43dd74173895f2088ffe628f9ff5f3e9b80e4c2`,
  `ad3a68a01eafa6e8a2f65c6b7f3bd0b5169c2ca1`,
  `4227f819d4ec9f8fafd33cb50c9383b4c2eb54ae`,
  `f249c0d619a022f1b5808a0c7c395d6d12f9f435`,
  `2358dd84cb361710f765f0213912f79ae7dc0bc6`,
  `4b32da5222c5fd101d13ee03e16b6ef8e3542a90`

Local exact-head validation:

- both repaired scenarios plus both configuration regressions, 10 consecutive
  iterations: PASS (`339.030s`)
- complete `TreeDB/internal/raftplacement` normal: PASS (`36.436s`)
- complete package race with `-race -p 1`: PASS (`50.191s`)
- package vet: PASS
- Windows/amd64 package cross-compile with `go test -c`: PASS
- `git diff --check`: PASS

Exact-head review repairs in `b43dd74173895f2088ffe628f9ff5f3e9b80e4c2`:

- align both in-memory transport timeouts with the five-second coordination
  window
- require continuous unique-leader stability for at least the configured
  leader lease
- propagate one bounded 80-second context through integration operations and
  readiness polling
- preserve fail-closed production admission/ambiguity behavior with no
  operation retry

Repair-head validation:

- both repaired scenarios plus both configuration regressions: PASS
  (`53.119s`)
- independent combined repetition of those four tests, 3 consecutive
  iterations: PASS (`161.898s`)
- complete `TreeDB/internal/raftplacement` normal: PASS (`59.170s`)
- complete package race with `-race -p 1`: PASS (`64.716s`)
- package vet, Windows/amd64 package cross-compile, and `git diff --check`: PASS

Final exact-head review repair in
`ad3a68a01eafa6e8a2f65c6b7f3bd0b5169c2ca1`:

- centralize leader dwell tracking across both harnesses
- reset dwell after an observation gap longer than one second, so an
  unobserved same-node step-down/re-election cannot inherit prior wall time
- assert that the maximum observation gap remains below the configured
  election and leader-lease timeouts
- add a deterministic clock regression proving a full post-gap lease is
  required

Final-head validation:

- focused dwell/configuration/lifecycle tests: PASS
- independent coordinator repetition of the restore, lifecycle, timing, and
  deterministic gap regressions, 3 consecutive iterations: PASS (`159.112s`)
- complete `TreeDB/internal/raftplacement` normal: PASS (`53.823s`)
- complete package race with `-race -p 1`: PASS (`71.331s`)
- package vet, Windows/amd64 package cross-compile, and `git diff --check`: PASS

Final review repair in `4227f819d4ec9f8fafd33cb50c9383b4c2eb54ae`:

- align the lifecycle caller's former 20-second whole-test context with the
  existing named 80-second integration-test budget
- leave the bounded deadline, Raft configuration, production API, operation
  behavior, and no-retry contract unchanged

Final review-repair validation:

- lifecycle, lifecycle configuration, gap regression, and integration
  configuration: PASS (`11.282s`)
- independent coordinator repetition of restore, lifecycle, timing, and
  deterministic-gap regressions, 3 consecutive iterations: PASS (`155.763s`)
- complete `TreeDB/internal/raftplacement` normal: PASS (`54.744s`)
- complete package race with `-race -p 1`: PASS (`69.172s`)
- package vet, Windows/amd64 package cross-compile, and `git diff --check`: PASS

Topology-caller deadline repair in
`f249c0d619a022f1b5808a0c7c395d6d12f9f435`:

- audit every direct M8 production topology caller: the production runner
  already uses two minutes and the lifecycle harness test already uses the
  named 80-second budget
- align the two remaining benchmark test callers, formerly 30 and 45 seconds,
  with one named bounded 80-second topology-test budget
- leave every per-request deadline, production path, Raft configuration,
  operation behavior, retry policy, and ambiguity semantic unchanged

Topology-repair validation:

- focused 10k topology and existing-assets relabel scenarios: PASS
  (`17.54s` / `19.62s`; `37.166s` combined)
- independent coordinator execution of both affected scenarios: PASS
  (`38.118s`)
- complete `cmd/treedb_vector_partition_bench` normal: PASS (`61.127s`)
- complete package race with `-race -p 1`: PASS (`310.414s`)
- package vet, Windows/amd64 package cross-compile, and `git diff --check`: PASS

Fail-closed leader-observation repairs in
`2358dd84cb361710f765f0213912f79ae7dc0bc6` and
`4b32da5222c5fd101d13ee03e16b6ef8e3542a90`:

- invalidate the entire leader sample on the first provider admission-status
  error in both lifecycle and integration waiters
- clear candidate identity and its timestamp for every incomplete or
  leaderless sample, so the first subsequent complete unique-leader sample
  starts a fully new lease dwell
- add a deterministic probe-failure regression proving neither the pre-error
  dwell nor the failed-sample timestamp can be inherited
- leave production admission, ambiguity, lifecycle, retry, and Raft APIs
  unchanged

Exact final-head validation:

- probe-failure/gap/lifecycle/configuration and restore/failover/rejoin
  scenarios: PASS
- independent coordinator execution of probe-failure/gap/lifecycle/restore:
  PASS (`50.749s`)
- complete `TreeDB/internal/raftplacement` normal: PASS (`51.662s`)
- complete package race with `-race -p 1`: PASS (`71.786s`)
- package vet, Windows/amd64 package cross-compile, and `git diff --check`: PASS

Prior-head hosted certification (diagnostic after the deadline repair):

- PR TreeDB matrix: run
  [30329986493](https://github.com/snissn/gomap/actions/runs/30329986493) —
  PASS (all 17 substantive jobs plus `TreeDB required gate`, including
  `windows-core-2`)
- persistent proof `ci-proof/3665-windows-raft-2`: run
  [30330297625](https://github.com/snissn/gomap/actions/runs/30330297625)
- persistent proof `ci-proof/3665-windows-raft-3`: run
  [30330298841](https://github.com/snissn/gomap/actions/runs/30330298841)

These runs resolve to prior head
`ad3a68a01eafa6e8a2f65c6b7f3bd0b5169c2ca1` and are retained as
diagnostic evidence only.

Prior final-head hosted certification (diagnostic after the topology-caller
deadline repair):

- PR TreeDB matrix:
  [30331601269](https://github.com/snissn/gomap/actions/runs/30331601269) —
  PASS (all 17 substantive jobs plus `TreeDB required gate`, including
  `windows-core-2`)
- persistent proof `ci-proof/3665-final-windows-raft-2`:
  [30332157283](https://github.com/snissn/gomap/actions/runs/30332157283)
- persistent proof `ci-proof/3665-final-windows-raft-3`:
  [30332158623](https://github.com/snissn/gomap/actions/runs/30332158623)

All these runs resolve to prior head
`4227f819d4ec9f8fafd33cb50c9383b4c2eb54ae`.

Superseded topology-head hosted certification (diagnostic after the
fail-closed observation repair):

- PR TreeDB matrix:
  [30333511223](https://github.com/snissn/gomap/actions/runs/30333511223) —
  superseded by the later branch push

This run resolves to prior head
`f249c0d619a022f1b5808a0c7c395d6d12f9f435`.

Exact final-head hosted certification:

- PR TreeDB matrix:
  [30334564761](https://github.com/snissn/gomap/actions/runs/30334564761) —
  PASS (all 17 substantive jobs plus `TreeDB required gate`, including
  `windows-core-2`)
- persistent proof `ci-proof/3665-callers-final-2`:
  [30336226379](https://github.com/snissn/gomap/actions/runs/30336226379) —
  PASS (all 17 substantive jobs plus `TreeDB required gate`, including
  `windows-core-2`)
- persistent proof `ci-proof/3665-callers-final-3`:
  [30336226241](https://github.com/snissn/gomap/actions/runs/30336226241) —
  PASS (all 17 substantive jobs plus `TreeDB required gate`, including
  `windows-core-2`)

Exact-head Codex review reported no major issues on
`4b32da5222c5fd101d13ee03e16b6ef8e3542a90`; all review threads are
resolved.

All merge-counted final runs must resolve to exact head
`4b32da5222c5fd101d13ee03e16b6ef8e3542a90`.

## Performance classification

Not performance-relevant. This changes only test-harness readiness/configuration
and leaves production Raft admission and commit-ambiguity behavior unchanged.

## Merge gates

- Focused normal, race, vet, and repeated readiness/lifecycle tests pass.
- Exact-head mature Codex review is clean with zero unresolved threads.
- Latest-head required CI is green.
- Three independent exact-head TreeDB matrices complete green, including
  `windows-core-2`.
