### PR TITLE
vector: select pinned KaHIP placement for structured embeddings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -2,3 +2,4 @@
 TreeDB/docs/spec/authority-inventory.md text eol=lf
 TreeDB/docs/performance/vector-partition-m1-0aae57a7a.raw.txt -text
 TreeDB/docs/performance/vector-partition-m1-b16bcbf98.raw.txt -text
+scripts/treedb_kahip_partition.py text eol=lf

--- a/TreeDB/docs/spec/vector-partition-m2.md
+++ b/TreeDB/docs/spec/vector-partition-m2.md
@@ -79,9 +79,11 @@ The selected offline comparison backend is `kahip==3.25` (MIT Python module,
 wheel SHA-256 `e6ea76524e9fc01b27e6f5c5f00b7eec71c94cbd1e84678ce2a14d64dfc9eda4`),
 ECO mode, single OpenMP worker, seed from the validated request, epsilon .05,
 and an unweighted symmetrized copy of the directed graph. It is invoked only
-through `scripts/treedb_kahip_partition.py` and the bound external JSON seam;
-it is never an online dependency. The adapter rejects any module version other
-than 3.25 and requests above the V1 1M-by-degree-16 (16M directed edge)
+through an explicit `-partition-kahip-script` path (normally
+`scripts/treedb_kahip_partition.py`) and the bound external JSON seam; it is
+never an online dependency. The adapter rejects any module version other than
+3.25 or RECORD SHA-256
+`7ff011253147286fcebc9185573662bf31dbcfbab1944f9b4940032f49ea5217`, and requests above the V1 1M-by-degree-16 (16M directed edge)
 envelope. On the retained 100k embedding-mixture graph
 `5a095727ed0f82815643daddb47bd11a08c9630ede6f9b1d7e7ec427dc8e9937`,
 the reference greedy result was p4 `.8303`, cut `1122051`, load `6521/6563`;

--- a/TreeDB/docs/spec/vector-partition-m2.md
+++ b/TreeDB/docs/spec/vector-partition-m2.md
@@ -75,8 +75,20 @@ Its query count, generated matrix bytes, exact corpus-by-query work, top-k, and
 fixture checksum are validated before the diagnostic data is allocated or
 used.
 
-Before a production backend can be chosen, pin its version, source and license,
-input/output command, resource limits, and independent validator evidence.
+The selected offline comparison backend is `kahip==3.25` (MIT Python module,
+wheel SHA-256 `e6ea76524e9fc01b27e6f5c5f00b7eec71c94cbd1e84678ce2a14d64dfc9eda4`),
+ECO mode, single OpenMP worker, seed from the validated request, epsilon .05,
+and an unweighted symmetrized copy of the directed graph. It is invoked only
+through `scripts/treedb_kahip_partition.py` and the bound external JSON seam;
+it is never an online dependency. The adapter rejects any module version other
+than 3.25 and requests above the V1 1M-by-degree-16 (16M directed edge)
+envelope. On the retained 100k embedding-mixture graph
+`5a095727ed0f82815643daddb47bd11a08c9630ede6f9b1d7e7ec427dc8e9937`,
+the reference greedy result was p4 `.8303`, cut `1122051`, load `6521/6563`;
+the KaHIP artifact
+`954591a9f21e166e78c19a7f8885a74b2faf6bb0e85a26a1fe13dab3191a1a1e`
+was p1/p2/p4/p8/p16 `1.0`, cut `0`, load `6283/6563`. This is a bounded
+offline placement result, not a claim about graph quality or online serving.
 
 ## Exporter-corpus builder and reproducibility evidence
 

--- a/TreeDB/docs/spec/vector-partition-m2.md
+++ b/TreeDB/docs/spec/vector-partition-m2.md
@@ -88,7 +88,7 @@ envelope. On the retained 100k embedding-mixture graph
 `5a095727ed0f82815643daddb47bd11a08c9630ede6f9b1d7e7ec427dc8e9937`,
 the reference greedy result was p4 `.8303`, cut `1122051`, load `6521/6563`;
 the KaHIP artifact
-`954591a9f21e166e78c19a7f8885a74b2faf6bb0e85a26a1fe13dab3191a1a1e`
+`022359b1aedfa738cde7f2e82e01263c855eb72075b1f2a927d3a5753d6fde9c`
 was p1/p2/p4/p8/p16 `1.0`, cut `0`, load `6283/6563`. This is a bounded
 offline placement result, not a claim about graph quality or online serving.
 

--- a/TreeDB/docs/spec/vector-partition-m2.md
+++ b/TreeDB/docs/spec/vector-partition-m2.md
@@ -49,8 +49,8 @@ malformed output, or success. On Unix it also kills the dedicated process group
 after `Wait`, including when the root exits normally while a same-group child
 holds an inherited pipe. A child that deliberately calls `setsid` escapes that
 OS process-group boundary; the portable Go adapter cannot claim containment of
-such hostile descendants. No external partitioner is currently selected or
-required.
+such hostile descendants. The selected KaHIP backend below is offline only;
+no online external partitioner is selected or required.
 
 ## Reproducible M0 fixture invocation
 

--- a/TreeDB/docs/spec/vector-partition-m2.md
+++ b/TreeDB/docs/spec/vector-partition-m2.md
@@ -84,7 +84,8 @@ through an explicit `-partition-kahip-script` path (normally
 never an online dependency. The adapter rejects any module version other than
 3.25 or RECORD SHA-256
 `7ff011253147286fcebc9185573662bf31dbcfbab1944f9b4940032f49ea5217`, and requests above the V1 1M-by-degree-16 (16M directed edge)
-envelope. On the retained 100k embedding-mixture graph
+envelope, above `16384` partitions, or with more partitions than vectors.
+On the retained 100k embedding-mixture graph
 `5a095727ed0f82815643daddb47bd11a08c9630ede6f9b1d7e7ec427dc8e9937`,
 the reference greedy result was p4 `.8303`, cut `1122051`, load `6521/6563`;
 the KaHIP artifact

--- a/TreeDB/docs/spec/vector-partition-m2.md
+++ b/TreeDB/docs/spec/vector-partition-m2.md
@@ -81,7 +81,7 @@ ECO mode, single OpenMP worker, seed from the validated request, epsilon .05,
 and an unweighted symmetrized copy of the directed graph. It is invoked only
 through an explicit `-partition-kahip-script` path (normally
 `scripts/treedb_kahip_partition.py`) and the bound external JSON seam; it is
-never an online dependency. The adapter rejects any module version other than
+never an online dependency. The adapter rejects any distribution version other than
 3.25 or RECORD SHA-256
 `7ff011253147286fcebc9185573662bf31dbcfbab1944f9b4940032f49ea5217`, and requests above the V1 1M-by-degree-16 (16M directed edge)
 envelope, above `16384` partitions, or with more partitions than vectors.

--- a/TreeDB/docs/spec/vector-partition-m2.md
+++ b/TreeDB/docs/spec/vector-partition-m2.md
@@ -85,6 +85,10 @@ never an online dependency. The adapter rejects any distribution version other t
 3.25 or RECORD SHA-256
 `7ff011253147286fcebc9185573662bf31dbcfbab1944f9b4940032f49ea5217`, and requests above the V1 1M-by-degree-16 (16M directed edge)
 envelope, above `16384` partitions, or with more partitions than vectors.
+`-partition-kahip-python` is a trusted local offline execution substrate. V1
+attests the pinned adapter bytes and installed KaHIP RECORD payloads, not the
+Python interpreter, OS, shared-library loader, or container; results from an
+untrusted runtime are outside this evidence contract.
 On the retained 100k embedding-mixture graph
 `5a095727ed0f82815643daddb47bd11a08c9630ede6f9b1d7e7ec427dc8e9937`,
 the reference greedy result was p4 `.8303`, cut `1122051`, load `6521/6563`;

--- a/cmd/treedb_vector_partition_bench/main.go
+++ b/cmd/treedb_vector_partition_bench/main.go
@@ -121,6 +121,21 @@ type config struct {
 	m8ShardLimits         nativewire.VectorPartitionShardSearchLimitsV1
 }
 
+type kahipRequestPartitioner struct{}
+
+func (kahipRequestPartitioner) Name() string    { return "kahip_request_seed_v1" }
+func (kahipRequestPartitioner) License() string { return "request-only" }
+func (kahipRequestPartitioner) Partition(g vectorpartition.Graph, parts, cap int) ([]int, error) {
+	if parts < 1 || cap < 1 || len(g.Neighbors) < parts {
+		return nil, errors.New("invalid KaHIP request shape")
+	}
+	out := make([]int, len(g.Neighbors))
+	for i := range out {
+		out[i] = i % parts
+	}
+	return out, nil
+}
+
 type partitionRun struct {
 	SchemaVersion  int                     `json:"schema_version"`
 	ResultKind     string                  `json:"result_kind"`
@@ -556,7 +571,11 @@ func runWithRuntimeCapabilities(args []string, stdout io.Writer, capabilities be
 		// graph controls. Simulation probes, stage selection, and simulation
 		// memory planning are intentionally irrelevant here; M3 separately
 		// consumes explicit overlap ratios, queries, and top-k.
-		if err := vectorpartition.ValidateReferenceInputShape(cfg.partition, fixture.Vectors, fixture.Dimensions); err != nil {
+		validateShape := vectorpartition.ValidateReferenceInputShape
+		if cfg.kahipPython != "" {
+			validateShape = vectorpartition.ValidateInputShape
+		}
+		if err := validateShape(cfg.partition, fixture.Vectors, fixture.Dimensions); err != nil {
 			return err
 		}
 		// The artifact's Source.Checksum is computed over these generated vectors
@@ -943,7 +962,11 @@ func runPartitionStage(cfg config, fixture fixtureManifest, vectors, queries [][
 		input[i] = vectorpartition.Vector{ID: fmt.Sprintf("doc-%06d", i), Values: values}
 	}
 	started := time.Now()
-	artifact, err := vectorpartition.BuildWithPartitioner(input, cfg.partition, vectorpartition.Source{SourceID: "m0_fixture:" + fixture.Checksum}, vectorpartition.ReferencePartitioner{})
+	backend := vectorpartition.Partitioner(vectorpartition.ReferencePartitioner{})
+	if cfg.kahipPython != "" {
+		backend = kahipRequestPartitioner{}
+	}
+	artifact, err := vectorpartition.BuildWithPartitioner(input, cfg.partition, vectorpartition.Source{SourceID: "m0_fixture:" + fixture.Checksum}, backend)
 	if err != nil {
 		return fmt.Errorf("build validated vector partition artifact: %w", err)
 	}

--- a/cmd/treedb_vector_partition_bench/main.go
+++ b/cmd/treedb_vector_partition_bench/main.go
@@ -94,6 +94,7 @@ type config struct {
 	partitionAssignment   string
 	partitionTruthOracle  bool
 	kahipPython           string
+	kahipScript           string
 	partition             vectorpartition.Config
 	partitionHNSWM        int
 	router                *treeDBRepresentativeRouter
@@ -726,6 +727,7 @@ func parseConfig(args []string) (config, error) {
 	fs.StringVar(&cfg.partitionAssignment, "partition-assignment", cfg.partitionAssignment, "partition assignment for partition/M3 stages: graph or stable_id_hash")
 	fs.BoolVar(&cfg.partitionTruthOracle, "partition-truth-oracle", false, "emit exact truth primary-partition coverage diagnostic for -stage partition")
 	fs.StringVar(&cfg.kahipPython, "partition-kahip-python", "", "offline KaHIP 3.25 Python executable for partition/M3 build stages; never used online; adapter is scripts/treedb_kahip_partition.py")
+	fs.StringVar(&cfg.kahipScript, "partition-kahip-script", "", "explicit offline KaHIP adapter script path required with -partition-kahip-python")
 	fs.IntVar(&cfg.partition.Repetitions, "partition-repetitions", cfg.partition.Repetitions, "dense-ball graph sketch repetitions")
 	fs.Int64Var(&cfg.partition.MaxDistanceWork, "partition-max-distance-work", cfg.partition.MaxDistanceWork, "explicit reference graph scalar-work bound")
 	fs.Int64Var(&cfg.partition.MaxPartitionWork, "partition-max-partition-work", cfg.partition.MaxPartitionWork, "qualification-only reference partition work bound; default remains conservative")
@@ -867,6 +869,9 @@ func parseConfig(args []string) (config, error) {
 	if cfg.kahipPython != "" && ((cfg.stage != "partition" && cfg.stage != "overlap,partition_index") || cfg.partitionAssignment != partitionAssignmentGraphV1) {
 		return config{}, errors.New("-partition-kahip-python requires partition or overlap,partition_index stage with graph assignment")
 	}
+	if (cfg.kahipPython == "") != (cfg.kahipScript == "") {
+		return config{}, errors.New("-partition-kahip-python and -partition-kahip-script must be provided together")
+	}
 	if cfg.partitionAssignment != partitionAssignmentGraphV1 && cfg.stage != "partition" && cfg.stage != "overlap,partition_index" {
 		return config{}, errors.New("-partition-assignment applies only to partition and overlap,partition_index stages")
 	}
@@ -950,7 +955,7 @@ func runPartitionStage(cfg config, fixture fixtureManifest, vectors, queries [][
 		}
 		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
 		defer cancel()
-		artifact, err = vectorpartition.RunExternalJSONForRequestWithLimits(ctx, []string{cfg.kahipPython, "scripts/treedb_kahip_partition.py"}, input, vectorpartition.ExternalJSONLimits{MaxInput: len(input), MaxOutput: len(input) + 1024}, request)
+		artifact, err = vectorpartition.RunExternalJSONForRequestWithLimits(ctx, []string{cfg.kahipPython, cfg.kahipScript}, input, vectorpartition.ExternalJSONLimits{MaxInput: len(input), MaxOutput: kahipOutputCap(input, request)}, request)
 		if err != nil {
 			return fmt.Errorf("KaHIP 3.25 offline partition: %w", err)
 		}
@@ -1023,6 +1028,12 @@ func runPartitionStage(cfg config, fixture fixtureManifest, vectors, queries [][
 	}
 	_, err = fmt.Fprintf(stdout, "partition artifact=%s edges=%d cut=%d cap=%d\n", path, artifact.Metrics.GraphEdges, artifact.Metrics.EdgeCut, artifact.Metrics.Cap)
 	return err
+}
+
+func kahipOutputCap(input []byte, a vectorpartition.Artifact) int {
+	// Each canonical JSON assignment label may grow from one digit to five
+	// (partitions are capped at 16384); reserve a small fixed metadata delta.
+	return len(input) + len(a.IDs)*5 + 1024
 }
 
 func partitionTruthOracleForArtifactV1(vectors, queries [][]float64, assignment []int, graph [][]int, partitions, topK int) (partitionTruthOracleV1, error) {

--- a/cmd/treedb_vector_partition_bench/main.go
+++ b/cmd/treedb_vector_partition_bench/main.go
@@ -40,7 +40,10 @@ const (
 	maxPartitions                           = 16_384
 	kahipMaxDirectedEdges             int64 = 16_000_000
 	kahipAdapterMaxBytes                    = 64 << 10
-	kahipAdapterSHA256                      = "1403cdc2e3ffffc6395dd563bb97a760ba7d6be761a19a2ebd273625ca7914e3"
+	kahipAdapterSHA256                      = "ae4ca8f5f26bd510a507a0f4ba50adaf1e5514ee9e20340cb9d494aba8f54825"
+	kahipDefaultTimeout                     = 5 * time.Minute
+	kahipMinSeed                      int64 = -1 << 31
+	kahipMaxSeed                      int64 = 1<<31 - 1
 	maxFixtureBytes                   int64 = 4 << 30
 	maxBenchmarkWorkUnits             int64 = 200_000_000
 	maxManifestBytes                  int64 = 64 << 10
@@ -99,6 +102,7 @@ type config struct {
 	kahipPython           string
 	kahipScript           string
 	kahipSource           string
+	kahipTimeout          time.Duration
 	partition             vectorpartition.Config
 	partitionHNSWM        int
 	router                *treeDBRepresentativeRouter
@@ -548,6 +552,11 @@ func runWithRuntimeCapabilities(args []string, stdout io.Writer, capabilities be
 	if err != nil {
 		return err
 	}
+	if cfg.kahipPython != "" {
+		if err := validateKaHIPSeedV1(fixture.Seed); err != nil {
+			return err
+		}
+	}
 	if cfg.partitions > fixture.Vectors {
 		return errors.New("partitions cannot exceed fixture vectors")
 	}
@@ -714,6 +723,7 @@ func parseConfig(args []string) (config, error) {
 		format: "json", topK: 10, recallTarget: .9, seed: 1, stage: "simulation",
 		warmup:              1,
 		partitionAssignment: partitionAssignmentGraphV1,
+		kahipTimeout:        kahipDefaultTimeout,
 		partition:           vectorpartition.DefaultConfig(), routerConfig: vectorpartition.DefaultRouterConfigV1(),
 		routerCandidates: 1024, sourceHNSWDegree: partitionHNSWDegree,
 		m8MaxRSSBytes: uint64(maxFixtureBytes), m8MaxAssetBytes: uint64(maxFixtureBytes), m8MaxExactTruthVisits: maxBenchmarkWorkUnits,
@@ -756,6 +766,7 @@ func parseConfig(args []string) (config, error) {
 	fs.BoolVar(&cfg.partitionTruthOracle, "partition-truth-oracle", false, "emit exact truth primary-partition coverage diagnostic for -stage partition")
 	fs.StringVar(&cfg.kahipPython, "partition-kahip-python", "", "offline KaHIP 3.25 Python executable for partition/M3 build stages; never used online; adapter is scripts/treedb_kahip_partition.py")
 	fs.StringVar(&cfg.kahipScript, "partition-kahip-script", "", "explicit offline KaHIP adapter script path required with -partition-kahip-python")
+	fs.DurationVar(&cfg.kahipTimeout, "partition-kahip-timeout", cfg.kahipTimeout, "positive offline KaHIP execution timeout")
 	fs.IntVar(&cfg.partition.Repetitions, "partition-repetitions", cfg.partition.Repetitions, "dense-ball graph sketch repetitions")
 	fs.Int64Var(&cfg.partition.MaxDistanceWork, "partition-max-distance-work", cfg.partition.MaxDistanceWork, "explicit reference graph scalar-work bound")
 	fs.Int64Var(&cfg.partition.MaxPartitionWork, "partition-max-partition-work", cfg.partition.MaxPartitionWork, "qualification-only reference partition work bound; default remains conservative")
@@ -903,6 +914,14 @@ func parseConfig(args []string) (config, error) {
 	if (cfg.kahipPython == "") != (cfg.kahipScript == "") {
 		return config{}, errors.New("-partition-kahip-python and -partition-kahip-script must be provided together")
 	}
+	if cfg.kahipPython != "" && cfg.kahipTimeout <= 0 {
+		return config{}, errors.New("-partition-kahip-timeout must be positive")
+	}
+	if cfg.kahipPython != "" {
+		if err := validateKaHIPSeedV1(cfg.seed); err != nil {
+			return config{}, err
+		}
+	}
 	if cfg.kahipPython != "" {
 		python, err := exec.LookPath(cfg.kahipPython)
 		if err != nil {
@@ -1026,7 +1045,7 @@ func runPartitionStage(cfg config, fixture fixtureManifest, vectors, queries [][
 		if err != nil {
 			return err
 		}
-		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+		ctx, cancel := context.WithTimeout(context.Background(), cfg.kahipTimeout)
 		defer cancel()
 		artifact, err = vectorpartition.RunExternalJSONForRequestWithLimits(ctx, kahipAdapterCommand(cfg), input, vectorpartition.ExternalJSONLimits{MaxInput: len(input), MaxOutput: kahipOutputCap(input, request)}, request)
 		if err != nil {
@@ -1117,6 +1136,13 @@ func validateKaHIPFinalGraphEnvelopeV1(vectors, degree int) error {
 	directedEdges, err := memoryMul(int64(vectors), int64(degree))
 	if err != nil || directedEdges > kahipMaxDirectedEdges {
 		return fmt.Errorf("KaHIP final directed-edge envelope exceeds %d", kahipMaxDirectedEdges)
+	}
+	return nil
+}
+
+func validateKaHIPSeedV1(seed int64) error {
+	if seed < kahipMinSeed || seed > kahipMaxSeed {
+		return fmt.Errorf("KaHIP seed must be in [%d,%d]", kahipMinSeed, kahipMaxSeed)
 	}
 	return nil
 }

--- a/cmd/treedb_vector_partition_bench/main.go
+++ b/cmd/treedb_vector_partition_bench/main.go
@@ -93,6 +93,7 @@ type config struct {
 	m8VariantDBs          []string
 	partitionAssignment   string
 	partitionTruthOracle  bool
+	kahipPython           string
 	partition             vectorpartition.Config
 	partitionHNSWM        int
 	router                *treeDBRepresentativeRouter
@@ -724,6 +725,7 @@ func parseConfig(args []string) (config, error) {
 	fs.StringVar(&cfg.m8TruthCacheSHA256, "m8-truth-cache-sha256", "", "independently trusted SHA-256 of the canonical truth-cache artifact required for cache reuse")
 	fs.StringVar(&cfg.partitionAssignment, "partition-assignment", cfg.partitionAssignment, "partition assignment for partition/M3 stages: graph or stable_id_hash")
 	fs.BoolVar(&cfg.partitionTruthOracle, "partition-truth-oracle", false, "emit exact truth primary-partition coverage diagnostic for -stage partition")
+	fs.StringVar(&cfg.kahipPython, "partition-kahip-python", "", "offline KaHIP 3.25 Python executable for partition/M3 build stages; never used online; adapter is scripts/treedb_kahip_partition.py")
 	fs.IntVar(&cfg.partition.Repetitions, "partition-repetitions", cfg.partition.Repetitions, "dense-ball graph sketch repetitions")
 	fs.Int64Var(&cfg.partition.MaxDistanceWork, "partition-max-distance-work", cfg.partition.MaxDistanceWork, "explicit reference graph scalar-work bound")
 	fs.Int64Var(&cfg.partition.MaxPartitionWork, "partition-max-partition-work", cfg.partition.MaxPartitionWork, "qualification-only reference partition work bound; default remains conservative")
@@ -862,6 +864,9 @@ func parseConfig(args []string) (config, error) {
 	if cfg.partitionAssignment != partitionAssignmentGraphV1 && cfg.partitionAssignment != partitionAssignmentStableIDHashV1 {
 		return config{}, errors.New("-partition-assignment must be graph or stable_id_hash")
 	}
+	if cfg.kahipPython != "" && ((cfg.stage != "partition" && cfg.stage != "overlap,partition_index") || cfg.partitionAssignment != partitionAssignmentGraphV1) {
+		return config{}, errors.New("-partition-kahip-python requires partition or overlap,partition_index stage with graph assignment")
+	}
 	if cfg.partitionAssignment != partitionAssignmentGraphV1 && cfg.stage != "partition" && cfg.stage != "overlap,partition_index" {
 		return config{}, errors.New("-partition-assignment applies only to partition and overlap,partition_index stages")
 	}
@@ -936,6 +941,19 @@ func runPartitionStage(cfg config, fixture fixtureManifest, vectors, queries [][
 	artifact, err := vectorpartition.BuildWithPartitioner(input, cfg.partition, vectorpartition.Source{SourceID: "m0_fixture:" + fixture.Checksum}, vectorpartition.ReferencePartitioner{})
 	if err != nil {
 		return fmt.Errorf("build validated vector partition artifact: %w", err)
+	}
+	if cfg.kahipPython != "" {
+		request := artifact
+		input, err := vectorpartition.CanonicalJSON(request)
+		if err != nil {
+			return err
+		}
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+		defer cancel()
+		artifact, err = vectorpartition.RunExternalJSONForRequestWithLimits(ctx, []string{cfg.kahipPython, "scripts/treedb_kahip_partition.py"}, input, vectorpartition.ExternalJSONLimits{MaxInput: len(input), MaxOutput: len(input) + 1024}, request)
+		if err != nil {
+			return fmt.Errorf("KaHIP 3.25 offline partition: %w", err)
+		}
 	}
 	graphArtifactDigest, err := vectorpartition.Digest(artifact)
 	if err != nil {

--- a/cmd/treedb_vector_partition_bench/main.go
+++ b/cmd/treedb_vector_partition_bench/main.go
@@ -38,6 +38,7 @@ const (
 	maxVectors                              = 1_000_000
 	maxDimensions                           = 4_096
 	maxPartitions                           = 16_384
+	kahipMaxDirectedEdges             int64 = 16_000_000
 	maxFixtureBytes                   int64 = 4 << 30
 	maxBenchmarkWorkUnits             int64 = 200_000_000
 	maxManifestBytes                  int64 = 64 << 10
@@ -578,6 +579,11 @@ func runWithRuntimeCapabilities(args []string, stdout io.Writer, capabilities be
 		if err := validateShape(cfg.partition, fixture.Vectors, fixture.Dimensions); err != nil {
 			return err
 		}
+		if cfg.kahipPython != "" {
+			if err := validateKaHIPFinalGraphEnvelopeV1(fixture.Vectors, cfg.partition.Degree); err != nil {
+				return err
+			}
+		}
 		// The artifact's Source.Checksum is computed over these generated vectors
 		// by BuildWithPartitioner. The manifest checksum additionally commits the
 		// simulation-only query/truth stream, so verifying it here would recreate
@@ -1078,6 +1084,14 @@ func kahipOutputCap(input []byte, a vectorpartition.Artifact) int {
 	// Each canonical JSON assignment label may grow from one digit to five
 	// (partitions are capped at 16384); reserve a small fixed metadata delta.
 	return len(input) + len(a.IDs)*5 + 1024
+}
+
+func validateKaHIPFinalGraphEnvelopeV1(vectors, degree int) error {
+	directedEdges, err := memoryMul(int64(vectors), int64(degree))
+	if err != nil || directedEdges > kahipMaxDirectedEdges {
+		return fmt.Errorf("KaHIP final directed-edge envelope exceeds %d", kahipMaxDirectedEdges)
+	}
+	return nil
 }
 
 func partitionTruthOracleForArtifactV1(vectors, queries [][]float64, assignment []int, graph [][]int, partitions, topK int) (partitionTruthOracleV1, error) {

--- a/cmd/treedb_vector_partition_bench/main.go
+++ b/cmd/treedb_vector_partition_bench/main.go
@@ -894,6 +894,24 @@ func parseConfig(args []string) (config, error) {
 	if (cfg.kahipPython == "") != (cfg.kahipScript == "") {
 		return config{}, errors.New("-partition-kahip-python and -partition-kahip-script must be provided together")
 	}
+	if cfg.kahipPython != "" {
+		python, err := exec.LookPath(cfg.kahipPython)
+		if err != nil {
+			return config{}, fmt.Errorf("-partition-kahip-python: %w", err)
+		}
+		if cfg.kahipPython, err = filepath.Abs(python); err != nil {
+			return config{}, fmt.Errorf("-partition-kahip-python: %w", err)
+		}
+		script, err := filepath.Abs(cfg.kahipScript)
+		if err != nil {
+			return config{}, fmt.Errorf("-partition-kahip-script: %w", err)
+		}
+		info, err := os.Stat(script)
+		if err != nil || !info.Mode().IsRegular() || info.Mode().Perm()&0444 == 0 {
+			return config{}, errors.New("-partition-kahip-script must be a readable regular file")
+		}
+		cfg.kahipScript = script
+	}
 	if cfg.partitionAssignment != partitionAssignmentGraphV1 && cfg.stage != "partition" && cfg.stage != "overlap,partition_index" {
 		return config{}, errors.New("-partition-assignment applies only to partition and overlap,partition_index stages")
 	}

--- a/cmd/treedb_vector_partition_bench/main.go
+++ b/cmd/treedb_vector_partition_bench/main.go
@@ -913,8 +913,15 @@ func parseConfig(args []string) (config, error) {
 			return config{}, fmt.Errorf("-partition-kahip-script: %w", err)
 		}
 		info, err := os.Stat(script)
-		if err != nil || !info.Mode().IsRegular() || info.Mode().Perm()&0444 == 0 {
-			return config{}, errors.New("-partition-kahip-script must be a readable regular file")
+		if err != nil || !info.Mode().IsRegular() {
+			return config{}, errors.New("-partition-kahip-script must be a regular file")
+		}
+		file, err := os.Open(script)
+		if err != nil {
+			return config{}, fmt.Errorf("-partition-kahip-script: %w", err)
+		}
+		if err := file.Close(); err != nil {
+			return config{}, fmt.Errorf("-partition-kahip-script: %w", err)
 		}
 		cfg.kahipScript = script
 	}

--- a/cmd/treedb_vector_partition_bench/main.go
+++ b/cmd/treedb_vector_partition_bench/main.go
@@ -39,6 +39,8 @@ const (
 	maxDimensions                           = 4_096
 	maxPartitions                           = 16_384
 	kahipMaxDirectedEdges             int64 = 16_000_000
+	kahipAdapterMaxBytes                    = 64 << 10
+	kahipAdapterSHA256                      = "1403cdc2e3ffffc6395dd563bb97a760ba7d6be761a19a2ebd273625ca7914e3"
 	maxFixtureBytes                   int64 = 4 << 30
 	maxBenchmarkWorkUnits             int64 = 200_000_000
 	maxManifestBytes                  int64 = 64 << 10
@@ -920,8 +922,20 @@ func parseConfig(args []string) (config, error) {
 		if err != nil {
 			return config{}, fmt.Errorf("-partition-kahip-script: %w", err)
 		}
-		if err := file.Close(); err != nil {
-			return config{}, fmt.Errorf("-partition-kahip-script: %w", err)
+		scriptBytes, readErr := io.ReadAll(io.LimitReader(file, kahipAdapterMaxBytes+1))
+		closeErr := file.Close()
+		if readErr != nil {
+			return config{}, fmt.Errorf("-partition-kahip-script: %w", readErr)
+		}
+		if closeErr != nil {
+			return config{}, fmt.Errorf("-partition-kahip-script: %w", closeErr)
+		}
+		if len(scriptBytes) > kahipAdapterMaxBytes {
+			return config{}, fmt.Errorf("-partition-kahip-script exceeds %d-byte cap", kahipAdapterMaxBytes)
+		}
+		sum := sha256.Sum256(scriptBytes)
+		if hex.EncodeToString(sum[:]) != kahipAdapterSHA256 {
+			return config{}, errors.New("-partition-kahip-script does not match the pinned adapter")
 		}
 		cfg.kahipScript = script
 	}

--- a/cmd/treedb_vector_partition_bench/main.go
+++ b/cmd/treedb_vector_partition_bench/main.go
@@ -888,6 +888,9 @@ func parseConfig(args []string) (config, error) {
 	if cfg.kahipPython != "" && ((cfg.stage != "partition" && cfg.stage != "overlap,partition_index") || cfg.partitionAssignment != partitionAssignmentGraphV1) {
 		return config{}, errors.New("-partition-kahip-python requires partition or overlap,partition_index stage with graph assignment")
 	}
+	if cfg.kahipPython != "" && cfg.partition.Imbalance != 0.05 {
+		return config{}, errors.New("-partition-kahip-python requires -imbalance 0.05")
+	}
 	if (cfg.kahipPython == "") != (cfg.kahipScript == "") {
 		return config{}, errors.New("-partition-kahip-python and -partition-kahip-script must be provided together")
 	}

--- a/cmd/treedb_vector_partition_bench/main.go
+++ b/cmd/treedb_vector_partition_bench/main.go
@@ -764,7 +764,7 @@ func parseConfig(args []string) (config, error) {
 	fs.StringVar(&cfg.m8TruthCacheSHA256, "m8-truth-cache-sha256", "", "independently trusted SHA-256 of the canonical truth-cache artifact required for cache reuse")
 	fs.StringVar(&cfg.partitionAssignment, "partition-assignment", cfg.partitionAssignment, "partition assignment for partition/M3 stages: graph or stable_id_hash")
 	fs.BoolVar(&cfg.partitionTruthOracle, "partition-truth-oracle", false, "emit exact truth primary-partition coverage diagnostic for -stage partition")
-	fs.StringVar(&cfg.kahipPython, "partition-kahip-python", "", "offline KaHIP 3.25 Python executable for partition/M3 build stages; never used online; adapter is scripts/treedb_kahip_partition.py")
+	fs.StringVar(&cfg.kahipPython, "partition-kahip-python", "", "trusted local offline Python for KaHIP 3.25 partition/M3 build stages; never used online; adapter is scripts/treedb_kahip_partition.py")
 	fs.StringVar(&cfg.kahipScript, "partition-kahip-script", "", "explicit offline KaHIP adapter script path required with -partition-kahip-python")
 	fs.DurationVar(&cfg.kahipTimeout, "partition-kahip-timeout", cfg.kahipTimeout, "positive offline KaHIP execution timeout")
 	fs.IntVar(&cfg.partition.Repetitions, "partition-repetitions", cfg.partition.Repetitions, "dense-ball graph sketch repetitions")

--- a/cmd/treedb_vector_partition_bench/main.go
+++ b/cmd/treedb_vector_partition_bench/main.go
@@ -98,6 +98,7 @@ type config struct {
 	partitionTruthOracle  bool
 	kahipPython           string
 	kahipScript           string
+	kahipSource           string
 	partition             vectorpartition.Config
 	partitionHNSWM        int
 	router                *treeDBRepresentativeRouter
@@ -938,6 +939,7 @@ func parseConfig(args []string) (config, error) {
 			return config{}, errors.New("-partition-kahip-script does not match the pinned adapter")
 		}
 		cfg.kahipScript = script
+		cfg.kahipSource = string(scriptBytes)
 	}
 	if cfg.partitionAssignment != partitionAssignmentGraphV1 && cfg.stage != "partition" && cfg.stage != "overlap,partition_index" {
 		return config{}, errors.New("-partition-assignment applies only to partition and overlap,partition_index stages")
@@ -1026,7 +1028,7 @@ func runPartitionStage(cfg config, fixture fixtureManifest, vectors, queries [][
 		}
 		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
 		defer cancel()
-		artifact, err = vectorpartition.RunExternalJSONForRequestWithLimits(ctx, []string{cfg.kahipPython, cfg.kahipScript}, input, vectorpartition.ExternalJSONLimits{MaxInput: len(input), MaxOutput: kahipOutputCap(input, request)}, request)
+		artifact, err = vectorpartition.RunExternalJSONForRequestWithLimits(ctx, kahipAdapterCommand(cfg), input, vectorpartition.ExternalJSONLimits{MaxInput: len(input), MaxOutput: kahipOutputCap(input, request)}, request)
 		if err != nil {
 			return fmt.Errorf("KaHIP 3.25 offline partition: %w", err)
 		}
@@ -1105,6 +1107,10 @@ func kahipOutputCap(input []byte, a vectorpartition.Artifact) int {
 	// Each canonical JSON assignment label may grow from one digit to five
 	// (partitions are capped at 16384); reserve a small fixed metadata delta.
 	return len(input) + len(a.IDs)*5 + 1024
+}
+
+func kahipAdapterCommand(cfg config) []string {
+	return []string{cfg.kahipPython, "-c", cfg.kahipSource}
 }
 
 func validateKaHIPFinalGraphEnvelopeV1(vectors, degree int) error {

--- a/cmd/treedb_vector_partition_bench/main_test.go
+++ b/cmd/treedb_vector_partition_bench/main_test.go
@@ -1511,7 +1511,7 @@ func TestPartitionAssignmentParsesOnlyMaterializationStagesV1(t *testing.T) {
 }
 
 func TestKaHIPOfflineSelectorIsLimitedToGraphMaterializationV1(t *testing.T) {
-	base := []string{"-dataset", fixturePath(t), "-out", t.TempDir(), "-partitions", "4", "-partition-kahip-python", "/tmp/kahip-python"}
+	base := []string{"-dataset", fixturePath(t), "-out", t.TempDir(), "-partitions", "4", "-partition-kahip-python", "/tmp/kahip-python", "-partition-kahip-script", "/tmp/kahip.py"}
 	for _, stage := range []string{"partition", "overlap,partition_index"} {
 		cfg, err := parseConfig(append(append([]string(nil), base...), "-stage", stage))
 		if err != nil || cfg.kahipPython == "" {
@@ -1525,6 +1525,13 @@ func TestKaHIPOfflineSelectorIsLimitedToGraphMaterializationV1(t *testing.T) {
 		if _, err := parseConfig(args); err == nil {
 			t.Fatalf("accepted KaHIP outside graph materialization: %#v", args)
 		}
+	}
+}
+
+func TestKaHIPOutputCapAllowsCanonicalLabelGrowthV1(t *testing.T) {
+	a := vectorpartition.Artifact{IDs: make([]string, 1_000_000)}
+	if got, want := kahipOutputCap(make([]byte, 10), a), 5_001_034; got != want {
+		t.Fatalf("cap=%d want=%d", got, want)
 	}
 }
 

--- a/cmd/treedb_vector_partition_bench/main_test.go
+++ b/cmd/treedb_vector_partition_bench/main_test.go
@@ -1515,15 +1515,23 @@ func TestKaHIPOfflineSelectorIsLimitedToGraphMaterializationV1(t *testing.T) {
 	if err := os.WriteFile(python, []byte("#!/bin/sh\n"), 0o700); err != nil {
 		t.Fatal(err)
 	}
+	adapterSource, err := filepath.Abs(filepath.Join("..", "..", "scripts", "treedb_kahip_partition.py"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	adapter, err := os.ReadFile(adapterSource)
+	if err != nil {
+		t.Fatal(err)
+	}
 	script := filepath.Join(t.TempDir(), "kahip.py")
-	if err := os.WriteFile(script, []byte("# adapter\n"), 0o600); err != nil {
+	if err := os.WriteFile(script, adapter, 0o600); err != nil {
 		t.Fatal(err)
 	}
 	base := []string{"-dataset", fixturePath(t), "-out", t.TempDir(), "-partitions", "4", "-partition-kahip-python", python, "-partition-kahip-script", script}
 	if runtime.GOOS != "windows" && os.Geteuid() != 0 {
 		t.Run("unreadable_script", func(t *testing.T) {
 			unreadable := filepath.Join(t.TempDir(), "unreadable.py")
-			if err := os.WriteFile(unreadable, []byte("# adapter\n"), 0o600); err != nil {
+			if err := os.WriteFile(unreadable, adapter, 0o600); err != nil {
 				t.Fatal(err)
 			}
 			args := append([]string(nil), base...)
@@ -1562,6 +1570,16 @@ func TestKaHIPOfflineSelectorIsLimitedToGraphMaterializationV1(t *testing.T) {
 			t.Fatalf("accepted KaHIP outside graph materialization: %#v", args)
 		}
 	}
+	tampered := filepath.Join(t.TempDir(), "kahip-tampered.py")
+	if err := os.WriteFile(tampered, append(adapter, '\n'), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	args := append([]string(nil), base...)
+	args[len(args)-1] = tampered
+	args = append(args, "-stage", "partition")
+	if _, err := parseConfig(args); err == nil {
+		t.Fatal("accepted modified KaHIP adapter")
+	}
 }
 
 func TestKaHIPOutputCapAllowsCanonicalLabelGrowthV1(t *testing.T) {
@@ -1589,8 +1607,8 @@ func TestKaHIPFinalGraphEnvelopePreflightsBeforeBuildV1(t *testing.T) {
 	if err := os.WriteFile(python, []byte("#!/bin/sh\n"), 0o700); err != nil {
 		t.Fatal(err)
 	}
-	script := filepath.Join(t.TempDir(), "kahip.py")
-	if err := os.WriteFile(script, []byte("# adapter\n"), 0o600); err != nil {
+	script, err := filepath.Abs(filepath.Join("..", "..", "scripts", "treedb_kahip_partition.py"))
+	if err != nil {
 		t.Fatal(err)
 	}
 	err = runWithHermeticProvenance(t, []string{

--- a/cmd/treedb_vector_partition_bench/main_test.go
+++ b/cmd/treedb_vector_partition_bench/main_test.go
@@ -1508,6 +1508,25 @@ func TestPartitionAssignmentParsesOnlyMaterializationStagesV1(t *testing.T) {
 			t.Fatalf("accepted malformed assignment config %#v", args)
 		}
 	}
+	if runtime.GOOS != "windows" && os.Geteuid() != 0 {
+		t.Run("unreadable_script", func(t *testing.T) {
+			unreadable := filepath.Join(t.TempDir(), "unreadable.py")
+			if err := os.WriteFile(unreadable, []byte("# adapter\n"), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			if err := os.Chmod(unreadable, 0); err != nil {
+				t.Fatal(err)
+			}
+			file, err := os.Open(unreadable)
+			if err == nil {
+				_ = file.Close()
+				t.Skip("current credentials can read a mode-000 regular file")
+			}
+			if _, err := parseConfig(append(append([]string(nil), base...), "-stage", "partition", "-partition-kahip-script", unreadable)); err == nil {
+				t.Fatal("accepted unreadable KaHIP adapter")
+			}
+		})
+	}
 }
 
 func TestKaHIPOfflineSelectorIsLimitedToGraphMaterializationV1(t *testing.T) {

--- a/cmd/treedb_vector_partition_bench/main_test.go
+++ b/cmd/treedb_vector_partition_bench/main_test.go
@@ -1618,6 +1618,20 @@ func TestKaHIPAdapterRoundTripV1(t *testing.T) {
 			t.Fatalf("forged %s request reached KaHIP: err=%v output=%s", forgedCase.name, err, output)
 		}
 	}
+	shadowDir := t.TempDir()
+	shadowMarker := filepath.Join(shadowDir, "loaded")
+	if err := os.WriteFile(filepath.Join(shadowDir, "kahip.py"), []byte("open(__import__('os').environ['KAHIP_SHADOW_MARKER'], 'w').write('loaded')\nraise RuntimeError('shadow imported')\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PYTHONPATH", shadowDir)
+	t.Setenv("KAHIP_SHADOW_MARKER", shadowMarker)
+	got, err = vectorpartition.RunExternalJSONForRequestWithLimits(ctx, []string{python, script}, raw, vectorpartition.ExternalJSONLimits{MaxInput: len(raw), MaxOutput: len(raw) + 1024}, request)
+	if err != nil || got.Backend != "kahip_python_3.25_eco_symmetrized_v1_seed_1" {
+		t.Fatalf("verified KaHIP adapter failed with shadow module: artifact=%+v err=%v", got, err)
+	}
+	if _, err := os.Stat(shadowMarker); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("shadow kahip module was imported: %v", err)
+	}
 }
 
 func TestPartitionLocalHNSWMIsIndependentAndM3OnlyV1(t *testing.T) {

--- a/cmd/treedb_vector_partition_bench/main_test.go
+++ b/cmd/treedb_vector_partition_bench/main_test.go
@@ -1521,6 +1521,7 @@ func TestKaHIPOfflineSelectorIsLimitedToGraphMaterializationV1(t *testing.T) {
 	for _, args := range [][]string{
 		append(append([]string(nil), base...), "-stage", "simulation"),
 		append(append([]string(nil), base...), "-stage", "partition", "-partition-assignment", partitionAssignmentStableIDHashV1),
+		append(append([]string(nil), base...), "-stage", "partition", "-imbalance", "0.04"),
 	} {
 		if _, err := parseConfig(args); err == nil {
 			t.Fatalf("accepted KaHIP outside graph materialization: %#v", args)

--- a/cmd/treedb_vector_partition_bench/main_test.go
+++ b/cmd/treedb_vector_partition_bench/main_test.go
@@ -1580,6 +1580,18 @@ func TestKaHIPAdapterRoundTripV1(t *testing.T) {
 	if err == nil || !strings.Contains(err.Error(), "pinned kahip") {
 		t.Fatalf("same-version wrong distribution identity accepted: %v", err)
 	}
+	badPayload := strings.Replace(string(adapter), "hashlib.sha256(payload).digest() != expected", "hashlib.sha256(payload).digest() == expected", 1)
+	if badPayload == string(adapter) {
+		t.Fatal("test did not replace KaHIP payload integrity check")
+	}
+	badScript = filepath.Join(t.TempDir(), "kahip_wrong_payload.py")
+	if err := os.WriteFile(badScript, []byte(badPayload), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	_, err = vectorpartition.RunExternalJSONForRequestWithLimits(ctx, []string{python, badScript}, raw, vectorpartition.ExternalJSONLimits{MaxInput: len(raw), MaxOutput: len(raw) + 1024}, request)
+	if err == nil || !strings.Contains(err.Error(), "payload integrity") {
+		t.Fatalf("tampered installed payload accepted: %v", err)
+	}
 }
 
 func TestPartitionLocalHNSWMIsIndependentAndM3OnlyV1(t *testing.T) {

--- a/cmd/treedb_vector_partition_bench/main_test.go
+++ b/cmd/treedb_vector_partition_bench/main_test.go
@@ -1555,8 +1555,11 @@ func TestKaHIPOfflineSelectorIsLimitedToGraphMaterializationV1(t *testing.T) {
 	}
 	for _, stage := range []string{"partition", "overlap,partition_index"} {
 		cfg, err := parseConfig(append(append([]string(nil), base...), "-stage", stage))
-		if err != nil || cfg.kahipPython != python || cfg.kahipScript != script {
+		if err != nil || cfg.kahipPython != python || cfg.kahipScript != script || cfg.kahipSource != string(adapter) {
 			t.Fatalf("stage=%s cfg=%+v err=%v", stage, cfg, err)
+		}
+		if command := kahipAdapterCommand(cfg); len(command) != 3 || command[0] != python || command[1] != "-c" || command[2] != string(adapter) {
+			t.Fatalf("KaHIP command=%q", command)
 		}
 	}
 	for _, args := range [][]string{
@@ -1644,18 +1647,18 @@ func TestKaHIPAdapterRoundTripV1(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	adapter, err := os.ReadFile(script)
+	if err != nil {
+		t.Fatal(err)
+	}
 	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
 	defer cancel()
-	got, err := vectorpartition.RunExternalJSONForRequestWithLimits(ctx, []string{python, script}, raw, vectorpartition.ExternalJSONLimits{MaxInput: len(raw), MaxOutput: len(raw) + 1024}, request)
+	got, err := vectorpartition.RunExternalJSONForRequestWithLimits(ctx, []string{python, "-c", string(adapter)}, raw, vectorpartition.ExternalJSONLimits{MaxInput: len(raw), MaxOutput: len(raw) + 1024}, request)
 	if err != nil {
 		t.Fatal(err)
 	}
 	if got.Backend != "kahip_python_3.25_eco_symmetrized_v1_seed_1" || got.Metrics.MaxPartitionSize > got.Metrics.Cap {
 		t.Fatalf("invalid KaHIP artifact: %+v", got)
-	}
-	adapter, err := os.ReadFile(script)
-	if err != nil {
-		t.Fatal(err)
 	}
 	wrongRecord := strings.Replace(string(adapter), "RECORD_SHA256 = \"7ff011253147286fcebc9185573662bf31dbcfbab1944f9b4940032f49ea5217\"", "RECORD_SHA256 = \"0000000000000000000000000000000000000000000000000000000000000000\"", 1)
 	if wrongRecord == string(adapter) {

--- a/cmd/treedb_vector_partition_bench/main_test.go
+++ b/cmd/treedb_vector_partition_bench/main_test.go
@@ -1555,7 +1555,7 @@ func TestKaHIPOfflineSelectorIsLimitedToGraphMaterializationV1(t *testing.T) {
 	}
 	for _, stage := range []string{"partition", "overlap,partition_index"} {
 		cfg, err := parseConfig(append(append([]string(nil), base...), "-stage", stage))
-		if err != nil || cfg.kahipPython != python || cfg.kahipScript != script || cfg.kahipSource != string(adapter) {
+		if err != nil || cfg.kahipPython != python || cfg.kahipScript != script || cfg.kahipSource != string(adapter) || cfg.kahipTimeout != kahipDefaultTimeout {
 			t.Fatalf("stage=%s cfg=%+v err=%v", stage, cfg, err)
 		}
 		if command := kahipAdapterCommand(cfg); len(command) != 3 || command[0] != python || command[1] != "-c" || command[2] != string(adapter) {
@@ -1568,10 +1568,16 @@ func TestKaHIPOfflineSelectorIsLimitedToGraphMaterializationV1(t *testing.T) {
 		append(append([]string(nil), base...), "-stage", "partition", "-imbalance", "0.04"),
 		append(append([]string(nil), base...), "-stage", "partition", "-partition-kahip-python", filepath.Join(t.TempDir(), "missing-python")),
 		append(append([]string(nil), base...), "-stage", "partition", "-partition-kahip-script", t.TempDir()),
+		append(append([]string(nil), base...), "-stage", "partition", "-partition-kahip-timeout", "0s"),
+		append(append([]string(nil), base...), "-stage", "partition", "-seed", "2147483648"),
 	} {
 		if _, err := parseConfig(args); err == nil {
 			t.Fatalf("accepted KaHIP outside graph materialization: %#v", args)
 		}
+	}
+	configured, err := parseConfig(append(append([]string(nil), base...), "-stage", "partition", "-partition-kahip-timeout", "45m"))
+	if err != nil || configured.kahipTimeout != 45*time.Minute {
+		t.Fatalf("KaHIP timeout config=%+v err=%v", configured, err)
 	}
 	tampered := filepath.Join(t.TempDir(), "kahip-tampered.py")
 	if err := os.WriteFile(tampered, append(adapter, '\n'), 0o600); err != nil {
@@ -1708,6 +1714,23 @@ func TestKaHIPAdapterRoundTripV1(t *testing.T) {
 		if err == nil || !bytes.Contains(output, []byte(forgedCase.want)) {
 			t.Fatalf("forged %s request reached KaHIP: err=%v output=%s", forgedCase.name, err, output)
 		}
+	}
+	var forgedSeed map[string]any
+	if err := json.Unmarshal(raw, &forgedSeed); err != nil {
+		t.Fatal(err)
+	}
+	forgedSeed["config"].(map[string]any)["seed"] = int64(2_147_483_648)
+	forgedRaw, err := json.Marshal(forgedSeed)
+	if err != nil {
+		t.Fatal(err)
+	}
+	input := filepath.Join(t.TempDir(), "seed_out_of_range.json")
+	if err := os.WriteFile(input, forgedRaw, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	output, err := exec.CommandContext(ctx, python, script, input, filepath.Join(t.TempDir(), "out.json")).CombinedOutput()
+	if err == nil || !bytes.Contains(output, []byte("configuration mismatch")) {
+		t.Fatalf("out-of-range KaHIP seed reached native call: err=%v output=%s", err, output)
 	}
 	shadowDir := t.TempDir()
 	shadowMarker := filepath.Join(shadowDir, "loaded")

--- a/cmd/treedb_vector_partition_bench/main_test.go
+++ b/cmd/treedb_vector_partition_bench/main_test.go
@@ -1592,6 +1592,31 @@ func TestKaHIPAdapterRoundTripV1(t *testing.T) {
 	if err == nil || !strings.Contains(err.Error(), "payload integrity") {
 		t.Fatalf("tampered installed payload accepted: %v", err)
 	}
+	for _, forgedCase := range []struct {
+		name, want string
+		partitions int
+	}{
+		{"partition_cap", "configuration mismatch", 16_385},
+		{"more_partitions_than_nodes", "invalid graph", len(request.IDs) + 1},
+	} {
+		var forged map[string]any
+		if err := json.Unmarshal(raw, &forged); err != nil {
+			t.Fatal(err)
+		}
+		forged["config"].(map[string]any)["partitions"] = forgedCase.partitions
+		forgedRaw, err := json.Marshal(forged)
+		if err != nil {
+			t.Fatal(err)
+		}
+		input := filepath.Join(t.TempDir(), forgedCase.name+".json")
+		if err := os.WriteFile(input, forgedRaw, 0o600); err != nil {
+			t.Fatal(err)
+		}
+		output, err := exec.CommandContext(ctx, python, script, input, filepath.Join(t.TempDir(), "out.json")).CombinedOutput()
+		if err == nil || !bytes.Contains(output, []byte(forgedCase.want)) {
+			t.Fatalf("forged %s request reached KaHIP: err=%v output=%s", forgedCase.name, err, output)
+		}
+	}
 }
 
 func TestPartitionLocalHNSWMIsIndependentAndM3OnlyV1(t *testing.T) {

--- a/cmd/treedb_vector_partition_bench/main_test.go
+++ b/cmd/treedb_vector_partition_bench/main_test.go
@@ -18,6 +18,7 @@ import (
 	"strconv"
 	"strings"
 	"testing"
+	"time"
 	"unsafe"
 
 	"github.com/snissn/gomap/TreeDB/collections"
@@ -1506,6 +1507,55 @@ func TestPartitionAssignmentParsesOnlyMaterializationStagesV1(t *testing.T) {
 		if _, err := parseConfig(args); err == nil {
 			t.Fatalf("accepted malformed assignment config %#v", args)
 		}
+	}
+}
+
+func TestKaHIPOfflineSelectorIsLimitedToGraphMaterializationV1(t *testing.T) {
+	base := []string{"-dataset", fixturePath(t), "-out", t.TempDir(), "-partitions", "4", "-partition-kahip-python", "/tmp/kahip-python"}
+	for _, stage := range []string{"partition", "overlap,partition_index"} {
+		cfg, err := parseConfig(append(append([]string(nil), base...), "-stage", stage))
+		if err != nil || cfg.kahipPython == "" {
+			t.Fatalf("stage=%s cfg=%+v err=%v", stage, cfg, err)
+		}
+	}
+	for _, args := range [][]string{
+		append(append([]string(nil), base...), "-stage", "simulation"),
+		append(append([]string(nil), base...), "-stage", "partition", "-partition-assignment", partitionAssignmentStableIDHashV1),
+	} {
+		if _, err := parseConfig(args); err == nil {
+			t.Fatalf("accepted KaHIP outside graph materialization: %#v", args)
+		}
+	}
+}
+
+func TestKaHIPAdapterRoundTripV1(t *testing.T) {
+	python := os.Getenv("TREEDB_KAHIP_PYTHON")
+	if python == "" {
+		t.Skip("set TREEDB_KAHIP_PYTHON to run the pinned offline KaHIP adapter")
+	}
+	cfg := vectorpartition.DefaultConfig()
+	cfg.Partitions, cfg.Pivots, cfg.MaxLeafBucket, cfg.Degree, cfg.Repetitions, cfg.MaxVectors, cfg.MaxEdges = 2, 2, 2, 2, 1, 16, 32
+	v := []vectorpartition.Vector{{ID: "a", Values: []float64{1, 0}}, {ID: "b", Values: []float64{.99, .01}}, {ID: "c", Values: []float64{0, 1}}, {ID: "d", Values: []float64{.01, .99}}}
+	request, err := vectorpartition.Build(v, cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	raw, err := vectorpartition.CanonicalJSON(request)
+	if err != nil {
+		t.Fatal(err)
+	}
+	script, err := filepath.Abs(filepath.Join("..", "..", "scripts", "treedb_kahip_partition.py"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
+	defer cancel()
+	got, err := vectorpartition.RunExternalJSONForRequestWithLimits(ctx, []string{python, script}, raw, vectorpartition.ExternalJSONLimits{MaxInput: len(raw), MaxOutput: len(raw) + 1024}, request)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Backend != "kahip_python_3.25_eco_symmetrized_v1_seed_1" || got.Metrics.MaxPartitionSize > got.Metrics.Cap {
+		t.Fatalf("invalid KaHIP artifact: %+v", got)
 	}
 }
 

--- a/cmd/treedb_vector_partition_bench/main_test.go
+++ b/cmd/treedb_vector_partition_bench/main_test.go
@@ -1564,6 +1564,22 @@ func TestKaHIPAdapterRoundTripV1(t *testing.T) {
 	if got.Backend != "kahip_python_3.25_eco_symmetrized_v1_seed_1" || got.Metrics.MaxPartitionSize > got.Metrics.Cap {
 		t.Fatalf("invalid KaHIP artifact: %+v", got)
 	}
+	adapter, err := os.ReadFile(script)
+	if err != nil {
+		t.Fatal(err)
+	}
+	wrongRecord := strings.Replace(string(adapter), "RECORD_SHA256 = \"7ff011253147286fcebc9185573662bf31dbcfbab1944f9b4940032f49ea5217\"", "RECORD_SHA256 = \"0000000000000000000000000000000000000000000000000000000000000000\"", 1)
+	if wrongRecord == string(adapter) {
+		t.Fatal("test did not replace pinned KaHIP distribution identity")
+	}
+	badScript := filepath.Join(t.TempDir(), "kahip_wrong_record.py")
+	if err := os.WriteFile(badScript, []byte(wrongRecord), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	_, err = vectorpartition.RunExternalJSONForRequestWithLimits(ctx, []string{python, badScript}, raw, vectorpartition.ExternalJSONLimits{MaxInput: len(raw), MaxOutput: len(raw) + 1024}, request)
+	if err == nil || !strings.Contains(err.Error(), "pinned kahip") {
+		t.Fatalf("same-version wrong distribution identity accepted: %v", err)
+	}
 }
 
 func TestPartitionLocalHNSWMIsIndependentAndM3OnlyV1(t *testing.T) {

--- a/cmd/treedb_vector_partition_bench/main_test.go
+++ b/cmd/treedb_vector_partition_bench/main_test.go
@@ -1546,6 +1546,41 @@ func TestKaHIPOutputCapAllowsCanonicalLabelGrowthV1(t *testing.T) {
 	}
 }
 
+func TestKaHIPFinalGraphEnvelopePreflightsBeforeBuildV1(t *testing.T) {
+	manifest := fixtureManifest{
+		SchemaVersion: schemaVersion, Fixture: "kahip-envelope", Generator: fixtureGenerator,
+		Arithmetic: fixtureArithmetic, Vectors: 250_001, Queries: 1, Dimensions: 1,
+		Metric: "cosine", Seed: 1, Checksum: strings.Repeat("0", 64),
+	}
+	raw, err := json.Marshal(manifest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	dataset := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dataset, "fixture_manifest.json"), raw, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	python := filepath.Join(t.TempDir(), "kahip-python")
+	if err := os.WriteFile(python, []byte("#!/bin/sh\n"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	script := filepath.Join(t.TempDir(), "kahip.py")
+	if err := os.WriteFile(script, []byte("# adapter\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	err = runWithHermeticProvenance(t, []string{
+		"-dataset", dataset, "-out", t.TempDir(), "-stage", "partition", "-partitions", "1",
+		"-partition-degree", "64", "-partition-repetitions", "1",
+		"-partition-kahip-python", python, "-partition-kahip-script", script,
+	}, io.Discard)
+	if err == nil || !strings.Contains(err.Error(), "KaHIP final directed-edge envelope") {
+		t.Fatalf("over-envelope KaHIP fixture reached build: %v", err)
+	}
+	if err := validateKaHIPFinalGraphEnvelopeV1(250_000, 64); err != nil {
+		t.Fatalf("16M degree-64 KaHIP shape rejected: %v", err)
+	}
+}
+
 func TestKaHIPAdapterRoundTripV1(t *testing.T) {
 	python := os.Getenv("TREEDB_KAHIP_PYTHON")
 	if python == "" {

--- a/cmd/treedb_vector_partition_bench/main_test.go
+++ b/cmd/treedb_vector_partition_bench/main_test.go
@@ -1508,25 +1508,6 @@ func TestPartitionAssignmentParsesOnlyMaterializationStagesV1(t *testing.T) {
 			t.Fatalf("accepted malformed assignment config %#v", args)
 		}
 	}
-	if runtime.GOOS != "windows" && os.Geteuid() != 0 {
-		t.Run("unreadable_script", func(t *testing.T) {
-			unreadable := filepath.Join(t.TempDir(), "unreadable.py")
-			if err := os.WriteFile(unreadable, []byte("# adapter\n"), 0o600); err != nil {
-				t.Fatal(err)
-			}
-			if err := os.Chmod(unreadable, 0); err != nil {
-				t.Fatal(err)
-			}
-			file, err := os.Open(unreadable)
-			if err == nil {
-				_ = file.Close()
-				t.Skip("current credentials can read a mode-000 regular file")
-			}
-			if _, err := parseConfig(append(append([]string(nil), base...), "-stage", "partition", "-partition-kahip-script", unreadable)); err == nil {
-				t.Fatal("accepted unreadable KaHIP adapter")
-			}
-		})
-	}
 }
 
 func TestKaHIPOfflineSelectorIsLimitedToGraphMaterializationV1(t *testing.T) {
@@ -1539,6 +1520,31 @@ func TestKaHIPOfflineSelectorIsLimitedToGraphMaterializationV1(t *testing.T) {
 		t.Fatal(err)
 	}
 	base := []string{"-dataset", fixturePath(t), "-out", t.TempDir(), "-partitions", "4", "-partition-kahip-python", python, "-partition-kahip-script", script}
+	if runtime.GOOS != "windows" && os.Geteuid() != 0 {
+		t.Run("unreadable_script", func(t *testing.T) {
+			unreadable := filepath.Join(t.TempDir(), "unreadable.py")
+			if err := os.WriteFile(unreadable, []byte("# adapter\n"), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			args := append([]string(nil), base...)
+			args[len(args)-1] = unreadable
+			args = append(args, "-stage", "partition")
+			if _, err := parseConfig(args); err != nil {
+				t.Fatalf("readable KaHIP adapter rejected: %v", err)
+			}
+			if err := os.Chmod(unreadable, 0); err != nil {
+				t.Fatal(err)
+			}
+			file, err := os.Open(unreadable)
+			if err == nil {
+				_ = file.Close()
+				t.Skip("current credentials can read a mode-000 regular file")
+			}
+			if _, err := parseConfig(args); err == nil {
+				t.Fatal("accepted unreadable KaHIP adapter")
+			}
+		})
+	}
 	for _, stage := range []string{"partition", "overlap,partition_index"} {
 		cfg, err := parseConfig(append(append([]string(nil), base...), "-stage", stage))
 		if err != nil || cfg.kahipPython != python || cfg.kahipScript != script {

--- a/cmd/treedb_vector_partition_bench/main_test.go
+++ b/cmd/treedb_vector_partition_bench/main_test.go
@@ -1511,10 +1511,18 @@ func TestPartitionAssignmentParsesOnlyMaterializationStagesV1(t *testing.T) {
 }
 
 func TestKaHIPOfflineSelectorIsLimitedToGraphMaterializationV1(t *testing.T) {
-	base := []string{"-dataset", fixturePath(t), "-out", t.TempDir(), "-partitions", "4", "-partition-kahip-python", "/tmp/kahip-python", "-partition-kahip-script", "/tmp/kahip.py"}
+	python := filepath.Join(t.TempDir(), "kahip-python")
+	if err := os.WriteFile(python, []byte("#!/bin/sh\n"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	script := filepath.Join(t.TempDir(), "kahip.py")
+	if err := os.WriteFile(script, []byte("# adapter\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	base := []string{"-dataset", fixturePath(t), "-out", t.TempDir(), "-partitions", "4", "-partition-kahip-python", python, "-partition-kahip-script", script}
 	for _, stage := range []string{"partition", "overlap,partition_index"} {
 		cfg, err := parseConfig(append(append([]string(nil), base...), "-stage", stage))
-		if err != nil || cfg.kahipPython == "" {
+		if err != nil || cfg.kahipPython != python || cfg.kahipScript != script {
 			t.Fatalf("stage=%s cfg=%+v err=%v", stage, cfg, err)
 		}
 	}
@@ -1522,6 +1530,8 @@ func TestKaHIPOfflineSelectorIsLimitedToGraphMaterializationV1(t *testing.T) {
 		append(append([]string(nil), base...), "-stage", "simulation"),
 		append(append([]string(nil), base...), "-stage", "partition", "-partition-assignment", partitionAssignmentStableIDHashV1),
 		append(append([]string(nil), base...), "-stage", "partition", "-imbalance", "0.04"),
+		append(append([]string(nil), base...), "-stage", "partition", "-partition-kahip-python", filepath.Join(t.TempDir(), "missing-python")),
+		append(append([]string(nil), base...), "-stage", "partition", "-partition-kahip-script", t.TempDir()),
 	} {
 		if _, err := parseConfig(args); err == nil {
 			t.Fatalf("accepted KaHIP outside graph materialization: %#v", args)

--- a/cmd/treedb_vector_partition_bench/main_test.go
+++ b/cmd/treedb_vector_partition_bench/main_test.go
@@ -1580,7 +1580,7 @@ func TestKaHIPAdapterRoundTripV1(t *testing.T) {
 	if err == nil || !strings.Contains(err.Error(), "pinned kahip") {
 		t.Fatalf("same-version wrong distribution identity accepted: %v", err)
 	}
-	badPayload := strings.Replace(string(adapter), "hashlib.sha256(payload).digest() != expected", "hashlib.sha256(payload).digest() == expected", 1)
+	badPayload := strings.Replace(string(adapter), "payload = distribution.locate_file(path).read_bytes()", "payload = distribution.locate_file(path).read_bytes() + b\"x\"", 1)
 	if badPayload == string(adapter) {
 		t.Fatal("test did not replace KaHIP payload integrity check")
 	}

--- a/scripts/treedb_kahip_partition.py
+++ b/scripts/treedb_kahip_partition.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python3
+"""Pinned offline KaHIP 3.25 adapter for TreeDB's validated JSON contract."""
+import json, os, sys
+# KaHIP's Python extension reads OpenMP settings during import. Force a single
+# worker so its offline output identity does not depend on host scheduling.
+os.environ["OMP_NUM_THREADS"] = "1"
+import kahip
+
+if len(sys.argv) != 3 or kahip.__version__ != "3.25":
+    raise SystemExit("requires kahip Python module version 3.25")
+with open(sys.argv[1], encoding="utf-8") as f: a = json.load(f)
+c = a["config"]
+if c["imbalance"] != 0.05 or c["partitions"] < 1:
+    raise SystemExit("KaHIP request identity/configuration mismatch")
+n = len(a["ids"])
+if n == 0 or n > 1_000_000 or len(a["graph"]["neighbors"]) != n:
+    raise SystemExit("invalid graph")
+rows=[set() for _ in range(n)]
+directed=0
+for u, ns in enumerate(a["graph"]["neighbors"]):
+    directed += len(ns)
+    # V1's canonical offline envelope is one million vectors at degree 16.
+    # Do not accept the broader graph-builder reservation (64M edges).
+    if directed > 16_000_000: raise SystemExit("selected KaHIP directed-edge envelope exceeded")
+    for v in ns:
+        if not isinstance(v, int) or v < 0 or v >= n or v == u: raise SystemExit("invalid graph edge")
+        rows[u].add(v); rows[v].add(u)
+xadj=[0]; adjncy=[]
+for ns in rows:
+    ns=sorted(ns)
+    adjncy.extend(ns); xadj.append(len(adjncy))
+cut, assignment = kahip.kaffpa([1]*n, xadj, [1]*len(adjncy), adjncy, c["partitions"], c["imbalance"], False, c["seed"], kahip.ECO)
+if len(assignment) != n or any(not isinstance(p,int) or p < 0 or p >= c["partitions"] for p in assignment): raise SystemExit("invalid KaHIP assignment")
+loads=[0]*c["partitions"]
+for p in assignment: loads[p]+=1
+if max(loads) > a["metrics"]["cap"] or min(loads) < 1: raise SystemExit("KaHIP assignment violates capacity")
+directed_cut=sum(assignment[u]!=assignment[v] for u,ns in enumerate(a["graph"]["neighbors"]) for v in ns)
+a["assignment"]=assignment
+a["backend"]="kahip_python_3.25_eco_symmetrized_v1_seed_%d" % c["seed"]
+a["backend_license"]="MIT; Python module kahip==3.25; ECO; epsilon=0.05; symmetrized_unweighted_v1"
+a["metrics"]["edge_cut"]=directed_cut
+a["metrics"]["max_partition_size"]=max(loads)
+with open(sys.argv[2],"w",encoding="utf-8") as f: json.dump(a,f,separators=(",",":"))

--- a/scripts/treedb_kahip_partition.py
+++ b/scripts/treedb_kahip_partition.py
@@ -59,11 +59,15 @@ with open(sys.argv[1], encoding="utf-8") as input_file:
     artifact = json.load(input_file)
 config = artifact["config"]
 partitions = config["partitions"]
+seed = config["seed"]
 if (
     config["imbalance"] != 0.05
     or type(partitions) is not int
     or partitions < 1
     or partitions > 16_384
+    or type(seed) is not int
+    or seed < -2_147_483_648
+    or seed > 2_147_483_647
 ):
     raise SystemExit("KaHIP request identity/configuration mismatch")
 nodes = len(artifact["ids"])
@@ -96,7 +100,7 @@ _, assignment = kahip.kaffpa(
     partitions,
     config["imbalance"],
     False,
-    config["seed"],
+    seed,
     1,  # KaHIP ECO mode
 )
 if len(assignment) != nodes or any(not isinstance(partition, int) or partition < 0 or partition >= partitions for partition in assignment):
@@ -112,7 +116,7 @@ directed_cut = sum(
     for target in targets
 )
 artifact["assignment"] = assignment
-artifact["backend"] = "kahip_python_3.25_eco_symmetrized_v1_seed_%d" % config["seed"]
+artifact["backend"] = "kahip_python_3.25_eco_symmetrized_v1_seed_%d" % seed
 artifact["backend_license"] = "MIT; kahip==3.25; wheel_sha256=%s; record_sha256=%s; ECO; epsilon=0.05; symmetrized_unweighted_v1" % (WHEEL_SHA256, RECORD_SHA256)
 artifact["metrics"]["edge_cut"] = directed_cut
 artifact["metrics"]["max_partition_size"] = max(loads)

--- a/scripts/treedb_kahip_partition.py
+++ b/scripts/treedb_kahip_partition.py
@@ -1,43 +1,91 @@
 #!/usr/bin/env python3
 """Pinned offline KaHIP 3.25 adapter for TreeDB's validated JSON contract."""
-import json, os, sys
+
+import hashlib
+import importlib.metadata
+import json
+import os
+import sys
+
 # KaHIP's Python extension reads OpenMP settings during import. Force a single
 # worker so its offline output identity does not depend on host scheduling.
 os.environ["OMP_NUM_THREADS"] = "1"
 import kahip
 
-if len(sys.argv) != 3 or kahip.__version__ != "3.25":
-    raise SystemExit("requires kahip Python module version 3.25")
-with open(sys.argv[1], encoding="utf-8") as f: a = json.load(f)
-c = a["config"]
-if c["imbalance"] != 0.05 or c["partitions"] < 1:
+WHEEL_SHA256 = "e6ea76524e9fc01b27e6f5c5f00b7eec71c94cbd1e84678ce2a14d64dfc9eda4"
+RECORD_SHA256 = "7ff011253147286fcebc9185573662bf31dbcfbab1944f9b4940032f49ea5217"
+
+
+def pinned_kahip():
+    distribution = importlib.metadata.distribution("kahip")
+    record = next(path for path in distribution.files if str(path).endswith("RECORD"))
+    record_hash = hashlib.sha256(distribution.locate_file(record).read_bytes()).hexdigest()
+    if (
+        kahip.__version__ != "3.25"
+        or distribution.version != "3.25"
+        or distribution.metadata["License"] != "MIT"
+        or record_hash != RECORD_SHA256
+    ):
+        raise SystemExit("requires pinned kahip==3.25 MIT distribution")
+
+
+if len(sys.argv) != 3:
+    raise SystemExit("usage: treedb_kahip_partition.py INPUT OUTPUT")
+pinned_kahip()
+with open(sys.argv[1], encoding="utf-8") as input_file:
+    artifact = json.load(input_file)
+config = artifact["config"]
+if config["imbalance"] != 0.05 or config["partitions"] < 1:
     raise SystemExit("KaHIP request identity/configuration mismatch")
-n = len(a["ids"])
-if n == 0 or n > 1_000_000 or len(a["graph"]["neighbors"]) != n:
+nodes = len(artifact["ids"])
+neighbors = artifact["graph"]["neighbors"]
+if nodes == 0 or nodes > 1_000_000 or len(neighbors) != nodes:
     raise SystemExit("invalid graph")
-rows=[set() for _ in range(n)]
-directed=0
-for u, ns in enumerate(a["graph"]["neighbors"]):
-    directed += len(ns)
+rows = [set() for _ in range(nodes)]
+directed = 0
+for source, targets in enumerate(neighbors):
+    directed += len(targets)
     # V1's canonical offline envelope is one million vectors at degree 16.
     # Do not accept the broader graph-builder reservation (64M edges).
-    if directed > 16_000_000: raise SystemExit("selected KaHIP directed-edge envelope exceeded")
-    for v in ns:
-        if not isinstance(v, int) or v < 0 or v >= n or v == u: raise SystemExit("invalid graph edge")
-        rows[u].add(v); rows[v].add(u)
-xadj=[0]; adjncy=[]
-for ns in rows:
-    ns=sorted(ns)
-    adjncy.extend(ns); xadj.append(len(adjncy))
-cut, assignment = kahip.kaffpa([1]*n, xadj, [1]*len(adjncy), adjncy, c["partitions"], c["imbalance"], False, c["seed"], kahip.ECO)
-if len(assignment) != n or any(not isinstance(p,int) or p < 0 or p >= c["partitions"] for p in assignment): raise SystemExit("invalid KaHIP assignment")
-loads=[0]*c["partitions"]
-for p in assignment: loads[p]+=1
-if max(loads) > a["metrics"]["cap"] or min(loads) < 1: raise SystemExit("KaHIP assignment violates capacity")
-directed_cut=sum(assignment[u]!=assignment[v] for u,ns in enumerate(a["graph"]["neighbors"]) for v in ns)
-a["assignment"]=assignment
-a["backend"]="kahip_python_3.25_eco_symmetrized_v1_seed_%d" % c["seed"]
-a["backend_license"]="MIT; Python module kahip==3.25; ECO; epsilon=0.05; symmetrized_unweighted_v1"
-a["metrics"]["edge_cut"]=directed_cut
-a["metrics"]["max_partition_size"]=max(loads)
-with open(sys.argv[2],"w",encoding="utf-8") as f: json.dump(a,f,separators=(",",":"))
+    if directed > 16_000_000:
+        raise SystemExit("selected KaHIP directed-edge envelope exceeded")
+    for target in targets:
+        if not isinstance(target, int) or target < 0 or target >= nodes or target == source:
+            raise SystemExit("invalid graph edge")
+        rows[source].add(target)
+        rows[target].add(source)
+xadj = [0]
+adjncy = []
+for row in rows:
+    adjncy.extend(sorted(row))
+    xadj.append(len(adjncy))
+_, assignment = kahip.kaffpa(
+    [1] * nodes,
+    xadj,
+    [1] * len(adjncy),
+    adjncy,
+    config["partitions"],
+    config["imbalance"],
+    False,
+    config["seed"],
+    kahip.ECO,
+)
+if len(assignment) != nodes or any(not isinstance(partition, int) or partition < 0 or partition >= config["partitions"] for partition in assignment):
+    raise SystemExit("invalid KaHIP assignment")
+loads = [0] * config["partitions"]
+for partition in assignment:
+    loads[partition] += 1
+if max(loads) > artifact["metrics"]["cap"] or min(loads) < 1:
+    raise SystemExit("KaHIP assignment violates capacity")
+directed_cut = sum(
+    assignment[source] != assignment[target]
+    for source, targets in enumerate(neighbors)
+    for target in targets
+)
+artifact["assignment"] = assignment
+artifact["backend"] = "kahip_python_3.25_eco_symmetrized_v1_seed_%d" % config["seed"]
+artifact["backend_license"] = "MIT; kahip==3.25; wheel_sha256=%s; record_sha256=%s; ECO; epsilon=0.05; symmetrized_unweighted_v1" % (WHEEL_SHA256, RECORD_SHA256)
+artifact["metrics"]["edge_cut"] = directed_cut
+artifact["metrics"]["max_partition_size"] = max(loads)
+with open(sys.argv[2], "w", encoding="utf-8") as output_file:
+    json.dump(artifact, output_file, separators=(",", ":"))

--- a/scripts/treedb_kahip_partition.py
+++ b/scripts/treedb_kahip_partition.py
@@ -51,11 +51,17 @@ if kahip.__version__ != "3.25":
 with open(sys.argv[1], encoding="utf-8") as input_file:
     artifact = json.load(input_file)
 config = artifact["config"]
-if config["imbalance"] != 0.05 or config["partitions"] < 1:
+partitions = config["partitions"]
+if (
+    config["imbalance"] != 0.05
+    or type(partitions) is not int
+    or partitions < 1
+    or partitions > 16_384
+):
     raise SystemExit("KaHIP request identity/configuration mismatch")
 nodes = len(artifact["ids"])
 neighbors = artifact["graph"]["neighbors"]
-if nodes == 0 or nodes > 1_000_000 or len(neighbors) != nodes:
+if nodes == 0 or nodes > 1_000_000 or partitions > nodes or len(neighbors) != nodes:
     raise SystemExit("invalid graph")
 rows = [set() for _ in range(nodes)]
 directed = 0
@@ -80,15 +86,15 @@ _, assignment = kahip.kaffpa(
     xadj,
     [1] * len(adjncy),
     adjncy,
-    config["partitions"],
+    partitions,
     config["imbalance"],
     False,
     config["seed"],
     kahip.ECO,
 )
-if len(assignment) != nodes or any(not isinstance(partition, int) or partition < 0 or partition >= config["partitions"] for partition in assignment):
+if len(assignment) != nodes or any(not isinstance(partition, int) or partition < 0 or partition >= partitions for partition in assignment):
     raise SystemExit("invalid KaHIP assignment")
-loads = [0] * config["partitions"]
+loads = [0] * partitions
 for partition in assignment:
     loads[partition] += 1
 if max(loads) > artifact["metrics"]["cap"] or min(loads) < 1:

--- a/scripts/treedb_kahip_partition.py
+++ b/scripts/treedb_kahip_partition.py
@@ -4,8 +4,8 @@
 import base64
 import csv
 import hashlib
-import importlib
 import importlib.metadata
+import importlib.util
 import json
 import os
 import sys
@@ -29,6 +29,7 @@ def pinned_kahip():
         or record_hash != RECORD_SHA256
     ):
         raise SystemExit("requires pinned kahip==3.25 MIT distribution")
+    extension_path = None
     for path, digest, size in csv.reader(record_bytes.decode("utf-8").splitlines()):
         if not digest:
             continue
@@ -39,15 +40,21 @@ def pinned_kahip():
         expected = base64.urlsafe_b64decode(encoded + "=" * (-len(encoded) % 4))
         if len(payload) != int(size) or hashlib.sha256(payload).digest() != expected:
             raise SystemExit("KaHIP RECORD payload integrity mismatch")
+        if str(path).startswith("kahip/kahip."):
+            extension_path = distribution.locate_file(path)
+    if extension_path is None:
+        raise SystemExit("pinned KaHIP native extension is missing")
+    return extension_path
 
 
 if len(sys.argv) != 3:
     raise SystemExit("usage: treedb_kahip_partition.py INPUT OUTPUT")
-pinned_kahip()
-kahip = importlib.import_module("kahip")
-
-if kahip.__version__ != "3.25":
-    raise SystemExit("requires pinned kahip==3.25 MIT distribution")
+extension_path = pinned_kahip()
+spec = importlib.util.spec_from_file_location("kahip.kahip", extension_path)
+if spec is None or spec.loader is None:
+    raise SystemExit("pinned KaHIP native extension is invalid")
+kahip = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(kahip)
 with open(sys.argv[1], encoding="utf-8") as input_file:
     artifact = json.load(input_file)
 config = artifact["config"]
@@ -90,7 +97,7 @@ _, assignment = kahip.kaffpa(
     config["imbalance"],
     False,
     config["seed"],
-    kahip.ECO,
+    1,  # KaHIP ECO mode
 )
 if len(assignment) != nodes or any(not isinstance(partition, int) or partition < 0 or partition >= partitions for partition in assignment):
     raise SystemExit("invalid KaHIP assignment")

--- a/scripts/treedb_kahip_partition.py
+++ b/scripts/treedb_kahip_partition.py
@@ -12,7 +12,6 @@ import sys
 # KaHIP's Python extension reads OpenMP settings during import. Force a single
 # worker so its offline output identity does not depend on host scheduling.
 os.environ["OMP_NUM_THREADS"] = "1"
-import kahip
 
 WHEEL_SHA256 = "e6ea76524e9fc01b27e6f5c5f00b7eec71c94cbd1e84678ce2a14d64dfc9eda4"
 RECORD_SHA256 = "7ff011253147286fcebc9185573662bf31dbcfbab1944f9b4940032f49ea5217"
@@ -24,8 +23,7 @@ def pinned_kahip():
     record_bytes = distribution.locate_file(record).read_bytes()
     record_hash = hashlib.sha256(record_bytes).hexdigest()
     if (
-        kahip.__version__ != "3.25"
-        or distribution.version != "3.25"
+        distribution.version != "3.25"
         or distribution.metadata["License"] != "MIT"
         or record_hash != RECORD_SHA256
     ):
@@ -45,6 +43,10 @@ def pinned_kahip():
 if len(sys.argv) != 3:
     raise SystemExit("usage: treedb_kahip_partition.py INPUT OUTPUT")
 pinned_kahip()
+import kahip
+
+if kahip.__version__ != "3.25":
+    raise SystemExit("requires pinned kahip==3.25 MIT distribution")
 with open(sys.argv[1], encoding="utf-8") as input_file:
     artifact = json.load(input_file)
 config = artifact["config"]

--- a/scripts/treedb_kahip_partition.py
+++ b/scripts/treedb_kahip_partition.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python3
 """Pinned offline KaHIP 3.25 adapter for TreeDB's validated JSON contract."""
 
+import base64
+import csv
 import hashlib
 import importlib.metadata
 import json
@@ -19,7 +21,8 @@ RECORD_SHA256 = "7ff011253147286fcebc9185573662bf31dbcfbab1944f9b4940032f49ea521
 def pinned_kahip():
     distribution = importlib.metadata.distribution("kahip")
     record = next(path for path in distribution.files if str(path).endswith("RECORD"))
-    record_hash = hashlib.sha256(distribution.locate_file(record).read_bytes()).hexdigest()
+    record_bytes = distribution.locate_file(record).read_bytes()
+    record_hash = hashlib.sha256(record_bytes).hexdigest()
     if (
         kahip.__version__ != "3.25"
         or distribution.version != "3.25"
@@ -27,6 +30,16 @@ def pinned_kahip():
         or record_hash != RECORD_SHA256
     ):
         raise SystemExit("requires pinned kahip==3.25 MIT distribution")
+    for path, digest, size in csv.reader(record_bytes.decode("utf-8").splitlines()):
+        if not digest:
+            continue
+        algorithm, encoded = digest.split("=", 1)
+        if algorithm != "sha256" or not size.isdecimal():
+            raise SystemExit("unsupported KaHIP RECORD entry")
+        payload = distribution.locate_file(path).read_bytes()
+        expected = base64.urlsafe_b64decode(encoded + "=" * (-len(encoded) % 4))
+        if len(payload) != int(size) or hashlib.sha256(payload).digest() != expected:
+            raise SystemExit("KaHIP RECORD payload integrity mismatch")
 
 
 if len(sys.argv) != 3:

--- a/scripts/treedb_kahip_partition.py
+++ b/scripts/treedb_kahip_partition.py
@@ -4,6 +4,7 @@
 import base64
 import csv
 import hashlib
+import importlib
 import importlib.metadata
 import json
 import os
@@ -43,7 +44,7 @@ def pinned_kahip():
 if len(sys.argv) != 3:
     raise SystemExit("usage: treedb_kahip_partition.py INPUT OUTPUT")
 pinned_kahip()
-import kahip
+kahip = importlib.import_module("kahip")
 
 if kahip.__version__ != "3.25":
     raise SystemExit("requires pinned kahip==3.25 MIT distribution")


### PR DESCRIPTION
Closes #4024

## Scope

Adds the smallest offline-only KaHIP 3.25 adapter through the existing exact-request external JSON seam. The selector is limited to graph primary materialization in partition and M3 build stages; no overlap policy, routing, or online dependency changes.

## Evidence

Retained 100k structured embedding-mixture graph `5a095727ed0f82815643daddb47bd11a08c9630ede6f9b1d7e7ec427dc8e9937`:

| backend | p4 primary oracle | directed cut | max load/cap |
|---|---:|---:|---:|
| reference greedy | 0.8303 | 1,122,051 | 6521/6563 |
| KaHIP Python 3.25 ECO, OMP=1 | 1.0 | 0 | 6283/6563 |

KaHIP artifact: `/mnt/fast4tb/gomap-4024-placement/out-kahip-head-4f4a293/vector_partition_022359b1aedf_ffd419418529_3dba078aad70.json`, SHA-256 `022359b1aedfa738cde7f2e82e01263c855eb72075b1f2a927d3a5753d6fde9c`. Build: 79.289s. Report SHA-256 `d11be251f48a054a272fb5eea9bbc741295662ff68ff13647f730f26fa258caa`. p1/p2/p4/p8/p16 are all 1.0; truth is diagnostic only. `kahip==3.25`, MIT, pinned RECORD SHA-256 `7ff011253147286fcebc9185573662bf31dbcfbab1944f9b4940032f49ea5217`; source wheel SHA-256 `e6ea76524e9fc01b27e6f5c5f00b7eec71c94cbd1e84678ce2a14d64dfc9eda4`. The bundled CLI is deliberately unused.

## Validation

- `TREEDB_KAHIP_PYTHON=/mnt/fast4tb/gomap-4024-kahip-3.25/bin/python go test ./cmd/treedb_vector_partition_bench -run 'TestKaHIP' -count=1`
- `go test ./TreeDB/internal/vectorpartition ./TreeDB/vectorpartition`

Existing external JSON seam coverage supplies cancellation, deadline, malformed-output, and input/output-cap failure checks. The prior macOS Root failure was unrelated: `TreeDB/db TestOrderedRootSpanNativeValueLogLeavesCheckpointReopenAndGC` failed with `ValueLogGC: treedb: recoverable root set changed`; this PR does not touch TreeDB/db, and sibling Root shards passed.

## Risks

Offline-only experimental structured-embedding placement. Invocation requires explicit pinned Python and adapter-script paths. The 16M directed-edge envelope is V1 canonical (1M vectors x degree 16), not the broader builder reservation. High-entropy qualification is separate #4030.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional offline KaHIP 3.25 partitioning for supported graph-materialization workflows.
  * Added deterministic partitioning with validated assignments, capacity limits, metadata, and edge-cut metrics.
  * Added bounded execution, input/output validation, integrity checks, and single-threaded processing.

* **Documentation**
  * Documented the pinned KaHIP configuration, provenance, resource limits, validation rules, and offline evaluation scope.

* **Tests**
  * Added coverage for supported configurations, output sizing, adapter integration, and artifact integrity validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->