### PR TITLE
vector: bind M3 routers to final overlap memberships

### DIFF
--- a/TreeDB/collections/vector_partition_router_v1.go
+++ b/TreeDB/collections/vector_partition_router_v1.go
@@ -250,8 +250,12 @@ func (c *Collection) BuildAndPublishVectorPartitionRouterV1(ctx context.Context,
 	if err != nil {
 		return fail(err)
 	}
+	finalMemberships := uint64(len(building.Memberships) + len(building.OverlapMemberships))
+	if finalMemberships > uint64(opts.Config.MaxVectors) {
+		return fail(fmt.Errorf("collections: vector partition router final memberships=%d exceed configured limit=%d", finalMemberships, opts.Config.MaxVectors))
+	}
 	maxRepresentatives, ok := checkedVectorPartitionRouterRepresentativeBoundV1(
-		building.SourceRowCount, building.PartitionCount, opts.Config.RepresentativesPerPartition,
+		finalMemberships, building.PartitionCount, opts.Config.RepresentativesPerPartition,
 	)
 	if !ok {
 		return fail(errors.New("collections: vector partition router representative preflight overflow"))
@@ -496,12 +500,15 @@ func validateVectorPartitionRouterInputV1(manifest VectorPartitionManifestV1, pa
 	if len(partitions) != int(manifest.PartitionCount) {
 		return fmt.Errorf("collections: vector partition router inputs=%d want partitions=%d", len(partitions), manifest.PartitionCount)
 	}
-	expected := make(map[uint32]map[uint64]struct{}, manifest.PartitionCount)
+	expected := make(map[uint32]map[uint64]string, manifest.PartitionCount)
 	for partitionID := uint32(0); partitionID < manifest.PartitionCount; partitionID++ {
-		expected[partitionID] = make(map[uint64]struct{})
+		expected[partitionID] = make(map[uint64]string)
 	}
 	for _, membership := range manifest.Memberships {
-		expected[membership.PartitionID][membership.VectorOrdinal] = struct{}{}
+		expected[membership.PartitionID][membership.VectorOrdinal] = string(VectorPartitionMembershipHomeV1)
+	}
+	for _, membership := range manifest.OverlapMemberships {
+		expected[membership.PartitionID][membership.VectorOrdinal] = string(VectorPartitionMembershipOverlapV1)
 	}
 	seenPartitions := make(map[uint32]struct{}, len(partitions))
 	for _, partition := range partitions {
@@ -513,15 +520,21 @@ func validateVectorPartitionRouterInputV1(manifest VectorPartitionManifestV1, pa
 		}
 		seenPartitions[partition.PartitionID] = struct{}{}
 		if len(partition.Vectors) != len(expected[partition.PartitionID]) {
-			return fmt.Errorf("collections: vector partition router partition %d vectors=%d want primary memberships=%d", partition.PartitionID, len(partition.Vectors), len(expected[partition.PartitionID]))
+			return fmt.Errorf("collections: vector partition router partition %d vectors=%d want final memberships=%d", partition.PartitionID, len(partition.Vectors), len(expected[partition.PartitionID]))
 		}
+		seenVectors := make(map[uint64]struct{}, len(partition.Vectors))
 		for _, vector := range partition.Vectors {
 			if len(vector.Values) != dimensions {
 				return fmt.Errorf("collections: vector partition router vector %d dimensions=%d want %d", vector.Ordinal, len(vector.Values), dimensions)
 			}
-			if _, exists := expected[partition.PartitionID][vector.Ordinal]; !exists {
-				return fmt.Errorf("collections: vector partition router vector %d is not a primary member of partition %d", vector.Ordinal, partition.PartitionID)
+			kind, exists := expected[partition.PartitionID][vector.Ordinal]
+			if !exists || vector.MembershipKind != string(kind) {
+				return fmt.Errorf("collections: vector partition router vector %d is not a final member of partition %d", vector.Ordinal, partition.PartitionID)
 			}
+			if _, exists := seenVectors[vector.Ordinal]; exists {
+				return fmt.Errorf("collections: duplicate vector partition router vector %d in partition %d", vector.Ordinal, partition.PartitionID)
+			}
+			seenVectors[vector.Ordinal] = struct{}{}
 		}
 	}
 	return nil
@@ -562,8 +575,9 @@ func (c *Collection) authoritativeVectorPartitionRouterInputV1(manifest VectorPa
 				}
 			}
 			authoritative[partitionOrdinal].Vectors[vectorOrdinal] = internalrouter.RouterVectorV1{
-				Ordinal: vector.Ordinal,
-				Values:  append([]float32(nil), source...),
+				Ordinal:        vector.Ordinal,
+				Values:         append([]float32(nil), source...),
+				MembershipKind: vector.MembershipKind,
 			}
 		}
 	}
@@ -636,7 +650,37 @@ func buildVectorPartitionRouterPackV1(manifest VectorPartitionManifestV1, model 
 	if err != nil {
 		return nil, err
 	}
+	input.MembershipDigest = vectorPartitionRouterFinalMembershipDigestV1(manifest)
 	return encodeColumnHNSWSearchPack(input)
+}
+
+// vectorPartitionRouterFinalMembershipDigestV1 binds a router asset to the
+// exact canonical home-plus-overlap relation, independently of its selected
+// representatives. Source identity is included so an ordinal cannot be reused
+// against a different vector generation.
+func vectorPartitionRouterFinalMembershipDigestV1(manifest VectorPartitionManifestV1) [sha256.Size]byte {
+	h := sha256.New()
+	h.Write([]byte("treedb/vector-partition-router-final-membership/v1"))
+	var encoded [8]byte
+	for _, value := range []uint64{manifest.SourceGeneration, manifest.SourceChecksum, manifest.SourceSchemaHash, manifest.SourceRowCount, manifest.Generation} {
+		binary.BigEndian.PutUint64(encoded[:], value)
+		h.Write(encoded[:])
+	}
+	for kind, memberships := range [][]VectorPartitionMembershipV1{manifest.Memberships, manifest.OverlapMemberships} {
+		binary.BigEndian.PutUint64(encoded[:], uint64(kind))
+		h.Write(encoded[:])
+		binary.BigEndian.PutUint64(encoded[:], uint64(len(memberships)))
+		h.Write(encoded[:])
+		for _, membership := range memberships {
+			binary.BigEndian.PutUint64(encoded[:], membership.VectorOrdinal)
+			h.Write(encoded[:])
+			binary.BigEndian.PutUint32(encoded[:4], membership.PartitionID)
+			h.Write(encoded[:4])
+		}
+	}
+	var digest [sha256.Size]byte
+	copy(digest[:], h.Sum(nil))
+	return digest
 }
 
 func checkedVectorPartitionRouterRepresentativeBoundV1(sourceRows uint64, partitions uint32, representativesPerPartition int) (uint64, bool) {
@@ -659,6 +703,12 @@ func checkedVectorPartitionRouterScalarWorkV1(manifest VectorPartitionManifestV1
 	}
 	counts := make([]uint64, manifest.PartitionCount)
 	for _, membership := range manifest.Memberships {
+		if membership.PartitionID >= manifest.PartitionCount {
+			return 0, false
+		}
+		counts[membership.PartitionID]++
+	}
+	for _, membership := range manifest.OverlapMemberships {
 		if membership.PartitionID >= manifest.PartitionCount {
 			return 0, false
 		}
@@ -1008,6 +1058,7 @@ func (c *Collection) openVectorPartitionRouterManifestWithContextV1(ctx context.
 			ManifestChecksum:   manifest.SourceChecksum,
 			SchemaHash:         manifest.SourceSchemaHash,
 		},
+		ExpectedMembershipDigest: vectorPartitionRouterFinalMembershipDigestV1(manifest),
 	})
 	if err != nil {
 		return nil, err

--- a/TreeDB/collections/vector_partition_router_v1_test.go
+++ b/TreeDB/collections/vector_partition_router_v1_test.go
@@ -293,15 +293,18 @@ func TestPartitionRouterBuildPublishSearchReopenAndPinsV1(t *testing.T) {
 	for partition := range partitions {
 		partitions[partition].PartitionID = uint32(partition)
 	}
-	for _, sourceRow := range sourceRows {
-		membership := building.Memberships[sourceRow.VectorOrdinal]
-		if membership.VectorOrdinal != sourceRow.VectorOrdinal {
-			t.Fatalf("noncanonical test membership ordinal=%d source=%d", membership.VectorOrdinal, sourceRow.VectorOrdinal)
+	for kind, memberships := range [][]VectorPartitionMembershipV1{building.Memberships, building.OverlapMemberships} {
+		for _, membership := range memberships {
+			if membership.VectorOrdinal >= uint64(len(sourceRows)) {
+				t.Fatalf("test membership ordinal=%d outside source rows", membership.VectorOrdinal)
+			}
+			sourceRow := sourceRows[membership.VectorOrdinal]
+			partitions[membership.PartitionID].Vectors = append(partitions[membership.PartitionID].Vectors, internalrouter.RouterVectorV1{
+				Ordinal:        sourceRow.VectorOrdinal,
+				Values:         sourceRow.Values,
+				MembershipKind: []string{string(VectorPartitionMembershipHomeV1), string(VectorPartitionMembershipOverlapV1)}[kind],
+			})
 		}
-		partitions[membership.PartitionID].Vectors = append(partitions[membership.PartitionID].Vectors, internalrouter.RouterVectorV1{
-			Ordinal: sourceRow.VectorOrdinal,
-			Values:  sourceRow.Values,
-		})
 	}
 	cfg := internalrouter.DefaultRouterConfigV1()
 	cfg.BranchFactor = 2
@@ -342,6 +345,15 @@ func TestPartitionRouterBuildPublishSearchReopenAndPinsV1(t *testing.T) {
 		ManifestGeneration: building.SourceGeneration,
 		ManifestChecksum:   building.SourceChecksum,
 		SchemaHash:         building.SourceSchemaHash,
+	}
+	wrongMembership := building
+	wrongMembership.OverlapMemberships = nil
+	wrongMembership.Canonicalize()
+	if _, err := decodeColumnHNSWSearchPack(firstPack, columnHNSWSearchPackDecodeOptions{
+		ExpectedBaseIdentity:     baseIdentity,
+		ExpectedMembershipDigest: vectorPartitionRouterFinalMembershipDigestV1(wrongMembership),
+	}); err == nil {
+		t.Fatal("router pack accepted a stale final-membership digest")
 	}
 	prepared, _ := testColumnHNSWSearchPackPreparedViewFromBytes2314(t, firstPack, mappedresource.SourceHeapCopy, baseIdentity)
 	stale := building
@@ -516,8 +528,9 @@ func cloneVectorPartitionRouterInputsV1(input []internalrouter.RouterPartitionV1
 		cloned[partitionOrdinal].Vectors = make([]internalrouter.RouterVectorV1, len(partition.Vectors))
 		for vectorOrdinal, vector := range partition.Vectors {
 			cloned[partitionOrdinal].Vectors[vectorOrdinal] = internalrouter.RouterVectorV1{
-				Ordinal: vector.Ordinal,
-				Values:  append([]float32(nil), vector.Values...),
+				Ordinal:        vector.Ordinal,
+				Values:         append([]float32(nil), vector.Values...),
+				MembershipKind: vector.MembershipKind,
 			}
 		}
 	}
@@ -636,6 +649,12 @@ func vectorPartitionRouterBuildingFixtureV1(t *testing.T, database *backenddb.DB
 		manifest.Memberships = append(manifest.Memberships, VectorPartitionMembershipV1{
 			VectorOrdinal: sourceRow.VectorOrdinal, PartitionID: uint32(inputOrdinal / 2),
 		})
+	}
+	for _, membership := range manifest.Memberships {
+		if membership.PartitionID == 0 {
+			manifest.OverlapMemberships = append(manifest.OverlapMemberships, VectorPartitionMembershipV1{VectorOrdinal: membership.VectorOrdinal, PartitionID: 1})
+			break
+		}
 	}
 	for ordinal, ref := range refs {
 		raw, err := readColumnPhysicalAssetFromManager(database.ColumnAssetRootDir(), ref)

--- a/TreeDB/internal/vectorpartition/overlap.go
+++ b/TreeDB/internal/vectorpartition/overlap.go
@@ -27,6 +27,15 @@ type Membership struct {
 
 const overlapReplicaPolicyV1 = "boundary_utility_v1"
 
+// ReplicaUtilityClassV1 is the authoritative utility classification for a
+// non-home membership.
+type ReplicaUtilityClassV1 string
+
+const (
+	ReplicaUtilityPositiveGainV1 ReplicaUtilityClassV1 = "positive_gain"
+	ReplicaUtilityZeroUtilityV1  ReplicaUtilityClassV1 = "zero_utility"
+)
+
 // Replica records the construction reason for one non-home membership. It is
 // diagnostic construction metadata only: no held-out query data contributes to
 // Gain or Class.
@@ -35,7 +44,7 @@ type Replica struct {
 	Partition     int
 	Policy        string
 	Gain          int
-	Class         string // positive_gain or zero_utility
+	Class         ReplicaUtilityClassV1
 }
 
 // OverlapResult is canonical (ordinal, partition order) and records budget
@@ -189,7 +198,7 @@ func BuildOverlap(a Artifact, cfg OverlapConfig) (OverlapResult, error) {
 			loads[p.part]++
 			used++
 			useful++
-			replicas = append(replicas, Replica{VectorOrdinal: p.node, Partition: p.part, Policy: overlapReplicaPolicyV1, Gain: gain, Class: "positive_gain"})
+			replicas = append(replicas, Replica{VectorOrdinal: p.node, Partition: p.part, Policy: overlapReplicaPolicyV1, Gain: gain, Class: ReplicaUtilityPositiveGainV1})
 			applied++
 		}
 		if applied == 0 {
@@ -273,10 +282,10 @@ func fillExactOverlapSlotsWithReplicas(a Artifact, members []map[int]struct{}, i
 				continue
 			}
 			gain := overlapCutReduction(members, i, partition, a.Graph.Neighbors[i], incoming[i])
-			class := "zero_utility"
+			class := ReplicaUtilityZeroUtilityV1
 			if gain > 0 {
 				useful++
-				class = "positive_gain"
+				class = ReplicaUtilityPositiveGainV1
 			} else {
 				filler++
 			}
@@ -354,13 +363,13 @@ func ValidateOverlap(a Artifact, cfg OverlapConfig, r OverlapResult) error {
 	}
 	seen := make(map[[2]int]struct{}, len(r.Memberships))
 	replicas := make(map[[2]int]Replica, len(r.Replicas))
-	utility := 0
+	utility, useful, filler := 0, 0, 0
 	destinations := make([]map[int]struct{}, a.Config.Partitions)
 	for partition := range destinations {
 		destinations[partition] = make(map[int]struct{})
 	}
 	for i, replica := range r.Replicas {
-		if replica.VectorOrdinal < 0 || replica.VectorOrdinal >= len(a.IDs) || replica.Partition < 0 || replica.Partition >= a.Config.Partitions || replica.Policy != overlapReplicaPolicyV1 || replica.Gain < 0 || (replica.Gain == 0 && replica.Class != "zero_utility") || (replica.Gain > 0 && replica.Class != "positive_gain") || (i > 0 && (replica.VectorOrdinal < r.Replicas[i-1].VectorOrdinal || replica.VectorOrdinal == r.Replicas[i-1].VectorOrdinal && replica.Partition <= r.Replicas[i-1].Partition)) {
+		if replica.VectorOrdinal < 0 || replica.VectorOrdinal >= len(a.IDs) || replica.Partition < 0 || replica.Partition >= a.Config.Partitions || replica.Policy != overlapReplicaPolicyV1 || replica.Gain < 0 || (replica.Gain == 0 && replica.Class != ReplicaUtilityZeroUtilityV1) || (replica.Gain > 0 && replica.Class != ReplicaUtilityPositiveGainV1) || (i > 0 && (replica.VectorOrdinal < r.Replicas[i-1].VectorOrdinal || replica.VectorOrdinal == r.Replicas[i-1].VectorOrdinal && replica.Partition <= r.Replicas[i-1].Partition)) {
 			return errors.New("invalid overlap replica")
 		}
 		key := [2]int{replica.VectorOrdinal, replica.Partition}
@@ -369,9 +378,14 @@ func ValidateOverlap(a Artifact, cfg OverlapConfig, r OverlapResult) error {
 		}
 		replicas[key] = replica
 		utility += replica.Gain
+		if replica.Class == ReplicaUtilityPositiveGainV1 {
+			useful++
+		} else {
+			filler++
+		}
 		destinations[replica.Partition][a.Assignment[replica.VectorOrdinal]] = struct{}{}
 	}
-	if utility != r.CumulativeUtility {
+	if utility != r.CumulativeUtility || useful != r.Useful || filler != r.Filler {
 		return errors.New("overlap utility accounting mismatch")
 	}
 	for partition := range destinations {

--- a/TreeDB/internal/vectorpartition/overlap.go
+++ b/TreeDB/internal/vectorpartition/overlap.go
@@ -25,19 +25,35 @@ type Membership struct {
 	Home          bool
 }
 
+const overlapReplicaPolicyV1 = "boundary_utility_v1"
+
+// Replica records the construction reason for one non-home membership. It is
+// diagnostic construction metadata only: no held-out query data contributes to
+// Gain or Class.
+type Replica struct {
+	VectorOrdinal int
+	Partition     int
+	Policy        string
+	Gain          int
+	Class         string // positive_gain or zero_utility
+}
+
 // OverlapResult is canonical (ordinal, partition order) and records budget
 // left unused when the capacity/affinity constraints prevent another move.
 type OverlapResult struct {
-	Memberships   []Membership
-	Budget        int
-	Used          int
-	Unspent       int
-	Capacity      int
-	Loads         []int
-	EdgeCutBefore int
-	EdgeCutAfter  int
-	Useful        int // memberships applied with a positive directed cut reduction
-	Filler        int // exact-target memberships added after useful proposals ended
+	Memberships          []Membership
+	Budget               int
+	Used                 int
+	Unspent              int
+	Capacity             int
+	Loads                []int
+	EdgeCutBefore        int
+	EdgeCutAfter         int
+	Useful               int // memberships applied with a positive directed cut reduction
+	Filler               int // exact-target memberships added after useful proposals ended
+	Replicas             []Replica
+	CumulativeUtility    int
+	DestinationDiversity []int
 }
 
 // OverlapShortfallError reports an exact-build request that could not be
@@ -88,6 +104,7 @@ func BuildOverlap(a Artifact, cfg OverlapConfig) (OverlapResult, error) {
 		}
 	}
 	used, useful, filler := 0, 0, 0
+	replicas := make([]Replica, 0, budget)
 	type proposal struct {
 		node, part, gain int
 		id               string
@@ -143,7 +160,7 @@ func BuildOverlap(a Artifact, cfg OverlapConfig) (OverlapResult, error) {
 			// is exhausted, deterministically fill remaining legal non-home
 			// slots. Adding memberships cannot increase the overlap edge cut.
 			if cfg.RequireExact {
-				filled, usefulFilled, fillerFilled := fillExactOverlapSlots(a, members, incoming, loads, capacity, budget-used)
+				filled, usefulFilled, fillerFilled := fillExactOverlapSlotsWithReplicas(a, members, incoming, loads, capacity, budget-used, &replicas)
 				used += filled
 				useful += usefulFilled
 				filler += fillerFilled
@@ -164,18 +181,20 @@ func BuildOverlap(a Artifact, cfg OverlapConfig) (OverlapResult, error) {
 			if _, exists := members[p.node][p.part]; exists {
 				continue
 			}
-			if overlapCutReduction(members, p.node, p.part, a.Graph.Neighbors[p.node], incoming[p.node]) == 0 {
+			gain := overlapCutReduction(members, p.node, p.part, a.Graph.Neighbors[p.node], incoming[p.node])
+			if gain == 0 {
 				continue
 			}
 			members[p.node][p.part] = struct{}{}
 			loads[p.part]++
 			used++
 			useful++
+			replicas = append(replicas, Replica{VectorOrdinal: p.node, Partition: p.part, Policy: overlapReplicaPolicyV1, Gain: gain, Class: "positive_gain"})
 			applied++
 		}
 		if applied == 0 {
 			if cfg.RequireExact {
-				filled, usefulFilled, fillerFilled := fillExactOverlapSlots(a, members, incoming, loads, capacity, budget-used)
+				filled, usefulFilled, fillerFilled := fillExactOverlapSlotsWithReplicas(a, members, incoming, loads, capacity, budget-used, &replicas)
 				used += filled
 				useful += usefulFilled
 				filler += fillerFilled
@@ -192,6 +211,7 @@ func BuildOverlap(a Artifact, cfg OverlapConfig) (OverlapResult, error) {
 		EdgeCutBefore: a.Metrics.EdgeCut,
 		Useful:        useful,
 		Filler:        filler,
+		Replicas:      replicas,
 	}
 	for i, set := range members {
 		for p := range set {
@@ -204,6 +224,24 @@ func BuildOverlap(a Artifact, cfg OverlapConfig) (OverlapResult, error) {
 		}
 		return out.Memberships[i].Partition < out.Memberships[j].Partition
 	})
+	sort.Slice(out.Replicas, func(i, j int) bool {
+		if out.Replicas[i].VectorOrdinal != out.Replicas[j].VectorOrdinal {
+			return out.Replicas[i].VectorOrdinal < out.Replicas[j].VectorOrdinal
+		}
+		return out.Replicas[i].Partition < out.Replicas[j].Partition
+	})
+	out.DestinationDiversity = make([]int, a.Config.Partitions)
+	destinations := make([]map[int]struct{}, a.Config.Partitions)
+	for partition := range destinations {
+		destinations[partition] = make(map[int]struct{})
+	}
+	for _, replica := range out.Replicas {
+		out.CumulativeUtility += replica.Gain
+		destinations[replica.Partition][a.Assignment[replica.VectorOrdinal]] = struct{}{}
+	}
+	for partition := range destinations {
+		out.DestinationDiversity[partition] = len(destinations[partition])
+	}
 	out.EdgeCutAfter = overlapEdgeCut(a, out.Memberships)
 	if cfg.RequireExact && out.Unspent != 0 {
 		return OverlapResult{}, &OverlapShortfallError{Requested: out.Budget, Realized: out.Used, Rejected: out.Unspent, Capacity: out.Capacity}
@@ -219,6 +257,10 @@ func BuildOverlap(a Artifact, cfg OverlapConfig) (OverlapResult, error) {
 // validated artifact; partition order is stable. A vector's durable cap and
 // the declared total-membership cap are both rechecked at application time.
 func fillExactOverlapSlots(a Artifact, members []map[int]struct{}, incoming [][]int, loads []int, capacity, remaining int) (used, useful, filler int) {
+	return fillExactOverlapSlotsWithReplicas(a, members, incoming, loads, capacity, remaining, nil)
+}
+
+func fillExactOverlapSlotsWithReplicas(a Artifact, members []map[int]struct{}, incoming [][]int, loads []int, capacity, remaining int, replicas *[]Replica) (used, useful, filler int) {
 	for i := range a.IDs {
 		if used == remaining || len(members[i])-1 >= MaxOverlapMembershipsPerVector {
 			continue
@@ -230,10 +272,16 @@ func fillExactOverlapSlots(a Artifact, members []map[int]struct{}, incoming [][]
 			if _, exists := members[i][partition]; exists {
 				continue
 			}
-			if overlapCutReduction(members, i, partition, a.Graph.Neighbors[i], incoming[i]) > 0 {
+			gain := overlapCutReduction(members, i, partition, a.Graph.Neighbors[i], incoming[i])
+			class := "zero_utility"
+			if gain > 0 {
 				useful++
+				class = "positive_gain"
 			} else {
 				filler++
+			}
+			if replicas != nil {
+				*replicas = append(*replicas, Replica{VectorOrdinal: i, Partition: partition, Policy: overlapReplicaPolicyV1, Gain: gain, Class: class})
 			}
 			members[i][partition] = struct{}{}
 			loads[partition]++
@@ -298,13 +346,39 @@ func ValidateOverlap(a Artifact, cfg OverlapConfig, r OverlapResult) error {
 	if capacity < a.Metrics.Cap {
 		return fmt.Errorf("overlap capacity %d below immutable home load cap %d", capacity, a.Metrics.Cap)
 	}
-	if r.Budget != wantBudget || r.Budget < 0 || r.Used < 0 || r.Used > r.Budget || r.Useful < 0 || r.Filler < 0 || r.Useful+r.Filler != r.Used || r.Unspent != r.Budget-r.Used || r.Capacity != capacity || len(r.Loads) != a.Config.Partitions || len(r.Memberships) != len(a.IDs)+r.Used || r.EdgeCutBefore != a.Metrics.EdgeCut {
+	if r.Budget != wantBudget || r.Budget < 0 || r.Used < 0 || r.Used > r.Budget || r.Useful < 0 || r.Filler < 0 || r.Useful+r.Filler != r.Used || r.Unspent != r.Budget-r.Used || r.Capacity != capacity || len(r.Loads) != a.Config.Partitions || len(r.Memberships) != len(a.IDs)+r.Used || len(r.Replicas) != r.Used || len(r.DestinationDiversity) != a.Config.Partitions || r.EdgeCutBefore != a.Metrics.EdgeCut {
 		return errors.New("invalid overlap accounting")
 	}
 	if cfg.RequireExact && r.Unspent != 0 {
 		return &OverlapShortfallError{Requested: r.Budget, Realized: r.Used, Rejected: r.Unspent, Capacity: r.Capacity}
 	}
 	seen := make(map[[2]int]struct{}, len(r.Memberships))
+	replicas := make(map[[2]int]Replica, len(r.Replicas))
+	utility := 0
+	destinations := make([]map[int]struct{}, a.Config.Partitions)
+	for partition := range destinations {
+		destinations[partition] = make(map[int]struct{})
+	}
+	for i, replica := range r.Replicas {
+		if replica.VectorOrdinal < 0 || replica.VectorOrdinal >= len(a.IDs) || replica.Partition < 0 || replica.Partition >= a.Config.Partitions || replica.Policy != overlapReplicaPolicyV1 || replica.Gain < 0 || (replica.Gain == 0 && replica.Class != "zero_utility") || (replica.Gain > 0 && replica.Class != "positive_gain") || (i > 0 && (replica.VectorOrdinal < r.Replicas[i-1].VectorOrdinal || replica.VectorOrdinal == r.Replicas[i-1].VectorOrdinal && replica.Partition <= r.Replicas[i-1].Partition)) {
+			return errors.New("invalid overlap replica")
+		}
+		key := [2]int{replica.VectorOrdinal, replica.Partition}
+		if _, exists := replicas[key]; exists {
+			return errors.New("duplicate overlap replica")
+		}
+		replicas[key] = replica
+		utility += replica.Gain
+		destinations[replica.Partition][a.Assignment[replica.VectorOrdinal]] = struct{}{}
+	}
+	if utility != r.CumulativeUtility {
+		return errors.New("overlap utility accounting mismatch")
+	}
+	for partition := range destinations {
+		if r.DestinationDiversity[partition] != len(destinations[partition]) {
+			return errors.New("overlap destination diversity mismatch")
+		}
+	}
 	homes := make([]int, len(a.IDs))
 	loads := make([]int, a.Config.Partitions)
 	perVector := make([]int, len(a.IDs))
@@ -325,6 +399,9 @@ func ValidateOverlap(a Artifact, cfg OverlapConfig, r OverlapResult) error {
 		}
 		loads[m.Partition]++
 		if !m.Home {
+			if _, exists := replicas[key]; !exists {
+				return errors.New("overlap replica membership is missing")
+			}
 			perVector[m.VectorOrdinal]++
 			if perVector[m.VectorOrdinal] > MaxOverlapMembershipsPerVector {
 				return errors.New("overlap membership per-vector cap exceeded")

--- a/TreeDB/internal/vectorpartition/overlap.go
+++ b/TreeDB/internal/vectorpartition/overlap.go
@@ -434,6 +434,8 @@ func ValidateOverlap(a Artifact, cfg OverlapConfig, r OverlapResult) error {
 	}
 	if got := overlapEdgeCut(a, r.Memberships); got != r.EdgeCutAfter || got > r.EdgeCutBefore {
 		return errors.New("invalid overlap edge-cut accounting")
+	} else if r.CumulativeUtility != r.EdgeCutBefore-got {
+		return errors.New("overlap utility does not match edge-cut reduction")
 	}
 	return nil
 }

--- a/TreeDB/internal/vectorpartition/overlap_test.go
+++ b/TreeDB/internal/vectorpartition/overlap_test.go
@@ -51,14 +51,17 @@ func TestOverlapDeterministicBoundaryAndZeroEquivalent(t *testing.T) {
 			{VectorOrdinal: 2, Partition: 1, Home: true},
 			{VectorOrdinal: 3, Partition: 1, Home: true},
 		},
-		Budget:        2,
-		Used:          1,
-		Unspent:       1,
-		Capacity:      4,
-		Loads:         []int{3, 2},
-		EdgeCutBefore: 4,
-		EdgeCutAfter:  0,
-		Useful:        1,
+		Budget:               2,
+		Used:                 1,
+		Unspent:              1,
+		Capacity:             4,
+		Loads:                []int{3, 2},
+		EdgeCutBefore:        4,
+		EdgeCutAfter:         0,
+		Useful:               1,
+		Replicas:             []Replica{{VectorOrdinal: 2, Partition: 0, Policy: overlapReplicaPolicyV1, Gain: 4, Class: "positive_gain"}},
+		CumulativeUtility:    4,
+		DestinationDiversity: []int{1, 0},
 	}
 	if !reflect.DeepEqual(one, want) {
 		t.Fatalf("boundary overlap=%+v want %+v", one, want)
@@ -106,6 +109,33 @@ func TestOverlapExactTreatmentFillsLegalNonAffinitySlotsV1(t *testing.T) {
 	}
 	if got.Budget != 2 || got.Used != 2 || got.Useful != 0 || got.Filler != 2 || got.Unspent != 0 || got.EdgeCutBefore != 0 || got.EdgeCutAfter != 0 {
 		t.Fatalf("exact fallback=%+v", got)
+	}
+	for _, replica := range got.Replicas {
+		if replica.Policy != overlapReplicaPolicyV1 || replica.Gain != 0 || replica.Class != "zero_utility" {
+			t.Fatalf("zero-cut replica was not honestly classified: %+v", replica)
+		}
+	}
+}
+
+func TestOverlapExactTreatmentRanksUtilityBeforeOrdinalFillV1(t *testing.T) {
+	c := Config{Metric: "cosine", Seed: 1, Repetitions: 1, Pivots: 2, MaxLeafBucket: 2, Degree: 3, Partitions: 2, Imbalance: 1, MaxVectors: 5, MaxEdges: 15}
+	v := []Vector{{"a", []float64{1}}, {"b", []float64{.9}}, {"c", []float64{.8}}, {"d", []float64{.7}}, {"e", []float64{.6}}}
+	built, err := Build(v, c)
+	if err != nil {
+		t.Fatal(err)
+	}
+	a := Artifact{SchemaVersion: SchemaVersion, Backend: "test", BackendLicense: "test", Source: built.Source, Config: c, IDs: []string{"a", "b", "c", "d", "e"}, Graph: Graph{Neighbors: [][]int{{}, {}, {}, {0, 1}, {}}}, Assignment: []int{0, 0, 1, 1, 1}}
+	a.Metrics = metrics(a)
+	got, err := BuildOverlap(a, OverlapConfig{Ratio: .4, Capacity: 5, RequireExact: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := []Replica{
+		{VectorOrdinal: 0, Partition: 1, Policy: overlapReplicaPolicyV1, Gain: 0, Class: "zero_utility"},
+		{VectorOrdinal: 3, Partition: 0, Policy: overlapReplicaPolicyV1, Gain: 2, Class: "positive_gain"},
+	}
+	if got.Used != 2 || got.Useful != 1 || got.Filler != 1 || got.CumulativeUtility != 2 || !reflect.DeepEqual(got.Replicas, want) {
+		t.Fatalf("utility order/fill=%+v want replicas=%+v", got, want)
 	}
 }
 

--- a/TreeDB/internal/vectorpartition/overlap_test.go
+++ b/TreeDB/internal/vectorpartition/overlap_test.go
@@ -66,6 +66,13 @@ func TestOverlapDeterministicBoundaryAndZeroEquivalent(t *testing.T) {
 	if !reflect.DeepEqual(one, want) {
 		t.Fatalf("boundary overlap=%+v want %+v", one, want)
 	}
+	tampered := one
+	tampered.Replicas = append([]Replica(nil), one.Replicas...)
+	tampered.Replicas[0].Gain++
+	tampered.CumulativeUtility++
+	if err := ValidateOverlap(a, OverlapConfig{Ratio: .5}, tampered); err == nil {
+		t.Fatal("utility detached from edge-cut reduction accepted")
+	}
 }
 
 func TestOverlapExactCapacityTreatmentV1(t *testing.T) {

--- a/TreeDB/internal/vectorpartition/overlap_test.go
+++ b/TreeDB/internal/vectorpartition/overlap_test.go
@@ -59,7 +59,7 @@ func TestOverlapDeterministicBoundaryAndZeroEquivalent(t *testing.T) {
 		EdgeCutBefore:        4,
 		EdgeCutAfter:         0,
 		Useful:               1,
-		Replicas:             []Replica{{VectorOrdinal: 2, Partition: 0, Policy: overlapReplicaPolicyV1, Gain: 4, Class: "positive_gain"}},
+		Replicas:             []Replica{{VectorOrdinal: 2, Partition: 0, Policy: overlapReplicaPolicyV1, Gain: 4, Class: ReplicaUtilityPositiveGainV1}},
 		CumulativeUtility:    4,
 		DestinationDiversity: []int{1, 0},
 	}
@@ -111,9 +111,14 @@ func TestOverlapExactTreatmentFillsLegalNonAffinitySlotsV1(t *testing.T) {
 		t.Fatalf("exact fallback=%+v", got)
 	}
 	for _, replica := range got.Replicas {
-		if replica.Policy != overlapReplicaPolicyV1 || replica.Gain != 0 || replica.Class != "zero_utility" {
+		if replica.Policy != overlapReplicaPolicyV1 || replica.Gain != 0 || replica.Class != ReplicaUtilityZeroUtilityV1 {
 			t.Fatalf("zero-cut replica was not honestly classified: %+v", replica)
 		}
+	}
+	tampered := got
+	tampered.Useful, tampered.Filler = got.Filler, got.Useful
+	if err := ValidateOverlap(a, OverlapConfig{Ratio: .5, Capacity: 3, RequireExact: true}, tampered); err == nil {
+		t.Fatal("aggregate replica-class swap accepted")
 	}
 }
 
@@ -131,8 +136,8 @@ func TestOverlapExactTreatmentRanksUtilityBeforeOrdinalFillV1(t *testing.T) {
 		t.Fatal(err)
 	}
 	want := []Replica{
-		{VectorOrdinal: 0, Partition: 1, Policy: overlapReplicaPolicyV1, Gain: 0, Class: "zero_utility"},
-		{VectorOrdinal: 3, Partition: 0, Policy: overlapReplicaPolicyV1, Gain: 2, Class: "positive_gain"},
+		{VectorOrdinal: 0, Partition: 1, Policy: overlapReplicaPolicyV1, Gain: 0, Class: ReplicaUtilityZeroUtilityV1},
+		{VectorOrdinal: 3, Partition: 0, Policy: overlapReplicaPolicyV1, Gain: 2, Class: ReplicaUtilityPositiveGainV1},
 	}
 	if got.Used != 2 || got.Useful != 1 || got.Filler != 1 || got.CumulativeUtility != 2 || !reflect.DeepEqual(got.Replicas, want) {
 		t.Fatalf("utility order/fill=%+v want replicas=%+v", got, want)

--- a/TreeDB/internal/vectorpartition/router.go
+++ b/TreeDB/internal/vectorpartition/router.go
@@ -15,7 +15,9 @@ import (
 )
 
 const (
-	routerMaxVectors         = 1_000_000
+	// A 1M-source V1 build can carry its exact 20% overlap membership into
+	// router construction without relaxing the bounded envelope.
+	routerMaxVectors         = 1_200_000
 	routerMaxDimensions      = 4096
 	routerMaxPartitions      = 16384
 	routerMaxRepresentatives = 1_000_000
@@ -58,8 +60,9 @@ func DefaultRouterConfigV1() RouterConfigV1 {
 }
 
 type RouterVectorV1 struct {
-	Ordinal uint64    `json:"ordinal"`
-	Values  []float32 `json:"values"`
+	Ordinal        uint64    `json:"ordinal"`
+	Values         []float32 `json:"values"`
+	MembershipKind string    `json:"membership_kind,omitempty"`
 }
 
 type RouterPartitionV1 struct {
@@ -161,9 +164,9 @@ func ValidateRouterConfigV1(cfg RouterConfigV1) error {
 	}
 }
 
-// BuildRouterV1 deterministically coarsens each disjoint partition into a
-// bounded hierarchy of cosine representatives. Input order does not affect the
-// result.
+// BuildRouterV1 deterministically coarsens each partition's canonical final
+// membership set into a bounded hierarchy of cosine representatives. A source
+// ordinal may occur in more than one partition, but never twice in one.
 func BuildRouterV1(partitions []RouterPartitionV1, cfg RouterConfigV1) (RouterModelV1, error) {
 	var model RouterModelV1
 	if err := ValidateRouterConfigV1(cfg); err != nil {
@@ -186,7 +189,6 @@ func BuildRouterV1(partitions []RouterPartitionV1, cfg RouterConfigV1) (RouterMo
 	dimensions := 0
 	totalVectors := 0
 	totalRepresentativeBudget := 0
-	seenOrdinals := make(map[uint64]struct{})
 	normalized := make([][]routerBuildVectorV1, len(input))
 	for partitionOrdinal, partition := range input {
 		if len(partition.Vectors) == 0 {
@@ -199,10 +201,6 @@ func BuildRouterV1(partitions []RouterPartitionV1, cfg RouterConfigV1) (RouterMo
 			if vectorOrdinal > 0 && vector.Ordinal == vectors[vectorOrdinal-1].Ordinal {
 				return model, fmt.Errorf("vectorpartition: duplicate router vector ordinal %d", vector.Ordinal)
 			}
-			if _, exists := seenOrdinals[vector.Ordinal]; exists {
-				return model, fmt.Errorf("vectorpartition: router vector ordinal %d appears in multiple partitions", vector.Ordinal)
-			}
-			seenOrdinals[vector.Ordinal] = struct{}{}
 			if dimensions == 0 {
 				dimensions = len(vector.Values)
 				if dimensions == 0 || dimensions > cfg.MaxDimensions {
@@ -438,7 +436,7 @@ func ValidateRouterModelWithContextV1(ctx context.Context, model RouterModelV1) 
 	var previousLeaf uint32
 	representativesPerPartition := make(map[uint32]int, len(roots))
 	representedLeaves := make(map[uint32]struct{}, len(model.Representatives))
-	representedSources := make(map[uint64]struct{}, len(model.Representatives))
+	representedSources := make(map[[2]uint64]struct{}, len(model.Representatives))
 	for i, representative := range model.Representatives {
 		if i&63 == 0 {
 			if err := ctx.Err(); err != nil {
@@ -459,10 +457,11 @@ func ValidateRouterModelWithContextV1(ctx context.Context, model RouterModelV1) 
 			return fmt.Errorf("vectorpartition: duplicate representative leaf %d", representative.LeafNodeID)
 		}
 		representedLeaves[representative.LeafNodeID] = struct{}{}
-		if _, exists := representedSources[representative.SourceOrdinal]; exists {
-			return fmt.Errorf("vectorpartition: duplicate representative source ordinal %d", representative.SourceOrdinal)
+		sourceKey := [2]uint64{uint64(representative.PartitionID), representative.SourceOrdinal}
+		if _, exists := representedSources[sourceKey]; exists {
+			return fmt.Errorf("vectorpartition: duplicate representative source ordinal %d in partition %d", representative.SourceOrdinal, representative.PartitionID)
 		}
-		representedSources[representative.SourceOrdinal] = struct{}{}
+		representedSources[sourceKey] = struct{}{}
 		representativesPerPartition[representative.PartitionID]++
 		if representativesPerPartition[representative.PartitionID] > model.Config.RepresentativesPerPartition {
 			return fmt.Errorf("vectorpartition: partition %d exceeds representative budget", representative.PartitionID)

--- a/TreeDB/vectorpartition/api.go
+++ b/TreeDB/vectorpartition/api.go
@@ -30,12 +30,15 @@ type RouterRouteResultV1 = internal.RouterRouteResultV1
 type OverlapConfig = internal.OverlapConfig
 type Membership = internal.Membership
 type Replica = internal.Replica
+type ReplicaUtilityClassV1 = internal.ReplicaUtilityClassV1
 type OverlapResult = internal.OverlapResult
 type OverlapShortfallError = internal.OverlapShortfallError
 
 const (
 	SchemaVersion                  = internal.SchemaVersion
 	MaxOverlapMembershipsPerVector = internal.MaxOverlapMembershipsPerVector
+	ReplicaUtilityPositiveGainV1   = internal.ReplicaUtilityPositiveGainV1
+	ReplicaUtilityZeroUtilityV1    = internal.ReplicaUtilityZeroUtilityV1
 )
 
 func DefaultConfig() Config         { return internal.DefaultConfig() }

--- a/TreeDB/vectorpartition/api.go
+++ b/TreeDB/vectorpartition/api.go
@@ -29,6 +29,7 @@ type RouterPartitionScoreV1 = internal.RouterPartitionScoreV1
 type RouterRouteResultV1 = internal.RouterRouteResultV1
 type OverlapConfig = internal.OverlapConfig
 type Membership = internal.Membership
+type Replica = internal.Replica
 type OverlapResult = internal.OverlapResult
 type OverlapShortfallError = internal.OverlapShortfallError
 

--- a/cmd/treedb_vector_partition_bench/m3_partition_index.go
+++ b/cmd/treedb_vector_partition_bench/m3_partition_index.go
@@ -22,7 +22,7 @@ import (
 )
 
 const (
-	m3ReportSchemaVersion   = 3
+	m3ReportSchemaVersion   = 4
 	m3BenchmarkCollection   = "m3_partition_source"
 	m3WarmupPasses          = 1
 	m3SourceInsertBatchRows = 8 * 1024
@@ -55,57 +55,68 @@ type m3PartitionIndexReport struct {
 }
 
 type m3PartitionIndexRow struct {
-	Ratio                        float64 `json:"ratio"`
-	Budget                       int     `json:"budget"`
-	Used                         int     `json:"used"`
-	Unspent                      int     `json:"unspent"`
-	Capacity                     int     `json:"capacity"`
-	OverlapRequested             int     `json:"overlap_requested"`
-	OverlapRealized              int     `json:"overlap_realized"`
-	OverlapRejected              int     `json:"overlap_rejected"`
-	OverlapUseful                int     `json:"overlap_useful"`
-	OverlapFiller                int     `json:"overlap_filler"`
-	OverlapUnusedCapacity        int     `json:"overlap_unused_capacity"`
-	CutReductionPerUsefulReplica float64 `json:"cut_reduction_per_useful_replica"`
-	ReplicationFactor            float64 `json:"replication_factor"`
-	PartitionLoads               []int   `json:"partition_loads"`
-	EdgeCutBefore                int     `json:"edge_cut_before"`
-	EdgeCutAfter                 int     `json:"edge_cut_after"`
-	BuildWallNanos               int64   `json:"build_wall_nanos"`
-	PeakRSSBytes                 int64   `json:"peak_rss_bytes"`
-	PeakRSSAvailable             bool    `json:"peak_rss_available"`
-	ResidentBytes                int64   `json:"resident_bytes"`
-	ResidentBytesAvailable       bool    `json:"resident_bytes_available"`
-	SourcePhysicalBytes          int64   `json:"source_physical_bytes"`
-	PeakDerivedTemporaryBytes    int64   `json:"peak_derived_temporary_bytes"`
-	FinalDerivedPhysicalBytes    int64   `json:"final_derived_physical_bytes"`
-	PhysicalBytesPerSourceVector float64 `json:"physical_bytes_per_source_vector"`
-	PackBytes                    uint64  `json:"pack_payload_bytes"`
-	PartitionHNSWM               int     `json:"partition_hnsw_m"`
-	MappedBytes                  uint64  `json:"mapped_bytes"`
-	HeapBytes                    uint64  `json:"heap_bytes"`
-	SearcherOpenWallNanos        int64   `json:"searcher_open_wall_nanos"`
-	PackOpenNanos                uint64  `json:"pack_open_nanos"`
-	Queries                      int     `json:"queries"`
-	LocalSearches                int     `json:"local_searches"`
-	WarmupPasses                 int     `json:"warmup_passes"`
-	WarmNSPerOp                  float64 `json:"warm_ns_per_op"`
-	WarmQPS                      float64 `json:"warm_qps"`
-	WarmBytesPerOp               float64 `json:"warm_bytes_per_op"`
-	WarmAllocsPerOp              float64 `json:"warm_allocs_per_op"`
-	CandidatesPerOp              float64 `json:"candidates_per_op"`
-	EdgesPerOp                   float64 `json:"edges_per_op"`
-	ExactLocalRecallAtK          float64 `json:"exact_local_recall_at_k"`
-	ManifestDigest               string  `json:"manifest_digest"`
-	SourceGeneration             uint64  `json:"source_generation"`
-	SourceChecksum               uint64  `json:"source_checksum"`
-	SourceSchemaHash             uint64  `json:"source_schema_hash"`
-	SourceRows                   uint64  `json:"source_rows"`
-	SearchRoute                  string  `json:"search_route"`
-	MissingAssets                uint64  `json:"missing_assets"`
-	CorruptAssets                uint64  `json:"corrupt_assets"`
-	StaleAssets                  uint64  `json:"stale_assets"`
-	PersistentDBDir              string  `json:"persistent_db_dir,omitempty"`
+	Ratio                        float64            `json:"ratio"`
+	Budget                       int                `json:"budget"`
+	Used                         int                `json:"used"`
+	Unspent                      int                `json:"unspent"`
+	Capacity                     int                `json:"capacity"`
+	OverlapRequested             int                `json:"overlap_requested"`
+	OverlapRealized              int                `json:"overlap_realized"`
+	OverlapRejected              int                `json:"overlap_rejected"`
+	OverlapUseful                int                `json:"overlap_useful"`
+	OverlapFiller                int                `json:"overlap_filler"`
+	OverlapCumulativeUtility     int                `json:"overlap_cumulative_utility"`
+	OverlapDestinationDiversity  []int              `json:"overlap_destination_diversity"`
+	OverlapReplicas              []m3OverlapReplica `json:"overlap_replicas"`
+	OverlapUnusedCapacity        int                `json:"overlap_unused_capacity"`
+	CutReductionPerUsefulReplica float64            `json:"cut_reduction_per_useful_replica"`
+	ReplicationFactor            float64            `json:"replication_factor"`
+	PartitionLoads               []int              `json:"partition_loads"`
+	EdgeCutBefore                int                `json:"edge_cut_before"`
+	EdgeCutAfter                 int                `json:"edge_cut_after"`
+	BuildWallNanos               int64              `json:"build_wall_nanos"`
+	PeakRSSBytes                 int64              `json:"peak_rss_bytes"`
+	PeakRSSAvailable             bool               `json:"peak_rss_available"`
+	ResidentBytes                int64              `json:"resident_bytes"`
+	ResidentBytesAvailable       bool               `json:"resident_bytes_available"`
+	SourcePhysicalBytes          int64              `json:"source_physical_bytes"`
+	PeakDerivedTemporaryBytes    int64              `json:"peak_derived_temporary_bytes"`
+	FinalDerivedPhysicalBytes    int64              `json:"final_derived_physical_bytes"`
+	PhysicalBytesPerSourceVector float64            `json:"physical_bytes_per_source_vector"`
+	PackBytes                    uint64             `json:"pack_payload_bytes"`
+	PartitionHNSWM               int                `json:"partition_hnsw_m"`
+	MappedBytes                  uint64             `json:"mapped_bytes"`
+	HeapBytes                    uint64             `json:"heap_bytes"`
+	SearcherOpenWallNanos        int64              `json:"searcher_open_wall_nanos"`
+	PackOpenNanos                uint64             `json:"pack_open_nanos"`
+	Queries                      int                `json:"queries"`
+	LocalSearches                int                `json:"local_searches"`
+	WarmupPasses                 int                `json:"warmup_passes"`
+	WarmNSPerOp                  float64            `json:"warm_ns_per_op"`
+	WarmQPS                      float64            `json:"warm_qps"`
+	WarmBytesPerOp               float64            `json:"warm_bytes_per_op"`
+	WarmAllocsPerOp              float64            `json:"warm_allocs_per_op"`
+	CandidatesPerOp              float64            `json:"candidates_per_op"`
+	EdgesPerOp                   float64            `json:"edges_per_op"`
+	ExactLocalRecallAtK          float64            `json:"exact_local_recall_at_k"`
+	ManifestDigest               string             `json:"manifest_digest"`
+	SourceGeneration             uint64             `json:"source_generation"`
+	SourceChecksum               uint64             `json:"source_checksum"`
+	SourceSchemaHash             uint64             `json:"source_schema_hash"`
+	SourceRows                   uint64             `json:"source_rows"`
+	SearchRoute                  string             `json:"search_route"`
+	MissingAssets                uint64             `json:"missing_assets"`
+	CorruptAssets                uint64             `json:"corrupt_assets"`
+	StaleAssets                  uint64             `json:"stale_assets"`
+	PersistentDBDir              string             `json:"persistent_db_dir,omitempty"`
+}
+
+type m3OverlapReplica struct {
+	SourceOrdinal uint64 `json:"source_ordinal"`
+	Destination   int    `json:"destination"`
+	Policy        string `json:"policy"`
+	Gain          int    `json:"gain"`
+	Class         string `json:"class"`
 }
 
 func runM3PartitionIndexStage(cfg config, fixture fixtureManifest, artifact vectorpartition.Artifact, artifactDigest, graphArtifactDigest, suffix string, vectors, queries [][]float64, stdout io.Writer) error {
@@ -368,9 +379,16 @@ func benchmarkM3PartitionIndexRow(cfg config, fixture fixtureManifest, artifactD
 	if err != nil {
 		return m3PartitionIndexRow{}, err
 	}
-	routerPartitions, err := m3RouterPartitions(artifact, sourceOrdinals, vectors)
+	routerPartitions, err := m3RouterPartitions(artifact, overlap, sourceOrdinals, vectors)
 	if err != nil {
 		return m3PartitionIndexRow{}, err
+	}
+	replicaSourceOrdinals := make([]uint64, len(overlap.Replicas))
+	for i, replica := range overlap.Replicas {
+		if replica.VectorOrdinal < 0 || replica.VectorOrdinal >= len(sourceOrdinals) {
+			return m3PartitionIndexRow{}, errors.New("M3 overlap replica ordinal is invalid")
+		}
+		replicaSourceOrdinals[i] = uint64(sourceOrdinals[replica.VectorOrdinal])
 	}
 	sourceRows = nil
 	sourceOrdinals = nil
@@ -602,6 +620,8 @@ func benchmarkM3PartitionIndexRow(cfg config, fixture fixtureManifest, artifactD
 		OverlapRejected:              overlap.Unspent,
 		OverlapUseful:                overlap.Useful,
 		OverlapFiller:                overlap.Filler,
+		OverlapCumulativeUtility:     overlap.CumulativeUtility,
+		OverlapDestinationDiversity:  append([]int(nil), overlap.DestinationDiversity...),
 		OverlapUnusedCapacity:        unusedCapacity,
 		CutReductionPerUsefulReplica: cutReductionPerUseful,
 		ReplicationFactor:            float64(len(overlap.Memberships)) / float64(len(artifact.IDs)),
@@ -643,6 +663,10 @@ func benchmarkM3PartitionIndexRow(cfg config, fixture fixtureManifest, artifactD
 		CorruptAssets:                lifecycle.CorruptAssets,
 		StaleAssets:                  lifecycle.StaleAssets,
 		PersistentDBDir:              persistentDBDir,
+	}
+	row.OverlapReplicas = make([]m3OverlapReplica, len(overlap.Replicas))
+	for i, replica := range overlap.Replicas {
+		row.OverlapReplicas[i] = m3OverlapReplica{SourceOrdinal: replicaSourceOrdinals[i], Destination: replica.Partition, Policy: replica.Policy, Gain: replica.Gain, Class: replica.Class}
 	}
 	if !cleanup {
 		descriptor := m3VariantDescriptorV1{
@@ -750,9 +774,9 @@ func m3SourceOrdinalsByArtifactID(artifact vectorpartition.Artifact, rows []coll
 	return sourceOrdinals, nil
 }
 
-func m3RouterPartitions(artifact vectorpartition.Artifact, sourceOrdinals []int, vectors [][]float64) ([]vectorpartition.RouterPartitionV1, error) {
+func m3RouterPartitions(artifact vectorpartition.Artifact, overlap vectorpartition.OverlapResult, sourceOrdinals []int, vectors [][]float64) ([]vectorpartition.RouterPartitionV1, error) {
 	if len(artifact.Assignment) == 0 || len(artifact.Assignment) != len(sourceOrdinals) || len(vectors) != len(sourceOrdinals) ||
-		artifact.Config.Partitions < 1 || len(vectors[0]) < 1 {
+		artifact.Config.Partitions < 1 || len(vectors[0]) < 1 || len(overlap.Memberships) < len(artifact.Assignment) {
 		return nil, errors.New("M3 router source shape mismatch")
 	}
 	dimensions := len(vectors[0])
@@ -762,12 +786,22 @@ func m3RouterPartitions(artifact vectorpartition.Artifact, sourceOrdinals []int,
 	counts := make([]int, artifact.Config.Partitions)
 	seenSourceOrdinals := make([]bool, len(sourceOrdinals))
 	for ordinal, partition := range artifact.Assignment {
-		if partition < 0 || partition >= len(counts) || sourceOrdinals[ordinal] < 0 || sourceOrdinals[ordinal] >= len(vectors) ||
-			seenSourceOrdinals[sourceOrdinals[ordinal]] || len(vectors[ordinal]) != dimensions {
+		if partition < 0 || partition >= len(counts) || sourceOrdinals[ordinal] < 0 || sourceOrdinals[ordinal] >= len(vectors) || seenSourceOrdinals[sourceOrdinals[ordinal]] || len(vectors[ordinal]) != dimensions {
 			return nil, errors.New("M3 router assignment or source ordinal is invalid")
 		}
 		seenSourceOrdinals[sourceOrdinals[ordinal]] = true
-		counts[partition]++
+	}
+	seenMemberships := make(map[[2]int]struct{}, len(overlap.Memberships))
+	for _, membership := range overlap.Memberships {
+		if membership.VectorOrdinal < 0 || membership.VectorOrdinal >= len(vectors) || membership.Partition < 0 || membership.Partition >= len(counts) || membership.Home != (membership.Partition == artifact.Assignment[membership.VectorOrdinal]) {
+			return nil, errors.New("M3 final router membership is invalid")
+		}
+		key := [2]int{membership.VectorOrdinal, membership.Partition}
+		if _, duplicate := seenMemberships[key]; duplicate {
+			return nil, errors.New("M3 final router membership is duplicate")
+		}
+		seenMemberships[key] = struct{}{}
+		counts[membership.Partition]++
 	}
 	partitions := make([]vectorpartition.RouterPartitionV1, len(counts))
 	for partition := range partitions {
@@ -775,15 +809,21 @@ func m3RouterPartitions(artifact vectorpartition.Artifact, sourceOrdinals []int,
 		partitions[partition].Vectors = make([]vectorpartition.RouterVectorV1, 0, counts[partition])
 	}
 	values := make([]float32, len(vectors)*dimensions)
-	for artifactOrdinal, partition := range artifact.Assignment {
+	for _, membership := range overlap.Memberships {
+		artifactOrdinal, partition := membership.VectorOrdinal, membership.Partition
 		offset := artifactOrdinal * dimensions
 		row := values[offset : offset+dimensions : offset+dimensions]
 		for dimension, value := range vectors[artifactOrdinal] {
 			row[dimension] = float32(value)
 		}
+		kind := string(collections.VectorPartitionMembershipOverlapV1)
+		if membership.Home {
+			kind = string(collections.VectorPartitionMembershipHomeV1)
+		}
 		partitions[partition].Vectors = append(partitions[partition].Vectors, vectorpartition.RouterVectorV1{
-			Ordinal: uint64(sourceOrdinals[artifactOrdinal]),
-			Values:  row,
+			Ordinal:        uint64(sourceOrdinals[artifactOrdinal]),
+			Values:         row,
+			MembershipKind: kind,
 		})
 	}
 	return partitions, nil
@@ -972,6 +1012,41 @@ func validateM3PartitionIndexReport(report m3PartitionIndexReport) error {
 		}
 		if row.Budget != wantBudget || row.Used != wantBudget || row.OverlapRequested != wantBudget || row.OverlapRealized != wantBudget || row.Budget < 0 || row.Used < 0 || row.Unspent != row.Budget-row.Used || row.Capacity < 1 || row.OverlapRejected != row.Unspent || row.OverlapRejected != 0 || row.OverlapUseful < 0 || row.OverlapFiller < 0 || row.OverlapUseful+row.OverlapFiller != row.OverlapRealized || row.OverlapUnusedCapacity != wantUnusedCapacity || row.CutReductionPerUsefulReplica != wantCutReductionPerUseful || row.ReplicationFactor < 1 || row.EdgeCutAfter > row.EdgeCutBefore || row.BuildWallNanos <= 0 || row.SourcePhysicalBytes <= 0 || row.PeakDerivedTemporaryBytes < row.FinalDerivedPhysicalBytes || row.FinalDerivedPhysicalBytes <= 0 || row.PackBytes == 0 || row.PartitionHNSWM < 2 || row.FinalDerivedPhysicalBytes < int64(row.PackBytes) || row.PhysicalBytesPerSourceVector <= 0 || row.SearcherOpenWallNanos <= 0 || row.PackOpenNanos == 0 || row.LocalSearches <= 0 || row.WarmNSPerOp <= 0 || row.WarmQPS <= 0 || row.CandidatesPerOp <= 0 || row.ExactLocalRecallAtK < 0 || row.ExactLocalRecallAtK > 1 || row.ManifestDigest == "" || row.SourceRows != uint64(report.Dataset.Vectors) || row.SearchRoute != collections.VectorPartitionSearchRouteHNSWSearchPackV1 || row.MissingAssets != 0 || row.CorruptAssets != 0 || row.StaleAssets != 0 {
 			return fmt.Errorf("invalid M3 evidence row: %+v", row)
+		}
+		if len(row.OverlapReplicas) != row.OverlapRealized || len(row.OverlapDestinationDiversity) != len(row.PartitionLoads) {
+			return fmt.Errorf("invalid M3 overlap replica evidence: %+v", row)
+		}
+		utility, useful, filler := 0, 0, 0
+		seenReplica := make(map[[2]uint64]struct{}, len(row.OverlapReplicas))
+		for _, replica := range row.OverlapReplicas {
+			key := [2]uint64{replica.SourceOrdinal, uint64(replica.Destination)}
+			if replica.Destination < 0 || replica.Destination >= len(row.PartitionLoads) || replica.Policy == "" || replica.Gain < 0 || (replica.Class != "positive_gain" && replica.Class != "zero_utility") {
+				return fmt.Errorf("invalid M3 overlap replica: %+v", replica)
+			}
+			if _, duplicate := seenReplica[key]; duplicate {
+				return fmt.Errorf("duplicate M3 overlap replica: %+v", replica)
+			}
+			seenReplica[key] = struct{}{}
+			utility += replica.Gain
+			if replica.Class == "positive_gain" {
+				if replica.Gain == 0 {
+					return fmt.Errorf("zero-gain positive M3 overlap replica: %+v", replica)
+				}
+				useful++
+			} else {
+				if replica.Gain != 0 {
+					return fmt.Errorf("positive-gain filler M3 overlap replica: %+v", replica)
+				}
+				filler++
+			}
+		}
+		if utility != row.OverlapCumulativeUtility || useful != row.OverlapUseful || filler != row.OverlapFiller {
+			return fmt.Errorf("invalid M3 overlap utility evidence: %+v", row)
+		}
+		for _, diversity := range row.OverlapDestinationDiversity {
+			if diversity < 0 || diversity > row.OverlapRealized {
+				return fmt.Errorf("invalid M3 overlap diversity evidence: %+v", row)
+			}
 		}
 		for _, value := range []float64{row.Ratio, row.ReplicationFactor, row.PhysicalBytesPerSourceVector, row.WarmNSPerOp, row.WarmQPS, row.WarmBytesPerOp, row.WarmAllocsPerOp, row.CandidatesPerOp, row.EdgesPerOp, row.ExactLocalRecallAtK} {
 			if math.IsNaN(value) || math.IsInf(value, 0) {

--- a/cmd/treedb_vector_partition_bench/m3_partition_index.go
+++ b/cmd/treedb_vector_partition_bench/m3_partition_index.go
@@ -666,7 +666,7 @@ func benchmarkM3PartitionIndexRow(cfg config, fixture fixtureManifest, artifactD
 	}
 	row.OverlapReplicas = make([]m3OverlapReplica, len(overlap.Replicas))
 	for i, replica := range overlap.Replicas {
-		row.OverlapReplicas[i] = m3OverlapReplica{SourceOrdinal: replicaSourceOrdinals[i], Destination: replica.Partition, Policy: replica.Policy, Gain: replica.Gain, Class: replica.Class}
+		row.OverlapReplicas[i] = m3OverlapReplica{SourceOrdinal: replicaSourceOrdinals[i], Destination: replica.Partition, Policy: replica.Policy, Gain: replica.Gain, Class: string(replica.Class)}
 	}
 	if !cleanup {
 		descriptor := m3VariantDescriptorV1{
@@ -1020,7 +1020,7 @@ func validateM3PartitionIndexReport(report m3PartitionIndexReport) error {
 		seenReplica := make(map[[2]uint64]struct{}, len(row.OverlapReplicas))
 		for _, replica := range row.OverlapReplicas {
 			key := [2]uint64{replica.SourceOrdinal, uint64(replica.Destination)}
-			if replica.Destination < 0 || replica.Destination >= len(row.PartitionLoads) || replica.Policy == "" || replica.Gain < 0 || (replica.Class != "positive_gain" && replica.Class != "zero_utility") {
+			if replica.Destination < 0 || replica.Destination >= len(row.PartitionLoads) || replica.Policy == "" || replica.Gain < 0 || (replica.Class != string(vectorpartition.ReplicaUtilityPositiveGainV1) && replica.Class != string(vectorpartition.ReplicaUtilityZeroUtilityV1)) {
 				return fmt.Errorf("invalid M3 overlap replica: %+v", replica)
 			}
 			if _, duplicate := seenReplica[key]; duplicate {
@@ -1028,7 +1028,7 @@ func validateM3PartitionIndexReport(report m3PartitionIndexReport) error {
 			}
 			seenReplica[key] = struct{}{}
 			utility += replica.Gain
-			if replica.Class == "positive_gain" {
+			if replica.Class == string(vectorpartition.ReplicaUtilityPositiveGainV1) {
 				if replica.Gain == 0 {
 					return fmt.Errorf("zero-gain positive M3 overlap replica: %+v", replica)
 				}

--- a/cmd/treedb_vector_partition_bench/m8_production_assets.go
+++ b/cmd/treedb_vector_partition_bench/m8_production_assets.go
@@ -99,7 +99,11 @@ func newM8ProductionMultiGroupAssetsV1(vectors [][]float64, groups []string, par
 	for _, row := range rows {
 		part := int(row.VectorOrdinal % uint64(partitions))
 		h.manifest.Memberships = append(h.manifest.Memberships, collections.VectorPartitionMembershipV1{VectorOrdinal: row.VectorOrdinal, PartitionID: uint32(part)})
-		routerParts[part].Vectors = append(routerParts[part].Vectors, vectorpartition.RouterVectorV1{Ordinal: row.VectorOrdinal, Values: row.Values})
+		routerParts[part].Vectors = append(routerParts[part].Vectors, vectorpartition.RouterVectorV1{
+			Ordinal:        row.VectorOrdinal,
+			Values:         row.Values,
+			MembershipKind: string(collections.VectorPartitionMembershipHomeV1),
+		})
 	}
 	h.manifest.Canonicalize()
 	inputs := make([]collections.VectorPartitionSearchAssetV1, partitions)

--- a/cmd/treedb_vector_partition_bench/main.go
+++ b/cmd/treedb_vector_partition_bench/main.go
@@ -2972,7 +2972,9 @@ func newTreeDBRepresentativeRouter(vectors [][]float64, partitions int, routerCo
 		})
 		routerPartitions[partition].PartitionID = uint32(partition)
 		routerPartitions[partition].Vectors = append(routerPartitions[partition].Vectors, vectorpartition.RouterVectorV1{
-			Ordinal: sourceRow.VectorOrdinal, Values: sourceRow.Values,
+			Ordinal:        sourceRow.VectorOrdinal,
+			Values:         sourceRow.Values,
+			MembershipKind: string(collections.VectorPartitionMembershipHomeV1),
 		})
 	}
 	for documentOrdinal, seen := range seenDocuments {

--- a/cmd/treedb_vector_partition_bench/main_test.go
+++ b/cmd/treedb_vector_partition_bench/main_test.go
@@ -936,7 +936,7 @@ func TestM3OverlapPartitionIndexBuildsReopensAndSearchesNativePacks(t *testing.T
 		})
 	}
 	for _, row := range report.Rows {
-		if row.SourcePhysicalBytes <= 0 || row.PeakDerivedTemporaryBytes < row.FinalDerivedPhysicalBytes || row.FinalDerivedPhysicalBytes < int64(row.PackBytes) || row.PackBytes == 0 || row.PartitionHNSWM != 4 || row.LocalSearches != 8*4 || row.SearchRoute != collections.VectorPartitionSearchRouteHNSWSearchPackV1 || row.MissingAssets != 0 || row.CorruptAssets != 0 || row.StaleAssets != 0 || row.ExactLocalRecallAtK <= 0 || row.EdgesPerOp <= 0 {
+		if row.SourcePhysicalBytes <= 0 || row.PeakDerivedTemporaryBytes < row.FinalDerivedPhysicalBytes || row.FinalDerivedPhysicalBytes < int64(row.PackBytes) || row.PackBytes == 0 || row.PartitionHNSWM != 4 || row.LocalSearches != 8*4 || row.SearchRoute != collections.VectorPartitionSearchRouteHNSWSearchPackV1 || row.MissingAssets != 0 || row.CorruptAssets != 0 || row.StaleAssets != 0 || row.ExactLocalRecallAtK <= 0 || row.EdgesPerOp <= 0 || len(row.OverlapReplicas) != row.OverlapRealized || len(row.OverlapDestinationDiversity) != len(row.PartitionLoads) {
 			t.Fatalf("M3 row=%+v", row)
 		}
 	}
@@ -1010,8 +1010,12 @@ func TestM3RouterPartitionsBindArtifactToNativeOrdinalsV1(t *testing.T) {
 		Config:     vectorpartition.Config{Partitions: 2},
 		Assignment: []int{1, 0, 1},
 	}
+	overlap := vectorpartition.OverlapResult{Memberships: []vectorpartition.Membership{
+		{VectorOrdinal: 0, Partition: 1, Home: true}, {VectorOrdinal: 1, Partition: 0, Home: true}, {VectorOrdinal: 1, Partition: 1}, {VectorOrdinal: 2, Partition: 1, Home: true},
+	}}
 	partitions, err := m3RouterPartitions(
 		artifact,
+		overlap,
 		[]int{2, 0, 1},
 		[][]float64{{1, 2}, {3, 4}, {5, 6}},
 	)
@@ -1019,7 +1023,7 @@ func TestM3RouterPartitionsBindArtifactToNativeOrdinalsV1(t *testing.T) {
 		t.Fatal(err)
 	}
 	if len(partitions) != 2 || partitions[0].PartitionID != 0 || partitions[1].PartitionID != 1 ||
-		len(partitions[0].Vectors) != 1 || len(partitions[1].Vectors) != 2 {
+		len(partitions[0].Vectors) != 1 || len(partitions[1].Vectors) != 3 {
 		t.Fatalf("router partitions=%+v", partitions)
 	}
 	if got := partitions[0].Vectors[0]; got.Ordinal != 0 || len(got.Values) != 2 || got.Values[0] != 3 || got.Values[1] != 4 {
@@ -1028,8 +1032,11 @@ func TestM3RouterPartitionsBindArtifactToNativeOrdinalsV1(t *testing.T) {
 	if got := partitions[1].Vectors[0]; got.Ordinal != 2 || got.Values[0] != 1 || got.Values[1] != 2 {
 		t.Fatalf("partition 1 first vector=%+v", got)
 	}
-	if got := partitions[1].Vectors[1]; got.Ordinal != 1 || got.Values[0] != 5 || got.Values[1] != 6 {
-		t.Fatalf("partition 1 second vector=%+v", got)
+	if got := partitions[1].Vectors[1]; got.Ordinal != 0 || got.Values[0] != 3 || got.Values[1] != 4 || got.MembershipKind != string(collections.VectorPartitionMembershipOverlapV1) {
+		t.Fatalf("partition 1 overlap vector=%+v", got)
+	}
+	if got := partitions[1].Vectors[2]; got.Ordinal != 1 || got.Values[0] != 5 || got.Values[1] != 6 {
+		t.Fatalf("partition 1 third vector=%+v", got)
 	}
 }
 


### PR DESCRIPTION
Closes #4025

## Objective

Make the exact M3 overlap membership set observable and make structured router construction consume that canonical home-plus-overlap relation.

## Non-goals

No scoring, HNSW, representative, result-deduplication, exact-union, kRt, or high-entropy (#4030) policy changes.

## Design

- Records every non-home replica with policy, destination, directed-cut gain, positive-gain/zero-utility class, cumulative utility, and destination diversity in schema-v4 M3 evidence.
- Keeps exact `floor(ratio * source rows)` behavior under hard capacity; deterministic zero-utility fill starts only after positive boundary utility is exhausted.
- Validates final router input per `(partition, source ordinal, membership kind)`, rebuilds it from authoritative source rows, and binds router packs to source identity plus the canonical final-membership digest.
- Uses the bounded 1,200,000 router-member envelope for the declared 1M source-row plus 20% overlap case.

## Correctness

- `go test ./TreeDB/internal/vectorpartition ./TreeDB/collections ./cmd/treedb_vector_partition_bench`
- `go test -race ./TreeDB/internal/vectorpartition -run TestOverlap -count=1`
- `go test -race ./TreeDB/collections -run ^TestPartitionRouterBuildPublishSearchReopenAndPinsV1$ -count=1`

Coverage includes utility-before-ordinal fill, honest zero-cut exact fillers, capacity/determinism, stale final-membership digest, duplicate-within-shard rejection, authoritative source reconstruction, reopen, and final router membership kinds.

## Retained 100k evidence

All rows use the structured embedding mixture, seed 4017, pinned offline KaHIP 3.25 ECO assignment `022359b1aedfa738cde7f2e82e01263c855eb72075b1f2a927d3a5753d6fde9c`, and exact head `0a115df5f9ff96998ca05c4253528ebbbaee2694`.

| metric | result |
|---|---:|
| exact overlap budget / realized | 20,000 / 20,000 |
| positive-gain / zero-utility | 0 / 20,000 |
| directed cut before / after | 0 / 0 |
| primary-home p4 oracle | 1.0000 |
| final-membership p4 oracle | 1.0000 |
| exact representative p4 recall | 0.9960 |
| end-to-end p4 recall, ef64 | 0.9242 |
| exact local recall across all packs | 0.9918625 |
| final derived bytes vs retained disjoint | 88,536,981 / 73,843,953 = 1.1983x |
| M3 build wall / peak RSS | 41.713s / 1,067,913,216 B |

The p4 oracle was emitted by the existing M8 membership oracle against a newly retained exact-head M3 DB; it reused the trusted #4023 truth cache and ran one exact p4 cell. The report row passes. The report-level `experimental_gate_failures` status is not the #4025 gate: it includes later M8 throughput/storage qualification outside this issue.

Artifacts retained outside the repository:

- `/mnt/fast4tb/gomap-4025-structured-D1Cwyg`: original M3 report SHA-256 `91e8486bb5992c0477e31eb3e77a54e4ac605f95b71e5961bf32ed716fc02727`; build report SHA-256 `f34fa56e541f80789e71e5eb3dd058c6c9ba35d265170319cd4141e61ffb8264`.
- `/mnt/fast4tb/gomap-4025-final-oracle-head0a11`: persisted M3 report SHA-256 `1e28b9b0e8698834c4a5e04e5b373d6ea87728561f976ff2f226e9279fd48bf0`; descriptor SHA-256 `0149c7bc70c10cb145acef87e664fbbad812dd60db50361412d95e0d3b91b9d6`; M8 report SHA-256 `73f7a21f17125fb8e3c62158e5614f618ebf4ae259b3d05c37ac7b56c6d472fb`.

## Exact evidence commands

```sh
go run ./cmd/treedb_vector_partition_bench -stage overlap,partition_index -dataset /mnt/fast4tb/gomap-4015-fixtures/embedding_mixture_100k -out /mnt/fast4tb/gomap-4025-final-oracle-head0a11/m3-out -m3-persist-db /mnt/fast4tb/gomap-4025-final-oracle-head0a11/m3-db -partitions 16 -overlap 0.20 -m3-max-benchmark-visits 400000000 -top-k 10 -seed 4017 -partition-kahip-python /mnt/fast4tb/gomap-4024-kahip-3.25/bin/python -partition-kahip-script /mnt/fast4tb/gomap-4025-overlap/scripts/treedb_kahip_partition.py -format text

go run ./cmd/treedb_vector_partition_bench -mode production_multi_group -dataset /mnt/fast4tb/gomap-4015-fixtures/embedding_mixture_100k -out /mnt/fast4tb/gomap-4025-final-oracle-head0a11/m8-out -m8-existing-db /mnt/fast4tb/gomap-4025-final-oracle-head0a11/m3-db -partitions 16 -raft-groups 4 -raft-nodes-per-group 3 -overlap 0.20 -probes 4 -top-k 10 -seed 4017 -concurrency 1 -ef-search 64 -warmup 0 -m8-max-exact-truth-visits 200000000 -m8-max-rss-bytes 4294967296 -m8-max-persistent-asset-bytes 4294967296 -m8-truth-cache /mnt/fast4tb/gomap-4023-100k/truth-cache -m8-truth-cache-sha256 0e9bce9465c9e1fa70c7833364e88c332bc831cfc52c628c90085e1c3068763c -format text
```

## Rollout

Experimental and off by default. Omit the overlap stage or set `-overlap 0` to disable. High-entropy qualification remains separately tracked by #4030.