### PR TITLE
Fix persistent partition-local HNSW reachability

### DIFF
--- a/TreeDB/collections/vector_index_rebuild_test.go
+++ b/TreeDB/collections/vector_index_rebuild_test.go
@@ -935,6 +935,46 @@ func TestColumnGraphRebuildVectorIndexAdjacencyValidatesAllDimsBeforeScoringV2A(
 	}
 }
 
+// This compact ordered fixture used to reproduce the directed entry-reachability
+// collapse that was observed in retained partition-local packs. The assertion
+// is deliberately structural: exact scoring cannot compensate for a pack whose
+// native entry cannot traverse to its stored rows.
+func TestVectorPartitionLocalGraphAdjacencyKeepsLayer0EntryReachable(t *testing.T) {
+	const count = 4096
+	def := columnGraphRebuildVectorIndexDefinitionV2A(16, 16)
+	rows := make([]columnVectorGraphAssetRow, count)
+	for i := range rows {
+		vector := make([]float32, 16)
+		cluster := (i / 97) % 4
+		vector[cluster] = 1
+		for d := 4; d < len(vector); d++ {
+			vector[d] = float32(((i+1)*(d+3)+1)%31) / 310
+		}
+		rows[i] = columnVectorGraphAssetRow{ID: []byte(fmt.Sprintf("ordered-%05d", i)), Vector: vector, InvNorm: 1}
+	}
+	if err := buildVectorPartitionLocalGraphAdjacencyV1(rows, def); err != nil {
+		t.Fatalf("buildVectorPartitionLocalGraphAdjacencyV1: %v", err)
+	}
+	seen := make([]bool, len(rows))
+	seen[0] = true
+	queue := []int{0}
+	for head := 0; head < len(queue); head++ {
+		adjacency := rows[queue[head]].Adjacency
+		if len(adjacency) > 0 && adjacency[0] == columnVectorGraphLayeredAdjacencyMagic {
+			adjacency = adjacency[3 : 3+int(adjacency[2])]
+		}
+		for _, neighbor := range adjacency {
+			if int(neighbor) < len(rows) && !seen[neighbor] {
+				seen[neighbor] = true
+				queue = append(queue, int(neighbor))
+			}
+		}
+	}
+	if len(queue) != len(rows) {
+		t.Fatalf("layer-0 entry reaches %d/%d rows", len(queue), len(rows))
+	}
+}
+
 func TestColumnGraphRebuildVectorIndexReachabilityReclaimsSupersededGraphSegmentV2A(t *testing.T) {
 	rows := []columnGraphRebuildInputRowV2A{
 		{id: "doc-a", vector: []float32{1, 0, 0}},

--- a/TreeDB/collections/vector_index_rebuild_test.go
+++ b/TreeDB/collections/vector_index_rebuild_test.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"math"
 	"os"
+	"slices"
 	"strings"
 	"testing"
 
@@ -952,27 +953,80 @@ func TestVectorPartitionLocalGraphAdjacencyKeepsLayer0EntryReachable(t *testing.
 		}
 		rows[i] = columnVectorGraphAssetRow{ID: []byte(fmt.Sprintf("ordered-%05d", i)), Vector: vector, InvNorm: 1}
 	}
+	native := cloneColumnVectorGraphAssetRows3999(rows)
+	repeated := cloneColumnVectorGraphAssetRows3999(rows)
+	if err := buildColumnVectorGraphAdjacency(native, def); err != nil {
+		t.Fatalf("buildColumnVectorGraphAdjacency: %v", err)
+	}
+	if got, err := vectorPartitionLayer0Reachability3999(native); err != nil {
+		t.Fatalf("native layer-0 reachability: %v", err)
+	} else if got >= len(native) {
+		t.Fatalf("native layer-0 entry reaches %d/%d rows; fixture no longer reproduces the base failure", got, len(native))
+	}
 	if err := buildVectorPartitionLocalGraphAdjacencyV1(rows, def); err != nil {
 		t.Fatalf("buildVectorPartitionLocalGraphAdjacencyV1: %v", err)
 	}
-	seen := make([]bool, len(rows))
-	seen[0] = true
-	queue := []int{0}
-	for head := 0; head < len(queue); head++ {
-		adjacency := rows[queue[head]].Adjacency
-		if len(adjacency) > 0 && adjacency[0] == columnVectorGraphLayeredAdjacencyMagic {
-			adjacency = adjacency[3 : 3+int(adjacency[2])]
+	if err := buildVectorPartitionLocalGraphAdjacencyV1(repeated, def); err != nil {
+		t.Fatalf("repeat buildVectorPartitionLocalGraphAdjacencyV1: %v", err)
+	}
+	if got, err := vectorPartitionLayer0Reachability3999(rows); err != nil {
+		t.Fatalf("repaired layer-0 reachability: %v", err)
+	} else if got != len(rows) {
+		t.Fatalf("repaired layer-0 entry reaches %d/%d rows", got, len(rows))
+	}
+	for row := range rows {
+		layer0, repairedSuffix, err := vectorPartitionLayer0AdjacencySplitV1(rows[row].Adjacency)
+		if err != nil || len(layer0) > 2*def.M {
+			t.Fatalf("repaired row=%d layer-0 degree=%d err=%v", row, len(layer0), err)
 		}
-		for _, neighbor := range adjacency {
-			if int(neighbor) < len(rows) && !seen[neighbor] {
+		_, nativeSuffix, nativeErr := vectorPartitionLayer0AdjacencySplitV1(native[row].Adjacency)
+		if nativeErr != nil || !slices.Equal(repairedSuffix, nativeSuffix) {
+			t.Fatalf("repaired row=%d higher-layer encoding changed repaired=%v native=%v err=%v", row, repairedSuffix, nativeSuffix, nativeErr)
+		}
+		for _, neighbor := range layer0 {
+			if int(neighbor) >= len(rows) || neighbor == uint32(row) {
+				t.Fatalf("repaired row=%d invalid neighbor=%d", row, neighbor)
+			}
+		}
+		if !slices.Equal(rows[row].Adjacency, repeated[row].Adjacency) {
+			t.Fatalf("repaired adjacency is nondeterministic at row=%d", row)
+		}
+	}
+}
+
+func cloneColumnVectorGraphAssetRows3999(in []columnVectorGraphAssetRow) []columnVectorGraphAssetRow {
+	out := make([]columnVectorGraphAssetRow, len(in))
+	for i := range in {
+		out[i] = in[i]
+		out[i].ID = append([]byte(nil), in[i].ID...)
+		out[i].Vector = append([]float32(nil), in[i].Vector...)
+	}
+	return out
+}
+
+func vectorPartitionLayer0Reachability3999(rows []columnVectorGraphAssetRow) (int, error) {
+	if len(rows) == 0 {
+		return 0, nil
+	}
+	seen := make([]bool, len(rows))
+	queue := []int{0}
+	seen[0] = true
+	for head := 0; head < len(queue); head++ {
+		layer0, _, err := vectorPartitionLayer0AdjacencySplitV1(rows[queue[head]].Adjacency)
+		if err != nil {
+			return 0, err
+		}
+		for _, neighbor := range layer0 {
+			if int(neighbor) >= len(rows) {
+				return 0, fmt.Errorf("neighbor=%d out of range rows=%d", neighbor, len(rows))
+			}
+			if !seen[neighbor] {
 				seen[neighbor] = true
 				queue = append(queue, int(neighbor))
 			}
 		}
 	}
-	if len(queue) != len(rows) {
-		t.Fatalf("layer-0 entry reaches %d/%d rows", len(queue), len(rows))
-	}
+	return len(queue), nil
 }
 
 func TestColumnGraphRebuildVectorIndexReachabilityReclaimsSupersededGraphSegmentV2A(t *testing.T) {

--- a/TreeDB/collections/vector_partition_persistent_searcher_v1.go
+++ b/TreeDB/collections/vector_partition_persistent_searcher_v1.go
@@ -41,6 +41,96 @@ func compactPartitionAdjacencyV1(in []uint32) []uint32 {
 	return in[:n]
 }
 
+const vectorPartitionLocalNavigationBranchV1 = 8
+
+// buildVectorPartitionLocalGraphAdjacencyV1 retains the shared native graph
+// construction, then reserves a bounded layer-0 navigation tree in the
+// partition-only pack. It gives the entry a logarithmic-hop route to every
+// local row while leaving global column-graph and router assets unchanged.
+func buildVectorPartitionLocalGraphAdjacencyV1(rows []columnVectorGraphAssetRow, def VectorIndexDefinition) error {
+	if err := buildColumnVectorGraphAdjacency(rows, def); err != nil {
+		return err
+	}
+	return addVectorPartitionLocalNavigationOverlayV1(rows, max(1, def.M*2))
+}
+
+func addVectorPartitionLocalNavigationOverlayV1(rows []columnVectorGraphAssetRow, degreeLimit int) error {
+	if len(rows) < 2 {
+		return nil
+	}
+	branch := max(1, min(vectorPartitionLocalNavigationBranchV1, degreeLimit-1))
+	children := make([][]uint32, len(rows))
+	for child := 1; child < len(rows); child++ {
+		parent := (child - 1) / branch
+		children[parent] = append(children[parent], uint32(child))
+	}
+	for row := range rows {
+		native, suffix, err := vectorPartitionLayer0AdjacencySplitV1(rows[row].Adjacency)
+		if err != nil {
+			return err
+		}
+		overlay := make([]uint32, 0, len(children[row])+1)
+		if row != 0 {
+			overlay = append(overlay, uint32((row-1)/branch))
+		}
+		overlay = append(overlay, children[row]...)
+		if len(overlay) > degreeLimit {
+			return fmt.Errorf("partition-local navigation row=%d degree=%d exceeds limit=%d", row, len(overlay), degreeLimit)
+		}
+		out := append([]uint32(nil), overlay...)
+		for _, neighbor := range native {
+			if int(neighbor) >= len(rows) || neighbor == uint32(row) {
+				return fmt.Errorf("partition-local native neighbor row=%d neighbor=%d", row, neighbor)
+			}
+			duplicate := false
+			for _, existing := range out {
+				if existing == neighbor {
+					duplicate = true
+					break
+				}
+			}
+			if !duplicate && len(out) < degreeLimit {
+				out = append(out, neighbor)
+			}
+		}
+		rows[row].Adjacency = vectorPartitionLayer0AdjacencyJoinV1(out, suffix)
+	}
+	return nil
+}
+
+// split returns the layer-0 neighbors plus the exact encoded higher-layer
+// suffix. A nil suffix denotes the legacy layer-0-only representation.
+func vectorPartitionLayer0AdjacencySplitV1(adjacency []uint32) ([]uint32, []uint32, error) {
+	if len(adjacency) == 0 {
+		return nil, nil, nil
+	}
+	if adjacency[0] != columnVectorGraphLayeredAdjacencyMagic {
+		return append([]uint32(nil), adjacency...), nil, nil
+	}
+	if len(adjacency) < 3 {
+		return nil, nil, errors.New("partition-local layered adjacency header")
+	}
+	count := int(adjacency[2])
+	if count < 0 || count > len(adjacency)-3 {
+		return nil, nil, errors.New("partition-local layered adjacency layer-0 count")
+	}
+	suffix := make([]uint32, 1, 1+len(adjacency)-(3+count))
+	suffix[0] = adjacency[1]
+	suffix = append(suffix, adjacency[3+count:]...)
+	return append([]uint32(nil), adjacency[3:3+count]...), suffix, nil
+}
+
+func vectorPartitionLayer0AdjacencyJoinV1(layer0, suffix []uint32) []uint32 {
+	if suffix == nil {
+		return layer0
+	}
+	out := make([]uint32, 0, 3+len(layer0)+len(suffix))
+	out = append(out, columnVectorGraphLayeredAdjacencyMagic, suffix[0], uint32(len(layer0)))
+	out = append(out, layer0...)
+	out = append(out, suffix[1:]...)
+	return out
+}
+
 func vectorPartitionLocalAssetIDV1(partition uint32) string {
 	return fmt.Sprintf("hnsw_search_pack_v1/partition/%d", partition)
 }
@@ -546,7 +636,7 @@ func (c *Collection) materializeVectorPartitionLocalSearchAssetsV1(index string,
 			}
 			rows[j] = columnVectorGraphAssetRow{ID: append([]byte(nil), source.id...), Vector: append([]float32(nil), r.Vector...), InvNorm: r.InvNorm, BaseRowRef: ref}
 		}
-		if err := buildColumnVectorGraphAdjacency(rows, def); err != nil {
+		if err := buildVectorPartitionLocalGraphAdjacencyV1(rows, def); err != nil {
 			return nil, nil, fmt.Errorf("%w: build partition-local graph: %v", ErrVectorPartitionSearchUnavailable, err)
 		}
 		maxLayer := 0

--- a/TreeDB/collections/vector_partition_persistent_searcher_v1.go
+++ b/TreeDB/collections/vector_partition_persistent_searcher_v1.go
@@ -51,14 +51,19 @@ func buildVectorPartitionLocalGraphAdjacencyV1(rows []columnVectorGraphAssetRow,
 	if err := buildColumnVectorGraphAdjacency(rows, def); err != nil {
 		return err
 	}
-	return addVectorPartitionLocalNavigationOverlayV1(rows, max(1, def.M*2))
+	return addVectorPartitionLocalNavigationOverlayV1(rows, def.M*2)
 }
 
 func addVectorPartitionLocalNavigationOverlayV1(rows []columnVectorGraphAssetRow, degreeLimit int) error {
 	if len(rows) < 2 {
 		return nil
 	}
-	branch := max(1, min(vectorPartitionLocalNavigationBranchV1, degreeLimit-1))
+	if degreeLimit < 3 {
+		return fmt.Errorf("partition-local navigation degree limit=%d cannot reserve a native edge", degreeLimit)
+	}
+	// Reserve one layer-0 native edge for every row. M=16 keeps the existing
+	// branch=8 layout byte-for-byte; lower M reduces the overlay fanout.
+	branch := min(vectorPartitionLocalNavigationBranchV1, degreeLimit-2)
 	children := make([][]uint32, len(rows))
 	for child := 1; child < len(rows); child++ {
 		parent := (child - 1) / branch
@@ -79,7 +84,7 @@ func addVectorPartitionLocalNavigationOverlayV1(rows []columnVectorGraphAssetRow
 		}
 		out := append([]uint32(nil), overlay...)
 		for _, neighbor := range native {
-			if int(neighbor) >= len(rows) || neighbor == uint32(row) {
+			if uint64(neighbor) >= uint64(len(rows)) || neighbor == uint32(row) {
 				return fmt.Errorf("partition-local native neighbor row=%d neighbor=%d", row, neighbor)
 			}
 			duplicate := false

--- a/TreeDB/collections/vector_partition_persistent_searcher_v1.go
+++ b/TreeDB/collections/vector_partition_persistent_searcher_v1.go
@@ -58,8 +58,30 @@ func addVectorPartitionLocalNavigationOverlayV1(rows []columnVectorGraphAssetRow
 	if len(rows) < 2 {
 		return nil
 	}
-	if degreeLimit < 3 {
-		return fmt.Errorf("partition-local navigation degree limit=%d cannot reserve a native edge", degreeLimit)
+	if degreeLimit < 2 {
+		return fmt.Errorf("partition-local navigation degree limit=%d", degreeLimit)
+	}
+	if degreeLimit == 2 {
+		// M=1 has room for exactly a navigation successor plus one native edge.
+		// The directed ring reaches every row without widening the declared cap.
+		for row := range rows {
+			native, suffix, err := vectorPartitionLayer0AdjacencySplitV1(rows[row].Adjacency)
+			if err != nil {
+				return err
+			}
+			out := []uint32{uint32((row + 1) % len(rows))}
+			for _, neighbor := range native {
+				if uint64(neighbor) >= uint64(len(rows)) || neighbor == uint32(row) {
+					return fmt.Errorf("partition-local native neighbor row=%d neighbor=%d", row, neighbor)
+				}
+				if neighbor != out[0] {
+					out = append(out, neighbor)
+					break
+				}
+			}
+			rows[row].Adjacency = vectorPartitionLayer0AdjacencyJoinV1(out, suffix)
+		}
+		return nil
 	}
 	// Reserve one layer-0 native edge for every row. M=16 keeps the existing
 	// branch=8 layout byte-for-byte; lower M reduces the overlay fanout.

--- a/TreeDB/collections/vector_partition_persistent_searcher_v1.go
+++ b/TreeDB/collections/vector_partition_persistent_searcher_v1.go
@@ -74,6 +74,8 @@ func addVectorPartitionLocalNavigationOverlayV1(rows []columnVectorGraphAssetRow
 				if uint64(neighbor) >= uint64(len(rows)) || neighbor == uint32(row) {
 					return fmt.Errorf("partition-local native neighbor row=%d neighbor=%d", row, neighbor)
 				}
+			}
+			for _, neighbor := range native {
 				if neighbor != out[0] {
 					out = append(out, neighbor)
 					break

--- a/TreeDB/collections/vector_partition_persistent_searcher_v1_test.go
+++ b/TreeDB/collections/vector_partition_persistent_searcher_v1_test.go
@@ -8,6 +8,7 @@ import (
 	"math"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 	"testing"
 )
@@ -302,6 +303,45 @@ func TestVectorPartitionNativePackPreflightAndLayeredAdjacencyV1(t *testing.T) {
 		if got[i] != want[i] {
 			t.Fatalf("remapped adjacency=%v want %v", got, want)
 		}
+	}
+}
+
+func TestVectorPartitionLocalNavigationOverlayReservesNativeEdgeAtM2V1(t *testing.T) {
+	rows := make([]columnVectorGraphAssetRow, 8)
+	nativeEdges := []uint32{4, 5, 7, 0, 0, 1, 3, 4}
+	for i := range rows {
+		// Every value is outside this row's parent/child overlay set.
+		rows[i].Adjacency = []uint32{nativeEdges[i]}
+	}
+	if err := addVectorPartitionLocalNavigationOverlayV1(rows, 4); err != nil {
+		t.Fatal(err)
+	}
+	for i := range rows {
+		layer0, _, err := vectorPartitionLayer0AdjacencySplitV1(rows[i].Adjacency)
+		if err != nil || len(layer0) > 4 || len(layer0) == 0 {
+			t.Fatalf("row=%d layer0=%v err=%v", i, layer0, err)
+		}
+		native := nativeEdges[i]
+		if !slices.Contains(layer0, native) {
+			t.Fatalf("row=%d lost reserved native edge=%d: %v", i, native, layer0)
+		}
+	}
+	if got, err := vectorPartitionLayer0Reachability3999(rows); err != nil || got != len(rows) {
+		t.Fatalf("M=2 overlay reachability=%d err=%v want=%d", got, err, len(rows))
+	}
+	if err := addVectorPartitionLocalNavigationOverlayV1(rows, 2); err == nil {
+		t.Fatal("M=1 layer-0 degree=2 overlay unexpectedly accepted")
+	}
+}
+
+func TestVectorPartitionPackDiagnosticsMaxLayerFailsClosedV1(t *testing.T) {
+	for _, tc := range []struct{ maxLayer, layers int }{{-1, 1}, {1, 1}} {
+		if err := validateVectorPartitionPackDiagnosticsMaxLayerV1(tc.maxLayer, tc.layers); err == nil {
+			t.Fatalf("maxLayer=%d layers=%d unexpectedly accepted", tc.maxLayer, tc.layers)
+		}
+	}
+	if err := validateVectorPartitionPackDiagnosticsMaxLayerV1(0, 1); err != nil {
+		t.Fatalf("valid max layer: %v", err)
 	}
 }
 

--- a/TreeDB/collections/vector_partition_persistent_searcher_v1_test.go
+++ b/TreeDB/collections/vector_partition_persistent_searcher_v1_test.go
@@ -329,8 +329,26 @@ func TestVectorPartitionLocalNavigationOverlayReservesNativeEdgeAtM2V1(t *testin
 	if got, err := vectorPartitionLayer0Reachability3999(rows); err != nil || got != len(rows) {
 		t.Fatalf("M=2 overlay reachability=%d err=%v want=%d", got, err, len(rows))
 	}
-	if err := addVectorPartitionLocalNavigationOverlayV1(rows, 2); err == nil {
-		t.Fatal("M=1 layer-0 degree=2 overlay unexpectedly accepted")
+	m1a := make([]columnVectorGraphAssetRow, len(rows))
+	m1b := make([]columnVectorGraphAssetRow, len(rows))
+	for i := range rows {
+		m1a[i].Adjacency = []uint32{nativeEdges[i]}
+		m1b[i].Adjacency = []uint32{nativeEdges[i]}
+	}
+	if err := addVectorPartitionLocalNavigationOverlayV1(m1a, 2); err != nil {
+		t.Fatalf("M=1 overlay: %v", err)
+	}
+	if err := addVectorPartitionLocalNavigationOverlayV1(m1b, 2); err != nil {
+		t.Fatalf("repeat M=1 overlay: %v", err)
+	}
+	if got, err := vectorPartitionLayer0Reachability3999(m1a); err != nil || got != len(m1a) {
+		t.Fatalf("M=1 overlay reachability=%d err=%v want=%d", got, err, len(m1a))
+	}
+	for i := range m1a {
+		layer0, _, err := vectorPartitionLayer0AdjacencySplitV1(m1a[i].Adjacency)
+		if err != nil || len(layer0) > 2 || !slices.Contains(layer0, nativeEdges[i]) || !slices.Equal(m1a[i].Adjacency, m1b[i].Adjacency) {
+			t.Fatalf("M=1 row=%d layer0=%v err=%v repeat=%v", i, layer0, err, m1b[i].Adjacency)
+		}
 	}
 }
 

--- a/TreeDB/collections/vector_partition_persistent_searcher_v1_test.go
+++ b/TreeDB/collections/vector_partition_persistent_searcher_v1_test.go
@@ -352,6 +352,16 @@ func TestVectorPartitionLocalNavigationOverlayReservesNativeEdgeAtM2V1(t *testin
 	}
 }
 
+func TestVectorPartitionLocalNavigationOverlayM1ValidatesEveryNativeEdgeV1(t *testing.T) {
+	rows := make([]columnVectorGraphAssetRow, 3)
+	// The first edge is eligible for retention. The later invalid edge must
+	// still be checked before M=1 chooses at most one native edge.
+	rows[0].Adjacency = []uint32{1, 3}
+	if err := addVectorPartitionLocalNavigationOverlayV1(rows, 2); err == nil {
+		t.Fatal("accepted later invalid M=1 native edge")
+	}
+}
+
 func TestVectorPartitionPackDiagnosticsMaxLayerFailsClosedV1(t *testing.T) {
 	for _, tc := range []struct{ maxLayer, layers int }{{-1, 1}, {1, 1}} {
 		if err := validateVectorPartitionPackDiagnosticsMaxLayerV1(tc.maxLayer, tc.layers); err == nil {

--- a/TreeDB/collections/vector_partition_persistent_searcher_v1_test.go
+++ b/TreeDB/collections/vector_partition_persistent_searcher_v1_test.go
@@ -453,6 +453,13 @@ func TestVectorPartitionMaterializationBuildsPartitionLocalConnectedGraphV1(t *t
 		t.Fatal(err)
 	}
 	defer searcher.Close()
+	diagnostics, err := searcher.PackDiagnosticsV1()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if diagnostics.Rows != uint64(len(selected)) || diagnostics.ReachableRows != diagnostics.Rows || diagnostics.TraversalRoots != 1 || len(diagnostics.RowsByLayer) == 0 || len(diagnostics.EdgesByLayer) == 0 {
+		t.Fatalf("partition-local pack diagnostics=%+v", diagnostics)
+	}
 	for id, query := range selected {
 		got, err := searcher.Search(query, 1)
 		if err != nil {

--- a/TreeDB/collections/vector_partition_searcher_v1.go
+++ b/TreeDB/collections/vector_partition_searcher_v1.go
@@ -380,6 +380,9 @@ func (s *VectorPartitionLocalSearcherV1) PackDiagnosticsV1() (VectorPartitionPac
 	if rows <= 0 || len(pack.AdjacencyLayers) == 0 || pack.Header.EntryOrdinal < 0 || pack.Header.EntryOrdinal >= rows {
 		return VectorPartitionPackDiagnosticsV1{}, ErrVectorPartitionSearchUnavailable
 	}
+	if err := validateVectorPartitionPackDiagnosticsMaxLayerV1(pack.Header.MaxLayer, len(pack.AdjacencyLayers)); err != nil {
+		return VectorPartitionPackDiagnosticsV1{}, err
+	}
 	d := VectorPartitionPackDiagnosticsV1{Rows: uint64(rows), MaxLayer: pack.Header.MaxLayer, RowsByLayer: make([]uint64, pack.Header.MaxLayer+1), EdgesByLayer: make([]uint64, len(pack.AdjacencyLayers)), Layer0DegreeLimit: uint64(max(1, pack.Header.M*2))}
 	for ordinal, level := range pack.Levels {
 		if int(level) > pack.Header.MaxLayer || ordinal >= rows {
@@ -410,7 +413,7 @@ func (s *VectorPartitionLocalSearcherV1) PackDiagnosticsV1() (VectorPartitionPac
 				d.Layer0SaturatedRows++
 			}
 			for _, neighbor := range base.Neighbors[startOffset:endOffset] {
-				if int(neighbor) >= rows {
+				if uint64(neighbor) >= uint64(rows) {
 					return 0, ErrVectorPartitionSearchUnavailable
 				}
 				if !seen[neighbor] {
@@ -437,6 +440,13 @@ func (s *VectorPartitionLocalSearcherV1) PackDiagnosticsV1() (VectorPartitionPac
 		d.TraversalRoots++
 	}
 	return d, nil
+}
+
+func validateVectorPartitionPackDiagnosticsMaxLayerV1(maxLayer, adjacencyLayers int) error {
+	if maxLayer < 0 || maxLayer >= adjacencyLayers {
+		return fmt.Errorf("%w: pack max layer=%d adjacency layers=%d", ErrVectorPartitionSearchUnavailable, maxLayer, adjacencyLayers)
+	}
+	return nil
 }
 
 // SearchScratchBytesV1 returns a conservative upper bound for the transient

--- a/TreeDB/collections/vector_partition_searcher_v1.go
+++ b/TreeDB/collections/vector_partition_searcher_v1.go
@@ -341,6 +341,104 @@ type VectorPartitionSearchStatusV1 struct {
 	Retired                             bool
 }
 
+// VectorPartitionPackDiagnosticsV1 is an explicit offline inspection result
+// for one immutable local HNSW pack. It is intentionally separate from Status:
+// computing connectivity walks the full persisted graph and must never become
+// request-path work.
+type VectorPartitionPackDiagnosticsV1 struct {
+	Rows                uint64   `json:"rows"`
+	ReachableRows       uint64   `json:"reachable_rows"`
+	TraversalRoots      uint64   `json:"traversal_roots"`
+	MaxLayer            int      `json:"max_layer"`
+	RowsByLayer         []uint64 `json:"rows_by_layer"`
+	EdgesByLayer        []uint64 `json:"edges_by_layer"`
+	Layer0DegreeLimit   uint64   `json:"layer0_degree_limit"`
+	Layer0SaturatedRows uint64   `json:"layer0_saturated_rows"`
+}
+
+// PackDiagnosticsV1 scans the immutable prepared pack and reports topology
+// evidence needed to distinguish construction/reachability defects from a
+// request ef_search budget. It fails closed when no native pack is active.
+func (s *VectorPartitionLocalSearcherV1) PackDiagnosticsV1() (VectorPartitionPackDiagnosticsV1, error) {
+	if s == nil {
+		return VectorPartitionPackDiagnosticsV1{}, ErrVectorPartitionSearchUnavailable
+	}
+	if err := s.Acquire(); err != nil {
+		return VectorPartitionPackDiagnosticsV1{}, err
+	}
+	defer s.Release()
+	s.mu.Lock()
+	pack := s.prepared
+	s.mu.Unlock()
+	if pack == nil {
+		return VectorPartitionPackDiagnosticsV1{}, ErrVectorPartitionSearchUnavailable
+	}
+	if err := pack.validateLive(); err != nil {
+		return VectorPartitionPackDiagnosticsV1{}, ErrVectorPartitionSearchUnavailable
+	}
+	rows := pack.Header.Rows
+	if rows <= 0 || len(pack.AdjacencyLayers) == 0 || pack.Header.EntryOrdinal < 0 || pack.Header.EntryOrdinal >= rows {
+		return VectorPartitionPackDiagnosticsV1{}, ErrVectorPartitionSearchUnavailable
+	}
+	d := VectorPartitionPackDiagnosticsV1{Rows: uint64(rows), MaxLayer: pack.Header.MaxLayer, RowsByLayer: make([]uint64, pack.Header.MaxLayer+1), EdgesByLayer: make([]uint64, len(pack.AdjacencyLayers)), Layer0DegreeLimit: uint64(max(1, pack.Header.M*2))}
+	for ordinal, level := range pack.Levels {
+		if int(level) > pack.Header.MaxLayer || ordinal >= rows {
+			return VectorPartitionPackDiagnosticsV1{}, ErrVectorPartitionSearchUnavailable
+		}
+		for layer := 0; layer <= int(level); layer++ {
+			d.RowsByLayer[layer]++
+		}
+	}
+	for layer, adjacency := range pack.AdjacencyLayers {
+		if len(adjacency.Offsets) != rows+1 {
+			return VectorPartitionPackDiagnosticsV1{}, ErrVectorPartitionSearchUnavailable
+		}
+		d.EdgesByLayer[layer] = uint64(len(adjacency.Neighbors))
+	}
+	base := pack.AdjacencyLayers[0]
+	seen := make([]bool, rows)
+	visit := func(start int) (int, error) {
+		queue := []int{start}
+		seen[start] = true
+		for head := 0; head < len(queue); head++ {
+			ordinal := queue[head]
+			startOffset, endOffset := base.Offsets[ordinal], base.Offsets[ordinal+1]
+			if endOffset < startOffset || endOffset > uint64(len(base.Neighbors)) {
+				return 0, ErrVectorPartitionSearchUnavailable
+			}
+			if uint64(endOffset-startOffset) >= d.Layer0DegreeLimit {
+				d.Layer0SaturatedRows++
+			}
+			for _, neighbor := range base.Neighbors[startOffset:endOffset] {
+				if int(neighbor) >= rows {
+					return 0, ErrVectorPartitionSearchUnavailable
+				}
+				if !seen[neighbor] {
+					seen[neighbor] = true
+					queue = append(queue, int(neighbor))
+				}
+			}
+		}
+		return len(queue), nil
+	}
+	reachable, err := visit(pack.Header.EntryOrdinal)
+	if err != nil {
+		return VectorPartitionPackDiagnosticsV1{}, err
+	}
+	d.ReachableRows = uint64(reachable)
+	d.TraversalRoots = 1
+	for ordinal := range seen {
+		if seen[ordinal] {
+			continue
+		}
+		if _, err := visit(ordinal); err != nil {
+			return VectorPartitionPackDiagnosticsV1{}, err
+		}
+		d.TraversalRoots++
+	}
+	return d, nil
+}
+
 // SearchScratchBytesV1 returns a conservative upper bound for the transient
 // candidate/search scratch allocated by one SearchWithOptionsV1 call. Serving
 // layers use it before search so a small ef_search cannot conceal the

--- a/TreeDB/docs/performance/vector-partition-m8.md
+++ b/TreeDB/docs/performance/vector-partition-m8.md
@@ -435,8 +435,6 @@ The JSON artifact is clean exact-head evidence. Profile paths are host-local
 retained records, not portable repository assets; their hashes make later
 identity checks deterministic.
 
-## Comparison boundary and disposition
-
 ## #3999 partition-local HNSW reachability refresh
 
 Commit `357e40c62` rebuilds only persistent partition-local packs with a
@@ -460,6 +458,8 @@ The report remains `experimental_gate_failures`: probe reduction is #3998,
 overlap storage is #4001, while exhaustive-correctness, end-to-end QPS, and
 tail-latency gates are still unsatisfied M8-system evidence rather than
 partition-local reachability/recall failures.
+
+## Comparison boundary and disposition
 
 This report compares only TreeDB's own exhaustive oracle and graph-routed
 production-shaped loopback path on the stated host and retained fixtures. It

--- a/TreeDB/docs/performance/vector-partition-m8.md
+++ b/TreeDB/docs/performance/vector-partition-m8.md
@@ -437,7 +437,7 @@ identity checks deterministic.
 
 ## #3999 partition-local HNSW reachability refresh
 
-The measured implementation head `f565ae97a7fbbb659941fdf28cf75d45ddbc9397`
+The measured implementation head `2ec108a625419a3a3f372a0eb5dca29c433052f5`
 rebuilds only persistent partition-local packs with a bounded, deterministic
 layer-0 navigation overlay. It preserves the `2*M` layer-0 cap (32 at M=16)
 while providing a route from the pack entry to every local row; global
@@ -448,29 +448,29 @@ runtime behavior.
 The authoritative uncontended evidence uses the fresh graph/disjoint 1M DB
 `/mnt/fast4tb/tmp/issue3999_m3_lk3imU/db_graph_disjoint`. The all-16-partition
 M8 `ef_search=4096` cell recorded recall@10 and local-HNSW recall@10 `0.975`,
-exact representative-routing recall `1.0`, QPS `10.255`, and p50/p95/p99
-`97.266/117.941/123.513ms`. Its measured query wall clock was `20.581s`
-(`137.93s` command wall clock; `18.191s` build).
+exact representative-routing recall `1.0`, QPS `11.158`, and p50/p95/p99
+`87.586/111.463/121.120ms`. Its measured query wall clock was `20.251s`
+(`133.31s` command wall clock; `19.609s` build).
 
 The profiled artifact is
-`/mnt/fast4tb/tmp/issue3999_m8_f565_VAXFRv/vector_partition_m8_f565ae97a7fb_ca6f595a28e8.json`
-(SHA-256 `0cf4ab84c8a361e51aa18ab55b32fccd93a46ec4e8f824207bec086e89d563bd`).
+`/mnt/fast4tb/tmp/issue3999_m8_2ec_UxtWPM/vector_partition_m8_2ec108a62541_ca6f595a28e8.json`
+(SHA-256 `84bb62aeb9cebcc4c6bba733bfacbc68f6a3a46be4709264e723d748f777c36c`).
 It records `dirty=false` and `partition_pack_reachability=pass`: exactly 16
 diagnostics bind to the 16 manifest partition loads, every diagnostic `rows`
 matches its load, the diagnostic/load/retained-variant totals are each
 `1,000,000`, and every pack has `reachable_rows == rows` and
 `traversal_roots == 1`. Resource bounds pass with peak RSS
-`1,851,252,736 / 4,294,967,296` bytes and persistent assets
+`1,731,821,568 / 4,294,967,296` bytes and persistent assets
 `282,881,928 / 536,870,912` bytes.
 
 The seven captured profile hashes are: allocation baseline
-`f7501feb7deca692be86e5a12e4d8c373f43fc8ff45c8cca281ff04ffb72f31c`,
-allocation final `8a1601bb027e92c8678154a001fe20f7f67af08a550328ede9af071c1a09da06`,
-CPU `30eb7e1134a8d093b698f0df6b6c98151ddec6cafc7fd56dc5861dd7417399df`,
-heap `cb7a46593c934492025b12511400a6d7d64872af02bc5eee21e18db5b44d0dfa`,
-block `abf56de37cad70a49f00cf1b10935ee947143bfe57f21ac3b3d174d7b8fc33ce`,
-mutex `8361a5d397693209a5c61dac8a3b6a1a9e710501f9cb50a71700946daf2f09c3`,
-and trace `25acfe82dbfae31ba6777ac0c8245a3b7a4af4591bdc43d82dc4094260e08c41`.
+`aba4330b3185456dba3c34fe3dc14a4073742a88e3efe510b8470e1d85b23b74`,
+allocation final `f9c5e3141e60c702e5cbe79d23e67245402334d5819c6b419e2b2399b4d10b13`,
+CPU `f809683540eaac0051ee4271b945aad74ff71508fbafff1c21a354b44325338f`,
+heap `a5748e085dbc7734f8ee5365632e8fbcacede12853d7588315ccbabf4b105116`,
+block `a641bf71369e47f80f53517ffce258202b1f0bdaebf53ffea9cb145b7a037bd7`,
+mutex `881ea506a541d1742651a4fa3155937df01146e03e68e4b54bd4f231a3b744b8`,
+and trace `5a15d8304b5f7bf73b3a9c713bfe95fb7197b75d7414bfb2e6ff2496c47a3c6c`.
 
 The report remains `experimental_gate_failures`: probe reduction is #3998,
 overlap storage is #4001, while exhaustive-correctness, end-to-end QPS, and

--- a/TreeDB/docs/performance/vector-partition-m8.md
+++ b/TreeDB/docs/performance/vector-partition-m8.md
@@ -437,22 +437,40 @@ identity checks deterministic.
 
 ## #3999 partition-local HNSW reachability refresh
 
-Commit `357e40c62` rebuilds only persistent partition-local packs with a
-bounded, deterministic layer-0 navigation overlay. It preserves the `2*M`
-layer-0 cap (32 at M=16) while providing a logarithmic-hop route from the pack
-entry to every local row; global column-graph and router construction are
-unchanged.
+The measured implementation head `f565ae97a7fbbb659941fdf28cf75d45ddbc9397`
+rebuilds only persistent partition-local packs with a bounded, deterministic
+layer-0 navigation overlay. It preserves the `2*M` layer-0 cap (32 at M=16)
+while providing a route from the pack entry to every local row; global
+column-graph and router construction are unchanged. A subsequent
+documentation-only record commit does not change this implementation or its
+runtime behavior.
 
-Fresh graph/disjoint 1M evidence used
+The authoritative uncontended evidence uses the fresh graph/disjoint 1M DB
 `/mnt/fast4tb/tmp/issue3999_m3_lk3imU/db_graph_disjoint`. The all-16-partition
-M8 `ef_search=4096` cell recorded recall@10 `0.975`, local-HNSW recall@10
-`0.975`, exact representative-routing recall `1.0`, and all 16 packs with
-`reachable_rows == rows` and `traversal_roots == 1`. The profiled artifact is
-`/mnt/fast4tb/tmp/issue3999_m8_profile_IYajgs/vector_partition_m8_357e40c6217a_ca6f595a28e8.json`
-(SHA-256 `3f23892f99d096dd25e83a747d5b2ea17fca46fb35b7f95820c10d881f066bf0`).
-Its CPU, block, mutex, trace, heap, and allocation artifacts were captured;
-the run overlapped a local test suite, so its timing profiles are contextual,
-not a baseline comparison.
+M8 `ef_search=4096` cell recorded recall@10 and local-HNSW recall@10 `0.975`,
+exact representative-routing recall `1.0`, QPS `10.255`, and p50/p95/p99
+`97.266/117.941/123.513ms`. Its measured query wall clock was `20.581s`
+(`137.93s` command wall clock; `18.191s` build).
+
+The profiled artifact is
+`/mnt/fast4tb/tmp/issue3999_m8_f565_VAXFRv/vector_partition_m8_f565ae97a7fb_ca6f595a28e8.json`
+(SHA-256 `0cf4ab84c8a361e51aa18ab55b32fccd93a46ec4e8f824207bec086e89d563bd`).
+It records `dirty=false` and `partition_pack_reachability=pass`: exactly 16
+diagnostics bind to the 16 manifest partition loads, every diagnostic `rows`
+matches its load, the diagnostic/load/retained-variant totals are each
+`1,000,000`, and every pack has `reachable_rows == rows` and
+`traversal_roots == 1`. Resource bounds pass with peak RSS
+`1,851,252,736 / 4,294,967,296` bytes and persistent assets
+`282,881,928 / 536,870,912` bytes.
+
+The seven captured profile hashes are: allocation baseline
+`f7501feb7deca692be86e5a12e4d8c373f43fc8ff45c8cca281ff04ffb72f31c`,
+allocation final `8a1601bb027e92c8678154a001fe20f7f67af08a550328ede9af071c1a09da06`,
+CPU `30eb7e1134a8d093b698f0df6b6c98151ddec6cafc7fd56dc5861dd7417399df`,
+heap `cb7a46593c934492025b12511400a6d7d64872af02bc5eee21e18db5b44d0dfa`,
+block `abf56de37cad70a49f00cf1b10935ee947143bfe57f21ac3b3d174d7b8fc33ce`,
+mutex `8361a5d397693209a5c61dac8a3b6a1a9e710501f9cb50a71700946daf2f09c3`,
+and trace `25acfe82dbfae31ba6777ac0c8245a3b7a4af4591bdc43d82dc4094260e08c41`.
 
 The report remains `experimental_gate_failures`: probe reduction is #3998,
 overlap storage is #4001, while exhaustive-correctness, end-to-end QPS, and

--- a/TreeDB/docs/performance/vector-partition-m8.md
+++ b/TreeDB/docs/performance/vector-partition-m8.md
@@ -437,6 +437,30 @@ identity checks deterministic.
 
 ## Comparison boundary and disposition
 
+## #3999 partition-local HNSW reachability refresh
+
+Commit `357e40c62` rebuilds only persistent partition-local packs with a
+bounded, deterministic layer-0 navigation overlay. It preserves the `2*M`
+layer-0 cap (32 at M=16) while providing a logarithmic-hop route from the pack
+entry to every local row; global column-graph and router construction are
+unchanged.
+
+Fresh graph/disjoint 1M evidence used
+`/mnt/fast4tb/tmp/issue3999_m3_lk3imU/db_graph_disjoint`. The all-16-partition
+M8 `ef_search=4096` cell recorded recall@10 `0.975`, local-HNSW recall@10
+`0.975`, exact representative-routing recall `1.0`, and all 16 packs with
+`reachable_rows == rows` and `traversal_roots == 1`. The profiled artifact is
+`/mnt/fast4tb/tmp/issue3999_m8_profile_IYajgs/vector_partition_m8_357e40c6217a_ca6f595a28e8.json`
+(SHA-256 `3f23892f99d096dd25e83a747d5b2ea17fca46fb35b7f95820c10d881f066bf0`).
+Its CPU, block, mutex, trace, heap, and allocation artifacts were captured;
+the run overlapped a local test suite, so its timing profiles are contextual,
+not a baseline comparison.
+
+The report remains `experimental_gate_failures`: probe reduction is #3998,
+overlap storage is #4001, while exhaustive-correctness, end-to-end QPS, and
+tail-latency gates are still unsatisfied M8-system evidence rather than
+partition-local reachability/recall failures.
+
 This report compares only TreeDB's own exhaustive oracle and graph-routed
 production-shaped loopback path on the stated host and retained fixtures. It
 makes no paper-QPS, multi-host, billion-vector, online mutation freshness,

--- a/cmd/treedb_vector_partition_bench/m8_production_assets_test.go
+++ b/cmd/treedb_vector_partition_bench/m8_production_assets_test.go
@@ -59,10 +59,14 @@ func TestM8ProductionReportRejectsUnexercisedDataGroupV1(t *testing.T) {
 			CommitIndex: 1, ReadIndex: 1, AppliedIndex: 1, ReadEvidenceKind: "production", ProvesProductionConsensus: true, EndpointHits: hits,
 		}
 	}
-	diagnostics := func(partitions int) []m8PartitionPackDiagnosticsV1 {
-		out := make([]m8PartitionPackDiagnosticsV1, partitions)
-		for partition := range out {
-			out[partition] = m8PartitionPackDiagnosticsV1{PartitionID: uint32(partition), Rows: 1, ReachableRows: 1, TraversalRoots: 1}
+	loads := make([]uint64, 4)
+	for row := 0; row < fixture.Vectors; row++ {
+		loads[row%len(loads)]++
+	}
+	diagnostics := func(loads []uint64) []m8PartitionPackDiagnosticsV1 {
+		out := make([]m8PartitionPackDiagnosticsV1, len(loads))
+		for partition, load := range loads {
+			out[partition] = m8PartitionPackDiagnosticsV1{PartitionID: uint32(partition), Rows: load, ReachableRows: load, TraversalRoots: 1}
 		}
 		return out
 	}
@@ -79,10 +83,10 @@ func TestM8ProductionReportRejectsUnexercisedDataGroupV1(t *testing.T) {
 			CoordinatorMergeIDParity: true, CoordinatorMergeScoreParity: true,
 			ApproximateRouterCandidateBudget: 1, ApproximateRouterPartitionCoverageComplete: true, ResidualLossOwners: []string{"none_observed"},
 		}}},
-		PackDiagnostics: diagnostics(4),
+		PackDiagnostics: diagnostics(loads),
 		UntimedBoundary: m8ProductionResourceBoundaryV1{SelectedPartitions: 4, EfSearch: 10, WallClockNanos: 1, Maxima: m8ProductionResourceObservedMaximaV1{Requests: 2, RPCs: 1, RequestBytes: 1, ShardPartitions: 2, ShardRequestBytes: 1}},
 		Failure:         m8ProductionFailureEvidenceV1{Passed: true, Error: "unavailable group rejected", ResourceBoundary: m8ProductionFaultResourceBoundaryV1{SelectedPartitions: 4, EfSearch: 4096, WallClockNanos: 1, Maxima: m8ProductionResourceObservedMaximaV1{Requests: 2, RPCs: 1, RequestBytes: 1, ShardPartitions: 2, ShardRequestBytes: 1}}}, GateLedger: m8ProductionGateLedgerV1{FailureHonesty: "pass", PartitionPackReachability: "pass"},
-		Resources: m8ProductionResourceEvidenceV1{PersistentAssetBytes: 1}, TimedBoundary: "measured", Limitations: []string{"test"},
+		Resources: m8ProductionResourceEvidenceV1{PersistentAssetBytes: 1, PartitionLoads: loads}, TimedBoundary: "measured", Limitations: []string{"test"},
 	}
 	if err := validateM8ProductionReportV1(report); err != nil {
 		t.Fatalf("valid endpoint coverage rejected: %v", err)
@@ -91,6 +95,7 @@ func TestM8ProductionReportRejectsUnexercisedDataGroupV1(t *testing.T) {
 		"missing":      report.PackDiagnostics[:3],
 		"duplicate":    {report.PackDiagnostics[0], report.PackDiagnostics[0], report.PackDiagnostics[2], report.PackDiagnostics[3]},
 		"disconnected": {report.PackDiagnostics[0], {PartitionID: 1, Rows: 1, ReachableRows: 0, TraversalRoots: 2}, report.PackDiagnostics[2], report.PackDiagnostics[3]},
+		"row_mismatch": {report.PackDiagnostics[0], {PartitionID: 1, Rows: report.PackDiagnostics[1].Rows - 1, ReachableRows: report.PackDiagnostics[1].Rows - 1, TraversalRoots: 1}, report.PackDiagnostics[2], report.PackDiagnostics[3]},
 	} {
 		t.Run("rejects_"+name+"_pack_diagnostics", func(t *testing.T) {
 			invalid := report
@@ -130,7 +135,7 @@ func TestM8PartitionPackDiagnosticsFailClosedV1(t *testing.T) {
 		{PartitionID: 0, Rows: 3, ReachableRows: 3, TraversalRoots: 1},
 		{PartitionID: 1, Rows: 2, ReachableRows: 2, TraversalRoots: 1},
 	}
-	if !validM8PartitionPackDiagnosticsV1(valid, 2) {
+	if !validM8PartitionPackDiagnosticsV1(valid, 2, []uint64{3, 2}) {
 		t.Fatal("rejected complete reachable diagnostics")
 	}
 	for name, diagnostics := range map[string][]m8PartitionPackDiagnosticsV1{
@@ -138,9 +143,10 @@ func TestM8PartitionPackDiagnosticsFailClosedV1(t *testing.T) {
 		"duplicate":    {valid[0], {PartitionID: 0, Rows: 2, ReachableRows: 2, TraversalRoots: 1}},
 		"disconnected": {valid[0], {PartitionID: 1, Rows: 2, ReachableRows: 1, TraversalRoots: 2}},
 		"empty":        {{PartitionID: 0, Rows: 0, ReachableRows: 0, TraversalRoots: 1}, valid[1]},
+		"row_mismatch": {valid[0], {PartitionID: 1, Rows: 1, ReachableRows: 1, TraversalRoots: 1}},
 	} {
 		t.Run(name, func(t *testing.T) {
-			if validM8PartitionPackDiagnosticsV1(diagnostics, 2) {
+			if validM8PartitionPackDiagnosticsV1(diagnostics, 2, []uint64{3, 2}) {
 				t.Fatalf("accepted %s diagnostics: %+v", name, diagnostics)
 			}
 		})

--- a/cmd/treedb_vector_partition_bench/m8_production_assets_test.go
+++ b/cmd/treedb_vector_partition_bench/m8_production_assets_test.go
@@ -59,6 +59,13 @@ func TestM8ProductionReportRejectsUnexercisedDataGroupV1(t *testing.T) {
 			CommitIndex: 1, ReadIndex: 1, AppliedIndex: 1, ReadEvidenceKind: "production", ProvesProductionConsensus: true, EndpointHits: hits,
 		}
 	}
+	diagnostics := func(partitions int) []m8PartitionPackDiagnosticsV1 {
+		out := make([]m8PartitionPackDiagnosticsV1, partitions)
+		for partition := range out {
+			out[partition] = m8PartitionPackDiagnosticsV1{PartitionID: uint32(partition), Rows: 1, ReachableRows: 1, TraversalRoots: 1}
+		}
+		return out
+	}
 	report := m8ProductionReportV1{
 		SchemaVersion: 2, ResultKind: "m8_production_multi_group_evidence_v2", Mode: m8ProductionMultiGroupModeV1, ProductionEvidence: true,
 		GeneratedAt: time.Now(), Command: []string{"m8-test"}, BaseSHA: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", HeadSHA: "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
@@ -72,12 +79,27 @@ func TestM8ProductionReportRejectsUnexercisedDataGroupV1(t *testing.T) {
 			CoordinatorMergeIDParity: true, CoordinatorMergeScoreParity: true,
 			ApproximateRouterCandidateBudget: 1, ApproximateRouterPartitionCoverageComplete: true, ResidualLossOwners: []string{"none_observed"},
 		}}},
+		PackDiagnostics: diagnostics(4),
 		UntimedBoundary: m8ProductionResourceBoundaryV1{SelectedPartitions: 4, EfSearch: 10, WallClockNanos: 1, Maxima: m8ProductionResourceObservedMaximaV1{Requests: 2, RPCs: 1, RequestBytes: 1, ShardPartitions: 2, ShardRequestBytes: 1}},
-		Failure:         m8ProductionFailureEvidenceV1{Passed: true, Error: "unavailable group rejected", ResourceBoundary: m8ProductionFaultResourceBoundaryV1{SelectedPartitions: 4, EfSearch: 4096, WallClockNanos: 1, Maxima: m8ProductionResourceObservedMaximaV1{Requests: 2, RPCs: 1, RequestBytes: 1, ShardPartitions: 2, ShardRequestBytes: 1}}}, GateLedger: m8ProductionGateLedgerV1{FailureHonesty: "pass"},
+		Failure:         m8ProductionFailureEvidenceV1{Passed: true, Error: "unavailable group rejected", ResourceBoundary: m8ProductionFaultResourceBoundaryV1{SelectedPartitions: 4, EfSearch: 4096, WallClockNanos: 1, Maxima: m8ProductionResourceObservedMaximaV1{Requests: 2, RPCs: 1, RequestBytes: 1, ShardPartitions: 2, ShardRequestBytes: 1}}}, GateLedger: m8ProductionGateLedgerV1{FailureHonesty: "pass", PartitionPackReachability: "pass"},
 		Resources: m8ProductionResourceEvidenceV1{PersistentAssetBytes: 1}, TimedBoundary: "measured", Limitations: []string{"test"},
 	}
 	if err := validateM8ProductionReportV1(report); err != nil {
 		t.Fatalf("valid endpoint coverage rejected: %v", err)
+	}
+	for name, diagnostics := range map[string][]m8PartitionPackDiagnosticsV1{
+		"missing":      report.PackDiagnostics[:3],
+		"duplicate":    {report.PackDiagnostics[0], report.PackDiagnostics[0], report.PackDiagnostics[2], report.PackDiagnostics[3]},
+		"disconnected": {report.PackDiagnostics[0], {PartitionID: 1, Rows: 1, ReachableRows: 0, TraversalRoots: 2}, report.PackDiagnostics[2], report.PackDiagnostics[3]},
+	} {
+		t.Run("rejects_"+name+"_pack_diagnostics", func(t *testing.T) {
+			invalid := report
+			invalid.PackDiagnostics = diagnostics
+			invalid.GateLedger = m8ProductionGateLedgerForReportV1(invalid)
+			if err := validateM8ProductionReportV1(invalid); err == nil {
+				t.Fatalf("accepted %s partition-pack diagnostics", name)
+			}
+		})
 	}
 	measuredRows := report.Rows
 	measuredAfter := report.RouterSessions.AfterMeasured
@@ -100,6 +122,28 @@ func TestM8ProductionReportRejectsUnexercisedDataGroupV1(t *testing.T) {
 	report.Topology.Groups[1].EndpointHits = 0
 	if err := validateM8ProductionReportV1(report); err == nil {
 		t.Fatal("accepted report with an unexercised data-group endpoint")
+	}
+}
+
+func TestM8PartitionPackDiagnosticsFailClosedV1(t *testing.T) {
+	valid := []m8PartitionPackDiagnosticsV1{
+		{PartitionID: 0, Rows: 3, ReachableRows: 3, TraversalRoots: 1},
+		{PartitionID: 1, Rows: 2, ReachableRows: 2, TraversalRoots: 1},
+	}
+	if !validM8PartitionPackDiagnosticsV1(valid, 2) {
+		t.Fatal("rejected complete reachable diagnostics")
+	}
+	for name, diagnostics := range map[string][]m8PartitionPackDiagnosticsV1{
+		"missing":      valid[:1],
+		"duplicate":    {valid[0], {PartitionID: 0, Rows: 2, ReachableRows: 2, TraversalRoots: 1}},
+		"disconnected": {valid[0], {PartitionID: 1, Rows: 2, ReachableRows: 1, TraversalRoots: 2}},
+		"empty":        {{PartitionID: 0, Rows: 0, ReachableRows: 0, TraversalRoots: 1}, valid[1]},
+	} {
+		t.Run(name, func(t *testing.T) {
+			if validM8PartitionPackDiagnosticsV1(diagnostics, 2) {
+				t.Fatalf("accepted %s diagnostics: %+v", name, diagnostics)
+			}
+		})
 	}
 }
 

--- a/cmd/treedb_vector_partition_bench/m8_production_matrix.go
+++ b/cmd/treedb_vector_partition_bench/m8_production_matrix.go
@@ -66,18 +66,19 @@ type m8ProductionComparisonV1 struct {
 }
 
 type m8ProductionMatrixGatesV1 struct {
-	RequiredVariants string `json:"required_variants"`
-	ExhaustiveParity string `json:"exhaustive_correctness"`
-	FailureHonesty   string `json:"failure_honesty"`
-	Recall           string `json:"recall"`
-	ProbeReduction   string `json:"probe_reduction"`
-	EndToEndQPS      string `json:"matched_recall_qps"`
-	TailLatency      string `json:"matched_recall_tail"`
-	CoupledGraph     string `json:"coupled_graph_acceptance"`
-	Balance          string `json:"balance"`
-	OverlapStorage   string `json:"overlap_storage"`
-	ResourceBounds   string `json:"resource_bounds"`
-	ExistingBehavior string `json:"existing_behavior"`
+	RequiredVariants          string `json:"required_variants"`
+	ExhaustiveParity          string `json:"exhaustive_correctness"`
+	FailureHonesty            string `json:"failure_honesty"`
+	PartitionPackReachability string `json:"partition_pack_reachability"`
+	Recall                    string `json:"recall"`
+	ProbeReduction            string `json:"probe_reduction"`
+	EndToEndQPS               string `json:"matched_recall_qps"`
+	TailLatency               string `json:"matched_recall_tail"`
+	CoupledGraph              string `json:"coupled_graph_acceptance"`
+	Balance                   string `json:"balance"`
+	OverlapStorage            string `json:"overlap_storage"`
+	ResourceBounds            string `json:"resource_bounds"`
+	ExistingBehavior          string `json:"existing_behavior"`
 }
 
 func runM8ProductionMultiGroupV1(cfg config, fixture fixtureManifest, vectors, queries [][]float64, stdout io.Writer) error {
@@ -372,20 +373,21 @@ func m8BuildProductionMatrixV1(cfg config, fixture fixtureManifest, reports []m8
 	}
 	matrix.Gates = m8ProductionMatrixGatesV1{
 		RequiredVariants: requiredVariantsGate, ExhaustiveParity: m8AggregateVariantGateV1(matrix.Variants, func(l m8ProductionGateLedgerV1) string { return l.ExhaustiveParity }),
-		FailureHonesty:   m8AggregateVariantGateV1(matrix.Variants, func(l m8ProductionGateLedgerV1) string { return l.FailureHonesty }),
-		Recall:           m8AnyGraphVariantGateV1(matrix.Variants, func(l m8ProductionGateLedgerV1) string { return l.Recall }),
-		ProbeReduction:   m8AnyGraphVariantGateV1(matrix.Variants, func(l m8ProductionGateLedgerV1) string { return l.ProbeReduction }),
-		EndToEndQPS:      m8AnyGraphVariantGateV1(matrix.Variants, func(l m8ProductionGateLedgerV1) string { return l.EndToEndQPS }),
-		TailLatency:      m8AnyGraphVariantGateV1(matrix.Variants, func(l m8ProductionGateLedgerV1) string { return l.TailLatency }),
-		CoupledGraph:     m8AnyGraphVariantCoupledGatesPassV1(matrix.Variants),
-		Balance:          m8AggregateVariantGateV1(matrix.Variants, func(l m8ProductionGateLedgerV1) string { return l.Balance }),
-		OverlapStorage:   overlapGate,
-		ResourceBounds:   m8AggregateVariantGateV1(matrix.Variants, func(l m8ProductionGateLedgerV1) string { return l.ResourceBounds }),
-		ExistingBehavior: "pending_latest_head_required_suites",
+		FailureHonesty:            m8AggregateVariantGateV1(matrix.Variants, func(l m8ProductionGateLedgerV1) string { return l.FailureHonesty }),
+		PartitionPackReachability: m8AggregateVariantGateV1(matrix.Variants, func(l m8ProductionGateLedgerV1) string { return l.PartitionPackReachability }),
+		Recall:                    m8AnyGraphVariantGateV1(matrix.Variants, func(l m8ProductionGateLedgerV1) string { return l.Recall }),
+		ProbeReduction:            m8AnyGraphVariantGateV1(matrix.Variants, func(l m8ProductionGateLedgerV1) string { return l.ProbeReduction }),
+		EndToEndQPS:               m8AnyGraphVariantGateV1(matrix.Variants, func(l m8ProductionGateLedgerV1) string { return l.EndToEndQPS }),
+		TailLatency:               m8AnyGraphVariantGateV1(matrix.Variants, func(l m8ProductionGateLedgerV1) string { return l.TailLatency }),
+		CoupledGraph:              m8AnyGraphVariantCoupledGatesPassV1(matrix.Variants),
+		Balance:                   m8AggregateVariantGateV1(matrix.Variants, func(l m8ProductionGateLedgerV1) string { return l.Balance }),
+		OverlapStorage:            overlapGate,
+		ResourceBounds:            m8AggregateVariantGateV1(matrix.Variants, func(l m8ProductionGateLedgerV1) string { return l.ResourceBounds }),
+		ExistingBehavior:          "pending_latest_head_required_suites",
 	}
 	matrix.Status = "local_gate_pass"
 	matrix.Disposition = "local_gate_pass_multi_host_still_deferred"
-	for _, gate := range []string{matrix.Gates.RequiredVariants, matrix.Gates.ExhaustiveParity, matrix.Gates.FailureHonesty, matrix.Gates.Recall, matrix.Gates.ProbeReduction, matrix.Gates.EndToEndQPS, matrix.Gates.TailLatency, matrix.Gates.CoupledGraph, matrix.Gates.Balance, matrix.Gates.OverlapStorage, matrix.Gates.ResourceBounds} {
+	for _, gate := range []string{matrix.Gates.RequiredVariants, matrix.Gates.ExhaustiveParity, matrix.Gates.FailureHonesty, matrix.Gates.PartitionPackReachability, matrix.Gates.Recall, matrix.Gates.ProbeReduction, matrix.Gates.EndToEndQPS, matrix.Gates.TailLatency, matrix.Gates.CoupledGraph, matrix.Gates.Balance, matrix.Gates.OverlapStorage, matrix.Gates.ResourceBounds} {
 		if gate != "pass" {
 			matrix.Status = "experimental_gate_failures"
 			matrix.Disposition = "enablement_off_follow_up_required"

--- a/cmd/treedb_vector_partition_bench/m8_production_matrix_test.go
+++ b/cmd/treedb_vector_partition_bench/m8_production_matrix_test.go
@@ -27,7 +27,7 @@ func TestM8ProductionMatrixRequiresLikeForLikeVariantsAndOverlapStorageV1(t *tes
 	fixture := fixtureManifest{Checksum: strings.Repeat("b", 64)}
 	cfg := config{baseSHA: hash, headSHA: hash, partitions: 16, command: []string{"bench"}}
 	common := m8ProductionConfigEvidenceV1{RaftGroups: 4, RaftNodesPerGroup: 3, Partitions: 16, Probes: []int{4, 16}, TopK: 10, RecallTarget: .9, Concurrency: []int{1}, Warmup: 1, EfSearch: []int{128}, RouterCandidates: 1024, Seed: 1}
-	pass := m8ProductionGateLedgerV1{ExhaustiveParity: "pass", FailureHonesty: "pass", Recall: "pass", ProbeReduction: "pass", EndToEndQPS: "pass", TailLatency: "pass", Balance: "pass", ResourceBounds: "pass"}
+	pass := m8ProductionGateLedgerV1{ExhaustiveParity: "pass", FailureHonesty: "pass", PartitionPackReachability: "pass", Recall: "pass", ProbeReduction: "pass", EndToEndQPS: "pass", TailLatency: "pass", Balance: "pass", ResourceBounds: "pass"}
 	reports := make([]m8ProductionReportV1, 0, 3)
 	for _, variant := range []struct {
 		id, assignment string
@@ -67,9 +67,20 @@ func TestM8ProductionMatrixRequiresLikeForLikeVariantsAndOverlapStorageV1(t *tes
 	if err != nil {
 		t.Fatal(err)
 	}
-	if matrix.Status != "local_gate_pass" || matrix.Gates.OverlapStorage != "pass" || matrix.OverlapStorageRatio != 1.2 || len(matrix.Comparison) != 6 {
+	if matrix.Status != "local_gate_pass" || matrix.Gates.PartitionPackReachability != "pass" || matrix.Gates.OverlapStorage != "pass" || matrix.OverlapStorageRatio != 1.2 || len(matrix.Comparison) != 6 {
 		t.Fatalf("matrix=%+v", matrix)
 	}
+	for _, reachability := range []string{"", "fail"} {
+		reports[0].GateLedger.PartitionPackReachability = reachability
+		matrix, err = m8BuildProductionMatrixV1(cfg, fixture, reports)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if matrix.Status != "experimental_gate_failures" || matrix.Gates.PartitionPackReachability != "fail" {
+			t.Fatalf("reachability=%q matrix=%+v", reachability, matrix)
+		}
+	}
+	reports[0].GateLedger.PartitionPackReachability = "pass"
 	reports[0].Dirty = true
 	if _, err := m8BuildProductionMatrixV1(cfg, fixture, reports); err == nil || !strings.Contains(err.Error(), "dirty") {
 		t.Fatalf("dirty child report err=%v", err)
@@ -259,7 +270,7 @@ func TestM8ProductionMatrixFailsWhenOverlapBudgetIsUnderMaterializedV1(t *testin
 	fixture := fixtureManifest{Checksum: strings.Repeat("b", 64)}
 	cfg := config{baseSHA: hash, headSHA: hash, partitions: 16, command: []string{"bench"}}
 	common := m8ProductionConfigEvidenceV1{RaftGroups: 4, RaftNodesPerGroup: 3, Partitions: 16, Probes: []int{4}, TopK: 10, RecallTarget: .9, Concurrency: []int{1}, Warmup: 1, EfSearch: []int{128}, RouterCandidates: 1024, Seed: 1}
-	pass := m8ProductionGateLedgerV1{ExhaustiveParity: "pass", FailureHonesty: "pass", Recall: "pass", ProbeReduction: "pass", EndToEndQPS: "pass", TailLatency: "pass", Balance: "pass", ResourceBounds: "pass"}
+	pass := m8ProductionGateLedgerV1{ExhaustiveParity: "pass", FailureHonesty: "pass", PartitionPackReachability: "pass", Recall: "pass", ProbeReduction: "pass", EndToEndQPS: "pass", TailLatency: "pass", Balance: "pass", ResourceBounds: "pass"}
 	reports := make([]m8ProductionReportV1, 0, 3)
 	for _, variant := range []struct {
 		id, assignment string

--- a/cmd/treedb_vector_partition_bench/m8_production_runner.go
+++ b/cmd/treedb_vector_partition_bench/m8_production_runner.go
@@ -54,6 +54,7 @@ type m8ProductionReportV1 struct {
 	BuildNanos         int64                                                      `json:"build_nanos"`
 	Topology           nativewire.VectorPartitionM8ProductionMultiGroupEvidenceV1 `json:"topology"`
 	Rows               []m8ProductionRowV1                                        `json:"rows"`
+	PackDiagnostics    []m8PartitionPackDiagnosticsV1                             `json:"partition_pack_diagnostics,omitempty"`
 	Failure            m8ProductionFailureEvidenceV1                              `json:"failure"`
 	GateLedger         m8ProductionGateLedgerV1                                   `json:"gate_ledger"`
 	Profiles           m8ProductionProfileEvidenceV1                              `json:"profiles"`
@@ -90,12 +91,31 @@ type m8ProductionAttributionV1 struct {
 	ExactRepresentativeRecallAtK               float64  `json:"exact_representative_routing_recall_at_k"`
 	ApproximateRepresentativeRecallAtK         float64  `json:"approximate_representative_routing_recall_at_k"`
 	LocalHNSWRecallAtK                         float64  `json:"partition_local_hnsw_recall_at_k"`
+	LocalHNSWSearches                          uint64   `json:"partition_local_hnsw_searches"`
+	LocalHNSWCandidates                        uint64   `json:"partition_local_hnsw_candidates"`
+	LocalHNSWEdges                             uint64   `json:"partition_local_hnsw_edges"`
 	EndToEndRecallAtK                          float64  `json:"end_to_end_recall_at_k"`
 	CoordinatorMergeIDParity                   bool     `json:"coordinator_merge_id_parity"`
 	CoordinatorMergeScoreParity                bool     `json:"coordinator_merge_score_parity"`
 	ApproximateRouterCandidateBudget           int      `json:"approximate_router_candidate_budget"`
 	ApproximateRouterPartitionCoverageComplete bool     `json:"approximate_router_partition_coverage_complete"`
 	ResidualLossOwners                         []string `json:"residual_loss_owners"`
+}
+
+// m8PartitionPackDiagnosticsV1 records offline topology facts for each
+// generation-pinned local pack. It is deliberately separate from recall: a
+// directed layer-0 traversal can reveal an unreachable entry-reachable subset,
+// but is not a substitute for the exact-oracle quality measurement.
+type m8PartitionPackDiagnosticsV1 struct {
+	PartitionID         uint32   `json:"partition_id"`
+	Rows                uint64   `json:"rows"`
+	ReachableRows       uint64   `json:"reachable_rows"`
+	TraversalRoots      uint64   `json:"traversal_roots"`
+	MaxLayer            int      `json:"max_layer"`
+	RowsByLayer         []uint64 `json:"rows_by_layer"`
+	EdgesByLayer        []uint64 `json:"edges_by_layer"`
+	Layer0DegreeLimit   uint64   `json:"layer0_degree_limit"`
+	Layer0SaturatedRows uint64   `json:"layer0_saturated_rows"`
 }
 
 type m8ProductionRowV1 struct {
@@ -384,6 +404,11 @@ func runM8ProductionSingleVariantV1(cfg config, fixture fixtureManifest, vectors
 				runErr = errors.Join(runErr, attributionHarness.Close())
 			}
 		}()
+		diagnostics, diagnosticsErr := attributionHarness.packDiagnostics()
+		if diagnosticsErr != nil {
+			return fmt.Errorf("collect M8 partition-pack diagnostics: %w", diagnosticsErr)
+		}
+		report.PackDiagnostics = diagnostics
 		attribution := make(map[string]m8AttributionCellV1, len(cfg.probes)*len(cfg.efSearch))
 		exhaustive := make([][]m8CanonicalResultV1, len(queries))
 		for _, probes := range cfg.probes {
@@ -919,27 +944,58 @@ func m8ApproximateRouterCoverageV1(err error) (bool, error) {
 }
 
 func (h *m8AttributionHarnessV1) search(ctx context.Context, query []float32, partitions []uint32, topK, efSearch int, exact bool) ([]m8CanonicalResultV1, error) {
+	results, _, err := h.searchWithMetrics(ctx, query, partitions, topK, efSearch, exact)
+	return results, err
+}
+
+func (h *m8AttributionHarnessV1) searchWithMetrics(ctx context.Context, query []float32, partitions []uint32, topK, efSearch int, exact bool) ([]m8CanonicalResultV1, collections.VectorPartitionSearchMetricsV1, error) {
 	merged := make([]m8CanonicalResultV1, 0, len(partitions)*topK)
+	var metrics collections.VectorPartitionSearchMetricsV1
 	for _, partition := range partitions {
 		if partition >= uint32(len(h.searchers)) || h.searchers[partition] == nil {
-			return nil, errors.New("M8 attribution partition coverage is incomplete")
+			return nil, metrics, errors.New("M8 attribution partition coverage is incomplete")
 		}
 		opts := collections.VectorPartitionSearchOptionsV1{TopK: topK, EfSearch: efSearch}
 		var results []collections.VectorPartitionSearchResultV1
 		var err error
+		var partitionMetrics collections.VectorPartitionSearchMetricsV1
 		if exact {
 			results, _, err = h.searchers[partition].SearchExactWithOptionsV1(ctx, query, opts)
 		} else {
-			results, _, err = h.searchers[partition].SearchWithOptionsV1(ctx, query, opts)
+			results, partitionMetrics, err = h.searchers[partition].SearchWithOptionsV1(ctx, query, opts)
 		}
 		if err != nil {
-			return nil, fmt.Errorf("M8 attribution partition %d: %w", partition, err)
+			return nil, metrics, fmt.Errorf("M8 attribution partition %d: %w", partition, err)
+		}
+		if !exact {
+			metrics.Candidates += partitionMetrics.Candidates
+			metrics.Edges += partitionMetrics.Edges
 		}
 		for _, result := range results {
 			merged = append(merged, m8CanonicalResultV1{ID: result.ID, Score: result.Score})
 		}
 	}
-	return m8CanonicalResultsV1(merged, topK), nil
+	return m8CanonicalResultsV1(merged, topK), metrics, nil
+}
+
+func (h *m8AttributionHarnessV1) packDiagnostics() ([]m8PartitionPackDiagnosticsV1, error) {
+	diagnostics := make([]m8PartitionPackDiagnosticsV1, len(h.searchers))
+	for partition, searcher := range h.searchers {
+		if searcher == nil {
+			return nil, fmt.Errorf("M8 partition %d diagnostics: missing searcher", partition)
+		}
+		pack, err := searcher.PackDiagnosticsV1()
+		if err != nil {
+			return nil, fmt.Errorf("M8 partition %d diagnostics: %w", partition, err)
+		}
+		diagnostics[partition] = m8PartitionPackDiagnosticsV1{
+			PartitionID: uint32(partition), Rows: pack.Rows, ReachableRows: pack.ReachableRows,
+			TraversalRoots: pack.TraversalRoots, MaxLayer: pack.MaxLayer,
+			RowsByLayer: append([]uint64(nil), pack.RowsByLayer...), EdgesByLayer: append([]uint64(nil), pack.EdgesByLayer...),
+			Layer0DegreeLimit: pack.Layer0DegreeLimit, Layer0SaturatedRows: pack.Layer0SaturatedRows,
+		}
+	}
+	return diagnostics, nil
 }
 
 type m8AttributionCellV1 struct {
@@ -1002,10 +1058,14 @@ func m8BuildAttributionV1(ctx context.Context, assets *m8ProductionMultiGroupAss
 				return cell, err
 			}
 		}
-		cell.Local[i], err = harness.search(ctx, query, exactPartitions, topK, efSearch, false)
+		var localMetrics collections.VectorPartitionSearchMetricsV1
+		cell.Local[i], localMetrics, err = harness.searchWithMetrics(ctx, query, exactPartitions, topK, efSearch, false)
 		if err != nil {
 			return cell, err
 		}
+		cell.Evidence.LocalHNSWSearches += uint64(len(exactPartitions))
+		cell.Evidence.LocalHNSWCandidates += localMetrics.Candidates
+		cell.Evidence.LocalHNSWEdges += localMetrics.Edges
 		exactRecall += m8CanonicalRecallV1(truth[i], exactResults)
 		approximateRecall += m8CanonicalRecallV1(truth[i], approximateResults)
 		localRecall += m8CanonicalRecallV1(truth[i], cell.Local[i])

--- a/cmd/treedb_vector_partition_bench/m8_production_runner.go
+++ b/cmd/treedb_vector_partition_bench/m8_production_runner.go
@@ -181,16 +181,17 @@ type m8ProductionResourceBoundaryV1 struct {
 type m8ProductionFaultResourceBoundaryV1 = m8ProductionResourceBoundaryV1
 
 type m8ProductionGateLedgerV1 struct {
-	ExhaustiveParity string `json:"exhaustive_correctness"`
-	FailureHonesty   string `json:"failure_honesty"`
-	Recall           string `json:"recall"`
-	ProbeReduction   string `json:"probe_reduction"`
-	EndToEndQPS      string `json:"end_to_end_qps"`
-	TailLatency      string `json:"tail_latency"`
-	Balance          string `json:"balance"`
-	OverlapStorage   string `json:"overlap_storage"`
-	ResourceBounds   string `json:"resource_bounds"`
-	ExistingBehavior string `json:"existing_behavior"`
+	ExhaustiveParity          string `json:"exhaustive_correctness"`
+	FailureHonesty            string `json:"failure_honesty"`
+	PartitionPackReachability string `json:"partition_pack_reachability"`
+	Recall                    string `json:"recall"`
+	ProbeReduction            string `json:"probe_reduction"`
+	EndToEndQPS               string `json:"end_to_end_qps"`
+	TailLatency               string `json:"tail_latency"`
+	Balance                   string `json:"balance"`
+	OverlapStorage            string `json:"overlap_storage"`
+	ResourceBounds            string `json:"resource_bounds"`
+	ExistingBehavior          string `json:"existing_behavior"`
 }
 
 type m8ProductionProfileEvidenceV1 struct {
@@ -1642,7 +1643,10 @@ func m8RunUnavailableGroupV1(ctx context.Context, topology *nativewire.VectorPar
 }
 
 func m8ProductionGateLedgerForReportV1(report m8ProductionReportV1) m8ProductionGateLedgerV1 {
-	ledger := m8ProductionGateLedgerV1{ExhaustiveParity: "not_run", FailureHonesty: "fail", Recall: "fail", ProbeReduction: "fail", EndToEndQPS: "fail", TailLatency: "fail", Balance: "fail", OverlapStorage: "fail", ResourceBounds: "fail", ExistingBehavior: "pending_full_required_suites"}
+	ledger := m8ProductionGateLedgerV1{ExhaustiveParity: "not_run", FailureHonesty: "fail", PartitionPackReachability: "fail", Recall: "fail", ProbeReduction: "fail", EndToEndQPS: "fail", TailLatency: "fail", Balance: "fail", OverlapStorage: "fail", ResourceBounds: "fail", ExistingBehavior: "pending_full_required_suites"}
+	if validM8PartitionPackDiagnosticsV1(report.PackDiagnostics, report.Config.Partitions) {
+		ledger.PartitionPackReachability = "pass"
+	}
 	var exhaustive []m8ProductionRowV1
 	var candidates []m8ProductionRowV1
 	for _, row := range report.Rows {
@@ -1697,7 +1701,28 @@ func m8ProductionGateLedgerForReportV1(report m8ProductionReportV1) m8Production
 }
 
 func m8ProductionGateValuesV1(ledger m8ProductionGateLedgerV1) []string {
-	return []string{ledger.ExhaustiveParity, ledger.FailureHonesty, ledger.Recall, ledger.ProbeReduction, ledger.EndToEndQPS, ledger.TailLatency, ledger.Balance, ledger.OverlapStorage, ledger.ResourceBounds, ledger.ExistingBehavior}
+	return []string{ledger.ExhaustiveParity, ledger.FailureHonesty, ledger.PartitionPackReachability, ledger.Recall, ledger.ProbeReduction, ledger.EndToEndQPS, ledger.TailLatency, ledger.Balance, ledger.OverlapStorage, ledger.ResourceBounds, ledger.ExistingBehavior}
+}
+
+// validM8PartitionPackDiagnosticsV1 makes the partition-local persistent graph
+// topology an acceptance condition, not merely an informational artifact. A
+// structurally readable older pack can still contain disconnected directed
+// layer-0 components, so every configured partition must be reported exactly
+// once as a nonempty, fully reachable, single-root pack.
+func validM8PartitionPackDiagnosticsV1(diagnostics []m8PartitionPackDiagnosticsV1, partitions int) bool {
+	if partitions < 1 || len(diagnostics) != partitions {
+		return false
+	}
+	seen := make([]bool, partitions)
+	for _, diagnostic := range diagnostics {
+		partition := int(diagnostic.PartitionID)
+		if partition < 0 || partition >= partitions || seen[partition] || diagnostic.Rows == 0 ||
+			diagnostic.ReachableRows == 0 || diagnostic.ReachableRows != diagnostic.Rows || diagnostic.TraversalRoots != 1 {
+			return false
+		}
+		seen[partition] = true
+	}
+	return true
 }
 
 func m8ProductionAllGatesPassV1(ledger m8ProductionGateLedgerV1) bool {
@@ -1871,6 +1896,9 @@ func validateM8ProductionReportV1(report m8ProductionReportV1) error {
 	}
 	if len(report.Rows) == 0 {
 		return errors.New("M8 report has no measurement rows")
+	}
+	if !validM8PartitionPackDiagnosticsV1(report.PackDiagnostics, report.Config.Partitions) || report.GateLedger.PartitionPackReachability != "pass" {
+		return errors.New("M8 report has incomplete or unreachable partition-pack diagnostics")
 	}
 	var measuredSamples uint64
 	for _, row := range report.Rows {

--- a/cmd/treedb_vector_partition_bench/m8_production_runner.go
+++ b/cmd/treedb_vector_partition_bench/m8_production_runner.go
@@ -222,6 +222,7 @@ type m8ProductionHostEvidenceV1 struct {
 type m8ProductionResourceEvidenceV1 struct {
 	PersistentAssetBytes uint64                                  `json:"persistent_asset_bytes"`
 	PersistentAssetCap   uint64                                  `json:"persistent_asset_cap_bytes"`
+	PartitionLoads       []uint64                                `json:"partition_loads"`
 	PeakRSSBytes         int64                                   `json:"peak_rss_bytes,omitempty"`
 	PeakRSSCapBytes      uint64                                  `json:"peak_rss_cap_bytes"`
 	PeakRSSMeasured      bool                                    `json:"peak_rss_measured"`
@@ -385,31 +386,31 @@ func runM8ProductionSingleVariantV1(cfg config, fixture fixtureManifest, vectors
 	allUntimed := m8MergeProductionResourceBoundariesV1(report.UntimedBoundary, report.Failure.ResourceBoundary)
 	report.Resources = m8ProductionResourcesV1(cfg, fixture, assets, report.Rows, allUntimed, report.Topology)
 
-	// Attribution deliberately runs after the timed query/fault boundary,
+	// Diagnostics and attribution deliberately run after the timed query/fault boundary,
 	// profile capture, and peak-RSS snapshot. Its exhaustive mmap scans must not
 	// pre-fault the corpus or contaminate measured process-resource evidence.
 	// The snapshot does include the bounded top-k coordinator results retained
 	// from measured cells so post-measurement attribution can verify parity.
+	attributionHarness, err := newM8AttributionHarnessV1(assets)
+	if err != nil {
+		return fmt.Errorf("open M8 attribution harness: %w", err)
+	}
+	attributionHarnessClosed := false
+	defer func() {
+		if !attributionHarnessClosed {
+			runErr = errors.Join(runErr, attributionHarness.Close())
+		}
+	}()
+	diagnostics, diagnosticsErr := attributionHarness.packDiagnostics()
+	if diagnosticsErr != nil {
+		return fmt.Errorf("collect M8 partition-pack diagnostics: %w", diagnosticsErr)
+	}
+	report.PackDiagnostics = diagnostics
 	if len(measuredCells) > 0 {
 		approximateCandidates := min(cfg.routerCandidates, int(assets.status.Representatives))
 		if approximateCandidates < 1 {
 			return errors.New("M8 attribution requires an approximate router candidate budget")
 		}
-		attributionHarness, err := newM8AttributionHarnessV1(assets)
-		if err != nil {
-			return fmt.Errorf("open M8 attribution harness: %w", err)
-		}
-		attributionHarnessClosed := false
-		defer func() {
-			if !attributionHarnessClosed {
-				runErr = errors.Join(runErr, attributionHarness.Close())
-			}
-		}()
-		diagnostics, diagnosticsErr := attributionHarness.packDiagnostics()
-		if diagnosticsErr != nil {
-			return fmt.Errorf("collect M8 partition-pack diagnostics: %w", diagnosticsErr)
-		}
-		report.PackDiagnostics = diagnostics
 		attribution := make(map[string]m8AttributionCellV1, len(cfg.probes)*len(cfg.efSearch))
 		exhaustive := make([][]m8CanonicalResultV1, len(queries))
 		for _, probes := range cfg.probes {
@@ -421,11 +422,6 @@ func runM8ProductionSingleVariantV1(cfg config, fixture fixtureManifest, vectors
 				attribution[m8AttributionKeyV1(probes, efSearch)] = cell
 			}
 		}
-		closeErr := attributionHarness.Close()
-		attributionHarnessClosed = true
-		if closeErr != nil {
-			return fmt.Errorf("close M8 attribution harness: %w", closeErr)
-		}
 		for _, measured := range measuredCells {
 			cell, ok := attribution[m8AttributionKeyV1(measured.probes, measured.efSearch)]
 			if !ok {
@@ -435,6 +431,11 @@ func runM8ProductionSingleVariantV1(cfg config, fixture fixtureManifest, vectors
 				return fmt.Errorf("attach M8 attribution probes=%d ef=%d: %w", measured.probes, measured.efSearch, err)
 			}
 		}
+	}
+	closeErr := attributionHarness.Close()
+	attributionHarnessClosed = true
+	if closeErr != nil {
+		return fmt.Errorf("close M8 attribution harness: %w", closeErr)
 	}
 	report.GateLedger = m8ProductionGateLedgerForReportV1(report)
 	if m8ProductionAllGatesPassV1(report.GateLedger) {
@@ -1168,6 +1169,7 @@ func m8ProductionResourcesV1(cfg config, fixture fixtureManifest, assets *m8Prod
 		// than publishing a zero-load success.
 		out.MaxPartitionLoad = ^uint64(0)
 	} else {
+		out.PartitionLoads = loads
 		for _, load := range loads {
 			out.MaxPartitionLoad = max(out.MaxPartitionLoad, load)
 		}
@@ -1644,7 +1646,7 @@ func m8RunUnavailableGroupV1(ctx context.Context, topology *nativewire.VectorPar
 
 func m8ProductionGateLedgerForReportV1(report m8ProductionReportV1) m8ProductionGateLedgerV1 {
 	ledger := m8ProductionGateLedgerV1{ExhaustiveParity: "not_run", FailureHonesty: "fail", PartitionPackReachability: "fail", Recall: "fail", ProbeReduction: "fail", EndToEndQPS: "fail", TailLatency: "fail", Balance: "fail", OverlapStorage: "fail", ResourceBounds: "fail", ExistingBehavior: "pending_full_required_suites"}
-	if validM8PartitionPackDiagnosticsV1(report.PackDiagnostics, report.Config.Partitions) {
+	if validM8PartitionPackDiagnosticsV1(report.PackDiagnostics, report.Config.Partitions, report.Resources.PartitionLoads) {
 		ledger.PartitionPackReachability = "pass"
 	}
 	var exhaustive []m8ProductionRowV1
@@ -1709,18 +1711,58 @@ func m8ProductionGateValuesV1(ledger m8ProductionGateLedgerV1) []string {
 // structurally readable older pack can still contain disconnected directed
 // layer-0 components, so every configured partition must be reported exactly
 // once as a nonempty, fully reachable, single-root pack.
-func validM8PartitionPackDiagnosticsV1(diagnostics []m8PartitionPackDiagnosticsV1, partitions int) bool {
-	if partitions < 1 || len(diagnostics) != partitions {
+func validM8PartitionPackDiagnosticsV1(diagnostics []m8PartitionPackDiagnosticsV1, partitions int, loads []uint64) bool {
+	if partitions < 1 || len(diagnostics) != partitions || len(loads) != partitions {
 		return false
 	}
 	seen := make([]bool, partitions)
 	for _, diagnostic := range diagnostics {
 		partition := int(diagnostic.PartitionID)
 		if partition < 0 || partition >= partitions || seen[partition] || diagnostic.Rows == 0 ||
-			diagnostic.ReachableRows == 0 || diagnostic.ReachableRows != diagnostic.Rows || diagnostic.TraversalRoots != 1 {
+			diagnostic.Rows != loads[partition] || diagnostic.ReachableRows == 0 || diagnostic.ReachableRows != diagnostic.Rows || diagnostic.TraversalRoots != 1 {
 			return false
 		}
 		seen[partition] = true
+	}
+	return true
+}
+
+// validM8PartitionLoadsV1 binds diagnostic row counts to manifest-derived
+// evidence. Retained variants have an independently validated descriptor; for
+// non-variant runs the manifest-derived total must still account for every
+// fixture row and declared overlap membership, rather than accepting a small
+// self-consistent fabricated subset.
+func validM8PartitionLoadsV1(report m8ProductionReportV1) bool {
+	loads := report.Resources.PartitionLoads
+	if report.Config.Partitions < 1 || len(loads) != report.Config.Partitions || report.Dataset.Vectors < 1 || report.Resources.OverlapMemberships < 0 {
+		return false
+	}
+	expected := uint64(report.Dataset.Vectors)
+	overlap := uint64(report.Resources.OverlapMemberships)
+	if overlap > ^uint64(0)-expected {
+		return false
+	}
+	expected += overlap
+	var total uint64
+	for _, load := range loads {
+		if load == 0 || load > ^uint64(0)-total {
+			return false
+		}
+		total += load
+	}
+	if total != expected {
+		return false
+	}
+	if report.Variant == nil {
+		return true
+	}
+	if len(report.Variant.PartitionLoads) != len(loads) {
+		return false
+	}
+	for partition, load := range loads {
+		if report.Variant.PartitionLoads[partition] < 0 || load != uint64(report.Variant.PartitionLoads[partition]) {
+			return false
+		}
 	}
 	return true
 }
@@ -1897,7 +1939,7 @@ func validateM8ProductionReportV1(report m8ProductionReportV1) error {
 	if len(report.Rows) == 0 {
 		return errors.New("M8 report has no measurement rows")
 	}
-	if !validM8PartitionPackDiagnosticsV1(report.PackDiagnostics, report.Config.Partitions) || report.GateLedger.PartitionPackReachability != "pass" {
+	if !validM8PartitionLoadsV1(report) || !validM8PartitionPackDiagnosticsV1(report.PackDiagnostics, report.Config.Partitions, report.Resources.PartitionLoads) || report.GateLedger.PartitionPackReachability != "pass" {
 		return errors.New("M8 report has incomplete or unreachable partition-pack diagnostics")
 	}
 	var measuredSamples uint64

--- a/cmd/treedb_vector_partition_bench/main_test.go
+++ b/cmd/treedb_vector_partition_bench/main_test.go
@@ -1757,7 +1757,10 @@ func TestM8GateLedgerRequiresMatchedRecallQPSAndTailV1(t *testing.T) {
 			{Status: "pass", Probes: 4, EfSearch: 128, Concurrency: 16, RecallAtK: 0.92, QPS: 116, P95Nanos: 999},
 		},
 		Failure:   m8ProductionFailureEvidenceV1{Passed: true},
-		Resources: m8ProductionResourceEvidenceV1{PersistentAssetBytes: 1, PeakRSSMeasured: true, MaxPartitionLoad: 65_000, BalanceHardCap: 65_625, LimitComparisons: []m8ProductionResourceLimitComparisonV1{{Name: "bytes", Configured: 2, Observed: 1, Passed: true}}},
+		Resources: m8ProductionResourceEvidenceV1{PersistentAssetBytes: 1, PartitionLoads: make([]uint64, 16), PeakRSSMeasured: true, MaxPartitionLoad: 65_000, BalanceHardCap: 65_625, LimitComparisons: []m8ProductionResourceLimitComparisonV1{{Name: "bytes", Configured: 2, Observed: 1, Passed: true}}},
+	}
+	for partition := range report.Resources.PartitionLoads {
+		report.Resources.PartitionLoads[partition] = 1
 	}
 	ledger := m8ProductionGateLedgerForReportV1(report)
 	if ledger.ExhaustiveParity != "pass" || ledger.FailureHonesty != "pass" || ledger.PartitionPackReachability != "pass" || ledger.Recall != "pass" || ledger.ProbeReduction != "pass" || ledger.EndToEndQPS != "pass" || ledger.TailLatency != "pass" || ledger.Balance != "pass" || ledger.ResourceBounds != "pass" || ledger.OverlapStorage != "fail" {

--- a/cmd/treedb_vector_partition_bench/main_test.go
+++ b/cmd/treedb_vector_partition_bench/main_test.go
@@ -1745,6 +1745,13 @@ func TestM8ProfileCaptureWritesRequiredRuntimeArtifactsV1(t *testing.T) {
 func TestM8GateLedgerRequiresMatchedRecallQPSAndTailV1(t *testing.T) {
 	report := m8ProductionReportV1{
 		Config: m8ProductionConfigEvidenceV1{Partitions: 16, RecallTarget: 0.9},
+		PackDiagnostics: func() []m8PartitionPackDiagnosticsV1 {
+			diagnostics := make([]m8PartitionPackDiagnosticsV1, 16)
+			for partition := range diagnostics {
+				diagnostics[partition] = m8PartitionPackDiagnosticsV1{PartitionID: uint32(partition), Rows: 1, ReachableRows: 1, TraversalRoots: 1}
+			}
+			return diagnostics
+		}(),
 		Rows: []m8ProductionRowV1{
 			{Status: "pass", Probes: 16, EfSearch: 128, Concurrency: 16, RecallAtK: 0.99, QPS: 100, P95Nanos: 1000, ExactParityChecked: true, ExactParityPassed: true, Attribution: m8ProductionAttributionV1{ExhaustivePartitionRecallAtK: 1, ExhaustivePartitionIDParity: true, ExhaustivePartitionScoreParity: true}},
 			{Status: "pass", Probes: 4, EfSearch: 128, Concurrency: 16, RecallAtK: 0.92, QPS: 116, P95Nanos: 999},
@@ -1753,7 +1760,7 @@ func TestM8GateLedgerRequiresMatchedRecallQPSAndTailV1(t *testing.T) {
 		Resources: m8ProductionResourceEvidenceV1{PersistentAssetBytes: 1, PeakRSSMeasured: true, MaxPartitionLoad: 65_000, BalanceHardCap: 65_625, LimitComparisons: []m8ProductionResourceLimitComparisonV1{{Name: "bytes", Configured: 2, Observed: 1, Passed: true}}},
 	}
 	ledger := m8ProductionGateLedgerForReportV1(report)
-	if ledger.ExhaustiveParity != "pass" || ledger.FailureHonesty != "pass" || ledger.Recall != "pass" || ledger.ProbeReduction != "pass" || ledger.EndToEndQPS != "pass" || ledger.TailLatency != "pass" || ledger.Balance != "pass" || ledger.ResourceBounds != "pass" || ledger.OverlapStorage != "fail" {
+	if ledger.ExhaustiveParity != "pass" || ledger.FailureHonesty != "pass" || ledger.PartitionPackReachability != "pass" || ledger.Recall != "pass" || ledger.ProbeReduction != "pass" || ledger.EndToEndQPS != "pass" || ledger.TailLatency != "pass" || ledger.Balance != "pass" || ledger.ResourceBounds != "pass" || ledger.OverlapStorage != "fail" {
 		t.Fatalf("ledger=%+v", ledger)
 	}
 	report.Rows[0].Status = "fail"


### PR DESCRIPTION
Closes #3999.

## Summary

- Repairs partition-local persistent HNSW reachability with deterministic bounded layer-0 navigation, without changing shared column-graph/router construction.
- Makes pack topology evidence fail closed: all configured packs must be fully reachable, single-root, and row-bound to authoritative partition loads.
- Propagates partition-pack reachability through the M8 matrix aggregate gate.

## Final validation record

Final PR head: `4f2d978507c2d2e4f143d377846693bfef5f41fa` — documentation-only evidence record.

Measured runtime-code head: `2ec108a625419a3a3f372a0eb5dca29c433052f5` (`dirty=false`). The final docs-only commit does not alter the code exercised by the evidence.

- `go test ./TreeDB/collections -count=1` — PASS, 191.125s (wall 191.92s).
- `go test ./cmd/treedb_vector_partition_bench -count=1` — PASS, 76.095s (wall 76.56s).
- Uncontended profiled M8: `/mnt/fast4tb/tmp/issue3999_m8_2ec_UxtWPM/vector_partition_m8_2ec108a62541_ca6f595a28e8.json`
  - JSON SHA-256: `84bb62aeb9cebcc4c6bba733bfacbc68f6a3a46be4709264e723d748f777c36c`
  - command wall 133.31s; build 19.609s; measured query wall 20.251s
  - all 16 partitions at `ef_search=4096`: recall@10/local-HNSW recall@10 `0.975`; exact routing `1.0`; QPS `11.158`; p95 `111.463ms`
  - `partition_pack_reachability=pass`: 16 diagnostics bind exactly to 16 manifest loads; diagnostic/load/variant sums each 1,000,000; every pack has `reachable_rows == rows` and `traversal_roots == 1`
  - resource bounds pass: peak RSS 1,731,821,568 / 4,294,967,296 bytes; persistent assets 282,881,928 / 536,870,912 bytes
  - profile SHA-256: allocs `f9c5e3141e60c702e5cbe79d23e67245402334d5819c6b419e2b2399b4d10b13`; baseline `aba4330b3185456dba3c34fe3dc14a4073742a88e3efe510b8470e1d85b23b74`; block `a641bf71369e47f80f53517ffce258202b1f0bdaebf53ffea9cb145b7a037bd7`; CPU `f809683540eaac0051ee4271b945aad74ff71508fbafff1c21a354b44325338f`; heap `a5748e085dbc7734f8ee5365632e8fbcacede12853d7588315ccbabf4b105116`; mutex `881ea506a541d1742651a4fa3155937df01146e03e68e4b54bd4f231a3b744b8`; trace `5a15d8304b5f7bf73b3a9c713bfe95fb7197b75d7414bfb2e6ff2496c47a3c6c`.

M8 remains `experimental_gate_failures` only for non-#3999 system gates: probe reduction, overlap storage, exhaustive correctness, QPS, and tail latency.