### PR TITLE
mongo: certify Compass compatibility matrix

### DIFF
--- a/TreeDB/mongo_gateway/COMPATIBILITY.md
+++ b/TreeDB/mongo_gateway/COMPATIBILITY.md
@@ -197,7 +197,7 @@ gateway at commit `03e7a26e56100964f14f603f0248a1a6ccc50a68`, using
 database tree, listed the database, opened `compass_e2e.docs`, and rendered
 three BSON documents.
 
-This certifies that tested connection-and-browse flow only, not full Compass or
+This certifies only the tested connection-and-browse flow, not full Compass or
 MongoDB compatibility. The optional Compass Performance view remains
 non-blocking for basic connection and browsing: `top` and `serverStatus` return
 `CommandNotFound`, and its `currentOp` request uses unsupported `aggregate`.
@@ -280,8 +280,9 @@ implemented.
 
 ## Next Gap-Closing Candidates
 
-1. Run a real desktop GUI client after `connectionStatus` and add any next
-   unsupported command as a matrix row before implementing it.
+1. Decide whether optional Compass Performance metadata (`serverStatus`, `top`,
+   and aggregate-backed `currentOp`) is worth implementing; basic connection
+   and browsing do not depend on it.
 2. Decide whether unsupported filters should always fail closed or allow bounded
    scans behind a feature flag.
 3. Extend explicit `writeConcern` handling beyond the current cluster submitter

--- a/TreeDB/mongo_gateway/COMPATIBILITY.md
+++ b/TreeDB/mongo_gateway/COMPATIBILITY.md
@@ -72,6 +72,9 @@ block drifts from the executable matrix rows.
 | index gap | compound index | rejected |
 | index gap | index without treedbValueType | rejected |
 | command gap | aggregate | not implemented |
+| command gap | serverStatus | not implemented |
+| command gap | top | not implemented |
+| command gap | dbStats | not implemented |
 | command gap | count | not implemented |
 | command gap | findAndModify | not implemented |
 | transaction gap | transactions and retryable writes | not implemented |
@@ -173,7 +176,10 @@ enabled-path latency claim is made.
 | Command | `createIndexes` | `supported subset` | `TestMongoCompatibilityMatrix`, metadata tests | Single-field ascending indexes only, with `treedbValueType`. |
 | Command | `listIndexes` | `supported subset` standalone; `rejected` in routed cluster mode | `TestMongoCompatibilityMatrix`, metadata tests, `TestMongoRoutedMetadataReadsFailClosedBeforeLocalCatalogObservation` | Emits TreeDB-specific `treedbValueType` only when local metadata is authoritative. |
 | Command | `dropIndexes` | `supported subset` | `TestMongoCompatibilityMatrix`, metadata tests | No broad collection/database DDL surface. |
-| Command | `aggregate` | `not implemented` | `TestMongoCompatibilityMatrix` | No aggregation pipeline. |
+| Command | `aggregate` | `not implemented` | `TestMongoCompatibilityMatrix` | No aggregation pipeline; Compass Performance `currentOp` uses this command. |
+| Command | `serverStatus` | `not implemented` | `TestMongoCompatibilityMatrix` | Optional Compass Performance metadata is unsupported; this does not block basic connection or browsing. |
+| Command | `top` | `not implemented` | `TestMongoCompatibilityMatrix` | Optional Compass Performance metrics are unsupported; this does not block basic connection or browsing. |
+| Command | `dbStats` | `not implemented` | `TestMongoCompatibilityMatrix` | Database statistics are unsupported; this does not block basic connection or browsing. |
 | Command | `count`, `countDocuments`, `estimatedDocumentCount` | `not implemented` | `TestMongoCompatibilityMatrix` covers `count` command absence | Future fast count work should be explicit. |
 | Command | `distinct` | `not implemented` | Command falls through to `CommandNotFound` | No distinct scan/index planner. |
 | Command | `findAndModify` | `not implemented` | `TestMongoCompatibilityMatrix` | No atomic find/update command surface. |
@@ -185,38 +191,19 @@ enabled-path latency claim is made.
 
 ## Desktop Client Check
 
-Issue #1473 identified a MongoDB desktop-client connection failure on:
-`unsupported MongoDB gateway command: connectionStatus`. The gateway now handles
-that command with a minimal unauthenticated `authInfo` response and the
-compatibility matrix keeps it covered.
+On 2026-08-01, MongoDB Compass 1.49.12 on macOS 26.2 was tested against the
+gateway at commit `03e7a26e56100964f14f603f0248a1a6ccc50a68`, using
+`mongodb://127.0.0.1:27130/?directConnection=true`. Compass refreshed the
+database tree, listed the database, opened `compass_e2e.docs`, and rendered
+three BSON documents.
 
-The same desktop-client path later exposed
-`unsupported MongoDB gateway command: hostInfo`. The gateway now handles that
-command with minimal local runtime and OS metadata and keeps it covered in the
-matrix.
-
-The client path then exposed `unsupported MongoDB gateway command: buildInfo`.
-The gateway now handles that command with minimal MongoDB-compatible version
-and build metadata and keeps it covered in the matrix.
-
-The client path then exposed `unsupported MongoDB gateway command: create`.
-The gateway now handles plain collection creation as a TreeDB collection catalog
-entry, treats existing collections as idempotent no-op success, and rejects
-unsupported MongoDB collection options such as capped collections. That duplicate
-`create` behavior is an intentional GUI-compatibility deviation from MongoDB's
-`NamespaceExists` error.
-
-The client path then exposed a driver-side
-`Current topology does not support sessions` error. The gateway now advertises
-logical session timeout metadata in `hello` and accepts `endSessions`; this
-unblocks ordinary session-bearing driver commands without adding transaction
-semantics.
-
-This does not yet certify a full desktop GUI connection flow. If a client gets
-past `connectionStatus` / `hostInfo` / `buildInfo` / `create` / logical
-sessions and then asks for other metadata or DDL commands such as
-`listDatabases` or `serverStatus`, add those commands as explicit matrix rows
-before deciding whether to implement or reject them.
+This certifies that tested connection-and-browse flow only, not full Compass or
+MongoDB compatibility. The optional Compass Performance view remains
+non-blocking for basic connection and browsing: `top` and `serverStatus` return
+`CommandNotFound`, and its `currentOp` request uses unsupported `aggregate`.
+The small driver seeding run likewise reached document insertion but its final
+`dbStats` request returned `CommandNotFound`; database statistics are not
+implemented.
 
 ## Query Matrix
 

--- a/TreeDB/mongo_gateway/README.md
+++ b/TreeDB/mongo_gateway/README.md
@@ -41,8 +41,11 @@ mongodb://127.0.0.1:27017/?directConnection=true
 
 The gateway implements an intentionally narrow command subset around hello/ping,
 insert, find/getMore/killCursors, update, delete, and collection/index metadata.
-It does not provide authentication, replica set behavior, sharding, sessions,
-transactions, change streams, aggregation, or full MongoDB compatibility.
+It provides minimal logical-session compatibility (`logicalSessionTimeoutMinutes`,
+`lsid`, and `endSessions`) for driver interoperability, but not transactions,
+causal consistency, or other session semantics. It also does not provide
+authentication, replica set behavior, sharding, change streams, aggregation, or
+full MongoDB compatibility.
 
 Cluster submitter mode does not turn this gateway into a sharded Mongo server.
 For token/ring placement, exact `_id` equality finds are mapped to one catalog

--- a/TreeDB/mongo_gateway/compatibility_matrix_test.go
+++ b/TreeDB/mongo_gateway/compatibility_matrix_test.go
@@ -552,6 +552,24 @@ func mongoCompatibilityMatrixRows() []mongoCompatibilityMatrixRow {
 		},
 		{
 			category: "command gap",
+			feature:  "serverStatus",
+			status:   "not implemented",
+			probe:    expectCommandNotFound(bson.D{{Key: "serverStatus", Value: int32(1)}, {Key: "$db", Value: "admin"}}),
+		},
+		{
+			category: "command gap",
+			feature:  "top",
+			status:   "not implemented",
+			probe:    expectCommandNotFound(bson.D{{Key: "top", Value: int32(1)}, {Key: "$db", Value: "admin"}}),
+		},
+		{
+			category: "command gap",
+			feature:  "dbStats",
+			status:   "not implemented",
+			probe:    expectCommandNotFound(bson.D{{Key: "dbStats", Value: int32(1)}, {Key: "$db", Value: "app"}}),
+		},
+		{
+			category: "command gap",
 			feature:  "count",
 			status:   "not implemented",
 			probe:    expectCommandNotFound(bson.D{{Key: "count", Value: "users"}, {Key: "$db", Value: "app"}}),


### PR DESCRIPTION
## Objective

Certify the basic MongoDB Compass connection-and-browse path on TreeDB and make the remaining desktop-visible command gaps part of the executable compatibility inventory.

Closes #1473.
Closes #1493.

## What changed

- add executable `CommandNotFound` matrix rows for `serverStatus`, `top`, and `dbStats`
- regenerate the compatibility table from those rows
- record the successful Compass 1.49.12 connection-and-browse check on macOS 26.2 at base commit `03e7a26e56100964f14f603f0248a1a6ccc50a68`
- correct the README: the gateway has minimal logical-session interoperability, but not transactions, causal consistency, or broader session semantics

## Desktop-client evidence

Connection URI:

```text
mongodb://127.0.0.1:27130/?directConnection=true
```

Observed in Compass 1.49.12:

- connected to the gateway
- refreshed the database tree
- listed `compass_e2e`
- opened `compass_e2e.docs`
- rendered three seeded BSON documents

Local evidence captures:

- connected view SHA-256: `61f075b32e7b68db9d4eed3bde77a68e7759bbcb97d3f2bb74267f70894bd83f`
- document view SHA-256: `55ad6f2734d1509556dab6dded08487ac395c5a6c15c0f1f2f0b6633f4b84e4e`

The optional Compass Performance view still requests unsupported `top`, `serverStatus`, and aggregate-backed `currentOp`. The seeding helper also requests unsupported `dbStats` after successful insertion. These are now explicit, tested gaps and do not block the certified basic connection-and-browse flow.

## Validation

```sh
GOWORK=off go test ./TreeDB/mongo_gateway -run "TestMongoCompatibilityMatrix|TestMongoCompatibilityMatrixDocumentationUpToDate" -count=1
GOWORK=off go test ./TreeDB/mongo_gateway -count=1
GOWORK=off go vet ./TreeDB/mongo_gateway
git diff --check
```

All pass locally.

## Scope and risk

This is a compatibility-inventory and documentation closeout; production gateway behavior is unchanged. The test-first exception is intentional: current main already rejects these commands with `CommandNotFound`, and the new probes pin that existing behavior. Performance evidence is not relevant because no runtime or hot-path code changed.

This certifies only the tested direct Compass connection-and-browse flow, not full Compass or MongoDB compatibility. Authentication, transactions, broad aggregation, optional Performance metrics, and broader server semantics remain out of scope.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated compatibility information for `serverStatus`, `top`, and `dbStats`, including their impact on Compass Performance features.
  * Clarified supported logical-session capabilities and documented that transactions remain unsupported.
  * Recorded successful Compass connection and database browsing validation.

* **Tests**
  * Added coverage confirming unsupported commands return the expected “command not found” response.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->