### PR TITLE
mongo: support bounded top-level $or finds

### DIFF
--- a/TreeDB/mongo_gateway/COMPATIBILITY.md
+++ b/TreeDB/mongo_gateway/COMPATIBILITY.md
@@ -52,6 +52,7 @@ block drifts from the executable matrix rows.
 | crud | find by _id equality | supported |
 | query | indexed equality and range predicates | supported subset |
 | query | $in on indexed scalar fields | supported subset |
+| query | top-level $or expressions | supported subset |
 | query | projection, sort, skip, and limit | supported subset |
 | cursor | getMore and killCursors | supported |
 | read concern | local/available readConcern maps to local_stale | supported subset |
@@ -64,7 +65,6 @@ block drifts from the executable matrix rows.
 | session | logical session handshake and endSessions | supported subset |
 | metadata | createIndexes, listIndexes, and dropIndexes | supported subset |
 | document | native BSON storage mode | supported subset |
-| query gap | $or | rejected |
 | query gap | dotted projection | rejected |
 | update gap | upsert | rejected |
 | update gap | multi update | rejected |
@@ -215,7 +215,8 @@ implemented.
 | Indexed scalar `$in` | `supported subset` | `TestMongoCompatibilityMatrix` | Null/missing has special scan behavior. |
 | Indexed scalar ranges `$gt`, `$gte`, `$lt`, `$lte` | `supported subset` | `TestMongoCompatibilityMatrix` | Range behavior is typed by `treedbValueType`. |
 | Top-level `$and` | `supported subset` | `TestMongoCompatibilityMatrix` | Planner flattens supported subexpressions only. |
-| Top-level `$or`, `$nor`, `$not` | `rejected` / `not implemented` | `TestMongoCompatibilityMatrix` covers `$or` rejection | Needs explicit planner semantics. |
+| Top-level `$or` | `supported subset` | `TestMongoCompatibilityMatrix`, direct-wire and official-driver `$or` tests | One or more document branches using equality, range, `$in`, and `$and`; sibling predicates are ANDed. `$or` uses the bounded scan fallback; no index union. |
+| `$nor`, `$not` | `not implemented` | Unsupported operators reject | Needs explicit planner semantics. |
 | Regex/text/geospatial predicates | `not implemented` | Unsupported operators reject or command is absent | Out of MVP scope. |
 | Dotted predicates into nested objects/arrays | `supported subset` | dotted predicate tests | Projection and sort do not support dotted fields. |
 | Projection include/exclude top-level fields | `supported subset` | `TestMongoCompatibilityMatrix` | Cannot mix include/exclude except `_id`; dotted projection rejected. |

--- a/TreeDB/mongo_gateway/compatibility_matrix_test.go
+++ b/TreeDB/mongo_gateway/compatibility_matrix_test.go
@@ -191,6 +191,22 @@ func mongoCompatibilityMatrixRows() []mongoCompatibilityMatrixRow {
 		},
 		{
 			category: "query",
+			feature:  "top-level $or expressions",
+			status:   "supported subset",
+			probe: func(t *testing.T, server *Server) {
+				resp := serveCommand(t, server, 61, bson.D{
+					{Key: "find", Value: "users"},
+					{Key: "filter", Value: bson.D{{Key: "$or", Value: bson.A{
+						bson.D{{Key: "city", Value: "hnl"}},
+						bson.D{{Key: "age", Value: bson.D{{Key: "$gt", Value: int64(40)}}}},
+					}}}},
+					{Key: "$db", Value: "app"},
+				})
+				assertBatchIDs(t, cursorFirstBatch(t, resp), []string{"u1", "u2"})
+			},
+		},
+		{
+			category: "query",
 			feature:  "projection, sort, skip, and limit",
 			status:   "supported subset",
 			probe: func(t *testing.T, server *Server) {
@@ -436,19 +452,6 @@ func mongoCompatibilityMatrixRows() []mongoCompatibilityMatrixRow {
 				if subtype != 0 || !bytes.Equal(payload, []byte{1, 2, 3}) {
 					t.Fatalf("payload subtype/data=%#x/%v want 0/[1 2 3]", subtype, payload)
 				}
-			},
-		},
-		{
-			category: "query gap",
-			feature:  "$or",
-			status:   "rejected",
-			probe: func(t *testing.T, server *Server) {
-				resp := serveCommand(t, server, 17, bson.D{
-					{Key: "find", Value: "users"},
-					{Key: "filter", Value: bson.D{{Key: "$or", Value: bson.A{bson.D{{Key: "city", Value: "hnl"}}}}}},
-					{Key: "$db", Value: "app"},
-				})
-				assertCommandError(t, resp, "BadValue")
 			},
 		},
 		{

--- a/TreeDB/mongo_gateway/find_planner.go
+++ b/TreeDB/mongo_gateway/find_planner.go
@@ -41,6 +41,7 @@ type findSort struct {
 
 type findPlan struct {
 	predicates []findPredicate
+	orBranches [][]findPredicate
 	sort       findSort
 	skip       int32
 	limit      int32
@@ -53,7 +54,7 @@ type findResultSet struct {
 }
 
 func parseFindPlan(command wire.Document, filter wire.Document) (findPlan, error) {
-	predicates, err := parseFindPredicates(filter)
+	predicates, orBranches, err := parseFindFilter(filter)
 	if err != nil {
 		return findPlan{}, err
 	}
@@ -75,6 +76,7 @@ func parseFindPlan(command wire.Document, filter wire.Document) (findPlan, error
 	}
 	return findPlan{
 		predicates: predicates,
+		orBranches: orBranches,
 		sort:       sortSpec,
 		skip:       skip,
 		limit:      limit,
@@ -111,7 +113,7 @@ func (s *Server) executeFind(col *collections.Collection, plan findPlan) (findRe
 	}
 	filtered := make([]wire.Document, 0, len(docs))
 	for _, doc := range docs {
-		match, err := documentMatchesPredicates(doc, plan.predicates)
+		match, err := documentMatchesPlan(doc, plan)
 		if err != nil {
 			return findResultSet{}, err
 		}
@@ -215,7 +217,7 @@ func (s *Server) findPureIndexedRangeLimitDocuments(col *collections.Collection,
 }
 
 func pureIndexedRangeLimitPlan(meta collections.CollectionMeta, plan findPlan, maxDocuments int) (collections.IndexDefinition, collections.IndexRangeOptions, int, bool, bool, error) {
-	if plan.limit <= 0 || plan.skip != 0 || plan.sort.field != "" || len(plan.predicates) != 1 {
+	if len(plan.orBranches) != 0 || plan.limit <= 0 || plan.skip != 0 || plan.sort.field != "" || len(plan.predicates) != 1 {
 		return collections.IndexDefinition{}, collections.IndexRangeOptions{}, 0, false, false, nil
 	}
 	if int64(plan.limit) > int64(maxInt) {
@@ -248,6 +250,24 @@ func pureIndexedRangeLimitPlan(meta collections.CollectionMeta, plan findPlan, m
 func (s *Server) findCandidateDocuments(col *collections.Collection, materializer *collections.StoredDocumentJSONMaterializer, plan findPlan) ([]wire.Document, error) {
 	meta := col.MetaView()
 	maxDocuments := s.maxFindScanDocuments()
+	if len(plan.orBranches) != 0 {
+		records, truncated, err := col.ScanDocuments(maxDocuments)
+		if err != nil {
+			return nil, err
+		}
+		if truncated {
+			return nil, fmt.Errorf("Mongo gateway find requires a bounded scan and exceeded %d documents", maxDocuments)
+		}
+		out := make([]wire.Document, 0, len(records))
+		for _, record := range records {
+			doc, err := storedDocumentToBSON(col, materializer, record.Document)
+			if err != nil {
+				return nil, err
+			}
+			out = append(out, doc)
+		}
+		return out, nil
+	}
 	var primaryDocs []wire.Document
 	primarySet := false
 	predicates := plan.predicates
@@ -292,7 +312,7 @@ func (s *Server) findCandidateDocuments(col *collections.Collection, materialize
 }
 
 func (s *Server) findUnsortedScanDocuments(col *collections.Collection, materializer *collections.StoredDocumentJSONMaterializer, plan findPlan) ([]wire.Document, bool, error) {
-	if plan.sort.field != "" || findPlanHasDirectCandidate(col.MetaView(), plan.predicates) {
+	if plan.sort.field != "" || (len(plan.orBranches) == 0 && findPlanHasDirectCandidate(col.MetaView(), plan.predicates)) {
 		return nil, false, nil
 	}
 	maxDocuments := s.maxFindScanDocuments()
@@ -307,12 +327,12 @@ func (s *Server) findUnsortedScanDocuments(col *collections.Collection, material
 			return true, nil
 		}
 		var doc wire.Document
-		if !ok {
+		if !ok || len(plan.orBranches) > 0 {
 			doc, err = storedDocumentToBSON(col, materializer, record.Document)
 			if err != nil {
 				return false, err
 			}
-			match, err = documentMatchesPredicates(doc, plan.predicates)
+			match, err = documentMatchesPlan(doc, plan)
 			if err != nil {
 				return false, err
 			}
@@ -713,7 +733,7 @@ func primaryCandidatePredicate(predicates []findPredicate) (findPredicate, bool)
 }
 
 func simplePrimaryEqualityFindValue(plan findPlan) (bson.RawValue, bool) {
-	if plan.sort.field != "" || plan.skip != 0 || plan.limit > 1 {
+	if len(plan.orBranches) != 0 || plan.sort.field != "" || plan.skip != 0 || plan.limit > 1 {
 		return bson.RawValue{}, false
 	}
 	if len(plan.predicates) != 1 {
@@ -1090,10 +1110,50 @@ func documentsForIndexedRange(col *collections.Collection, materializer *collect
 }
 
 func parseFindPredicates(filter wire.Document) ([]findPredicate, error) {
+	predicates, _, err := parseFindFilter(filter)
+	return predicates, err
+}
+
+func parseFindFilter(filter wire.Document) ([]findPredicate, [][]findPredicate, error) {
 	if filter == nil {
-		return nil, nil
+		return nil, nil, nil
 	}
-	return parseFindPredicateDocument(filter)
+	elements, err := bson.Raw(filter).Elements()
+	if err != nil {
+		return nil, nil, err
+	}
+	var predicates []findPredicate
+	var orBranches [][]findPredicate
+	for _, elem := range elements {
+		key, err := elem.KeyErr()
+		if err != nil {
+			return nil, nil, err
+		}
+		if key == "$or" {
+			if orBranches != nil {
+				return nil, nil, errors.New("Mongo gateway find supports only one top-level $or")
+			}
+			orBranches, err = parseOrPredicates(elem.Value())
+			if err != nil {
+				return nil, nil, err
+			}
+			continue
+		}
+		if key == "$and" {
+			parsed, err := parseAndPredicates(elem.Value())
+			if err != nil {
+				return nil, nil, err
+			}
+			predicates = append(predicates, parsed...)
+			continue
+		}
+		parsed, err := parseFieldPredicate(key, elem.Value())
+		if err != nil {
+			return nil, nil, err
+		}
+		predicates = append(predicates, parsed...)
+	}
+	return predicates, orBranches, nil
 }
 
 func parseFindPredicateDocument(doc wire.Document) ([]findPredicate, error) {
@@ -1150,6 +1210,33 @@ func parseAndPredicates(value bson.RawValue) ([]findPredicate, error) {
 		out = append(out, preds...)
 	}
 	return out, nil
+}
+
+func parseOrPredicates(value bson.RawValue) ([][]findPredicate, error) {
+	array, ok := value.ArrayOK()
+	if !ok {
+		return nil, errors.New("Mongo gateway $or must be an array")
+	}
+	values, err := array.Values()
+	if err != nil {
+		return nil, err
+	}
+	if len(values) == 0 {
+		return nil, errors.New("Mongo gateway $or must contain at least one expression")
+	}
+	branches := make([][]findPredicate, 0, len(values))
+	for i, value := range values {
+		doc, ok := value.DocumentOK()
+		if !ok {
+			return nil, fmt.Errorf("Mongo gateway $or[%d] must be a document", i)
+		}
+		predicates, err := parseFindPredicateDocument(wire.Document(doc))
+		if err != nil {
+			return nil, err
+		}
+		branches = append(branches, predicates)
+	}
+	return branches, nil
 }
 
 func parseFieldPredicate(field string, value bson.RawValue) ([]findPredicate, error) {
@@ -1265,6 +1352,23 @@ func documentMatchesPredicates(doc wire.Document, predicates []findPredicate) (b
 		}
 	}
 	return true, nil
+}
+
+func documentMatchesPlan(doc wire.Document, plan findPlan) (bool, error) {
+	match, err := documentMatchesPredicates(doc, plan.predicates)
+	if err != nil || !match || len(plan.orBranches) == 0 {
+		return match, err
+	}
+	for _, branch := range plan.orBranches {
+		match, err := documentMatchesPredicates(doc, branch)
+		if err != nil {
+			return false, err
+		}
+		if match {
+			return true, nil
+		}
+	}
+	return false, nil
 }
 
 func missingValueMatchesPredicate(pred findPredicate) bool {

--- a/TreeDB/mongo_gateway/find_planner.go
+++ b/TreeDB/mongo_gateway/find_planner.go
@@ -344,7 +344,7 @@ func (s *Server) findUnsortedScanDocuments(col *collections.Collection, material
 			matched++
 			return true, nil
 		}
-		if ok {
+		if ok && len(plan.orBranches) == 0 {
 			doc, err = storedDocumentToBSON(col, materializer, record.Document)
 			if err != nil {
 				return false, err

--- a/TreeDB/mongo_gateway/server_driver_test.go
+++ b/TreeDB/mongo_gateway/server_driver_test.go
@@ -96,6 +96,28 @@ func TestServerOfficialGoDriverBasicCRUD(t *testing.T) {
 	if got["age"] != int64(37) {
 		t.Fatalf("decoded age=%v want 37", got["age"])
 	}
+	if _, err := coll.InsertMany(opCtx, []any{
+		bson.D{{Key: "_id", Value: "or-city"}, {Key: "active", Value: true}, {Key: "city", Value: "hnl"}, {Key: "age", Value: int64(30)}},
+		bson.D{{Key: "_id", Value: "or-age"}, {Key: "active", Value: true}, {Key: "city", Value: "lax"}, {Key: "age", Value: int64(45)}},
+		bson.D{{Key: "_id", Value: "or-inactive"}, {Key: "active", Value: false}, {Key: "city", Value: "hnl"}, {Key: "age", Value: int64(45)}},
+	}); err != nil {
+		t.Fatalf("driver insert many for $or: %v", err)
+	}
+	cursor, err := coll.Find(opCtx, bson.D{{Key: "active", Value: true}, {Key: "$or", Value: bson.A{
+		bson.D{{Key: "city", Value: "hnl"}},
+		bson.D{{Key: "age", Value: bson.D{{Key: "$gt", Value: int64(40)}}}},
+	}}})
+	if err != nil {
+		t.Fatalf("driver find $or: %v", err)
+	}
+	defer func() { _ = cursor.Close(opCtx) }()
+	var orDocs []bson.M
+	if err := cursor.All(opCtx, &orDocs); err != nil {
+		t.Fatalf("driver decode $or: %v", err)
+	}
+	if len(orDocs) != 2 {
+		t.Fatalf("driver $or documents=%d want 2", len(orDocs))
+	}
 
 	updateResult, err := coll.UpdateOne(opCtx,
 		bson.D{{Key: "_id", Value: id}},

--- a/TreeDB/mongo_gateway/server_test.go
+++ b/TreeDB/mongo_gateway/server_test.go
@@ -4964,6 +4964,89 @@ func TestServerFindCapsIndexedCandidates(t *testing.T) {
 	assertCommandError(t, tooMany, "BadValue")
 }
 
+func TestServerFindTopLevelOrAcrossDocumentFormats(t *testing.T) {
+	for _, format := range []collections.DocumentFormat{collections.DocumentFormatBSON, collections.DocumentFormatJSON, collections.DocumentFormatTemplateV1} {
+		t.Run(string(format), func(t *testing.T) {
+			db, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
+			if err != nil {
+				t.Fatalf("open db: %v", err)
+			}
+			defer func() { _ = db.Close() }()
+			server := NewServer()
+			server.DefaultCollectionOptions = collections.CollectionOptions{DocumentFormat: format}
+			server.Collections = collections.NewCollectionManager(db)
+			assertOK(t, serveCommand(t, server, 1, bson.D{{Key: "insert", Value: "users"}, {Key: "documents", Value: bson.A{
+				bson.D{{Key: "_id", Value: "both"}, {Key: "active", Value: true}, {Key: "city", Value: "hnl"}, {Key: "age", Value: int64(45)}},
+				bson.D{{Key: "_id", Value: "city"}, {Key: "active", Value: true}, {Key: "city", Value: "hnl"}, {Key: "age", Value: int64(30)}},
+				bson.D{{Key: "_id", Value: "age"}, {Key: "active", Value: true}, {Key: "city", Value: "lax"}, {Key: "age", Value: int64(45)}},
+				bson.D{{Key: "_id", Value: "inactive"}, {Key: "active", Value: false}, {Key: "city", Value: "hnl"}, {Key: "age", Value: int64(45)}},
+			}}, {Key: "$db", Value: "app"}}))
+			assertOK(t, serveCommand(t, server, 11, bson.D{{Key: "createIndexes", Value: "users"}, {Key: "indexes", Value: bson.A{bson.D{
+				{Key: "key", Value: bson.D{{Key: "age", Value: int32(1)}}}, {Key: "name", Value: "age_1"}, {Key: "treedbValueType", Value: "int64"},
+			}}}, {Key: "$db", Value: "app"}}))
+			response := serveCommand(t, server, 2, bson.D{{Key: "find", Value: "users"}, {Key: "filter", Value: bson.D{
+				{Key: "active", Value: true},
+				{Key: "$or", Value: bson.A{
+					bson.D{{Key: "city", Value: "hnl"}},
+					bson.D{{Key: "$and", Value: bson.A{bson.D{{Key: "age", Value: bson.D{{Key: "$gt", Value: int64(40)}}}}}}},
+				}},
+			}}, {Key: "sort", Value: bson.D{{Key: "_id", Value: int32(1)}}}, {Key: "$db", Value: "app"}})
+			assertBatchIDs(t, cursorFirstBatch(t, response), []string{"age", "both", "city"})
+			byID := serveCommand(t, server, 3, bson.D{{Key: "find", Value: "users"}, {Key: "filter", Value: bson.D{
+				{Key: "_id", Value: "both"}, {Key: "$or", Value: bson.A{bson.D{{Key: "city", Value: "missing"}}}},
+			}}, {Key: "projection", Value: bson.D{{Key: "_id", Value: int32(1)}}}, {Key: "$db", Value: "app"}})
+			assertBatchIDs(t, cursorFirstBatch(t, byID), nil)
+			rangeLimit := serveCommand(t, server, 4, bson.D{{Key: "find", Value: "users"}, {Key: "filter", Value: bson.D{
+				{Key: "age", Value: bson.D{{Key: "$gte", Value: int64(0)}}},
+				{Key: "$or", Value: bson.A{bson.D{{Key: "city", Value: "missing"}}}},
+			}}, {Key: "limit", Value: int32(1)}, {Key: "$db", Value: "app"}})
+			assertBatchIDs(t, cursorFirstBatch(t, rangeLimit), nil)
+		})
+	}
+}
+
+func TestServerFindTopLevelOrRejectsMalformedAndRespectsScanCap(t *testing.T) {
+	db, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+	server := NewServer()
+	server.MaxFindScanDocuments = 1
+	server.Collections = collections.NewCollectionManager(db)
+	assertOK(t, serveCommand(t, server, 1, bson.D{{Key: "insert", Value: "users"}, {Key: "documents", Value: bson.A{
+		bson.D{{Key: "_id", Value: "one"}, {Key: "city", Value: "lax"}},
+		bson.D{{Key: "_id", Value: "two"}, {Key: "city", Value: "hnl"}},
+	}}, {Key: "$db", Value: "app"}}))
+	for _, filter := range []bson.D{
+		{{Key: "$or", Value: bson.A{}}},
+		{{Key: "$or", Value: bson.A{"not-a-document"}}},
+		{{Key: "$or", Value: bson.A{bson.D{{Key: "city", Value: bson.D{{Key: "$regex", Value: "hnl"}}}}}}},
+	} {
+		assertCommandError(t, serveCommand(t, server, 2, bson.D{{Key: "find", Value: "users"}, {Key: "filter", Value: filter}, {Key: "$db", Value: "app"}}), "BadValue")
+	}
+	assertCommandError(t, serveCommand(t, server, 3, bson.D{{Key: "find", Value: "users"}, {Key: "filter", Value: bson.D{{Key: "$or", Value: bson.A{bson.D{{Key: "city", Value: "hnl"}}}}}}, {Key: "$db", Value: "app"}}), "BadValue")
+}
+
+func BenchmarkDocumentMatchesPlanTopLevelOr(b *testing.B) {
+	plan, err := parseFindPlan(nil, mustDocument(b, bson.D{{Key: "active", Value: true}, {Key: "$or", Value: bson.A{
+		bson.D{{Key: "city", Value: "hnl"}},
+		bson.D{{Key: "age", Value: bson.D{{Key: "$gt", Value: int64(40)}}}},
+	}}}))
+	if err != nil {
+		b.Fatalf("parse plan: %v", err)
+	}
+	doc := mustDocument(b, bson.D{{Key: "_id", Value: "u1"}, {Key: "active", Value: true}, {Key: "city", Value: "hnl"}, {Key: "age", Value: int64(45)}})
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		match, err := documentMatchesPlan(doc, plan)
+		if err != nil || !match {
+			b.Fatalf("match=%v err=%v", match, err)
+		}
+	}
+}
+
 func TestServerFindUnindexedLimitStopsBeforeScanCap(t *testing.T) {
 	db, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
 	if err != nil {


### PR DESCRIPTION
## Summary

- support one top-level `$or` with non-empty document branches over the existing equality, range, `$in`, and `$and` subset
- AND sibling predicates with the OR result and evaluate each scanned document once
- route every `$or` plan through the existing bounded scan fallback; no index union or direct/index shortcut
- document the supported subset in the executable compatibility matrix and gateway compatibility guide

Closes #4036
Parent: #4035

## Validation

- `GOWORK=off go test ./TreeDB/mongo_gateway -run 'TestServerFindTopLevelOr|TestServerOfficialGoDriverBasicCRUD|TestMongoCompatibilityMatrix' -count=1`
- `GOWORK=off go test ./TreeDB/mongo_gateway -run '^$' -bench BenchmarkDocumentMatchesPlanTopLevelOr -benchmem -count=3`
  - 145.6-146.9 ns/op, 128 B/op, 4 allocs/op (Apple M3, latest head)
- `GOWORK=off go test ./TreeDB/mongo_gateway -count=1`

## Scope

Malformed `$or` shapes fail with `BadValue`; `$nor`, `$not`, regex, and index unions remain unsupported.
