### PR TITLE
Mongo gateway: add bounded update mutations and upserts

### DIFF
--- a/TreeDB/mongo_gateway/COMPATIBILITY.md
+++ b/TreeDB/mongo_gateway/COMPATIBILITY.md
@@ -69,6 +69,8 @@ block drifts from the executable matrix rows.
 | update | exact _id upsert | supported subset |
 | update gap | multi update | rejected |
 | update | $inc | supported subset |
+| update | $unset | supported subset |
+| update | ReplaceOne by exact _id | supported subset |
 | index gap | compound index | rejected |
 | index gap | index without treedbValueType | rejected |
 | command gap | aggregate | not implemented |
@@ -228,11 +230,12 @@ implemented.
 
 | Surface | Status | Harness / evidence | Current gap |
 |---|---|---|---|
-| `updateOne` by `_id` with `$set` | `supported subset` | `TestMongoCompatibilityMatrix` | Top-level fields only; `_id` mutation rejected. |
-| Batched distinct-ID `$set` updates | `supported subset` | update batch tests | Unique-index conflicts may fall back to ordered singles. |
+| `updateOne` / `ReplaceOne` by exact `_id` | `supported subset` | `TestMongoCompatibilityMatrix`, direct-wire and driver update tests | Standalone BSON/JSON/template-v1 only; top-level fields, `_id` mutation rejected. |
+| Batched distinct-ID `$set` updates | `supported subset` | update batch tests | Unique-index conflicts may fall back to ordered singles; generic/replacement updates stay ordered. |
 | `multi: true` | `rejected` | `TestMongoCompatibilityMatrix` | No multi-update planner. |
-| `upsert: true` | `rejected` | `TestMongoCompatibilityMatrix` | No upsert semantics. |
-| `$inc`, `$unset`, `$push`, pipeline updates | `rejected` / `not implemented` | `TestMongoCompatibilityMatrix` covers `$inc` rejection | Only `$set` is implemented. |
+| Exact-`_id` `upsert: true` | `supported subset` | `TestMongoCompatibilityMatrix`, direct-wire and driver upsert tests | Top-level `$set`/`$inc`/`$unset` and replacement only; cluster/routed upserts rejected. |
+| Top-level `$set`, `$inc`, `$unset` | `supported subset` | `TestMongoCompatibilityMatrix`, mutation tests | `$inc` supports int32/int64/double only; null/non-numeric targets reject. `$push`, pipeline, dotted paths, and other operators are rejected. |
+| Cluster/routed generic, replacement, and upsert updates | `rejected` | cluster submitter tests | Only existing standalone semantics are supported; cluster accepts its native BSON `$set` route only. |
 | `delete` by `_id`, limit `0` or `1` | `supported subset` | `TestMongoCompatibilityMatrix` | Non-`_id` filters rejected. |
 
 ## BSON And Storage Matrix

--- a/TreeDB/mongo_gateway/COMPATIBILITY.md
+++ b/TreeDB/mongo_gateway/COMPATIBILITY.md
@@ -66,7 +66,7 @@ block drifts from the executable matrix rows.
 | metadata | createIndexes, listIndexes, and dropIndexes | supported subset |
 | document | native BSON storage mode | supported subset |
 | query gap | dotted projection | rejected |
-| update gap | upsert | rejected |
+| update | exact _id upsert | supported subset |
 | update gap | multi update | rejected |
 | update | $inc | supported subset |
 | index gap | compound index | rejected |

--- a/TreeDB/mongo_gateway/COMPATIBILITY.md
+++ b/TreeDB/mongo_gateway/COMPATIBILITY.md
@@ -68,7 +68,7 @@ block drifts from the executable matrix rows.
 | query gap | dotted projection | rejected |
 | update gap | upsert | rejected |
 | update gap | multi update | rejected |
-| update gap | $inc | rejected |
+| update | $inc | supported subset |
 | index gap | compound index | rejected |
 | index gap | index without treedbValueType | rejected |
 | command gap | aggregate | not implemented |

--- a/TreeDB/mongo_gateway/COMPATIBILITY.md
+++ b/TreeDB/mongo_gateway/COMPATIBILITY.md
@@ -230,11 +230,11 @@ implemented.
 
 | Surface | Status | Harness / evidence | Current gap |
 |---|---|---|---|
-| `updateOne` / `ReplaceOne` by exact `_id` | `supported subset` | `TestMongoCompatibilityMatrix`, direct-wire and driver update tests | Standalone BSON/JSON/template-v1 only; top-level fields, `_id` mutation rejected. |
+| `updateOne` / `ReplaceOne` by exact `_id` | `supported subset` | `TestMongoCompatibilityMatrix`, direct-wire and driver update tests | Standalone BSON/JSON/template-v1 only. Modifiers are top-level `$set`/`$inc`/`$unset`; replacement documents preserve an omitted `_id`, allow the same `_id`, and reject a changed `_id`. |
 | Batched distinct-ID `$set` updates | `supported subset` | update batch tests | Unique-index conflicts may fall back to ordered singles; generic/replacement updates stay ordered. |
 | `multi: true` | `rejected` | `TestMongoCompatibilityMatrix` | No multi-update planner. |
-| Exact-`_id` `upsert: true` | `supported subset` | `TestMongoCompatibilityMatrix`, direct-wire and driver upsert tests | Top-level `$set`/`$inc`/`$unset` and replacement only; cluster/routed upserts rejected. |
-| Top-level `$set`, `$inc`, `$unset` | `supported subset` | `TestMongoCompatibilityMatrix`, mutation tests | `$inc` supports int32/int64/double only; null/non-numeric targets reject. `$push`, pipeline, dotted paths, and other operators are rejected. |
+| Exact-`_id` `upsert: true` | `supported subset` | `TestMongoCompatibilityMatrix`, direct-wire and driver upsert tests | Modifier and replacement upserts return `n: 1`, `nModified: 0`, and typed `upserted` entries; cluster/routed upserts are rejected. |
+| Top-level `$set`, `$inc`, `$unset` | `supported subset` | `TestMongoCompatibilityMatrix`, mutation tests | `$inc` supports int32/int64/double only; null/non-numeric targets reject. Dotted fields, `$push`, pipelines, and other operators are rejected. |
 | Cluster/routed generic, replacement, and upsert updates | `rejected` | cluster submitter tests | Only existing standalone semantics are supported; cluster accepts its native BSON `$set` route only. |
 | `delete` by `_id`, limit `0` or `1` | `supported subset` | `TestMongoCompatibilityMatrix` | Non-`_id` filters rejected. |
 

--- a/TreeDB/mongo_gateway/cluster_submitter.go
+++ b/TreeDB/mongo_gateway/cluster_submitter.go
@@ -156,6 +156,15 @@ func (s *Server) clusterUpdateResponse(ctx context.Context, command wire.Documen
 		return commandError(commandCodeBadValue, "BadValue", err.Error())
 	}
 	if !exists {
+		for i, update := range updates {
+			item, err := parseMongoUpdateItem(i, update)
+			if err != nil {
+				return mongoUpdateParseCommandError(err)
+			}
+			if !item.bsonSetFieldsOK {
+				return commandError(commandCodeBadValue, "BadValue", fmt.Sprintf("updates[%d]: cluster Mongo gateway currently supports only top-level BSON $set updateOne by _id", i))
+			}
+		}
 		if s.clusterRouteProviderConfigured() {
 			return mongoClusterMutationCommandError(mongoClusterMissingCollectionMetadataError())
 		}

--- a/TreeDB/mongo_gateway/cluster_submitter.go
+++ b/TreeDB/mongo_gateway/cluster_submitter.go
@@ -139,6 +139,15 @@ func (s *Server) clusterUpdateResponse(ctx context.Context, command wire.Documen
 	if err != nil {
 		return commandError(commandCodeFailedToParse, "FailedToParse", err.Error())
 	}
+	for i, update := range updates {
+		upsert, err := optionalBoolField(update, "upsert")
+		if err != nil {
+			return commandError(commandCodeFailedToParse, "FailedToParse", fmt.Sprintf("updates[%d]: %v", i, err))
+		}
+		if upsert {
+			return commandError(commandCodeBadValue, "BadValue", fmt.Sprintf("updates[%d]: cluster Mongo gateway currently does not support upsert", i))
+		}
+	}
 	if err := s.admitClusterMutation(ctx); err != nil {
 		return mongoClusterMutationCommandError(err)
 	}

--- a/TreeDB/mongo_gateway/cluster_submitter.go
+++ b/TreeDB/mongo_gateway/cluster_submitter.go
@@ -139,15 +139,6 @@ func (s *Server) clusterUpdateResponse(ctx context.Context, command wire.Documen
 	if err != nil {
 		return commandError(commandCodeFailedToParse, "FailedToParse", err.Error())
 	}
-	for i, update := range updates {
-		upsert, err := optionalBoolField(update, "upsert")
-		if err != nil {
-			return commandError(commandCodeFailedToParse, "FailedToParse", fmt.Sprintf("updates[%d]: %v", i, err))
-		}
-		if upsert {
-			return commandError(commandCodeBadValue, "BadValue", fmt.Sprintf("updates[%d]: cluster Mongo gateway currently does not support upsert", i))
-		}
-	}
 	if err := s.admitClusterMutation(ctx); err != nil {
 		return mongoClusterMutationCommandError(err)
 	}
@@ -160,6 +151,9 @@ func (s *Server) clusterUpdateResponse(ctx context.Context, command wire.Documen
 			item, err := parseMongoUpdateItem(i, update)
 			if err != nil {
 				return mongoUpdateParseCommandError(err)
+			}
+			if item.upsert {
+				return commandError(commandCodeBadValue, "BadValue", fmt.Sprintf("updates[%d]: cluster Mongo gateway currently does not support upsert", i))
 			}
 			if !item.bsonSetFieldsOK {
 				return commandError(commandCodeBadValue, "BadValue", fmt.Sprintf("updates[%d]: cluster Mongo gateway currently supports only top-level BSON $set updateOne by _id", i))
@@ -187,6 +181,9 @@ func (s *Server) clusterUpdateResponse(ctx context.Context, command wire.Documen
 		item, err := parseMongoUpdateItem(i, update)
 		if err != nil {
 			return mongoUpdateParseCommandError(err)
+		}
+		if item.upsert {
+			return commandError(commandCodeBadValue, "BadValue", fmt.Sprintf("updates[%d]: cluster Mongo gateway currently does not support upsert", i))
 		}
 		if !item.bsonSetFieldsOK {
 			return commandError(commandCodeBadValue, "BadValue", fmt.Sprintf("updates[%d]: cluster Mongo gateway currently supports only top-level BSON $set updateOne by _id", i))

--- a/TreeDB/mongo_gateway/cluster_submitter_test.go
+++ b/TreeDB/mongo_gateway/cluster_submitter_test.go
@@ -2454,6 +2454,9 @@ func TestClusterSubmitterUpdateSubmitsPriorOrderedItemsBeforeUnsupportedUpsert(t
 	if len(ids) != 1 {
 		t.Fatalf("submitted document ids=%d want 1", len(ids))
 	}
+	if want, err := encodePrimaryKey(mustRawValue(t, "u1")); err != nil || !bytes.Equal(ids[0], want) {
+		t.Fatalf("submitted document id=%v want u1 (err=%v)", ids[0], err)
+	}
 	assertMongoClusterCallAckPolicy(t, calls[0], iwire.AckVisible)
 }
 

--- a/TreeDB/mongo_gateway/cluster_submitter_test.go
+++ b/TreeDB/mongo_gateway/cluster_submitter_test.go
@@ -2341,6 +2341,47 @@ func TestClusterSubmitterUpdateBSONSetRoutesCountsAndNoLocalMutation(t *testing.
 	}
 }
 
+func TestClusterSubmitterGenericUpdatesFailClosedWithoutLocalMutation(t *testing.T) {
+	db, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	server := NewServer()
+	server.Collections = collections.NewCollectionManager(db)
+	server.DefaultCollectionOptions = collections.CollectionOptions{DocumentFormat: collections.DocumentFormatBSON}
+	assertOK(t, serveCommand(t, server, 325830, bson.D{
+		{Key: "insert", Value: "users"},
+		{Key: "documents", Value: bson.A{bson.D{{Key: "_id", Value: "u1"}, {Key: "age", Value: int32(10)}, {Key: "name", Value: "Ada"}}}},
+		{Key: "$db", Value: "app"},
+	}))
+	submitter := &mongoClusterFakeSubmitter{}
+	setMongoClusterTestSubmitter(server, submitter, 8)
+	for _, update := range []bson.D{
+		{{Key: "$inc", Value: bson.D{{Key: "age", Value: int32(1)}}}},
+		{{Key: "name", Value: "Grace"}},
+	} {
+		response := serveCommand(t, server, 325831, bson.D{
+			{Key: "update", Value: "users"},
+			{Key: "updates", Value: bson.A{bson.D{{Key: "q", Value: bson.D{{Key: "_id", Value: "u1"}}}, {Key: "u", Value: update}}}},
+			{Key: "$db", Value: "app"},
+		})
+		assertCommandError(t, response, "BadValue")
+	}
+	if calls := submitter.snapshotCalls(); len(calls) != 0 {
+		t.Fatalf("generic updates submitted %d cluster calls", len(calls))
+	}
+	found := serveCommand(t, server, 325832, bson.D{{Key: "find", Value: "users"}, {Key: "filter", Value: bson.D{{Key: "_id", Value: "u1"}}}, {Key: "$db", Value: "app"}})
+	doc := cursorFirstBatch(t, found)[0]
+	if age, _ := doc.Lookup("age").Int32OK(); age != 10 {
+		t.Fatalf("local age=%d want 10", age)
+	}
+	if name, _ := doc.Lookup("name").StringValueOK(); name != "Ada" {
+		t.Fatalf("local name=%q want Ada", name)
+	}
+}
+
 func TestClusterSubmitterUpdateSubmitsPriorOrderedItemsBeforeUnsupported(t *testing.T) {
 	submitter := &mongoClusterFakeSubmitter{}
 	server := NewServer()

--- a/TreeDB/mongo_gateway/cluster_submitter_test.go
+++ b/TreeDB/mongo_gateway/cluster_submitter_test.go
@@ -2449,6 +2449,42 @@ func TestClusterSubmitterUpdateMissingCollectionReturnsZeroCounts(t *testing.T) 
 	}
 }
 
+func TestClusterSubmitterMissingCollectionRejectsUnsupportedUpdates(t *testing.T) {
+	db, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	submitter := &mongoClusterFakeSubmitter{}
+	server := NewServer()
+	server.Collections = collections.NewCollectionManager(db)
+	server.DefaultCollectionOptions = collections.CollectionOptions{DocumentFormat: collections.DocumentFormatBSON}
+	setMongoClusterTestSubmitter(server, submitter, 24)
+	for i, update := range []bson.D{
+		{{Key: "$inc", Value: bson.D{{Key: "age", Value: int32(1)}}}},
+		{{Key: "name", Value: "Grace"}},
+		{{Key: "$set", Value: bson.D{{Key: "name", Value: "Grace"}}}},
+	} {
+		item := bson.D{{Key: "q", Value: bson.D{{Key: "_id", Value: "u1"}}}, {Key: "u", Value: update}}
+		if i == 2 {
+			item = append(item, bson.E{Key: "upsert", Value: true})
+		}
+		response := serveCommand(t, server, int32(325824+i), bson.D{
+			{Key: "update", Value: "missing"},
+			{Key: "updates", Value: bson.A{item}},
+			{Key: "$db", Value: "app"},
+		})
+		assertCommandError(t, response, "BadValue")
+	}
+	if calls := submitter.snapshotCalls(); len(calls) != 0 {
+		t.Fatalf("submit calls=%d want 0", len(calls))
+	}
+	if _, err := server.Collections.OpenCollection("app.missing"); !errors.Is(err, collections.ErrCollectionNotFound) {
+		t.Fatalf("missing collection was created: %v", err)
+	}
+}
+
 func TestClusterSubmitterDeleteRoutesCommandEntry(t *testing.T) {
 	submitter := &mongoClusterFakeSubmitter{}
 	server := NewServer()

--- a/TreeDB/mongo_gateway/cluster_submitter_test.go
+++ b/TreeDB/mongo_gateway/cluster_submitter_test.go
@@ -2419,6 +2419,44 @@ func TestClusterSubmitterUpdateSubmitsPriorOrderedItemsBeforeUnsupported(t *test
 	assertMongoClusterCallAckPolicy(t, calls[0], iwire.AckVisible)
 }
 
+func TestClusterSubmitterUpdateSubmitsPriorOrderedItemsBeforeUnsupportedUpsert(t *testing.T) {
+	submitter := &mongoClusterFakeSubmitter{}
+	server := NewServer()
+	server.DefaultCollectionOptions = collections.CollectionOptions{DocumentFormat: collections.DocumentFormatBSON}
+	setMongoClusterTestSubmitter(server, submitter, 18)
+
+	response := serveCommand(t, server, 325819, bson.D{
+		{Key: "update", Value: "users"},
+		{Key: "updates", Value: bson.A{
+			bson.D{
+				{Key: "q", Value: bson.D{{Key: "_id", Value: "u1"}}},
+				{Key: "u", Value: bson.D{{Key: "$set", Value: bson.D{{Key: "name", Value: "Grace"}}}}},
+			},
+			bson.D{
+				{Key: "q", Value: bson.D{{Key: "_id", Value: "u2"}}},
+				{Key: "u", Value: bson.D{{Key: "$set", Value: bson.D{{Key: "name", Value: "Ada"}}}}},
+				{Key: "upsert", Value: true},
+			},
+		}},
+		{Key: "$db", Value: "app"},
+	})
+	assertCommandError(t, response, "BadValue")
+	assertErrmsgContains(t, response, "updates[1]")
+
+	calls := submitter.snapshotCalls()
+	if len(calls) != 1 {
+		t.Fatalf("submit calls=%d want 1", len(calls))
+	}
+	if got := calls[0].entry.Decoded.CommandID; got != iwire.CommandUpdateBSONSet {
+		t.Fatalf("command id=%d want update_bson_set", got)
+	}
+	ids := mongoClusterTestIDs(calls[0].entry.Decoded.Sections)
+	if len(ids) != 1 {
+		t.Fatalf("submitted document ids=%d want 1", len(ids))
+	}
+	assertMongoClusterCallAckPolicy(t, calls[0], iwire.AckVisible)
+}
+
 func TestClusterSubmitterUpdateMissingCollectionReturnsZeroCounts(t *testing.T) {
 	db, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
 	if err != nil {

--- a/TreeDB/mongo_gateway/cluster_submitter_test.go
+++ b/TreeDB/mongo_gateway/cluster_submitter_test.go
@@ -2369,6 +2369,11 @@ func TestClusterSubmitterGenericUpdatesFailClosedWithoutLocalMutation(t *testing
 		})
 		assertCommandError(t, response, "BadValue")
 	}
+	assertCommandError(t, serveCommand(t, server, 325833, bson.D{
+		{Key: "update", Value: "users"},
+		{Key: "updates", Value: bson.A{bson.D{{Key: "q", Value: bson.D{{Key: "_id", Value: "u1"}}}, {Key: "u", Value: bson.D{{Key: "$set", Value: bson.D{{Key: "name", Value: "Grace"}}}}}, {Key: "upsert", Value: true}}}},
+		{Key: "$db", Value: "app"},
+	}), "BadValue")
 	if calls := submitter.snapshotCalls(); len(calls) != 0 {
 		t.Fatalf("generic updates submitted %d cluster calls", len(calls))
 	}

--- a/TreeDB/mongo_gateway/command_wal_reopen_test.go
+++ b/TreeDB/mongo_gateway/command_wal_reopen_test.go
@@ -67,6 +67,29 @@ func TestStandaloneServerCommandWALCRUDReopens(t *testing.T) {
 				stopStandaloneMongoClientForTest(t, client, cancel, ln, serveErr, standalone)
 				t.Fatalf("UpdateOne matched=%d modified=%d, want 1/1", updateResult.MatchedCount, updateResult.ModifiedCount)
 			}
+			mutationResult, err := coll.UpdateOne(opCtx,
+				bson.D{{Key: "_id", Value: "u1"}},
+				bson.D{{Key: "$inc", Value: bson.D{{Key: "generation", Value: int32(3)}}}, {Key: "$unset", Value: bson.D{{Key: "name", Value: true}}}},
+			)
+			if err != nil || mutationResult.MatchedCount != 1 || mutationResult.ModifiedCount != 1 {
+				stopStandaloneMongoClientForTest(t, client, cancel, ln, serveErr, standalone)
+				t.Fatalf("generic UpdateOne result=%+v err=%v want 1/1", mutationResult, err)
+			}
+			replaceResult, err := coll.ReplaceOne(opCtx, bson.D{{Key: "_id", Value: "u1"}}, bson.D{{Key: "generation", Value: int32(6)}, {Key: "name", Value: "replaced"}})
+			if err != nil || replaceResult.MatchedCount != 1 || replaceResult.ModifiedCount != 1 {
+				stopStandaloneMongoClientForTest(t, client, cancel, ln, serveErr, standalone)
+				t.Fatalf("ReplaceOne result=%+v err=%v want 1/1", replaceResult, err)
+			}
+			modifierUpsert, err := coll.UpdateOne(opCtx, bson.D{{Key: "_id", Value: "u3"}}, bson.D{{Key: "$inc", Value: bson.D{{Key: "generation", Value: int32(1)}}}}, options.UpdateOne().SetUpsert(true))
+			if err != nil || modifierUpsert.UpsertedCount != 1 || modifierUpsert.UpsertedID != "u3" {
+				stopStandaloneMongoClientForTest(t, client, cancel, ln, serveErr, standalone)
+				t.Fatalf("modifier upsert result=%+v err=%v", modifierUpsert, err)
+			}
+			replacementUpsert, err := coll.ReplaceOne(opCtx, bson.D{{Key: "_id", Value: "u4"}}, bson.D{{Key: "name", Value: "upserted"}}, options.Replace().SetUpsert(true))
+			if err != nil || replacementUpsert.UpsertedCount != 1 || replacementUpsert.UpsertedID != "u4" {
+				stopStandaloneMongoClientForTest(t, client, cancel, ln, serveErr, standalone)
+				t.Fatalf("replacement upsert result=%+v err=%v", replacementUpsert, err)
+			}
 			deleteResult, err := coll.DeleteOne(opCtx, bson.D{{Key: "_id", Value: "u2"}})
 			if err != nil {
 				stopStandaloneMongoClientForTest(t, client, cancel, ln, serveErr, standalone)
@@ -114,12 +137,22 @@ func TestStandaloneServerCommandWALCRUDReopens(t *testing.T) {
 				t.Fatalf("stored BSON validation: %v", err)
 			}
 			name, ok := raw.Lookup("name").StringValueOK()
-			if !ok || name != "ada2" {
-				t.Fatalf("stored name=%q ok=%v, want ada2", name, ok)
+			if !ok || name != "replaced" {
+				t.Fatalf("stored name=%q ok=%v, want replaced", name, ok)
 			}
 			generation, ok := raw.Lookup("generation").Int32OK()
-			if !ok || generation != 2 {
-				t.Fatalf("stored generation=%d ok=%v, want 2", generation, ok)
+			if !ok || generation != 6 {
+				t.Fatalf("stored generation=%d ok=%v, want 6", generation, ok)
+			}
+			for _, id := range []string{"u3", "u4"} {
+				key, _, err := prepareInsertDocument(mustDocument(t, bson.D{{Key: "_id", Value: id}}), collections.DocumentFormatBSON)
+				if err != nil {
+					t.Fatalf("prepare %s key: %v", id, err)
+				}
+				stored, err := reopenedCollection.Get(key)
+				if err != nil || stored == nil {
+					t.Fatalf("get %s after reopen: stored=%v err=%v", id, stored, err)
+				}
 			}
 			keyU2, _, err := prepareInsertDocument(mustDocument(t, bson.D{{Key: "_id", Value: "u2"}}), collections.DocumentFormatBSON)
 			if err != nil {

--- a/TreeDB/mongo_gateway/command_wal_reopen_test.go
+++ b/TreeDB/mongo_gateway/command_wal_reopen_test.go
@@ -172,6 +172,70 @@ func TestStandaloneServerCommandWALCRUDReopens(t *testing.T) {
 	}
 }
 
+func TestMongoMutationCommandWALValueLogPointersReopen(t *testing.T) {
+	dir := t.TempDir()
+	opts := treedb.OptionsFor(treedb.ProfileCommandWALDurable, dir)
+	opts.ValueLog.PointerThreshold = 1
+	backend, closeBackend, err := treedb.OpenBackend(opts)
+	if err != nil {
+		t.Fatalf("open backend: %v", err)
+	}
+	server := NewServer()
+	server.Collections = collections.NewCollectionManager(backend)
+	server.DefaultCollectionOptions = collections.CollectionOptions{DocumentFormat: collections.DocumentFormatBSON}
+	assertOK(t, serveCommand(t, server, 1, bson.D{{Key: "insert", Value: "users"}, {Key: "documents", Value: bson.A{bson.D{{Key: "_id", Value: "u1"}, {Key: "generation", Value: int32(1)}}}}, {Key: "$db", Value: "app"}}))
+	assertOK(t, serveCommand(t, server, 2, bson.D{{Key: "update", Value: "users"}, {Key: "updates", Value: bson.A{
+		bson.D{{Key: "q", Value: bson.D{{Key: "_id", Value: "u1"}}}, {Key: "u", Value: bson.D{{Key: "$inc", Value: bson.D{{Key: "generation", Value: int32(5)}}}}}},
+		bson.D{{Key: "q", Value: bson.D{{Key: "_id", Value: "u2"}}}, {Key: "u", Value: bson.D{{Key: "$set", Value: bson.D{{Key: "name", Value: "upserted"}}}}}, {Key: "upsert", Value: true}},
+	}}, {Key: "$db", Value: "app"}}))
+	if err := server.Collections.FlushAll(); err != nil {
+		_ = closeBackend()
+		t.Fatalf("flush collections: %v", err)
+	}
+	if err := backend.Checkpoint(); err != nil {
+		_ = closeBackend()
+		t.Fatalf("checkpoint: %v", err)
+	}
+	if err := closeBackend(); err != nil {
+		t.Fatalf("close backend: %v", err)
+	}
+
+	reopened, closeReopened, err := treedb.OpenBackend(opts)
+	if err != nil {
+		t.Fatalf("reopen backend: %v", err)
+	}
+	defer func() { _ = closeReopened() }()
+	collection, err := collections.NewCollectionManager(reopened).OpenCollection("app.users")
+	if err != nil {
+		t.Fatalf("open collection after reopen: %v", err)
+	}
+	for _, want := range []struct {
+		id         string
+		generation int32
+		name       string
+	}{{id: "u1", generation: 6}, {id: "u2", name: "upserted"}} {
+		key, _, err := prepareInsertDocument(mustDocument(t, bson.D{{Key: "_id", Value: want.id}}), collections.DocumentFormatBSON)
+		if err != nil {
+			t.Fatalf("prepare %s key: %v", want.id, err)
+		}
+		stored, err := collection.Get(key)
+		if err != nil {
+			t.Fatalf("get %s after reopen: %v", want.id, err)
+		}
+		raw := bson.Raw(stored)
+		if want.generation != 0 {
+			if got, ok := raw.Lookup("generation").Int32OK(); !ok || got != want.generation {
+				t.Fatalf("%s generation=%d ok=%v, want %d", want.id, got, ok, want.generation)
+			}
+		}
+		if want.name != "" {
+			if got, ok := raw.Lookup("name").StringValueOK(); !ok || got != want.name {
+				t.Fatalf("%s name=%q ok=%v, want %q", want.id, got, ok, want.name)
+			}
+		}
+	}
+}
+
 func startStandaloneMongoClientForTest(t *testing.T, standalone *StandaloneServer) (*mongo.Client, context.CancelFunc, net.Listener, chan error) {
 	t.Helper()
 	ctx, cancel := context.WithCancel(context.Background())

--- a/TreeDB/mongo_gateway/commands.go
+++ b/TreeDB/mongo_gateway/commands.go
@@ -940,6 +940,7 @@ type mongoUpdateItem struct {
 	bsonSetFields   []collections.BSONSetField
 	setFieldsOK     bool
 	bsonSetFieldsOK bool
+	mutation        mongoMutation
 }
 
 type mongoUpdateParseError struct {
@@ -979,6 +980,10 @@ func parseMongoUpdateItem(index int, update wire.Document) (mongoUpdateItem, err
 	if err != nil {
 		return mongoUpdateItem{}, mongoUpdateParseError{code: commandCodeFailedToParse, codeName: "FailedToParse", message: fmt.Sprintf("updates[%d]: %v", index, err)}
 	}
+	mutation, err := parseMongoMutation(updateDoc)
+	if err != nil {
+		return mongoUpdateItem{}, mongoUpdateParseError{code: commandCodeBadValue, codeName: "BadValue", message: fmt.Sprintf("updates[%d]: %v", index, err)}
+	}
 	setFields, bsonSetFields, setFieldsOK := mongoSetUpdateFields(updateDoc)
 	bsonSetFields, bsonSetFieldNames, bsonSetFieldsOK := mongoBSONSetUpdateFields(updateDoc)
 	if !setFieldsOK && bsonSetFieldsOK {
@@ -992,6 +997,7 @@ func parseMongoUpdateItem(index int, update wire.Document) (mongoUpdateItem, err
 		bsonSetFields:   bsonSetFields,
 		setFieldsOK:     setFieldsOK,
 		bsonSetFieldsOK: bsonSetFieldsOK,
+		mutation:        mutation,
 	}, nil
 }
 
@@ -1124,7 +1130,7 @@ func applyMongoUpdateToStoredDocument(col *collections.Collection, materializer 
 	if err != nil {
 		return nil, false, fmt.Errorf("updates[%d]: %w", update.index, err)
 	}
-	updated, changed, err := applySetUpdate(raw, update.updateDoc)
+	updated, changed, err := applyMongoMutation(raw, update.mutation)
 	if err != nil {
 		return nil, false, fmt.Errorf("updates[%d]: %w", update.index, err)
 	}
@@ -3582,8 +3588,11 @@ type mongoMutation struct {
 // parseMongoMutation is deliberately separate from the established $set path.
 func parseMongoMutation(update wire.Document) (mongoMutation, error) {
 	elements, err := bson.Raw(update).Elements()
-	if err != nil || len(elements) == 0 {
+	if err != nil {
 		return mongoMutation{}, errors.New("Mongo gateway update must be a non-empty document")
+	}
+	if len(elements) == 0 {
+		return mongoMutation{replace: update}, nil
 	}
 	first, err := elements[0].KeyErr()
 	if err != nil {

--- a/TreeDB/mongo_gateway/commands.go
+++ b/TreeDB/mongo_gateway/commands.go
@@ -898,6 +898,9 @@ func (s *Server) updateResponse(ctx context.Context, command wire.Document, sequ
 					hasUpsert = hasUpsert || prior.upsert
 				}
 				if hasUpsert {
+					if err := s.validateMongoMissingCollectionUpserts(parsed); err != nil {
+						return mongoUpdateWriteCommandError(err)
+					}
 					col, err = s.openOrCreateCollection(name)
 					if err != nil {
 						return commandError(commandCodeBadValue, "BadValue", err.Error())
@@ -927,6 +930,9 @@ func (s *Server) updateResponse(ctx context.Context, command wire.Document, sequ
 		}
 		if !hasUpsert {
 			return marshalUpdateResponse(0, 0, nil)
+		}
+		if err := s.validateMongoMissingCollectionUpserts(parsed); err != nil {
+			return mongoUpdateWriteCommandError(err)
 		}
 		col, err = s.openOrCreateCollection(name)
 		if err != nil {
@@ -1131,16 +1137,7 @@ func runMongoUpdateOneWithUpsert(col *collections.Collection, update mongoUpdate
 }
 
 func mongoInsertUpsert(col *collections.Collection, update mongoUpdateItem) (bool, bool, bool, error) {
-	base, err := marshalDocument(bson.D{{Key: "_id", Value: update.id}})
-	if err != nil {
-		return false, false, false, err
-	}
-	var doc wire.Document
-	if update.pureSet {
-		doc, _, err = applySetUpdate(base, update.updateDoc)
-	} else {
-		doc, _, err = applyMongoMutation(base, update.mutation)
-	}
+	doc, err := mongoUpsertDocument(update)
 	if err != nil {
 		return false, false, false, err
 	}
@@ -1155,6 +1152,43 @@ func mongoInsertUpsert(col *collections.Collection, update mongoUpdateItem) (boo
 		return false, false, false, err
 	}
 	return false, false, true, nil
+}
+
+func (s *Server) validateMongoMissingCollectionUpserts(updates []mongoUpdateItem) error {
+	for _, update := range updates {
+		if !update.upsert {
+			continue
+		}
+		doc, err := mongoUpsertDocument(update)
+		if err != nil {
+			return mongoUpdateErrorWithIndex(update.index, err)
+		}
+		key, _, err := prepareInsertDocument(doc, s.DefaultCollectionOptions.DocumentFormat)
+		if err != nil {
+			return mongoUpdateErrorWithIndex(update.index, err)
+		}
+		if !bytes.Equal(key, update.key) {
+			return mongoUpdateErrorWithIndex(update.index, errors.New("Mongo gateway update cannot modify _id"))
+		}
+	}
+	return nil
+}
+
+func mongoUpsertDocument(update mongoUpdateItem) (wire.Document, error) {
+	base, err := marshalDocument(bson.D{{Key: "_id", Value: update.id}})
+	if err != nil {
+		return nil, err
+	}
+	var doc wire.Document
+	if update.pureSet {
+		doc, _, err = applySetUpdate(base, update.updateDoc)
+	} else {
+		doc, _, err = applyMongoMutation(base, update.mutation)
+	}
+	if err != nil {
+		return nil, err
+	}
+	return doc, nil
 }
 
 func runMongoUpdateBatch(col *collections.Collection, updates []mongoUpdateItem) (int32, int32, bool, error) {

--- a/TreeDB/mongo_gateway/commands.go
+++ b/TreeDB/mongo_gateway/commands.go
@@ -1182,7 +1182,11 @@ func mongoUpsertDocument(update mongoUpdateItem) (wire.Document, error) {
 	}
 	var doc wire.Document
 	if update.pureSet {
-		doc, _, err = applySetUpdate(base, update.updateDoc)
+		if update.bsonSetFieldsOK && !update.setFieldsOK {
+			doc, _, err = applyBSONSetUpdate(base, update.bsonSetFields)
+		} else {
+			doc, _, err = applySetUpdate(base, update.updateDoc)
+		}
 	} else {
 		doc, _, err = applyMongoMutation(base, update.mutation)
 	}
@@ -3680,6 +3684,20 @@ func applySetUpdate(doc wire.Document, update wire.Document) (wire.Document, boo
 	if err != nil {
 		return nil, false, err
 	}
+	return applySetFields(doc, sets, setOrder)
+}
+
+func applyBSONSetUpdate(doc wire.Document, fields []collections.BSONSetField) (wire.Document, bool, error) {
+	sets := make(map[string]bson.RawValue, len(fields))
+	setOrder := make([]string, 0, len(fields))
+	for _, field := range fields {
+		sets[field.Key] = field.Value
+		setOrder = append(setOrder, field.Key)
+	}
+	return applySetFields(doc, sets, setOrder)
+}
+
+func applySetFields(doc wire.Document, sets map[string]bson.RawValue, setOrder []string) (wire.Document, bool, error) {
 	if len(sets) == 0 {
 		return doc, false, nil
 	}

--- a/TreeDB/mongo_gateway/commands.go
+++ b/TreeDB/mongo_gateway/commands.go
@@ -3703,6 +3703,9 @@ func parseMongoMutation(update wire.Document) (mongoMutation, error) {
 		return mongoMutation{}, errors.New("Mongo gateway update must be a non-empty document")
 	}
 	if len(elements) == 0 {
+		if _, err := validateMongoReplacement(update); err != nil {
+			return mongoMutation{}, err
+		}
 		return mongoMutation{replace: update}, nil
 	}
 	first, err := elements[0].KeyErr()
@@ -3715,6 +3718,9 @@ func parseMongoMutation(update wire.Document) (mongoMutation, error) {
 			if strings.HasPrefix(key, "$") {
 				return mongoMutation{}, errors.New("Mongo gateway update cannot mix replacement fields and operators")
 			}
+		}
+		if _, err := validateMongoReplacement(update); err != nil {
+			return mongoMutation{}, err
 		}
 		return mongoMutation{replace: update}, nil
 	}
@@ -3837,16 +3843,16 @@ func applyMongoMutation(doc wire.Document, mutation mongoMutation) (wire.Documen
 }
 
 func applyMongoReplacement(doc, replacement wire.Document) (wire.Document, bool, error) {
+	elements, err := validateMongoReplacement(replacement)
+	if err != nil {
+		return nil, false, err
+	}
 	oldID, newID := bson.Raw(doc).Lookup("_id"), bson.Raw(replacement).Lookup("_id")
 	if !newID.IsZero() && !newID.Equal(oldID) {
 		return nil, false, errors.New("Mongo gateway update cannot modify _id")
 	}
 	if !newID.IsZero() {
 		return replacement, !bytes.Equal(doc, replacement), nil
-	}
-	elements, err := bson.Raw(replacement).Elements()
-	if err != nil {
-		return nil, false, err
 	}
 	out := bson.D{{Key: "_id", Value: oldID}}
 	for _, elem := range elements {
@@ -3855,6 +3861,28 @@ func applyMongoReplacement(doc, replacement wire.Document) (wire.Document, bool,
 	}
 	raw, err := bson.Marshal(out)
 	return wire.Document(raw), !bytes.Equal(doc, raw), err
+}
+
+func validateMongoReplacement(replacement wire.Document) ([]bson.RawElement, error) {
+	elements, err := bson.Raw(replacement).Elements()
+	if err != nil {
+		return nil, err
+	}
+	for _, elem := range elements {
+		key, err := elem.KeyErr()
+		if err != nil {
+			return nil, err
+		}
+		if key != "_id" {
+			if err := validateSetFieldName(key); err != nil {
+				return nil, err
+			}
+		}
+		if err := elem.Value().Validate(); err != nil {
+			return nil, err
+		}
+	}
+	return elements, nil
 }
 
 func mongoMutationNumeric(v bson.RawValue) bool {

--- a/TreeDB/mongo_gateway/commands.go
+++ b/TreeDB/mongo_gateway/commands.go
@@ -1266,7 +1266,11 @@ func applyMongoUpdateToStoredDocument(col *collections.Collection, materializer 
 	var updated wire.Document
 	var changed bool
 	if update.pureSet {
-		updated, changed, err = applySetUpdate(raw, update.updateDoc)
+		if normalizedMongoUpdateDocumentFormat(col) == collections.DocumentFormatBSON && update.bsonSetFieldsOK {
+			updated, changed, err = applyBSONSetUpdate(raw, update.bsonSetFields)
+		} else {
+			updated, changed, err = applySetUpdate(raw, update.updateDoc)
+		}
 	} else {
 		updated, changed, err = applyMongoMutation(raw, update.mutation)
 	}

--- a/TreeDB/mongo_gateway/commands.go
+++ b/TreeDB/mongo_gateway/commands.go
@@ -891,12 +891,27 @@ func (s *Server) updateResponse(ctx context.Context, command wire.Document, sequ
 	for i, update := range updates {
 		item, err := parseMongoUpdateItem(i, update)
 		if err != nil {
-			if len(parsed) > 0 && !missingCollection {
+			parseErr := err
+			if len(parsed) > 0 && missingCollection {
+				hasUpsert := false
+				for _, prior := range parsed {
+					hasUpsert = hasUpsert || prior.upsert
+				}
+				if hasUpsert {
+					col, err = s.openOrCreateCollection(name)
+					if err != nil {
+						return commandError(commandCodeBadValue, "BadValue", err.Error())
+					}
+					if _, _, _, runErr := runMongoUpdatesSequentialWithUpserts(col, parsed); runErr != nil {
+						return mongoUpdateWriteCommandError(runErr)
+					}
+				}
+			} else if len(parsed) > 0 {
 				if _, _, runErr := runMongoUpdatesSequential(col, parsed); runErr != nil {
 					return mongoUpdateWriteCommandError(runErr)
 				}
 			}
-			return mongoUpdateParseCommandError(err)
+			return mongoUpdateParseCommandError(parseErr)
 		}
 		keyString := string(item.key)
 		if _, ok := seenKeys[keyString]; ok {
@@ -956,6 +971,7 @@ type mongoUpdateItem struct {
 	bsonSetFields   []collections.BSONSetField
 	setFieldsOK     bool
 	bsonSetFieldsOK bool
+	pureSet         bool
 	mutation        mongoMutation
 	upsert          bool
 	id              bson.RawValue
@@ -997,14 +1013,17 @@ func parseMongoUpdateItem(index int, update wire.Document) (mongoUpdateItem, err
 	if err != nil {
 		return mongoUpdateItem{}, mongoUpdateParseError{code: commandCodeFailedToParse, codeName: "FailedToParse", message: fmt.Sprintf("updates[%d]: %v", index, err)}
 	}
-	mutation, err := parseMongoMutation(updateDoc)
-	if err != nil {
-		return mongoUpdateItem{}, mongoUpdateParseError{code: commandCodeBadValue, codeName: "BadValue", message: fmt.Sprintf("updates[%d]: %v", index, err)}
-	}
 	setFields, bsonSetFields, setFieldsOK := mongoSetUpdateFields(updateDoc)
 	bsonSetFields, bsonSetFieldNames, bsonSetFieldsOK := mongoBSONSetUpdateFields(updateDoc)
 	if !setFieldsOK && bsonSetFieldsOK {
 		setFields = bsonSetFieldNames
+	}
+	var mutation mongoMutation
+	if !setFieldsOK {
+		mutation, err = parseMongoMutation(updateDoc)
+		if err != nil {
+			return mongoUpdateItem{}, mongoUpdateParseError{code: commandCodeBadValue, codeName: "BadValue", message: fmt.Sprintf("updates[%d]: %v", index, err)}
+		}
 	}
 	return mongoUpdateItem{
 		index:           index,
@@ -1014,6 +1033,7 @@ func parseMongoUpdateItem(index int, update wire.Document) (mongoUpdateItem, err
 		bsonSetFields:   bsonSetFields,
 		setFieldsOK:     setFieldsOK,
 		bsonSetFieldsOK: bsonSetFieldsOK,
+		pureSet:         setFieldsOK,
 		mutation:        mutation,
 		upsert:          upsert,
 		id:              id,
@@ -1114,7 +1134,12 @@ func mongoInsertUpsert(col *collections.Collection, update mongoUpdateItem) (boo
 	if err != nil {
 		return false, false, false, err
 	}
-	doc, _, err := applyMongoMutation(base, update.mutation)
+	var doc wire.Document
+	if update.pureSet {
+		doc, _, err = applySetUpdate(base, update.updateDoc)
+	} else {
+		doc, _, err = applyMongoMutation(base, update.mutation)
+	}
 	if err != nil {
 		return false, false, false, err
 	}
@@ -1198,7 +1223,13 @@ func applyMongoUpdateToStoredDocument(col *collections.Collection, materializer 
 	if err != nil {
 		return nil, false, fmt.Errorf("updates[%d]: %w", update.index, err)
 	}
-	updated, changed, err := applyMongoMutation(raw, update.mutation)
+	var updated wire.Document
+	var changed bool
+	if update.pureSet {
+		updated, changed, err = applySetUpdate(raw, update.updateDoc)
+	} else {
+		updated, changed, err = applyMongoMutation(raw, update.mutation)
+	}
 	if err != nil {
 		return nil, false, fmt.Errorf("updates[%d]: %w", update.index, err)
 	}

--- a/TreeDB/mongo_gateway/commands.go
+++ b/TreeDB/mongo_gateway/commands.go
@@ -1019,7 +1019,8 @@ func parseMongoUpdateItem(index int, update wire.Document) (mongoUpdateItem, err
 		setFields = bsonSetFieldNames
 	}
 	var mutation mongoMutation
-	if !setFieldsOK {
+	pureSet := setFieldsOK || bsonSetFieldsOK
+	if !pureSet {
 		mutation, err = parseMongoMutation(updateDoc)
 		if err != nil {
 			return mongoUpdateItem{}, mongoUpdateParseError{code: commandCodeBadValue, codeName: "BadValue", message: fmt.Sprintf("updates[%d]: %v", index, err)}
@@ -1033,7 +1034,7 @@ func parseMongoUpdateItem(index int, update wire.Document) (mongoUpdateItem, err
 		bsonSetFields:   bsonSetFields,
 		setFieldsOK:     setFieldsOK,
 		bsonSetFieldsOK: bsonSetFieldsOK,
-		pureSet:         setFieldsOK,
+		pureSet:         pureSet,
 		mutation:        mutation,
 		upsert:          upsert,
 		id:              id,

--- a/TreeDB/mongo_gateway/commands.go
+++ b/TreeDB/mongo_gateway/commands.go
@@ -3568,6 +3568,215 @@ func applySetUpdate(doc wire.Document, update wire.Document) (wire.Document, boo
 	return wire.Document(raw), changed, nil
 }
 
+type mongoMutationField struct {
+	name  string
+	value bson.RawValue
+}
+
+type mongoMutation struct {
+	set, inc []mongoMutationField
+	unset    []string
+	replace  wire.Document
+}
+
+// parseMongoMutation is deliberately separate from the established $set path.
+func parseMongoMutation(update wire.Document) (mongoMutation, error) {
+	elements, err := bson.Raw(update).Elements()
+	if err != nil || len(elements) == 0 {
+		return mongoMutation{}, errors.New("Mongo gateway update must be a non-empty document")
+	}
+	first, err := elements[0].KeyErr()
+	if err != nil {
+		return mongoMutation{}, err
+	}
+	if !strings.HasPrefix(first, "$") {
+		for _, elem := range elements {
+			key, _ := elem.KeyErr()
+			if strings.HasPrefix(key, "$") {
+				return mongoMutation{}, errors.New("Mongo gateway update cannot mix replacement fields and operators")
+			}
+		}
+		return mongoMutation{replace: update}, nil
+	}
+	mutation := mongoMutation{}
+	seen := make(map[string]struct{})
+	for _, elem := range elements {
+		op, err := elem.KeyErr()
+		if err != nil {
+			return mongoMutation{}, err
+		}
+		if op != "$set" && op != "$inc" && op != "$unset" {
+			return mongoMutation{}, fmt.Errorf("Mongo gateway unsupported update operator %q", op)
+		}
+		fields, ok := elem.Value().DocumentOK()
+		if !ok {
+			return mongoMutation{}, fmt.Errorf("Mongo gateway %s value must be a document", op)
+		}
+		items, err := fields.Elements()
+		if err != nil {
+			return mongoMutation{}, err
+		}
+		for _, item := range items {
+			name, err := item.KeyErr()
+			if err != nil {
+				return mongoMutation{}, err
+			}
+			if err := validateSetFieldName(name); err != nil {
+				return mongoMutation{}, err
+			}
+			if _, ok := seen[name]; ok {
+				return mongoMutation{}, fmt.Errorf("Mongo gateway update operators cannot target field %q more than once", name)
+			}
+			seen[name] = struct{}{}
+			value := item.Value()
+			if err := value.Validate(); err != nil {
+				return mongoMutation{}, err
+			}
+			switch op {
+			case "$set":
+				mutation.set = append(mutation.set, mongoMutationField{name, value})
+			case "$inc":
+				if !mongoMutationNumeric(value) {
+					return mongoMutation{}, fmt.Errorf("Mongo gateway $inc field %q must be numeric", name)
+				}
+				mutation.inc = append(mutation.inc, mongoMutationField{name, value})
+			case "$unset":
+				mutation.unset = append(mutation.unset, name)
+			}
+		}
+	}
+	return mutation, nil
+}
+
+func applyMongoMutation(doc wire.Document, mutation mongoMutation) (wire.Document, bool, error) {
+	if mutation.replace != nil {
+		return applyMongoReplacement(doc, mutation.replace)
+	}
+	set := make(map[string]bson.RawValue, len(mutation.set))
+	inc := make(map[string]bson.RawValue, len(mutation.inc))
+	unset := make(map[string]struct{}, len(mutation.unset))
+	for _, field := range mutation.set {
+		set[field.name] = field.value
+	}
+	for _, field := range mutation.inc {
+		inc[field.name] = field.value
+	}
+	for _, name := range mutation.unset {
+		unset[name] = struct{}{}
+	}
+	elements, err := bson.Raw(doc).Elements()
+	if err != nil {
+		return nil, false, err
+	}
+	out := make(bson.D, 0, len(elements)+len(set)+len(inc))
+	seen := make(map[string]struct{}, len(elements))
+	changed := false
+	for _, elem := range elements {
+		name, _ := elem.KeyErr()
+		value := elem.Value()
+		seen[name] = struct{}{}
+		if _, ok := unset[name]; ok {
+			changed = true
+			continue
+		}
+		if next, ok := set[name]; ok {
+			if !next.Equal(value) {
+				changed = true
+			}
+			value = next
+		}
+		if delta, ok := inc[name]; ok {
+			next, err := mongoMutationIncrement(value, delta)
+			if err != nil {
+				return nil, false, err
+			}
+			if !next.Equal(value) {
+				changed = true
+			}
+			value = next
+		}
+		out = append(out, bson.E{Key: name, Value: value})
+	}
+	for _, field := range mutation.set {
+		if _, ok := seen[field.name]; !ok {
+			out = append(out, bson.E{Key: field.name, Value: field.value})
+			changed = true
+		}
+	}
+	for _, field := range mutation.inc {
+		if _, ok := seen[field.name]; !ok {
+			out = append(out, bson.E{Key: field.name, Value: field.value})
+			changed = true
+		}
+	}
+	if !changed {
+		return doc, false, nil
+	}
+	raw, err := bson.Marshal(out)
+	return wire.Document(raw), true, err
+}
+
+func applyMongoReplacement(doc, replacement wire.Document) (wire.Document, bool, error) {
+	oldID, newID := bson.Raw(doc).Lookup("_id"), bson.Raw(replacement).Lookup("_id")
+	if !newID.IsZero() && !newID.Equal(oldID) {
+		return nil, false, errors.New("Mongo gateway update cannot modify _id")
+	}
+	if !newID.IsZero() {
+		return replacement, !bytes.Equal(doc, replacement), nil
+	}
+	elements, err := bson.Raw(replacement).Elements()
+	if err != nil {
+		return nil, false, err
+	}
+	out := bson.D{{Key: "_id", Value: oldID}}
+	for _, elem := range elements {
+		key, _ := elem.KeyErr()
+		out = append(out, bson.E{Key: key, Value: elem.Value()})
+	}
+	raw, err := bson.Marshal(out)
+	return wire.Document(raw), !bytes.Equal(doc, raw), err
+}
+
+func mongoMutationNumeric(v bson.RawValue) bool {
+	return v.Type == bson.TypeInt32 || v.Type == bson.TypeInt64 || v.Type == bson.TypeDouble
+}
+func mongoMutationInt64(v bson.RawValue) int64 {
+	if n, ok := v.Int64OK(); ok {
+		return n
+	}
+	n, _ := v.Int32OK()
+	return int64(n)
+}
+func mongoMutationRaw(v any) (bson.RawValue, error) {
+	typ, raw, err := bson.MarshalValue(v)
+	return bson.RawValue{Type: typ, Value: raw}, err
+}
+func mongoMutationIncrement(value, delta bson.RawValue) (bson.RawValue, error) {
+	if !mongoMutationNumeric(value) {
+		return bson.RawValue{}, errors.New("Mongo gateway $inc target must be numeric and not null")
+	}
+	if value.Type == bson.TypeDouble || delta.Type == bson.TypeDouble {
+		a, _ := value.DoubleOK()
+		if value.Type != bson.TypeDouble {
+			a = float64(mongoMutationInt64(value))
+		}
+		b, _ := delta.DoubleOK()
+		if delta.Type != bson.TypeDouble {
+			b = float64(mongoMutationInt64(delta))
+		}
+		return mongoMutationRaw(a + b)
+	}
+	a, b := mongoMutationInt64(value), mongoMutationInt64(delta)
+	if (b > 0 && a > math.MaxInt64-b) || (b < 0 && a < math.MinInt64-b) {
+		return bson.RawValue{}, errors.New("Mongo gateway $inc overflow")
+	}
+	sum := a + b
+	if value.Type == bson.TypeInt32 && delta.Type == bson.TypeInt32 && sum >= math.MinInt32 && sum <= math.MaxInt32 {
+		return mongoMutationRaw(int32(sum))
+	}
+	return mongoMutationRaw(sum)
+}
+
 type createIndexDefinition struct {
 	scalarDef collections.IndexDefinition
 	vectorDef collections.VectorIndexDefinition

--- a/TreeDB/mongo_gateway/commands.go
+++ b/TreeDB/mongo_gateway/commands.go
@@ -881,10 +881,8 @@ func (s *Server) updateResponse(ctx context.Context, command wire.Document, sequ
 	}
 
 	col, err := s.Collections.OpenCollection(name)
-	if err != nil {
-		if errors.Is(err, collections.ErrCollectionNotFound) {
-			return marshalUpdateResponse(0, 0)
-		}
+	missingCollection := errors.Is(err, collections.ErrCollectionNotFound)
+	if err != nil && !missingCollection {
 		return commandError(commandCodeBadValue, "BadValue", err.Error())
 	}
 	parsed := make([]mongoUpdateItem, 0, len(updates))
@@ -893,7 +891,7 @@ func (s *Server) updateResponse(ctx context.Context, command wire.Document, sequ
 	for i, update := range updates {
 		item, err := parseMongoUpdateItem(i, update)
 		if err != nil {
-			if len(parsed) > 0 {
+			if len(parsed) > 0 && !missingCollection {
 				if _, _, runErr := runMongoUpdatesSequential(col, parsed); runErr != nil {
 					return mongoUpdateWriteCommandError(runErr)
 				}
@@ -907,8 +905,26 @@ func (s *Server) updateResponse(ctx context.Context, command wire.Document, sequ
 		seenKeys[keyString] = struct{}{}
 		parsed = append(parsed, item)
 	}
+	if missingCollection {
+		hasUpsert := false
+		for _, item := range parsed {
+			hasUpsert = hasUpsert || item.upsert
+		}
+		if !hasUpsert {
+			return marshalUpdateResponse(0, 0, nil)
+		}
+		col, err = s.openOrCreateCollection(name)
+		if err != nil {
+			return commandError(commandCodeBadValue, "BadValue", err.Error())
+		}
+	}
 	var matched, modified int32
-	if len(parsed) == 1 {
+	var upserted []mongoUpdateUpserted
+	hasUpsert := false
+	for _, item := range parsed {
+		hasUpsert = hasUpsert || item.upsert
+	}
+	if len(parsed) == 1 && !hasUpsert {
 		var matchedOne, modifiedOne bool
 		matchedOne, modifiedOne, err = s.runMongoUpdateCoalesced(name, col, parsed[0])
 		if matchedOne {
@@ -917,19 +933,19 @@ func (s *Server) updateResponse(ctx context.Context, command wire.Document, sequ
 		if modifiedOne {
 			modified = 1
 		}
-	} else if len(parsed) > 1 && !hasDuplicateKey {
+	} else if len(parsed) > 1 && !hasDuplicateKey && !hasUpsert {
 		var batched bool
 		matched, modified, batched, err = runMongoUpdateBatch(col, parsed)
 		if err != nil || !batched {
 			matched, modified, err = runMongoUpdatesSequential(col, parsed)
 		}
 	} else {
-		matched, modified, err = runMongoUpdatesSequential(col, parsed)
+		matched, modified, upserted, err = runMongoUpdatesSequentialWithUpserts(col, parsed)
 	}
 	if err != nil {
 		return mongoUpdateWriteCommandError(err)
 	}
-	return marshalUpdateResponse(matched, modified)
+	return marshalUpdateResponse(matched, modified, upserted)
 }
 
 type mongoUpdateItem struct {
@@ -941,6 +957,8 @@ type mongoUpdateItem struct {
 	setFieldsOK     bool
 	bsonSetFieldsOK bool
 	mutation        mongoMutation
+	upsert          bool
+	id              bson.RawValue
 }
 
 type mongoUpdateParseError struct {
@@ -971,10 +989,9 @@ func parseMongoUpdateItem(index int, update wire.Document) (mongoUpdateItem, err
 	} else if multi {
 		return mongoUpdateItem{}, mongoUpdateParseError{code: commandCodeBadValue, codeName: "BadValue", message: fmt.Sprintf("updates[%d]: Mongo gateway update currently supports updateOne only", index)}
 	}
-	if upsert, err := optionalBoolField(update, "upsert"); err != nil {
+	upsert, err := optionalBoolField(update, "upsert")
+	if err != nil {
 		return mongoUpdateItem{}, mongoUpdateParseError{code: commandCodeFailedToParse, codeName: "FailedToParse", message: fmt.Sprintf("updates[%d]: %v", index, err)}
-	} else if upsert {
-		return mongoUpdateItem{}, mongoUpdateParseError{code: commandCodeBadValue, codeName: "BadValue", message: fmt.Sprintf("updates[%d]: Mongo gateway update currently does not support upsert", index)}
 	}
 	updateDoc, err := requiredDocumentField(update, "u")
 	if err != nil {
@@ -998,6 +1015,8 @@ func parseMongoUpdateItem(index int, update wire.Document) (mongoUpdateItem, err
 		setFieldsOK:     setFieldsOK,
 		bsonSetFieldsOK: bsonSetFieldsOK,
 		mutation:        mutation,
+		upsert:          upsert,
+		id:              id,
 	}, nil
 }
 
@@ -1018,12 +1037,23 @@ func mongoUpdateWriteCommandError(err error) (wire.Document, error) {
 }
 
 func runMongoUpdatesSequential(col *collections.Collection, updates []mongoUpdateItem) (int32, int32, error) {
+	matched, modified, _, err := runMongoUpdatesSequentialWithUpserts(col, updates)
+	return matched, modified, err
+}
+
+type mongoUpdateUpserted struct {
+	index int
+	id    bson.RawValue
+}
+
+func runMongoUpdatesSequentialWithUpserts(col *collections.Collection, updates []mongoUpdateItem) (int32, int32, []mongoUpdateUpserted, error) {
 	var matched int32
 	var modified int32
+	var upserted []mongoUpdateUpserted
 	for _, update := range updates {
-		matchedOne, modifiedOne, err := runMongoUpdateOne(col, update)
+		matchedOne, modifiedOne, inserted, err := runMongoUpdateOneWithUpsert(col, update)
 		if err != nil {
-			return 0, 0, mongoUpdateErrorWithIndex(update.index, err)
+			return 0, 0, nil, mongoUpdateErrorWithIndex(update.index, err)
 		}
 		if matchedOne {
 			matched++
@@ -1031,8 +1061,12 @@ func runMongoUpdatesSequential(col *collections.Collection, updates []mongoUpdat
 		if modifiedOne {
 			modified++
 		}
+		if inserted {
+			matched++
+			upserted = append(upserted, mongoUpdateUpserted{index: update.index, id: update.id})
+		}
 	}
-	return matched, modified, nil
+	return matched, modified, upserted, nil
 }
 
 func mongoUpdateErrorWithIndex(index int, err error) error {
@@ -1047,20 +1081,54 @@ func mongoUpdateErrorWithIndex(index int, err error) error {
 }
 
 func runMongoUpdateOne(col *collections.Collection, update mongoUpdateItem) (bool, bool, error) {
+	matched, modified, _, err := runMongoUpdateOneWithUpsert(col, update)
+	return matched, modified, err
+}
+
+func runMongoUpdateOneWithUpsert(col *collections.Collection, update mongoUpdateItem) (bool, bool, bool, error) {
 	if mongoUpdateCanUseBSONSet(col, update) {
 		matched, modified, err := col.UpdateBSONSet(update.key, update.bsonSetFields)
-		return matched, modified, mongoUpdateErrorWithIndex(update.index, err)
+		if err != nil || matched || !update.upsert {
+			return matched, modified, false, mongoUpdateErrorWithIndex(update.index, err)
+		}
+		return mongoInsertUpsert(col, update)
 	}
 	materializer, err := storedDocumentMaterializerForCollection(col)
 	if err != nil {
-		return false, false, fmt.Errorf("updates[%d]: %w", update.index, err)
+		return false, false, false, fmt.Errorf("updates[%d]: %w", update.index, err)
 	}
 	if materializer != nil {
 		defer func() { _ = materializer.Close() }()
 	}
-	return col.Update(update.key, func(stored []byte) ([]byte, bool, error) {
+	matched, modified, err := col.Update(update.key, func(stored []byte) ([]byte, bool, error) {
 		return applyMongoUpdateToStoredDocument(col, materializer, update, stored)
 	})
+	if err != nil || matched || !update.upsert {
+		return matched, modified, false, err
+	}
+	return mongoInsertUpsert(col, update)
+}
+
+func mongoInsertUpsert(col *collections.Collection, update mongoUpdateItem) (bool, bool, bool, error) {
+	base, err := marshalDocument(bson.D{{Key: "_id", Value: update.id}})
+	if err != nil {
+		return false, false, false, err
+	}
+	doc, _, err := applyMongoMutation(base, update.mutation)
+	if err != nil {
+		return false, false, false, err
+	}
+	key, stored, err := prepareInsertDocument(doc, col.MetaView().Options.DocumentFormat)
+	if err != nil {
+		return false, false, false, err
+	}
+	if !bytes.Equal(key, update.key) {
+		return false, false, false, errors.New("Mongo gateway update cannot modify _id")
+	}
+	if _, err := col.Insert(key, stored); err != nil {
+		return false, false, false, err
+	}
+	return false, false, true, nil
 }
 
 func runMongoUpdateBatch(col *collections.Collection, updates []mongoUpdateItem) (int32, int32, bool, error) {
@@ -1608,7 +1676,7 @@ func mongoUpdateItemsCanUseBSONSet(col *collections.Collection, updates []mongoU
 }
 
 func mongoUpdateCanUseBSONSet(col *collections.Collection, update mongoUpdateItem) bool {
-	return col != nil && normalizedMongoUpdateDocumentFormat(col) == collections.DocumentFormatBSON && update.bsonSetFieldsOK
+	return col != nil && !update.upsert && normalizedMongoUpdateDocumentFormat(col) == collections.DocumentFormatBSON && update.bsonSetFieldsOK
 }
 
 func normalizedMongoUpdateDocumentFormat(col *collections.Collection) collections.DocumentFormat {
@@ -1623,6 +1691,9 @@ func normalizedMongoUpdateDocumentFormat(col *collections.Collection) collection
 }
 
 func mongoUpdateCanUseBatchMeta(meta collections.CollectionMeta, update mongoUpdateItem) bool {
+	if update.upsert {
+		return false
+	}
 	format := meta.Options.DocumentFormat
 	if format == collections.DocumentFormatDefault {
 		format = collections.DocumentFormatJSON
@@ -2403,12 +2474,20 @@ func (s *Server) killCursorsResponse(command wire.Document, cursorOwner int64) (
 	})
 }
 
-func marshalUpdateResponse(matched, modified int32) (wire.Document, error) {
-	return marshalDocument(bson.D{
+func marshalUpdateResponse(matched, modified int32, upserted ...[]mongoUpdateUpserted) (wire.Document, error) {
+	response := bson.D{
 		{Key: "ok", Value: 1.0},
 		{Key: "n", Value: matched},
 		{Key: "nModified", Value: modified},
-	})
+	}
+	if len(upserted) > 0 && len(upserted[0]) > 0 {
+		items := make(bson.A, len(upserted[0]))
+		for i, item := range upserted[0] {
+			items[i] = bson.D{{Key: "index", Value: int32(item.index)}, {Key: "_id", Value: item.id}}
+		}
+		response = append(response, bson.E{Key: "upserted", Value: items})
+	}
+	return marshalDocument(response)
 }
 
 func marshalDeleteResponse(deleted int32) (wire.Document, error) {

--- a/TreeDB/mongo_gateway/commands.go
+++ b/TreeDB/mongo_gateway/commands.go
@@ -898,7 +898,7 @@ func (s *Server) updateResponse(ctx context.Context, command wire.Document, sequ
 					hasUpsert = hasUpsert || prior.upsert
 				}
 				if hasUpsert {
-					if err := s.validateMongoMissingCollectionUpserts(parsed); err != nil {
+					if err := s.validateMongoMissingCollectionFirstUpsert(parsed); err != nil {
 						return mongoUpdateWriteCommandError(err)
 					}
 					col, err = s.openOrCreateCollection(name)
@@ -931,7 +931,7 @@ func (s *Server) updateResponse(ctx context.Context, command wire.Document, sequ
 		if !hasUpsert {
 			return marshalUpdateResponse(0, 0, nil)
 		}
-		if err := s.validateMongoMissingCollectionUpserts(parsed); err != nil {
+		if err := s.validateMongoMissingCollectionFirstUpsert(parsed); err != nil {
 			return mongoUpdateWriteCommandError(err)
 		}
 		col, err = s.openOrCreateCollection(name)
@@ -1154,7 +1154,7 @@ func mongoInsertUpsert(col *collections.Collection, update mongoUpdateItem) (boo
 	return false, false, true, nil
 }
 
-func (s *Server) validateMongoMissingCollectionUpserts(updates []mongoUpdateItem) error {
+func (s *Server) validateMongoMissingCollectionFirstUpsert(updates []mongoUpdateItem) error {
 	for _, update := range updates {
 		if !update.upsert {
 			continue
@@ -1170,6 +1170,7 @@ func (s *Server) validateMongoMissingCollectionUpserts(updates []mongoUpdateItem
 		if !bytes.Equal(key, update.key) {
 			return mongoUpdateErrorWithIndex(update.index, errors.New("Mongo gateway update cannot modify _id"))
 		}
+		return nil
 	}
 	return nil
 }

--- a/TreeDB/mongo_gateway/compatibility_matrix_test.go
+++ b/TreeDB/mongo_gateway/compatibility_matrix_test.go
@@ -475,13 +475,26 @@ func mongoCompatibilityMatrixRows() []mongoCompatibilityMatrixRow {
 				resp := serveCommand(t, server, 19, bson.D{
 					{Key: "update", Value: "users"},
 					{Key: "updates", Value: bson.A{bson.D{
-						{Key: "q", Value: bson.D{{Key: "_id", Value: "u1"}}},
+						{Key: "q", Value: bson.D{{Key: "_id", Value: "upsert-matrix"}}},
 						{Key: "u", Value: bson.D{{Key: "$set", Value: bson.D{{Key: "city", Value: "sea"}}}}},
 						{Key: "upsert", Value: true},
 					}}},
 					{Key: "$db", Value: "app"},
 				})
 				assertOK(t, resp)
+				assertInt32(t, resp, "n", 1)
+				assertInt32(t, resp, "nModified", 0)
+				upserted, ok := bson.Raw(resp).Lookup("upserted").ArrayOK()
+				if !ok {
+					t.Fatalf("missing upserted: %v", resp)
+				}
+				values, err := upserted.Values()
+				if err != nil || len(values) != 1 {
+					t.Fatalf("upserted=%v err=%v", values, err)
+				}
+				if id, ok := values[0].Document().Lookup("_id").StringValueOK(); !ok || id != "upsert-matrix" {
+					t.Fatalf("upserted _id=%q ok=%v", id, ok)
+				}
 			},
 		},
 		{
@@ -515,6 +528,8 @@ func mongoCompatibilityMatrixRows() []mongoCompatibilityMatrixRow {
 					{Key: "$db", Value: "app"},
 				})
 				assertOK(t, resp)
+				assertInt32(t, resp, "n", 1)
+				assertInt32(t, resp, "nModified", 1)
 			},
 		},
 		{
@@ -531,6 +546,8 @@ func mongoCompatibilityMatrixRows() []mongoCompatibilityMatrixRow {
 					{Key: "$db", Value: "app"},
 				})
 				assertOK(t, resp)
+				assertInt32(t, resp, "n", 1)
+				assertInt32(t, resp, "nModified", 1)
 			},
 		},
 		{
@@ -547,6 +564,8 @@ func mongoCompatibilityMatrixRows() []mongoCompatibilityMatrixRow {
 					{Key: "$db", Value: "app"},
 				})
 				assertOK(t, resp)
+				assertInt32(t, resp, "n", 1)
+				assertInt32(t, resp, "nModified", 1)
 			},
 		},
 		{

--- a/TreeDB/mongo_gateway/compatibility_matrix_test.go
+++ b/TreeDB/mongo_gateway/compatibility_matrix_test.go
@@ -502,9 +502,9 @@ func mongoCompatibilityMatrixRows() []mongoCompatibilityMatrixRow {
 			},
 		},
 		{
-			category: "update gap",
+			category: "update",
 			feature:  "$inc",
-			status:   "rejected",
+			status:   "supported subset",
 			probe: func(t *testing.T, server *Server) {
 				resp := serveCommand(t, server, 21, bson.D{
 					{Key: "update", Value: "users"},
@@ -514,7 +514,7 @@ func mongoCompatibilityMatrixRows() []mongoCompatibilityMatrixRow {
 					}}},
 					{Key: "$db", Value: "app"},
 				})
-				assertCommandError(t, resp, "BadValue")
+				assertOK(t, resp)
 			},
 		},
 		{

--- a/TreeDB/mongo_gateway/compatibility_matrix_test.go
+++ b/TreeDB/mongo_gateway/compatibility_matrix_test.go
@@ -518,6 +518,38 @@ func mongoCompatibilityMatrixRows() []mongoCompatibilityMatrixRow {
 			},
 		},
 		{
+			category: "update",
+			feature:  "$unset",
+			status:   "supported subset",
+			probe: func(t *testing.T, server *Server) {
+				resp := serveCommand(t, server, 211, bson.D{
+					{Key: "update", Value: "users"},
+					{Key: "updates", Value: bson.A{bson.D{
+						{Key: "q", Value: bson.D{{Key: "_id", Value: "u1"}}},
+						{Key: "u", Value: bson.D{{Key: "$unset", Value: bson.D{{Key: "city", Value: true}}}}},
+					}}},
+					{Key: "$db", Value: "app"},
+				})
+				assertOK(t, resp)
+			},
+		},
+		{
+			category: "update",
+			feature:  "ReplaceOne by exact _id",
+			status:   "supported subset",
+			probe: func(t *testing.T, server *Server) {
+				resp := serveCommand(t, server, 212, bson.D{
+					{Key: "update", Value: "users"},
+					{Key: "updates", Value: bson.A{bson.D{
+						{Key: "q", Value: bson.D{{Key: "_id", Value: "u1"}}},
+						{Key: "u", Value: bson.D{{Key: "name", Value: "replacement"}}},
+					}}},
+					{Key: "$db", Value: "app"},
+				})
+				assertOK(t, resp)
+			},
+		},
+		{
 			category: "index gap",
 			feature:  "compound index",
 			status:   "rejected",

--- a/TreeDB/mongo_gateway/compatibility_matrix_test.go
+++ b/TreeDB/mongo_gateway/compatibility_matrix_test.go
@@ -468,9 +468,9 @@ func mongoCompatibilityMatrixRows() []mongoCompatibilityMatrixRow {
 			},
 		},
 		{
-			category: "update gap",
-			feature:  "upsert",
-			status:   "rejected",
+			category: "update",
+			feature:  "exact _id upsert",
+			status:   "supported subset",
 			probe: func(t *testing.T, server *Server) {
 				resp := serveCommand(t, server, 19, bson.D{
 					{Key: "update", Value: "users"},
@@ -481,7 +481,7 @@ func mongoCompatibilityMatrixRows() []mongoCompatibilityMatrixRow {
 					}}},
 					{Key: "$db", Value: "app"},
 				})
-				assertCommandError(t, resp, "BadValue")
+				assertOK(t, resp)
 			},
 		},
 		{

--- a/TreeDB/mongo_gateway/mongo_mutation_bench_test.go
+++ b/TreeDB/mongo_gateway/mongo_mutation_bench_test.go
@@ -1,0 +1,34 @@
+package mongogateway
+
+import (
+	"testing"
+
+	"github.com/snissn/gomap/TreeDB/mongo_gateway/wire"
+	"go.mongodb.org/mongo-driver/v2/bson"
+)
+
+var benchmarkMongoMutationDocumentSink wire.Document
+
+func BenchmarkApplyMongoMutationInc(b *testing.B) {
+	doc, err := bson.Marshal(bson.D{{Key: "_id", Value: "benchmark-user"}, {Key: "count", Value: int64(41)}})
+	if err != nil {
+		b.Fatal(err)
+	}
+	update, err := bson.Marshal(bson.D{{Key: "$inc", Value: bson.D{{Key: "count", Value: int32(1)}}}})
+	if err != nil {
+		b.Fatal(err)
+	}
+	mutation, err := parseMongoMutation(update)
+	if err != nil {
+		b.Fatal(err)
+	}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		updated, _, err := applyMongoMutation(doc, mutation)
+		if err != nil {
+			b.Fatal(err)
+		}
+		benchmarkMongoMutationDocumentSink = updated
+	}
+}

--- a/TreeDB/mongo_gateway/mongo_update_parse_bench_test.go
+++ b/TreeDB/mongo_gateway/mongo_update_parse_bench_test.go
@@ -1,0 +1,28 @@
+package mongogateway
+
+import (
+	"testing"
+
+	"go.mongodb.org/mongo-driver/v2/bson"
+)
+
+var benchmarkMongoUpdateItemSink mongoUpdateItem
+
+func BenchmarkParseMongoUpdateItemPureSet(b *testing.B) {
+	raw, err := bson.Marshal(bson.D{
+		{Key: "q", Value: bson.D{{Key: "_id", Value: "benchmark-user"}}},
+		{Key: "u", Value: bson.D{{Key: "$set", Value: bson.D{{Key: "name", Value: "grace"}, {Key: "age", Value: int32(42)}}}}},
+	})
+	if err != nil {
+		b.Fatal(err)
+	}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		item, err := parseMongoUpdateItem(0, raw)
+		if err != nil {
+			b.Fatal(err)
+		}
+		benchmarkMongoUpdateItemSink = item
+	}
+}

--- a/TreeDB/mongo_gateway/server_driver_test.go
+++ b/TreeDB/mongo_gateway/server_driver_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	treedb "github.com/snissn/gomap/TreeDB"
 	"github.com/snissn/gomap/TreeDB/collections"
 	backenddb "github.com/snissn/gomap/TreeDB/db"
 	"go.mongodb.org/mongo-driver/v2/bson"
@@ -14,6 +15,34 @@ import (
 	"go.mongodb.org/mongo-driver/v2/mongo/options"
 	"go.mongodb.org/mongo-driver/v2/mongo/writeconcern"
 )
+
+func TestStandaloneServerOfficialGoDriverBSONSetBinaryUpsert(t *testing.T) {
+	standalone, err := OpenStandaloneServer(StandaloneOptions{
+		Dir:     t.TempDir(),
+		Profile: treedb.ProfileCommandWALDurable,
+		DefaultCollectionOptions: collections.CollectionOptions{
+			DocumentFormat: collections.DocumentFormatBSON,
+		},
+	})
+	if err != nil {
+		t.Fatalf("open standalone: %v", err)
+	}
+	client, cancel, ln, serveErr := startStandaloneMongoClientForTest(t, standalone)
+	defer stopStandaloneMongoClientForTest(t, client, cancel, ln, serveErr, standalone)
+	opCtx, opCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer opCancel()
+	result, err := client.Database("app").Collection("users").UpdateOne(opCtx,
+		bson.D{{Key: "_id", Value: "binary-upsert"}},
+		bson.D{{Key: "$set", Value: bson.D{{Key: "payload", Value: bson.Binary{Subtype: 0x00, Data: []byte{1, 2, 3}}}}}},
+		options.UpdateOne().SetUpsert(true),
+	)
+	if err != nil {
+		t.Fatalf("driver BSON binary upsert: %v", err)
+	}
+	if result.MatchedCount != 0 || result.ModifiedCount != 0 || result.UpsertedCount != 1 || result.UpsertedID != "binary-upsert" {
+		t.Fatalf("binary upsert result=%+v", result)
+	}
+}
 
 func TestServerOfficialGoDriverBasicCRUD(t *testing.T) {
 	db, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})

--- a/TreeDB/mongo_gateway/server_driver_test.go
+++ b/TreeDB/mongo_gateway/server_driver_test.go
@@ -42,6 +42,25 @@ func TestStandaloneServerOfficialGoDriverBSONSetBinaryUpsert(t *testing.T) {
 	if result.MatchedCount != 0 || result.ModifiedCount != 0 || result.UpsertedCount != 1 || result.UpsertedID != "binary-upsert" {
 		t.Fatalf("binary upsert result=%+v", result)
 	}
+	result, err = client.Database("app").Collection("users").UpdateOne(opCtx,
+		bson.D{{Key: "_id", Value: "binary-upsert"}},
+		bson.D{{Key: "$set", Value: bson.D{{Key: "payload", Value: bson.Binary{Subtype: 0x00, Data: []byte{4, 5}}}}}},
+		options.UpdateOne().SetUpsert(true),
+	)
+	if err != nil {
+		t.Fatalf("driver BSON binary matched upsert: %v", err)
+	}
+	if result.MatchedCount != 1 || result.ModifiedCount != 1 || result.UpsertedCount != 0 {
+		t.Fatalf("matched binary upsert result=%+v", result)
+	}
+	var stored bson.Raw
+	if err := client.Database("app").Collection("users").FindOne(opCtx, bson.D{{Key: "_id", Value: "binary-upsert"}}).Decode(&stored); err != nil {
+		t.Fatalf("driver find binary upsert: %v", err)
+	}
+	subtype, payload := stored.Lookup("payload").Binary()
+	if subtype != 0x00 || string(payload) != string([]byte{4, 5}) {
+		t.Fatalf("driver binary payload subtype/data=%#x/%v", subtype, payload)
+	}
 }
 
 func TestServerOfficialGoDriverBasicCRUD(t *testing.T) {

--- a/TreeDB/mongo_gateway/server_driver_test.go
+++ b/TreeDB/mongo_gateway/server_driver_test.go
@@ -172,6 +172,23 @@ func TestServerOfficialGoDriverBasicCRUD(t *testing.T) {
 		t.Fatalf("replacement retained city: %v", got)
 	}
 
+	upsertID := bson.NewObjectID()
+	upsertResult, err := coll.UpdateOne(opCtx, bson.D{{Key: "_id", Value: upsertID}}, bson.D{{Key: "$inc", Value: bson.D{{Key: "age", Value: int32(1)}}}}, options.UpdateOne().SetUpsert(true))
+	if err != nil {
+		t.Fatalf("driver modifier upsert: %v", err)
+	}
+	if upsertResult.MatchedCount != 0 || upsertResult.ModifiedCount != 0 || upsertResult.UpsertedCount != 1 || upsertResult.UpsertedID != upsertID {
+		t.Fatalf("modifier upsert result=%+v want inserted %v", upsertResult, upsertID)
+	}
+	replacementID := bson.NewObjectID()
+	replacementUpsert, err := coll.ReplaceOne(opCtx, bson.D{{Key: "_id", Value: replacementID}}, bson.D{{Key: "name", Value: "upserted"}}, options.Replace().SetUpsert(true))
+	if err != nil {
+		t.Fatalf("driver replacement upsert: %v", err)
+	}
+	if replacementUpsert.MatchedCount != 0 || replacementUpsert.ModifiedCount != 0 || replacementUpsert.UpsertedCount != 1 || replacementUpsert.UpsertedID != replacementID {
+		t.Fatalf("replacement upsert result=%+v want inserted %v", replacementUpsert, replacementID)
+	}
+
 	deleteResult, err := coll.DeleteOne(opCtx, bson.D{{Key: "_id", Value: id}})
 	if err != nil {
 		t.Fatalf("driver delete one: %v", err)

--- a/TreeDB/mongo_gateway/server_driver_test.go
+++ b/TreeDB/mongo_gateway/server_driver_test.go
@@ -144,6 +144,34 @@ func TestServerOfficialGoDriverBasicCRUD(t *testing.T) {
 		t.Fatalf("decoded city=%v want London", got["city"])
 	}
 
+	mutationResult, err := coll.UpdateOne(opCtx,
+		bson.D{{Key: "_id", Value: id}},
+		bson.D{{Key: "$inc", Value: bson.D{{Key: "age", Value: int32(2)}}}, {Key: "$unset", Value: bson.D{{Key: "city", Value: true}}}},
+	)
+	if err != nil {
+		t.Fatalf("driver generic update one: %v", err)
+	}
+	if mutationResult.MatchedCount != 1 || mutationResult.ModifiedCount != 1 {
+		t.Fatalf("generic update matched=%d modified=%d want 1/1", mutationResult.MatchedCount, mutationResult.ModifiedCount)
+	}
+	replaceResult, err := coll.ReplaceOne(opCtx, bson.D{{Key: "_id", Value: id}}, bson.D{{Key: "name", Value: "grace"}, {Key: "age", Value: int64(40)}})
+	if err != nil {
+		t.Fatalf("driver replace one: %v", err)
+	}
+	if replaceResult.MatchedCount != 1 || replaceResult.ModifiedCount != 1 {
+		t.Fatalf("replace result matched=%d modified=%d want 1/1", replaceResult.MatchedCount, replaceResult.ModifiedCount)
+	}
+	got = nil
+	if err := coll.FindOne(opCtx, bson.D{{Key: "_id", Value: id}}).Decode(&got); err != nil {
+		t.Fatalf("driver find one after replacement: %v", err)
+	}
+	if got["name"] != "grace" || got["age"] != int64(40) {
+		t.Fatalf("replacement document=%v", got)
+	}
+	if _, ok := got["city"]; ok {
+		t.Fatalf("replacement retained city: %v", got)
+	}
+
 	deleteResult, err := coll.DeleteOne(opCtx, bson.D{{Key: "_id", Value: id}})
 	if err != nil {
 		t.Fatalf("driver delete one: %v", err)

--- a/TreeDB/mongo_gateway/server_test.go
+++ b/TreeDB/mongo_gateway/server_test.go
@@ -2112,11 +2112,8 @@ func TestServerUpdateCoalescedSkipsCoalescerForUnrecognizedUpdateShape(t *testin
 		t.Fatal("test update unexpectedly parsed as $set")
 	}
 	matched, modified, err := server.runMongoUpdateCoalesced("app.users", col, update)
-	if err == nil {
-		t.Fatal("runMongoUpdateCoalesced succeeded for unsupported $inc update")
-	}
-	if matched || modified {
-		t.Fatalf("matched=%v modified=%v want false,false", matched, modified)
+	if err != nil || !matched || !modified {
+		t.Fatalf("matched=%v modified=%v err=%v want true,true,nil", matched, modified, err)
 	}
 	server.updateMu.Lock()
 	_, cached := server.updateCoalescers["app.users"]
@@ -5984,7 +5981,6 @@ func TestMongoMutationRejectsInvalidShapesAndOverflow(t *testing.T) {
 		{{Key: "$inc", Value: bson.D{{Key: "a.b", Value: 1}}}},
 		{{Key: "$set", Value: bson.D{{Key: "x", Value: 1}}}, {Key: "$inc", Value: bson.D{{Key: "x", Value: 1}}}},
 		{{Key: "$push", Value: bson.D{{Key: "x", Value: 1}}}},
-		{},
 	} {
 		if _, err := parseMongoMutation(mustDocument(t, update)); err == nil {
 			t.Fatalf("accepted %v", update)

--- a/TreeDB/mongo_gateway/server_test.go
+++ b/TreeDB/mongo_gateway/server_test.go
@@ -6049,6 +6049,12 @@ func TestMongoMutationRejectsInvalidShapesAndOverflow(t *testing.T) {
 	if _, _, err := applyMongoReplacement(mustDocument(t, bson.D{{Key: "_id", Value: "u1"}}), changedID); err == nil {
 		t.Fatal("changed _id accepted")
 	}
+	doc := mustDocument(t, bson.D{{Key: "_id", Value: "u1"}, {Key: "name", Value: "ada"}})
+	invalidReplacement := mustDocument(t, bson.D{{Key: "_id", Value: "u1"}, {Key: "name", Value: "ada"}, {Key: "profile.name", Value: "bad"}})
+	updated, changed, err := applyMongoReplacement(doc, invalidReplacement)
+	if err == nil || updated != nil || changed || !bytes.Equal(doc, mustDocument(t, bson.D{{Key: "_id", Value: "u1"}, {Key: "name", Value: "ada"}})) {
+		t.Fatalf("invalid replacement updated=%v changed=%v err=%v", updated, changed, err)
+	}
 }
 
 func TestServerUpdateGenericMutationsAcrossDocumentFormats(t *testing.T) {
@@ -6064,14 +6070,20 @@ func TestServerUpdateGenericMutationsAcrossDocumentFormats(t *testing.T) {
 			s.Collections = collections.NewCollectionManager(db)
 			assertOK(t, serveCommand(t, s, 1, bson.D{{Key: "insert", Value: "users"}, {Key: "documents", Value: bson.A{bson.D{{Key: "_id", Value: "u1"}, {Key: "n", Value: int32(2147483647)}, {Key: "old", Value: true}, {Key: "nullValue", Value: nil}, {Key: "textValue", Value: "bad"}}}}, {Key: "$db", Value: "app"}}))
 
-			update := func(requestID int32, value bson.D) bson.Raw {
-				return serveCommand(t, s, requestID, bson.D{{Key: "update", Value: "users"}, {Key: "updates", Value: bson.A{bson.D{{Key: "q", Value: bson.D{{Key: "_id", Value: "u1"}}}, {Key: "u", Value: value}}}}, {Key: "$db", Value: "app"}})
+			requestID := int32(2)
+			nextRequestID := func() int32 {
+				id := requestID
+				requestID++
+				return id
 			}
-			resp := update(2, bson.D{{Key: "$set", Value: bson.D{{Key: "name", Value: "ada"}}}, {Key: "$inc", Value: bson.D{{Key: "n", Value: int32(1)}, {Key: "missing", Value: int64(-2)}}}, {Key: "$unset", Value: bson.D{{Key: "old", Value: true}, {Key: "absent", Value: true}}}})
+			update := func(value bson.D) bson.Raw {
+				return serveCommand(t, s, nextRequestID(), bson.D{{Key: "update", Value: "users"}, {Key: "updates", Value: bson.A{bson.D{{Key: "q", Value: bson.D{{Key: "_id", Value: "u1"}}}, {Key: "u", Value: value}}}}, {Key: "$db", Value: "app"}})
+			}
+			resp := update(bson.D{{Key: "$set", Value: bson.D{{Key: "name", Value: "ada"}}}, {Key: "$inc", Value: bson.D{{Key: "n", Value: int32(1)}, {Key: "missing", Value: int64(-2)}}}, {Key: "$unset", Value: bson.D{{Key: "old", Value: true}, {Key: "absent", Value: true}}}})
 			assertOK(t, resp)
 			assertInt32(t, resp, "n", 1)
 			assertInt32(t, resp, "nModified", 1)
-			find := serveCommand(t, s, 3, bson.D{{Key: "find", Value: "users"}, {Key: "filter", Value: bson.D{{Key: "_id", Value: "u1"}}}, {Key: "$db", Value: "app"}})
+			find := serveCommand(t, s, nextRequestID(), bson.D{{Key: "find", Value: "users"}, {Key: "filter", Value: bson.D{{Key: "_id", Value: "u1"}}}, {Key: "$db", Value: "app"}})
 			got := cursorFirstBatch(t, find)[0]
 			if n, ok := got.Lookup("n").Int64OK(); !ok || n != 2147483648 {
 				t.Fatalf("n=%d ok=%v", n, ok)
@@ -6082,12 +6094,12 @@ func TestServerUpdateGenericMutationsAcrossDocumentFormats(t *testing.T) {
 			if !got.Lookup("old").IsZero() {
 				t.Fatal("old remains")
 			}
-			noop := update(4, bson.D{{Key: "$unset", Value: bson.D{{Key: "stillAbsent", Value: true}}}})
+			noop := update(bson.D{{Key: "$unset", Value: bson.D{{Key: "stillAbsent", Value: true}}}})
 			assertOK(t, noop)
 			assertInt32(t, noop, "nModified", 0)
 			// int64 plus double is a double.
-			assertOK(t, update(4, bson.D{{Key: "$inc", Value: bson.D{{Key: "n", Value: 0.5}}}}))
-			find = serveCommand(t, s, 5, bson.D{{Key: "find", Value: "users"}, {Key: "filter", Value: bson.D{{Key: "_id", Value: "u1"}}}, {Key: "$db", Value: "app"}})
+			assertOK(t, update(bson.D{{Key: "$inc", Value: bson.D{{Key: "n", Value: 0.5}}}}))
+			find = serveCommand(t, s, nextRequestID(), bson.D{{Key: "find", Value: "users"}, {Key: "filter", Value: bson.D{{Key: "_id", Value: "u1"}}}, {Key: "$db", Value: "app"}})
 			if n, ok := cursorFirstBatch(t, find)[0].Lookup("n").DoubleOK(); !ok || n != 2147483648.5 {
 				t.Fatalf("double n=%v ok=%v", n, ok)
 			}
@@ -6101,20 +6113,20 @@ func TestServerUpdateGenericMutationsAcrossDocumentFormats(t *testing.T) {
 				{{Key: "$set", Value: bson.D{{Key: "_id", Value: "u2"}}}},
 				{{Key: "$push", Value: bson.D{{Key: "n", Value: 1}}}},
 			} {
-				assertCommandError(t, update(6, badUpdate), "BadValue")
+				assertCommandError(t, update(badUpdate), "BadValue")
 			}
-			find = serveCommand(t, s, 6, bson.D{{Key: "find", Value: "users"}, {Key: "filter", Value: bson.D{{Key: "_id", Value: "u1"}}}, {Key: "$db", Value: "app"}})
+			find = serveCommand(t, s, nextRequestID(), bson.D{{Key: "find", Value: "users"}, {Key: "filter", Value: bson.D{{Key: "_id", Value: "u1"}}}, {Key: "$db", Value: "app"}})
 			if n, _ := cursorFirstBatch(t, find)[0].Lookup("n").DoubleOK(); n != 2147483648.5 {
 				t.Fatalf("failed item changed n=%v", n)
 			}
-			assertOK(t, update(6, bson.D{{Key: "$inc", Value: bson.D{{Key: "largest", Value: int64(math.MaxInt64)}}}}))
-			assertCommandError(t, update(6, bson.D{{Key: "$inc", Value: bson.D{{Key: "largest", Value: int64(1)}}}}), "BadValue")
-			assertOK(t, update(7, bson.D{{Key: "name", Value: "grace"}})) // omitted _id is preserved
-			noop = update(8, bson.D{{Key: "_id", Value: "u1"}, {Key: "name", Value: "grace"}})
+			assertOK(t, update(bson.D{{Key: "$inc", Value: bson.D{{Key: "largest", Value: int64(math.MaxInt64)}}}}))
+			assertCommandError(t, update(bson.D{{Key: "$inc", Value: bson.D{{Key: "largest", Value: int64(1)}}}}), "BadValue")
+			assertOK(t, update(bson.D{{Key: "name", Value: "grace"}})) // omitted _id is preserved
+			noop = update(bson.D{{Key: "_id", Value: "u1"}, {Key: "name", Value: "grace"}})
 			assertOK(t, noop)
 			assertInt32(t, noop, "nModified", 0)
-			assertCommandError(t, update(9, bson.D{{Key: "_id", Value: "u2"}}), "BadValue")
-			assertOK(t, update(10, bson.D{})) // an empty replacement retains _id
+			assertCommandError(t, update(bson.D{{Key: "_id", Value: "u2"}}), "BadValue")
+			assertOK(t, update(bson.D{})) // an empty replacement retains _id
 		})
 	}
 }

--- a/TreeDB/mongo_gateway/server_test.go
+++ b/TreeDB/mongo_gateway/server_test.go
@@ -1471,6 +1471,46 @@ func TestParseMongoUpdateItemUnsupportedFlagsIncludeIndex(t *testing.T) {
 	}
 }
 
+func TestParseMongoUpdateItemPureSetSkipsGenericMutation(t *testing.T) {
+	item, err := parseMongoUpdateItem(0, mustDocument(t, bson.D{
+		{Key: "q", Value: bson.D{{Key: "_id", Value: "u1"}}},
+		{Key: "u", Value: bson.D{{Key: "$set", Value: bson.D{{Key: "name", Value: "grace"}}}}},
+	}))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !item.pureSet || !item.bsonSetFieldsOK || len(item.mutation.set) != 0 || len(item.mutation.inc) != 0 || len(item.mutation.unset) != 0 || item.mutation.replace != nil {
+		t.Fatalf("pure set item=%+v", item)
+	}
+}
+
+func TestServerUpdateMissingCollectionExecutesEarlierUpsertBeforeParseError(t *testing.T) {
+	db, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+	s := NewServer()
+	s.Collections = collections.NewCollectionManager(db)
+	response := serveCommand(t, s, 22597, bson.D{
+		{Key: "update", Value: "users"},
+		{Key: "updates", Value: bson.A{
+			bson.D{{Key: "q", Value: bson.D{{Key: "_id", Value: "u1"}}}, {Key: "u", Value: bson.D{{Key: "$inc", Value: bson.D{{Key: "score", Value: int32(1)}}}}}, {Key: "upsert", Value: true}},
+			bson.D{{Key: "q", Value: bson.D{{Key: "_id", Value: "u2"}}}, {Key: "u", Value: bson.D{{Key: "$push", Value: bson.D{{Key: "score", Value: int32(2)}}}}}},
+		}},
+		{Key: "$db", Value: "app"},
+	})
+	assertCommandError(t, response, "BadValue")
+	found := serveCommand(t, s, 22598, bson.D{{Key: "find", Value: "users"}, {Key: "filter", Value: bson.D{{Key: "_id", Value: "u1"}}}, {Key: "$db", Value: "app"}})
+	batch := cursorFirstBatch(t, found)
+	if len(batch) != 1 {
+		t.Fatalf("firstBatch len=%d want 1", len(batch))
+	}
+	if score, _ := batch[0].Lookup("score").Int32OK(); score != 1 {
+		t.Fatalf("score=%d want 1", score)
+	}
+}
+
 func TestServerUpdateAppliesEarlierOrderedUpdatesBeforeLaterWriteError(t *testing.T) {
 	db, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
 	if err != nil {
@@ -6009,7 +6049,7 @@ func TestServerUpdateGenericMutationsAcrossDocumentFormats(t *testing.T) {
 			s := NewServer()
 			s.DefaultCollectionOptions = collections.CollectionOptions{DocumentFormat: format}
 			s.Collections = collections.NewCollectionManager(db)
-			assertOK(t, serveCommand(t, s, 1, bson.D{{Key: "insert", Value: "users"}, {Key: "documents", Value: bson.A{bson.D{{Key: "_id", Value: "u1"}, {Key: "n", Value: int32(2147483647)}, {Key: "old", Value: true}}}}, {Key: "$db", Value: "app"}}))
+			assertOK(t, serveCommand(t, s, 1, bson.D{{Key: "insert", Value: "users"}, {Key: "documents", Value: bson.A{bson.D{{Key: "_id", Value: "u1"}, {Key: "n", Value: int32(2147483647)}, {Key: "old", Value: true}, {Key: "nullValue", Value: nil}, {Key: "textValue", Value: "bad"}}}}, {Key: "$db", Value: "app"}}))
 
 			update := func(requestID int32, value bson.D) bson.Raw {
 				return serveCommand(t, s, requestID, bson.D{{Key: "update", Value: "users"}, {Key: "updates", Value: bson.A{bson.D{{Key: "q", Value: bson.D{{Key: "_id", Value: "u1"}}}, {Key: "u", Value: value}}}}, {Key: "$db", Value: "app"}})
@@ -6029,8 +6069,11 @@ func TestServerUpdateGenericMutationsAcrossDocumentFormats(t *testing.T) {
 			if !got.Lookup("old").IsZero() {
 				t.Fatal("old remains")
 			}
-			// int64 plus double is a double, while unsetting a missing field is a no-op.
-			assertOK(t, update(4, bson.D{{Key: "$inc", Value: bson.D{{Key: "n", Value: 0.5}}}, {Key: "$unset", Value: bson.D{{Key: "stillAbsent", Value: true}}}}))
+			noop := update(4, bson.D{{Key: "$unset", Value: bson.D{{Key: "stillAbsent", Value: true}}}})
+			assertOK(t, noop)
+			assertInt32(t, noop, "nModified", 0)
+			// int64 plus double is a double.
+			assertOK(t, update(4, bson.D{{Key: "$inc", Value: bson.D{{Key: "n", Value: 0.5}}}}))
 			find = serveCommand(t, s, 5, bson.D{{Key: "find", Value: "users"}, {Key: "filter", Value: bson.D{{Key: "_id", Value: "u1"}}}, {Key: "$db", Value: "app"}})
 			if n, ok := cursorFirstBatch(t, find)[0].Lookup("n").DoubleOK(); !ok || n != 2147483648.5 {
 				t.Fatalf("double n=%v ok=%v", n, ok)
@@ -6038,6 +6081,8 @@ func TestServerUpdateGenericMutationsAcrossDocumentFormats(t *testing.T) {
 			for _, badUpdate := range []bson.D{
 				{{Key: "$inc", Value: bson.D{{Key: "n", Value: "bad"}}}},
 				{{Key: "$inc", Value: bson.D{{Key: "n", Value: nil}}}},
+				{{Key: "$inc", Value: bson.D{{Key: "nullValue", Value: int32(1)}}}},
+				{{Key: "$inc", Value: bson.D{{Key: "textValue", Value: int32(1)}}}},
 				{{Key: "$set", Value: bson.D{{Key: "n", Value: 1}}}, {Key: "$unset", Value: bson.D{{Key: "n", Value: true}}}},
 				{{Key: "$set", Value: bson.D{{Key: "x.y", Value: 1}}}},
 				{{Key: "$set", Value: bson.D{{Key: "_id", Value: "u2"}}}},
@@ -6052,7 +6097,9 @@ func TestServerUpdateGenericMutationsAcrossDocumentFormats(t *testing.T) {
 			assertOK(t, update(6, bson.D{{Key: "$inc", Value: bson.D{{Key: "largest", Value: int64(math.MaxInt64)}}}}))
 			assertCommandError(t, update(6, bson.D{{Key: "$inc", Value: bson.D{{Key: "largest", Value: int64(1)}}}}), "BadValue")
 			assertOK(t, update(7, bson.D{{Key: "name", Value: "grace"}})) // omitted _id is preserved
-			assertOK(t, update(8, bson.D{{Key: "_id", Value: "u1"}, {Key: "name", Value: "grace"}}))
+			noop = update(8, bson.D{{Key: "_id", Value: "u1"}, {Key: "name", Value: "grace"}})
+			assertOK(t, noop)
+			assertInt32(t, noop, "nModified", 0)
 			assertCommandError(t, update(9, bson.D{{Key: "_id", Value: "u2"}}), "BadValue")
 			assertOK(t, update(10, bson.D{})) // an empty replacement retains _id
 		})

--- a/TreeDB/mongo_gateway/server_test.go
+++ b/TreeDB/mongo_gateway/server_test.go
@@ -1452,7 +1452,6 @@ func TestParseMongoUpdateItemUnsupportedFlagsIncludeIndex(t *testing.T) {
 		want string
 	}{
 		{name: "multi", flag: bson.E{Key: "multi", Value: true}, want: "updateOne only"},
-		{name: "upsert", flag: bson.E{Key: "upsert", Value: true}, want: "does not support upsert"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -6057,6 +6056,77 @@ func TestServerUpdateGenericMutationsAcrossDocumentFormats(t *testing.T) {
 			assertCommandError(t, update(9, bson.D{{Key: "_id", Value: "u2"}}), "BadValue")
 			assertOK(t, update(10, bson.D{})) // an empty replacement retains _id
 		})
+	}
+}
+
+func TestServerUpdateUpsertAcrossDocumentFormats(t *testing.T) {
+	for _, format := range []collections.DocumentFormat{collections.DocumentFormatBSON, collections.DocumentFormatJSON, collections.DocumentFormatTemplateV1} {
+		t.Run(string(format), func(t *testing.T) {
+			db, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer db.Close()
+			s := NewServer()
+			s.DefaultCollectionOptions = collections.CollectionOptions{DocumentFormat: format}
+			s.Collections = collections.NewCollectionManager(db)
+			response := serveCommand(t, s, 7001, bson.D{
+				{Key: "update", Value: "users"},
+				{Key: "updates", Value: bson.A{bson.D{{Key: "q", Value: bson.D{{Key: "_id", Value: "u1"}}}, {Key: "u", Value: bson.D{{Key: "$inc", Value: bson.D{{Key: "age", Value: int32(-2)}}}}}, {Key: "upsert", Value: true}}}},
+				{Key: "$db", Value: "app"},
+			})
+			assertOK(t, response)
+			assertInt32(t, response, "n", 1)
+			assertInt32(t, response, "nModified", 0)
+			upserted, ok := bson.Raw(response).Lookup("upserted").ArrayOK()
+			if !ok {
+				t.Fatalf("missing upserted: %v", response)
+			}
+			values, err := upserted.Values()
+			if err != nil || len(values) != 1 {
+				t.Fatalf("upserted=%v err=%v", values, err)
+			}
+			if id, _ := values[0].Document().Lookup("_id").StringValueOK(); id != "u1" {
+				t.Fatalf("upserted id=%q", id)
+			}
+			response = serveCommand(t, s, 7002, bson.D{
+				{Key: "update", Value: "users"},
+				{Key: "updates", Value: bson.A{
+					bson.D{{Key: "q", Value: bson.D{{Key: "_id", Value: "u1"}}}, {Key: "u", Value: bson.D{{Key: "$inc", Value: bson.D{{Key: "age", Value: int32(1)}}}}}, {Key: "upsert", Value: true}},
+					bson.D{{Key: "q", Value: bson.D{{Key: "_id", Value: int64(2)}}}, {Key: "u", Value: bson.D{{Key: "name", Value: "grace"}}}, {Key: "upsert", Value: true}},
+				}},
+				{Key: "$db", Value: "app"},
+			})
+			assertOK(t, response)
+			assertInt32(t, response, "n", 2)
+			assertInt32(t, response, "nModified", 1)
+			upserted, ok = bson.Raw(response).Lookup("upserted").ArrayOK()
+			if !ok {
+				t.Fatalf("missing mixed upserted: %v", response)
+			}
+			values, err = upserted.Values()
+			if err != nil || len(values) != 1 || values[0].Document().Lookup("index").Int32() != 1 {
+				t.Fatalf("mixed upserted=%v err=%v", values, err)
+			}
+			if id, ok := values[0].Document().Lookup("_id").Int64OK(); !ok || id != 2 {
+				t.Fatalf("upserted typed id=%d ok=%v", id, ok)
+			}
+			assertCommandError(t, serveCommand(t, s, 7003, bson.D{{Key: "update", Value: "users"}, {Key: "updates", Value: bson.A{bson.D{{Key: "q", Value: bson.D{{Key: "_id", Value: "bad"}}}, {Key: "u", Value: bson.D{{Key: "_id", Value: "other"}}}, {Key: "upsert", Value: true}}}}, {Key: "$db", Value: "app"}}), "BadValue")
+		})
+	}
+}
+
+func TestServerUpdateInvalidUpsertDoesNotCreateCollection(t *testing.T) {
+	db, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+	s := NewServer()
+	s.Collections = collections.NewCollectionManager(db)
+	assertCommandError(t, serveCommand(t, s, 7010, bson.D{{Key: "update", Value: "missing"}, {Key: "updates", Value: bson.A{bson.D{{Key: "q", Value: bson.D{{Key: "_id", Value: "u1"}}}, {Key: "u", Value: bson.D{{Key: "$inc", Value: bson.D{{Key: "age", Value: "bad"}}}}}, {Key: "upsert", Value: true}}}}, {Key: "$db", Value: "app"}}), "BadValue")
+	if _, err := s.Collections.OpenCollection("app.missing"); !errors.Is(err, collections.ErrCollectionNotFound) {
+		t.Fatalf("invalid upsert created collection: %v", err)
 	}
 }
 

--- a/TreeDB/mongo_gateway/server_test.go
+++ b/TreeDB/mongo_gateway/server_test.go
@@ -1415,12 +1415,11 @@ func TestServerUpdateAppliesEarlierOrderedUpdatesBeforeLaterParseError(t *testin
 		{Key: "updates", Value: bson.A{
 			bson.D{
 				{Key: "q", Value: bson.D{{Key: "_id", Value: "u1"}}},
-				{Key: "u", Value: bson.D{{Key: "$set", Value: bson.D{{Key: "score", Value: int32(1)}}}}},
+				{Key: "u", Value: bson.D{{Key: "$inc", Value: bson.D{{Key: "score", Value: int32(1)}}}}},
 			},
 			bson.D{
 				{Key: "q", Value: bson.D{{Key: "_id", Value: "u2"}}},
-				{Key: "multi", Value: true},
-				{Key: "u", Value: bson.D{{Key: "$set", Value: bson.D{{Key: "score", Value: int32(2)}}}}},
+				{Key: "u", Value: bson.D{{Key: "$push", Value: bson.D{{Key: "score", Value: int32(2)}}}}},
 			},
 		}},
 		{Key: "$db", Value: "app"},
@@ -5997,6 +5996,67 @@ func TestMongoMutationRejectsInvalidShapesAndOverflow(t *testing.T) {
 	changedID := mustDocument(t, bson.D{{Key: "_id", Value: "u2"}})
 	if _, _, err := applyMongoReplacement(mustDocument(t, bson.D{{Key: "_id", Value: "u1"}}), changedID); err == nil {
 		t.Fatal("changed _id accepted")
+	}
+}
+
+func TestServerUpdateGenericMutationsAcrossDocumentFormats(t *testing.T) {
+	for _, format := range []collections.DocumentFormat{collections.DocumentFormatBSON, collections.DocumentFormatJSON, collections.DocumentFormatTemplateV1} {
+		t.Run(string(format), func(t *testing.T) {
+			db, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer db.Close()
+			s := NewServer()
+			s.DefaultCollectionOptions = collections.CollectionOptions{DocumentFormat: format}
+			s.Collections = collections.NewCollectionManager(db)
+			assertOK(t, serveCommand(t, s, 1, bson.D{{Key: "insert", Value: "users"}, {Key: "documents", Value: bson.A{bson.D{{Key: "_id", Value: "u1"}, {Key: "n", Value: int32(2147483647)}, {Key: "old", Value: true}}}}, {Key: "$db", Value: "app"}}))
+
+			update := func(requestID int32, value bson.D) bson.Raw {
+				return serveCommand(t, s, requestID, bson.D{{Key: "update", Value: "users"}, {Key: "updates", Value: bson.A{bson.D{{Key: "q", Value: bson.D{{Key: "_id", Value: "u1"}}}, {Key: "u", Value: value}}}}, {Key: "$db", Value: "app"}})
+			}
+			resp := update(2, bson.D{{Key: "$set", Value: bson.D{{Key: "name", Value: "ada"}}}, {Key: "$inc", Value: bson.D{{Key: "n", Value: int32(1)}, {Key: "missing", Value: int64(-2)}}}, {Key: "$unset", Value: bson.D{{Key: "old", Value: true}, {Key: "absent", Value: true}}}})
+			assertOK(t, resp)
+			assertInt32(t, resp, "n", 1)
+			assertInt32(t, resp, "nModified", 1)
+			find := serveCommand(t, s, 3, bson.D{{Key: "find", Value: "users"}, {Key: "filter", Value: bson.D{{Key: "_id", Value: "u1"}}}, {Key: "$db", Value: "app"}})
+			got := cursorFirstBatch(t, find)[0]
+			if n, ok := got.Lookup("n").Int64OK(); !ok || n != 2147483648 {
+				t.Fatalf("n=%d ok=%v", n, ok)
+			}
+			if n, _ := got.Lookup("missing").Int64OK(); n != -2 {
+				t.Fatalf("missing=%d", n)
+			}
+			if !got.Lookup("old").IsZero() {
+				t.Fatal("old remains")
+			}
+			// int64 plus double is a double, while unsetting a missing field is a no-op.
+			assertOK(t, update(4, bson.D{{Key: "$inc", Value: bson.D{{Key: "n", Value: 0.5}}}, {Key: "$unset", Value: bson.D{{Key: "stillAbsent", Value: true}}}}))
+			find = serveCommand(t, s, 5, bson.D{{Key: "find", Value: "users"}, {Key: "filter", Value: bson.D{{Key: "_id", Value: "u1"}}}, {Key: "$db", Value: "app"}})
+			if n, ok := cursorFirstBatch(t, find)[0].Lookup("n").DoubleOK(); !ok || n != 2147483648.5 {
+				t.Fatalf("double n=%v ok=%v", n, ok)
+			}
+			for _, badUpdate := range []bson.D{
+				{{Key: "$inc", Value: bson.D{{Key: "n", Value: "bad"}}}},
+				{{Key: "$inc", Value: bson.D{{Key: "n", Value: nil}}}},
+				{{Key: "$set", Value: bson.D{{Key: "n", Value: 1}}}, {Key: "$unset", Value: bson.D{{Key: "n", Value: true}}}},
+				{{Key: "$set", Value: bson.D{{Key: "x.y", Value: 1}}}},
+				{{Key: "$set", Value: bson.D{{Key: "_id", Value: "u2"}}}},
+				{{Key: "$push", Value: bson.D{{Key: "n", Value: 1}}}},
+			} {
+				assertCommandError(t, update(6, badUpdate), "BadValue")
+			}
+			find = serveCommand(t, s, 6, bson.D{{Key: "find", Value: "users"}, {Key: "filter", Value: bson.D{{Key: "_id", Value: "u1"}}}, {Key: "$db", Value: "app"}})
+			if n, _ := cursorFirstBatch(t, find)[0].Lookup("n").DoubleOK(); n != 2147483648.5 {
+				t.Fatalf("failed item changed n=%v", n)
+			}
+			assertOK(t, update(6, bson.D{{Key: "$inc", Value: bson.D{{Key: "largest", Value: int64(math.MaxInt64)}}}}))
+			assertCommandError(t, update(6, bson.D{{Key: "$inc", Value: bson.D{{Key: "largest", Value: int64(1)}}}}), "BadValue")
+			assertOK(t, update(7, bson.D{{Key: "name", Value: "grace"}})) // omitted _id is preserved
+			assertOK(t, update(8, bson.D{{Key: "_id", Value: "u1"}, {Key: "name", Value: "grace"}}))
+			assertCommandError(t, update(9, bson.D{{Key: "_id", Value: "u2"}}), "BadValue")
+			assertOK(t, update(10, bson.D{})) // an empty replacement retains _id
+		})
 	}
 }
 

--- a/TreeDB/mongo_gateway/server_test.go
+++ b/TreeDB/mongo_gateway/server_test.go
@@ -5947,6 +5947,63 @@ func TestApplySetUpdateAppendsNewFieldsInSetOrder(t *testing.T) {
 	}
 }
 
+func TestMongoMutationApplyOperatorsAndReplacement(t *testing.T) {
+	doc := mustDocument(t, bson.D{{Key: "_id", Value: "u1"}, {Key: "count", Value: int32(1)}, {Key: "old", Value: true}})
+	mutation, err := parseMongoMutation(mustDocument(t, bson.D{{Key: "$set", Value: bson.D{{Key: "name", Value: "ada"}}}, {Key: "$inc", Value: bson.D{{Key: "count", Value: int32(2)}, {Key: "new", Value: int64(-1)}}}, {Key: "$unset", Value: bson.D{{Key: "old", Value: true}}}}))
+	if err != nil {
+		t.Fatalf("parse mutation: %v", err)
+	}
+	updated, changed, err := applyMongoMutation(doc, mutation)
+	if err != nil || !changed {
+		t.Fatalf("apply changed=%v err=%v", changed, err)
+	}
+	if got, _ := bson.Raw(updated).Lookup("count").Int32OK(); got != 3 {
+		t.Fatalf("count=%d want 3", got)
+	}
+	if got, _ := bson.Raw(updated).Lookup("new").Int64OK(); got != -1 {
+		t.Fatalf("new=%d want -1", got)
+	}
+	if !bson.Raw(updated).Lookup("old").IsZero() {
+		t.Fatal("unset field remains")
+	}
+	replacement, err := parseMongoMutation(mustDocument(t, bson.D{{Key: "name", Value: "grace"}}))
+	if err != nil {
+		t.Fatal(err)
+	}
+	updated, _, err = applyMongoMutation(doc, replacement)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got, _ := bson.Raw(updated).Lookup("_id").StringValueOK(); got != "u1" {
+		t.Fatalf("_id=%q", got)
+	}
+}
+
+func TestMongoMutationRejectsInvalidShapesAndOverflow(t *testing.T) {
+	for _, update := range []bson.D{
+		{{Key: "$inc", Value: bson.D{{Key: "a.b", Value: 1}}}},
+		{{Key: "$set", Value: bson.D{{Key: "x", Value: 1}}}, {Key: "$inc", Value: bson.D{{Key: "x", Value: 1}}}},
+		{{Key: "$push", Value: bson.D{{Key: "x", Value: 1}}}},
+		{},
+	} {
+		if _, err := parseMongoMutation(mustDocument(t, update)); err == nil {
+			t.Fatalf("accepted %v", update)
+		}
+	}
+	_, err := mongoMutationIncrement(mustRawValue(t, int64(math.MaxInt64)), mustRawValue(t, int64(1)))
+	if err == nil {
+		t.Fatal("overflow accepted")
+	}
+	_, err = mongoMutationIncrement(bson.RawValue{Type: bson.TypeNull}, mustRawValue(t, int32(1)))
+	if err == nil {
+		t.Fatal("null accepted")
+	}
+	changedID := mustDocument(t, bson.D{{Key: "_id", Value: "u2"}})
+	if _, _, err := applyMongoReplacement(mustDocument(t, bson.D{{Key: "_id", Value: "u1"}}), changedID); err == nil {
+		t.Fatal("changed _id accepted")
+	}
+}
+
 func TestCompareDocumentFieldTreatsMissingAsNull(t *testing.T) {
 	missing := mustDocument(t, bson.D{{Key: "_id", Value: "missing"}})
 	nullValue := mustDocument(t, bson.D{{Key: "_id", Value: "null"}, {Key: "rank", Value: nil}})

--- a/TreeDB/mongo_gateway/server_test.go
+++ b/TreeDB/mongo_gateway/server_test.go
@@ -1010,6 +1010,49 @@ func TestServerUpdateBSONSetAllowsNativeBinaryValues(t *testing.T) {
 	}
 }
 
+func TestServerBSONSetUpsertAllowsNativeBinaryValues(t *testing.T) {
+	for _, format := range []collections.DocumentFormat{collections.DocumentFormatBSON, collections.DocumentFormatJSON, collections.DocumentFormatTemplateV1} {
+		t.Run(string(format), func(t *testing.T) {
+			db, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer db.Close()
+			server := NewServer()
+			server.Collections = collections.NewCollectionManager(db)
+			server.DefaultCollectionOptions = collections.CollectionOptions{DocumentFormat: format}
+			response := serveCommand(t, server, 22543, bson.D{
+				{Key: "update", Value: "users"},
+				{Key: "updates", Value: bson.A{bson.D{
+					{Key: "q", Value: bson.D{{Key: "_id", Value: "binary-upsert"}}},
+					{Key: "u", Value: bson.D{{Key: "$set", Value: bson.D{{Key: "payload", Value: bson.Binary{Subtype: 0x00, Data: []byte{2, 3, 4}}}}}}},
+					{Key: "upsert", Value: true},
+				}}},
+				{Key: "$db", Value: "app"},
+			})
+			if format != collections.DocumentFormatBSON {
+				assertCommandError(t, response, "BadValue")
+				if _, err := server.Collections.OpenCollection("app.users"); !errors.Is(err, collections.ErrCollectionNotFound) {
+					t.Fatalf("unsupported BSON upsert created collection: %v", err)
+				}
+				return
+			}
+			assertOK(t, response)
+			assertInt32(t, response, "n", 1)
+			assertInt32(t, response, "nModified", 0)
+			found := serveCommand(t, server, 22544, bson.D{{Key: "find", Value: "users"}, {Key: "filter", Value: bson.D{{Key: "_id", Value: "binary-upsert"}}}, {Key: "$db", Value: "app"}})
+			batch := cursorFirstBatch(t, found)
+			if len(batch) != 1 {
+				t.Fatalf("batch len=%d want 1", len(batch))
+			}
+			subtype, payload := batch[0].Lookup("payload").Binary()
+			if subtype != 0x00 || !bytes.Equal(payload, []byte{2, 3, 4}) {
+				t.Fatalf("payload subtype/data=%#x/%v want 0/[2 3 4]", subtype, payload)
+			}
+		})
+	}
+}
+
 func TestServerUpdateTemplateV1RefreshesMaterializerBetweenStatements(t *testing.T) {
 	db, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
 	if err != nil {

--- a/TreeDB/mongo_gateway/server_test.go
+++ b/TreeDB/mongo_gateway/server_test.go
@@ -1049,6 +1049,23 @@ func TestServerBSONSetUpsertAllowsNativeBinaryValues(t *testing.T) {
 			if subtype != 0x00 || !bytes.Equal(payload, []byte{2, 3, 4}) {
 				t.Fatalf("payload subtype/data=%#x/%v want 0/[2 3 4]", subtype, payload)
 			}
+			response = serveCommand(t, server, 22545, bson.D{
+				{Key: "update", Value: "users"},
+				{Key: "updates", Value: bson.A{bson.D{
+					{Key: "q", Value: bson.D{{Key: "_id", Value: "binary-upsert"}}},
+					{Key: "u", Value: bson.D{{Key: "$set", Value: bson.D{{Key: "payload", Value: bson.Binary{Subtype: 0x00, Data: []byte{5, 6}}}}}}},
+					{Key: "upsert", Value: true},
+				}}},
+				{Key: "$db", Value: "app"},
+			})
+			assertOK(t, response)
+			assertInt32(t, response, "n", 1)
+			assertInt32(t, response, "nModified", 1)
+			found = serveCommand(t, server, 22546, bson.D{{Key: "find", Value: "users"}, {Key: "filter", Value: bson.D{{Key: "_id", Value: "binary-upsert"}}}, {Key: "$db", Value: "app"}})
+			subtype, payload = cursorFirstBatch(t, found)[0].Lookup("payload").Binary()
+			if subtype != 0x00 || !bytes.Equal(payload, []byte{5, 6}) {
+				t.Fatalf("matched payload subtype/data=%#x/%v want 0/[5 6]", subtype, payload)
+			}
 		})
 	}
 }

--- a/TreeDB/mongo_gateway/server_test.go
+++ b/TreeDB/mongo_gateway/server_test.go
@@ -1522,6 +1522,24 @@ func TestServerUpdateMissingCollectionExecutesEarlierUpsertBeforeParseError(t *t
 	if score, _ := batch[0].Lookup("score").Int32OK(); score != 1 {
 		t.Fatalf("score=%d want 1", score)
 	}
+	response = serveCommand(t, s, 22599, bson.D{
+		{Key: "update", Value: "replacement-users"},
+		{Key: "updates", Value: bson.A{
+			bson.D{{Key: "q", Value: bson.D{{Key: "_id", Value: "u1"}}}, {Key: "u", Value: bson.D{{Key: "$inc", Value: bson.D{{Key: "score", Value: int32(1)}}}}}, {Key: "upsert", Value: true}},
+			bson.D{{Key: "q", Value: bson.D{{Key: "_id", Value: "u2"}}}, {Key: "u", Value: bson.D{{Key: "_id", Value: "different"}}}, {Key: "upsert", Value: true}},
+		}},
+		{Key: "$db", Value: "app"},
+	})
+	assertCommandError(t, response, "BadValue")
+	assertErrmsgContains(t, response, "updates[1]")
+	found = serveCommand(t, s, 22600, bson.D{{Key: "find", Value: "replacement-users"}, {Key: "filter", Value: bson.D{{Key: "_id", Value: "u1"}}}, {Key: "$db", Value: "app"}})
+	batch = cursorFirstBatch(t, found)
+	if len(batch) != 1 {
+		t.Fatalf("replacement prefix batch len=%d want 1", len(batch))
+	}
+	if score, _ := batch[0].Lookup("score").Int32OK(); score != 1 {
+		t.Fatalf("replacement prefix score=%d want 1", score)
+	}
 }
 
 func TestServerUpdateAppliesEarlierOrderedUpdatesBeforeLaterWriteError(t *testing.T) {

--- a/TreeDB/mongo_gateway/server_test.go
+++ b/TreeDB/mongo_gateway/server_test.go
@@ -1484,6 +1484,19 @@ func TestParseMongoUpdateItemPureSetSkipsGenericMutation(t *testing.T) {
 	}
 }
 
+func TestParseMongoUpdateItemBSONOnlyPureSetSkipsGenericMutation(t *testing.T) {
+	item, err := parseMongoUpdateItem(0, mustDocument(t, bson.D{
+		{Key: "q", Value: bson.D{{Key: "_id", Value: "u1"}}},
+		{Key: "u", Value: bson.D{{Key: "$set", Value: bson.D{{Key: "payload", Value: bson.Binary{Subtype: 0, Data: []byte{1}}}}}}},
+	}))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !item.pureSet || item.setFieldsOK || !item.bsonSetFieldsOK || len(item.mutation.set) != 0 || len(item.mutation.inc) != 0 || len(item.mutation.unset) != 0 || item.mutation.replace != nil {
+		t.Fatalf("BSON-only pure set item=%+v", item)
+	}
+}
+
 func TestServerUpdateMissingCollectionExecutesEarlierUpsertBeforeParseError(t *testing.T) {
 	db, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
 	if err != nil {

--- a/TreeDB/mongo_gateway/server_test.go
+++ b/TreeDB/mongo_gateway/server_test.go
@@ -6200,6 +6200,23 @@ func TestServerUpdateInvalidUpsertDoesNotCreateCollection(t *testing.T) {
 	if _, err := s.Collections.OpenCollection("app.missing"); !errors.Is(err, collections.ErrCollectionNotFound) {
 		t.Fatalf("invalid upsert created collection: %v", err)
 	}
+	for _, format := range []collections.DocumentFormat{collections.DocumentFormatBSON, collections.DocumentFormatJSON, collections.DocumentFormatTemplateV1} {
+		t.Run(string(format), func(t *testing.T) {
+			db, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer db.Close()
+			server := NewServer()
+			server.Collections = collections.NewCollectionManager(db)
+			server.DefaultCollectionOptions = collections.CollectionOptions{DocumentFormat: format}
+			response := serveCommand(t, server, 7011, bson.D{{Key: "update", Value: "replacement-mismatch"}, {Key: "updates", Value: bson.A{bson.D{{Key: "q", Value: bson.D{{Key: "_id", Value: "u1"}}}, {Key: "u", Value: bson.D{{Key: "_id", Value: "u2"}, {Key: "name", Value: "wrong"}}}, {Key: "upsert", Value: true}}}}, {Key: "$db", Value: "app"}})
+			assertCommandError(t, response, "BadValue")
+			if _, err := server.Collections.OpenCollection("app.replacement-mismatch"); !errors.Is(err, collections.ErrCollectionNotFound) {
+				t.Fatalf("replacement mismatch created collection: %v", err)
+			}
+		})
+	}
 }
 
 func TestCompareDocumentFieldTreatsMissingAsNull(t *testing.T) {


### PR DESCRIPTION
## Objective

Add the bounded standalone MongoDB update subset from #4037: exact-`_id` UpdateOne/ReplaceOne supports top-level `$set`, `$inc`, `$unset`, replacement documents, and modifier or replacement upsert. This closes #4037 and advances parent #4035.

## Context

The gateway previously accepted only the established top-level BSON `$set` path. This adds common single-document mutation semantics while preserving that path and its parser/dispatcher fast path.

## Non-goals

- Dotted paths, arrays/positional operators, `$push`, `$setOnInsert`, pipelines, array filters, collation, hints, or arbitrary filters.
- `multi`, transactions, retryable writes, a new collection transaction API, and native/cluster command widening.

## Design

- Standalone writes require exactly one `_id` equality predicate.
- Supported top-level modifiers are `$set`, `$inc`, and `$unset`; mixed operators require disjoint fields. `$inc` accepts BSON int32/int64/double, promotes safely, and rejects null/non-numeric targets and overflow.
- Replacement/ReplaceOne preserves an omitted matched `_id`, accepts the same `_id`, and rejects a changed `_id`. Exact-`_id` modifier and replacement upserts insert through the configured BSON, JSON, or template-v1 collection encoding and return ordered `upserted` entries.
- Update arrays remain ordered; `n` includes matches/inserts and `nModified` excludes inserts.
- Existing pure top-level BSON `$set` retains its established parser and index fast path; generic parsing/apply is skipped for that shape.
- Command-WAL relaxed and durable standalone reopen paths cover mutations/replacements/upserts. Cluster/routed generic operators, replacements, and all upserts fail closed without submission or local mutation.

## Scope

- Includes: `TreeDB/mongo_gateway` update parsing/application, upsert accounting, cluster guards, compatibility matrix/docs, direct-wire/driver/WAL tests, and focused benchmarks.
- Excludes: on-disk format changes and all non-goals above.

## Correctness

Direct-wire coverage exercises BSON, JSON, and template-v1 for `$inc`, `$unset`, mixed modifiers, replacement, malformed input, ordered arrays, and modifier/replacement upsert. Official Go driver coverage verifies UpdateOne, ReplaceOne, result counts, and upsert IDs. The executable matrix and compatibility docs name the bounded contract.

Tests run:

```sh
GOWORK=off go test ./TreeDB/mongo_gateway -run 'Test(ServerUpdateGenericMutationsAcrossDocumentFormats|ServerUpdateUpsertAcrossDocumentFormats|ServerUpdateMissingCollectionExecutesEarlierUpsertBeforeParseError|ParseMongoUpdateItem(BSONOnly)?PureSetSkipsGenericMutation|StandaloneServerCommandWALCRUDReopens|MongoCompatibilityMatrix|ServerOfficialGoDriverBasicCRUD|ClusterSubmitterGenericUpdatesFailClosedWithoutLocalMutation)' -count=1
# PASS

GOWORK=off go test ./TreeDB/mongo_gateway -run TestMongoCompatibilityMatrixDocumentationUpToDate -update-mongo-compatibility-docs
# PASS

GOWORK=off go test ./TreeDB/mongo_gateway -count=1
# PASS (14.347s on final local run)

gofmt -w TreeDB/mongo_gateway/*.go
git diff --check
# clean
```

## Performance

```sh
GOWORK=off go test ./TreeDB/mongo_gateway -run '^$' -bench 'Benchmark(ParseMongoUpdateItemPureSet|ApplyMongoMutationInc)$' -benchmem -count=5
```

| Benchmark | Evidence | Result |
|---|---:|---|
| Identical pure `$set` parser, Apple M3 | base `b9648ed3895918ad85e1250ee7583fb11d866769` vs candidate, n=8 | 1.167 us/op median -> 1.184 us/op median (+1.41%, p=0.008); both 2292 B/op, 32 allocs/op |
| Candidate `$inc` applicator, Apple M3 | focused n=5 | 666.5-705.7 ns/op, 824-825 B/op, 17 allocs/op |

The pure-`$set` timing shift is non-material: memory/allocation results are unchanged and the candidate retains the prior pure-set parser/dispatcher path.

## Rollout / Toggle Plan

- Default: enabled for the bounded standalone gateway subset.
- Disable/revert: revert this PR; there is no persisted format or runtime toggle.

## Follow-ups

- Parent: #4035.
- Cluster/native mutation command expansion remains deliberately out of scope.

## Column Graph Native Workstream (#1646, if applicable)

Not applicable.

## Optimization PR Checklist (TreeDB)

- [x] Single bounded Mongo gateway objective.
- [x] Regression, direct-wire, official-driver, matrix/docs, and command-WAL reopen coverage added.
- [x] Focused parser baseline and generic `$inc` benchmarks added.
- [x] No on-disk format, mmap, checksum, or concurrency-state changes.

Closes #4037


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for MongoDB replacement updates and `$set`, `$inc`, and `$unset` operations.
  * Added modifier and replacement upserts, including returned upserted document identifiers.
  * Improved update support across BSON, JSON, and TemplateV1 document formats.

* **Bug Fixes**
  * Added validation for invalid update shapes, numeric overflow, and protected `_id` fields.
  * Unsupported cluster upserts and generic updates now return clear errors without changing data.
  * Preserved update ordering and prevented invalid operations from creating collections.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->