### PR TITLE
Wire vector search into production topology

### DIFF
--- a/TreeDB/nativewire/vector_partition_m8_production_topology_v1.go
+++ b/TreeDB/nativewire/vector_partition_m8_production_topology_v1.go
@@ -59,6 +59,7 @@ type VectorPartitionM8ProductionGroupEvidenceV1 struct {
 
 type VectorPartitionM8ProductionMultiGroupV1 struct {
 	coordinator *VectorPartitionCoordinatorV1
+	dispatcher  *VectorPartitionShardSearchTCPDispatcherV1
 	data        map[raftcluster.GroupID]*raftcluster.ThreeNodeHarness
 	meta        *raftplacement.CatalogMetaLifecycleHarnessV1
 	listeners   map[raftcluster.GroupID]net.Listener
@@ -200,6 +201,7 @@ func NewVectorPartitionM8ProductionMultiGroupV1(ctx context.Context, opts Vector
 	if err != nil {
 		return nil, err
 	}
+	h.dispatcher = dispatcher
 	counting := VectorPartitionShardSearchDispatcherFuncV1(func(callCtx context.Context, request VectorPartitionShardSearchRequestV1) (VectorPartitionShardSearchResponseV1, error) {
 		current := h.inflight.Add(1)
 		defer h.inflight.Add(^uint64(0))
@@ -449,6 +451,9 @@ func (h *VectorPartitionM8ProductionMultiGroupV1) Close() error {
 		// close them before sources release their mapped persistent assets.
 		if h.coordinator != nil {
 			errs = append(errs, h.coordinator.Close())
+		}
+		if h.dispatcher != nil {
+			errs = append(errs, h.dispatcher.Close())
 		}
 		// Sources own mapped persistent search assets and must retire before their DB.
 		for _, source := range h.sources {

--- a/TreeDB/nativewire/vector_partition_m8_production_topology_v1.go
+++ b/TreeDB/nativewire/vector_partition_m8_production_topology_v1.go
@@ -92,6 +92,15 @@ func NewVectorPartitionM8ProductionMultiGroupV1(ctx context.Context, opts Vector
 	if opts.Collection == nil || opts.RouterSource == nil || opts.Manifest.State != "ready" || len(opts.Manifest.Placements) < 4 {
 		return nil, errors.New("nativewire: M8 production topology requires ready persistent assets")
 	}
+	coordinatorLimits, err := normalizeVectorPartitionCoordinatorLimitsV1(opts.CoordinatorLimits)
+	if err != nil {
+		return nil, err
+	}
+	shardLimits, err := normalizeVectorPartitionShardSearchLimitsV1(opts.ShardLimits)
+	if err != nil {
+		return nil, err
+	}
+	opts.CoordinatorLimits, opts.ShardLimits = coordinatorLimits, shardLimits
 	groups, err := vectorPartitionM8ValidateAssetsV1(opts.Manifest, opts.GroupAssetSetDigests)
 	if err != nil {
 		return nil, err
@@ -197,7 +206,7 @@ func NewVectorPartitionM8ProductionMultiGroupV1(ctx context.Context, opts Vector
 		h.endpoints[group] = listener.Addr().String()
 		h.serve(group, listener, service)
 	}
-	dispatcher, err := NewVectorPartitionShardSearchTCPDispatcherV1(h.endpoints)
+	dispatcher, err := newVectorPartitionShardSearchTCPDispatcherV1(h.endpoints, nil, coordinatorLimits.MaxConcurrentRequests, shardLimits)
 	if err != nil {
 		return nil, err
 	}

--- a/TreeDB/nativewire/vector_partition_m8_production_topology_v1.go
+++ b/TreeDB/nativewire/vector_partition_m8_production_topology_v1.go
@@ -204,13 +204,15 @@ func NewVectorPartitionM8ProductionMultiGroupV1(ctx context.Context, opts Vector
 		}
 		h.listeners[group] = listener
 		h.endpoints[group] = listener.Addr().String()
-		h.serve(group, listener, service)
 	}
 	dispatcher, err := newVectorPartitionShardSearchTCPDispatcherV1(h.endpoints, nil, coordinatorLimits.MaxConcurrentRequests, shardLimits)
 	if err != nil {
 		return nil, err
 	}
 	h.dispatcher = dispatcher
+	for group, listener := range h.listeners {
+		h.serve(group, listener, h.services[group], dispatcher.maxRequestFrame, dispatcher.maxResponseFrame)
+	}
 	counting := VectorPartitionShardSearchDispatcherFuncV1(func(callCtx context.Context, request VectorPartitionShardSearchRequestV1) (VectorPartitionShardSearchResponseV1, error) {
 		current := h.inflight.Add(1)
 		defer h.inflight.Add(^uint64(0))
@@ -343,7 +345,7 @@ func vectorPartitionM8ProofEntryV1() ([]byte, error) {
 	}
 	return entry, nil
 }
-func (h *VectorPartitionM8ProductionMultiGroupV1) serve(group raftcluster.GroupID, listener net.Listener, service *VectorPartitionShardSearchServiceV1) {
+func (h *VectorPartitionM8ProductionMultiGroupV1) serve(group raftcluster.GroupID, listener net.Listener, service *VectorPartitionShardSearchServiceV1, maxRequestFrame, maxResponseFrame uint32) {
 	h.wg.Add(1)
 	go func() {
 		defer h.wg.Done()
@@ -364,7 +366,7 @@ func (h *VectorPartitionM8ProductionMultiGroupV1) serve(group raftcluster.GroupI
 			go func() {
 				defer h.wg.Done()
 				defer func() { h.mu.Lock(); delete(h.conns, conn); h.mu.Unlock() }()
-				(VectorPartitionShardSearchTCPServerV1{Service: service, InitialTimeout: 2 * time.Second}).ServeConn(context.Background(), conn)
+				(VectorPartitionShardSearchTCPServerV1{Service: service, InitialTimeout: 2 * time.Second, MaxFrame: maxRequestFrame, MaxResponseFrame: maxResponseFrame}).ServeConn(context.Background(), conn)
 			}()
 		}
 	}()

--- a/TreeDB/nativewire/vector_partition_production_listener_socket_fallback_v1.go
+++ b/TreeDB/nativewire/vector_partition_production_listener_socket_fallback_v1.go
@@ -1,4 +1,4 @@
-//go:build js || plan9 || wasip1
+//go:build !windows && !aix && !android && !darwin && !dragonfly && !freebsd && !illumos && !ios && !linux && !netbsd && !openbsd && !solaris
 
 package nativewire
 

--- a/TreeDB/nativewire/vector_partition_production_listener_socket_fallback_v1.go
+++ b/TreeDB/nativewire/vector_partition_production_listener_socket_fallback_v1.go
@@ -1,0 +1,9 @@
+//go:build js || plan9 || wasip1
+
+package nativewire
+
+import "net"
+
+func vectorPartitionProductionListenerIPv6OnlyV1(*net.TCPListener) (bool, bool) {
+	return false, false
+}

--- a/TreeDB/nativewire/vector_partition_production_listener_socket_unix_v1.go
+++ b/TreeDB/nativewire/vector_partition_production_listener_socket_unix_v1.go
@@ -1,0 +1,21 @@
+//go:build aix || android || darwin || dragonfly || freebsd || illumos || ios || linux || netbsd || openbsd || solaris
+
+package nativewire
+
+import (
+	"net"
+	"syscall"
+)
+
+func vectorPartitionProductionListenerIPv6OnlyV1(listener *net.TCPListener) (bool, bool) {
+	raw, err := listener.SyscallConn()
+	if err != nil {
+		return false, false
+	}
+	var value int
+	var socketErr error
+	err = raw.Control(func(fd uintptr) {
+		value, socketErr = syscall.GetsockoptInt(int(fd), syscall.IPPROTO_IPV6, syscall.IPV6_V6ONLY)
+	})
+	return value != 0, err == nil && socketErr == nil
+}

--- a/TreeDB/nativewire/vector_partition_production_listener_socket_windows_v1.go
+++ b/TreeDB/nativewire/vector_partition_production_listener_socket_windows_v1.go
@@ -1,0 +1,21 @@
+//go:build windows
+
+package nativewire
+
+import (
+	"net"
+	"syscall"
+)
+
+func vectorPartitionProductionListenerIPv6OnlyV1(listener *net.TCPListener) (bool, bool) {
+	raw, err := listener.SyscallConn()
+	if err != nil {
+		return false, false
+	}
+	var value int
+	var socketErr error
+	err = raw.Control(func(fd uintptr) {
+		value, socketErr = syscall.GetsockoptInt(syscall.Handle(fd), syscall.IPPROTO_IPV6, syscall.IPV6_V6ONLY)
+	})
+	return value != 0, err == nil && socketErr == nil
+}

--- a/TreeDB/nativewire/vector_partition_production_topology_v1.go
+++ b/TreeDB/nativewire/vector_partition_production_topology_v1.go
@@ -87,6 +87,17 @@ func NewVectorPartitionProductionTopologyV1(opts VectorPartitionProductionTopolo
 	if len(h.endpoints) != len(owners) {
 		return nil, errors.New("nativewire: production vector topology has incomplete owner endpoint coverage")
 	}
+	for group, nodes := range opts.NodeEndpoints {
+		resolved, ok := opts.Catalog.Group(group)
+		if !ok || !owners[group] {
+			return nil, fmt.Errorf("nativewire: production vector topology node endpoint owner %q is invalid", group)
+		}
+		for node := range nodes {
+			if !slices.Contains(resolved.Members, node) {
+				return nil, fmt.Errorf("nativewire: production vector topology node %q is not a member of %q", node, group)
+			}
+		}
+	}
 	for _, shard := range opts.Shards {
 		if shard.GroupID == "" || shard.Listener == nil || shard.Service == nil || !owners[shard.GroupID] || h.listeners[shard.GroupID] != nil {
 			return nil, fmt.Errorf("nativewire: production vector topology shard %q is invalid", shard.GroupID)

--- a/TreeDB/nativewire/vector_partition_production_topology_v1.go
+++ b/TreeDB/nativewire/vector_partition_production_topology_v1.go
@@ -11,6 +11,7 @@ import (
 	"net"
 	"reflect"
 	"slices"
+	"strconv"
 	"sync"
 	"time"
 
@@ -404,6 +405,26 @@ func vectorPartitionProductionEndpointUsesListenerV1(endpoint string, listener n
 func vectorPartitionProductionEndpointAddressIsLocalV1(address *net.TCPAddr, local []net.Addr) bool {
 	if address.IP.IsLoopback() {
 		return true
+	}
+	if address.IP.IsLinkLocalUnicast() {
+		if address.Zone == "" {
+			return false
+		}
+		iface, err := net.InterfaceByName(address.Zone)
+		if err != nil {
+			index, indexErr := strconv.Atoi(address.Zone)
+			if indexErr != nil {
+				return false
+			}
+			iface, err = net.InterfaceByIndex(index)
+		}
+		if err != nil {
+			return false
+		}
+		local, err = iface.Addrs()
+		if err != nil {
+			return false
+		}
 	}
 	for _, addr := range local {
 		var ip net.IP

--- a/TreeDB/nativewire/vector_partition_production_topology_v1.go
+++ b/TreeDB/nativewire/vector_partition_production_topology_v1.go
@@ -358,7 +358,7 @@ func vectorPartitionProductionEndpointAddressMatchesListenerV1(advertised *net.T
 		return false
 	}
 	if !bound.IP.IsUnspecified() {
-		return bound.IP.Equal(advertised.IP)
+		return bound.IP.Equal(advertised.IP) && (bound.IP.To4() != nil || bound.Zone == advertised.Zone)
 	}
 	if bound.IP.To4() != nil || advertised.IP.To4() == nil {
 		return (bound.IP.To4() != nil) == (advertised.IP.To4() != nil)

--- a/TreeDB/nativewire/vector_partition_production_topology_v1.go
+++ b/TreeDB/nativewire/vector_partition_production_topology_v1.go
@@ -471,6 +471,9 @@ func vectorPartitionProductionEndpointAddressesV1(endpoint string) ([]*net.TCPAd
 		if address.IP.IsLinkLocalUnicast() && address.Zone == "" {
 			return nil, errors.New("TCP endpoint link-local address requires a zone")
 		}
+		if address.Zone != "" && !address.IP.IsLinkLocalUnicast() {
+			return nil, errors.New("TCP endpoint zone requires a link-local address")
+		}
 		if address.Zone != "" {
 			iface, err := vectorPartitionProductionInterfaceForZoneV1(address.Zone)
 			if err != nil {

--- a/TreeDB/nativewire/vector_partition_production_topology_v1.go
+++ b/TreeDB/nativewire/vector_partition_production_topology_v1.go
@@ -29,6 +29,7 @@ type VectorPartitionProductionTopologyOptionsV1 struct {
 	RouterSource        VectorPartitionCoordinatorRouterSourceV1
 	ReplicatedLifecycle VectorPartitionReplicatedLifecycleAuthorityV1
 	Endpoints           map[raftcluster.GroupID]string
+	NodeEndpoints       map[raftcluster.GroupID]map[raftcluster.NodeID]string
 	Shards              []VectorPartitionProductionShardV1
 	CoordinatorLimits   VectorPartitionCoordinatorLimitsV1
 	ShardLimits         VectorPartitionShardSearchLimitsV1
@@ -45,6 +46,7 @@ type VectorPartitionProductionTopologyStatusV1 struct {
 // Callers retain ownership of Raft, catalog, lifecycle, and local asset sources.
 type VectorPartitionProductionTopologyV1 struct {
 	coordinator *VectorPartitionCoordinatorV1
+	dispatcher  *VectorPartitionShardSearchTCPDispatcherV1
 	listeners   map[raftcluster.GroupID]net.Listener
 	endpoints   map[raftcluster.GroupID]string
 	services    map[raftcluster.GroupID]*VectorPartitionShardSearchServiceV1
@@ -63,8 +65,8 @@ func NewVectorPartitionProductionTopologyV1(opts VectorPartitionProductionTopolo
 	if err := opts.Catalog.ValidateVectorPartitionPlacementV1(opts.Placement); err != nil {
 		return nil, fmt.Errorf("nativewire: production vector topology placement: %w", err)
 	}
-	if len(opts.Endpoints) == 0 || len(opts.Shards) == 0 {
-		return nil, errors.New("nativewire: production vector topology requires endpoints and local shards")
+	if len(opts.Endpoints) == 0 {
+		return nil, errors.New("nativewire: production vector topology requires owner endpoints")
 	}
 	h := &VectorPartitionProductionTopologyV1{listeners: make(map[raftcluster.GroupID]net.Listener), endpoints: make(map[raftcluster.GroupID]string, len(opts.Endpoints)), services: make(map[raftcluster.GroupID]*VectorPartitionShardSearchServiceV1), conns: make(map[net.Conn]struct{})}
 	defer func() {
@@ -82,6 +84,9 @@ func NewVectorPartitionProductionTopologyV1(opts VectorPartitionProductionTopolo
 		}
 		h.endpoints[group] = endpoint
 	}
+	if len(h.endpoints) != len(owners) {
+		return nil, errors.New("nativewire: production vector topology has incomplete owner endpoint coverage")
+	}
 	for _, shard := range opts.Shards {
 		if shard.GroupID == "" || shard.Listener == nil || shard.Service == nil || !owners[shard.GroupID] || h.listeners[shard.GroupID] != nil {
 			return nil, fmt.Errorf("nativewire: production vector topology shard %q is invalid", shard.GroupID)
@@ -91,10 +96,11 @@ func NewVectorPartitionProductionTopologyV1(opts VectorPartitionProductionTopolo
 		}
 		h.listeners[shard.GroupID], h.services[shard.GroupID] = shard.Listener, shard.Service
 	}
-	dispatcher, err := NewVectorPartitionShardSearchTCPDispatcherV1(h.endpoints)
+	dispatcher, err := NewVectorPartitionShardSearchTCPDispatcherWithNodeEndpointsV1(h.endpoints, opts.NodeEndpoints)
 	if err != nil {
 		return nil, err
 	}
+	h.dispatcher = dispatcher
 	h.coordinator, err = NewVectorPartitionCoordinatorV1(VectorPartitionCoordinatorOptionsV1{Catalog: opts.Catalog, Placement: opts.Placement, RouterSource: opts.RouterSource, Dispatcher: dispatcher, ReplicatedLifecycle: opts.ReplicatedLifecycle, RequireReplicatedLifecycle: true, Limits: opts.CoordinatorLimits, ShardLimits: opts.ShardLimits})
 	if err != nil {
 		return nil, err
@@ -145,7 +151,7 @@ func (h *VectorPartitionProductionTopologyV1) Status() VectorPartitionProduction
 	}
 	h.mu.Lock()
 	defer h.mu.Unlock()
-	status := VectorPartitionProductionTopologyStatusV1{Ready: !h.closed && h.coordinator != nil && len(h.listeners) != 0, Closed: h.closed, Endpoints: make(map[raftcluster.GroupID]string, len(h.endpoints))}
+	status := VectorPartitionProductionTopologyStatusV1{Ready: !h.closed && h.coordinator != nil, Closed: h.closed, Endpoints: make(map[raftcluster.GroupID]string, len(h.endpoints))}
 	for group, endpoint := range h.endpoints {
 		status.Endpoints[group] = endpoint
 	}
@@ -176,6 +182,9 @@ func (h *VectorPartitionProductionTopologyV1) Close() error {
 		}
 		h.mu.Unlock()
 		h.wg.Wait()
+		if h.dispatcher != nil {
+			errs = append(errs, h.dispatcher.Close())
+		}
 		if h.coordinator != nil {
 			errs = append(errs, h.coordinator.Close())
 		}

--- a/TreeDB/nativewire/vector_partition_production_topology_v1.go
+++ b/TreeDB/nativewire/vector_partition_production_topology_v1.go
@@ -65,6 +65,15 @@ func NewVectorPartitionProductionTopologyV1(opts VectorPartitionProductionTopolo
 	if opts.RouterSource == nil || opts.ReplicatedLifecycle == nil {
 		return nil, errors.New("nativewire: production vector topology requires router and replicated lifecycle")
 	}
+	coordinatorLimits, err := normalizeVectorPartitionCoordinatorLimitsV1(opts.CoordinatorLimits)
+	if err != nil {
+		return nil, err
+	}
+	shardLimits, err := normalizeVectorPartitionShardSearchLimitsV1(opts.ShardLimits)
+	if err != nil {
+		return nil, err
+	}
+	opts.CoordinatorLimits, opts.ShardLimits = coordinatorLimits, shardLimits
 	if err := opts.Catalog.ValidateVectorPartitionPlacementV1(opts.Placement); err != nil {
 		return nil, fmt.Errorf("nativewire: production vector topology placement: %w", err)
 	}
@@ -147,7 +156,7 @@ func NewVectorPartitionProductionTopologyV1(opts VectorPartitionProductionTopolo
 		}
 		group, _ := opts.Catalog.Group(shard.GroupID)
 		if shard.Service.localGroup != shard.GroupID || !slices.Contains(group.Members, shard.Service.localNodeID) ||
-			!reflect.DeepEqual(shard.Service.route.placement, opts.Placement) {
+			!reflect.DeepEqual(shard.Service.route.placement, opts.Placement) || shard.Service.limits != shardLimits {
 			return nil, fmt.Errorf("nativewire: production vector topology shard %q service does not match topology", shard.GroupID)
 		}
 		if endpoint := h.endpoints[shard.GroupID]; endpoint == "" || !vectorPartitionProductionEndpointMatchesListenerV1(endpoint, shard.Listener) {
@@ -175,10 +184,7 @@ func NewVectorPartitionProductionTopologyV1(opts VectorPartitionProductionTopolo
 		localListeners[listenerKey] = shard.GroupID
 		h.listeners[shard.GroupID], h.services[shard.GroupID] = shard.Listener, shard.Service
 	}
-	maxConnectionsPerEndpoint := opts.CoordinatorLimits.MaxConcurrentRequests
-	if maxConnectionsPerEndpoint == 0 {
-		maxConnectionsPerEndpoint = DefaultVectorPartitionCoordinatorLimitsV1().MaxConcurrentRequests
-	}
+	maxConnectionsPerEndpoint := coordinatorLimits.MaxConcurrentRequests
 	dispatcher, err := newVectorPartitionShardSearchTCPDispatcherV1(h.endpoints, opts.NodeEndpoints, maxConnectionsPerEndpoint)
 	if err != nil {
 		return nil, err
@@ -189,12 +195,13 @@ func NewVectorPartitionProductionTopologyV1(opts VectorPartitionProductionTopolo
 		return nil, err
 	}
 	for group, listener := range h.listeners {
-		h.serve(group, listener, h.services[group], opts.ShardIdleTimeout)
+		h.serve(group, listener, h.services[group], opts.ShardIdleTimeout, maxConnectionsPerEndpoint)
 	}
 	return h, nil
 }
 
-func (h *VectorPartitionProductionTopologyV1) serve(group raftcluster.GroupID, listener net.Listener, service *VectorPartitionShardSearchServiceV1, idleTimeout time.Duration) {
+func (h *VectorPartitionProductionTopologyV1) serve(group raftcluster.GroupID, listener net.Listener, service *VectorPartitionShardSearchServiceV1, idleTimeout time.Duration, maxConnections int) {
+	connectionSlots := make(chan struct{}, maxConnections)
 	h.mu.Lock()
 	h.serving[group] = true
 	h.mu.Unlock()
@@ -215,9 +222,16 @@ func (h *VectorPartitionProductionTopologyV1) serve(group raftcluster.GroupID, l
 				}
 				return
 			}
+			select {
+			case connectionSlots <- struct{}{}:
+			default:
+				_ = conn.Close()
+				continue
+			}
 			h.mu.Lock()
 			if h.closed {
 				h.mu.Unlock()
+				<-connectionSlots
 				_ = conn.Close()
 				return
 			}
@@ -226,6 +240,7 @@ func (h *VectorPartitionProductionTopologyV1) serve(group raftcluster.GroupID, l
 			h.mu.Unlock()
 			go func() {
 				defer h.wg.Done()
+				defer func() { <-connectionSlots }()
 				defer func() { h.mu.Lock(); delete(h.conns, conn); h.mu.Unlock() }()
 				(VectorPartitionShardSearchTCPServerV1{Service: service, InitialTimeout: idleTimeout}).ServeConn(context.Background(), conn)
 			}()
@@ -267,7 +282,13 @@ func vectorPartitionProductionEndpointMatchesListenerV1(endpoint string, listene
 		return endpoint == listener.Addr().String()
 	}
 	advertised, err := net.ResolveTCPAddr("tcp", endpoint)
-	return err == nil && advertised.Port == bound.Port && (bound.IP.IsUnspecified() || bound.IP.Equal(advertised.IP))
+	if err != nil || advertised.Port != bound.Port {
+		return false
+	}
+	if !bound.IP.IsUnspecified() {
+		return bound.IP.Equal(advertised.IP)
+	}
+	return (bound.IP.To4() != nil) == (advertised.IP.To4() != nil)
 }
 
 func vectorPartitionProductionEndpointKeyV1(endpoint string) (string, error) {

--- a/TreeDB/nativewire/vector_partition_production_topology_v1.go
+++ b/TreeDB/nativewire/vector_partition_production_topology_v1.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"fmt"
 	"net"
+	"reflect"
 	"slices"
 	"sync"
 	"time"
@@ -33,6 +34,7 @@ type VectorPartitionProductionTopologyOptionsV1 struct {
 	Shards              []VectorPartitionProductionShardV1
 	CoordinatorLimits   VectorPartitionCoordinatorLimitsV1
 	ShardLimits         VectorPartitionShardSearchLimitsV1
+	ShardIdleTimeout    time.Duration
 }
 
 type VectorPartitionProductionTopologyStatusV1 struct {
@@ -50,6 +52,7 @@ type VectorPartitionProductionTopologyV1 struct {
 	listeners   map[raftcluster.GroupID]net.Listener
 	endpoints   map[raftcluster.GroupID]string
 	services    map[raftcluster.GroupID]*VectorPartitionShardSearchServiceV1
+	serving     map[raftcluster.GroupID]bool
 	mu          sync.Mutex
 	conns       map[net.Conn]struct{}
 	wg          sync.WaitGroup
@@ -68,7 +71,13 @@ func NewVectorPartitionProductionTopologyV1(opts VectorPartitionProductionTopolo
 	if len(opts.Endpoints) == 0 {
 		return nil, errors.New("nativewire: production vector topology requires owner endpoints")
 	}
-	h := &VectorPartitionProductionTopologyV1{listeners: make(map[raftcluster.GroupID]net.Listener), endpoints: make(map[raftcluster.GroupID]string, len(opts.Endpoints)), services: make(map[raftcluster.GroupID]*VectorPartitionShardSearchServiceV1), conns: make(map[net.Conn]struct{})}
+	if opts.ShardIdleTimeout < 0 {
+		return nil, errors.New("nativewire: production vector topology shard idle timeout is negative")
+	}
+	if opts.ShardIdleTimeout == 0 {
+		opts.ShardIdleTimeout = 30 * time.Second
+	}
+	h := &VectorPartitionProductionTopologyV1{listeners: make(map[raftcluster.GroupID]net.Listener), endpoints: make(map[raftcluster.GroupID]string, len(opts.Endpoints)), services: make(map[raftcluster.GroupID]*VectorPartitionShardSearchServiceV1), serving: make(map[raftcluster.GroupID]bool), conns: make(map[net.Conn]struct{})}
 	defer func() {
 		if err != nil {
 			_ = h.Close()
@@ -102,7 +111,12 @@ func NewVectorPartitionProductionTopologyV1(opts VectorPartitionProductionTopolo
 		if shard.GroupID == "" || shard.Listener == nil || shard.Service == nil || !owners[shard.GroupID] || h.listeners[shard.GroupID] != nil {
 			return nil, fmt.Errorf("nativewire: production vector topology shard %q is invalid", shard.GroupID)
 		}
-		if endpoint := h.endpoints[shard.GroupID]; endpoint == "" || endpoint != shard.Listener.Addr().String() {
+		group, _ := opts.Catalog.Group(shard.GroupID)
+		if shard.Service.localGroup != shard.GroupID || !slices.Contains(group.Members, shard.Service.localNodeID) ||
+			!reflect.DeepEqual(shard.Service.route.placement, opts.Placement) {
+			return nil, fmt.Errorf("nativewire: production vector topology shard %q service does not match topology", shard.GroupID)
+		}
+		if endpoint := h.endpoints[shard.GroupID]; endpoint == "" || !vectorPartitionProductionEndpointMatchesListenerV1(endpoint, shard.Listener) {
 			return nil, fmt.Errorf("nativewire: production vector topology shard %q endpoint does not match listener", shard.GroupID)
 		}
 		h.listeners[shard.GroupID], h.services[shard.GroupID] = shard.Listener, shard.Service
@@ -121,18 +135,30 @@ func NewVectorPartitionProductionTopologyV1(opts VectorPartitionProductionTopolo
 		return nil, err
 	}
 	for group, listener := range h.listeners {
-		h.serve(group, listener, h.services[group])
+		h.serve(group, listener, h.services[group], opts.ShardIdleTimeout)
 	}
 	return h, nil
 }
 
-func (h *VectorPartitionProductionTopologyV1) serve(_ raftcluster.GroupID, listener net.Listener, service *VectorPartitionShardSearchServiceV1) {
+func (h *VectorPartitionProductionTopologyV1) serve(group raftcluster.GroupID, listener net.Listener, service *VectorPartitionShardSearchServiceV1, idleTimeout time.Duration) {
+	h.mu.Lock()
+	h.serving[group] = true
+	h.mu.Unlock()
 	h.wg.Add(1)
 	go func() {
 		defer h.wg.Done()
+		defer func() { h.mu.Lock(); h.serving[group] = false; h.mu.Unlock() }()
 		for {
 			conn, err := listener.Accept()
 			if err != nil {
+				h.mu.Lock()
+				closed := h.closed
+				h.mu.Unlock()
+				var netErr net.Error
+				if !closed && !errors.Is(err, net.ErrClosed) && errors.As(err, &netErr) && netErr.Temporary() {
+					time.Sleep(5 * time.Millisecond)
+					continue
+				}
 				return
 			}
 			h.mu.Lock()
@@ -147,7 +173,7 @@ func (h *VectorPartitionProductionTopologyV1) serve(_ raftcluster.GroupID, liste
 			go func() {
 				defer h.wg.Done()
 				defer func() { h.mu.Lock(); delete(h.conns, conn); h.mu.Unlock() }()
-				(VectorPartitionShardSearchTCPServerV1{Service: service, InitialTimeout: 2 * time.Second}).ServeConn(context.Background(), conn)
+				(VectorPartitionShardSearchTCPServerV1{Service: service, InitialTimeout: idleTimeout}).ServeConn(context.Background(), conn)
 			}()
 		}
 	}()
@@ -166,7 +192,11 @@ func (h *VectorPartitionProductionTopologyV1) Status() VectorPartitionProduction
 	}
 	h.mu.Lock()
 	defer h.mu.Unlock()
-	status := VectorPartitionProductionTopologyStatusV1{Ready: !h.closed && h.coordinator != nil, Closed: h.closed, Endpoints: make(map[raftcluster.GroupID]string, len(h.endpoints))}
+	ready := !h.closed && h.coordinator != nil
+	for group := range h.listeners {
+		ready = ready && h.serving[group]
+	}
+	status := VectorPartitionProductionTopologyStatusV1{Ready: ready, Closed: h.closed, Endpoints: make(map[raftcluster.GroupID]string, len(h.endpoints))}
 	for group, endpoint := range h.endpoints {
 		status.Endpoints[group] = endpoint
 	}
@@ -175,6 +205,15 @@ func (h *VectorPartitionProductionTopologyV1) Status() VectorPartitionProduction
 	}
 	slices.Sort(status.ShardGroups)
 	return status
+}
+
+func vectorPartitionProductionEndpointMatchesListenerV1(endpoint string, listener net.Listener) bool {
+	bound, ok := listener.Addr().(*net.TCPAddr)
+	if !ok {
+		return endpoint == listener.Addr().String()
+	}
+	advertised, err := net.ResolveTCPAddr("tcp", endpoint)
+	return err == nil && advertised.Port == bound.Port && (bound.IP.IsUnspecified() || bound.IP.Equal(advertised.IP))
 }
 
 func (h *VectorPartitionProductionTopologyV1) Close() error {

--- a/TreeDB/nativewire/vector_partition_production_topology_v1.go
+++ b/TreeDB/nativewire/vector_partition_production_topology_v1.go
@@ -174,6 +174,32 @@ func NewVectorPartitionProductionTopologyV1(opts VectorPartitionProductionTopolo
 		if endpoint := opts.NodeEndpoints[shard.GroupID][shard.Service.localNodeID]; endpoint != "" && !vectorPartitionProductionEndpointMatchesListenerV1(endpoint, shard.Listener) {
 			return nil, fmt.Errorf("nativewire: production vector topology shard %q local node endpoint does not match listener", shard.GroupID)
 		}
+		for group, endpoint := range h.endpoints {
+			if group == shard.GroupID {
+				continue
+			}
+			usesLocalListener, err := vectorPartitionProductionEndpointUsesListenerV1(endpoint, shard.Listener)
+			if err != nil {
+				return nil, fmt.Errorf("nativewire: production vector topology group %q endpoint: %w", group, err)
+			}
+			if usesLocalListener {
+				return nil, fmt.Errorf("nativewire: production vector topology group %q uses shard %q listener", group, shard.GroupID)
+			}
+		}
+		for group, nodes := range opts.NodeEndpoints {
+			if group == shard.GroupID {
+				continue
+			}
+			for node, endpoint := range nodes {
+				usesLocalListener, err := vectorPartitionProductionEndpointUsesListenerV1(endpoint, shard.Listener)
+				if err != nil {
+					return nil, fmt.Errorf("nativewire: production vector topology node %q endpoint: %w", node, err)
+				}
+				if usesLocalListener {
+					return nil, fmt.Errorf("nativewire: production vector topology node %q in %q uses shard %q listener", node, group, shard.GroupID)
+				}
+			}
+		}
 		for _, member := range group.Members {
 			if member == shard.Service.localNodeID {
 				continue

--- a/TreeDB/nativewire/vector_partition_production_topology_v1.go
+++ b/TreeDB/nativewire/vector_partition_production_topology_v1.go
@@ -156,10 +156,6 @@ func NewVectorPartitionProductionTopologyV1(opts VectorPartitionProductionTopolo
 		if endpoint := opts.NodeEndpoints[shard.GroupID][shard.Service.localNodeID]; endpoint != "" && !vectorPartitionProductionEndpointMatchesListenerV1(endpoint, shard.Listener) {
 			return nil, fmt.Errorf("nativewire: production vector topology shard %q local node endpoint does not match listener", shard.GroupID)
 		}
-		fallbackKey, err := vectorPartitionProductionEndpointKeyV1(h.endpoints[shard.GroupID])
-		if err != nil {
-			return nil, err
-		}
 		for _, member := range group.Members {
 			if member == shard.Service.localNodeID {
 				continue
@@ -168,11 +164,7 @@ func NewVectorPartitionProductionTopologyV1(opts VectorPartitionProductionTopolo
 			if endpoint == "" {
 				return nil, fmt.Errorf("nativewire: production vector topology shard %q cannot route to member %q", shard.GroupID, member)
 			}
-			key, err := vectorPartitionProductionEndpointKeyV1(endpoint)
-			if err != nil {
-				return nil, err
-			}
-			if key == fallbackKey {
+			if vectorPartitionProductionEndpointMatchesListenerV1(endpoint, shard.Listener) {
 				return nil, fmt.Errorf("nativewire: production vector topology shard %q remote member %q uses the local fallback", shard.GroupID, member)
 			}
 		}

--- a/TreeDB/nativewire/vector_partition_production_topology_v1.go
+++ b/TreeDB/nativewire/vector_partition_production_topology_v1.go
@@ -115,26 +115,30 @@ func NewVectorPartitionProductionTopologyV1(opts VectorPartitionProductionTopolo
 			if !slices.Contains(resolved.Members, node) {
 				return nil, fmt.Errorf("nativewire: production vector topology node %q is not a member of %q", node, group)
 			}
-			key, err := vectorPartitionProductionEndpointKeyV1(endpoint)
+			keys, err := vectorPartitionProductionEndpointKeysV1(endpoint)
 			if err != nil {
 				return nil, fmt.Errorf("nativewire: production vector topology node %q endpoint: %w", node, err)
 			}
-			if owner := groupEndpointNodes[key]; owner != "" && owner != node {
-				return nil, fmt.Errorf("nativewire: production vector topology nodes %q and %q in %q share an endpoint", owner, node, group)
+			for _, key := range keys {
+				if owner := groupEndpointNodes[key]; owner != "" && owner != node {
+					return nil, fmt.Errorf("nativewire: production vector topology nodes %q and %q in %q share an endpoint", owner, node, group)
+				}
+				groupEndpointNodes[key] = node
 			}
-			groupEndpointNodes[key] = node
 		}
 	}
 	endpointOwners := make(map[string]raftcluster.GroupID, len(opts.Endpoints)+len(opts.NodeEndpoints))
 	recordEndpoint := func(group raftcluster.GroupID, endpoint string) error {
-		key, err := vectorPartitionProductionEndpointKeyV1(endpoint)
+		keys, err := vectorPartitionProductionEndpointKeysV1(endpoint)
 		if err != nil {
 			return fmt.Errorf("nativewire: production vector topology group %q endpoint: %w", group, err)
 		}
-		if owner := endpointOwners[key]; owner != "" && owner != group {
-			return fmt.Errorf("nativewire: production vector topology groups %q and %q share an endpoint", owner, group)
+		for _, key := range keys {
+			if owner := endpointOwners[key]; owner != "" && owner != group {
+				return fmt.Errorf("nativewire: production vector topology groups %q and %q share an endpoint", owner, group)
+			}
+			endpointOwners[key] = group
 		}
-		endpointOwners[key] = group
 		return nil
 	}
 	for group, endpoint := range h.endpoints {
@@ -300,11 +304,11 @@ func vectorPartitionProductionEndpointMatchesListenerV1(endpoint string, listene
 		return false
 	}
 	for _, address := range advertised {
-		if vectorPartitionProductionEndpointAddressMatchesListenerV1(address, listener) {
-			return true
+		if !vectorPartitionProductionEndpointAddressMatchesListenerV1(address, listener) {
+			return false
 		}
 	}
-	return false
+	return len(advertised) != 0
 }
 
 func vectorPartitionProductionEndpointAddressMatchesListenerV1(advertised *net.TCPAddr, listener net.Listener) bool {
@@ -412,18 +416,16 @@ func vectorPartitionProductionEndpointAddressesV1(endpoint string) ([]*net.TCPAd
 	return addresses, nil
 }
 
-func vectorPartitionProductionEndpointKeyV1(endpoint string) (string, error) {
-	resolved, err := net.ResolveTCPAddr("tcp", endpoint)
+func vectorPartitionProductionEndpointKeysV1(endpoint string) ([]string, error) {
+	resolved, err := vectorPartitionProductionEndpointAddressesV1(endpoint)
 	if err != nil {
-		return "", err
+		return nil, err
 	}
-	if resolved.Port == 0 {
-		return "", errors.New("TCP endpoint port is zero")
+	keys := make([]string, len(resolved))
+	for i, address := range resolved {
+		keys[i] = address.String()
 	}
-	if len(resolved.IP) == 0 || resolved.IP.IsUnspecified() {
-		return "", errors.New("TCP endpoint host is unspecified")
-	}
-	return resolved.String(), nil
+	return keys, nil
 }
 
 func (h *VectorPartitionProductionTopologyV1) Close() error {

--- a/TreeDB/nativewire/vector_partition_production_topology_v1.go
+++ b/TreeDB/nativewire/vector_partition_production_topology_v1.go
@@ -468,6 +468,9 @@ func vectorPartitionProductionEndpointAddressesV1(endpoint string) ([]*net.TCPAd
 			continue
 		}
 		address := &net.TCPAddr{IP: addr.IP, Port: port, Zone: addr.Zone}
+		if address.IP.IsLinkLocalUnicast() && address.Zone == "" {
+			return nil, errors.New("TCP endpoint link-local address requires a zone")
+		}
 		if address.Zone != "" {
 			iface, err := vectorPartitionProductionInterfaceForZoneV1(address.Zone)
 			if err != nil {

--- a/TreeDB/nativewire/vector_partition_production_topology_v1.go
+++ b/TreeDB/nativewire/vector_partition_production_topology_v1.go
@@ -295,12 +295,24 @@ func (h *VectorPartitionProductionTopologyV1) Status() VectorPartitionProduction
 }
 
 func vectorPartitionProductionEndpointMatchesListenerV1(endpoint string, listener net.Listener) bool {
+	advertised, err := vectorPartitionProductionEndpointAddressesV1(endpoint)
+	if err != nil {
+		return false
+	}
+	for _, address := range advertised {
+		if vectorPartitionProductionEndpointAddressMatchesListenerV1(address, listener) {
+			return true
+		}
+	}
+	return false
+}
+
+func vectorPartitionProductionEndpointAddressMatchesListenerV1(advertised *net.TCPAddr, listener net.Listener) bool {
 	bound, ok := listener.Addr().(*net.TCPAddr)
 	if !ok {
 		return false
 	}
-	advertised, err := net.ResolveTCPAddr("tcp", endpoint)
-	if err != nil || advertised.Port != bound.Port || len(advertised.IP) == 0 || advertised.IP.IsUnspecified() {
+	if advertised == nil || advertised.Port != bound.Port || len(advertised.IP) == 0 || advertised.IP.IsUnspecified() {
 		return false
 	}
 	if !bound.IP.IsUnspecified() {
@@ -318,37 +330,86 @@ func vectorPartitionProductionEndpointMatchesListenerV1(endpoint string, listene
 }
 
 func vectorPartitionProductionEndpointUsesListenerV1(endpoint string, listener net.Listener) (bool, error) {
-	if !vectorPartitionProductionEndpointMatchesListenerV1(endpoint, listener) {
+	advertised, err := vectorPartitionProductionEndpointAddressesV1(endpoint)
+	if err != nil {
+		return false, err
+	}
+	compatible := advertised[:0]
+	for _, address := range advertised {
+		if vectorPartitionProductionEndpointAddressMatchesListenerV1(address, listener) {
+			compatible = append(compatible, address)
+		}
+	}
+	if len(compatible) == 0 {
 		return false, nil
 	}
 	bound := listener.Addr().(*net.TCPAddr)
 	if !bound.IP.IsUnspecified() {
 		return true, nil
 	}
-	advertised, err := net.ResolveTCPAddr("tcp", endpoint)
-	if err != nil {
-		return false, err
-	}
-	if advertised.IP.IsLoopback() {
-		return true, nil
+	for _, address := range compatible {
+		if address.IP.IsLoopback() {
+			return true, nil
+		}
 	}
 	addrs, err := net.InterfaceAddrs()
 	if err != nil {
 		return false, err
 	}
-	for _, addr := range addrs {
-		var ip net.IP
-		switch addr := addr.(type) {
-		case *net.IPNet:
-			ip = addr.IP
-		case *net.IPAddr:
-			ip = addr.IP
-		}
-		if ip.Equal(advertised.IP) {
-			return true, nil
+	for _, address := range compatible {
+		for _, addr := range addrs {
+			var ip net.IP
+			switch addr := addr.(type) {
+			case *net.IPNet:
+				ip = addr.IP
+			case *net.IPAddr:
+				ip = addr.IP
+			}
+			if ip.Equal(address.IP) {
+				return true, nil
+			}
 		}
 	}
 	return false, nil
+}
+
+func vectorPartitionProductionEndpointAddressesV1(endpoint string) ([]*net.TCPAddr, error) {
+	host, service, err := net.SplitHostPort(endpoint)
+	if err != nil {
+		return nil, err
+	}
+	if host == "" {
+		return nil, errors.New("TCP endpoint host is unspecified")
+	}
+	port, err := net.LookupPort("tcp", service)
+	if err != nil {
+		return nil, err
+	}
+	if port == 0 {
+		return nil, errors.New("TCP endpoint port is zero")
+	}
+	resolved, err := net.DefaultResolver.LookupIPAddr(context.Background(), host)
+	if err != nil {
+		return nil, err
+	}
+	addresses := make([]*net.TCPAddr, 0, len(resolved))
+	seen := make(map[string]struct{}, len(resolved))
+	for _, addr := range resolved {
+		if len(addr.IP) == 0 || addr.IP.IsUnspecified() {
+			continue
+		}
+		address := &net.TCPAddr{IP: addr.IP, Port: port, Zone: addr.Zone}
+		key := address.String()
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+		addresses = append(addresses, address)
+	}
+	if len(addresses) == 0 {
+		return nil, errors.New("TCP endpoint host is unspecified")
+	}
+	return addresses, nil
 }
 
 func vectorPartitionProductionEndpointKeyV1(endpoint string) (string, error) {

--- a/TreeDB/nativewire/vector_partition_production_topology_v1.go
+++ b/TreeDB/nativewire/vector_partition_production_topology_v1.go
@@ -190,7 +190,7 @@ func NewVectorPartitionProductionTopologyV1(opts VectorPartitionProductionTopolo
 		h.listeners[shard.GroupID], h.services[shard.GroupID] = shard.Listener, shard.Service
 	}
 	maxPoolConnections := coordinatorLimits.MaxConcurrentRequests
-	dispatcher, err := newVectorPartitionShardSearchTCPDispatcherV1(h.endpoints, opts.NodeEndpoints, maxPoolConnections)
+	dispatcher, err := newVectorPartitionShardSearchTCPDispatcherV1(h.endpoints, opts.NodeEndpoints, maxPoolConnections, shardLimits)
 	if err != nil {
 		return nil, err
 	}
@@ -202,12 +202,12 @@ func NewVectorPartitionProductionTopologyV1(opts VectorPartitionProductionTopolo
 	for group, listener := range h.listeners {
 		// Keep accepted sockets bounded without letting one dispatcher pool consume
 		// the whole listener while its keep-alives are idle.
-		h.serve(group, listener, h.services[group], opts.ShardIdleTimeout, coordinatorLimits.MaxRequests)
+		h.serve(group, listener, h.services[group], opts.ShardIdleTimeout, coordinatorLimits.MaxRequests, dispatcher.maxRequestFrame, dispatcher.maxResponseFrame)
 	}
 	return h, nil
 }
 
-func (h *VectorPartitionProductionTopologyV1) serve(group raftcluster.GroupID, listener net.Listener, service *VectorPartitionShardSearchServiceV1, idleTimeout time.Duration, maxConnections int) {
+func (h *VectorPartitionProductionTopologyV1) serve(group raftcluster.GroupID, listener net.Listener, service *VectorPartitionShardSearchServiceV1, idleTimeout time.Duration, maxConnections int, maxRequestFrame, maxResponseFrame uint32) {
 	connectionSlots := make(chan struct{}, maxConnections)
 	h.mu.Lock()
 	h.serving[group] = true
@@ -256,7 +256,7 @@ func (h *VectorPartitionProductionTopologyV1) serve(group raftcluster.GroupID, l
 				defer h.wg.Done()
 				defer func() { <-connectionSlots }()
 				defer func() { h.mu.Lock(); delete(h.conns, conn); h.mu.Unlock() }()
-				(VectorPartitionShardSearchTCPServerV1{Service: service, InitialTimeout: idleTimeout}).ServeConn(context.Background(), conn)
+				(VectorPartitionShardSearchTCPServerV1{Service: service, MaxFrame: maxRequestFrame, MaxResponseFrame: maxResponseFrame, InitialTimeout: idleTimeout}).ServeConn(context.Background(), conn)
 			}()
 		}
 	}()
@@ -296,7 +296,7 @@ func vectorPartitionProductionEndpointMatchesListenerV1(endpoint string, listene
 		return endpoint == listener.Addr().String()
 	}
 	advertised, err := net.ResolveTCPAddr("tcp", endpoint)
-	if err != nil || advertised.Port != bound.Port {
+	if err != nil || advertised.Port != bound.Port || len(advertised.IP) == 0 || advertised.IP.IsUnspecified() {
 		return false
 	}
 	if !bound.IP.IsUnspecified() {

--- a/TreeDB/nativewire/vector_partition_production_topology_v1.go
+++ b/TreeDB/nativewire/vector_partition_production_topology_v1.go
@@ -126,7 +126,6 @@ func NewVectorPartitionProductionTopologyV1(opts VectorPartitionProductionTopolo
 		}
 	}
 	endpointOwners := make(map[string]raftcluster.GroupID, len(opts.Endpoints)+len(opts.NodeEndpoints))
-	endpointKeys := make(map[string]string, len(opts.Endpoints)+len(opts.NodeEndpoints))
 	recordEndpoint := func(group raftcluster.GroupID, endpoint string) error {
 		key, err := vectorPartitionProductionEndpointKeyV1(endpoint)
 		if err != nil {
@@ -136,7 +135,6 @@ func NewVectorPartitionProductionTopologyV1(opts VectorPartitionProductionTopolo
 			return fmt.Errorf("nativewire: production vector topology groups %q and %q share an endpoint", owner, group)
 		}
 		endpointOwners[key] = group
-		endpointKeys[endpoint] = key
 		return nil
 	}
 	for group, endpoint := range h.endpoints {
@@ -180,9 +178,11 @@ func NewVectorPartitionProductionTopologyV1(opts VectorPartitionProductionTopolo
 			if endpoint == "" {
 				return nil, fmt.Errorf("nativewire: production vector topology shard %q cannot route to member %q", shard.GroupID, member)
 			}
-			localNodeEndpoint := opts.NodeEndpoints[shard.GroupID][shard.Service.localNodeID]
-			if endpointKeys[endpoint] == endpointKeys[h.endpoints[shard.GroupID]] ||
-				(localNodeEndpoint != "" && endpointKeys[endpoint] == endpointKeys[localNodeEndpoint]) {
+			usesLocalListener, err := vectorPartitionProductionEndpointUsesListenerV1(endpoint, shard.Listener)
+			if err != nil {
+				return nil, fmt.Errorf("nativewire: production vector topology shard %q remote member %q endpoint: %w", shard.GroupID, member, err)
+			}
+			if usesLocalListener {
 				return nil, fmt.Errorf("nativewire: production vector topology shard %q remote member %q uses the local fallback", shard.GroupID, member)
 			}
 		}
@@ -315,6 +315,40 @@ func vectorPartitionProductionEndpointMatchesListenerV1(endpoint string, listene
 	}
 	ipv6Only, ok := vectorPartitionProductionListenerIPv6OnlyV1(tcpListener)
 	return ok && !ipv6Only
+}
+
+func vectorPartitionProductionEndpointUsesListenerV1(endpoint string, listener net.Listener) (bool, error) {
+	if !vectorPartitionProductionEndpointMatchesListenerV1(endpoint, listener) {
+		return false, nil
+	}
+	bound := listener.Addr().(*net.TCPAddr)
+	if !bound.IP.IsUnspecified() {
+		return true, nil
+	}
+	advertised, err := net.ResolveTCPAddr("tcp", endpoint)
+	if err != nil {
+		return false, err
+	}
+	if advertised.IP.IsLoopback() {
+		return true, nil
+	}
+	addrs, err := net.InterfaceAddrs()
+	if err != nil {
+		return false, err
+	}
+	for _, addr := range addrs {
+		var ip net.IP
+		switch addr := addr.(type) {
+		case *net.IPNet:
+			ip = addr.IP
+		case *net.IPAddr:
+			ip = addr.IP
+		}
+		if ip.Equal(advertised.IP) {
+			return true, nil
+		}
+	}
+	return false, nil
 }
 
 func vectorPartitionProductionEndpointKeyV1(endpoint string) (string, error) {

--- a/TreeDB/nativewire/vector_partition_production_topology_v1.go
+++ b/TreeDB/nativewire/vector_partition_production_topology_v1.go
@@ -106,7 +106,10 @@ func NewVectorPartitionProductionTopologyV1(opts VectorPartitionProductionTopolo
 			if !slices.Contains(resolved.Members, node) {
 				return nil, fmt.Errorf("nativewire: production vector topology node %q is not a member of %q", node, group)
 			}
-			key := vectorPartitionProductionEndpointKeyV1(endpoint)
+			key, err := vectorPartitionProductionEndpointKeyV1(endpoint)
+			if err != nil {
+				return nil, fmt.Errorf("nativewire: production vector topology node %q endpoint: %w", node, err)
+			}
 			if owner := groupEndpointNodes[key]; owner != "" && owner != node {
 				return nil, fmt.Errorf("nativewire: production vector topology nodes %q and %q in %q share an endpoint", owner, node, group)
 			}
@@ -115,7 +118,10 @@ func NewVectorPartitionProductionTopologyV1(opts VectorPartitionProductionTopolo
 	}
 	endpointOwners := make(map[string]raftcluster.GroupID, len(opts.Endpoints)+len(opts.NodeEndpoints))
 	recordEndpoint := func(group raftcluster.GroupID, endpoint string) error {
-		key := vectorPartitionProductionEndpointKeyV1(endpoint)
+		key, err := vectorPartitionProductionEndpointKeyV1(endpoint)
+		if err != nil {
+			return fmt.Errorf("nativewire: production vector topology group %q endpoint: %w", group, err)
+		}
 		if owner := endpointOwners[key]; owner != "" && owner != group {
 			return fmt.Errorf("nativewire: production vector topology groups %q and %q share an endpoint", owner, group)
 		}
@@ -150,9 +156,24 @@ func NewVectorPartitionProductionTopologyV1(opts VectorPartitionProductionTopolo
 		if endpoint := opts.NodeEndpoints[shard.GroupID][shard.Service.localNodeID]; endpoint != "" && !vectorPartitionProductionEndpointMatchesListenerV1(endpoint, shard.Listener) {
 			return nil, fmt.Errorf("nativewire: production vector topology shard %q local node endpoint does not match listener", shard.GroupID)
 		}
+		fallbackKey, err := vectorPartitionProductionEndpointKeyV1(h.endpoints[shard.GroupID])
+		if err != nil {
+			return nil, err
+		}
 		for _, member := range group.Members {
-			if member != shard.Service.localNodeID && opts.NodeEndpoints[shard.GroupID][member] == "" {
+			if member == shard.Service.localNodeID {
+				continue
+			}
+			endpoint := opts.NodeEndpoints[shard.GroupID][member]
+			if endpoint == "" {
 				return nil, fmt.Errorf("nativewire: production vector topology shard %q cannot route to member %q", shard.GroupID, member)
+			}
+			key, err := vectorPartitionProductionEndpointKeyV1(endpoint)
+			if err != nil {
+				return nil, err
+			}
+			if key == fallbackKey {
+				return nil, fmt.Errorf("nativewire: production vector topology shard %q remote member %q uses the local fallback", shard.GroupID, member)
 			}
 		}
 		listenerKey := shard.Listener.Addr().Network() + "\x00" + shard.Listener.Addr().String()
@@ -257,12 +278,15 @@ func vectorPartitionProductionEndpointMatchesListenerV1(endpoint string, listene
 	return err == nil && advertised.Port == bound.Port && (bound.IP.IsUnspecified() || bound.IP.Equal(advertised.IP))
 }
 
-func vectorPartitionProductionEndpointKeyV1(endpoint string) string {
+func vectorPartitionProductionEndpointKeyV1(endpoint string) (string, error) {
 	resolved, err := net.ResolveTCPAddr("tcp", endpoint)
 	if err != nil {
-		return endpoint
+		return "", err
 	}
-	return resolved.String()
+	if resolved.Port == 0 {
+		return "", errors.New("TCP endpoint port is zero")
+	}
+	return resolved.String(), nil
 }
 
 func (h *VectorPartitionProductionTopologyV1) Close() error {

--- a/TreeDB/nativewire/vector_partition_production_topology_v1.go
+++ b/TreeDB/nativewire/vector_partition_production_topology_v1.go
@@ -107,6 +107,8 @@ func NewVectorPartitionProductionTopologyV1(opts VectorPartitionProductionTopolo
 			}
 		}
 	}
+	localListeners := make(map[string]raftcluster.GroupID, len(opts.Shards))
+	localEndpoints := make(map[string]raftcluster.GroupID, len(opts.Shards)*2)
 	for _, shard := range opts.Shards {
 		if shard.GroupID == "" || shard.Listener == nil || shard.Service == nil || !owners[shard.GroupID] || h.listeners[shard.GroupID] != nil {
 			return nil, fmt.Errorf("nativewire: production vector topology shard %q is invalid", shard.GroupID)
@@ -118,6 +120,24 @@ func NewVectorPartitionProductionTopologyV1(opts VectorPartitionProductionTopolo
 		}
 		if endpoint := h.endpoints[shard.GroupID]; endpoint == "" || !vectorPartitionProductionEndpointMatchesListenerV1(endpoint, shard.Listener) {
 			return nil, fmt.Errorf("nativewire: production vector topology shard %q endpoint does not match listener", shard.GroupID)
+		}
+		if endpoint := opts.NodeEndpoints[shard.GroupID][shard.Service.localNodeID]; endpoint != "" && !vectorPartitionProductionEndpointMatchesListenerV1(endpoint, shard.Listener) {
+			return nil, fmt.Errorf("nativewire: production vector topology shard %q local node endpoint does not match listener", shard.GroupID)
+		}
+		listenerKey := shard.Listener.Addr().Network() + "\x00" + shard.Listener.Addr().String()
+		if owner := localListeners[listenerKey]; owner != "" && owner != shard.GroupID {
+			return nil, fmt.Errorf("nativewire: production vector topology shard groups %q and %q share a listener", owner, shard.GroupID)
+		}
+		localListeners[listenerKey] = shard.GroupID
+		for _, endpoint := range []string{h.endpoints[shard.GroupID], opts.NodeEndpoints[shard.GroupID][shard.Service.localNodeID]} {
+			if endpoint == "" {
+				continue
+			}
+			endpointKey := vectorPartitionProductionEndpointKeyV1(endpoint)
+			if owner := localEndpoints[endpointKey]; owner != "" && owner != shard.GroupID {
+				return nil, fmt.Errorf("nativewire: production vector topology shard groups %q and %q share an endpoint", owner, shard.GroupID)
+			}
+			localEndpoints[endpointKey] = shard.GroupID
 		}
 		h.listeners[shard.GroupID], h.services[shard.GroupID] = shard.Listener, shard.Service
 	}
@@ -214,6 +234,14 @@ func vectorPartitionProductionEndpointMatchesListenerV1(endpoint string, listene
 	}
 	advertised, err := net.ResolveTCPAddr("tcp", endpoint)
 	return err == nil && advertised.Port == bound.Port && (bound.IP.IsUnspecified() || bound.IP.Equal(advertised.IP))
+}
+
+func vectorPartitionProductionEndpointKeyV1(endpoint string) string {
+	resolved, err := net.ResolveTCPAddr("tcp", endpoint)
+	if err != nil {
+		return endpoint
+	}
+	return resolved.String()
 }
 
 func (h *VectorPartitionProductionTopologyV1) Close() error {

--- a/TreeDB/nativewire/vector_partition_production_topology_v1.go
+++ b/TreeDB/nativewire/vector_partition_production_topology_v1.go
@@ -209,6 +209,7 @@ func (h *VectorPartitionProductionTopologyV1) serve(group raftcluster.GroupID, l
 	go func() {
 		defer h.wg.Done()
 		defer func() { h.mu.Lock(); h.serving[group] = false; h.mu.Unlock() }()
+		var retryDelay time.Duration
 		for {
 			conn, err := listener.Accept()
 			if err != nil {
@@ -217,11 +218,17 @@ func (h *VectorPartitionProductionTopologyV1) serve(group raftcluster.GroupID, l
 				h.mu.Unlock()
 				var netErr net.Error
 				if !closed && !errors.Is(err, net.ErrClosed) && errors.As(err, &netErr) && netErr.Temporary() {
-					time.Sleep(5 * time.Millisecond)
+					if retryDelay == 0 {
+						retryDelay = 5 * time.Millisecond
+					} else {
+						retryDelay = min(2*retryDelay, time.Second)
+					}
+					time.Sleep(retryDelay)
 					continue
 				}
 				return
 			}
+			retryDelay = 0
 			select {
 			case connectionSlots <- struct{}{}:
 			default:

--- a/TreeDB/nativewire/vector_partition_production_topology_v1.go
+++ b/TreeDB/nativewire/vector_partition_production_topology_v1.go
@@ -302,7 +302,15 @@ func vectorPartitionProductionEndpointMatchesListenerV1(endpoint string, listene
 	if !bound.IP.IsUnspecified() {
 		return bound.IP.Equal(advertised.IP)
 	}
-	return (bound.IP.To4() != nil) == (advertised.IP.To4() != nil)
+	if bound.IP.To4() != nil || advertised.IP.To4() == nil {
+		return (bound.IP.To4() != nil) == (advertised.IP.To4() != nil)
+	}
+	tcpListener, ok := listener.(*net.TCPListener)
+	if !ok {
+		return false
+	}
+	ipv6Only, ok := vectorPartitionProductionListenerIPv6OnlyV1(tcpListener)
+	return ok && !ipv6Only
 }
 
 func vectorPartitionProductionEndpointKeyV1(endpoint string) (string, error) {

--- a/TreeDB/nativewire/vector_partition_production_topology_v1.go
+++ b/TreeDB/nativewire/vector_partition_production_topology_v1.go
@@ -101,14 +101,40 @@ func NewVectorPartitionProductionTopologyV1(opts VectorPartitionProductionTopolo
 		if !ok || !owners[group] {
 			return nil, fmt.Errorf("nativewire: production vector topology node endpoint owner %q is invalid", group)
 		}
-		for node := range nodes {
+		groupEndpointNodes := make(map[string]raftcluster.NodeID, len(nodes))
+		for node, endpoint := range nodes {
 			if !slices.Contains(resolved.Members, node) {
 				return nil, fmt.Errorf("nativewire: production vector topology node %q is not a member of %q", node, group)
+			}
+			key := vectorPartitionProductionEndpointKeyV1(endpoint)
+			if owner := groupEndpointNodes[key]; owner != "" && owner != node {
+				return nil, fmt.Errorf("nativewire: production vector topology nodes %q and %q in %q share an endpoint", owner, node, group)
+			}
+			groupEndpointNodes[key] = node
+		}
+	}
+	endpointOwners := make(map[string]raftcluster.GroupID, len(opts.Endpoints)+len(opts.NodeEndpoints))
+	recordEndpoint := func(group raftcluster.GroupID, endpoint string) error {
+		key := vectorPartitionProductionEndpointKeyV1(endpoint)
+		if owner := endpointOwners[key]; owner != "" && owner != group {
+			return fmt.Errorf("nativewire: production vector topology groups %q and %q share an endpoint", owner, group)
+		}
+		endpointOwners[key] = group
+		return nil
+	}
+	for group, endpoint := range h.endpoints {
+		if err := recordEndpoint(group, endpoint); err != nil {
+			return nil, err
+		}
+	}
+	for group, nodes := range opts.NodeEndpoints {
+		for _, endpoint := range nodes {
+			if err := recordEndpoint(group, endpoint); err != nil {
+				return nil, err
 			}
 		}
 	}
 	localListeners := make(map[string]raftcluster.GroupID, len(opts.Shards))
-	localEndpoints := make(map[string]raftcluster.GroupID, len(opts.Shards)*2)
 	for _, shard := range opts.Shards {
 		if shard.GroupID == "" || shard.Listener == nil || shard.Service == nil || !owners[shard.GroupID] || h.listeners[shard.GroupID] != nil {
 			return nil, fmt.Errorf("nativewire: production vector topology shard %q is invalid", shard.GroupID)
@@ -124,21 +150,16 @@ func NewVectorPartitionProductionTopologyV1(opts VectorPartitionProductionTopolo
 		if endpoint := opts.NodeEndpoints[shard.GroupID][shard.Service.localNodeID]; endpoint != "" && !vectorPartitionProductionEndpointMatchesListenerV1(endpoint, shard.Listener) {
 			return nil, fmt.Errorf("nativewire: production vector topology shard %q local node endpoint does not match listener", shard.GroupID)
 		}
+		for _, member := range group.Members {
+			if member != shard.Service.localNodeID && opts.NodeEndpoints[shard.GroupID][member] == "" {
+				return nil, fmt.Errorf("nativewire: production vector topology shard %q cannot route to member %q", shard.GroupID, member)
+			}
+		}
 		listenerKey := shard.Listener.Addr().Network() + "\x00" + shard.Listener.Addr().String()
 		if owner := localListeners[listenerKey]; owner != "" && owner != shard.GroupID {
 			return nil, fmt.Errorf("nativewire: production vector topology shard groups %q and %q share a listener", owner, shard.GroupID)
 		}
 		localListeners[listenerKey] = shard.GroupID
-		for _, endpoint := range []string{h.endpoints[shard.GroupID], opts.NodeEndpoints[shard.GroupID][shard.Service.localNodeID]} {
-			if endpoint == "" {
-				continue
-			}
-			endpointKey := vectorPartitionProductionEndpointKeyV1(endpoint)
-			if owner := localEndpoints[endpointKey]; owner != "" && owner != shard.GroupID {
-				return nil, fmt.Errorf("nativewire: production vector topology shard groups %q and %q share an endpoint", owner, shard.GroupID)
-			}
-			localEndpoints[endpointKey] = shard.GroupID
-		}
 		h.listeners[shard.GroupID], h.services[shard.GroupID] = shard.Listener, shard.Service
 	}
 	maxConnectionsPerEndpoint := opts.CoordinatorLimits.MaxConcurrentRequests

--- a/TreeDB/nativewire/vector_partition_production_topology_v1.go
+++ b/TreeDB/nativewire/vector_partition_production_topology_v1.go
@@ -1,0 +1,185 @@
+package nativewire
+
+// Production vector-partition topology composes already-authoritative catalog,
+// lifecycle, read-coordinator, and TCP service dependencies.  It deliberately
+// does not create Raft groups, catalogs, or vector assets.
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"slices"
+	"sync"
+	"time"
+
+	"github.com/snissn/gomap/TreeDB/internal/raftcluster"
+	"github.com/snissn/gomap/TreeDB/internal/raftplacement"
+)
+
+type VectorPartitionProductionShardV1 struct {
+	GroupID  raftcluster.GroupID
+	Listener net.Listener
+	Service  *VectorPartitionShardSearchServiceV1
+}
+
+type VectorPartitionProductionTopologyOptionsV1 struct {
+	Catalog             raftplacement.ResolvedCatalogV1
+	Placement           raftplacement.VectorPartitionPlacementRecordV1
+	RouterSource        VectorPartitionCoordinatorRouterSourceV1
+	ReplicatedLifecycle VectorPartitionReplicatedLifecycleAuthorityV1
+	Endpoints           map[raftcluster.GroupID]string
+	Shards              []VectorPartitionProductionShardV1
+	CoordinatorLimits   VectorPartitionCoordinatorLimitsV1
+	ShardLimits         VectorPartitionShardSearchLimitsV1
+}
+
+type VectorPartitionProductionTopologyStatusV1 struct {
+	Ready       bool
+	Closed      bool
+	Endpoints   map[raftcluster.GroupID]string
+	ShardGroups []raftcluster.GroupID
+}
+
+// VectorPartitionProductionTopologyV1 owns only listeners and the coordinator.
+// Callers retain ownership of Raft, catalog, lifecycle, and local asset sources.
+type VectorPartitionProductionTopologyV1 struct {
+	coordinator *VectorPartitionCoordinatorV1
+	listeners   map[raftcluster.GroupID]net.Listener
+	endpoints   map[raftcluster.GroupID]string
+	services    map[raftcluster.GroupID]*VectorPartitionShardSearchServiceV1
+	mu          sync.Mutex
+	conns       map[net.Conn]struct{}
+	wg          sync.WaitGroup
+	closed      bool
+	closeOnce   sync.Once
+	closeErr    error
+}
+
+func NewVectorPartitionProductionTopologyV1(opts VectorPartitionProductionTopologyOptionsV1) (_ *VectorPartitionProductionTopologyV1, err error) {
+	if opts.RouterSource == nil || opts.ReplicatedLifecycle == nil {
+		return nil, errors.New("nativewire: production vector topology requires router and replicated lifecycle")
+	}
+	if err := opts.Catalog.ValidateVectorPartitionPlacementV1(opts.Placement); err != nil {
+		return nil, fmt.Errorf("nativewire: production vector topology placement: %w", err)
+	}
+	if len(opts.Endpoints) == 0 || len(opts.Shards) == 0 {
+		return nil, errors.New("nativewire: production vector topology requires endpoints and local shards")
+	}
+	h := &VectorPartitionProductionTopologyV1{listeners: make(map[raftcluster.GroupID]net.Listener), endpoints: make(map[raftcluster.GroupID]string, len(opts.Endpoints)), services: make(map[raftcluster.GroupID]*VectorPartitionShardSearchServiceV1), conns: make(map[net.Conn]struct{})}
+	defer func() {
+		if err != nil {
+			_ = h.Close()
+		}
+	}()
+	owners := make(map[raftcluster.GroupID]bool, len(opts.Placement.Partitions))
+	for _, part := range opts.Placement.Partitions {
+		owners[part.GroupID] = true
+	}
+	for group, endpoint := range opts.Endpoints {
+		if !owners[group] || endpoint == "" {
+			return nil, fmt.Errorf("nativewire: production vector topology endpoint %q is not a partition owner", group)
+		}
+		h.endpoints[group] = endpoint
+	}
+	for _, shard := range opts.Shards {
+		if shard.GroupID == "" || shard.Listener == nil || shard.Service == nil || !owners[shard.GroupID] || h.listeners[shard.GroupID] != nil {
+			return nil, fmt.Errorf("nativewire: production vector topology shard %q is invalid", shard.GroupID)
+		}
+		if endpoint := h.endpoints[shard.GroupID]; endpoint == "" || endpoint != shard.Listener.Addr().String() {
+			return nil, fmt.Errorf("nativewire: production vector topology shard %q endpoint does not match listener", shard.GroupID)
+		}
+		h.listeners[shard.GroupID], h.services[shard.GroupID] = shard.Listener, shard.Service
+	}
+	dispatcher, err := NewVectorPartitionShardSearchTCPDispatcherV1(h.endpoints)
+	if err != nil {
+		return nil, err
+	}
+	h.coordinator, err = NewVectorPartitionCoordinatorV1(VectorPartitionCoordinatorOptionsV1{Catalog: opts.Catalog, Placement: opts.Placement, RouterSource: opts.RouterSource, Dispatcher: dispatcher, ReplicatedLifecycle: opts.ReplicatedLifecycle, RequireReplicatedLifecycle: true, Limits: opts.CoordinatorLimits, ShardLimits: opts.ShardLimits})
+	if err != nil {
+		return nil, err
+	}
+	for group, listener := range h.listeners {
+		h.serve(group, listener, h.services[group])
+	}
+	return h, nil
+}
+
+func (h *VectorPartitionProductionTopologyV1) serve(_ raftcluster.GroupID, listener net.Listener, service *VectorPartitionShardSearchServiceV1) {
+	h.wg.Add(1)
+	go func() {
+		defer h.wg.Done()
+		for {
+			conn, err := listener.Accept()
+			if err != nil {
+				return
+			}
+			h.mu.Lock()
+			if h.closed {
+				h.mu.Unlock()
+				_ = conn.Close()
+				return
+			}
+			h.conns[conn] = struct{}{}
+			h.wg.Add(1)
+			h.mu.Unlock()
+			go func() {
+				defer h.wg.Done()
+				defer func() { h.mu.Lock(); delete(h.conns, conn); h.mu.Unlock() }()
+				(VectorPartitionShardSearchTCPServerV1{Service: service, InitialTimeout: 2 * time.Second}).ServeConn(context.Background(), conn)
+			}()
+		}
+	}()
+}
+
+func (h *VectorPartitionProductionTopologyV1) Coordinator() *VectorPartitionCoordinatorV1 {
+	if h == nil {
+		return nil
+	}
+	return h.coordinator
+}
+
+func (h *VectorPartitionProductionTopologyV1) Status() VectorPartitionProductionTopologyStatusV1 {
+	if h == nil {
+		return VectorPartitionProductionTopologyStatusV1{}
+	}
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	status := VectorPartitionProductionTopologyStatusV1{Ready: !h.closed && h.coordinator != nil && len(h.listeners) != 0, Closed: h.closed, Endpoints: make(map[raftcluster.GroupID]string, len(h.endpoints))}
+	for group, endpoint := range h.endpoints {
+		status.Endpoints[group] = endpoint
+	}
+	for group := range h.listeners {
+		status.ShardGroups = append(status.ShardGroups, group)
+	}
+	slices.Sort(status.ShardGroups)
+	return status
+}
+
+func (h *VectorPartitionProductionTopologyV1) Close() error {
+	if h == nil {
+		return nil
+	}
+	h.closeOnce.Do(func() {
+		var errs []error
+		h.mu.Lock()
+		h.closed = true
+		for _, listener := range h.listeners {
+			if err := listener.Close(); err != nil && !errors.Is(err, net.ErrClosed) {
+				errs = append(errs, err)
+			}
+		}
+		for conn := range h.conns {
+			if err := conn.Close(); err != nil && !errors.Is(err, net.ErrClosed) {
+				errs = append(errs, err)
+			}
+		}
+		h.mu.Unlock()
+		h.wg.Wait()
+		if h.coordinator != nil {
+			errs = append(errs, h.coordinator.Close())
+		}
+		h.closeErr = errors.Join(errs...)
+	})
+	return h.closeErr
+}

--- a/TreeDB/nativewire/vector_partition_production_topology_v1.go
+++ b/TreeDB/nativewire/vector_partition_production_topology_v1.go
@@ -107,7 +107,11 @@ func NewVectorPartitionProductionTopologyV1(opts VectorPartitionProductionTopolo
 		}
 		h.listeners[shard.GroupID], h.services[shard.GroupID] = shard.Listener, shard.Service
 	}
-	dispatcher, err := NewVectorPartitionShardSearchTCPDispatcherWithNodeEndpointsV1(h.endpoints, opts.NodeEndpoints)
+	maxConnectionsPerEndpoint := opts.CoordinatorLimits.MaxConcurrentRequests
+	if maxConnectionsPerEndpoint == 0 {
+		maxConnectionsPerEndpoint = DefaultVectorPartitionCoordinatorLimitsV1().MaxConcurrentRequests
+	}
+	dispatcher, err := newVectorPartitionShardSearchTCPDispatcherV1(h.endpoints, opts.NodeEndpoints, maxConnectionsPerEndpoint)
 	if err != nil {
 		return nil, err
 	}

--- a/TreeDB/nativewire/vector_partition_production_topology_v1.go
+++ b/TreeDB/nativewire/vector_partition_production_topology_v1.go
@@ -126,6 +126,7 @@ func NewVectorPartitionProductionTopologyV1(opts VectorPartitionProductionTopolo
 		}
 	}
 	endpointOwners := make(map[string]raftcluster.GroupID, len(opts.Endpoints)+len(opts.NodeEndpoints))
+	endpointKeys := make(map[string]string, len(opts.Endpoints)+len(opts.NodeEndpoints))
 	recordEndpoint := func(group raftcluster.GroupID, endpoint string) error {
 		key, err := vectorPartitionProductionEndpointKeyV1(endpoint)
 		if err != nil {
@@ -135,6 +136,7 @@ func NewVectorPartitionProductionTopologyV1(opts VectorPartitionProductionTopolo
 			return fmt.Errorf("nativewire: production vector topology groups %q and %q share an endpoint", owner, group)
 		}
 		endpointOwners[key] = group
+		endpointKeys[endpoint] = key
 		return nil
 	}
 	for group, endpoint := range h.endpoints {
@@ -178,7 +180,9 @@ func NewVectorPartitionProductionTopologyV1(opts VectorPartitionProductionTopolo
 			if endpoint == "" {
 				return nil, fmt.Errorf("nativewire: production vector topology shard %q cannot route to member %q", shard.GroupID, member)
 			}
-			if vectorPartitionProductionEndpointMatchesListenerV1(endpoint, shard.Listener) {
+			localNodeEndpoint := opts.NodeEndpoints[shard.GroupID][shard.Service.localNodeID]
+			if endpointKeys[endpoint] == endpointKeys[h.endpoints[shard.GroupID]] ||
+				(localNodeEndpoint != "" && endpointKeys[endpoint] == endpointKeys[localNodeEndpoint]) {
 				return nil, fmt.Errorf("nativewire: production vector topology shard %q remote member %q uses the local fallback", shard.GroupID, member)
 			}
 		}

--- a/TreeDB/nativewire/vector_partition_production_topology_v1.go
+++ b/TreeDB/nativewire/vector_partition_production_topology_v1.go
@@ -303,8 +303,20 @@ func vectorPartitionProductionEndpointMatchesListenerV1(endpoint string, listene
 	if err != nil {
 		return false
 	}
+	bound, ok := listener.Addr().(*net.TCPAddr)
+	if !ok {
+		return false
+	}
+	var local []net.Addr
+	if bound.IP.IsUnspecified() {
+		local, err = net.InterfaceAddrs()
+		if err != nil {
+			return false
+		}
+	}
 	for _, address := range advertised {
-		if !vectorPartitionProductionEndpointAddressMatchesListenerV1(address, listener) {
+		if !vectorPartitionProductionEndpointAddressMatchesListenerV1(address, listener) ||
+			(bound.IP.IsUnspecified() && !vectorPartitionProductionEndpointAddressIsLocalV1(address, local)) {
 			return false
 		}
 	}
@@ -351,30 +363,35 @@ func vectorPartitionProductionEndpointUsesListenerV1(endpoint string, listener n
 	if !bound.IP.IsUnspecified() {
 		return true, nil
 	}
-	for _, address := range compatible {
-		if address.IP.IsLoopback() {
-			return true, nil
-		}
-	}
 	addrs, err := net.InterfaceAddrs()
 	if err != nil {
 		return false, err
 	}
 	for _, address := range compatible {
-		for _, addr := range addrs {
-			var ip net.IP
-			switch addr := addr.(type) {
-			case *net.IPNet:
-				ip = addr.IP
-			case *net.IPAddr:
-				ip = addr.IP
-			}
-			if ip.Equal(address.IP) {
-				return true, nil
-			}
+		if vectorPartitionProductionEndpointAddressIsLocalV1(address, addrs) {
+			return true, nil
 		}
 	}
 	return false, nil
+}
+
+func vectorPartitionProductionEndpointAddressIsLocalV1(address *net.TCPAddr, local []net.Addr) bool {
+	if address.IP.IsLoopback() {
+		return true
+	}
+	for _, addr := range local {
+		var ip net.IP
+		switch addr := addr.(type) {
+		case *net.IPNet:
+			ip = addr.IP
+		case *net.IPAddr:
+			ip = addr.IP
+		}
+		if ip.Equal(address.IP) {
+			return true
+		}
+	}
+	return false
 }
 
 func vectorPartitionProductionEndpointAddressesV1(endpoint string) ([]*net.TCPAddr, error) {

--- a/TreeDB/nativewire/vector_partition_production_topology_v1.go
+++ b/TreeDB/nativewire/vector_partition_production_topology_v1.go
@@ -293,7 +293,7 @@ func (h *VectorPartitionProductionTopologyV1) Status() VectorPartitionProduction
 func vectorPartitionProductionEndpointMatchesListenerV1(endpoint string, listener net.Listener) bool {
 	bound, ok := listener.Addr().(*net.TCPAddr)
 	if !ok {
-		return endpoint == listener.Addr().String()
+		return false
 	}
 	advertised, err := net.ResolveTCPAddr("tcp", endpoint)
 	if err != nil || advertised.Port != bound.Port || len(advertised.IP) == 0 || advertised.IP.IsUnspecified() {

--- a/TreeDB/nativewire/vector_partition_production_topology_v1.go
+++ b/TreeDB/nativewire/vector_partition_production_topology_v1.go
@@ -359,7 +359,15 @@ func vectorPartitionProductionEndpointAddressMatchesListenerV1(advertised *net.T
 		return false
 	}
 	if !bound.IP.IsUnspecified() {
-		return bound.IP.Equal(advertised.IP) && (bound.IP.To4() != nil || bound.Zone == advertised.Zone)
+		if !bound.IP.Equal(advertised.IP) || bound.IP.To4() != nil {
+			return bound.IP.Equal(advertised.IP)
+		}
+		if bound.Zone == advertised.Zone {
+			return true
+		}
+		boundInterface, boundErr := vectorPartitionProductionInterfaceForZoneV1(bound.Zone)
+		advertisedInterface, advertisedErr := vectorPartitionProductionInterfaceForZoneV1(advertised.Zone)
+		return boundErr == nil && advertisedErr == nil && boundInterface.Index == advertisedInterface.Index
 	}
 	if bound.IP.To4() != nil || advertised.IP.To4() == nil {
 		return (bound.IP.To4() != nil) == (advertised.IP.To4() != nil)
@@ -410,14 +418,7 @@ func vectorPartitionProductionEndpointAddressIsLocalV1(address *net.TCPAddr, loc
 		if address.Zone == "" {
 			return false
 		}
-		iface, err := net.InterfaceByName(address.Zone)
-		if err != nil {
-			index, indexErr := strconv.Atoi(address.Zone)
-			if indexErr != nil {
-				return false
-			}
-			iface, err = net.InterfaceByIndex(index)
-		}
+		iface, err := vectorPartitionProductionInterfaceForZoneV1(address.Zone)
 		if err != nil {
 			return false
 		}
@@ -467,6 +468,13 @@ func vectorPartitionProductionEndpointAddressesV1(endpoint string) ([]*net.TCPAd
 			continue
 		}
 		address := &net.TCPAddr{IP: addr.IP, Port: port, Zone: addr.Zone}
+		if address.Zone != "" {
+			iface, err := vectorPartitionProductionInterfaceForZoneV1(address.Zone)
+			if err != nil {
+				return nil, fmt.Errorf("TCP endpoint zone %q is invalid: %w", address.Zone, err)
+			}
+			address.Zone = strconv.Itoa(iface.Index)
+		}
 		key := address.String()
 		if _, ok := seen[key]; ok {
 			continue
@@ -478,6 +486,13 @@ func vectorPartitionProductionEndpointAddressesV1(endpoint string) ([]*net.TCPAd
 		return nil, errors.New("TCP endpoint host is unspecified")
 	}
 	return addresses, nil
+}
+
+func vectorPartitionProductionInterfaceForZoneV1(zone string) (*net.Interface, error) {
+	if index, err := strconv.Atoi(zone); err == nil {
+		return net.InterfaceByIndex(index)
+	}
+	return net.InterfaceByName(zone)
 }
 
 func vectorPartitionProductionEndpointKeysV1(endpoint string) ([]string, error) {

--- a/TreeDB/nativewire/vector_partition_production_topology_v1.go
+++ b/TreeDB/nativewire/vector_partition_production_topology_v1.go
@@ -150,13 +150,18 @@ func NewVectorPartitionProductionTopologyV1(opts VectorPartitionProductionTopolo
 		}
 	}
 	localListeners := make(map[string]raftcluster.GroupID, len(opts.Shards))
+	catalogHints := make(map[raftcluster.GroupID]raftcluster.NodeID, len(opts.Catalog.Groups))
+	for _, group := range opts.Catalog.Groups {
+		catalogHints[group.ID] = group.LeaderHint
+	}
 	for _, shard := range opts.Shards {
 		if shard.GroupID == "" || shard.Listener == nil || shard.Service == nil || !owners[shard.GroupID] || h.listeners[shard.GroupID] != nil {
 			return nil, fmt.Errorf("nativewire: production vector topology shard %q is invalid", shard.GroupID)
 		}
 		group, _ := opts.Catalog.Group(shard.GroupID)
 		if shard.Service.localGroup != shard.GroupID || !slices.Contains(group.Members, shard.Service.localNodeID) ||
-			!reflect.DeepEqual(shard.Service.route.placement, opts.Placement) || shard.Service.limits != shardLimits {
+			!reflect.DeepEqual(shard.Service.route.placement, opts.Placement) || !reflect.DeepEqual(shard.Service.route.hints, catalogHints) ||
+			shard.Service.limits != shardLimits {
 			return nil, fmt.Errorf("nativewire: production vector topology shard %q service does not match topology", shard.GroupID)
 		}
 		if endpoint := h.endpoints[shard.GroupID]; endpoint == "" || !vectorPartitionProductionEndpointMatchesListenerV1(endpoint, shard.Listener) {
@@ -184,8 +189,8 @@ func NewVectorPartitionProductionTopologyV1(opts VectorPartitionProductionTopolo
 		localListeners[listenerKey] = shard.GroupID
 		h.listeners[shard.GroupID], h.services[shard.GroupID] = shard.Listener, shard.Service
 	}
-	maxConnectionsPerEndpoint := coordinatorLimits.MaxConcurrentRequests
-	dispatcher, err := newVectorPartitionShardSearchTCPDispatcherV1(h.endpoints, opts.NodeEndpoints, maxConnectionsPerEndpoint)
+	maxPoolConnections := coordinatorLimits.MaxConcurrentRequests
+	dispatcher, err := newVectorPartitionShardSearchTCPDispatcherV1(h.endpoints, opts.NodeEndpoints, maxPoolConnections)
 	if err != nil {
 		return nil, err
 	}
@@ -195,7 +200,9 @@ func NewVectorPartitionProductionTopologyV1(opts VectorPartitionProductionTopolo
 		return nil, err
 	}
 	for group, listener := range h.listeners {
-		h.serve(group, listener, h.services[group], opts.ShardIdleTimeout, maxConnectionsPerEndpoint)
+		// Keep accepted sockets bounded without letting one dispatcher pool consume
+		// the whole listener while its keep-alives are idle.
+		h.serve(group, listener, h.services[group], opts.ShardIdleTimeout, coordinatorLimits.MaxRequests)
 	}
 	return h, nil
 }

--- a/TreeDB/nativewire/vector_partition_production_topology_v1.go
+++ b/TreeDB/nativewire/vector_partition_production_topology_v1.go
@@ -321,6 +321,9 @@ func vectorPartitionProductionEndpointKeyV1(endpoint string) (string, error) {
 	if resolved.Port == 0 {
 		return "", errors.New("TCP endpoint port is zero")
 	}
+	if len(resolved.IP) == 0 || resolved.IP.IsUnspecified() {
+		return "", errors.New("TCP endpoint host is unspecified")
+	}
 	return resolved.String(), nil
 }
 

--- a/TreeDB/nativewire/vector_partition_production_topology_v1_test.go
+++ b/TreeDB/nativewire/vector_partition_production_topology_v1_test.go
@@ -1,0 +1,56 @@
+package nativewire
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"testing"
+
+	"github.com/snissn/gomap/TreeDB/collections"
+	"github.com/snissn/gomap/TreeDB/internal/raftcluster"
+	"github.com/snissn/gomap/TreeDB/internal/raftplacement"
+)
+
+func TestVectorPartitionProductionTopologyRequiresLiveAuthorityAndOwnsLifecycleV1(t *testing.T) {
+	ref := raftplacement.CollectionRefV1{Database: "db", Catalog: "catalog", Collection: "docs"}
+	catalog, err := raftplacement.Validate(raftplacement.CatalogV1{Groups: []raftplacement.GroupV1{{ID: "group-a", Members: []raftcluster.NodeID{"node-a"}, LeaderHint: "node-a"}}, Placements: []raftplacement.CollectionPlacementV1{{Collection: ref, GroupID: "group-a", Mode: raftplacement.PlacementModeCollectionV1}}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	placement := raftplacement.VectorPartitionPlacementRecordV1{Collection: ref, IndexName: "embedding", IndexDefinitionDigest: fmt.Sprintf("%064x", 1), SourceGeneration: 1, SourceChecksum: 2, SourceSchemaHash: 3, SourceRowCount: 4, PartitionGeneration: 5, PartitionCount: 1, Partitions: []raftplacement.VectorPartitionGroupV1{{PartitionID: 0, GroupID: "group-a"}}}
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer listener.Close()
+	router := &testVectorPartitionCoordinatorRouterV1{status: collections.VectorPartitionRouterRuntimeStatusV1{Manifest: collections.VectorPartitionManifestV1{Format: collections.VectorPartitionManifestFormatV1, State: "ready", Collection: ref.Collection, IndexName: placement.IndexName, IndexDefinitionDigest: placement.IndexDefinitionDigest, SourceGeneration: 1, SourceChecksum: 2, SourceSchemaHash: 3, SourceRowCount: 4, Generation: 5, RouterGeneration: 5, PartitionCount: 1, ReadySetDigest: fmt.Sprintf("%064x", 2), Placements: []collections.VectorPartitionPlacementV1{{PartitionID: 0, GroupID: "group-a"}}}, Representatives: 1, Partitions: 1}, partitions: []collections.VectorPartitionRouterPartitionScoreV1{{PartitionID: 0}}}
+	opts := VectorPartitionProductionTopologyOptionsV1{Catalog: catalog, Placement: placement, RouterSource: &testVectorPartitionCoordinatorRouterSourceV1{router: router}, Endpoints: map[raftcluster.GroupID]string{"group-a": listener.Addr().String()}, Shards: []VectorPartitionProductionShardV1{{GroupID: "group-a", Listener: listener, Service: &VectorPartitionShardSearchServiceV1{}}}}
+	if _, err := NewVectorPartitionProductionTopologyV1(opts); err == nil {
+		t.Fatal("missing lifecycle authority succeeded")
+	}
+	opts.ReplicatedLifecycle = &recordingVectorPartitionReplicatedLifecycleAuthorityV1{}
+	topology, err := NewVectorPartitionProductionTopologyV1(opts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	status := topology.Status()
+	if !status.Ready || status.Closed || len(status.ShardGroups) != 1 {
+		t.Fatalf("unexpected status: %+v", status)
+	}
+	if err := topology.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if status := topology.Status(); !status.Closed || status.Ready {
+		t.Fatalf("close status: %+v", status)
+	}
+	if _, err := topology.Coordinator().Search(context.Background(), VectorPartitionCoordinatorRequestV1{}); err == nil {
+		t.Fatal("closed coordinator accepted request")
+	}
+}
+
+func TestVectorPartitionProductionTopologyRejectsNonOwnerEndpointV1(t *testing.T) {
+	_, err := NewVectorPartitionProductionTopologyV1(VectorPartitionProductionTopologyOptionsV1{Endpoints: map[raftcluster.GroupID]string{"not-an-owner": "127.0.0.1:1"}, Shards: []VectorPartitionProductionShardV1{{GroupID: "not-an-owner"}}, RouterSource: &testVectorPartitionCoordinatorRouterSourceV1{}, ReplicatedLifecycle: &recordingVectorPartitionReplicatedLifecycleAuthorityV1{}})
+	if err == nil {
+		t.Fatal("invalid production topology succeeded")
+	}
+}

--- a/TreeDB/nativewire/vector_partition_production_topology_v1_test.go
+++ b/TreeDB/nativewire/vector_partition_production_topology_v1_test.go
@@ -141,7 +141,7 @@ func TestVectorPartitionProductionTopologyRequiresLiveAuthorityAndOwnsLifecycleV
 		t.Fatal(err)
 	}
 	placement := raftplacement.VectorPartitionPlacementRecordV1{Collection: ref, IndexName: "embedding", IndexDefinitionDigest: fmt.Sprintf("%064x", 1), SourceGeneration: 1, SourceChecksum: 2, SourceSchemaHash: 3, SourceRowCount: 4, PartitionGeneration: 5, PartitionCount: 1, Partitions: []raftplacement.VectorPartitionGroupV1{{PartitionID: 0, GroupID: "group-a"}}}
-	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	listener, err := net.Listen("tcp4", "0.0.0.0:0")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -170,7 +170,8 @@ func TestVectorPartitionProductionTopologyRequiresLiveAuthorityAndOwnsLifecycleV
 	if _, err := NewVectorPartitionProductionTopologyV1(opts); err == nil {
 		t.Fatal("local shard succeeded without remote member endpoints")
 	}
-	opts.NodeEndpoints = map[raftcluster.GroupID]map[raftcluster.NodeID]string{"group-a": {"node-b": listener.Addr().String(), "node-c": "127.0.0.1:2"}}
+	localAlias := fmt.Sprintf("127.0.0.1:%d", listener.Addr().(*net.TCPAddr).Port)
+	opts.NodeEndpoints = map[raftcluster.GroupID]map[raftcluster.NodeID]string{"group-a": {"node-b": localAlias, "node-c": "127.0.0.1:2"}}
 	if _, err := NewVectorPartitionProductionTopologyV1(opts); err == nil {
 		t.Fatal("remote shard member used local fallback")
 	}

--- a/TreeDB/nativewire/vector_partition_production_topology_v1_test.go
+++ b/TreeDB/nativewire/vector_partition_production_topology_v1_test.go
@@ -46,7 +46,7 @@ func TestVectorPartitionProductionTopologyRollsBackPartialStartAndRestartsV1(t *
 	if err != nil {
 		t.Fatal(err)
 	}
-	service := &VectorPartitionShardSearchServiceV1{localGroup: "group-a", localNodeID: "node-a", limits: DefaultVectorPartitionShardSearchLimitsV1(), route: vectorPartitionShardSearchRouteV1{placement: placement}}
+	service := &VectorPartitionShardSearchServiceV1{localGroup: "group-a", localNodeID: "node-a", limits: DefaultVectorPartitionShardSearchLimitsV1(), route: vectorPartitionShardSearchRouteV1{placement: placement, hints: map[raftcluster.GroupID]raftcluster.NodeID{"group-a": "node-a"}}}
 	opts := VectorPartitionProductionTopologyOptionsV1{Catalog: catalog, Placement: placement, RouterSource: &testVectorPartitionCoordinatorRouterSourceV1{}, ReplicatedLifecycle: &recordingVectorPartitionReplicatedLifecycleAuthorityV1{}, Endpoints: map[raftcluster.GroupID]string{"group-a": listener.Addr().String()}, Shards: []VectorPartitionProductionShardV1{{GroupID: "group-a", Listener: listener, Service: service}, {GroupID: "group-a", Listener: listener, Service: service}}}
 	if _, err := NewVectorPartitionProductionTopologyV1(opts); err == nil {
 		t.Fatal("partial start unexpectedly succeeded")
@@ -178,6 +178,18 @@ func TestVectorPartitionProductionTopologyRequiresLiveAuthorityAndOwnsLifecycleV
 	if _, err := NewVectorPartitionProductionTopologyV1(opts); err == nil {
 		t.Fatal("mismatched shard limits succeeded")
 	}
+	staleHintCatalog, err := raftplacement.Validate(raftplacement.CatalogV1{Groups: []raftplacement.GroupV1{{ID: "group-a", Members: []raftcluster.NodeID{"node-a", "node-b", "node-c"}, LeaderHint: "node-c"}}, Placements: []raftplacement.CollectionPlacementV1{{Collection: ref, GroupID: "group-a", Mode: raftplacement.PlacementModeCollectionV1}}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	staleHintService, err := NewVectorPartitionShardSearchServiceV1(VectorPartitionShardSearchServiceOptionsV1{Catalog: staleHintCatalog, Placement: placement, LocalNodeID: "node-a", LocalGroupID: "group-a", ReadCoordinator: &fakeVectorPartitionReadCoordinatorV1{}, GenerationSource: &fakeVectorPartitionGenerationSourceV1{}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	opts.Shards[0].Service = staleHintService
+	if _, err := NewVectorPartitionProductionTopologyV1(opts); err == nil {
+		t.Fatal("mismatched shard leader hints succeeded")
+	}
 	opts.Shards[0].Service = validService
 	if _, err := NewVectorPartitionProductionTopologyV1(opts); err == nil {
 		t.Fatal("local shard succeeded without remote member endpoints")
@@ -198,6 +210,7 @@ func TestVectorPartitionProductionTopologyRequiresLiveAuthorityAndOwnsLifecycleV
 	}
 	opts.NodeEndpoints["group-a"]["node-a"] = listener.Addr().String()
 	opts.CoordinatorLimits.MaxConcurrentRequests = 1
+	opts.CoordinatorLimits.MaxRequests = 2
 	topology, err := NewVectorPartitionProductionTopologyV1(opts)
 	if err != nil {
 		t.Fatal(err)
@@ -229,10 +242,28 @@ func TestVectorPartitionProductionTopologyRequiresLiveAuthorityAndOwnsLifecycleV
 		t.Fatal(err)
 	}
 	defer second.Close()
-	if err := second.SetReadDeadline(time.Now().Add(time.Second)); err != nil {
+	deadline = time.Now().Add(time.Second)
+	for {
+		topology.mu.Lock()
+		connections := len(topology.conns)
+		topology.mu.Unlock()
+		if connections == 2 {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("second shard connection was not admitted")
+		}
+		time.Sleep(time.Millisecond)
+	}
+	third, err := net.Dial("tcp4", localAlias)
+	if err != nil {
 		t.Fatal(err)
 	}
-	if _, err := second.Read(make([]byte, 1)); err == nil {
+	defer third.Close()
+	if err := third.SetReadDeadline(time.Now().Add(time.Second)); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := third.Read(make([]byte, 1)); err == nil {
 		t.Fatal("excess shard connection remained open")
 	} else if netErr, ok := err.(net.Error); ok && netErr.Timeout() {
 		t.Fatal("excess shard connection was not rejected")

--- a/TreeDB/nativewire/vector_partition_production_topology_v1_test.go
+++ b/TreeDB/nativewire/vector_partition_production_topology_v1_test.go
@@ -483,7 +483,7 @@ func TestVectorPartitionProductionTopologyAllowsCoordinatorOnlyAndRejectsIncompl
 	if _, err := NewVectorPartitionProductionTopologyV1(opts); err == nil {
 		t.Fatal("malformed owner endpoint succeeded")
 	}
-	for _, endpoint := range []string{":2", "0.0.0.0:2", "[::]:2", "[fe80::1]:2"} {
+	for _, endpoint := range []string{":2", "0.0.0.0:2", "[::]:2", "[fe80::1]:2", "[::1%lo]:2"} {
 		opts.Endpoints["group-b"] = endpoint
 		if _, err := NewVectorPartitionProductionTopologyV1(opts); err == nil {
 			t.Fatalf("unspecified owner endpoint %q succeeded", endpoint)

--- a/TreeDB/nativewire/vector_partition_production_topology_v1_test.go
+++ b/TreeDB/nativewire/vector_partition_production_topology_v1_test.go
@@ -136,7 +136,7 @@ func (temporaryAcceptErrorV1) Temporary() bool { return true }
 
 func TestVectorPartitionProductionTopologyRequiresLiveAuthorityAndOwnsLifecycleV1(t *testing.T) {
 	ref := raftplacement.CollectionRefV1{Database: "db", Catalog: "catalog", Collection: "docs"}
-	catalog, err := raftplacement.Validate(raftplacement.CatalogV1{Groups: []raftplacement.GroupV1{{ID: "group-a", Members: []raftcluster.NodeID{"node-a"}, LeaderHint: "node-a"}}, Placements: []raftplacement.CollectionPlacementV1{{Collection: ref, GroupID: "group-a", Mode: raftplacement.PlacementModeCollectionV1}}})
+	catalog, err := raftplacement.Validate(raftplacement.CatalogV1{Groups: []raftplacement.GroupV1{{ID: "group-a", Members: []raftcluster.NodeID{"node-a", "node-b"}, LeaderHint: "node-b"}}, Placements: []raftplacement.CollectionPlacementV1{{Collection: ref, GroupID: "group-a", Mode: raftplacement.PlacementModeCollectionV1}}})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -167,7 +167,14 @@ func TestVectorPartitionProductionTopologyRequiresLiveAuthorityAndOwnsLifecycleV
 		t.Fatal("mismatched shard service succeeded")
 	}
 	opts.Shards[0].Service = validService
-	opts.NodeEndpoints = map[raftcluster.GroupID]map[raftcluster.NodeID]string{"group-a": {"node-a": "127.0.0.1:1"}}
+	if _, err := NewVectorPartitionProductionTopologyV1(opts); err == nil {
+		t.Fatal("local shard succeeded without remote member endpoints")
+	}
+	opts.NodeEndpoints = map[raftcluster.GroupID]map[raftcluster.NodeID]string{"group-a": {"node-a": "127.0.0.1:1", "node-b": "127.0.0.1:1"}}
+	if _, err := NewVectorPartitionProductionTopologyV1(opts); err == nil {
+		t.Fatal("distinct shard members shared an endpoint")
+	}
+	opts.NodeEndpoints["group-a"]["node-b"] = "127.0.0.1:2"
 	if _, err := NewVectorPartitionProductionTopologyV1(opts); err == nil {
 		t.Fatal("mismatched local node endpoint succeeded")
 	}
@@ -229,7 +236,11 @@ func TestVectorPartitionProductionTopologyAllowsCoordinatorOnlyAndRejectsIncompl
 	if _, err := NewVectorPartitionProductionTopologyV1(opts); err == nil {
 		t.Fatal("foreign node endpoint succeeded")
 	}
-	opts.NodeEndpoints = map[raftcluster.GroupID]map[raftcluster.NodeID]string{"group-a": {"node-a": "127.0.0.1:1"}}
+	opts.NodeEndpoints = map[raftcluster.GroupID]map[raftcluster.NodeID]string{"group-a": {"node-a": "127.0.0.1:1"}, "group-b": {"node-b": "127.0.0.1:1"}}
+	if _, err := NewVectorPartitionProductionTopologyV1(opts); err == nil {
+		t.Fatal("cross-group node endpoint collision succeeded")
+	}
+	opts.NodeEndpoints["group-b"]["node-b"] = "127.0.0.1:2"
 	topology, err := NewVectorPartitionProductionTopologyV1(opts)
 	if err != nil {
 		t.Fatal(err)

--- a/TreeDB/nativewire/vector_partition_production_topology_v1_test.go
+++ b/TreeDB/nativewire/vector_partition_production_topology_v1_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net"
 	"strings"
+	"sync/atomic"
 	"testing"
 
 	"github.com/snissn/gomap/TreeDB/collections"
@@ -44,7 +45,8 @@ func TestVectorPartitionProductionTopologyRollsBackPartialStartAndRestartsV1(t *
 	if err != nil {
 		t.Fatal(err)
 	}
-	opts := VectorPartitionProductionTopologyOptionsV1{Catalog: catalog, Placement: placement, RouterSource: &testVectorPartitionCoordinatorRouterSourceV1{}, ReplicatedLifecycle: &recordingVectorPartitionReplicatedLifecycleAuthorityV1{}, Endpoints: map[raftcluster.GroupID]string{"group-a": listener.Addr().String()}, Shards: []VectorPartitionProductionShardV1{{GroupID: "group-a", Listener: listener, Service: &VectorPartitionShardSearchServiceV1{}}, {GroupID: "group-a", Listener: listener, Service: &VectorPartitionShardSearchServiceV1{}}}}
+	service := &VectorPartitionShardSearchServiceV1{localGroup: "group-a", localNodeID: "node-a", route: vectorPartitionShardSearchRouteV1{placement: placement}}
+	opts := VectorPartitionProductionTopologyOptionsV1{Catalog: catalog, Placement: placement, RouterSource: &testVectorPartitionCoordinatorRouterSourceV1{}, ReplicatedLifecycle: &recordingVectorPartitionReplicatedLifecycleAuthorityV1{}, Endpoints: map[raftcluster.GroupID]string{"group-a": listener.Addr().String()}, Shards: []VectorPartitionProductionShardV1{{GroupID: "group-a", Listener: listener, Service: service}, {GroupID: "group-a", Listener: listener, Service: service}}}
 	if _, err := NewVectorPartitionProductionTopologyV1(opts); err == nil {
 		t.Fatal("partial start unexpectedly succeeded")
 	}
@@ -95,17 +97,42 @@ func newVectorPartitionProductionTopologyTwoGroupTestV1(t *testing.T) (*VectorPa
 		_ = listenerA.Close()
 		t.Fatal(err)
 	}
+	endpointA := listenerA.Addr().String()
+	boundA := listenerA.Addr().(*net.TCPAddr)
+	listenerA = &temporaryWildcardTCPListenerV1{Listener: listenerA, addr: &net.TCPAddr{IP: net.IPv4zero, Port: boundA.Port}}
 	router := &testVectorPartitionCoordinatorRouterV1{status: collections.VectorPartitionRouterRuntimeStatusV1{Manifest: manifest, ModelDigest: strings.Repeat("c", 64), Representatives: 2, Partitions: 2}, partitions: []collections.VectorPartitionRouterPartitionScoreV1{{PartitionID: 0}, {PartitionID: 1, Distance: 0.1}}}
-	topology, err := NewVectorPartitionProductionTopologyV1(VectorPartitionProductionTopologyOptionsV1{Catalog: catalog, Placement: placement, RouterSource: &testVectorPartitionCoordinatorRouterSourceV1{router: router}, ReplicatedLifecycle: &recordingVectorPartitionReplicatedLifecycleAuthorityV1{}, Endpoints: map[raftcluster.GroupID]string{"group-a": listenerA.Addr().String(), "group-b": listenerB.Addr().String()}, Shards: []VectorPartitionProductionShardV1{{GroupID: "group-a", Listener: listenerA, Service: service("group-a", "node-a", 0)}, {GroupID: "group-b", Listener: listenerB, Service: service("group-b", "node-b", 1)}}})
+	topology, err := NewVectorPartitionProductionTopologyV1(VectorPartitionProductionTopologyOptionsV1{Catalog: catalog, Placement: placement, RouterSource: &testVectorPartitionCoordinatorRouterSourceV1{router: router}, ReplicatedLifecycle: &recordingVectorPartitionReplicatedLifecycleAuthorityV1{}, Endpoints: map[raftcluster.GroupID]string{"group-a": endpointA, "group-b": listenerB.Addr().String()}, Shards: []VectorPartitionProductionShardV1{{GroupID: "group-a", Listener: listenerA, Service: service("group-a", "node-a", 0)}, {GroupID: "group-b", Listener: listenerB, Service: service("group-b", "node-b", 1)}}})
 	if err != nil {
 		_ = listenerA.Close()
 		_ = listenerB.Close()
 		t.Fatal(err)
 	}
+	t.Cleanup(func() { _ = topology.Close() })
 	request := testVectorPartitionCoordinatorRequestV1(2)
 	request.IndexDefinitionDigest = vectorPartitionShardSearchDigestTestV1
 	return topology, request, reads
 }
+
+type temporaryWildcardTCPListenerV1 struct {
+	net.Listener
+	addr     net.Addr
+	injected atomic.Bool
+}
+
+func (l *temporaryWildcardTCPListenerV1) Accept() (net.Conn, error) {
+	if !l.injected.Swap(true) {
+		return nil, temporaryAcceptErrorV1{}
+	}
+	return l.Listener.Accept()
+}
+
+func (l *temporaryWildcardTCPListenerV1) Addr() net.Addr { return l.addr }
+
+type temporaryAcceptErrorV1 struct{}
+
+func (temporaryAcceptErrorV1) Error() string   { return "temporary accept error" }
+func (temporaryAcceptErrorV1) Timeout() bool   { return false }
+func (temporaryAcceptErrorV1) Temporary() bool { return true }
 
 func TestVectorPartitionProductionTopologyRequiresLiveAuthorityAndOwnsLifecycleV1(t *testing.T) {
 	ref := raftplacement.CollectionRefV1{Database: "db", Catalog: "catalog", Collection: "docs"}
@@ -125,6 +152,21 @@ func TestVectorPartitionProductionTopologyRequiresLiveAuthorityAndOwnsLifecycleV
 		t.Fatal("missing lifecycle authority succeeded")
 	}
 	opts.ReplicatedLifecycle = &recordingVectorPartitionReplicatedLifecycleAuthorityV1{}
+	validService, err := NewVectorPartitionShardSearchServiceV1(VectorPartitionShardSearchServiceOptionsV1{Catalog: catalog, Placement: placement, LocalNodeID: "node-a", LocalGroupID: "group-a", ReadCoordinator: &fakeVectorPartitionReadCoordinatorV1{}, GenerationSource: &fakeVectorPartitionGenerationSourceV1{}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	badPlacement := placement
+	badPlacement.PartitionGeneration++
+	badService, err := NewVectorPartitionShardSearchServiceV1(VectorPartitionShardSearchServiceOptionsV1{Catalog: catalog, Placement: badPlacement, LocalNodeID: "node-a", LocalGroupID: "group-a", ReadCoordinator: &fakeVectorPartitionReadCoordinatorV1{}, GenerationSource: &fakeVectorPartitionGenerationSourceV1{}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	opts.Shards[0].Service = badService
+	if _, err := NewVectorPartitionProductionTopologyV1(opts); err == nil {
+		t.Fatal("mismatched shard service succeeded")
+	}
+	opts.Shards[0].Service = validService
 	topology, err := NewVectorPartitionProductionTopologyV1(opts)
 	if err != nil {
 		t.Fatal(err)
@@ -161,7 +203,7 @@ func TestVectorPartitionProductionTopologyAllowsCoordinatorOnlyAndRejectsIncompl
 	if _, err := NewVectorPartitionProductionTopologyV1(opts); err == nil {
 		t.Fatal("foreign node endpoint succeeded")
 	}
-	opts.NodeEndpoints = nil
+	opts.NodeEndpoints = map[raftcluster.GroupID]map[raftcluster.NodeID]string{"group-a": {"node-a": "127.0.0.1:1"}}
 	topology, err := NewVectorPartitionProductionTopologyV1(opts)
 	if err != nil {
 		t.Fatal(err)

--- a/TreeDB/nativewire/vector_partition_production_topology_v1_test.go
+++ b/TreeDB/nativewire/vector_partition_production_topology_v1_test.go
@@ -345,6 +345,14 @@ func TestVectorPartitionProductionEndpointMatchesListenerAddressFamilyV1(t *test
 	if vectorPartitionProductionEndpointAddressMatchesListenerV1(&net.TCPAddr{IP: net.ParseIP("fe80::1"), Port: 1, Zone: "lo"}, scoped) {
 		t.Fatal("mismatched scoped IPv6 zone was accepted")
 	}
+	linkLocal := net.ParseIP("fe80::1")
+	local := []net.Addr{&net.IPNet{IP: linkLocal, Mask: net.CIDRMask(64, 128)}}
+	if vectorPartitionProductionEndpointAddressIsLocalV1(&net.TCPAddr{IP: linkLocal}, local) {
+		t.Fatal("link-local endpoint without a zone was accepted")
+	}
+	if vectorPartitionProductionEndpointAddressIsLocalV1(&net.TCPAddr{IP: linkLocal, Zone: "no-such-vector-interface"}, local) {
+		t.Fatal("link-local endpoint with a foreign zone was accepted")
+	}
 	wildcard, err := net.Listen("tcp4", "0.0.0.0:0")
 	if err != nil {
 		t.Fatal(err)

--- a/TreeDB/nativewire/vector_partition_production_topology_v1_test.go
+++ b/TreeDB/nativewire/vector_partition_production_topology_v1_test.go
@@ -483,7 +483,7 @@ func TestVectorPartitionProductionTopologyAllowsCoordinatorOnlyAndRejectsIncompl
 	if _, err := NewVectorPartitionProductionTopologyV1(opts); err == nil {
 		t.Fatal("malformed owner endpoint succeeded")
 	}
-	for _, endpoint := range []string{":2", "0.0.0.0:2", "[::]:2"} {
+	for _, endpoint := range []string{":2", "0.0.0.0:2", "[::]:2", "[fe80::1]:2"} {
 		opts.Endpoints["group-b"] = endpoint
 		if _, err := NewVectorPartitionProductionTopologyV1(opts); err == nil {
 			t.Fatalf("unspecified owner endpoint %q succeeded", endpoint)

--- a/TreeDB/nativewire/vector_partition_production_topology_v1_test.go
+++ b/TreeDB/nativewire/vector_partition_production_topology_v1_test.go
@@ -345,6 +345,26 @@ func TestVectorPartitionProductionEndpointMatchesListenerAddressFamilyV1(t *test
 	if vectorPartitionProductionEndpointAddressMatchesListenerV1(&net.TCPAddr{IP: net.ParseIP("fe80::1"), Port: 1, Zone: "lo"}, scoped) {
 		t.Fatal("mismatched scoped IPv6 zone was accepted")
 	}
+	interfaces, err := net.Interfaces()
+	if err != nil || len(interfaces) == 0 {
+		t.Fatalf("network interfaces=%v error=%v", interfaces, err)
+	}
+	iface := interfaces[0]
+	scoped.addr = &net.TCPAddr{IP: net.ParseIP("fe80::1"), Port: 1, Zone: iface.Name}
+	if !vectorPartitionProductionEndpointAddressMatchesListenerV1(&net.TCPAddr{IP: net.ParseIP("fe80::1"), Port: 1, Zone: fmt.Sprint(iface.Index)}, scoped) {
+		t.Fatal("equivalent scoped IPv6 zone forms did not match")
+	}
+	nameKeys, err := vectorPartitionProductionEndpointKeysV1(fmt.Sprintf("[fe80::1%%%s]:1", iface.Name))
+	if err != nil {
+		t.Fatal(err)
+	}
+	indexKeys, err := vectorPartitionProductionEndpointKeysV1(fmt.Sprintf("[fe80::1%%%d]:1", iface.Index))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(nameKeys) != 1 || len(indexKeys) != 1 || nameKeys[0] != indexKeys[0] {
+		t.Fatalf("scoped endpoint keys name=%v index=%v", nameKeys, indexKeys)
+	}
 	linkLocal := net.ParseIP("fe80::1")
 	local := []net.Addr{&net.IPNet{IP: linkLocal, Mask: net.CIDRMask(64, 128)}}
 	if vectorPartitionProductionEndpointAddressIsLocalV1(&net.TCPAddr{IP: linkLocal}, local) {

--- a/TreeDB/nativewire/vector_partition_production_topology_v1_test.go
+++ b/TreeDB/nativewire/vector_partition_production_topology_v1_test.go
@@ -351,6 +351,25 @@ func TestVectorPartitionProductionEndpointMatchesListenerAddressFamilyV1(t *test
 			t.Fatalf("resolved endpoint omitted localhost address %s: %+v", address.IP, addresses)
 		}
 	}
+	allCompatible := true
+	for _, address := range addresses {
+		allCompatible = allCompatible && vectorPartitionProductionEndpointAddressMatchesListenerV1(address, wildcard)
+	}
+	if matches := vectorPartitionProductionEndpointMatchesListenerV1(wildcardEndpoint, wildcard); matches != allCompatible {
+		t.Fatalf("wildcard listener hostname match=%t want=%t addresses=%+v", matches, allCompatible, addresses)
+	}
+	keys, err := vectorPartitionProductionEndpointKeysV1(wildcardEndpoint)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(keys) != len(addresses) {
+		t.Fatalf("endpoint keys=%v addresses=%+v", keys, addresses)
+	}
+	for i, address := range addresses {
+		if keys[i] != address.String() {
+			t.Fatalf("endpoint key[%d]=%q want %q", i, keys[i], address)
+		}
+	}
 	if uses, err := vectorPartitionProductionEndpointUsesListenerV1(wildcardEndpoint, wildcard); err != nil || !uses {
 		t.Fatalf("wildcard listener hostname match=%t error=%v addresses=%+v", uses, err, addresses)
 	}

--- a/TreeDB/nativewire/vector_partition_production_topology_v1_test.go
+++ b/TreeDB/nativewire/vector_partition_production_topology_v1_test.go
@@ -255,15 +255,18 @@ func TestVectorPartitionProductionTopologyRejectsSharedShardListenerV1(t *testin
 		t.Fatal(err)
 	}
 	placement := raftplacement.VectorPartitionPlacementRecordV1{Collection: ref, IndexName: "embedding", IndexDefinitionDigest: fmt.Sprintf("%064x", 1), SourceGeneration: 1, SourceChecksum: 2, SourceSchemaHash: 3, SourceRowCount: 4, PartitionGeneration: 5, PartitionCount: 2, Partitions: []raftplacement.VectorPartitionGroupV1{{PartitionID: 0, GroupID: "group-a"}, {PartitionID: 1, GroupID: "group-b"}}}
-	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	listener, err := net.Listen("tcp4", "0.0.0.0:0")
 	if err != nil {
 		t.Fatal(err)
 	}
-	endpoint := listener.Addr().String()
+	defer listener.Close()
+	port := listener.Addr().(*net.TCPAddr).Port
+	endpointA := fmt.Sprintf("127.0.0.1:%d", port)
+	endpointB := fmt.Sprintf("127.0.0.2:%d", port)
 	service := func(group raftcluster.GroupID, node raftcluster.NodeID) *VectorPartitionShardSearchServiceV1 {
 		return &VectorPartitionShardSearchServiceV1{localGroup: group, localNodeID: node, limits: DefaultVectorPartitionShardSearchLimitsV1(), route: vectorPartitionShardSearchRouteV1{placement: placement}}
 	}
-	_, err = NewVectorPartitionProductionTopologyV1(VectorPartitionProductionTopologyOptionsV1{Catalog: catalog, Placement: placement, RouterSource: &testVectorPartitionCoordinatorRouterSourceV1{}, ReplicatedLifecycle: &recordingVectorPartitionReplicatedLifecycleAuthorityV1{}, Endpoints: map[raftcluster.GroupID]string{"group-a": endpoint, "group-b": endpoint}, Shards: []VectorPartitionProductionShardV1{{GroupID: "group-a", Listener: listener, Service: service("group-a", "node-a")}, {GroupID: "group-b", Listener: listener, Service: service("group-b", "node-b")}}})
+	_, err = NewVectorPartitionProductionTopologyV1(VectorPartitionProductionTopologyOptionsV1{Catalog: catalog, Placement: placement, RouterSource: &testVectorPartitionCoordinatorRouterSourceV1{}, ReplicatedLifecycle: &recordingVectorPartitionReplicatedLifecycleAuthorityV1{}, Endpoints: map[raftcluster.GroupID]string{"group-a": endpointA, "group-b": endpointB}, Shards: []VectorPartitionProductionShardV1{{GroupID: "group-a", Listener: listener, Service: service("group-a", "node-a")}, {GroupID: "group-b", Listener: listener, Service: service("group-b", "node-b")}}})
 	if err == nil {
 		t.Fatal("shared shard listener succeeded")
 	}

--- a/TreeDB/nativewire/vector_partition_production_topology_v1_test.go
+++ b/TreeDB/nativewire/vector_partition_production_topology_v1_test.go
@@ -4,12 +4,108 @@ import (
 	"context"
 	"fmt"
 	"net"
+	"strings"
 	"testing"
 
 	"github.com/snissn/gomap/TreeDB/collections"
 	"github.com/snissn/gomap/TreeDB/internal/raftcluster"
 	"github.com/snissn/gomap/TreeDB/internal/raftplacement"
 )
+
+func TestVectorPartitionProductionTopologyTwoGroupTCPGenerationPinnedV1(t *testing.T) {
+	topology, request, reads := newVectorPartitionProductionTopologyTwoGroupTestV1(t)
+	defer topology.Close()
+	response, err := topology.Coordinator().Search(context.Background(), request)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(response.Neighbors) != 2 || reads["group-a"].callCount() != 1 || reads["group-b"].callCount() != 1 {
+		t.Fatalf("response=%+v read calls a=%d b=%d", response, reads["group-a"].callCount(), reads["group-b"].callCount())
+	}
+	if _, err := topology.Coordinator().Search(context.Background(), request); err != nil {
+		t.Fatal(err)
+	}
+	if err := topology.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if response, err := topology.Coordinator().Search(context.Background(), request); err == nil || len(response.Neighbors) != 0 {
+		t.Fatalf("closed topology returned partial response=%+v err=%v", response, err)
+	}
+}
+
+func TestVectorPartitionProductionTopologyRollsBackPartialStartAndRestartsV1(t *testing.T) {
+	ref := raftplacement.CollectionRefV1{Database: "db", Catalog: "catalog", Collection: "docs"}
+	catalog, err := raftplacement.Validate(raftplacement.CatalogV1{Groups: []raftplacement.GroupV1{{ID: "group-a", Members: []raftcluster.NodeID{"node-a"}, LeaderHint: "node-a"}}, Placements: []raftplacement.CollectionPlacementV1{{Collection: ref, GroupID: "group-a", Mode: raftplacement.PlacementModeCollectionV1}}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	placement := raftplacement.VectorPartitionPlacementRecordV1{Collection: ref, IndexName: "embedding", IndexDefinitionDigest: fmt.Sprintf("%064x", 1), SourceGeneration: 1, SourceChecksum: 2, SourceSchemaHash: 3, SourceRowCount: 4, PartitionGeneration: 5, PartitionCount: 1, Partitions: []raftplacement.VectorPartitionGroupV1{{PartitionID: 0, GroupID: "group-a"}}}
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	opts := VectorPartitionProductionTopologyOptionsV1{Catalog: catalog, Placement: placement, RouterSource: &testVectorPartitionCoordinatorRouterSourceV1{}, ReplicatedLifecycle: &recordingVectorPartitionReplicatedLifecycleAuthorityV1{}, Endpoints: map[raftcluster.GroupID]string{"group-a": listener.Addr().String()}, Shards: []VectorPartitionProductionShardV1{{GroupID: "group-a", Listener: listener, Service: &VectorPartitionShardSearchServiceV1{}}, {GroupID: "group-a", Listener: listener, Service: &VectorPartitionShardSearchServiceV1{}}}}
+	if _, err := NewVectorPartitionProductionTopologyV1(opts); err == nil {
+		t.Fatal("partial start unexpectedly succeeded")
+	}
+	if _, err := listener.Accept(); err == nil {
+		t.Fatal("partial-start listener was not rolled back")
+	}
+	topology, _, _ := newVectorPartitionProductionTopologyTwoGroupTestV1(t)
+	if err := topology.Close(); err != nil {
+		t.Fatal(err)
+	}
+	// A fresh topology after a complete shutdown exercises the restart surface.
+	restarted, _, _ := newVectorPartitionProductionTopologyTwoGroupTestV1(t)
+	if !restarted.Status().Ready {
+		t.Fatal("restarted topology is not ready")
+	}
+	if err := restarted.Close(); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func newVectorPartitionProductionTopologyTwoGroupTestV1(t *testing.T) (*VectorPartitionProductionTopologyV1, VectorPartitionCoordinatorRequestV1, map[raftcluster.GroupID]*fakeVectorPartitionReadCoordinatorV1) {
+	t.Helper()
+	ref := raftplacement.CollectionRefV1{Database: "db", Catalog: "default", Collection: "docs"}
+	groups := []raftplacement.GroupV1{{ID: "group-a", Members: []raftcluster.NodeID{"node-a"}, LeaderHint: "node-a"}, {ID: "group-b", Members: []raftcluster.NodeID{"node-b"}, LeaderHint: "node-b"}}
+	catalog, err := raftplacement.Validate(raftplacement.CatalogV1{Groups: groups, Placements: []raftplacement.CollectionPlacementV1{{Collection: ref, GroupID: "group-a", Mode: raftplacement.PlacementModeCollectionV1}}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	placement := raftplacement.VectorPartitionPlacementRecordV1{Collection: ref, IndexName: "embedding", IndexDefinitionDigest: vectorPartitionShardSearchDigestTestV1, SourceGeneration: 11, SourceChecksum: 22, SourceSchemaHash: 33, SourceRowCount: 2, PartitionGeneration: 7, PartitionCount: 2, Partitions: []raftplacement.VectorPartitionGroupV1{{PartitionID: 0, GroupID: "group-a"}, {PartitionID: 1, GroupID: "group-b"}}}
+	manifest := collections.VectorPartitionManifestV1{Format: collections.VectorPartitionManifestFormatV1, State: "ready", Collection: ref.Collection, IndexName: placement.IndexName, IndexDefinitionDigest: placement.IndexDefinitionDigest, SourceGeneration: placement.SourceGeneration, SourceChecksum: placement.SourceChecksum, SourceSchemaHash: placement.SourceSchemaHash, SourceRowCount: placement.SourceRowCount, Generation: placement.PartitionGeneration, RouterGeneration: placement.PartitionGeneration, ReadySetDigest: strings.Repeat("b", 64), PartitionCount: 2, Placements: []collections.VectorPartitionPlacementV1{{PartitionID: 0, GroupID: "group-a"}, {PartitionID: 1, GroupID: "group-b"}}, Memberships: []collections.VectorPartitionMembershipV1{{VectorOrdinal: 0, PartitionID: 0}, {VectorOrdinal: 1, PartitionID: 1}}}
+	reads := make(map[raftcluster.GroupID]*fakeVectorPartitionReadCoordinatorV1, 2)
+	service := func(group raftcluster.GroupID, node raftcluster.NodeID, partition uint32) *VectorPartitionShardSearchServiceV1 {
+		read := &fakeVectorPartitionReadCoordinatorV1{proof: raftcluster.ReadIndexProof{NodeID: node, GroupID: group, Term: 1, Index: 9, HasQuorum: true, EvidenceKind: raftcluster.ReadIndexEvidenceProduction}, progress: raftcluster.AppliedProgress{NodeID: node, GroupID: group, Term: 1, Index: 9, HasApplied: true}}
+		reads[group] = read
+		source := &fakeVectorPartitionGenerationSourceV1{manifest: manifest, assets: map[uint32]collections.VectorPartitionSearchAssetV1{partition: vectorPartitionShardSearchAssetTestV1(partition, []string{string(group)}, [][]float32{{1, 0}})}, openErr: map[uint32]error{}, searchers: map[uint32]*collections.VectorPartitionLocalSearcherV1{}}
+		s, err := NewVectorPartitionShardSearchServiceV1(VectorPartitionShardSearchServiceOptionsV1{Catalog: catalog, Placement: placement, LocalNodeID: node, LocalGroupID: group, ReadCoordinator: read, GenerationSource: source})
+		if err != nil {
+			t.Fatal(err)
+		}
+		return s
+	}
+	listenerA, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	listenerB, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		_ = listenerA.Close()
+		t.Fatal(err)
+	}
+	router := &testVectorPartitionCoordinatorRouterV1{status: collections.VectorPartitionRouterRuntimeStatusV1{Manifest: manifest, ModelDigest: strings.Repeat("c", 64), Representatives: 2, Partitions: 2}, partitions: []collections.VectorPartitionRouterPartitionScoreV1{{PartitionID: 0}, {PartitionID: 1, Distance: 0.1}}}
+	topology, err := NewVectorPartitionProductionTopologyV1(VectorPartitionProductionTopologyOptionsV1{Catalog: catalog, Placement: placement, RouterSource: &testVectorPartitionCoordinatorRouterSourceV1{router: router}, ReplicatedLifecycle: &recordingVectorPartitionReplicatedLifecycleAuthorityV1{}, Endpoints: map[raftcluster.GroupID]string{"group-a": listenerA.Addr().String(), "group-b": listenerB.Addr().String()}, Shards: []VectorPartitionProductionShardV1{{GroupID: "group-a", Listener: listenerA, Service: service("group-a", "node-a", 0)}, {GroupID: "group-b", Listener: listenerB, Service: service("group-b", "node-b", 1)}}})
+	if err != nil {
+		_ = listenerA.Close()
+		_ = listenerB.Close()
+		t.Fatal(err)
+	}
+	request := testVectorPartitionCoordinatorRequestV1(2)
+	request.IndexDefinitionDigest = vectorPartitionShardSearchDigestTestV1
+	return topology, request, reads
+}
 
 func TestVectorPartitionProductionTopologyRequiresLiveAuthorityAndOwnsLifecycleV1(t *testing.T) {
 	ref := raftplacement.CollectionRefV1{Database: "db", Catalog: "catalog", Collection: "docs"}
@@ -61,6 +157,11 @@ func TestVectorPartitionProductionTopologyAllowsCoordinatorOnlyAndRejectsIncompl
 		t.Fatal("incomplete owner endpoint coverage succeeded")
 	}
 	opts.Endpoints["group-b"] = "127.0.0.1:2"
+	opts.NodeEndpoints = map[raftcluster.GroupID]map[raftcluster.NodeID]string{"group-a": {"node-z": "127.0.0.1:3"}}
+	if _, err := NewVectorPartitionProductionTopologyV1(opts); err == nil {
+		t.Fatal("foreign node endpoint succeeded")
+	}
+	opts.NodeEndpoints = nil
 	topology, err := NewVectorPartitionProductionTopologyV1(opts)
 	if err != nil {
 		t.Fatal(err)

--- a/TreeDB/nativewire/vector_partition_production_topology_v1_test.go
+++ b/TreeDB/nativewire/vector_partition_production_topology_v1_test.go
@@ -323,7 +323,7 @@ func TestVectorPartitionProductionTopologyRejectsSharedShardListenerV1(t *testin
 		return &VectorPartitionShardSearchServiceV1{localGroup: group, localNodeID: node, limits: DefaultVectorPartitionShardSearchLimitsV1(), route: vectorPartitionShardSearchRouteV1{placement: placement, hints: map[raftcluster.GroupID]raftcluster.NodeID{"group-a": "", "group-b": ""}}}
 	}
 	_, err = NewVectorPartitionProductionTopologyV1(VectorPartitionProductionTopologyOptionsV1{Catalog: catalog, Placement: placement, RouterSource: &testVectorPartitionCoordinatorRouterSourceV1{}, ReplicatedLifecycle: &recordingVectorPartitionReplicatedLifecycleAuthorityV1{}, Endpoints: map[raftcluster.GroupID]string{"group-a": endpointA, "group-b": endpointB}, Shards: []VectorPartitionProductionShardV1{{GroupID: "group-a", Listener: listener, Service: service("group-a", "node-a")}, {GroupID: "group-b", Listener: listener, Service: service("group-b", "node-b")}}})
-	if err == nil || !strings.Contains(err.Error(), "share a listener") {
+	if err == nil || !strings.Contains(err.Error(), "uses shard") {
 		t.Fatalf("shared shard listener error=%v", err)
 	}
 }
@@ -473,6 +473,27 @@ func TestVectorPartitionProductionTopologyAllowsCoordinatorOnlyAndRejectsIncompl
 	}
 	if err := topology.Close(); err != nil {
 		t.Fatal(err)
+	}
+	listener, err := net.Listen("tcp4", "0.0.0.0:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer listener.Close()
+	service, err := NewVectorPartitionShardSearchServiceV1(VectorPartitionShardSearchServiceOptionsV1{Catalog: catalog, Placement: placement, LocalNodeID: "node-a", LocalGroupID: "group-a", ReadCoordinator: &fakeVectorPartitionReadCoordinatorV1{}, GenerationSource: &fakeVectorPartitionGenerationSourceV1{}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	port := listener.Addr().(*net.TCPAddr).Port
+	opts.Shards = []VectorPartitionProductionShardV1{{GroupID: "group-a", Listener: listener, Service: service}}
+	opts.Endpoints = map[raftcluster.GroupID]string{"group-a": fmt.Sprintf("127.0.0.1:%d", port), "group-b": fmt.Sprintf("127.0.0.2:%d", port)}
+	opts.NodeEndpoints = nil
+	if _, err := NewVectorPartitionProductionTopologyV1(opts); err == nil {
+		t.Fatal("foreign owner endpoint used wildcard shard listener")
+	}
+	opts.Endpoints["group-b"] = "127.0.0.1:2"
+	opts.NodeEndpoints = map[raftcluster.GroupID]map[raftcluster.NodeID]string{"group-b": {"node-b": fmt.Sprintf("127.0.0.2:%d", port)}}
+	if _, err := NewVectorPartitionProductionTopologyV1(opts); err == nil {
+		t.Fatal("foreign node endpoint used wildcard shard listener")
 	}
 }
 

--- a/TreeDB/nativewire/vector_partition_production_topology_v1_test.go
+++ b/TreeDB/nativewire/vector_partition_production_topology_v1_test.go
@@ -48,6 +48,31 @@ func TestVectorPartitionProductionTopologyRequiresLiveAuthorityAndOwnsLifecycleV
 	}
 }
 
+func TestVectorPartitionProductionTopologyAllowsCoordinatorOnlyAndRejectsIncompleteOwnersV1(t *testing.T) {
+	ref := raftplacement.CollectionRefV1{Database: "db", Catalog: "catalog", Collection: "docs"}
+	catalog, err := raftplacement.Validate(raftplacement.CatalogV1{Groups: []raftplacement.GroupV1{{ID: "group-a", Members: []raftcluster.NodeID{"node-a"}, LeaderHint: "node-a"}, {ID: "group-b", Members: []raftcluster.NodeID{"node-b"}, LeaderHint: "node-b"}}, Placements: []raftplacement.CollectionPlacementV1{{Collection: ref, GroupID: "group-a", Mode: raftplacement.PlacementModeCollectionV1}}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	placement := raftplacement.VectorPartitionPlacementRecordV1{Collection: ref, IndexName: "embedding", IndexDefinitionDigest: fmt.Sprintf("%064x", 1), SourceGeneration: 1, SourceChecksum: 2, SourceSchemaHash: 3, SourceRowCount: 4, PartitionGeneration: 5, PartitionCount: 2, Partitions: []raftplacement.VectorPartitionGroupV1{{PartitionID: 0, GroupID: "group-a"}, {PartitionID: 1, GroupID: "group-b"}}}
+	router := &testVectorPartitionCoordinatorRouterV1{}
+	opts := VectorPartitionProductionTopologyOptionsV1{Catalog: catalog, Placement: placement, RouterSource: &testVectorPartitionCoordinatorRouterSourceV1{router: router}, ReplicatedLifecycle: &recordingVectorPartitionReplicatedLifecycleAuthorityV1{}, Endpoints: map[raftcluster.GroupID]string{"group-a": "127.0.0.1:1"}}
+	if _, err := NewVectorPartitionProductionTopologyV1(opts); err == nil {
+		t.Fatal("incomplete owner endpoint coverage succeeded")
+	}
+	opts.Endpoints["group-b"] = "127.0.0.1:2"
+	topology, err := NewVectorPartitionProductionTopologyV1(opts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if status := topology.Status(); !status.Ready || len(status.ShardGroups) != 0 {
+		t.Fatalf("coordinator-only status=%+v", status)
+	}
+	if err := topology.Close(); err != nil {
+		t.Fatal(err)
+	}
+}
+
 func TestVectorPartitionProductionTopologyRejectsNonOwnerEndpointV1(t *testing.T) {
 	_, err := NewVectorPartitionProductionTopologyV1(VectorPartitionProductionTopologyOptionsV1{Endpoints: map[raftcluster.GroupID]string{"not-an-owner": "127.0.0.1:1"}, Shards: []VectorPartitionProductionShardV1{{GroupID: "not-an-owner"}}, RouterSource: &testVectorPartitionCoordinatorRouterSourceV1{}, ReplicatedLifecycle: &recordingVectorPartitionReplicatedLifecycleAuthorityV1{}})
 	if err == nil {

--- a/TreeDB/nativewire/vector_partition_production_topology_v1_test.go
+++ b/TreeDB/nativewire/vector_partition_production_topology_v1_test.go
@@ -147,8 +147,9 @@ func TestVectorPartitionProductionTopologyRequiresLiveAuthorityAndOwnsLifecycleV
 		t.Fatal(err)
 	}
 	defer listener.Close()
+	localAlias := fmt.Sprintf("127.0.0.1:%d", listener.Addr().(*net.TCPAddr).Port)
 	router := &testVectorPartitionCoordinatorRouterV1{status: collections.VectorPartitionRouterRuntimeStatusV1{Manifest: collections.VectorPartitionManifestV1{Format: collections.VectorPartitionManifestFormatV1, State: "ready", Collection: ref.Collection, IndexName: placement.IndexName, IndexDefinitionDigest: placement.IndexDefinitionDigest, SourceGeneration: 1, SourceChecksum: 2, SourceSchemaHash: 3, SourceRowCount: 4, Generation: 5, RouterGeneration: 5, PartitionCount: 1, ReadySetDigest: fmt.Sprintf("%064x", 2), Placements: []collections.VectorPartitionPlacementV1{{PartitionID: 0, GroupID: "group-a"}}}, Representatives: 1, Partitions: 1}, partitions: []collections.VectorPartitionRouterPartitionScoreV1{{PartitionID: 0}}}
-	opts := VectorPartitionProductionTopologyOptionsV1{Catalog: catalog, Placement: placement, RouterSource: &testVectorPartitionCoordinatorRouterSourceV1{router: router}, Endpoints: map[raftcluster.GroupID]string{"group-a": listener.Addr().String()}, Shards: []VectorPartitionProductionShardV1{{GroupID: "group-a", Listener: listener, Service: &VectorPartitionShardSearchServiceV1{}}}}
+	opts := VectorPartitionProductionTopologyOptionsV1{Catalog: catalog, Placement: placement, RouterSource: &testVectorPartitionCoordinatorRouterSourceV1{router: router}, Endpoints: map[raftcluster.GroupID]string{"group-a": localAlias}, Shards: []VectorPartitionProductionShardV1{{GroupID: "group-a", Listener: listener, Service: &VectorPartitionShardSearchServiceV1{}}}}
 	if _, err := NewVectorPartitionProductionTopologyV1(opts); err == nil {
 		t.Fatal("missing lifecycle authority succeeded")
 	}
@@ -194,7 +195,6 @@ func TestVectorPartitionProductionTopologyRequiresLiveAuthorityAndOwnsLifecycleV
 	if _, err := NewVectorPartitionProductionTopologyV1(opts); err == nil {
 		t.Fatal("local shard succeeded without remote member endpoints")
 	}
-	localAlias := fmt.Sprintf("127.0.0.1:%d", listener.Addr().(*net.TCPAddr).Port)
 	opts.NodeEndpoints = map[raftcluster.GroupID]map[raftcluster.NodeID]string{"group-a": {"node-b": localAlias, "node-c": "127.0.0.1:2"}}
 	if _, err := NewVectorPartitionProductionTopologyV1(opts); err == nil {
 		t.Fatal("remote shard member used local fallback")
@@ -208,7 +208,7 @@ func TestVectorPartitionProductionTopologyRequiresLiveAuthorityAndOwnsLifecycleV
 	if _, err := NewVectorPartitionProductionTopologyV1(opts); err == nil {
 		t.Fatal("mismatched local node endpoint succeeded")
 	}
-	opts.NodeEndpoints["group-a"]["node-a"] = listener.Addr().String()
+	opts.NodeEndpoints["group-a"]["node-a"] = localAlias
 	opts.CoordinatorLimits.MaxConcurrentRequests = 1
 	opts.CoordinatorLimits.MaxRequests = 2
 	topology, err := NewVectorPartitionProductionTopologyV1(opts)
@@ -312,6 +312,9 @@ func TestVectorPartitionProductionEndpointMatchesListenerAddressFamilyV1(t *test
 	port := listener.Addr().(*net.TCPAddr).Port
 	if vectorPartitionProductionEndpointMatchesListenerV1(fmt.Sprintf("127.0.0.1:%d", port), listener) {
 		t.Fatal("IPv6 listener matched IPv4 endpoint")
+	}
+	if vectorPartitionProductionEndpointMatchesListenerV1(fmt.Sprintf(":%d", port), listener) {
+		t.Fatal("IPv6 listener matched hostless endpoint")
 	}
 	if !vectorPartitionProductionEndpointMatchesListenerV1(fmt.Sprintf("[::1]:%d", port), listener) {
 		t.Fatal("IPv6 listener rejected IPv6 endpoint")

--- a/TreeDB/nativewire/vector_partition_production_topology_v1_test.go
+++ b/TreeDB/nativewire/vector_partition_production_topology_v1_test.go
@@ -295,11 +295,11 @@ func TestVectorPartitionProductionTopologyRejectsSharedShardListenerV1(t *testin
 	endpointA := fmt.Sprintf("127.0.0.1:%d", port)
 	endpointB := fmt.Sprintf("127.0.0.2:%d", port)
 	service := func(group raftcluster.GroupID, node raftcluster.NodeID) *VectorPartitionShardSearchServiceV1 {
-		return &VectorPartitionShardSearchServiceV1{localGroup: group, localNodeID: node, limits: DefaultVectorPartitionShardSearchLimitsV1(), route: vectorPartitionShardSearchRouteV1{placement: placement}}
+		return &VectorPartitionShardSearchServiceV1{localGroup: group, localNodeID: node, limits: DefaultVectorPartitionShardSearchLimitsV1(), route: vectorPartitionShardSearchRouteV1{placement: placement, hints: map[raftcluster.GroupID]raftcluster.NodeID{"group-a": "", "group-b": ""}}}
 	}
 	_, err = NewVectorPartitionProductionTopologyV1(VectorPartitionProductionTopologyOptionsV1{Catalog: catalog, Placement: placement, RouterSource: &testVectorPartitionCoordinatorRouterSourceV1{}, ReplicatedLifecycle: &recordingVectorPartitionReplicatedLifecycleAuthorityV1{}, Endpoints: map[raftcluster.GroupID]string{"group-a": endpointA, "group-b": endpointB}, Shards: []VectorPartitionProductionShardV1{{GroupID: "group-a", Listener: listener, Service: service("group-a", "node-a")}, {GroupID: "group-b", Listener: listener, Service: service("group-b", "node-b")}}})
-	if err == nil {
-		t.Fatal("shared shard listener succeeded")
+	if err == nil || !strings.Contains(err.Error(), "share a listener") {
+		t.Fatalf("shared shard listener error=%v", err)
 	}
 }
 
@@ -367,6 +367,12 @@ func TestVectorPartitionProductionTopologyAllowsCoordinatorOnlyAndRejectsIncompl
 	opts.Endpoints["group-b"] = "missing-port"
 	if _, err := NewVectorPartitionProductionTopologyV1(opts); err == nil {
 		t.Fatal("malformed owner endpoint succeeded")
+	}
+	for _, endpoint := range []string{":2", "0.0.0.0:2", "[::]:2"} {
+		opts.Endpoints["group-b"] = endpoint
+		if _, err := NewVectorPartitionProductionTopologyV1(opts); err == nil {
+			t.Fatalf("unspecified owner endpoint %q succeeded", endpoint)
+		}
 	}
 	opts.Endpoints["group-b"] = "127.0.0.1:2"
 	opts.NodeEndpoints = map[raftcluster.GroupID]map[raftcluster.NodeID]string{"group-a": {"node-z": "127.0.0.1:3"}}

--- a/TreeDB/nativewire/vector_partition_production_topology_v1_test.go
+++ b/TreeDB/nativewire/vector_partition_production_topology_v1_test.go
@@ -214,6 +214,8 @@ func TestVectorPartitionProductionTopologyRequiresLiveAuthorityAndOwnsLifecycleV
 		t.Fatal("mismatched local node endpoint succeeded")
 	}
 	opts.NodeEndpoints["group-a"]["node-a"] = localAlias
+	opts.NodeEndpoints["group-a"]["node-b"] = fmt.Sprintf("127.0.0.2:%d", listener.Addr().(*net.TCPAddr).Port)
+	opts.NodeEndpoints["group-a"]["node-c"] = fmt.Sprintf("127.0.0.3:%d", listener.Addr().(*net.TCPAddr).Port)
 	opts.CoordinatorLimits.MaxConcurrentRequests = 1
 	opts.CoordinatorLimits.MaxRequests = 2
 	topology, err := NewVectorPartitionProductionTopologyV1(opts)
@@ -223,6 +225,9 @@ func TestVectorPartitionProductionTopologyRequiresLiveAuthorityAndOwnsLifecycleV
 	status := topology.Status()
 	if !status.Ready || status.Closed || len(status.ShardGroups) != 1 {
 		t.Fatalf("unexpected status: %+v", status)
+	}
+	if endpoint, ok := topology.dispatcher.endpoint("group-a", "node-b"); !ok || endpoint != opts.NodeEndpoints["group-a"]["node-b"] {
+		t.Fatalf("remote member endpoint=%q ok=%t", endpoint, ok)
 	}
 	first, err := net.Dial("tcp4", localAlias)
 	if err != nil {

--- a/TreeDB/nativewire/vector_partition_production_topology_v1_test.go
+++ b/TreeDB/nativewire/vector_partition_production_topology_v1_test.go
@@ -120,6 +120,11 @@ type temporaryWildcardTCPListenerV1 struct {
 	injected atomic.Bool
 }
 
+type nonTCPAddrV1 string
+
+func (a nonTCPAddrV1) Network() string { return "unix" }
+func (a nonTCPAddrV1) String() string  { return string(a) }
+
 func (l *temporaryWildcardTCPListenerV1) Accept() (net.Conn, error) {
 	if !l.injected.Swap(true) {
 		return nil, temporaryAcceptErrorV1{}
@@ -304,6 +309,16 @@ func TestVectorPartitionProductionTopologyRejectsSharedShardListenerV1(t *testin
 }
 
 func TestVectorPartitionProductionEndpointMatchesListenerAddressFamilyV1(t *testing.T) {
+	tcpListener, err := net.Listen("tcp4", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer tcpListener.Close()
+	endpoint := tcpListener.Addr().String()
+	if vectorPartitionProductionEndpointMatchesListenerV1(endpoint, &temporaryWildcardTCPListenerV1{Listener: tcpListener, addr: nonTCPAddrV1(endpoint)}) {
+		t.Fatal("non-TCP listener matched TCP endpoint")
+	}
+
 	listener, err := net.Listen("tcp6", "[::]:0")
 	if err != nil {
 		t.Skipf("IPv6 unavailable: %v", err)

--- a/TreeDB/nativewire/vector_partition_production_topology_v1_test.go
+++ b/TreeDB/nativewire/vector_partition_production_topology_v1_test.go
@@ -338,6 +338,13 @@ func TestVectorPartitionProductionEndpointMatchesListenerAddressFamilyV1(t *test
 	if vectorPartitionProductionEndpointMatchesListenerV1(endpoint, &temporaryWildcardTCPListenerV1{Listener: tcpListener, addr: nonTCPAddrV1(endpoint)}) {
 		t.Fatal("non-TCP listener matched TCP endpoint")
 	}
+	scoped := &temporaryWildcardTCPListenerV1{Listener: tcpListener, addr: &net.TCPAddr{IP: net.ParseIP("fe80::1"), Port: 1, Zone: "eth0"}}
+	if !vectorPartitionProductionEndpointAddressMatchesListenerV1(&net.TCPAddr{IP: net.ParseIP("fe80::1"), Port: 1, Zone: "eth0"}, scoped) {
+		t.Fatal("matching scoped IPv6 endpoint was rejected")
+	}
+	if vectorPartitionProductionEndpointAddressMatchesListenerV1(&net.TCPAddr{IP: net.ParseIP("fe80::1"), Port: 1, Zone: "lo"}, scoped) {
+		t.Fatal("mismatched scoped IPv6 zone was accepted")
+	}
 	wildcard, err := net.Listen("tcp4", "0.0.0.0:0")
 	if err != nil {
 		t.Fatal(err)

--- a/TreeDB/nativewire/vector_partition_production_topology_v1_test.go
+++ b/TreeDB/nativewire/vector_partition_production_topology_v1_test.go
@@ -214,8 +214,13 @@ func TestVectorPartitionProductionTopologyRequiresLiveAuthorityAndOwnsLifecycleV
 		t.Fatal("mismatched local node endpoint succeeded")
 	}
 	opts.NodeEndpoints["group-a"]["node-a"] = localAlias
-	opts.NodeEndpoints["group-a"]["node-b"] = fmt.Sprintf("127.0.0.2:%d", listener.Addr().(*net.TCPAddr).Port)
-	opts.NodeEndpoints["group-a"]["node-c"] = fmt.Sprintf("127.0.0.3:%d", listener.Addr().(*net.TCPAddr).Port)
+	port := listener.Addr().(*net.TCPAddr).Port
+	opts.NodeEndpoints["group-a"]["node-b"] = fmt.Sprintf("127.0.0.2:%d", port)
+	if _, err := NewVectorPartitionProductionTopologyV1(opts); err == nil {
+		t.Fatal("remote shard member used a wildcard listener alias")
+	}
+	opts.NodeEndpoints["group-a"]["node-b"] = fmt.Sprintf("192.0.2.2:%d", port)
+	opts.NodeEndpoints["group-a"]["node-c"] = fmt.Sprintf("192.0.2.3:%d", port)
 	opts.CoordinatorLimits.MaxConcurrentRequests = 1
 	opts.CoordinatorLimits.MaxRequests = 2
 	topology, err := NewVectorPartitionProductionTopologyV1(opts)

--- a/TreeDB/nativewire/vector_partition_production_topology_v1_test.go
+++ b/TreeDB/nativewire/vector_partition_production_topology_v1_test.go
@@ -221,6 +221,16 @@ func TestVectorPartitionProductionTopologyRequiresLiveAuthorityAndOwnsLifecycleV
 	}
 	opts.NodeEndpoints["group-a"]["node-b"] = fmt.Sprintf("192.0.2.2:%d", port)
 	opts.NodeEndpoints["group-a"]["node-c"] = fmt.Sprintf("192.0.2.3:%d", port)
+	opts.Endpoints["group-a"] = fmt.Sprintf("192.0.2.4:%d", port)
+	if _, err := NewVectorPartitionProductionTopologyV1(opts); err == nil {
+		t.Fatal("wildcard listener accepted a non-local owner endpoint")
+	}
+	opts.Endpoints["group-a"] = localAlias
+	opts.NodeEndpoints["group-a"]["node-a"] = fmt.Sprintf("192.0.2.4:%d", port)
+	if _, err := NewVectorPartitionProductionTopologyV1(opts); err == nil {
+		t.Fatal("wildcard listener accepted a non-local local-node endpoint")
+	}
+	opts.NodeEndpoints["group-a"]["node-a"] = localAlias
 	opts.CoordinatorLimits.MaxConcurrentRequests = 1
 	opts.CoordinatorLimits.MaxRequests = 2
 	topology, err := NewVectorPartitionProductionTopologyV1(opts)

--- a/TreeDB/nativewire/vector_partition_production_topology_v1_test.go
+++ b/TreeDB/nativewire/vector_partition_production_topology_v1_test.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/snissn/gomap/TreeDB/collections"
 	"github.com/snissn/gomap/TreeDB/internal/raftcluster"
@@ -45,7 +46,7 @@ func TestVectorPartitionProductionTopologyRollsBackPartialStartAndRestartsV1(t *
 	if err != nil {
 		t.Fatal(err)
 	}
-	service := &VectorPartitionShardSearchServiceV1{localGroup: "group-a", localNodeID: "node-a", route: vectorPartitionShardSearchRouteV1{placement: placement}}
+	service := &VectorPartitionShardSearchServiceV1{localGroup: "group-a", localNodeID: "node-a", limits: DefaultVectorPartitionShardSearchLimitsV1(), route: vectorPartitionShardSearchRouteV1{placement: placement}}
 	opts := VectorPartitionProductionTopologyOptionsV1{Catalog: catalog, Placement: placement, RouterSource: &testVectorPartitionCoordinatorRouterSourceV1{}, ReplicatedLifecycle: &recordingVectorPartitionReplicatedLifecycleAuthorityV1{}, Endpoints: map[raftcluster.GroupID]string{"group-a": listener.Addr().String()}, Shards: []VectorPartitionProductionShardV1{{GroupID: "group-a", Listener: listener, Service: service}, {GroupID: "group-a", Listener: listener, Service: service}}}
 	if _, err := NewVectorPartitionProductionTopologyV1(opts); err == nil {
 		t.Fatal("partial start unexpectedly succeeded")
@@ -167,6 +168,17 @@ func TestVectorPartitionProductionTopologyRequiresLiveAuthorityAndOwnsLifecycleV
 		t.Fatal("mismatched shard service succeeded")
 	}
 	opts.Shards[0].Service = validService
+	strictLimits := DefaultVectorPartitionShardSearchLimitsV1()
+	strictLimits.MaxPartitions = 1
+	strictService, err := NewVectorPartitionShardSearchServiceV1(VectorPartitionShardSearchServiceOptionsV1{Catalog: catalog, Placement: placement, LocalNodeID: "node-a", LocalGroupID: "group-a", ReadCoordinator: &fakeVectorPartitionReadCoordinatorV1{}, GenerationSource: &fakeVectorPartitionGenerationSourceV1{}, Limits: strictLimits})
+	if err != nil {
+		t.Fatal(err)
+	}
+	opts.Shards[0].Service = strictService
+	if _, err := NewVectorPartitionProductionTopologyV1(opts); err == nil {
+		t.Fatal("mismatched shard limits succeeded")
+	}
+	opts.Shards[0].Service = validService
 	if _, err := NewVectorPartitionProductionTopologyV1(opts); err == nil {
 		t.Fatal("local shard succeeded without remote member endpoints")
 	}
@@ -185,6 +197,7 @@ func TestVectorPartitionProductionTopologyRequiresLiveAuthorityAndOwnsLifecycleV
 		t.Fatal("mismatched local node endpoint succeeded")
 	}
 	opts.NodeEndpoints["group-a"]["node-a"] = listener.Addr().String()
+	opts.CoordinatorLimits.MaxConcurrentRequests = 1
 	topology, err := NewVectorPartitionProductionTopologyV1(opts)
 	if err != nil {
 		t.Fatal(err)
@@ -192,6 +205,37 @@ func TestVectorPartitionProductionTopologyRequiresLiveAuthorityAndOwnsLifecycleV
 	status := topology.Status()
 	if !status.Ready || status.Closed || len(status.ShardGroups) != 1 {
 		t.Fatalf("unexpected status: %+v", status)
+	}
+	first, err := net.Dial("tcp4", localAlias)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer first.Close()
+	deadline := time.Now().Add(time.Second)
+	for {
+		topology.mu.Lock()
+		connections := len(topology.conns)
+		topology.mu.Unlock()
+		if connections == 1 {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("first shard connection was not admitted")
+		}
+		time.Sleep(time.Millisecond)
+	}
+	second, err := net.Dial("tcp4", localAlias)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer second.Close()
+	if err := second.SetReadDeadline(time.Now().Add(time.Second)); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := second.Read(make([]byte, 1)); err == nil {
+		t.Fatal("excess shard connection remained open")
+	} else if netErr, ok := err.(net.Error); ok && netErr.Timeout() {
+		t.Fatal("excess shard connection was not rejected")
 	}
 	if err := topology.Close(); err != nil {
 		t.Fatal(err)
@@ -217,11 +261,26 @@ func TestVectorPartitionProductionTopologyRejectsSharedShardListenerV1(t *testin
 	}
 	endpoint := listener.Addr().String()
 	service := func(group raftcluster.GroupID, node raftcluster.NodeID) *VectorPartitionShardSearchServiceV1 {
-		return &VectorPartitionShardSearchServiceV1{localGroup: group, localNodeID: node, route: vectorPartitionShardSearchRouteV1{placement: placement}}
+		return &VectorPartitionShardSearchServiceV1{localGroup: group, localNodeID: node, limits: DefaultVectorPartitionShardSearchLimitsV1(), route: vectorPartitionShardSearchRouteV1{placement: placement}}
 	}
 	_, err = NewVectorPartitionProductionTopologyV1(VectorPartitionProductionTopologyOptionsV1{Catalog: catalog, Placement: placement, RouterSource: &testVectorPartitionCoordinatorRouterSourceV1{}, ReplicatedLifecycle: &recordingVectorPartitionReplicatedLifecycleAuthorityV1{}, Endpoints: map[raftcluster.GroupID]string{"group-a": endpoint, "group-b": endpoint}, Shards: []VectorPartitionProductionShardV1{{GroupID: "group-a", Listener: listener, Service: service("group-a", "node-a")}, {GroupID: "group-b", Listener: listener, Service: service("group-b", "node-b")}}})
 	if err == nil {
 		t.Fatal("shared shard listener succeeded")
+	}
+}
+
+func TestVectorPartitionProductionEndpointMatchesListenerAddressFamilyV1(t *testing.T) {
+	listener, err := net.Listen("tcp6", "[::]:0")
+	if err != nil {
+		t.Skipf("IPv6 unavailable: %v", err)
+	}
+	defer listener.Close()
+	port := listener.Addr().(*net.TCPAddr).Port
+	if vectorPartitionProductionEndpointMatchesListenerV1(fmt.Sprintf("127.0.0.1:%d", port), listener) {
+		t.Fatal("IPv6 listener matched IPv4 endpoint")
+	}
+	if !vectorPartitionProductionEndpointMatchesListenerV1(fmt.Sprintf("[::1]:%d", port), listener) {
+		t.Fatal("IPv6 listener rejected IPv6 endpoint")
 	}
 }
 

--- a/TreeDB/nativewire/vector_partition_production_topology_v1_test.go
+++ b/TreeDB/nativewire/vector_partition_production_topology_v1_test.go
@@ -167,6 +167,11 @@ func TestVectorPartitionProductionTopologyRequiresLiveAuthorityAndOwnsLifecycleV
 		t.Fatal("mismatched shard service succeeded")
 	}
 	opts.Shards[0].Service = validService
+	opts.NodeEndpoints = map[raftcluster.GroupID]map[raftcluster.NodeID]string{"group-a": {"node-a": "127.0.0.1:1"}}
+	if _, err := NewVectorPartitionProductionTopologyV1(opts); err == nil {
+		t.Fatal("mismatched local node endpoint succeeded")
+	}
+	opts.NodeEndpoints["group-a"]["node-a"] = listener.Addr().String()
 	topology, err := NewVectorPartitionProductionTopologyV1(opts)
 	if err != nil {
 		t.Fatal(err)
@@ -183,6 +188,27 @@ func TestVectorPartitionProductionTopologyRequiresLiveAuthorityAndOwnsLifecycleV
 	}
 	if _, err := topology.Coordinator().Search(context.Background(), VectorPartitionCoordinatorRequestV1{}); err == nil {
 		t.Fatal("closed coordinator accepted request")
+	}
+}
+
+func TestVectorPartitionProductionTopologyRejectsSharedShardListenerV1(t *testing.T) {
+	ref := raftplacement.CollectionRefV1{Database: "db", Catalog: "catalog", Collection: "docs"}
+	catalog, err := raftplacement.Validate(raftplacement.CatalogV1{Groups: []raftplacement.GroupV1{{ID: "group-a", Members: []raftcluster.NodeID{"node-a"}}, {ID: "group-b", Members: []raftcluster.NodeID{"node-b"}}}, Placements: []raftplacement.CollectionPlacementV1{{Collection: ref, GroupID: "group-a", Mode: raftplacement.PlacementModeCollectionV1}}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	placement := raftplacement.VectorPartitionPlacementRecordV1{Collection: ref, IndexName: "embedding", IndexDefinitionDigest: fmt.Sprintf("%064x", 1), SourceGeneration: 1, SourceChecksum: 2, SourceSchemaHash: 3, SourceRowCount: 4, PartitionGeneration: 5, PartitionCount: 2, Partitions: []raftplacement.VectorPartitionGroupV1{{PartitionID: 0, GroupID: "group-a"}, {PartitionID: 1, GroupID: "group-b"}}}
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	endpoint := listener.Addr().String()
+	service := func(group raftcluster.GroupID, node raftcluster.NodeID) *VectorPartitionShardSearchServiceV1 {
+		return &VectorPartitionShardSearchServiceV1{localGroup: group, localNodeID: node, route: vectorPartitionShardSearchRouteV1{placement: placement}}
+	}
+	_, err = NewVectorPartitionProductionTopologyV1(VectorPartitionProductionTopologyOptionsV1{Catalog: catalog, Placement: placement, RouterSource: &testVectorPartitionCoordinatorRouterSourceV1{}, ReplicatedLifecycle: &recordingVectorPartitionReplicatedLifecycleAuthorityV1{}, Endpoints: map[raftcluster.GroupID]string{"group-a": endpoint, "group-b": endpoint}, Shards: []VectorPartitionProductionShardV1{{GroupID: "group-a", Listener: listener, Service: service("group-a", "node-a")}, {GroupID: "group-b", Listener: listener, Service: service("group-b", "node-b")}}})
+	if err == nil {
+		t.Fatal("shared shard listener succeeded")
 	}
 }
 

--- a/TreeDB/nativewire/vector_partition_production_topology_v1_test.go
+++ b/TreeDB/nativewire/vector_partition_production_topology_v1_test.go
@@ -316,6 +316,37 @@ func TestVectorPartitionProductionEndpointMatchesListenerAddressFamilyV1(t *test
 	if !vectorPartitionProductionEndpointMatchesListenerV1(fmt.Sprintf("[::1]:%d", port), listener) {
 		t.Fatal("IPv6 listener rejected IPv6 endpoint")
 	}
+	dualStack, err := net.Listen("tcp", ":0")
+	if err != nil {
+		t.Skipf("dual-stack listener unavailable: %v", err)
+	}
+	defer dualStack.Close()
+	bound := dualStack.Addr().(*net.TCPAddr)
+	if bound.IP.To4() != nil {
+		t.Skip("platform selected an IPv4 listener")
+	}
+	accepted := make(chan error, 1)
+	go func() {
+		conn, acceptErr := dualStack.Accept()
+		if acceptErr == nil {
+			acceptErr = conn.Close()
+		}
+		accepted <- acceptErr
+	}()
+	ipv4Endpoint := fmt.Sprintf("127.0.0.1:%d", bound.Port)
+	conn, err := net.DialTimeout("tcp4", ipv4Endpoint, time.Second)
+	if err != nil {
+		_ = dualStack.Close()
+		<-accepted
+		t.Skipf("dual-stack IPv4 unavailable: %v", err)
+	}
+	_ = conn.Close()
+	if err := <-accepted; err != nil {
+		t.Fatal(err)
+	}
+	if !vectorPartitionProductionEndpointMatchesListenerV1(ipv4Endpoint, dualStack) {
+		t.Fatal("dual-stack listener rejected reachable IPv4 endpoint")
+	}
 }
 
 func TestVectorPartitionProductionTopologyAllowsCoordinatorOnlyAndRejectsIncompleteOwnersV1(t *testing.T) {

--- a/TreeDB/nativewire/vector_partition_production_topology_v1_test.go
+++ b/TreeDB/nativewire/vector_partition_production_topology_v1_test.go
@@ -136,7 +136,7 @@ func (temporaryAcceptErrorV1) Temporary() bool { return true }
 
 func TestVectorPartitionProductionTopologyRequiresLiveAuthorityAndOwnsLifecycleV1(t *testing.T) {
 	ref := raftplacement.CollectionRefV1{Database: "db", Catalog: "catalog", Collection: "docs"}
-	catalog, err := raftplacement.Validate(raftplacement.CatalogV1{Groups: []raftplacement.GroupV1{{ID: "group-a", Members: []raftcluster.NodeID{"node-a", "node-b"}, LeaderHint: "node-b"}}, Placements: []raftplacement.CollectionPlacementV1{{Collection: ref, GroupID: "group-a", Mode: raftplacement.PlacementModeCollectionV1}}})
+	catalog, err := raftplacement.Validate(raftplacement.CatalogV1{Groups: []raftplacement.GroupV1{{ID: "group-a", Members: []raftcluster.NodeID{"node-a", "node-b", "node-c"}, LeaderHint: "node-b"}}, Placements: []raftplacement.CollectionPlacementV1{{Collection: ref, GroupID: "group-a", Mode: raftplacement.PlacementModeCollectionV1}}})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -170,11 +170,16 @@ func TestVectorPartitionProductionTopologyRequiresLiveAuthorityAndOwnsLifecycleV
 	if _, err := NewVectorPartitionProductionTopologyV1(opts); err == nil {
 		t.Fatal("local shard succeeded without remote member endpoints")
 	}
-	opts.NodeEndpoints = map[raftcluster.GroupID]map[raftcluster.NodeID]string{"group-a": {"node-a": "127.0.0.1:1", "node-b": "127.0.0.1:1"}}
+	opts.NodeEndpoints = map[raftcluster.GroupID]map[raftcluster.NodeID]string{"group-a": {"node-b": listener.Addr().String(), "node-c": "127.0.0.1:2"}}
+	if _, err := NewVectorPartitionProductionTopologyV1(opts); err == nil {
+		t.Fatal("remote shard member used local fallback")
+	}
+	opts.NodeEndpoints["group-a"]["node-b"] = "127.0.0.1:2"
 	if _, err := NewVectorPartitionProductionTopologyV1(opts); err == nil {
 		t.Fatal("distinct shard members shared an endpoint")
 	}
-	opts.NodeEndpoints["group-a"]["node-b"] = "127.0.0.1:2"
+	opts.NodeEndpoints["group-a"]["node-c"] = "127.0.0.1:3"
+	opts.NodeEndpoints["group-a"]["node-a"] = "127.0.0.1:1"
 	if _, err := NewVectorPartitionProductionTopologyV1(opts); err == nil {
 		t.Fatal("mismatched local node endpoint succeeded")
 	}
@@ -230,6 +235,10 @@ func TestVectorPartitionProductionTopologyAllowsCoordinatorOnlyAndRejectsIncompl
 	opts := VectorPartitionProductionTopologyOptionsV1{Catalog: catalog, Placement: placement, RouterSource: &testVectorPartitionCoordinatorRouterSourceV1{router: router}, ReplicatedLifecycle: &recordingVectorPartitionReplicatedLifecycleAuthorityV1{}, Endpoints: map[raftcluster.GroupID]string{"group-a": "127.0.0.1:1"}}
 	if _, err := NewVectorPartitionProductionTopologyV1(opts); err == nil {
 		t.Fatal("incomplete owner endpoint coverage succeeded")
+	}
+	opts.Endpoints["group-b"] = "missing-port"
+	if _, err := NewVectorPartitionProductionTopologyV1(opts); err == nil {
+		t.Fatal("malformed owner endpoint succeeded")
 	}
 	opts.Endpoints["group-b"] = "127.0.0.1:2"
 	opts.NodeEndpoints = map[raftcluster.GroupID]map[raftcluster.NodeID]string{"group-a": {"node-z": "127.0.0.1:3"}}

--- a/TreeDB/nativewire/vector_partition_production_topology_v1_test.go
+++ b/TreeDB/nativewire/vector_partition_production_topology_v1_test.go
@@ -328,6 +328,32 @@ func TestVectorPartitionProductionEndpointMatchesListenerAddressFamilyV1(t *test
 	if vectorPartitionProductionEndpointMatchesListenerV1(endpoint, &temporaryWildcardTCPListenerV1{Listener: tcpListener, addr: nonTCPAddrV1(endpoint)}) {
 		t.Fatal("non-TCP listener matched TCP endpoint")
 	}
+	wildcard, err := net.Listen("tcp4", "0.0.0.0:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer wildcard.Close()
+	wildcardEndpoint := fmt.Sprintf("localhost:%d", wildcard.Addr().(*net.TCPAddr).Port)
+	addresses, err := vectorPartitionProductionEndpointAddressesV1(wildcardEndpoint)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want, err := net.DefaultResolver.LookupIPAddr(context.Background(), "localhost")
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := make(map[string]bool, len(addresses))
+	for _, address := range addresses {
+		got[address.IP.String()] = true
+	}
+	for _, address := range want {
+		if !address.IP.IsUnspecified() && !got[address.IP.String()] {
+			t.Fatalf("resolved endpoint omitted localhost address %s: %+v", address.IP, addresses)
+		}
+	}
+	if uses, err := vectorPartitionProductionEndpointUsesListenerV1(wildcardEndpoint, wildcard); err != nil || !uses {
+		t.Fatalf("wildcard listener hostname match=%t error=%v addresses=%+v", uses, err, addresses)
+	}
 
 	listener, err := net.Listen("tcp6", "[::]:0")
 	if err != nil {

--- a/TreeDB/nativewire/vector_partition_shard_search_tcp_v1.go
+++ b/TreeDB/nativewire/vector_partition_shard_search_tcp_v1.go
@@ -20,7 +20,11 @@ import (
 	"github.com/snissn/gomap/TreeDB/internal/raftcluster"
 )
 
-const vectorPartitionShardSearchTCPMaxFrameBytesV1 uint32 = 64 << 20
+const (
+	vectorPartitionShardSearchTCPMaxFrameBytesV1      uint32 = 64 << 20
+	vectorPartitionShardSearchTCPMinFrameBytesV1      uint64 = 4 << 10
+	vectorPartitionShardSearchTCPJSONExpansionBoundV1 uint64 = 6
+)
 
 // VectorPartitionShardSearchTCPDispatcherV1 is a bounded, length-framed TCP
 // dispatcher for distinct M5 service endpoints.  It is intentionally not an
@@ -30,7 +34,8 @@ type VectorPartitionShardSearchTCPDispatcherV1 struct {
 	endpoints                 map[raftcluster.GroupID]string
 	nodeEndpoints             map[raftcluster.GroupID]map[raftcluster.NodeID]string
 	dial                      func(context.Context, string, string) (net.Conn, error)
-	maxFrame                  uint32
+	maxRequestFrame           uint32
+	maxResponseFrame          uint32
 	maxConnectionsPerEndpoint int
 	mu                        sync.Mutex
 	pools                     map[string]*vectorPartitionShardSearchTCPEndpointPoolV1
@@ -61,15 +66,27 @@ func NewVectorPartitionShardSearchTCPDispatcherV1(endpoints map[raftcluster.Grou
 // routes a coordinator retry to the leader-hinted node when that endpoint is
 // known. Group endpoints remain the safe fallback for one service per group.
 func NewVectorPartitionShardSearchTCPDispatcherWithNodeEndpointsV1(endpoints map[raftcluster.GroupID]string, nodeEndpoints map[raftcluster.GroupID]map[raftcluster.NodeID]string) (*VectorPartitionShardSearchTCPDispatcherV1, error) {
-	return newVectorPartitionShardSearchTCPDispatcherV1(endpoints, nodeEndpoints, DefaultVectorPartitionCoordinatorLimitsV1().MaxConcurrentRequests)
+	return newVectorPartitionShardSearchTCPDispatcherV1(endpoints, nodeEndpoints, DefaultVectorPartitionCoordinatorLimitsV1().MaxConcurrentRequests, DefaultVectorPartitionShardSearchLimitsV1())
 }
 
-func newVectorPartitionShardSearchTCPDispatcherV1(endpoints map[raftcluster.GroupID]string, nodeEndpoints map[raftcluster.GroupID]map[raftcluster.NodeID]string, maxConnectionsPerEndpoint int) (*VectorPartitionShardSearchTCPDispatcherV1, error) {
+func newVectorPartitionShardSearchTCPDispatcherV1(endpoints map[raftcluster.GroupID]string, nodeEndpoints map[raftcluster.GroupID]map[raftcluster.NodeID]string, maxConnectionsPerEndpoint int, limits VectorPartitionShardSearchLimitsV1) (*VectorPartitionShardSearchTCPDispatcherV1, error) {
 	if len(endpoints) == 0 {
 		return nil, errors.New("nativewire: M5 TCP dispatcher requires endpoints")
 	}
 	if maxConnectionsPerEndpoint < 1 {
 		return nil, errors.New("nativewire: M5 TCP dispatcher requires a positive per-endpoint connection limit")
+	}
+	limits, err := normalizeVectorPartitionShardSearchLimitsV1(limits)
+	if err != nil {
+		return nil, err
+	}
+	maxRequestFrame, err := vectorPartitionShardSearchTCPFrameBoundV1(limits.MaxRequestBytes)
+	if err != nil {
+		return nil, err
+	}
+	maxResponseFrame, err := vectorPartitionShardSearchTCPFrameBoundV1(limits.MaxResponseBytes)
+	if err != nil {
+		return nil, err
 	}
 	copyEndpoints := make(map[raftcluster.GroupID]string, len(endpoints))
 	for group, endpoint := range endpoints {
@@ -97,14 +114,15 @@ func newVectorPartitionShardSearchTCPDispatcherV1(endpoints map[raftcluster.Grou
 		endpoints:                 copyEndpoints,
 		nodeEndpoints:             copyNodeEndpoints,
 		dial:                      dialer.DialContext,
-		maxFrame:                  vectorPartitionShardSearchTCPMaxFrameBytesV1,
+		maxRequestFrame:           maxRequestFrame,
+		maxResponseFrame:          maxResponseFrame,
 		maxConnectionsPerEndpoint: maxConnectionsPerEndpoint,
 		pools:                     make(map[string]*vectorPartitionShardSearchTCPEndpointPoolV1),
 	}, nil
 }
 
 func (d *VectorPartitionShardSearchTCPDispatcherV1) DispatchVectorPartitionShardSearchV1(ctx context.Context, request VectorPartitionShardSearchRequestV1) (VectorPartitionShardSearchResponseV1, error) {
-	if d == nil || d.dial == nil || d.maxFrame == 0 {
+	if d == nil || d.dial == nil || d.maxRequestFrame == 0 || d.maxResponseFrame == 0 {
 		return VectorPartitionShardSearchResponseV1{}, errors.New("nativewire: M5 TCP dispatcher is not configured")
 	}
 	for attempt := 0; ; attempt++ {
@@ -141,10 +159,10 @@ func (d *VectorPartitionShardSearchTCPDispatcherV1) dispatchVectorPartitionShard
 		return VectorPartitionShardSearchResponseV1{}, vectorPartitionShardSearchTCPRetryableTransportErrorV1(requestCtx, request.TargetGroupID, err)
 	}
 	frame := vectorPartitionShardSearchTCPFrameV1{Request: &request}
-	if err := writeVectorPartitionShardSearchTCPFrameV1(conn, frame, d.maxFrame); err != nil {
+	if err := writeVectorPartitionShardSearchTCPFrameV1(conn, frame, d.maxRequestFrame); err != nil {
 		return VectorPartitionShardSearchResponseV1{}, vectorPartitionShardSearchTCPRetryableTransportErrorV1(requestCtx, request.TargetGroupID, err)
 	}
-	frame, err = readVectorPartitionShardSearchTCPFrameV1(conn, d.maxFrame)
+	frame, err = readVectorPartitionShardSearchTCPFrameV1(conn, d.maxResponseFrame)
 	if err != nil {
 		if request.DeadlineUnixNano != 0 && !time.Now().Before(time.Unix(0, request.DeadlineUnixNano)) {
 			return VectorPartitionShardSearchResponseV1{}, &VectorPartitionShardSearchErrorV1{Code: VectorPartitionShardSearchErrorDeadlineV1, GroupID: request.TargetGroupID, Err: context.DeadlineExceeded}
@@ -310,9 +328,10 @@ func vectorPartitionShardSearchTCPReconnectableV1(err error) bool {
 // VectorPartitionShardSearchTCPServerV1 serves one M5 service over the same
 // bounded framing contract used by the dispatcher.
 type VectorPartitionShardSearchTCPServerV1 struct {
-	Service        VectorPartitionShardSearchHandlerV1
-	MaxFrame       uint32
-	InitialTimeout time.Duration
+	Service          VectorPartitionShardSearchHandlerV1
+	MaxFrame         uint32
+	MaxResponseFrame uint32
+	InitialTimeout   time.Duration
 }
 
 // VectorPartitionShardSearchHandlerV1 is the narrow server dependency needed
@@ -326,6 +345,10 @@ func (s VectorPartitionShardSearchTCPServerV1) ServeConn(ctx context.Context, co
 	maxFrame := s.MaxFrame
 	if maxFrame == 0 {
 		maxFrame = vectorPartitionShardSearchTCPMaxFrameBytesV1
+	}
+	maxResponseFrame := s.MaxResponseFrame
+	if maxResponseFrame == 0 {
+		maxResponseFrame = maxFrame
 	}
 	initialTimeout := s.InitialTimeout
 	if initialTimeout < 0 {
@@ -345,11 +368,11 @@ func (s VectorPartitionShardSearchTCPServerV1) ServeConn(ctx context.Context, co
 			// A peer that sends no frame (or never reads) must not strand this server
 			// goroutine while we try to report the bounded framing failure.
 			_ = conn.SetWriteDeadline(time.Now().Add(initialTimeout))
-			_ = writeVectorPartitionShardSearchTCPFrameV1(conn, vectorPartitionShardSearchTCPFrameV1{Error: &vectorPartitionShardSearchTCPErrorV1{Code: VectorPartitionShardSearchErrorInvalidRequestV1, Message: "invalid M5 TCP request"}}, maxFrame)
+			_ = writeVectorPartitionShardSearchTCPFrameV1(conn, vectorPartitionShardSearchTCPFrameV1{Error: &vectorPartitionShardSearchTCPErrorV1{Code: VectorPartitionShardSearchErrorInvalidRequestV1, Message: "invalid M5 TCP request"}}, maxResponseFrame)
 			return
 		}
 		if s.Service == nil {
-			s.writeFrame(conn, vectorPartitionShardSearchTCPFrameV1{Error: &vectorPartitionShardSearchTCPErrorV1{Code: VectorPartitionShardSearchErrorGroupUnavailableV1, GroupID: frame.Request.TargetGroupID, Message: "M5 service is unavailable"}}, maxFrame, time.Now().Add(initialTimeout))
+			_ = s.writeFrame(conn, vectorPartitionShardSearchTCPFrameV1{Error: &vectorPartitionShardSearchTCPErrorV1{Code: VectorPartitionShardSearchErrorGroupUnavailableV1, GroupID: frame.Request.TargetGroupID, Message: "M5 service is unavailable"}}, maxResponseFrame, time.Now().Add(initialTimeout))
 			return
 		}
 		requestCtx, cancel := vectorPartitionShardSearchTCPRequestContextV1(ctx, frame.Request.DeadlineUnixNano)
@@ -365,16 +388,20 @@ func (s VectorPartitionShardSearchTCPServerV1) ServeConn(ctx context.Context, co
 			writeDeadline = deadline
 		}
 		if err != nil {
-			s.writeFrame(conn, vectorPartitionShardSearchTCPFrameV1{Error: vectorPartitionShardSearchTCPErrorFromErrorV1(err)}, maxFrame, writeDeadline)
+			if s.writeFrame(conn, vectorPartitionShardSearchTCPFrameV1{Error: vectorPartitionShardSearchTCPErrorFromErrorV1(err)}, maxResponseFrame, writeDeadline) != nil {
+				return
+			}
 			continue
 		}
-		s.writeFrame(conn, vectorPartitionShardSearchTCPFrameV1{Response: &response}, maxFrame, writeDeadline)
+		if s.writeFrame(conn, vectorPartitionShardSearchTCPFrameV1{Response: &response}, maxResponseFrame, writeDeadline) != nil {
+			return
+		}
 	}
 }
 
-func (s VectorPartitionShardSearchTCPServerV1) writeFrame(conn net.Conn, frame vectorPartitionShardSearchTCPFrameV1, maxFrame uint32, deadline time.Time) {
+func (s VectorPartitionShardSearchTCPServerV1) writeFrame(conn net.Conn, frame vectorPartitionShardSearchTCPFrameV1, maxFrame uint32, deadline time.Time) error {
 	_ = conn.SetWriteDeadline(deadline)
-	_ = writeVectorPartitionShardSearchTCPFrameV1(conn, frame, maxFrame)
+	return writeVectorPartitionShardSearchTCPFrameV1(conn, frame, maxFrame)
 }
 
 type vectorPartitionShardSearchTCPFrameV1 struct {
@@ -458,6 +485,17 @@ func readVectorPartitionShardSearchTCPFrameV1(r io.Reader, max uint32) (vectorPa
 		return vectorPartitionShardSearchTCPFrameV1{}, errors.New("M5 TCP frame has trailing JSON values")
 	}
 	return frame, nil
+}
+
+func vectorPartitionShardSearchTCPFrameBoundV1(logicalBytes uint64) (uint32, error) {
+	// encoding/json can expand one input byte to a six-byte Unicode escape;
+	// logical request/response accounting already reserves fixed envelopes.
+	if logicalBytes == 0 || logicalBytes > uint64(^uint32(0))/vectorPartitionShardSearchTCPJSONExpansionBoundV1 {
+		return 0, errors.New("nativewire: M5 TCP logical byte limit exceeds the frame bound")
+	}
+	frameBytes := logicalBytes * vectorPartitionShardSearchTCPJSONExpansionBoundV1
+	frameBytes = max(frameBytes, vectorPartitionShardSearchTCPMinFrameBytesV1)
+	return uint32(frameBytes), nil
 }
 
 func vectorPartitionShardSearchTCPDeadlineV1(ctx context.Context, deadlineUnixNano int64, conn net.Conn) error {

--- a/TreeDB/nativewire/vector_partition_shard_search_tcp_v1.go
+++ b/TreeDB/nativewire/vector_partition_shard_search_tcp_v1.go
@@ -348,7 +348,11 @@ func (s VectorPartitionShardSearchTCPServerV1) ServeConn(ctx context.Context, co
 	}
 	maxResponseFrame := s.MaxResponseFrame
 	if maxResponseFrame == 0 {
-		maxResponseFrame = maxFrame
+		var err error
+		maxResponseFrame, err = vectorPartitionShardSearchTCPFrameBoundV1(DefaultVectorPartitionShardSearchLimitsV1().MaxResponseBytes)
+		if err != nil {
+			return
+		}
 	}
 	initialTimeout := s.InitialTimeout
 	if initialTimeout < 0 {

--- a/TreeDB/nativewire/vector_partition_shard_search_tcp_v1.go
+++ b/TreeDB/nativewire/vector_partition_shard_search_tcp_v1.go
@@ -125,6 +125,9 @@ func (d *VectorPartitionShardSearchTCPDispatcherV1) DispatchVectorPartitionShard
 	if d == nil || d.dial == nil || d.maxRequestFrame == 0 || d.maxResponseFrame == 0 {
 		return VectorPartitionShardSearchResponseV1{}, errors.New("nativewire: M5 TCP dispatcher is not configured")
 	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
 	for attempt := 0; ; attempt++ {
 		response, err := d.dispatchVectorPartitionShardSearchOnceV1(ctx, request)
 		if err == nil || attempt != 0 || ctx.Err() != nil || !vectorPartitionShardSearchTCPReconnectableV1(err) {

--- a/TreeDB/nativewire/vector_partition_shard_search_tcp_v1.go
+++ b/TreeDB/nativewire/vector_partition_shard_search_tcp_v1.go
@@ -112,6 +112,7 @@ func (d *VectorPartitionShardSearchTCPDispatcherV1) DispatchVectorPartitionShard
 		if err == nil || attempt != 0 || ctx.Err() != nil || !vectorPartitionShardSearchTCPReconnectableV1(err) {
 			return response, err
 		}
+		d.discardIdle(request.TargetGroupID, request.TargetNodeID)
 	}
 }
 
@@ -179,15 +180,8 @@ func (d *VectorPartitionShardSearchTCPDispatcherV1) acquire(ctx context.Context,
 	}
 	pool := d.pools[endpoint]
 	if pool == nil {
-		if d.pools == nil {
-			d.pools = make(map[string]*vectorPartitionShardSearchTCPEndpointPoolV1)
-		}
-		maxConnections := d.maxConnectionsPerEndpoint
-		if maxConnections == 0 {
-			maxConnections = DefaultVectorPartitionCoordinatorLimitsV1().MaxConcurrentRequests
-		}
 		pool = &vectorPartitionShardSearchTCPEndpointPoolV1{
-			slots: make(chan struct{}, maxConnections),
+			slots: make(chan struct{}, d.maxConnectionsPerEndpoint),
 			all:   make(map[net.Conn]struct{}),
 		}
 		d.pools[endpoint] = pool
@@ -195,6 +189,19 @@ func (d *VectorPartitionShardSearchTCPDispatcherV1) acquire(ctx context.Context,
 	d.mu.Unlock()
 	conn, err := pool.acquire(ctx, d.dial, endpoint)
 	return pool, conn, err
+}
+
+func (d *VectorPartitionShardSearchTCPDispatcherV1) discardIdle(group raftcluster.GroupID, node raftcluster.NodeID) {
+	endpoint, ok := d.endpoint(group, node)
+	if !ok {
+		return
+	}
+	d.mu.Lock()
+	pool := d.pools[endpoint]
+	d.mu.Unlock()
+	if pool != nil {
+		pool.discardIdle()
+	}
 }
 
 func (p *vectorPartitionShardSearchTCPEndpointPoolV1) acquire(ctx context.Context, dial func(context.Context, string, string) (net.Conn, error), endpoint string) (net.Conn, error) {
@@ -245,6 +252,19 @@ func (p *vectorPartitionShardSearchTCPEndpointPoolV1) release(conn net.Conn, reu
 		_ = conn.Close()
 	}
 	<-p.slots
+}
+
+func (p *vectorPartitionShardSearchTCPEndpointPoolV1) discardIdle() {
+	p.mu.Lock()
+	idle := p.idle
+	p.idle = nil
+	for _, conn := range idle {
+		delete(p.all, conn)
+	}
+	p.mu.Unlock()
+	for _, conn := range idle {
+		_ = conn.Close()
+	}
 }
 func (p *vectorPartitionShardSearchTCPEndpointPoolV1) close() error {
 	p.mu.Lock()
@@ -336,8 +356,11 @@ func (s VectorPartitionShardSearchTCPServerV1) ServeConn(ctx context.Context, co
 		requestCtx, cancel := vectorPartitionShardSearchTCPRequestContextV1(ctx, frame.Request.DeadlineUnixNano)
 		stopPeerMonitor := vectorPartitionShardSearchTCPMonitorPeerDisconnectV1(conn, requestCtx, cancel)
 		response, err := s.Service.Search(requestCtx, *frame.Request)
-		stopPeerMonitor()
+		peerInput := stopPeerMonitor()
 		cancel()
+		if peerInput {
+			return
+		}
 		writeDeadline := time.Now().Add(initialTimeout)
 		if deadline, ok := requestCtx.Deadline(); ok {
 			writeDeadline = deadline
@@ -499,14 +522,15 @@ func vectorPartitionShardSearchTCPRequestContextV1(ctx context.Context, deadline
 // successful response is not delayed by the polling deadline. Read deadlines
 // are cleared when the normal request completes and do not affect the response
 // write deadline.
-func vectorPartitionShardSearchTCPMonitorPeerDisconnectV1(conn net.Conn, ctx context.Context, cancel context.CancelFunc) func() {
+func vectorPartitionShardSearchTCPMonitorPeerDisconnectV1(conn net.Conn, ctx context.Context, cancel context.CancelFunc) func() bool {
 	if conn == nil || cancel == nil {
-		return func() {}
+		return func() bool { return false }
 	}
 	stop := make(chan struct{})
 	done := make(chan struct{})
 	var deadlineMu sync.Mutex
 	var stopOnce sync.Once
+	peerInput := false
 	go func() {
 		defer close(done)
 		var discard [1]byte
@@ -524,6 +548,7 @@ func vectorPartitionShardSearchTCPMonitorPeerDisconnectV1(conn net.Conn, ctx con
 			if err == nil {
 				// Extra input is invalid under the one-request contract. Treat it
 				// as a disconnected/abandoned caller rather than extending work.
+				peerInput = true
 				cancel()
 				return
 			}
@@ -547,7 +572,7 @@ func vectorPartitionShardSearchTCPMonitorPeerDisconnectV1(conn net.Conn, ctx con
 			return
 		}
 	}()
-	return func() {
+	return func() bool {
 		stopOnce.Do(func() {
 			close(stop)
 			deadlineMu.Lock()
@@ -558,6 +583,7 @@ func vectorPartitionShardSearchTCPMonitorPeerDisconnectV1(conn net.Conn, ctx con
 			<-done
 			_ = conn.SetReadDeadline(time.Time{})
 		})
+		return peerInput
 	}
 }
 

--- a/TreeDB/nativewire/vector_partition_shard_search_tcp_v1.go
+++ b/TreeDB/nativewire/vector_partition_shard_search_tcp_v1.go
@@ -27,15 +27,30 @@ const vectorPartitionShardSearchTCPMaxFrameBytesV1 uint32 = 64 << 20
 // in-process registry: every request and response crosses a serialized socket
 // boundary before the coordinator can consume it.
 type VectorPartitionShardSearchTCPDispatcherV1 struct {
-	endpoints map[raftcluster.GroupID]string
-	dial      func(context.Context, string, string) (net.Conn, error)
-	maxFrame  uint32
+	endpoints     map[raftcluster.GroupID]string
+	nodeEndpoints map[raftcluster.GroupID]map[raftcluster.NodeID]string
+	dial          func(context.Context, string, string) (net.Conn, error)
+	maxFrame      uint32
+	mu            sync.Mutex
+	conns         map[string]*vectorPartitionShardSearchTCPPooledConnV1
+}
+
+type vectorPartitionShardSearchTCPPooledConnV1 struct {
+	conn net.Conn
+	mu   sync.Mutex
 }
 
 // NewVectorPartitionShardSearchTCPDispatcherV1 validates and copies one TCP
 // endpoint per group.  Endpoints are normally loopback addresses for the M8 CI
 // topology and may be separate hosts in a deeper deployment.
 func NewVectorPartitionShardSearchTCPDispatcherV1(endpoints map[raftcluster.GroupID]string) (*VectorPartitionShardSearchTCPDispatcherV1, error) {
+	return NewVectorPartitionShardSearchTCPDispatcherWithNodeEndpointsV1(endpoints, nil)
+}
+
+// NewVectorPartitionShardSearchTCPDispatcherWithNodeEndpointsV1 additionally
+// routes a coordinator retry to the leader-hinted node when that endpoint is
+// known. Group endpoints remain the safe fallback for one service per group.
+func NewVectorPartitionShardSearchTCPDispatcherWithNodeEndpointsV1(endpoints map[raftcluster.GroupID]string, nodeEndpoints map[raftcluster.GroupID]map[raftcluster.NodeID]string) (*VectorPartitionShardSearchTCPDispatcherV1, error) {
 	if len(endpoints) == 0 {
 		return nil, errors.New("nativewire: M5 TCP dispatcher requires endpoints")
 	}
@@ -47,10 +62,26 @@ func NewVectorPartitionShardSearchTCPDispatcherV1(endpoints map[raftcluster.Grou
 		copyEndpoints[group] = endpoint
 	}
 	dialer := &net.Dialer{}
+	copyNodeEndpoints := make(map[raftcluster.GroupID]map[raftcluster.NodeID]string, len(nodeEndpoints))
+	for group, nodes := range nodeEndpoints {
+		if _, ok := copyEndpoints[group]; !ok {
+			return nil, errors.New("nativewire: M5 TCP node endpoint owner is unknown")
+		}
+		copyNodes := make(map[raftcluster.NodeID]string, len(nodes))
+		for node, endpoint := range nodes {
+			if node == "" || endpoint == "" {
+				return nil, errors.New("nativewire: M5 TCP node endpoint is incomplete")
+			}
+			copyNodes[node] = endpoint
+		}
+		copyNodeEndpoints[group] = copyNodes
+	}
 	return &VectorPartitionShardSearchTCPDispatcherV1{
-		endpoints: copyEndpoints,
-		dial:      dialer.DialContext,
-		maxFrame:  vectorPartitionShardSearchTCPMaxFrameBytesV1,
+		endpoints:     copyEndpoints,
+		nodeEndpoints: copyNodeEndpoints,
+		dial:          dialer.DialContext,
+		maxFrame:      vectorPartitionShardSearchTCPMaxFrameBytesV1,
+		conns:         make(map[string]*vectorPartitionShardSearchTCPPooledConnV1),
 	}, nil
 }
 
@@ -58,38 +89,102 @@ func (d *VectorPartitionShardSearchTCPDispatcherV1) DispatchVectorPartitionShard
 	if d == nil || d.dial == nil || d.maxFrame == 0 {
 		return VectorPartitionShardSearchResponseV1{}, errors.New("nativewire: M5 TCP dispatcher is not configured")
 	}
-	endpoint, ok := d.endpoints[request.TargetGroupID]
+	endpoint, ok := d.endpoint(request.TargetGroupID, request.TargetNodeID)
 	if !ok {
 		return VectorPartitionShardSearchResponseV1{}, &VectorPartitionShardSearchErrorV1{Code: VectorPartitionShardSearchErrorUnknownOwnerV1, GroupID: request.TargetGroupID, Err: ErrVectorPartitionShardSearchRouteMismatch}
 	}
-	conn, err := d.dial(ctx, "tcp", endpoint)
+	pooled, err := d.acquire(ctx, endpoint)
 	if err != nil {
 		return VectorPartitionShardSearchResponseV1{}, vectorPartitionShardSearchTCPTransportErrorV1(ctx, request.TargetGroupID, err)
 	}
-	defer conn.Close()
+	pooled.mu.Lock()
+	defer pooled.mu.Unlock()
+	conn := pooled.conn
 	stopCancelIO := vectorPartitionShardSearchTCPInterruptOnCancelV1(ctx, conn)
 	defer stopCancelIO()
 	if err := vectorPartitionShardSearchTCPDeadlineV1(ctx, request.DeadlineUnixNano, conn); err != nil {
+		d.discard(endpoint, pooled)
 		return VectorPartitionShardSearchResponseV1{}, vectorPartitionShardSearchTCPTransportErrorV1(ctx, request.TargetGroupID, err)
 	}
 	frame := vectorPartitionShardSearchTCPFrameV1{Request: &request}
 	if err := writeVectorPartitionShardSearchTCPFrameV1(conn, frame, d.maxFrame); err != nil {
+		d.discard(endpoint, pooled)
 		return VectorPartitionShardSearchResponseV1{}, vectorPartitionShardSearchTCPTransportErrorV1(ctx, request.TargetGroupID, err)
 	}
 	frame, err = readVectorPartitionShardSearchTCPFrameV1(conn, d.maxFrame)
 	if err != nil {
+		d.discard(endpoint, pooled)
 		if request.DeadlineUnixNano != 0 && !time.Now().Before(time.Unix(0, request.DeadlineUnixNano)) {
 			return VectorPartitionShardSearchResponseV1{}, &VectorPartitionShardSearchErrorV1{Code: VectorPartitionShardSearchErrorDeadlineV1, GroupID: request.TargetGroupID, Err: context.DeadlineExceeded}
 		}
 		return VectorPartitionShardSearchResponseV1{}, vectorPartitionShardSearchTCPTransportErrorV1(ctx, request.TargetGroupID, err)
 	}
 	if frame.Request != nil || (frame.Response == nil) == (frame.Error == nil) {
+		d.discard(endpoint, pooled)
 		return VectorPartitionShardSearchResponseV1{}, vectorPartitionShardSearchTCPTransportErrorV1(ctx, request.TargetGroupID, errors.New("ambiguous M5 response frame"))
 	}
 	if frame.Error != nil {
 		return VectorPartitionShardSearchResponseV1{}, frame.Error.toError()
 	}
+	_ = conn.SetDeadline(time.Time{})
 	return *frame.Response, nil
+}
+
+func (d *VectorPartitionShardSearchTCPDispatcherV1) endpoint(group raftcluster.GroupID, node raftcluster.NodeID) (string, bool) {
+	if nodes := d.nodeEndpoints[group]; nodes != nil && node != "" {
+		if endpoint, ok := nodes[node]; ok {
+			return endpoint, true
+		}
+	}
+	endpoint, ok := d.endpoints[group]
+	return endpoint, ok
+}
+func (d *VectorPartitionShardSearchTCPDispatcherV1) acquire(ctx context.Context, endpoint string) (*vectorPartitionShardSearchTCPPooledConnV1, error) {
+	d.mu.Lock()
+	if pooled := d.conns[endpoint]; pooled != nil {
+		d.mu.Unlock()
+		return pooled, nil
+	}
+	d.mu.Unlock()
+	conn, err := d.dial(ctx, "tcp", endpoint)
+	if err != nil {
+		return nil, err
+	}
+	pooled := &vectorPartitionShardSearchTCPPooledConnV1{conn: conn}
+	d.mu.Lock()
+	if existing := d.conns[endpoint]; existing != nil {
+		d.mu.Unlock()
+		_ = conn.Close()
+		return existing, nil
+	}
+	if d.conns == nil {
+		d.conns = make(map[string]*vectorPartitionShardSearchTCPPooledConnV1)
+	}
+	d.conns[endpoint] = pooled
+	d.mu.Unlock()
+	return pooled, nil
+}
+func (d *VectorPartitionShardSearchTCPDispatcherV1) discard(endpoint string, pooled *vectorPartitionShardSearchTCPPooledConnV1) {
+	d.mu.Lock()
+	if d.conns[endpoint] == pooled {
+		delete(d.conns, endpoint)
+	}
+	d.mu.Unlock()
+	_ = pooled.conn.Close()
+}
+func (d *VectorPartitionShardSearchTCPDispatcherV1) Close() error {
+	if d == nil {
+		return nil
+	}
+	d.mu.Lock()
+	conns := d.conns
+	d.conns = make(map[string]*vectorPartitionShardSearchTCPPooledConnV1)
+	d.mu.Unlock()
+	var errs []error
+	for _, pooled := range conns {
+		errs = append(errs, pooled.conn.Close())
+	}
+	return errors.Join(errs...)
 }
 
 // VectorPartitionShardSearchTCPServerV1 serves one M5 service over the same
@@ -119,34 +214,39 @@ func (s VectorPartitionShardSearchTCPServerV1) ServeConn(ctx context.Context, co
 	if initialTimeout == 0 {
 		initialTimeout = 5 * time.Second
 	}
-	_ = conn.SetReadDeadline(time.Now().Add(initialTimeout))
-	frame, err := readVectorPartitionShardSearchTCPFrameV1(conn, maxFrame)
-	_ = conn.SetReadDeadline(time.Time{})
-	if err != nil || frame.Request == nil || frame.Response != nil || frame.Error != nil {
-		// A peer that sends no frame (or never reads) must not strand this server
-		// goroutine while we try to report the bounded framing failure.
-		_ = conn.SetWriteDeadline(time.Now().Add(initialTimeout))
-		_ = writeVectorPartitionShardSearchTCPFrameV1(conn, vectorPartitionShardSearchTCPFrameV1{Error: &vectorPartitionShardSearchTCPErrorV1{Code: VectorPartitionShardSearchErrorInvalidRequestV1, Message: "invalid M5 TCP request"}}, maxFrame)
-		return
+	for {
+		_ = conn.SetReadDeadline(time.Now().Add(initialTimeout))
+		frame, err := readVectorPartitionShardSearchTCPFrameV1(conn, maxFrame)
+		_ = conn.SetReadDeadline(time.Time{})
+		if err != nil {
+			return
+		}
+		if frame.Request == nil || frame.Response != nil || frame.Error != nil {
+			// A peer that sends no frame (or never reads) must not strand this server
+			// goroutine while we try to report the bounded framing failure.
+			_ = conn.SetWriteDeadline(time.Now().Add(initialTimeout))
+			_ = writeVectorPartitionShardSearchTCPFrameV1(conn, vectorPartitionShardSearchTCPFrameV1{Error: &vectorPartitionShardSearchTCPErrorV1{Code: VectorPartitionShardSearchErrorInvalidRequestV1, Message: "invalid M5 TCP request"}}, maxFrame)
+			return
+		}
+		if s.Service == nil {
+			s.writeFrame(conn, vectorPartitionShardSearchTCPFrameV1{Error: &vectorPartitionShardSearchTCPErrorV1{Code: VectorPartitionShardSearchErrorGroupUnavailableV1, GroupID: frame.Request.TargetGroupID, Message: "M5 service is unavailable"}}, maxFrame, time.Now().Add(initialTimeout))
+			return
+		}
+		requestCtx, cancel := vectorPartitionShardSearchTCPRequestContextV1(ctx, frame.Request.DeadlineUnixNano)
+		stopPeerMonitor := vectorPartitionShardSearchTCPMonitorPeerDisconnectV1(conn, requestCtx, cancel)
+		response, err := s.Service.Search(requestCtx, *frame.Request)
+		stopPeerMonitor()
+		cancel()
+		writeDeadline := time.Now().Add(initialTimeout)
+		if deadline, ok := requestCtx.Deadline(); ok {
+			writeDeadline = deadline
+		}
+		if err != nil {
+			s.writeFrame(conn, vectorPartitionShardSearchTCPFrameV1{Error: vectorPartitionShardSearchTCPErrorFromErrorV1(err)}, maxFrame, writeDeadline)
+			continue
+		}
+		s.writeFrame(conn, vectorPartitionShardSearchTCPFrameV1{Response: &response}, maxFrame, writeDeadline)
 	}
-	if s.Service == nil {
-		s.writeFrame(conn, vectorPartitionShardSearchTCPFrameV1{Error: &vectorPartitionShardSearchTCPErrorV1{Code: VectorPartitionShardSearchErrorGroupUnavailableV1, GroupID: frame.Request.TargetGroupID, Message: "M5 service is unavailable"}}, maxFrame, time.Now().Add(initialTimeout))
-		return
-	}
-	requestCtx, cancel := vectorPartitionShardSearchTCPRequestContextV1(ctx, frame.Request.DeadlineUnixNano)
-	defer cancel()
-	stopPeerMonitor := vectorPartitionShardSearchTCPMonitorPeerDisconnectV1(conn, requestCtx, cancel)
-	response, err := s.Service.Search(requestCtx, *frame.Request)
-	stopPeerMonitor()
-	writeDeadline := time.Now().Add(initialTimeout)
-	if deadline, ok := requestCtx.Deadline(); ok {
-		writeDeadline = deadline
-	}
-	if err != nil {
-		s.writeFrame(conn, vectorPartitionShardSearchTCPFrameV1{Error: vectorPartitionShardSearchTCPErrorFromErrorV1(err)}, maxFrame, writeDeadline)
-		return
-	}
-	s.writeFrame(conn, vectorPartitionShardSearchTCPFrameV1{Response: &response}, maxFrame, writeDeadline)
 }
 
 func (s VectorPartitionShardSearchTCPServerV1) writeFrame(conn net.Conn, frame vectorPartitionShardSearchTCPFrameV1, maxFrame uint32, deadline time.Time) {

--- a/TreeDB/nativewire/vector_partition_shard_search_tcp_v1.go
+++ b/TreeDB/nativewire/vector_partition_shard_search_tcp_v1.go
@@ -154,12 +154,11 @@ func (d *VectorPartitionShardSearchTCPDispatcherV1) dispatchVectorPartitionShard
 	if frame.Request != nil || (frame.Response == nil) == (frame.Error == nil) {
 		return VectorPartitionShardSearchResponseV1{}, vectorPartitionShardSearchTCPTransportErrorV1(ctx, request.TargetGroupID, errors.New("ambiguous M5 response frame"))
 	}
-	reusable = true
+	stopCancelIO()
+	reusable = conn.SetDeadline(time.Time{}) == nil
 	if frame.Error != nil {
-		_ = conn.SetDeadline(time.Time{})
 		return VectorPartitionShardSearchResponseV1{}, frame.Error.toError()
 	}
-	_ = conn.SetDeadline(time.Time{})
 	return *frame.Response, nil
 }
 
@@ -487,16 +486,24 @@ func vectorPartitionShardSearchTCPInterruptOnCancelV1(ctx context.Context, conn 
 	if ctx == nil || ctx.Done() == nil {
 		return func() {}
 	}
+	stop := make(chan struct{})
 	done := make(chan struct{})
+	var stopOnce sync.Once
 	go func() {
+		defer close(done)
 		select {
 		case <-ctx.Done():
 			// A deadline wakes both Read and Write without racing the deferred Close.
 			_ = conn.SetDeadline(time.Now())
-		case <-done:
+		case <-stop:
 		}
 	}()
-	return func() { close(done) }
+	return func() {
+		stopOnce.Do(func() {
+			close(stop)
+			<-done
+		})
+	}
 }
 
 func vectorPartitionShardSearchTCPRequestContextV1(ctx context.Context, deadlineUnixNano int64) (context.Context, context.CancelFunc) {

--- a/TreeDB/nativewire/vector_partition_shard_search_tcp_v1.go
+++ b/TreeDB/nativewire/vector_partition_shard_search_tcp_v1.go
@@ -37,9 +37,14 @@ type VectorPartitionShardSearchTCPDispatcherV1 struct {
 }
 
 type vectorPartitionShardSearchTCPPooledConnV1 struct {
-	conn net.Conn
-	mu   sync.Mutex
+	conn  net.Conn
+	lease chan struct{}
 }
+
+type vectorPartitionShardSearchTCPTransportFailureV1 struct{ err error }
+
+func (e *vectorPartitionShardSearchTCPTransportFailureV1) Error() string { return e.err.Error() }
+func (e *vectorPartitionShardSearchTCPTransportFailureV1) Unwrap() error { return e.err }
 
 // NewVectorPartitionShardSearchTCPDispatcherV1 validates and copies one TCP
 // endpoint per group.  Endpoints are normally loopback addresses for the M8 CI
@@ -99,6 +104,8 @@ func (d *VectorPartitionShardSearchTCPDispatcherV1) DispatchVectorPartitionShard
 }
 
 func (d *VectorPartitionShardSearchTCPDispatcherV1) dispatchVectorPartitionShardSearchOnceV1(ctx context.Context, request VectorPartitionShardSearchRequestV1) (VectorPartitionShardSearchResponseV1, error) {
+	requestCtx, cancel := vectorPartitionShardSearchTCPRequestContextV1(ctx, request.DeadlineUnixNano)
+	defer cancel()
 	d.mu.Lock()
 	closed := d.closed
 	d.mu.Unlock()
@@ -109,23 +116,25 @@ func (d *VectorPartitionShardSearchTCPDispatcherV1) dispatchVectorPartitionShard
 	if !ok {
 		return VectorPartitionShardSearchResponseV1{}, &VectorPartitionShardSearchErrorV1{Code: VectorPartitionShardSearchErrorUnknownOwnerV1, GroupID: request.TargetGroupID, Err: ErrVectorPartitionShardSearchRouteMismatch}
 	}
-	pooled, err := d.acquire(ctx, endpoint)
+	pooled, err := d.acquire(requestCtx, endpoint)
 	if err != nil {
-		return VectorPartitionShardSearchResponseV1{}, vectorPartitionShardSearchTCPTransportErrorV1(ctx, request.TargetGroupID, err)
+		return VectorPartitionShardSearchResponseV1{}, vectorPartitionShardSearchTCPRetryableTransportErrorV1(requestCtx, request.TargetGroupID, err)
 	}
-	pooled.mu.Lock()
-	defer pooled.mu.Unlock()
+	if err := pooled.acquire(requestCtx); err != nil {
+		return VectorPartitionShardSearchResponseV1{}, vectorPartitionShardSearchTCPTransportErrorV1(requestCtx, request.TargetGroupID, err)
+	}
+	defer pooled.release()
 	conn := pooled.conn
-	stopCancelIO := vectorPartitionShardSearchTCPInterruptOnCancelV1(ctx, conn)
+	stopCancelIO := vectorPartitionShardSearchTCPInterruptOnCancelV1(requestCtx, conn)
 	defer stopCancelIO()
-	if err := vectorPartitionShardSearchTCPDeadlineV1(ctx, request.DeadlineUnixNano, conn); err != nil {
+	if err := vectorPartitionShardSearchTCPDeadlineV1(requestCtx, request.DeadlineUnixNano, conn); err != nil {
 		d.discard(endpoint, pooled)
-		return VectorPartitionShardSearchResponseV1{}, vectorPartitionShardSearchTCPTransportErrorV1(ctx, request.TargetGroupID, err)
+		return VectorPartitionShardSearchResponseV1{}, vectorPartitionShardSearchTCPRetryableTransportErrorV1(requestCtx, request.TargetGroupID, err)
 	}
 	frame := vectorPartitionShardSearchTCPFrameV1{Request: &request}
 	if err := writeVectorPartitionShardSearchTCPFrameV1(conn, frame, d.maxFrame); err != nil {
 		d.discard(endpoint, pooled)
-		return VectorPartitionShardSearchResponseV1{}, vectorPartitionShardSearchTCPTransportErrorV1(ctx, request.TargetGroupID, err)
+		return VectorPartitionShardSearchResponseV1{}, vectorPartitionShardSearchTCPRetryableTransportErrorV1(requestCtx, request.TargetGroupID, err)
 	}
 	frame, err = readVectorPartitionShardSearchTCPFrameV1(conn, d.maxFrame)
 	if err != nil {
@@ -133,7 +142,7 @@ func (d *VectorPartitionShardSearchTCPDispatcherV1) dispatchVectorPartitionShard
 		if request.DeadlineUnixNano != 0 && !time.Now().Before(time.Unix(0, request.DeadlineUnixNano)) {
 			return VectorPartitionShardSearchResponseV1{}, &VectorPartitionShardSearchErrorV1{Code: VectorPartitionShardSearchErrorDeadlineV1, GroupID: request.TargetGroupID, Err: context.DeadlineExceeded}
 		}
-		return VectorPartitionShardSearchResponseV1{}, vectorPartitionShardSearchTCPTransportErrorV1(ctx, request.TargetGroupID, err)
+		return VectorPartitionShardSearchResponseV1{}, vectorPartitionShardSearchTCPRetryableTransportErrorV1(requestCtx, request.TargetGroupID, err)
 	}
 	if frame.Request != nil || (frame.Response == nil) == (frame.Error == nil) {
 		d.discard(endpoint, pooled)
@@ -171,7 +180,7 @@ func (d *VectorPartitionShardSearchTCPDispatcherV1) acquire(ctx context.Context,
 	if err != nil {
 		return nil, err
 	}
-	pooled := &vectorPartitionShardSearchTCPPooledConnV1{conn: conn}
+	pooled := &vectorPartitionShardSearchTCPPooledConnV1{conn: conn, lease: make(chan struct{}, 1)}
 	d.mu.Lock()
 	if d.closed {
 		d.mu.Unlock()
@@ -190,6 +199,15 @@ func (d *VectorPartitionShardSearchTCPDispatcherV1) acquire(ctx context.Context,
 	d.mu.Unlock()
 	return pooled, nil
 }
+func (p *vectorPartitionShardSearchTCPPooledConnV1) acquire(ctx context.Context) error {
+	select {
+	case p.lease <- struct{}{}:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+func (p *vectorPartitionShardSearchTCPPooledConnV1) release() { <-p.lease }
 func (d *VectorPartitionShardSearchTCPDispatcherV1) discard(endpoint string, pooled *vectorPartitionShardSearchTCPPooledConnV1) {
 	d.mu.Lock()
 	if d.conns[endpoint] == pooled {
@@ -219,6 +237,10 @@ func (d *VectorPartitionShardSearchTCPDispatcherV1) Close() error {
 }
 
 func vectorPartitionShardSearchTCPReconnectableV1(err error) bool {
+	var transportErr *vectorPartitionShardSearchTCPTransportFailureV1
+	if !errors.As(err, &transportErr) {
+		return false
+	}
 	var shardErr *VectorPartitionShardSearchErrorV1
 	return errors.As(err, &shardErr) && shardErr.Code == VectorPartitionShardSearchErrorGroupUnavailableV1
 }
@@ -511,4 +533,8 @@ func vectorPartitionShardSearchTCPTransportErrorV1(ctx context.Context, groupID 
 		return &VectorPartitionShardSearchErrorV1{Code: VectorPartitionShardSearchErrorDeadlineV1, GroupID: groupID, Err: err}
 	}
 	return &VectorPartitionShardSearchErrorV1{Code: VectorPartitionShardSearchErrorGroupUnavailableV1, GroupID: groupID, Err: err}
+}
+
+func vectorPartitionShardSearchTCPRetryableTransportErrorV1(ctx context.Context, groupID raftcluster.GroupID, err error) error {
+	return &vectorPartitionShardSearchTCPTransportFailureV1{err: vectorPartitionShardSearchTCPTransportErrorV1(ctx, groupID, err)}
 }

--- a/TreeDB/nativewire/vector_partition_shard_search_tcp_v1.go
+++ b/TreeDB/nativewire/vector_partition_shard_search_tcp_v1.go
@@ -27,18 +27,22 @@ const vectorPartitionShardSearchTCPMaxFrameBytesV1 uint32 = 64 << 20
 // in-process registry: every request and response crosses a serialized socket
 // boundary before the coordinator can consume it.
 type VectorPartitionShardSearchTCPDispatcherV1 struct {
-	endpoints     map[raftcluster.GroupID]string
-	nodeEndpoints map[raftcluster.GroupID]map[raftcluster.NodeID]string
-	dial          func(context.Context, string, string) (net.Conn, error)
-	maxFrame      uint32
-	mu            sync.Mutex
-	conns         map[string]*vectorPartitionShardSearchTCPPooledConnV1
-	closed        bool
+	endpoints                 map[raftcluster.GroupID]string
+	nodeEndpoints             map[raftcluster.GroupID]map[raftcluster.NodeID]string
+	dial                      func(context.Context, string, string) (net.Conn, error)
+	maxFrame                  uint32
+	maxConnectionsPerEndpoint int
+	mu                        sync.Mutex
+	pools                     map[string]*vectorPartitionShardSearchTCPEndpointPoolV1
+	closed                    bool
 }
 
-type vectorPartitionShardSearchTCPPooledConnV1 struct {
-	conn  net.Conn
-	lease chan struct{}
+type vectorPartitionShardSearchTCPEndpointPoolV1 struct {
+	slots  chan struct{}
+	mu     sync.Mutex
+	idle   []net.Conn
+	all    map[net.Conn]struct{}
+	closed bool
 }
 
 type vectorPartitionShardSearchTCPTransportFailureV1 struct{ err error }
@@ -57,8 +61,15 @@ func NewVectorPartitionShardSearchTCPDispatcherV1(endpoints map[raftcluster.Grou
 // routes a coordinator retry to the leader-hinted node when that endpoint is
 // known. Group endpoints remain the safe fallback for one service per group.
 func NewVectorPartitionShardSearchTCPDispatcherWithNodeEndpointsV1(endpoints map[raftcluster.GroupID]string, nodeEndpoints map[raftcluster.GroupID]map[raftcluster.NodeID]string) (*VectorPartitionShardSearchTCPDispatcherV1, error) {
+	return newVectorPartitionShardSearchTCPDispatcherV1(endpoints, nodeEndpoints, DefaultVectorPartitionCoordinatorLimitsV1().MaxConcurrentRequests)
+}
+
+func newVectorPartitionShardSearchTCPDispatcherV1(endpoints map[raftcluster.GroupID]string, nodeEndpoints map[raftcluster.GroupID]map[raftcluster.NodeID]string, maxConnectionsPerEndpoint int) (*VectorPartitionShardSearchTCPDispatcherV1, error) {
 	if len(endpoints) == 0 {
 		return nil, errors.New("nativewire: M5 TCP dispatcher requires endpoints")
+	}
+	if maxConnectionsPerEndpoint < 1 {
+		return nil, errors.New("nativewire: M5 TCP dispatcher requires a positive per-endpoint connection limit")
 	}
 	copyEndpoints := make(map[raftcluster.GroupID]string, len(endpoints))
 	for group, endpoint := range endpoints {
@@ -83,11 +94,12 @@ func NewVectorPartitionShardSearchTCPDispatcherWithNodeEndpointsV1(endpoints map
 		copyNodeEndpoints[group] = copyNodes
 	}
 	return &VectorPartitionShardSearchTCPDispatcherV1{
-		endpoints:     copyEndpoints,
-		nodeEndpoints: copyNodeEndpoints,
-		dial:          dialer.DialContext,
-		maxFrame:      vectorPartitionShardSearchTCPMaxFrameBytesV1,
-		conns:         make(map[string]*vectorPartitionShardSearchTCPPooledConnV1),
+		endpoints:                 copyEndpoints,
+		nodeEndpoints:             copyNodeEndpoints,
+		dial:                      dialer.DialContext,
+		maxFrame:                  vectorPartitionShardSearchTCPMaxFrameBytesV1,
+		maxConnectionsPerEndpoint: maxConnectionsPerEndpoint,
+		pools:                     make(map[string]*vectorPartitionShardSearchTCPEndpointPoolV1),
 	}, nil
 }
 
@@ -116,38 +128,32 @@ func (d *VectorPartitionShardSearchTCPDispatcherV1) dispatchVectorPartitionShard
 	if !ok {
 		return VectorPartitionShardSearchResponseV1{}, &VectorPartitionShardSearchErrorV1{Code: VectorPartitionShardSearchErrorUnknownOwnerV1, GroupID: request.TargetGroupID, Err: ErrVectorPartitionShardSearchRouteMismatch}
 	}
-	pooled, err := d.acquire(requestCtx, endpoint)
+	pool, conn, err := d.acquire(requestCtx, endpoint)
 	if err != nil {
 		return VectorPartitionShardSearchResponseV1{}, vectorPartitionShardSearchTCPRetryableTransportErrorV1(requestCtx, request.TargetGroupID, err)
 	}
-	if err := pooled.acquire(requestCtx); err != nil {
-		return VectorPartitionShardSearchResponseV1{}, vectorPartitionShardSearchTCPTransportErrorV1(requestCtx, request.TargetGroupID, err)
-	}
-	defer pooled.release()
-	conn := pooled.conn
+	reusable := false
+	defer func() { pool.release(conn, reusable) }()
 	stopCancelIO := vectorPartitionShardSearchTCPInterruptOnCancelV1(requestCtx, conn)
 	defer stopCancelIO()
 	if err := vectorPartitionShardSearchTCPDeadlineV1(requestCtx, request.DeadlineUnixNano, conn); err != nil {
-		d.discard(endpoint, pooled)
 		return VectorPartitionShardSearchResponseV1{}, vectorPartitionShardSearchTCPRetryableTransportErrorV1(requestCtx, request.TargetGroupID, err)
 	}
 	frame := vectorPartitionShardSearchTCPFrameV1{Request: &request}
 	if err := writeVectorPartitionShardSearchTCPFrameV1(conn, frame, d.maxFrame); err != nil {
-		d.discard(endpoint, pooled)
 		return VectorPartitionShardSearchResponseV1{}, vectorPartitionShardSearchTCPRetryableTransportErrorV1(requestCtx, request.TargetGroupID, err)
 	}
 	frame, err = readVectorPartitionShardSearchTCPFrameV1(conn, d.maxFrame)
 	if err != nil {
-		d.discard(endpoint, pooled)
 		if request.DeadlineUnixNano != 0 && !time.Now().Before(time.Unix(0, request.DeadlineUnixNano)) {
 			return VectorPartitionShardSearchResponseV1{}, &VectorPartitionShardSearchErrorV1{Code: VectorPartitionShardSearchErrorDeadlineV1, GroupID: request.TargetGroupID, Err: context.DeadlineExceeded}
 		}
 		return VectorPartitionShardSearchResponseV1{}, vectorPartitionShardSearchTCPRetryableTransportErrorV1(requestCtx, request.TargetGroupID, err)
 	}
 	if frame.Request != nil || (frame.Response == nil) == (frame.Error == nil) {
-		d.discard(endpoint, pooled)
 		return VectorPartitionShardSearchResponseV1{}, vectorPartitionShardSearchTCPTransportErrorV1(ctx, request.TargetGroupID, errors.New("ambiguous M5 response frame"))
 	}
+	reusable = true
 	if frame.Error != nil {
 		_ = conn.SetDeadline(time.Time{})
 		return VectorPartitionShardSearchResponseV1{}, frame.Error.toError()
@@ -165,56 +171,93 @@ func (d *VectorPartitionShardSearchTCPDispatcherV1) endpoint(group raftcluster.G
 	endpoint, ok := d.endpoints[group]
 	return endpoint, ok
 }
-func (d *VectorPartitionShardSearchTCPDispatcherV1) acquire(ctx context.Context, endpoint string) (*vectorPartitionShardSearchTCPPooledConnV1, error) {
+func (d *VectorPartitionShardSearchTCPDispatcherV1) acquire(ctx context.Context, endpoint string) (*vectorPartitionShardSearchTCPEndpointPoolV1, net.Conn, error) {
 	d.mu.Lock()
 	if d.closed {
 		d.mu.Unlock()
-		return nil, net.ErrClosed
+		return nil, nil, net.ErrClosed
 	}
-	if pooled := d.conns[endpoint]; pooled != nil {
-		d.mu.Unlock()
-		return pooled, nil
+	pool := d.pools[endpoint]
+	if pool == nil {
+		if d.pools == nil {
+			d.pools = make(map[string]*vectorPartitionShardSearchTCPEndpointPoolV1)
+		}
+		maxConnections := d.maxConnectionsPerEndpoint
+		if maxConnections == 0 {
+			maxConnections = DefaultVectorPartitionCoordinatorLimitsV1().MaxConcurrentRequests
+		}
+		pool = &vectorPartitionShardSearchTCPEndpointPoolV1{
+			slots: make(chan struct{}, maxConnections),
+			all:   make(map[net.Conn]struct{}),
+		}
+		d.pools[endpoint] = pool
 	}
 	d.mu.Unlock()
-	conn, err := d.dial(ctx, "tcp", endpoint)
+	conn, err := pool.acquire(ctx, d.dial, endpoint)
+	return pool, conn, err
+}
+
+func (p *vectorPartitionShardSearchTCPEndpointPoolV1) acquire(ctx context.Context, dial func(context.Context, string, string) (net.Conn, error), endpoint string) (net.Conn, error) {
+	select {
+	case p.slots <- struct{}{}:
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	}
+	p.mu.Lock()
+	if p.closed {
+		p.mu.Unlock()
+		<-p.slots
+		return nil, net.ErrClosed
+	}
+	if n := len(p.idle); n != 0 {
+		conn := p.idle[n-1]
+		p.idle = p.idle[:n-1]
+		p.mu.Unlock()
+		return conn, nil
+	}
+	p.mu.Unlock()
+	conn, err := dial(ctx, "tcp", endpoint)
 	if err != nil {
+		<-p.slots
 		return nil, err
 	}
-	pooled := &vectorPartitionShardSearchTCPPooledConnV1{conn: conn, lease: make(chan struct{}, 1)}
-	d.mu.Lock()
-	if d.closed {
-		d.mu.Unlock()
+	p.mu.Lock()
+	if p.closed {
+		p.mu.Unlock()
 		_ = conn.Close()
+		<-p.slots
 		return nil, net.ErrClosed
 	}
-	if existing := d.conns[endpoint]; existing != nil {
-		d.mu.Unlock()
+	p.all[conn] = struct{}{}
+	p.mu.Unlock()
+	return conn, nil
+}
+func (p *vectorPartitionShardSearchTCPEndpointPoolV1) release(conn net.Conn, reusable bool) {
+	p.mu.Lock()
+	closed := p.closed
+	if reusable && !closed {
+		p.idle = append(p.idle, conn)
+	} else {
+		delete(p.all, conn)
+	}
+	p.mu.Unlock()
+	if !reusable || closed {
 		_ = conn.Close()
-		return existing, nil
 	}
-	if d.conns == nil {
-		d.conns = make(map[string]*vectorPartitionShardSearchTCPPooledConnV1)
-	}
-	d.conns[endpoint] = pooled
-	d.mu.Unlock()
-	return pooled, nil
+	<-p.slots
 }
-func (p *vectorPartitionShardSearchTCPPooledConnV1) acquire(ctx context.Context) error {
-	select {
-	case p.lease <- struct{}{}:
-		return nil
-	case <-ctx.Done():
-		return ctx.Err()
+func (p *vectorPartitionShardSearchTCPEndpointPoolV1) close() error {
+	p.mu.Lock()
+	p.closed = true
+	conns := p.all
+	p.all = make(map[net.Conn]struct{})
+	p.idle = nil
+	p.mu.Unlock()
+	var errs []error
+	for conn := range conns {
+		errs = append(errs, conn.Close())
 	}
-}
-func (p *vectorPartitionShardSearchTCPPooledConnV1) release() { <-p.lease }
-func (d *VectorPartitionShardSearchTCPDispatcherV1) discard(endpoint string, pooled *vectorPartitionShardSearchTCPPooledConnV1) {
-	d.mu.Lock()
-	if d.conns[endpoint] == pooled {
-		delete(d.conns, endpoint)
-	}
-	d.mu.Unlock()
-	_ = pooled.conn.Close()
+	return errors.Join(errs...)
 }
 func (d *VectorPartitionShardSearchTCPDispatcherV1) Close() error {
 	if d == nil {
@@ -226,12 +269,12 @@ func (d *VectorPartitionShardSearchTCPDispatcherV1) Close() error {
 		return nil
 	}
 	d.closed = true
-	conns := d.conns
-	d.conns = make(map[string]*vectorPartitionShardSearchTCPPooledConnV1)
+	pools := d.pools
+	d.pools = make(map[string]*vectorPartitionShardSearchTCPEndpointPoolV1)
 	d.mu.Unlock()
 	var errs []error
-	for _, pooled := range conns {
-		errs = append(errs, pooled.conn.Close())
+	for _, pool := range pools {
+		errs = append(errs, pool.close())
 	}
 	return errors.Join(errs...)
 }

--- a/TreeDB/nativewire/vector_partition_shard_search_tcp_v1.go
+++ b/TreeDB/nativewire/vector_partition_shard_search_tcp_v1.go
@@ -33,6 +33,7 @@ type VectorPartitionShardSearchTCPDispatcherV1 struct {
 	maxFrame      uint32
 	mu            sync.Mutex
 	conns         map[string]*vectorPartitionShardSearchTCPPooledConnV1
+	closed        bool
 }
 
 type vectorPartitionShardSearchTCPPooledConnV1 struct {
@@ -89,6 +90,21 @@ func (d *VectorPartitionShardSearchTCPDispatcherV1) DispatchVectorPartitionShard
 	if d == nil || d.dial == nil || d.maxFrame == 0 {
 		return VectorPartitionShardSearchResponseV1{}, errors.New("nativewire: M5 TCP dispatcher is not configured")
 	}
+	for attempt := 0; ; attempt++ {
+		response, err := d.dispatchVectorPartitionShardSearchOnceV1(ctx, request)
+		if err == nil || attempt != 0 || ctx.Err() != nil || !vectorPartitionShardSearchTCPReconnectableV1(err) {
+			return response, err
+		}
+	}
+}
+
+func (d *VectorPartitionShardSearchTCPDispatcherV1) dispatchVectorPartitionShardSearchOnceV1(ctx context.Context, request VectorPartitionShardSearchRequestV1) (VectorPartitionShardSearchResponseV1, error) {
+	d.mu.Lock()
+	closed := d.closed
+	d.mu.Unlock()
+	if closed {
+		return VectorPartitionShardSearchResponseV1{}, &VectorPartitionShardSearchErrorV1{Code: VectorPartitionShardSearchErrorGroupUnavailableV1, GroupID: request.TargetGroupID, Err: errors.New("nativewire: M5 TCP dispatcher is closed")}
+	}
 	endpoint, ok := d.endpoint(request.TargetGroupID, request.TargetNodeID)
 	if !ok {
 		return VectorPartitionShardSearchResponseV1{}, &VectorPartitionShardSearchErrorV1{Code: VectorPartitionShardSearchErrorUnknownOwnerV1, GroupID: request.TargetGroupID, Err: ErrVectorPartitionShardSearchRouteMismatch}
@@ -124,6 +140,7 @@ func (d *VectorPartitionShardSearchTCPDispatcherV1) DispatchVectorPartitionShard
 		return VectorPartitionShardSearchResponseV1{}, vectorPartitionShardSearchTCPTransportErrorV1(ctx, request.TargetGroupID, errors.New("ambiguous M5 response frame"))
 	}
 	if frame.Error != nil {
+		_ = conn.SetDeadline(time.Time{})
 		return VectorPartitionShardSearchResponseV1{}, frame.Error.toError()
 	}
 	_ = conn.SetDeadline(time.Time{})
@@ -141,6 +158,10 @@ func (d *VectorPartitionShardSearchTCPDispatcherV1) endpoint(group raftcluster.G
 }
 func (d *VectorPartitionShardSearchTCPDispatcherV1) acquire(ctx context.Context, endpoint string) (*vectorPartitionShardSearchTCPPooledConnV1, error) {
 	d.mu.Lock()
+	if d.closed {
+		d.mu.Unlock()
+		return nil, net.ErrClosed
+	}
 	if pooled := d.conns[endpoint]; pooled != nil {
 		d.mu.Unlock()
 		return pooled, nil
@@ -152,6 +173,11 @@ func (d *VectorPartitionShardSearchTCPDispatcherV1) acquire(ctx context.Context,
 	}
 	pooled := &vectorPartitionShardSearchTCPPooledConnV1{conn: conn}
 	d.mu.Lock()
+	if d.closed {
+		d.mu.Unlock()
+		_ = conn.Close()
+		return nil, net.ErrClosed
+	}
 	if existing := d.conns[endpoint]; existing != nil {
 		d.mu.Unlock()
 		_ = conn.Close()
@@ -177,6 +203,11 @@ func (d *VectorPartitionShardSearchTCPDispatcherV1) Close() error {
 		return nil
 	}
 	d.mu.Lock()
+	if d.closed {
+		d.mu.Unlock()
+		return nil
+	}
+	d.closed = true
 	conns := d.conns
 	d.conns = make(map[string]*vectorPartitionShardSearchTCPPooledConnV1)
 	d.mu.Unlock()
@@ -185,6 +216,11 @@ func (d *VectorPartitionShardSearchTCPDispatcherV1) Close() error {
 		errs = append(errs, pooled.conn.Close())
 	}
 	return errors.Join(errs...)
+}
+
+func vectorPartitionShardSearchTCPReconnectableV1(err error) bool {
+	var shardErr *VectorPartitionShardSearchErrorV1
+	return errors.As(err, &shardErr) && shardErr.Code == VectorPartitionShardSearchErrorGroupUnavailableV1
 }
 
 // VectorPartitionShardSearchTCPServerV1 serves one M5 service over the same
@@ -390,8 +426,9 @@ func vectorPartitionShardSearchTCPRequestContextV1(ctx context.Context, deadline
 }
 
 // vectorPartitionShardSearchTCPMonitorPeerDisconnectV1 is safe because the
-// framing contract carries exactly one request per connection.  After the
-// request has been decoded no further peer bytes are valid, so a bounded read
+// framing contract does not permit pipelining. After the current request has
+// been decoded no further peer bytes are valid until its response, so a bounded
+// read
 // loop can turn an EOF/reset into cancellation of remote M5 work. Stopping the
 // monitor interrupts its outstanding read before waiting, so an ordinary
 // successful response is not delayed by the polling deadline. Read deadlines

--- a/TreeDB/nativewire/vector_partition_shard_search_tcp_v1_test.go
+++ b/TreeDB/nativewire/vector_partition_shard_search_tcp_v1_test.go
@@ -93,6 +93,70 @@ func TestVectorPartitionShardSearchTCPDispatcherReconnectsAfterIdleCloseAndFails
 	}
 }
 
+func TestVectorPartitionShardSearchTCPDispatcherCancellationWhileWaitingForConnectionV1(t *testing.T) {
+	started := make(chan struct{})
+	release := make(chan struct{})
+	listener := newVectorPartitionShardSearchTCPListenerV1(t, vectorPartitionShardSearchHandlerFuncV1(func(context.Context, VectorPartitionShardSearchRequestV1) (VectorPartitionShardSearchResponseV1, error) {
+		close(started)
+		<-release
+		return VectorPartitionShardSearchResponseV1{Version: 1}, nil
+	}))
+	dispatcher, err := NewVectorPartitionShardSearchTCPDispatcherV1(map[raftcluster.GroupID]string{"group-a": listener.Addr().String()})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer dispatcher.Close()
+	firstDone := make(chan error, 1)
+	go func() {
+		_, err := dispatcher.DispatchVectorPartitionShardSearchV1(context.Background(), VectorPartitionShardSearchRequestV1{TargetGroupID: "group-a"})
+		firstDone <- err
+	}()
+	select {
+	case <-started:
+	case <-time.After(time.Second):
+		t.Fatal("first request did not acquire the pooled connection")
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	secondDone := make(chan error, 1)
+	go func() {
+		_, err := dispatcher.DispatchVectorPartitionShardSearchV1(ctx, VectorPartitionShardSearchRequestV1{TargetGroupID: "group-a"})
+		secondDone <- err
+	}()
+	cancel()
+	select {
+	case err := <-secondDone:
+		var shardErr *VectorPartitionShardSearchErrorV1
+		if !errors.As(err, &shardErr) || shardErr.Code != VectorPartitionShardSearchErrorCanceledV1 || !errors.Is(err, context.Canceled) {
+			t.Fatalf("waiting cancellation error=%v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("canceled request remained blocked behind the pooled connection")
+	}
+	close(release)
+	if err := <-firstDone; err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestVectorPartitionShardSearchTCPDispatcherDoesNotRetryServiceUnavailableV1(t *testing.T) {
+	var calls atomic.Uint64
+	listener := newVectorPartitionShardSearchTCPListenerV1(t, vectorPartitionShardSearchHandlerFuncV1(func(context.Context, VectorPartitionShardSearchRequestV1) (VectorPartitionShardSearchResponseV1, error) {
+		calls.Add(1)
+		return VectorPartitionShardSearchResponseV1{}, &VectorPartitionShardSearchErrorV1{Code: VectorPartitionShardSearchErrorGroupUnavailableV1, GroupID: "group-a", Err: errors.New("lifecycle unavailable")}
+	}))
+	dispatcher, err := NewVectorPartitionShardSearchTCPDispatcherV1(map[raftcluster.GroupID]string{"group-a": listener.Addr().String()})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer dispatcher.Close()
+	if _, err := dispatcher.DispatchVectorPartitionShardSearchV1(context.Background(), VectorPartitionShardSearchRequestV1{TargetGroupID: "group-a"}); err == nil {
+		t.Fatal("service failure succeeded")
+	}
+	if got := calls.Load(); got != 1 {
+		t.Fatalf("service calls=%d want one", got)
+	}
+}
+
 func TestVectorPartitionShardSearchTCPDispatcherUsesLeaderNodeEndpointV1(t *testing.T) {
 	leader := newVectorPartitionShardSearchTCPListenerV1(t, vectorPartitionShardSearchHandlerFuncV1(func(_ context.Context, r VectorPartitionShardSearchRequestV1) (VectorPartitionShardSearchResponseV1, error) {
 		return VectorPartitionShardSearchResponseV1{Version: 1, RequestID: r.RequestID}, nil

--- a/TreeDB/nativewire/vector_partition_shard_search_tcp_v1_test.go
+++ b/TreeDB/nativewire/vector_partition_shard_search_tcp_v1_test.go
@@ -48,6 +48,50 @@ func TestVectorPartitionShardSearchTCPDispatcherReusesConnectionV1(t *testing.T)
 	}
 }
 
+func TestVectorPartitionShardSearchTCPCancelWatcherStopsBeforeReuseV1(t *testing.T) {
+	left, right := net.Pipe()
+	defer left.Close()
+	defer right.Close()
+	deadlineStarted := make(chan struct{})
+	releaseDeadline := make(chan struct{})
+	conn := &vectorPartitionShardSearchTCPBlockingDeadlineConnV1{Conn: left, started: deadlineStarted, release: releaseDeadline}
+	ctx, cancel := context.WithCancel(context.Background())
+	stop := vectorPartitionShardSearchTCPInterruptOnCancelV1(ctx, conn)
+	cancel()
+	<-deadlineStarted
+	stopped := make(chan struct{})
+	go func() {
+		stop()
+		close(stopped)
+	}()
+	select {
+	case <-stopped:
+		t.Fatal("cancel watcher stopped before its deadline write completed")
+	case <-time.After(10 * time.Millisecond):
+	}
+	close(releaseDeadline)
+	select {
+	case <-stopped:
+	case <-time.After(time.Second):
+		t.Fatal("cancel watcher did not stop")
+	}
+	stop()
+}
+
+type vectorPartitionShardSearchTCPBlockingDeadlineConnV1 struct {
+	net.Conn
+	started chan struct{}
+	release chan struct{}
+}
+
+func (c *vectorPartitionShardSearchTCPBlockingDeadlineConnV1) SetDeadline(deadline time.Time) error {
+	if !deadline.IsZero() && !deadline.After(time.Now()) {
+		close(c.started)
+		<-c.release
+	}
+	return c.Conn.SetDeadline(deadline)
+}
+
 func TestVectorPartitionShardSearchTCPDispatcherReconnectsAfterIdleCloseAndFailsAfterCloseV1(t *testing.T) {
 	const poolSize = 2
 	listener, err := net.Listen("tcp", "127.0.0.1:0")

--- a/TreeDB/nativewire/vector_partition_shard_search_tcp_v1_test.go
+++ b/TreeDB/nativewire/vector_partition_shard_search_tcp_v1_test.go
@@ -5,11 +5,66 @@ import (
 	"errors"
 	"net"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
 	"github.com/snissn/gomap/TreeDB/internal/raftcluster"
 )
+
+func TestVectorPartitionShardSearchTCPDispatcherReusesConnectionV1(t *testing.T) {
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer listener.Close()
+	var accepts atomic.Uint64
+	go func() {
+		for {
+			conn, err := listener.Accept()
+			if err != nil {
+				return
+			}
+			accepts.Add(1)
+			go (VectorPartitionShardSearchTCPServerV1{Service: vectorPartitionShardSearchHandlerFuncV1(func(_ context.Context, r VectorPartitionShardSearchRequestV1) (VectorPartitionShardSearchResponseV1, error) {
+				return VectorPartitionShardSearchResponseV1{Version: 1, RequestID: r.RequestID}, nil
+			})}).ServeConn(context.Background(), conn)
+		}
+	}()
+	dispatcher, err := NewVectorPartitionShardSearchTCPDispatcherV1(map[raftcluster.GroupID]string{"group-a": listener.Addr().String()})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer dispatcher.Close()
+	for _, id := range []string{"first", "second"} {
+		if _, err := dispatcher.DispatchVectorPartitionShardSearchV1(context.Background(), VectorPartitionShardSearchRequestV1{TargetGroupID: "group-a", RequestID: id}); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if got := accepts.Load(); got != 1 {
+		t.Fatalf("connections=%d want one reused connection", got)
+	}
+}
+
+func TestVectorPartitionShardSearchTCPDispatcherUsesLeaderNodeEndpointV1(t *testing.T) {
+	leader := newVectorPartitionShardSearchTCPListenerV1(t, vectorPartitionShardSearchHandlerFuncV1(func(_ context.Context, r VectorPartitionShardSearchRequestV1) (VectorPartitionShardSearchResponseV1, error) {
+		return VectorPartitionShardSearchResponseV1{Version: 1, RequestID: r.RequestID}, nil
+	}))
+	stale := newVectorPartitionShardSearchTCPListenerV1(t, vectorPartitionShardSearchHandlerFuncV1(func(context.Context, VectorPartitionShardSearchRequestV1) (VectorPartitionShardSearchResponseV1, error) {
+		return VectorPartitionShardSearchResponseV1{}, &VectorPartitionShardSearchErrorV1{Code: VectorPartitionShardSearchErrorNotLeaderV1, GroupID: "group-a", LeaderHint: "node-b", Err: errors.New("moved")}
+	}))
+	dispatcher, err := NewVectorPartitionShardSearchTCPDispatcherWithNodeEndpointsV1(map[raftcluster.GroupID]string{"group-a": stale.Addr().String()}, map[raftcluster.GroupID]map[raftcluster.NodeID]string{"group-a": {"node-a": stale.Addr().String(), "node-b": leader.Addr().String()}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer dispatcher.Close()
+	if _, err := dispatcher.DispatchVectorPartitionShardSearchV1(context.Background(), VectorPartitionShardSearchRequestV1{TargetGroupID: "group-a", TargetNodeID: "node-a"}); err == nil {
+		t.Fatal("stale leader endpoint succeeded")
+	}
+	if response, err := dispatcher.DispatchVectorPartitionShardSearchV1(context.Background(), VectorPartitionShardSearchRequestV1{TargetGroupID: "group-a", TargetNodeID: "node-b", RequestID: "leader"}); err != nil || response.RequestID != "leader" {
+		t.Fatalf("leader endpoint response=%+v err=%v", response, err)
+	}
+}
 
 type vectorPartitionShardSearchHandlerFuncV1 func(context.Context, VectorPartitionShardSearchRequestV1) (VectorPartitionShardSearchResponseV1, error)
 
@@ -53,13 +108,15 @@ func TestVectorPartitionShardSearchTCPServerInterruptsPeerReadBeforeSuccessfulRe
 	if err != nil || frame.Response == nil || frame.Response.RequestID != "immediate" {
 		t.Fatalf("response frame=%+v err=%v", frame, err)
 	}
+	// The production transport keeps a healthy connection for the next request.
+	// Closing the peer must still release the server goroutine deterministically.
+	if err := client.Close(); err != nil {
+		t.Fatal(err)
+	}
 	select {
 	case <-serverDone:
 	case <-time.After(time.Second):
-		t.Fatal("server did not return after successful response")
-	}
-	if !server.interruptedReadBeforeWrite() {
-		t.Fatal("successful response was written without interrupting the peer-monitor read")
+		t.Fatal("server did not return after peer close")
 	}
 }
 

--- a/TreeDB/nativewire/vector_partition_shard_search_tcp_v1_test.go
+++ b/TreeDB/nativewire/vector_partition_shard_search_tcp_v1_test.go
@@ -78,6 +78,19 @@ func TestVectorPartitionShardSearchTCPDerivesSeparateFrameBoundsV1(t *testing.T)
 	}
 }
 
+func TestVectorPartitionShardSearchTCPDispatcherAcceptsNilContextV1(t *testing.T) {
+	dispatcher, err := NewVectorPartitionShardSearchTCPDispatcherV1(map[raftcluster.GroupID]string{"group-a": "127.0.0.1:1"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer dispatcher.Close()
+	_, err = dispatcher.DispatchVectorPartitionShardSearchV1(nil, VectorPartitionShardSearchRequestV1{TargetGroupID: "missing"})
+	var searchErr *VectorPartitionShardSearchErrorV1
+	if !errors.As(err, &searchErr) || searchErr.Code != VectorPartitionShardSearchErrorUnknownOwnerV1 {
+		t.Fatalf("error=%v want unknown owner", err)
+	}
+}
+
 func TestVectorPartitionM8ProductionTopologyOwnsDispatcherV1(t *testing.T) {
 	dispatcher, err := NewVectorPartitionShardSearchTCPDispatcherV1(map[raftcluster.GroupID]string{"group-a": "127.0.0.1:1"})
 	if err != nil {

--- a/TreeDB/nativewire/vector_partition_shard_search_tcp_v1_test.go
+++ b/TreeDB/nativewire/vector_partition_shard_search_tcp_v1_test.go
@@ -78,6 +78,23 @@ func TestVectorPartitionShardSearchTCPDerivesSeparateFrameBoundsV1(t *testing.T)
 	}
 }
 
+func TestVectorPartitionM8ProductionTopologyOwnsDispatcherV1(t *testing.T) {
+	dispatcher, err := NewVectorPartitionShardSearchTCPDispatcherV1(map[raftcluster.GroupID]string{"group-a": "127.0.0.1:1"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	topology := &VectorPartitionM8ProductionMultiGroupV1{dispatcher: dispatcher}
+	if err := topology.Close(); err != nil {
+		t.Fatal(err)
+	}
+	dispatcher.mu.Lock()
+	closed := dispatcher.closed
+	dispatcher.mu.Unlock()
+	if !closed {
+		t.Fatal("M8 topology left dispatcher open")
+	}
+}
+
 func TestVectorPartitionShardSearchTCPServerBoundsRequestAndFailedResponseFramesV1(t *testing.T) {
 	t.Run("request", func(t *testing.T) {
 		client, server := net.Pipe()

--- a/TreeDB/nativewire/vector_partition_shard_search_tcp_v1_test.go
+++ b/TreeDB/nativewire/vector_partition_shard_search_tcp_v1_test.go
@@ -93,28 +93,33 @@ func TestVectorPartitionShardSearchTCPDispatcherReconnectsAfterIdleCloseAndFails
 	}
 }
 
-func TestVectorPartitionShardSearchTCPDispatcherCancellationWhileWaitingForConnectionV1(t *testing.T) {
-	started := make(chan struct{})
+func TestVectorPartitionShardSearchTCPDispatcherCancellationWhilePoolIsFullV1(t *testing.T) {
+	const poolSize = 2
+	started := make(chan struct{}, poolSize)
 	release := make(chan struct{})
 	listener := newVectorPartitionShardSearchTCPListenerV1(t, vectorPartitionShardSearchHandlerFuncV1(func(context.Context, VectorPartitionShardSearchRequestV1) (VectorPartitionShardSearchResponseV1, error) {
-		close(started)
+		started <- struct{}{}
 		<-release
 		return VectorPartitionShardSearchResponseV1{Version: 1}, nil
 	}))
-	dispatcher, err := NewVectorPartitionShardSearchTCPDispatcherV1(map[raftcluster.GroupID]string{"group-a": listener.Addr().String()})
+	dispatcher, err := newVectorPartitionShardSearchTCPDispatcherV1(map[raftcluster.GroupID]string{"group-a": listener.Addr().String()}, nil, poolSize)
 	if err != nil {
 		t.Fatal(err)
 	}
 	defer dispatcher.Close()
-	firstDone := make(chan error, 1)
-	go func() {
-		_, err := dispatcher.DispatchVectorPartitionShardSearchV1(context.Background(), VectorPartitionShardSearchRequestV1{TargetGroupID: "group-a"})
-		firstDone <- err
-	}()
-	select {
-	case <-started:
-	case <-time.After(time.Second):
-		t.Fatal("first request did not acquire the pooled connection")
+	done := make(chan error, poolSize)
+	for range poolSize {
+		go func() {
+			_, err := dispatcher.DispatchVectorPartitionShardSearchV1(context.Background(), VectorPartitionShardSearchRequestV1{TargetGroupID: "group-a"})
+			done <- err
+		}()
+	}
+	for range poolSize {
+		select {
+		case <-started:
+		case <-time.After(time.Second):
+			t.Fatal("concurrent request did not acquire a distinct pooled connection")
+		}
 	}
 	ctx, cancel := context.WithCancel(context.Background())
 	secondDone := make(chan error, 1)
@@ -133,8 +138,10 @@ func TestVectorPartitionShardSearchTCPDispatcherCancellationWhileWaitingForConne
 		t.Fatal("canceled request remained blocked behind the pooled connection")
 	}
 	close(release)
-	if err := <-firstDone; err != nil {
-		t.Fatal(err)
+	for range poolSize {
+		if err := <-done; err != nil {
+			t.Fatal(err)
+		}
 	}
 }
 

--- a/TreeDB/nativewire/vector_partition_shard_search_tcp_v1_test.go
+++ b/TreeDB/nativewire/vector_partition_shard_search_tcp_v1_test.go
@@ -2,10 +2,12 @@ package nativewire
 
 import (
 	"context"
+	"encoding/binary"
 	"errors"
 	"fmt"
 	"io"
 	"net"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -46,6 +48,70 @@ func TestVectorPartitionShardSearchTCPDispatcherReusesConnectionV1(t *testing.T)
 	if got := accepts.Load(); got != 1 {
 		t.Fatalf("connections=%d want one reused connection", got)
 	}
+}
+
+func TestVectorPartitionShardSearchTCPDerivesSeparateFrameBoundsV1(t *testing.T) {
+	limits := DefaultVectorPartitionShardSearchLimitsV1()
+	dispatcher, err := newVectorPartitionShardSearchTCPDispatcherV1(map[raftcluster.GroupID]string{"group-a": "127.0.0.1:1"}, nil, 1, limits)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer dispatcher.Close()
+	if got, want := dispatcher.maxRequestFrame, uint32(limits.MaxRequestBytes*vectorPartitionShardSearchTCPJSONExpansionBoundV1); got != want {
+		t.Fatalf("request frame=%d want=%d", got, want)
+	}
+	if got, want := dispatcher.maxResponseFrame, uint32(limits.MaxResponseBytes*vectorPartitionShardSearchTCPJSONExpansionBoundV1); got != want {
+		t.Fatalf("response frame=%d want=%d", got, want)
+	}
+	limits.MaxResponseBytes = 128 << 20
+	dispatcher, err = newVectorPartitionShardSearchTCPDispatcherV1(map[raftcluster.GroupID]string{"group-a": "127.0.0.1:1"}, nil, 1, limits)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer dispatcher.Close()
+	if got, want := dispatcher.maxResponseFrame, uint32(limits.MaxResponseBytes*vectorPartitionShardSearchTCPJSONExpansionBoundV1); got != want {
+		t.Fatalf("custom response frame=%d want=%d", got, want)
+	}
+	limits.MaxResponseBytes = uint64(^uint32(0))/vectorPartitionShardSearchTCPJSONExpansionBoundV1 + 1
+	if _, err := newVectorPartitionShardSearchTCPDispatcherV1(map[raftcluster.GroupID]string{"group-a": "127.0.0.1:1"}, nil, 1, limits); err == nil {
+		t.Fatal("unencodable response limit succeeded")
+	}
+}
+
+func TestVectorPartitionShardSearchTCPServerBoundsRequestAndFailedResponseFramesV1(t *testing.T) {
+	t.Run("request", func(t *testing.T) {
+		client, server := net.Pipe()
+		defer client.Close()
+		called := atomic.Bool{}
+		go (VectorPartitionShardSearchTCPServerV1{MaxFrame: 64, MaxResponseFrame: 4096, Service: vectorPartitionShardSearchHandlerFuncV1(func(context.Context, VectorPartitionShardSearchRequestV1) (VectorPartitionShardSearchResponseV1, error) {
+			called.Store(true)
+			return VectorPartitionShardSearchResponseV1{}, nil
+		})}).ServeConn(context.Background(), server)
+		var prefix [4]byte
+		binary.BigEndian.PutUint32(prefix[:], 65)
+		if _, err := client.Write(prefix[:]); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := client.Read(make([]byte, 1)); !errors.Is(err, io.EOF) {
+			t.Fatalf("oversized request left connection open: %v", err)
+		}
+		if called.Load() {
+			t.Fatal("oversized request reached shard service")
+		}
+	})
+	t.Run("response", func(t *testing.T) {
+		client, server := net.Pipe()
+		defer client.Close()
+		go (VectorPartitionShardSearchTCPServerV1{MaxFrame: 4096, MaxResponseFrame: 64, Service: vectorPartitionShardSearchHandlerFuncV1(func(context.Context, VectorPartitionShardSearchRequestV1) (VectorPartitionShardSearchResponseV1, error) {
+			return VectorPartitionShardSearchResponseV1{RequestID: strings.Repeat("x", 4096)}, nil
+		})}).ServeConn(context.Background(), server)
+		if err := writeVectorPartitionShardSearchTCPFrameV1(client, vectorPartitionShardSearchTCPFrameV1{Request: &VectorPartitionShardSearchRequestV1{}}, 4096); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := readVectorPartitionShardSearchTCPFrameV1(client, 4096); !errors.Is(err, io.EOF) {
+			t.Fatalf("failed response write left connection open: %v", err)
+		}
+	})
 }
 
 func TestVectorPartitionShardSearchTCPCancelWatcherStopsBeforeReuseV1(t *testing.T) {
@@ -129,7 +195,7 @@ func TestVectorPartitionShardSearchTCPDispatcherReconnectsAfterIdleCloseAndFails
 			}()
 		}
 	}()
-	dispatcher, err := newVectorPartitionShardSearchTCPDispatcherV1(map[raftcluster.GroupID]string{"group-a": listener.Addr().String()}, nil, poolSize)
+	dispatcher, err := newVectorPartitionShardSearchTCPDispatcherV1(map[raftcluster.GroupID]string{"group-a": listener.Addr().String()}, nil, poolSize, VectorPartitionShardSearchLimitsV1{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -208,7 +274,7 @@ func TestVectorPartitionShardSearchTCPDispatcherCancellationWhilePoolIsFullV1(t 
 		<-release
 		return VectorPartitionShardSearchResponseV1{Version: 1}, nil
 	}))
-	dispatcher, err := newVectorPartitionShardSearchTCPDispatcherV1(map[raftcluster.GroupID]string{"group-a": listener.Addr().String()}, nil, poolSize)
+	dispatcher, err := newVectorPartitionShardSearchTCPDispatcherV1(map[raftcluster.GroupID]string{"group-a": listener.Addr().String()}, nil, poolSize, VectorPartitionShardSearchLimitsV1{})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/TreeDB/nativewire/vector_partition_shard_search_tcp_v1_test.go
+++ b/TreeDB/nativewire/vector_partition_shard_search_tcp_v1_test.go
@@ -46,6 +46,53 @@ func TestVectorPartitionShardSearchTCPDispatcherReusesConnectionV1(t *testing.T)
 	}
 }
 
+func TestVectorPartitionShardSearchTCPDispatcherReconnectsAfterIdleCloseAndFailsAfterCloseV1(t *testing.T) {
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer listener.Close()
+	idleClosed := make(chan struct{}, 1)
+	go func() {
+		for {
+			conn, err := listener.Accept()
+			if err != nil {
+				return
+			}
+			go func() {
+				(VectorPartitionShardSearchTCPServerV1{InitialTimeout: 10 * time.Millisecond, Service: vectorPartitionShardSearchHandlerFuncV1(func(_ context.Context, r VectorPartitionShardSearchRequestV1) (VectorPartitionShardSearchResponseV1, error) {
+					return VectorPartitionShardSearchResponseV1{Version: 1, RequestID: r.RequestID}, nil
+				})}).ServeConn(context.Background(), conn)
+				select {
+				case idleClosed <- struct{}{}:
+				default:
+				}
+			}()
+		}
+	}()
+	dispatcher, err := NewVectorPartitionShardSearchTCPDispatcherV1(map[raftcluster.GroupID]string{"group-a": listener.Addr().String()})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := dispatcher.DispatchVectorPartitionShardSearchV1(context.Background(), VectorPartitionShardSearchRequestV1{TargetGroupID: "group-a", RequestID: "first"}); err != nil {
+		t.Fatal(err)
+	}
+	select {
+	case <-idleClosed:
+	case <-time.After(time.Second):
+		t.Fatal("server did not close idle connection")
+	}
+	if response, err := dispatcher.DispatchVectorPartitionShardSearchV1(context.Background(), VectorPartitionShardSearchRequestV1{TargetGroupID: "group-a", RequestID: "reconnected"}); err != nil || response.RequestID != "reconnected" {
+		t.Fatalf("reconnect response=%+v err=%v", response, err)
+	}
+	if err := dispatcher.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := dispatcher.DispatchVectorPartitionShardSearchV1(context.Background(), VectorPartitionShardSearchRequestV1{TargetGroupID: "group-a"}); err == nil {
+		t.Fatal("closed dispatcher accepted request")
+	}
+}
+
 func TestVectorPartitionShardSearchTCPDispatcherUsesLeaderNodeEndpointV1(t *testing.T) {
 	leader := newVectorPartitionShardSearchTCPListenerV1(t, vectorPartitionShardSearchHandlerFuncV1(func(_ context.Context, r VectorPartitionShardSearchRequestV1) (VectorPartitionShardSearchResponseV1, error) {
 		return VectorPartitionShardSearchResponseV1{Version: 1, RequestID: r.RequestID}, nil

--- a/TreeDB/nativewire/vector_partition_shard_search_tcp_v1_test.go
+++ b/TreeDB/nativewire/vector_partition_shard_search_tcp_v1_test.go
@@ -3,6 +3,8 @@ package nativewire
 import (
 	"context"
 	"errors"
+	"fmt"
+	"io"
 	"net"
 	"sync"
 	"sync/atomic"
@@ -47,20 +49,33 @@ func TestVectorPartitionShardSearchTCPDispatcherReusesConnectionV1(t *testing.T)
 }
 
 func TestVectorPartitionShardSearchTCPDispatcherReconnectsAfterIdleCloseAndFailsAfterCloseV1(t *testing.T) {
+	const poolSize = 2
 	listener, err := net.Listen("tcp", "127.0.0.1:0")
 	if err != nil {
 		t.Fatal(err)
 	}
 	defer listener.Close()
-	idleClosed := make(chan struct{}, 1)
+	idleClosed := make(chan struct{}, poolSize)
+	started := make(chan struct{}, poolSize)
+	release := make(chan struct{})
+	var accepts atomic.Uint64
 	go func() {
 		for {
 			conn, err := listener.Accept()
 			if err != nil {
 				return
 			}
+			accepted := accepts.Add(1)
 			go func() {
-				(VectorPartitionShardSearchTCPServerV1{InitialTimeout: 10 * time.Millisecond, Service: vectorPartitionShardSearchHandlerFuncV1(func(_ context.Context, r VectorPartitionShardSearchRequestV1) (VectorPartitionShardSearchResponseV1, error) {
+				timeout := time.Second
+				if accepted <= poolSize {
+					timeout = 10 * time.Millisecond
+				}
+				(VectorPartitionShardSearchTCPServerV1{InitialTimeout: timeout, Service: vectorPartitionShardSearchHandlerFuncV1(func(_ context.Context, r VectorPartitionShardSearchRequestV1) (VectorPartitionShardSearchResponseV1, error) {
+					if r.RequestID != "reconnected" {
+						started <- struct{}{}
+						<-release
+					}
 					return VectorPartitionShardSearchResponseV1{Version: 1, RequestID: r.RequestID}, nil
 				})}).ServeConn(context.Background(), conn)
 				select {
@@ -70,20 +85,42 @@ func TestVectorPartitionShardSearchTCPDispatcherReconnectsAfterIdleCloseAndFails
 			}()
 		}
 	}()
-	dispatcher, err := NewVectorPartitionShardSearchTCPDispatcherV1(map[raftcluster.GroupID]string{"group-a": listener.Addr().String()})
+	dispatcher, err := newVectorPartitionShardSearchTCPDispatcherV1(map[raftcluster.GroupID]string{"group-a": listener.Addr().String()}, nil, poolSize)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if _, err := dispatcher.DispatchVectorPartitionShardSearchV1(context.Background(), VectorPartitionShardSearchRequestV1{TargetGroupID: "group-a", RequestID: "first"}); err != nil {
-		t.Fatal(err)
+	done := make(chan error, poolSize)
+	for i := range poolSize {
+		go func() {
+			_, err := dispatcher.DispatchVectorPartitionShardSearchV1(context.Background(), VectorPartitionShardSearchRequestV1{TargetGroupID: "group-a", RequestID: fmt.Sprintf("warm-%d", i)})
+			done <- err
+		}()
 	}
-	select {
-	case <-idleClosed:
-	case <-time.After(time.Second):
-		t.Fatal("server did not close idle connection")
+	for range poolSize {
+		select {
+		case <-started:
+		case <-time.After(time.Second):
+			t.Fatal("pooled connection did not start")
+		}
+	}
+	close(release)
+	for range poolSize {
+		if err := <-done; err != nil {
+			t.Fatal(err)
+		}
+	}
+	for range poolSize {
+		select {
+		case <-idleClosed:
+		case <-time.After(time.Second):
+			t.Fatal("server did not close pooled idle connection")
+		}
 	}
 	if response, err := dispatcher.DispatchVectorPartitionShardSearchV1(context.Background(), VectorPartitionShardSearchRequestV1{TargetGroupID: "group-a", RequestID: "reconnected"}); err != nil || response.RequestID != "reconnected" {
 		t.Fatalf("reconnect response=%+v err=%v", response, err)
+	}
+	if got := accepts.Load(); got != poolSize+1 {
+		t.Fatalf("connections=%d want %d", got, poolSize+1)
 	}
 	if err := dispatcher.Close(); err != nil {
 		t.Fatal(err)
@@ -91,6 +128,31 @@ func TestVectorPartitionShardSearchTCPDispatcherReconnectsAfterIdleCloseAndFails
 	if _, err := dispatcher.DispatchVectorPartitionShardSearchV1(context.Background(), VectorPartitionShardSearchRequestV1{TargetGroupID: "group-a"}); err == nil {
 		t.Fatal("closed dispatcher accepted request")
 	}
+}
+
+func TestVectorPartitionShardSearchTCPServerClosesAfterPeerInputDuringRequestV1(t *testing.T) {
+	serverConn, clientConn := net.Pipe()
+	started := make(chan struct{})
+	done := make(chan struct{})
+	go func() {
+		(VectorPartitionShardSearchTCPServerV1{Service: vectorPartitionShardSearchHandlerFuncV1(func(ctx context.Context, _ VectorPartitionShardSearchRequestV1) (VectorPartitionShardSearchResponseV1, error) {
+			close(started)
+			<-ctx.Done()
+			return VectorPartitionShardSearchResponseV1{}, ctx.Err()
+		})}).ServeConn(context.Background(), serverConn)
+		close(done)
+	}()
+	if err := writeVectorPartitionShardSearchTCPFrameV1(clientConn, vectorPartitionShardSearchTCPFrameV1{Request: &VectorPartitionShardSearchRequestV1{}}, vectorPartitionShardSearchTCPMaxFrameBytesV1); err != nil {
+		t.Fatal(err)
+	}
+	<-started
+	if _, err := clientConn.Write([]byte{0}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := readVectorPartitionShardSearchTCPFrameV1(clientConn, vectorPartitionShardSearchTCPMaxFrameBytesV1); !errors.Is(err, io.EOF) {
+		t.Fatalf("peer input left connection reusable: %v", err)
+	}
+	<-done
 }
 
 func TestVectorPartitionShardSearchTCPDispatcherCancellationWhilePoolIsFullV1(t *testing.T) {
@@ -332,10 +394,11 @@ func TestVectorPartitionShardSearchTCPDispatcherRejectsAmbiguousResponseFramesV1
 				_, _ = readVectorPartitionShardSearchTCPFrameV1(server, vectorPartitionShardSearchTCPMaxFrameBytesV1)
 				_ = writeVectorPartitionShardSearchTCPFrameV1(server, frame, vectorPartitionShardSearchTCPMaxFrameBytesV1)
 			}()
-			dispatcher := &VectorPartitionShardSearchTCPDispatcherV1{
-				endpoints: map[raftcluster.GroupID]string{"group-a": "pipe"}, maxFrame: vectorPartitionShardSearchTCPMaxFrameBytesV1,
-				dial: func(context.Context, string, string) (net.Conn, error) { return client, nil },
+			dispatcher, err := NewVectorPartitionShardSearchTCPDispatcherV1(map[raftcluster.GroupID]string{"group-a": "pipe"})
+			if err != nil {
+				t.Fatal(err)
 			}
+			dispatcher.dial = func(context.Context, string, string) (net.Conn, error) { return client, nil }
 			if _, err := dispatcher.DispatchVectorPartitionShardSearchV1(context.Background(), VectorPartitionShardSearchRequestV1{TargetGroupID: "group-a"}); err == nil {
 				t.Fatal("accepted ambiguous M5 response frame")
 			}

--- a/TreeDB/nativewire/vector_partition_shard_search_tcp_v1_test.go
+++ b/TreeDB/nativewire/vector_partition_shard_search_tcp_v1_test.go
@@ -129,6 +129,20 @@ func TestVectorPartitionShardSearchTCPServerBoundsRequestAndFailedResponseFrames
 			t.Fatalf("failed response write left connection open: %v", err)
 		}
 	})
+	t.Run("default response", func(t *testing.T) {
+		client, server := net.Pipe()
+		defer client.Close()
+		go (VectorPartitionShardSearchTCPServerV1{MaxFrame: 4096, Service: vectorPartitionShardSearchHandlerFuncV1(func(context.Context, VectorPartitionShardSearchRequestV1) (VectorPartitionShardSearchResponseV1, error) {
+			return VectorPartitionShardSearchResponseV1{RequestID: strings.Repeat("x", 8192)}, nil
+		})}).ServeConn(context.Background(), server)
+		if err := writeVectorPartitionShardSearchTCPFrameV1(client, vectorPartitionShardSearchTCPFrameV1{Request: &VectorPartitionShardSearchRequestV1{}}, 4096); err != nil {
+			t.Fatal(err)
+		}
+		frame, err := readVectorPartitionShardSearchTCPFrameV1(client, 16384)
+		if err != nil || frame.Response == nil || len(frame.Response.RequestID) != 8192 {
+			t.Fatalf("default response frame=%+v err=%v", frame, err)
+		}
+	})
 }
 
 func TestVectorPartitionShardSearchTCPCancelWatcherStopsBeforeReuseV1(t *testing.T) {
@@ -424,6 +438,9 @@ func TestVectorPartitionShardSearchTCPServerInterruptsPeerReadBeforeSuccessfulRe
 	case <-serverDone:
 	case <-time.After(time.Second):
 		t.Fatal("server did not return after peer close")
+	}
+	if !server.interruptedReadBeforeWrite() {
+		t.Fatal("successful response was written without interrupting the peer-monitor read")
 	}
 }
 

--- a/TreeDB/nativewire/vector_partition_shard_search_v1.go
+++ b/TreeDB/nativewire/vector_partition_shard_search_v1.go
@@ -397,6 +397,10 @@ func (s *VectorPartitionShardSearchServiceV1) Search(ctx context.Context, reques
 	s.stats.begin()
 	defer func() {
 		total := elapsedNanosV1(started)
+		total = max(total,
+			response.Timing.RouteOwnerNanos+response.Timing.ReadIndexApplyNanos+
+				response.Timing.GenerationOpenNanos+response.Timing.SearchNanos+
+				response.Timing.ResponseCopyNanos)
 		response.Timing.TotalNanos = total
 		if resultErr != nil {
 			s.stats.fail(classifyVectorPartitionShardSearchErrorV1(resultErr), total)


### PR DESCRIPTION
## Objective

Wire the existing vector-partition coordinator and shard service into a production-owned topology constructor without importing the M8 harness.

Closes #4014

## Design

- Validate live catalog placement and leader hints, concrete address-family-compatible owner endpoints, complete member-specific routing for locally served groups, endpoint uniqueness, normalized shard-service limits, the router source, and replicated lifecycle authority before serving.
- Start shard listeners only for declared partition owners; coordinator-only nodes remain supported.
- Reuse a bounded TCP connection pool per endpoint sized to configured shard concurrency, reconnect once after a transport loss, and route bounded leader retries to known node endpoints.
- Bound accepted shard connections separately from each dispatcher pool, derive distinct request/response wire-frame caps from the logical shard limits, join cancellation watchers before pooling sockets, and own listener, connection, dispatcher, and coordinator shutdown with partial-construction rollback in both production and M8 topologies.
- Expose a copied readiness/status snapshot.
- Preserve the existing request, response, fanout, deadline, cancellation, read-proof, generation-pin, and failure contracts.

## Boundaries

- No user-facing vector API; #4016 owns that layer.
- No rebuild/invalidation orchestration; #4017 owns that layer.
- No operations bundle or default enablement; #4018 owns that layer.
- No new storage format, Raft architecture, or ANN algorithm.

## Validation

- `GOWORK=off go test ./TreeDB/nativewire -count=1`
- `GOWORK=off go test ./TreeDB/nativewire -run 'TestVectorPartitionProductionTopology|TestVectorPartitionProductionEndpointMatchesListener' -count=100 -timeout=120s`
- `GOWORK=off go test -race ./TreeDB/nativewire -run 'TestVectorPartitionProductionTopology|TestVectorPartitionProductionEndpointMatchesListener' -count=10 -timeout=180s`
- `GOWORK=off go test ./TreeDB/nativewire -run 'TestVectorPartitionShardSearchTCPDerivesSeparateFrameBoundsV1|TestVectorPartitionShardSearchTCPServerBoundsRequestAndFailedResponseFramesV1|TestVectorPartitionProductionEndpointMatchesListenerAddressFamilyV1' -count=100`
- focused transport/topology selector with `-race -count=10`
- `GOWORK=off go vet ./TreeDB/nativewire`
- Windows and Darwin `go test -c` cross-compiles
- `GOWORK=off go test ./cmd/... -count=1` (at `8a9408c9b` before the final endpoint-validation patch)
- `git diff --check`

Coverage includes two-group generation-pinned TCP search, local and remote owners, member/leader-hint/address-family/hostless endpoint validation, truthful shared-listener rejection, connection reuse and reconnect, multi-pool accepted-connection admission, M8 dispatcher ownership, cancellation-watcher joining, request/response frame-limit alignment and failed writes, cancellation/deadline/disconnect behavior, incomplete topology refusal, partial-start rollback, shutdown, restart, and closed-path failure without partial neighbors. Build-file selection covers the fallback socket implementation on JS, Plan 9, and WASI.

## Performance

The existing 10k M8 production-topology test was run three times on merged main and this candidate with identical inputs:

| revision | runs | median | max RSS |
| --- | --- | ---: | ---: |
| merged main | 48.09s, 47.83s, 49.81s | 48.09s | 379,776 KiB |
| candidate | 48.97s, 49.23s, 48.85s | 48.97s | 376,576 KiB |

The +1.8% median wall delta is inside the observed run spread; peak RSS is 0.8% lower. No material regression is evidenced. The deterministic transport tests separately prove one accepted connection for repeated requests and successful reconnect after an idle close.

After the review-driven bounded-pool correction, the same current-head 10k test passed three consecutive runs in 146.883s total (48.96s/run) with 381,056 KiB peak RSS, materially unchanged from the candidate evidence above. Deterministic coverage also proves parallel leases up to the configured endpoint limit and context cancellation while saturated.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added production topology support for coordinated vector-partition searches over TCP.
  - Added topology status reporting, coordinator access, graceful shutdown, and restart handling.
  - Added node-aware endpoint routing with connection pooling, bounded concurrency, deadlines, and recoverable transport retries.
  - Added coordinator-only operation and platform-specific listener address validation.
  - Extended topology lifecycle management to include dispatcher startup and shutdown.

- **Bug Fixes**
  - Improved request cancellation, frame-size enforcement, connection recovery, peer-disconnect handling, and service-error behavior.
  - Corrected total search timing calculations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->