### PR TITLE
TreeDB: expose supported vector-partition search and lifecycle APIs

### DIFF
--- a/TreeDB/documentservice/service.go
+++ b/TreeDB/documentservice/service.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/snissn/gomap/TreeDB/collections"
 	backenddb "github.com/snissn/gomap/TreeDB/db"
+	"github.com/snissn/gomap/TreeDB/vectorpartition"
 )
 
 const maxServiceScanDocuments = int(^uint(0) >> 1)
@@ -27,7 +28,39 @@ type Service struct {
 
 	benchmarkSearchCacheMu sync.RWMutex
 	benchmarkSearchCache   map[string]*serviceBenchmarkSearchCacheEntry
+	vectorPartitionService *vectorpartition.ServiceV1
 	closed                 bool
+}
+
+// RegisterVectorPartitionServiceV1 installs the node-assembled partition
+// service at the normal document-service root. Applications obtain it with
+// VectorPartitionServiceV1 and never construct transport or lifecycle pieces.
+func (s *Service) RegisterVectorPartitionServiceV1(service *vectorpartition.ServiceV1) error {
+	if s == nil || service == nil {
+		return errors.New("document service: vector partition service is required")
+	}
+	s.benchmarkSearchCacheMu.Lock()
+	defer s.benchmarkSearchCacheMu.Unlock()
+	if s.closed {
+		return serviceClosedError()
+	}
+	if s.vectorPartitionService != nil {
+		return errors.New("document service: vector partition service already registered")
+	}
+	s.vectorPartitionService = service
+	return nil
+}
+
+func (s *Service) VectorPartitionServiceV1() (*vectorpartition.ServiceV1, error) {
+	if s == nil {
+		return nil, errors.New("document service: vector partition service is unavailable")
+	}
+	s.benchmarkSearchCacheMu.RLock()
+	defer s.benchmarkSearchCacheMu.RUnlock()
+	if s.closed || s.vectorPartitionService == nil {
+		return nil, errors.New("document service: vector partition service is unavailable")
+	}
+	return s.vectorPartitionService, nil
 }
 
 type serviceBenchmarkSearchCacheEntry struct {
@@ -54,6 +87,7 @@ func (s *Service) Close() error {
 		return nil
 	}
 	s.closed = true
+	s.vectorPartitionService = nil
 	for _, entry := range s.benchmarkSearchCache {
 		if entry != nil {
 			entries = append(entries, entry)

--- a/TreeDB/documentservice/service.go
+++ b/TreeDB/documentservice/service.go
@@ -35,6 +35,7 @@ type Service struct {
 // RegisterVectorPartitionServiceV1 installs the node-assembled partition
 // service at the normal document-service root. Applications obtain it with
 // VectorPartitionServiceV1 and never construct transport or lifecycle pieces.
+// The node retains backend ownership: Close only drops this service reference.
 func (s *Service) RegisterVectorPartitionServiceV1(service *vectorpartition.ServiceV1) error {
 	if s == nil || service == nil {
 		return errors.New("document service: vector partition service is required")

--- a/TreeDB/documentservice/vector_partition_service_v1_test.go
+++ b/TreeDB/documentservice/vector_partition_service_v1_test.go
@@ -1,0 +1,64 @@
+package documentservice
+
+import (
+	"context"
+	"testing"
+
+	"github.com/snissn/gomap/TreeDB/vectorpartition"
+)
+
+type documentVectorPartitionBackendV1 struct{ calls int }
+
+func (b *documentVectorPartitionBackendV1) SearchVectorPartitionV1(_ context.Context, r vectorpartition.SearchRequestV1) (vectorpartition.SearchResponseV1, error) {
+	b.calls++
+	return vectorpartition.SearchResponseV1{Generation: r.Generation}, nil
+}
+func (*documentVectorPartitionBackendV1) RegisterVectorPartitionV1(context.Context, vectorpartition.GenerationRegistrationV1) (vectorpartition.GenerationStatusV1, error) {
+	return vectorpartition.GenerationStatusV1{}, nil
+}
+func (*documentVectorPartitionBackendV1) GenerationStatusV1(context.Context, vectorpartition.GenerationIDV1) (vectorpartition.GenerationStatusV1, error) {
+	return vectorpartition.GenerationStatusV1{}, nil
+}
+func (*documentVectorPartitionBackendV1) PrepareVectorPartitionV1(context.Context, vectorpartition.GenerationIDV1) (vectorpartition.GenerationStatusV1, error) {
+	return vectorpartition.GenerationStatusV1{}, nil
+}
+func (*documentVectorPartitionBackendV1) ActivateVectorPartitionV1(context.Context, vectorpartition.GenerationIDV1) (vectorpartition.GenerationStatusV1, error) {
+	return vectorpartition.GenerationStatusV1{}, nil
+}
+func (*documentVectorPartitionBackendV1) InvalidateVectorPartitionV1(context.Context, vectorpartition.GenerationIDV1, string) (vectorpartition.GenerationStatusV1, error) {
+	return vectorpartition.GenerationStatusV1{}, nil
+}
+func (*documentVectorPartitionBackendV1) RetireVectorPartitionV1(context.Context, vectorpartition.GenerationIDV1) (vectorpartition.GenerationStatusV1, error) {
+	return vectorpartition.GenerationStatusV1{}, nil
+}
+func (*documentVectorPartitionBackendV1) RequestVectorPartitionRebuildV1(context.Context, vectorpartition.GenerationIDV1) (vectorpartition.GenerationStatusV1, error) {
+	return vectorpartition.GenerationStatusV1{}, nil
+}
+func (*documentVectorPartitionBackendV1) VectorPartitionCleanupEligibilityV1(context.Context, vectorpartition.GenerationIDV1) (vectorpartition.CleanupEligibilityV1, error) {
+	return vectorpartition.CleanupEligibilityV1{}, nil
+}
+
+func TestVectorPartitionServiceRegistrationDoesNotTransferBackendOwnershipV1(t *testing.T) {
+	backend := &documentVectorPartitionBackendV1{}
+	service, err := vectorpartition.NewServiceV1(backend)
+	if err != nil {
+		t.Fatal(err)
+	}
+	doc := New(nil)
+	if err := doc.RegisterVectorPartitionServiceV1(service); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := doc.VectorPartitionServiceV1(); err != nil {
+		t.Fatal(err)
+	}
+	if err := doc.Close(); err != nil {
+		t.Fatal(err)
+	}
+	id := vectorpartition.GenerationIDV1{Index: "embedding", Generation: 1}
+	if _, err := service.Search(context.Background(), vectorpartition.SearchRequestV1{Version: 1, Generation: id, Query: []float32{1}, Metric: vectorpartition.MetricCosineV1, TopK: 1, Probes: 1, EfSearch: 1, Consistency: vectorpartition.ConsistencyGenerationSnapshotV1, Limits: vectorpartition.SearchLimitsV1{RequestBytes: 4, CandidateBytes: 1, ResponseBytes: 1, MergeEntries: 1}}); err != nil {
+		t.Fatal(err)
+	}
+	if backend.calls != 1 {
+		t.Fatalf("backend calls = %d", backend.calls)
+	}
+}

--- a/TreeDB/internal/raftplacement/catalog_meta_lifecycle_harness_v1.go
+++ b/TreeDB/internal/raftplacement/catalog_meta_lifecycle_harness_v1.go
@@ -92,29 +92,14 @@ func OpenCatalogMetaLifecycleHarnessV1(ctx context.Context, opts CatalogMetaLife
 	if err != nil {
 		return nil, err
 	}
-	h := &CatalogMetaLifecycleHarnessV1{root: root, groupID: "catalog-meta", transports: map[raftcluster.NodeID]*hraft.InmemTransport{}, providers: map[raftcluster.NodeID]*raftcluster.CatalogMetaRaftProviderV1{}, authorities: map[raftcluster.NodeID]*CatalogMetaAuthorityV1{}}
+	h := &CatalogMetaLifecycleHarnessV1{root: root, groupID: "catalog-meta"}
 	fail := func(err error) (*CatalogMetaLifecycleHarnessV1, error) { _ = h.Close(); return nil, err }
 	for _, suffix := range []string{"a", "b", "c"} {
 		id := raftcluster.NodeID(prefix + "-" + suffix)
 		h.peers = append(h.peers, raftcluster.Peer{ID: id, Address: string(id), Capabilities: features})
-		_, tr := hraft.NewInmemTransportWithTimeout(hraft.ServerAddress(id), catalogMetaLifecycleHarnessCoordinationTimeoutV1)
-		h.transports[id] = tr
 	}
-	for _, from := range h.peers {
-		for _, to := range h.peers {
-			if from.ID != to.ID {
-				h.transports[from.ID].Connect(hraft.ServerAddress(to.Address), h.transports[to.ID])
-			}
-		}
-	}
-	for _, peer := range h.peers {
-		authority := NewCatalogMetaAuthorityV1()
-		provider, openErr := raftcluster.OpenCatalogMetaRaftProviderV1(raftcluster.CatalogMetaRaftProviderOptionsV1{Cluster: raftcluster.Config{Dir: filepath.Join(root, string(peer.ID), "db"), NodeID: peer.ID, GroupID: h.groupID, Peers: slices.Clone(h.peers), Features: features}, State: authority, Transport: h.transports[peer.ID], RaftConfig: catalogMetaLifecycleHarnessRaftConfigV1(), Bootstrap: true, ApplyTimeout: 3 * time.Second})
-		if openErr != nil {
-			return fail(fmt.Errorf("open catalog-meta node %s: %w", peer.ID, openErr))
-		}
-		h.authorities[peer.ID] = authority
-		h.providers[peer.ID] = provider
+	if err := h.openRuntimeV1(); err != nil {
+		return fail(err)
 	}
 	if err := h.waitLeader(ctx); err != nil {
 		return fail(err)
@@ -134,6 +119,35 @@ func OpenCatalogMetaLifecycleHarnessV1(ctx context.Context, opts CatalogMetaLife
 		return fail(err)
 	}
 	return h, nil
+}
+
+func (h *CatalogMetaLifecycleHarnessV1) openRuntimeV1() error {
+	h.transports = make(map[raftcluster.NodeID]*hraft.InmemTransport, len(h.peers))
+	h.providers = make(map[raftcluster.NodeID]*raftcluster.CatalogMetaRaftProviderV1, len(h.peers))
+	h.authorities = make(map[raftcluster.NodeID]*CatalogMetaAuthorityV1, len(h.peers))
+	features := catalogMetaLifecycleHarnessFeaturesV1()
+	for _, peer := range h.peers {
+		_, transport := hraft.NewInmemTransportWithTimeout(hraft.ServerAddress(peer.ID), catalogMetaLifecycleHarnessCoordinationTimeoutV1)
+		h.transports[peer.ID] = transport
+	}
+	for _, from := range h.peers {
+		for _, to := range h.peers {
+			if from.ID != to.ID {
+				h.transports[from.ID].Connect(hraft.ServerAddress(to.Address), h.transports[to.ID])
+			}
+		}
+	}
+	for _, peer := range h.peers {
+		authority := NewCatalogMetaAuthorityV1()
+		provider, err := raftcluster.OpenCatalogMetaRaftProviderV1(raftcluster.CatalogMetaRaftProviderOptionsV1{Cluster: raftcluster.Config{Dir: filepath.Join(h.root, string(peer.ID), "db"), NodeID: peer.ID, GroupID: h.groupID, Peers: slices.Clone(h.peers), Features: features}, State: authority, Transport: h.transports[peer.ID], RaftConfig: catalogMetaLifecycleHarnessRaftConfigV1(), Bootstrap: true, ApplyTimeout: 3 * time.Second})
+		if err != nil {
+			_ = h.closeRuntimeV1()
+			return fmt.Errorf("open catalog-meta node %s: %w", peer.ID, err)
+		}
+		h.authorities[peer.ID] = authority
+		h.providers[peer.ID] = provider
+	}
+	return nil
 }
 
 func catalogMetaLifecycleHarnessFeaturesV1() raftcluster.FeatureSet {
@@ -267,26 +281,72 @@ func (h *CatalogMetaLifecycleHarnessV1) WaitForAuthorities(ctx context.Context, 
 	}
 	return h.waitAuthorities(ctx, ready)
 }
+
+// RestartV1 closes and reopens every harness node over the same durable Raft
+// directories, then waits for a leader and replay through the last committed
+// catalog index.
+func (h *CatalogMetaLifecycleHarnessV1) RestartV1(ctx context.Context) error {
+	if h == nil || h.root == "" || h.LeaderFence() == nil {
+		return errors.New("catalog lifecycle harness unavailable")
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	applied, err := h.LeaderFence().LinearizableCatalogMetaAppliedIndexV1(ctx)
+	if err != nil {
+		return fmt.Errorf("fence catalog-meta before restart: %w", err)
+	}
+	if err := h.closeRuntimeV1(); err != nil {
+		return fmt.Errorf("close catalog-meta runtime for restart: %w", err)
+	}
+	if err := h.openRuntimeV1(); err != nil {
+		return err
+	}
+	fail := func(err error) error {
+		return errors.Join(err, h.closeRuntimeV1())
+	}
+	if err := h.waitLeader(ctx); err != nil {
+		return fail(err)
+	}
+	if err := h.waitAuthorities(ctx, func(authority *CatalogMetaAuthorityV1) bool {
+		replayed, ok := authority.CatalogMetaAppliedIndexV1()
+		return ok && replayed >= applied
+	}); err != nil {
+		return fail(fmt.Errorf("wait catalog-meta replay through index %d: %w", applied, err))
+	}
+	return nil
+}
+
+func (h *CatalogMetaLifecycleHarnessV1) closeRuntimeV1() error {
+	var errs []error
+	for _, provider := range h.providers {
+		if provider != nil {
+			errs = append(errs, provider.Close())
+		}
+	}
+	for _, transport := range h.transports {
+		if transport != nil {
+			errs = append(errs, transport.Close())
+		}
+	}
+	h.providers = nil
+	h.transports = nil
+	h.authorities = nil
+	h.leader = ""
+	return errors.Join(errs...)
+}
+
 func (h *CatalogMetaLifecycleHarnessV1) Close() error {
 	if h == nil {
 		return nil
 	}
-	var errs []error
-	for id, p := range h.providers {
-		if p != nil {
-			errs = append(errs, p.Close())
-			delete(h.providers, id)
-		}
-	}
-	for id, tr := range h.transports {
-		if tr != nil {
-			errs = append(errs, tr.Close())
-			delete(h.transports, id)
-		}
-	}
+	err := h.closeRuntimeV1()
 	if h.root != "" {
-		errs = append(errs, os.RemoveAll(h.root))
+		err = errors.Join(err, os.RemoveAll(h.root))
 		h.root = ""
 	}
-	return errors.Join(errs...)
+	return err
 }

--- a/TreeDB/internal/raftplacement/vector_partition_lifecycle_coordinator_v1.go
+++ b/TreeDB/internal/raftplacement/vector_partition_lifecycle_coordinator_v1.go
@@ -165,7 +165,15 @@ func (a *CatalogMetaAuthorityV1) lifecycleRecordForIndexGenerationV1(index Vecto
 // command refusal. This makes retry idempotent without weakening the ordering
 // invariant.
 func (c VectorPartitionLifecycleCoordinatorV1) InvalidateBeforeRelevantMutationV1(ctx context.Context, identity VectorPartitionLifecycleIndexIdentityV1, reason string) (VectorPartitionLifecycleMutationProofV1, error) {
-	return c.invalidateBeforeRelevantMutationV1(ctx, identity, reason, 0)
+	return c.invalidateBeforeRelevantMutationV1(ctx, identity, reason, 0, 0)
+}
+
+// InvalidateGenerationBeforeRelevantMutationV1 refuses to invalidate a successor that replaced the generation named by identity.
+func (c VectorPartitionLifecycleCoordinatorV1) InvalidateGenerationBeforeRelevantMutationV1(ctx context.Context, identity VectorPartitionLifecycleIdentityV1, reason string) (VectorPartitionLifecycleMutationProofV1, error) {
+	if err := validateVectorPartitionLifecycleIdentityV1(identity); err != nil {
+		return VectorPartitionLifecycleMutationProofV1{}, err
+	}
+	return c.invalidateBeforeRelevantMutationV1(ctx, identity.Index, reason, 0, identity.Generation)
 }
 
 // InvalidateBeforeRelevantMutationAtEpochV1 binds per-index invalidation to
@@ -175,10 +183,10 @@ func (c VectorPartitionLifecycleCoordinatorV1) InvalidateBeforeRelevantMutationA
 	if mutationEpoch == 0 {
 		return VectorPartitionLifecycleMutationProofV1{}, errors.Join(ErrVectorPartitionLifecycleGuard, fmt.Errorf("collection mutation epoch is required"))
 	}
-	return c.invalidateBeforeRelevantMutationV1(ctx, identity, reason, mutationEpoch)
+	return c.invalidateBeforeRelevantMutationV1(ctx, identity, reason, mutationEpoch, 0)
 }
 
-func (c VectorPartitionLifecycleCoordinatorV1) invalidateBeforeRelevantMutationV1(ctx context.Context, identity VectorPartitionLifecycleIndexIdentityV1, reason string, mutationEpoch uint64) (VectorPartitionLifecycleMutationProofV1, error) {
+func (c VectorPartitionLifecycleCoordinatorV1) invalidateBeforeRelevantMutationV1(ctx context.Context, identity VectorPartitionLifecycleIndexIdentityV1, reason string, mutationEpoch, expectedGeneration uint64) (VectorPartitionLifecycleMutationProofV1, error) {
 	if c.Authority == nil || c.Committer == nil {
 		return VectorPartitionLifecycleMutationProofV1{}, ErrCatalogMetaUnavailable
 	}
@@ -188,6 +196,9 @@ func (c VectorPartitionLifecycleCoordinatorV1) invalidateBeforeRelevantMutationV
 	proof, active, err := c.Authority.MutationProofV1(identity)
 	if err != nil {
 		return proof, err
+	}
+	if active && expectedGeneration != 0 && proof.ActiveGeneration != expectedGeneration {
+		return VectorPartitionLifecycleMutationProofV1{}, ErrVectorPartitionLifecycleIdentity
 	}
 	if !active {
 		if err := c.validateConfirmedMutationProofV1(identity, proof, "prior"); err != nil {

--- a/TreeDB/nativewire/vector_partition_production_topology_v1_test.go
+++ b/TreeDB/nativewire/vector_partition_production_topology_v1_test.go
@@ -69,6 +69,14 @@ func TestVectorPartitionProductionTopologyRollsBackPartialStartAndRestartsV1(t *
 }
 
 func newVectorPartitionProductionTopologyTwoGroupTestV1(t *testing.T) (*VectorPartitionProductionTopologyV1, VectorPartitionCoordinatorRequestV1, map[raftcluster.GroupID]*fakeVectorPartitionReadCoordinatorV1) {
+	return newVectorPartitionProductionTopologyTwoGroupWithLifecycleTestV1(t, &recordingVectorPartitionReplicatedLifecycleAuthorityV1{})
+}
+
+func newVectorPartitionProductionTopologyTwoGroupWithLifecycleTestV1(t *testing.T, lifecycle VectorPartitionReplicatedLifecycleAuthorityV1) (*VectorPartitionProductionTopologyV1, VectorPartitionCoordinatorRequestV1, map[raftcluster.GroupID]*fakeVectorPartitionReadCoordinatorV1) {
+	return newVectorPartitionProductionTopologyTwoGroupWithLifecycleReadySetTestV1(t, lifecycle, strings.Repeat("b", 64))
+}
+
+func newVectorPartitionProductionTopologyTwoGroupWithLifecycleReadySetTestV1(t *testing.T, lifecycle VectorPartitionReplicatedLifecycleAuthorityV1, readySetDigest string) (*VectorPartitionProductionTopologyV1, VectorPartitionCoordinatorRequestV1, map[raftcluster.GroupID]*fakeVectorPartitionReadCoordinatorV1) {
 	t.Helper()
 	ref := raftplacement.CollectionRefV1{Database: "db", Catalog: "default", Collection: "docs"}
 	groups := []raftplacement.GroupV1{{ID: "group-a", Members: []raftcluster.NodeID{"node-a"}, LeaderHint: "node-a"}, {ID: "group-b", Members: []raftcluster.NodeID{"node-b"}, LeaderHint: "node-b"}}
@@ -77,7 +85,7 @@ func newVectorPartitionProductionTopologyTwoGroupTestV1(t *testing.T) (*VectorPa
 		t.Fatal(err)
 	}
 	placement := raftplacement.VectorPartitionPlacementRecordV1{Collection: ref, IndexName: "embedding", IndexDefinitionDigest: vectorPartitionShardSearchDigestTestV1, SourceGeneration: 11, SourceChecksum: 22, SourceSchemaHash: 33, SourceRowCount: 2, PartitionGeneration: 7, PartitionCount: 2, Partitions: []raftplacement.VectorPartitionGroupV1{{PartitionID: 0, GroupID: "group-a"}, {PartitionID: 1, GroupID: "group-b"}}}
-	manifest := collections.VectorPartitionManifestV1{Format: collections.VectorPartitionManifestFormatV1, State: "ready", Collection: ref.Collection, IndexName: placement.IndexName, IndexDefinitionDigest: placement.IndexDefinitionDigest, SourceGeneration: placement.SourceGeneration, SourceChecksum: placement.SourceChecksum, SourceSchemaHash: placement.SourceSchemaHash, SourceRowCount: placement.SourceRowCount, Generation: placement.PartitionGeneration, RouterGeneration: placement.PartitionGeneration, ReadySetDigest: strings.Repeat("b", 64), PartitionCount: 2, Placements: []collections.VectorPartitionPlacementV1{{PartitionID: 0, GroupID: "group-a"}, {PartitionID: 1, GroupID: "group-b"}}, Memberships: []collections.VectorPartitionMembershipV1{{VectorOrdinal: 0, PartitionID: 0}, {VectorOrdinal: 1, PartitionID: 1}}}
+	manifest := collections.VectorPartitionManifestV1{Format: collections.VectorPartitionManifestFormatV1, State: "ready", Collection: ref.Collection, IndexName: placement.IndexName, IndexDefinitionDigest: placement.IndexDefinitionDigest, SourceGeneration: placement.SourceGeneration, SourceChecksum: placement.SourceChecksum, SourceSchemaHash: placement.SourceSchemaHash, SourceRowCount: placement.SourceRowCount, Generation: placement.PartitionGeneration, RouterGeneration: placement.PartitionGeneration, ReadySetDigest: readySetDigest, PartitionCount: 2, Placements: []collections.VectorPartitionPlacementV1{{PartitionID: 0, GroupID: "group-a"}, {PartitionID: 1, GroupID: "group-b"}}, Memberships: []collections.VectorPartitionMembershipV1{{VectorOrdinal: 0, PartitionID: 0}, {VectorOrdinal: 1, PartitionID: 1}}}
 	reads := make(map[raftcluster.GroupID]*fakeVectorPartitionReadCoordinatorV1, 2)
 	service := func(group raftcluster.GroupID, node raftcluster.NodeID, partition uint32) *VectorPartitionShardSearchServiceV1 {
 		read := &fakeVectorPartitionReadCoordinatorV1{proof: raftcluster.ReadIndexProof{NodeID: node, GroupID: group, Term: 1, Index: 9, HasQuorum: true, EvidenceKind: raftcluster.ReadIndexEvidenceProduction}, progress: raftcluster.AppliedProgress{NodeID: node, GroupID: group, Term: 1, Index: 9, HasApplied: true}}
@@ -102,7 +110,7 @@ func newVectorPartitionProductionTopologyTwoGroupTestV1(t *testing.T) (*VectorPa
 	boundA := listenerA.Addr().(*net.TCPAddr)
 	listenerA = &temporaryWildcardTCPListenerV1{Listener: listenerA, addr: &net.TCPAddr{IP: net.IPv4zero, Port: boundA.Port}}
 	router := &testVectorPartitionCoordinatorRouterV1{status: collections.VectorPartitionRouterRuntimeStatusV1{Manifest: manifest, ModelDigest: strings.Repeat("c", 64), Representatives: 2, Partitions: 2}, partitions: []collections.VectorPartitionRouterPartitionScoreV1{{PartitionID: 0}, {PartitionID: 1, Distance: 0.1}}}
-	topology, err := NewVectorPartitionProductionTopologyV1(VectorPartitionProductionTopologyOptionsV1{Catalog: catalog, Placement: placement, RouterSource: &testVectorPartitionCoordinatorRouterSourceV1{router: router}, ReplicatedLifecycle: &recordingVectorPartitionReplicatedLifecycleAuthorityV1{}, Endpoints: map[raftcluster.GroupID]string{"group-a": endpointA, "group-b": listenerB.Addr().String()}, Shards: []VectorPartitionProductionShardV1{{GroupID: "group-a", Listener: listenerA, Service: service("group-a", "node-a", 0)}, {GroupID: "group-b", Listener: listenerB, Service: service("group-b", "node-b", 1)}}})
+	topology, err := NewVectorPartitionProductionTopologyV1(VectorPartitionProductionTopologyOptionsV1{Catalog: catalog, Placement: placement, RouterSource: &testVectorPartitionCoordinatorRouterSourceV1{router: router}, ReplicatedLifecycle: lifecycle, Endpoints: map[raftcluster.GroupID]string{"group-a": endpointA, "group-b": listenerB.Addr().String()}, Shards: []VectorPartitionProductionShardV1{{GroupID: "group-a", Listener: listenerA, Service: service("group-a", "node-a", 0)}, {GroupID: "group-b", Listener: listenerB, Service: service("group-b", "node-b", 1)}}})
 	if err != nil {
 		_ = listenerA.Close()
 		_ = listenerB.Close()

--- a/TreeDB/nativewire/vector_partition_production_topology_v1_test.go
+++ b/TreeDB/nativewire/vector_partition_production_topology_v1_test.go
@@ -68,15 +68,15 @@ func TestVectorPartitionProductionTopologyRollsBackPartialStartAndRestartsV1(t *
 	}
 }
 
-func newVectorPartitionProductionTopologyTwoGroupTestV1(t *testing.T) (*VectorPartitionProductionTopologyV1, VectorPartitionCoordinatorRequestV1, map[raftcluster.GroupID]*fakeVectorPartitionReadCoordinatorV1) {
+func newVectorPartitionProductionTopologyTwoGroupTestV1(t testing.TB) (*VectorPartitionProductionTopologyV1, VectorPartitionCoordinatorRequestV1, map[raftcluster.GroupID]*fakeVectorPartitionReadCoordinatorV1) {
 	return newVectorPartitionProductionTopologyTwoGroupWithLifecycleTestV1(t, &recordingVectorPartitionReplicatedLifecycleAuthorityV1{})
 }
 
-func newVectorPartitionProductionTopologyTwoGroupWithLifecycleTestV1(t *testing.T, lifecycle VectorPartitionReplicatedLifecycleAuthorityV1) (*VectorPartitionProductionTopologyV1, VectorPartitionCoordinatorRequestV1, map[raftcluster.GroupID]*fakeVectorPartitionReadCoordinatorV1) {
+func newVectorPartitionProductionTopologyTwoGroupWithLifecycleTestV1(t testing.TB, lifecycle VectorPartitionReplicatedLifecycleAuthorityV1) (*VectorPartitionProductionTopologyV1, VectorPartitionCoordinatorRequestV1, map[raftcluster.GroupID]*fakeVectorPartitionReadCoordinatorV1) {
 	return newVectorPartitionProductionTopologyTwoGroupWithLifecycleReadySetTestV1(t, lifecycle, strings.Repeat("b", 64))
 }
 
-func newVectorPartitionProductionTopologyTwoGroupWithLifecycleReadySetTestV1(t *testing.T, lifecycle VectorPartitionReplicatedLifecycleAuthorityV1, readySetDigest string) (*VectorPartitionProductionTopologyV1, VectorPartitionCoordinatorRequestV1, map[raftcluster.GroupID]*fakeVectorPartitionReadCoordinatorV1) {
+func newVectorPartitionProductionTopologyTwoGroupWithLifecycleReadySetTestV1(t testing.TB, lifecycle VectorPartitionReplicatedLifecycleAuthorityV1, readySetDigest string) (*VectorPartitionProductionTopologyV1, VectorPartitionCoordinatorRequestV1, map[raftcluster.GroupID]*fakeVectorPartitionReadCoordinatorV1) {
 	t.Helper()
 	ref := raftplacement.CollectionRefV1{Database: "db", Catalog: "default", Collection: "docs"}
 	groups := []raftplacement.GroupV1{{ID: "group-a", Members: []raftcluster.NodeID{"node-a"}, LeaderHint: "node-a"}, {ID: "group-b", Members: []raftcluster.NodeID{"node-b"}, LeaderHint: "node-b"}}

--- a/TreeDB/nativewire/vector_partition_public_backend_v1.go
+++ b/TreeDB/nativewire/vector_partition_public_backend_v1.go
@@ -1,0 +1,159 @@
+package nativewire
+
+// This adapter is the sole bridge from the supported vectorpartition service
+// to the production topology and replicated lifecycle workflow. Its options
+// are node-construction inputs; callers of vectorpartition.ServiceV1 never see
+// these nativewire or raftplacement values.
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/snissn/gomap/TreeDB/internal/raftcluster"
+	"github.com/snissn/gomap/TreeDB/internal/raftplacement"
+	public "github.com/snissn/gomap/TreeDB/vectorpartition"
+)
+
+type VectorPartitionPublicBackendOptionsV1 struct {
+	Topology       *VectorPartitionProductionTopologyV1
+	RequestBase    VectorPartitionCoordinatorRequestV1
+	Lifecycle      raftplacement.VectorPartitionLifecycleCoordinatorV1
+	Identity       raftplacement.VectorPartitionLifecycleIdentityV1
+	RequiredGroups []raftcluster.GroupID
+	Builder        raftplacement.VectorPartitionLifecycleGroupBuilderV1
+	MutationEpoch  uint64
+	// RebuildRequest is an optional node-owned enqueue hook. It deliberately
+	// does not run a rebuild inline; scheduling and recovery policy are #4018.
+	RebuildRequest func(context.Context) error
+}
+
+type VectorPartitionPublicBackendV1 struct {
+	opts VectorPartitionPublicBackendOptionsV1
+}
+
+func NewVectorPartitionPublicBackendV1(opts VectorPartitionPublicBackendOptionsV1) (*VectorPartitionPublicBackendV1, error) {
+	if opts.Topology == nil || opts.Topology.Coordinator() == nil || opts.Identity.Generation == 0 || opts.Identity.Index.IndexName == "" || len(opts.RequiredGroups) == 0 {
+		return nil, errors.New("nativewire: public vector partition backend is incomplete")
+	}
+	if opts.Builder == nil || opts.Lifecycle.Authority == nil || opts.Lifecycle.Committer == nil {
+		return nil, errors.New("nativewire: public vector partition backend requires lifecycle authority and group builder")
+	}
+	return &VectorPartitionPublicBackendV1{opts: opts}, nil
+}
+
+func (b *VectorPartitionPublicBackendV1) SearchVectorPartitionV1(ctx context.Context, request public.SearchRequestV1) (public.SearchResponseV1, error) {
+	if b == nil || b.opts.Topology.Status().Closed {
+		return public.SearchResponseV1{}, errors.New("production topology is unavailable")
+	}
+	if err := b.checkID(request.Generation); err != nil {
+		return public.SearchResponseV1{}, err
+	}
+	r := b.opts.RequestBase
+	r.Query, r.IndexName, r.TopK, r.PartitionProbes, r.EfSearch, r.Consistency = request.Query, request.Generation.Index, request.TopK, request.Probes, request.EfSearch, VectorPartitionShardSearchConsistencyV1(request.Consistency)
+	if !request.Deadline.IsZero() {
+		r.DeadlineUnixNano = request.Deadline.UnixNano()
+	}
+	response, err := b.opts.Topology.Coordinator().Search(ctx, r)
+	if err != nil {
+		return public.SearchResponseV1{}, err
+	}
+	result := public.SearchResponseV1{Generation: request.Generation, Counters: public.SearchCountersV1{Requests: response.Counters.Requests, RPCs: response.Counters.RPCs, Retries: response.Counters.Retries, Redirects: response.Counters.Redirects, Candidates: response.Counters.Candidates, Edges: response.Counters.Edges}, Timing: public.SearchTimingV1{Total: time.Duration(response.Timing.TotalNanos)}}
+	result.Neighbors = make([]public.NeighborV1, len(response.Neighbors))
+	for i, n := range response.Neighbors {
+		result.Neighbors[i] = public.NeighborV1{ID: n.ID, Score: n.Score}
+	}
+	return result, nil
+}
+
+func (b *VectorPartitionPublicBackendV1) RegisterVectorPartitionV1(ctx context.Context, registration public.GenerationRegistrationV1) (public.GenerationStatusV1, error) {
+	if err := b.checkID(registration.GenerationIDV1); err != nil {
+		return public.GenerationStatusV1{}, err
+	}
+	i := b.opts.Identity
+	if registration.SourceGeneration != 0 && (registration.SourceGeneration != i.Source.Generation || registration.SourceChecksum != i.Source.Checksum || registration.SourceSchemaHash != i.Source.SchemaHash || registration.SourceRowCount != i.Source.RowCount) {
+		return public.GenerationStatusV1{}, errors.New("generation source does not match bound topology")
+	}
+	record, err := b.opts.Lifecycle.BeginBuildV1(ctx, i, b.opts.RequiredGroups, 0, b.opts.MutationEpoch)
+	if err != nil {
+		return public.GenerationStatusV1{}, err
+	}
+	for _, group := range b.opts.RequiredGroups {
+		record, err = b.opts.Lifecycle.BuildAndRecordGroupReadyV1(ctx, b.opts.Builder, i, group)
+		if err != nil {
+			return public.GenerationStatusV1{}, err
+		}
+	}
+	return publicStatusV1(record, false), nil
+}
+func (b *VectorPartitionPublicBackendV1) GenerationStatusV1(_ context.Context, id public.GenerationIDV1) (public.GenerationStatusV1, error) {
+	if err := b.checkID(id); err != nil {
+		return public.GenerationStatusV1{}, err
+	}
+	r, ok := b.opts.Lifecycle.Authority.VectorPartitionLifecycleRecordV1(b.opts.Identity)
+	if !ok {
+		return public.GenerationStatusV1{Generation: id, State: public.GenerationAbsentV1}, nil
+	}
+	return publicStatusV1(r, false), nil
+}
+func (b *VectorPartitionPublicBackendV1) PrepareVectorPartitionV1(ctx context.Context, id public.GenerationIDV1) (public.GenerationStatusV1, error) {
+	if err := b.checkID(id); err != nil {
+		return public.GenerationStatusV1{}, err
+	}
+	r, err := b.opts.Lifecycle.PrepareV1(ctx, b.opts.Identity)
+	return publicStatusV1(r, false), err
+}
+func (b *VectorPartitionPublicBackendV1) ActivateVectorPartitionV1(ctx context.Context, id public.GenerationIDV1) (public.GenerationStatusV1, error) {
+	if err := b.checkID(id); err != nil {
+		return public.GenerationStatusV1{}, err
+	}
+	r, err := b.opts.Lifecycle.ActivateV1(ctx, b.opts.Identity)
+	return publicStatusV1(r, err == nil && r.State == raftplacement.VectorPartitionLifecycleActiveV1), err
+}
+func (b *VectorPartitionPublicBackendV1) InvalidateVectorPartitionV1(ctx context.Context, id public.GenerationIDV1, reason string) (public.GenerationStatusV1, error) {
+	if err := b.checkID(id); err != nil {
+		return public.GenerationStatusV1{}, err
+	}
+	_, err := b.opts.Lifecycle.InvalidateBeforeRelevantMutationV1(ctx, b.opts.Identity.Index, reason)
+	if err != nil {
+		return public.GenerationStatusV1{}, err
+	}
+	return b.GenerationStatusV1(ctx, id)
+}
+func (b *VectorPartitionPublicBackendV1) RetireVectorPartitionV1(ctx context.Context, id public.GenerationIDV1) (public.GenerationStatusV1, error) {
+	if err := b.checkID(id); err != nil {
+		return public.GenerationStatusV1{}, err
+	}
+	r, err := b.opts.Lifecycle.RetireV1(ctx, b.opts.Identity)
+	return publicStatusV1(r, false), err
+}
+func (b *VectorPartitionPublicBackendV1) RequestVectorPartitionRebuildV1(ctx context.Context, id public.GenerationIDV1) (public.GenerationStatusV1, error) {
+	if err := b.checkID(id); err != nil {
+		return public.GenerationStatusV1{}, err
+	}
+	if b.opts.RebuildRequest == nil {
+		return public.GenerationStatusV1{}, errors.New("rebuild request is not configured")
+	}
+	if err := b.opts.RebuildRequest(ctx); err != nil {
+		return public.GenerationStatusV1{}, err
+	}
+	return b.GenerationStatusV1(ctx, id)
+}
+func (b *VectorPartitionPublicBackendV1) VectorPartitionCleanupEligibilityV1(ctx context.Context, id public.GenerationIDV1) (public.CleanupEligibilityV1, error) {
+	status, err := b.GenerationStatusV1(ctx, id)
+	if err != nil {
+		return public.CleanupEligibilityV1{}, err
+	}
+	return public.CleanupEligibilityV1{Eligible: status.State == public.GenerationCleanableV1, Status: status}, nil
+}
+
+func (b *VectorPartitionPublicBackendV1) checkID(id public.GenerationIDV1) error {
+	if b == nil || id.Index != b.opts.Identity.Index.IndexName || id.Generation != b.opts.Identity.Generation {
+		return fmt.Errorf("generation does not match bound topology")
+	}
+	return nil
+}
+func publicStatusV1(r raftplacement.VectorPartitionLifecycleRecordV1, active bool) public.GenerationStatusV1 {
+	return public.GenerationStatusV1{Generation: public.GenerationIDV1{Index: r.Identity.Index.IndexName, Generation: r.Identity.Generation}, State: public.GenerationStateV1(r.State), Active: active, Ready: len(r.RequiredGroups) != 0 && len(r.ReadyGroups) == len(r.RequiredGroups), Revision: r.Revision}
+}

--- a/TreeDB/nativewire/vector_partition_public_backend_v1.go
+++ b/TreeDB/nativewire/vector_partition_public_backend_v1.go
@@ -60,6 +60,9 @@ func (b *VectorPartitionPublicBackendV1) SearchVectorPartitionV1(ctx context.Con
 	if err != nil {
 		return public.SearchResponseV1{}, publicBackendErrorV1(err)
 	}
+	if response.PartitionGeneration != request.Generation.Generation {
+		return public.SearchResponseV1{}, &public.ErrorV1{Code: public.ErrorGenerationMismatchV1, Err: errors.New("serving topology returned another generation")}
+	}
 	result := public.SearchResponseV1{Generation: request.Generation, Counters: public.SearchCountersV1{
 		SelectedPartitions: response.Counters.SelectedPartitions, SelectedGroups: response.Counters.SelectedGroups,
 		Requests: response.Counters.Requests, RPCs: response.Counters.RPCs, Retries: response.Counters.Retries, Redirects: response.Counters.Redirects,
@@ -132,8 +135,11 @@ func (b *VectorPartitionPublicBackendV1) InvalidateVectorPartitionV1(ctx context
 	if err := b.checkID(id); err != nil {
 		return public.GenerationStatusV1{}, err
 	}
-	_, err := b.opts.Lifecycle.InvalidateBeforeRelevantMutationV1(ctx, b.opts.Identity.Index, reason)
+	_, err := b.opts.Lifecycle.InvalidateGenerationBeforeRelevantMutationV1(ctx, b.opts.Identity, reason)
 	if err != nil {
+		if errors.Is(err, raftplacement.ErrVectorPartitionLifecycleIdentity) {
+			return public.GenerationStatusV1{}, &public.ErrorV1{Code: public.ErrorGenerationMismatchV1, Err: err}
+		}
 		return public.GenerationStatusV1{}, err
 	}
 	return b.GenerationStatusV1(ctx, id)

--- a/TreeDB/nativewire/vector_partition_public_backend_v1.go
+++ b/TreeDB/nativewire/vector_partition_public_backend_v1.go
@@ -81,7 +81,18 @@ func (b *VectorPartitionPublicBackendV1) RegisterVectorPartitionV1(ctx context.C
 	if registration.SourceGeneration == 0 || registration.SourceChecksum == 0 || registration.SourceSchemaHash == 0 || registration.SourceRowCount == 0 || registration.SourceGeneration != i.Source.Generation || registration.SourceChecksum != i.Source.Checksum || registration.SourceSchemaHash != i.Source.SchemaHash || registration.SourceRowCount != i.Source.RowCount {
 		return public.GenerationStatusV1{}, &public.ErrorV1{Code: public.ErrorGenerationMismatchV1, Err: errors.New("generation source does not match bound topology")}
 	}
-	record, err := b.opts.Lifecycle.BeginBuildV1(ctx, i, b.opts.RequiredGroups, 0, b.opts.MutationEpoch)
+	previousGeneration := uint64(0)
+	if existing, ok := b.opts.Lifecycle.Authority.VectorPartitionLifecycleRecordV1(i); ok {
+		previousGeneration = existing.PreviousActiveGeneration
+	} else {
+		for _, status := range b.opts.Lifecycle.Authority.VectorPartitionLifecycleStatusesV1() {
+			if status.Active && status.Identity.Index == i.Index {
+				previousGeneration = status.Identity.Generation
+				break
+			}
+		}
+	}
+	record, err := b.opts.Lifecycle.BeginBuildV1(ctx, i, b.opts.RequiredGroups, previousGeneration, b.opts.MutationEpoch)
 	if err != nil {
 		return public.GenerationStatusV1{}, err
 	}

--- a/TreeDB/nativewire/vector_partition_public_backend_v1.go
+++ b/TreeDB/nativewire/vector_partition_public_backend_v1.go
@@ -60,7 +60,12 @@ func (b *VectorPartitionPublicBackendV1) SearchVectorPartitionV1(ctx context.Con
 	if err != nil {
 		return public.SearchResponseV1{}, publicBackendErrorV1(err)
 	}
-	result := public.SearchResponseV1{Generation: request.Generation, Counters: public.SearchCountersV1{Requests: response.Counters.Requests, RPCs: response.Counters.RPCs, Retries: response.Counters.Retries, Redirects: response.Counters.Redirects, Candidates: response.Counters.Candidates, Edges: response.Counters.Edges}, Timing: public.SearchTimingV1{Total: time.Duration(response.Timing.TotalNanos)}}
+	result := public.SearchResponseV1{Generation: request.Generation, Counters: public.SearchCountersV1{
+		SelectedPartitions: response.Counters.SelectedPartitions, SelectedGroups: response.Counters.SelectedGroups,
+		Requests: response.Counters.Requests, RPCs: response.Counters.RPCs, Retries: response.Counters.Retries, Redirects: response.Counters.Redirects,
+		Candidates: response.Counters.Candidates, Edges: response.Counters.Edges,
+		QueryBytes: response.Counters.QueryBytes, RequestBytes: response.Counters.RequestBytes, CandidateBytes: response.Counters.CandidateBytes, ResponseBytes: response.Counters.ResponseBytes,
+	}, Timing: public.SearchTimingV1{Total: time.Duration(response.Timing.TotalNanos)}}
 	result.Neighbors = make([]public.NeighborV1, len(response.Neighbors))
 	for i, n := range response.Neighbors {
 		result.Neighbors[i] = public.NeighborV1{ID: n.ID, Score: n.Score}

--- a/TreeDB/nativewire/vector_partition_public_backend_v1.go
+++ b/TreeDB/nativewire/vector_partition_public_backend_v1.go
@@ -74,7 +74,7 @@ func (b *VectorPartitionPublicBackendV1) RegisterVectorPartitionV1(ctx context.C
 	}
 	i := b.opts.Identity
 	if registration.SourceGeneration == 0 || registration.SourceChecksum == 0 || registration.SourceSchemaHash == 0 || registration.SourceRowCount == 0 || registration.SourceGeneration != i.Source.Generation || registration.SourceChecksum != i.Source.Checksum || registration.SourceSchemaHash != i.Source.SchemaHash || registration.SourceRowCount != i.Source.RowCount {
-		return public.GenerationStatusV1{}, errors.New("generation source does not match bound topology")
+		return public.GenerationStatusV1{}, &public.ErrorV1{Code: public.ErrorGenerationMismatchV1, Err: errors.New("generation source does not match bound topology")}
 	}
 	record, err := b.opts.Lifecycle.BeginBuildV1(ctx, i, b.opts.RequiredGroups, 0, b.opts.MutationEpoch)
 	if err != nil {
@@ -151,7 +151,7 @@ func (b *VectorPartitionPublicBackendV1) VectorPartitionCleanupEligibilityV1(ctx
 
 func (b *VectorPartitionPublicBackendV1) checkID(id public.GenerationIDV1) error {
 	if b == nil || id.Index != b.opts.Identity.Index.IndexName || id.Generation != b.opts.Identity.Generation {
-		return fmt.Errorf("generation does not match bound topology")
+		return &public.ErrorV1{Code: public.ErrorGenerationMismatchV1, Err: fmt.Errorf("generation does not match bound topology")}
 	}
 	return nil
 }

--- a/TreeDB/nativewire/vector_partition_public_backend_v1.go
+++ b/TreeDB/nativewire/vector_partition_public_backend_v1.go
@@ -201,8 +201,10 @@ func publicBackendErrorV1(err error) error {
 	var coordinatorErr *VectorPartitionCoordinatorErrorV1
 	if errors.As(err, &coordinatorErr) {
 		switch coordinatorErr.Code {
-		case VectorPartitionCoordinatorErrorInvalidRequestV1, VectorPartitionCoordinatorErrorRouteMismatchV1, VectorPartitionCoordinatorErrorBudgetExceededV1, VectorPartitionCoordinatorErrorMalformedResponseV1:
+		case VectorPartitionCoordinatorErrorInvalidRequestV1, VectorPartitionCoordinatorErrorRouteMismatchV1, VectorPartitionCoordinatorErrorBudgetExceededV1:
 			return &public.ErrorV1{Code: public.ErrorInvalidRequestV1, Err: err}
+		case VectorPartitionCoordinatorErrorMalformedResponseV1:
+			return &public.ErrorV1{Code: public.ErrorFailedV1, Err: err}
 		case VectorPartitionCoordinatorErrorGenerationMismatchV1:
 			return &public.ErrorV1{Code: public.ErrorGenerationMismatchV1, Err: err}
 		case VectorPartitionCoordinatorErrorCanceledV1:

--- a/TreeDB/nativewire/vector_partition_public_backend_v1.go
+++ b/TreeDB/nativewire/vector_partition_public_backend_v1.go
@@ -51,13 +51,14 @@ func (b *VectorPartitionPublicBackendV1) SearchVectorPartitionV1(ctx context.Con
 		return public.SearchResponseV1{}, err
 	}
 	r := b.opts.RequestBase
-	r.Query, r.IndexName, r.TopK, r.PartitionProbes, r.EfSearch, r.Consistency = request.Query, request.Generation.Index, request.TopK, request.Probes, request.EfSearch, VectorPartitionShardSearchConsistencyV1(request.Consistency)
+	r.Version, r.Query, r.IndexName, r.Metric, r.TopK, r.PartitionProbes, r.EfSearch, r.Consistency = request.Version, request.Query, request.Generation.Index, VectorPartitionShardSearchMetricV1(request.Metric), request.TopK, request.Probes, request.EfSearch, VectorPartitionShardSearchConsistencyV1(request.Consistency)
+	r.RequestBytesLimit, r.CandidateBytesLimit, r.ResponseBytesLimit, r.MergeEntriesLimit = request.Limits.RequestBytes, request.Limits.CandidateBytes, request.Limits.ResponseBytes, request.Limits.MergeEntries
 	if !request.Deadline.IsZero() {
 		r.DeadlineUnixNano = request.Deadline.UnixNano()
 	}
 	response, err := b.opts.Topology.Coordinator().Search(ctx, r)
 	if err != nil {
-		return public.SearchResponseV1{}, err
+		return public.SearchResponseV1{}, publicBackendErrorV1(err)
 	}
 	result := public.SearchResponseV1{Generation: request.Generation, Counters: public.SearchCountersV1{Requests: response.Counters.Requests, RPCs: response.Counters.RPCs, Retries: response.Counters.Retries, Redirects: response.Counters.Redirects, Candidates: response.Counters.Candidates, Edges: response.Counters.Edges}, Timing: public.SearchTimingV1{Total: time.Duration(response.Timing.TotalNanos)}}
 	result.Neighbors = make([]public.NeighborV1, len(response.Neighbors))
@@ -72,7 +73,7 @@ func (b *VectorPartitionPublicBackendV1) RegisterVectorPartitionV1(ctx context.C
 		return public.GenerationStatusV1{}, err
 	}
 	i := b.opts.Identity
-	if registration.SourceGeneration != 0 && (registration.SourceGeneration != i.Source.Generation || registration.SourceChecksum != i.Source.Checksum || registration.SourceSchemaHash != i.Source.SchemaHash || registration.SourceRowCount != i.Source.RowCount) {
+	if registration.SourceGeneration == 0 || registration.SourceChecksum == 0 || registration.SourceSchemaHash == 0 || registration.SourceRowCount == 0 || registration.SourceGeneration != i.Source.Generation || registration.SourceChecksum != i.Source.Checksum || registration.SourceSchemaHash != i.Source.SchemaHash || registration.SourceRowCount != i.Source.RowCount {
 		return public.GenerationStatusV1{}, errors.New("generation source does not match bound topology")
 	}
 	record, err := b.opts.Lifecycle.BeginBuildV1(ctx, i, b.opts.RequiredGroups, 0, b.opts.MutationEpoch)
@@ -154,6 +155,29 @@ func (b *VectorPartitionPublicBackendV1) checkID(id public.GenerationIDV1) error
 	}
 	return nil
 }
-func publicStatusV1(r raftplacement.VectorPartitionLifecycleRecordV1, active bool) public.GenerationStatusV1 {
-	return public.GenerationStatusV1{Generation: public.GenerationIDV1{Index: r.Identity.Index.IndexName, Generation: r.Identity.Generation}, State: public.GenerationStateV1(r.State), Active: active, Ready: len(r.RequiredGroups) != 0 && len(r.ReadyGroups) == len(r.RequiredGroups), Revision: r.Revision}
+func publicStatusV1(r raftplacement.VectorPartitionLifecycleRecordV1, _ bool) public.GenerationStatusV1 {
+	return public.GenerationStatusV1{Generation: public.GenerationIDV1{Index: r.Identity.Index.IndexName, Generation: r.Identity.Generation}, State: public.GenerationStateV1(r.State), Active: r.State == raftplacement.VectorPartitionLifecycleActiveV1, Ready: len(r.RequiredGroups) != 0 && len(r.ReadyGroups) == len(r.RequiredGroups), Revision: r.Revision}
+}
+
+func publicBackendErrorV1(err error) error {
+	if errors.Is(err, context.Canceled) {
+		return &public.ErrorV1{Code: public.ErrorCanceledV1, Err: err}
+	}
+	if errors.Is(err, context.DeadlineExceeded) {
+		return &public.ErrorV1{Code: public.ErrorDeadlineExceededV1, Err: err}
+	}
+	var coordinatorErr *VectorPartitionCoordinatorErrorV1
+	if errors.As(err, &coordinatorErr) {
+		switch coordinatorErr.Code {
+		case VectorPartitionCoordinatorErrorInvalidRequestV1, VectorPartitionCoordinatorErrorRouteMismatchV1, VectorPartitionCoordinatorErrorBudgetExceededV1, VectorPartitionCoordinatorErrorMalformedResponseV1:
+			return &public.ErrorV1{Code: public.ErrorInvalidRequestV1, Err: err}
+		case VectorPartitionCoordinatorErrorGenerationMismatchV1:
+			return &public.ErrorV1{Code: public.ErrorGenerationMismatchV1, Err: err}
+		case VectorPartitionCoordinatorErrorCanceledV1:
+			return &public.ErrorV1{Code: public.ErrorCanceledV1, Err: err}
+		case VectorPartitionCoordinatorErrorDeadlineV1:
+			return &public.ErrorV1{Code: public.ErrorDeadlineExceededV1, Err: err}
+		}
+	}
+	return &public.ErrorV1{Code: public.ErrorUnavailableV1, Err: err}
 }

--- a/TreeDB/nativewire/vector_partition_public_backend_v1.go
+++ b/TreeDB/nativewire/vector_partition_public_backend_v1.go
@@ -100,6 +100,16 @@ func (b *VectorPartitionPublicBackendV1) RegisterVectorPartitionV1(ctx context.C
 		return public.GenerationStatusV1{}, err
 	}
 	for _, group := range b.opts.RequiredGroups {
+		alreadyReady := false
+		for _, ready := range record.ReadyGroups {
+			if ready.GroupID == group {
+				alreadyReady = true
+				break
+			}
+		}
+		if alreadyReady {
+			continue
+		}
 		record, err = b.opts.Lifecycle.BuildAndRecordGroupReadyV1(ctx, b.opts.Builder, i, group)
 		if err != nil {
 			return public.GenerationStatusV1{}, err

--- a/TreeDB/nativewire/vector_partition_public_backend_v1.go
+++ b/TreeDB/nativewire/vector_partition_public_backend_v1.go
@@ -91,7 +91,7 @@ func (b *VectorPartitionPublicBackendV1) RegisterVectorPartitionV1(ctx context.C
 			return public.GenerationStatusV1{}, err
 		}
 	}
-	return publicStatusV1(record, false), nil
+	return publicStatusV1(record), nil
 }
 func (b *VectorPartitionPublicBackendV1) GenerationStatusV1(_ context.Context, id public.GenerationIDV1) (public.GenerationStatusV1, error) {
 	if err := b.checkID(id); err != nil {
@@ -101,21 +101,21 @@ func (b *VectorPartitionPublicBackendV1) GenerationStatusV1(_ context.Context, i
 	if !ok {
 		return public.GenerationStatusV1{Generation: id, State: public.GenerationAbsentV1}, nil
 	}
-	return publicStatusV1(r, false), nil
+	return publicStatusV1(r), nil
 }
 func (b *VectorPartitionPublicBackendV1) PrepareVectorPartitionV1(ctx context.Context, id public.GenerationIDV1) (public.GenerationStatusV1, error) {
 	if err := b.checkID(id); err != nil {
 		return public.GenerationStatusV1{}, err
 	}
 	r, err := b.opts.Lifecycle.PrepareV1(ctx, b.opts.Identity)
-	return publicStatusV1(r, false), err
+	return publicStatusV1(r), err
 }
 func (b *VectorPartitionPublicBackendV1) ActivateVectorPartitionV1(ctx context.Context, id public.GenerationIDV1) (public.GenerationStatusV1, error) {
 	if err := b.checkID(id); err != nil {
 		return public.GenerationStatusV1{}, err
 	}
 	r, err := b.opts.Lifecycle.ActivateV1(ctx, b.opts.Identity)
-	return publicStatusV1(r, err == nil && r.State == raftplacement.VectorPartitionLifecycleActiveV1), err
+	return publicStatusV1(r), err
 }
 func (b *VectorPartitionPublicBackendV1) InvalidateVectorPartitionV1(ctx context.Context, id public.GenerationIDV1, reason string) (public.GenerationStatusV1, error) {
 	if err := b.checkID(id); err != nil {
@@ -132,7 +132,7 @@ func (b *VectorPartitionPublicBackendV1) RetireVectorPartitionV1(ctx context.Con
 		return public.GenerationStatusV1{}, err
 	}
 	r, err := b.opts.Lifecycle.RetireV1(ctx, b.opts.Identity)
-	return publicStatusV1(r, false), err
+	return publicStatusV1(r), err
 }
 func (b *VectorPartitionPublicBackendV1) RequestVectorPartitionRebuildV1(ctx context.Context, id public.GenerationIDV1) (public.GenerationStatusV1, error) {
 	if err := b.checkID(id); err != nil {
@@ -160,7 +160,7 @@ func (b *VectorPartitionPublicBackendV1) checkID(id public.GenerationIDV1) error
 	}
 	return nil
 }
-func publicStatusV1(r raftplacement.VectorPartitionLifecycleRecordV1, _ bool) public.GenerationStatusV1 {
+func publicStatusV1(r raftplacement.VectorPartitionLifecycleRecordV1) public.GenerationStatusV1 {
 	return public.GenerationStatusV1{Generation: public.GenerationIDV1{Index: r.Identity.Index.IndexName, Generation: r.Identity.Generation}, State: public.GenerationStateV1(r.State), Active: r.State == raftplacement.VectorPartitionLifecycleActiveV1, Ready: len(r.RequiredGroups) != 0 && len(r.ReadyGroups) == len(r.RequiredGroups), Revision: r.Revision}
 }
 

--- a/TreeDB/nativewire/vector_partition_public_backend_v1.go
+++ b/TreeDB/nativewire/vector_partition_public_backend_v1.go
@@ -53,6 +53,7 @@ func (b *VectorPartitionPublicBackendV1) SearchVectorPartitionV1(ctx context.Con
 	r := b.opts.RequestBase
 	r.Version, r.Query, r.IndexName, r.Metric, r.TopK, r.PartitionProbes, r.EfSearch, r.Consistency = request.Version, request.Query, request.Generation.Index, VectorPartitionShardSearchMetricV1(request.Metric), request.TopK, request.Probes, request.EfSearch, VectorPartitionShardSearchConsistencyV1(request.Consistency)
 	r.RequestBytesLimit, r.CandidateBytesLimit, r.ResponseBytesLimit, r.MergeEntriesLimit = request.Limits.RequestBytes, request.Limits.CandidateBytes, request.Limits.ResponseBytes, request.Limits.MergeEntries
+	r.DeadlineUnixNano = 0
 	if !request.Deadline.IsZero() {
 		r.DeadlineUnixNano = request.Deadline.UnixNano()
 	}

--- a/TreeDB/nativewire/vector_partition_public_backend_v1_test.go
+++ b/TreeDB/nativewire/vector_partition_public_backend_v1_test.go
@@ -3,8 +3,10 @@ package nativewire
 import (
 	"context"
 	"errors"
+	"fmt"
 	"testing"
 
+	"github.com/snissn/gomap/TreeDB/internal/raftcluster"
 	"github.com/snissn/gomap/TreeDB/internal/raftplacement"
 	public "github.com/snissn/gomap/TreeDB/vectorpartition"
 )
@@ -29,6 +31,86 @@ func TestVectorPartitionPublicBackendMapsCoordinatorErrorsV1(t *testing.T) {
 	}
 	if got := publicBackendErrorV1(context.Canceled); !errors.Is(got, context.Canceled) {
 		t.Fatalf("canceled = %v", got)
+	}
+}
+
+func TestVectorPartitionPublicBackendMapsBoundGenerationMismatchV1(t *testing.T) {
+	backend := &VectorPartitionPublicBackendV1{opts: VectorPartitionPublicBackendOptionsV1{Identity: raftplacement.VectorPartitionLifecycleIdentityV1{Index: raftplacement.VectorPartitionLifecycleIndexIdentityV1{IndexName: "embedding"}, Source: raftplacement.VectorPartitionLifecycleSourceIdentityV1{Generation: 1, Checksum: 2, SchemaHash: 3, RowCount: 4}, Generation: 7}}}
+	service, err := public.NewServiceV1(backend)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := service.RequestRebuild(context.Background(), public.GenerationIDV1{Index: "embedding", Generation: 8}); !hasPublicErrorCodeV1(err, public.ErrorGenerationMismatchV1) {
+		t.Fatalf("id mismatch = %v", err)
+	}
+	if _, err := service.Register(context.Background(), public.GenerationRegistrationV1{GenerationIDV1: public.GenerationIDV1{Index: "embedding", Generation: 7}, SourceGeneration: 1, SourceChecksum: 2, SourceSchemaHash: 3, SourceRowCount: 5}); !hasPublicErrorCodeV1(err, public.ErrorGenerationMismatchV1) {
+		t.Fatalf("source mismatch = %v", err)
+	}
+}
+
+func hasPublicErrorCodeV1(err error, want public.ErrorCodeV1) bool {
+	var apiErr *public.ErrorV1
+	return errors.As(err, &apiErr) && apiErr.Code == want
+}
+
+type publicBackendLifecycleBuilderV1 struct{}
+
+func (publicBackendLifecycleBuilderV1) BuildAndStageVectorPartitionGroupV1(_ context.Context, _ raftplacement.VectorPartitionLifecycleIdentityV1, group raftcluster.GroupID) (raftplacement.VectorPartitionLifecycleGroupReadyV1, error) {
+	return raftplacement.VectorPartitionLifecycleGroupReadyV1{GroupID: group, AppliedIndex: 9, AssetSetDigest: fmt.Sprintf("%064x", len(group))}, nil
+}
+
+func TestVectorPartitionPublicBackendLifecycleOverCatalogMetaRaftV1(t *testing.T) {
+	ctx := t.Context()
+	topology, base, _ := newVectorPartitionProductionTopologyTwoGroupTestV1(t)
+	defer topology.Close()
+	catalog := raftplacement.CatalogV1{Features: raftplacement.DefaultFeatureSet(), Groups: []raftplacement.GroupV1{{ID: "group-a", Members: []raftcluster.NodeID{"node-a"}}, {ID: "group-b", Members: []raftcluster.NodeID{"node-b"}}}, Placements: []raftplacement.CollectionPlacementV1{{Collection: raftplacement.CollectionRefV1{Database: base.Database, Catalog: base.Catalog, Collection: base.Collection}, GroupID: "group-a", Mode: raftplacement.PlacementModeCollectionV1}}}
+	catalog.Features.Required = append(catalog.Features.Required, raftcluster.RequiredFeature{Name: raftcluster.FeatureVectorPartitionLifecycle, Version: raftcluster.SupportedFeatureFloors[raftcluster.FeatureVectorPartitionLifecycle]})
+	harness, err := raftplacement.OpenCatalogMetaLifecycleHarnessV1(ctx, raftplacement.CatalogMetaLifecycleHarnessOptionsV1{Catalog: catalog, Prefix: "public-vector"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer harness.Close()
+	meta, ok := harness.LeaderAuthority().Status()
+	if !ok {
+		t.Fatal("leader authority unavailable")
+	}
+	identity := raftplacement.VectorPartitionLifecycleIdentityV1{Index: raftplacement.VectorPartitionLifecycleIndexIdentityV1{Collection: raftplacement.CollectionRefV1{Database: base.Database, Catalog: base.Catalog, Collection: base.Collection}, CollectionIncarnation: 1, IndexName: base.IndexName, IndexDefinitionDigest: base.IndexDefinitionDigest, IndexEpoch: 1, CatalogEpoch: meta.Epoch, CatalogDigest: meta.Digest}, Source: raftplacement.VectorPartitionLifecycleSourceIdentityV1{Generation: 11, Checksum: 22, SchemaHash: 33, RowCount: 2}, Generation: 7}
+	backend, err := NewVectorPartitionPublicBackendV1(VectorPartitionPublicBackendOptionsV1{Topology: topology, RequestBase: base, Lifecycle: harness.LifecycleCoordinator(), Identity: identity, RequiredGroups: []raftcluster.GroupID{"group-a", "group-b"}, Builder: publicBackendLifecycleBuilderV1{}, MutationEpoch: 1, RebuildRequest: func(context.Context) error { return nil }})
+	if err != nil {
+		t.Fatal(err)
+	}
+	service, err := public.NewServiceV1(backend)
+	if err != nil {
+		t.Fatal(err)
+	}
+	id := public.GenerationIDV1{Index: base.IndexName, Generation: 7}
+	if _, err := service.Register(ctx, public.GenerationRegistrationV1{GenerationIDV1: id, SourceGeneration: 11, SourceChecksum: 22, SourceSchemaHash: 33, SourceRowCount: 2}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := service.Prepare(ctx, id); err != nil {
+		t.Fatal(err)
+	}
+	if status, err := service.Activate(ctx, id); err != nil || !status.Active {
+		t.Fatalf("activate = %#v, %v", status, err)
+	}
+	if status, err := service.Status(ctx, id); err != nil || !status.Active {
+		t.Fatalf("status = %#v, %v", status, err)
+	}
+	if _, err := harness.LeaderFence().LinearizableCatalogMetaAppliedIndexV1(ctx); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := service.Invalidate(ctx, id, "mutation"); err != nil {
+		t.Fatal(err)
+	}
+	proof, active, err := harness.LeaderAuthority().MutationProofV1(identity.Index)
+	if err != nil || active {
+		t.Fatalf("invalidation proof = %#v active=%v err=%v", proof, active, err)
+	}
+	if err := harness.LifecycleCoordinator().ConfirmRelevantMutationV1(ctx, proof); err != nil {
+		t.Fatal(err)
+	}
+	if status, err := service.Retire(ctx, id); err != nil || status.State != public.GenerationRetiredV1 {
+		t.Fatalf("retire = %#v, %v", status, err)
 	}
 }
 

--- a/TreeDB/nativewire/vector_partition_public_backend_v1_test.go
+++ b/TreeDB/nativewire/vector_partition_public_backend_v1_test.go
@@ -201,6 +201,7 @@ func TestVectorPartitionPublicBackendSearchesProductionTopologyV1(t *testing.T) 
 	if err != nil {
 		t.Fatal(err)
 	}
+	base.DeadlineUnixNano = time.Now().Add(-time.Second).UnixNano()
 	backend := &VectorPartitionPublicBackendV1{opts: VectorPartitionPublicBackendOptionsV1{
 		Topology: topology, RequestBase: base,
 		Identity: raftplacement.VectorPartitionLifecycleIdentityV1{Index: raftplacement.VectorPartitionLifecycleIndexIdentityV1{IndexName: base.IndexName}, Generation: 7},

--- a/TreeDB/nativewire/vector_partition_public_backend_v1_test.go
+++ b/TreeDB/nativewire/vector_partition_public_backend_v1_test.go
@@ -61,21 +61,30 @@ func (publicBackendLifecycleBuilderV1) BuildAndStageVectorPartitionGroupV1(_ con
 
 func TestVectorPartitionPublicBackendLifecycleOverCatalogMetaRaftV1(t *testing.T) {
 	ctx := t.Context()
-	topology, base, _ := newVectorPartitionProductionTopologyTwoGroupTestV1(t)
-	defer topology.Close()
-	catalog := raftplacement.CatalogV1{Features: raftplacement.DefaultFeatureSet(), Groups: []raftplacement.GroupV1{{ID: "group-a", Members: []raftcluster.NodeID{"node-a"}}, {ID: "group-b", Members: []raftcluster.NodeID{"node-b"}}}, Placements: []raftplacement.CollectionPlacementV1{{Collection: raftplacement.CollectionRefV1{Database: base.Database, Catalog: base.Catalog, Collection: base.Collection}, GroupID: "group-a", Mode: raftplacement.PlacementModeCollectionV1}}}
+	catalog := raftplacement.CatalogV1{Features: raftplacement.DefaultFeatureSet(), Groups: []raftplacement.GroupV1{{ID: "group-a", Members: []raftcluster.NodeID{"node-a"}}, {ID: "group-b", Members: []raftcluster.NodeID{"node-b"}}}, Placements: []raftplacement.CollectionPlacementV1{{Collection: raftplacement.CollectionRefV1{Database: "db", Catalog: "default", Collection: "docs"}, GroupID: "group-a", Mode: raftplacement.PlacementModeCollectionV1}}}
 	catalog.Features.Required = append(catalog.Features.Required, raftcluster.RequiredFeature{Name: raftcluster.FeatureVectorPartitionLifecycle, Version: raftcluster.SupportedFeatureFloors[raftcluster.FeatureVectorPartitionLifecycle]})
 	harness, err := raftplacement.OpenCatalogMetaLifecycleHarnessV1(ctx, raftplacement.CatalogMetaLifecycleHarnessOptionsV1{Catalog: catalog, Prefix: "public-vector"})
 	if err != nil {
 		t.Fatal(err)
 	}
 	defer harness.Close()
+	servingAuthority, err := NewLinearizableCatalogVectorPartitionLifecycleAuthorityV1(harness.LeaderAuthority(), harness.LeaderFence())
+	if err != nil {
+		t.Fatal(err)
+	}
 	meta, ok := harness.LeaderAuthority().Status()
 	if !ok {
 		t.Fatal("leader authority unavailable")
 	}
-	identity := raftplacement.VectorPartitionLifecycleIdentityV1{Index: raftplacement.VectorPartitionLifecycleIndexIdentityV1{Collection: raftplacement.CollectionRefV1{Database: base.Database, Catalog: base.Catalog, Collection: base.Collection}, CollectionIncarnation: 1, IndexName: base.IndexName, IndexDefinitionDigest: base.IndexDefinitionDigest, IndexEpoch: 1, CatalogEpoch: meta.Epoch, CatalogDigest: meta.Digest}, Source: raftplacement.VectorPartitionLifecycleSourceIdentityV1{Generation: 11, Checksum: 22, SchemaHash: 33, RowCount: 2}, Generation: 7}
-	backend, err := NewVectorPartitionPublicBackendV1(VectorPartitionPublicBackendOptionsV1{Topology: topology, RequestBase: base, Lifecycle: harness.LifecycleCoordinator(), Identity: identity, RequiredGroups: []raftcluster.GroupID{"group-a", "group-b"}, Builder: publicBackendLifecycleBuilderV1{}, MutationEpoch: 1, RebuildRequest: func(context.Context) error { return nil }})
+	identity := raftplacement.VectorPartitionLifecycleIdentityV1{Index: raftplacement.VectorPartitionLifecycleIndexIdentityV1{Collection: raftplacement.CollectionRefV1{Database: "db", Catalog: "default", Collection: "docs"}, CollectionIncarnation: 1, IndexName: "embedding", IndexDefinitionDigest: vectorPartitionShardSearchDigestTestV1, IndexEpoch: 1, CatalogEpoch: meta.Epoch, CatalogDigest: meta.Digest}, Source: raftplacement.VectorPartitionLifecycleSourceIdentityV1{Generation: 11, Checksum: 22, SchemaHash: 33, RowCount: 2}, Generation: 7}
+	requiredGroups := []raftcluster.GroupID{"group-a", "group-b"}
+	readySetDigest, err := raftplacement.VectorPartitionLifecycleReadySetDigestV1(identity, requiredGroups, []raftplacement.VectorPartitionLifecycleGroupReadyV1{{GroupID: "group-a", AppliedIndex: 9, AssetSetDigest: fmt.Sprintf("%064x", len("group-a"))}, {GroupID: "group-b", AppliedIndex: 9, AssetSetDigest: fmt.Sprintf("%064x", len("group-b"))}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	topology, base, reads := newVectorPartitionProductionTopologyTwoGroupWithLifecycleReadySetTestV1(t, servingAuthority, readySetDigest)
+	defer topology.Close()
+	backend, err := NewVectorPartitionPublicBackendV1(VectorPartitionPublicBackendOptionsV1{Topology: topology, RequestBase: base, Lifecycle: harness.LifecycleCoordinator(), Identity: identity, RequiredGroups: requiredGroups, Builder: publicBackendLifecycleBuilderV1{}, MutationEpoch: 1, RebuildRequest: func(context.Context) error { return nil }})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -95,6 +104,16 @@ func TestVectorPartitionPublicBackendLifecycleOverCatalogMetaRaftV1(t *testing.T
 	}
 	if status, err := service.Status(ctx, id); err != nil || !status.Active {
 		t.Fatalf("status = %#v, %v", status, err)
+	}
+	request := public.SearchRequestV1{Version: 1, Generation: id, Query: []float32{1, 0}, Metric: public.MetricCosineV1, TopK: base.TopK, Probes: base.PartitionProbes, EfSearch: base.EfSearch, Consistency: public.ConsistencyGenerationSnapshotV1, Limits: public.SearchLimitsV1{RequestBytes: base.RequestBytesLimit, CandidateBytes: base.CandidateBytesLimit, ResponseBytes: base.ResponseBytesLimit, MergeEntries: base.MergeEntriesLimit}}
+	response, err := service.Search(ctx, request)
+	if err != nil || len(response.Neighbors) == 0 {
+		t.Fatalf("search = %#v, %v", response, err)
+	}
+	for group, read := range reads {
+		if read.callCount() == 0 {
+			t.Fatalf("group %q did not produce read evidence", group)
+		}
 	}
 	if _, err := harness.LeaderFence().LinearizableCatalogMetaAppliedIndexV1(ctx); err != nil {
 		t.Fatal(err)

--- a/TreeDB/nativewire/vector_partition_public_backend_v1_test.go
+++ b/TreeDB/nativewire/vector_partition_public_backend_v1_test.go
@@ -77,18 +77,19 @@ func TestVectorPartitionPublicBackendLifecycleOverCatalogMetaRaftV1(t *testing.T
 	}
 	identity := raftplacement.VectorPartitionLifecycleIdentityV1{Index: raftplacement.VectorPartitionLifecycleIndexIdentityV1{Collection: raftplacement.CollectionRefV1{Database: "db", Catalog: "default", Collection: "docs"}, CollectionIncarnation: 1, IndexName: "embedding", IndexDefinitionDigest: vectorPartitionShardSearchDigestTestV1, IndexEpoch: 1, CatalogEpoch: meta.Epoch, CatalogDigest: meta.Digest}, Source: raftplacement.VectorPartitionLifecycleSourceIdentityV1{Generation: 11, Checksum: 22, SchemaHash: 33, RowCount: 2}, Generation: 7}
 	requiredGroups := []raftcluster.GroupID{"group-a", "group-b"}
-	readySetDigest, err := raftplacement.VectorPartitionLifecycleReadySetDigestV1(identity, requiredGroups, []raftplacement.VectorPartitionLifecycleGroupReadyV1{{GroupID: "group-a", AppliedIndex: 9, AssetSetDigest: fmt.Sprintf("%064x", len("group-a"))}, {GroupID: "group-b", AppliedIndex: 9, AssetSetDigest: fmt.Sprintf("%064x", len("group-b"))}})
-	if err != nil {
-		t.Fatal(err)
-	}
-	openService := func() (*public.ServiceV1, *VectorPartitionProductionTopologyV1, VectorPartitionCoordinatorRequestV1, map[raftcluster.GroupID]*fakeVectorPartitionReadCoordinatorV1) {
+	readyGroups := []raftplacement.VectorPartitionLifecycleGroupReadyV1{{GroupID: "group-a", AppliedIndex: 9, AssetSetDigest: fmt.Sprintf("%064x", len("group-a"))}, {GroupID: "group-b", AppliedIndex: 9, AssetSetDigest: fmt.Sprintf("%064x", len("group-b"))}}
+	openService := func(boundIdentity raftplacement.VectorPartitionLifecycleIdentityV1) (*public.ServiceV1, *VectorPartitionProductionTopologyV1, VectorPartitionCoordinatorRequestV1, map[raftcluster.GroupID]*fakeVectorPartitionReadCoordinatorV1) {
 		t.Helper()
+		readySetDigest, err := raftplacement.VectorPartitionLifecycleReadySetDigestV1(boundIdentity, requiredGroups, readyGroups)
+		if err != nil {
+			t.Fatal(err)
+		}
 		servingAuthority, err := NewLinearizableCatalogVectorPartitionLifecycleAuthorityV1(harness.LeaderAuthority(), harness.LeaderFence())
 		if err != nil {
 			t.Fatal(err)
 		}
 		topology, base, reads := newVectorPartitionProductionTopologyTwoGroupWithLifecycleReadySetTestV1(t, servingAuthority, readySetDigest)
-		backend, err := NewVectorPartitionPublicBackendV1(VectorPartitionPublicBackendOptionsV1{Topology: topology, RequestBase: base, Lifecycle: harness.LifecycleCoordinator(), Identity: identity, RequiredGroups: requiredGroups, Builder: publicBackendLifecycleBuilderV1{}, MutationEpoch: 1, RebuildRequest: func(context.Context) error { return nil }})
+		backend, err := NewVectorPartitionPublicBackendV1(VectorPartitionPublicBackendOptionsV1{Topology: topology, RequestBase: base, Lifecycle: harness.LifecycleCoordinator(), Identity: boundIdentity, RequiredGroups: requiredGroups, Builder: publicBackendLifecycleBuilderV1{}, MutationEpoch: 1, RebuildRequest: func(context.Context) error { return nil }})
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -98,7 +99,7 @@ func TestVectorPartitionPublicBackendLifecycleOverCatalogMetaRaftV1(t *testing.T
 		}
 		return service, topology, base, reads
 	}
-	service, topology, base, reads := openService()
+	service, topology, base, reads := openService(identity)
 	id := public.GenerationIDV1{Index: base.IndexName, Generation: 7}
 	if _, err := service.Register(ctx, public.GenerationRegistrationV1{GenerationIDV1: id, SourceGeneration: 11, SourceChecksum: 22, SourceSchemaHash: 33, SourceRowCount: 2}); err != nil {
 		t.Fatal(err)
@@ -131,8 +132,7 @@ func TestVectorPartitionPublicBackendLifecycleOverCatalogMetaRaftV1(t *testing.T
 	if err := harness.RestartV1(ctx); err != nil {
 		t.Fatal(err)
 	}
-	service, topology, base, reads = openService()
-	defer topology.Close()
+	service, topology, base, reads = openService(identity)
 	if status, err := service.Status(ctx, id); err != nil || !status.Active {
 		t.Fatalf("status after restart = %#v, %v", status, err)
 	}
@@ -145,10 +145,30 @@ func TestVectorPartitionPublicBackendLifecycleOverCatalogMetaRaftV1(t *testing.T
 			t.Fatalf("group %q did not produce post-restart read evidence", group)
 		}
 	}
+	if err := topology.Close(); err != nil {
+		t.Fatal(err)
+	}
+	successor := identity
+	successor.Generation++
+	service, topology, _, _ = openService(successor)
+	defer topology.Close()
+	id = public.GenerationIDV1{Index: base.IndexName, Generation: successor.Generation}
+	if _, err := service.Register(ctx, public.GenerationRegistrationV1{GenerationIDV1: id, SourceGeneration: 11, SourceChecksum: 22, SourceSchemaHash: 33, SourceRowCount: 2}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := service.Prepare(ctx, id); err != nil {
+		t.Fatal(err)
+	}
+	if status, err := service.Activate(ctx, id); err != nil || !status.Active {
+		t.Fatalf("activate successor = %#v, %v", status, err)
+	}
+	if previous, ok := harness.LeaderAuthority().VectorPartitionLifecycleRecordV1(identity); !ok || previous.State != raftplacement.VectorPartitionLifecycleRetiredV1 || previous.SupersededByGeneration != successor.Generation {
+		t.Fatalf("predecessor after cutover = %#v, ok=%v", previous, ok)
+	}
 	if _, err := service.Invalidate(ctx, id, "mutation"); err != nil {
 		t.Fatal(err)
 	}
-	proof, active, err := harness.LeaderAuthority().MutationProofV1(identity.Index)
+	proof, active, err := harness.LeaderAuthority().MutationProofV1(successor.Index)
 	if err != nil || active {
 		t.Fatalf("invalidation proof = %#v active=%v err=%v", proof, active, err)
 	}

--- a/TreeDB/nativewire/vector_partition_public_backend_v1_test.go
+++ b/TreeDB/nativewire/vector_partition_public_backend_v1_test.go
@@ -145,6 +145,7 @@ func TestVectorPartitionPublicBackendLifecycleOverCatalogMetaRaftV1(t *testing.T
 			t.Fatalf("group %q did not produce post-restart read evidence", group)
 		}
 	}
+	predecessorService, predecessorID := service, id
 	if err := topology.Close(); err != nil {
 		t.Fatal(err)
 	}
@@ -161,6 +162,12 @@ func TestVectorPartitionPublicBackendLifecycleOverCatalogMetaRaftV1(t *testing.T
 	}
 	if status, err := service.Activate(ctx, id); err != nil || !status.Active {
 		t.Fatalf("activate successor = %#v, %v", status, err)
+	}
+	if _, err := predecessorService.Invalidate(ctx, predecessorID, "stale mutation"); !hasPublicErrorCodeV1(err, public.ErrorGenerationMismatchV1) {
+		t.Fatalf("stale predecessor invalidation = %v", err)
+	}
+	if status, err := service.Status(ctx, id); err != nil || !status.Active {
+		t.Fatalf("successor after stale invalidation = %#v, %v", status, err)
 	}
 	if previous, ok := harness.LeaderAuthority().VectorPartitionLifecycleRecordV1(identity); !ok || previous.State != raftplacement.VectorPartitionLifecycleRetiredV1 || previous.SupersededByGeneration != successor.Generation {
 		t.Fatalf("predecessor after cutover = %#v, ok=%v", previous, ok)
@@ -216,6 +223,11 @@ func TestVectorPartitionPublicBackendSearchesProductionTopologyV1(t *testing.T) 
 		if read.callCount() == 0 {
 			t.Fatalf("group %q did not produce read evidence", group)
 		}
+	}
+	backend.opts.Identity.Generation++
+	request.Generation.Generation++
+	if response, err := service.Search(context.Background(), request); !hasPublicErrorCodeV1(err, public.ErrorGenerationMismatchV1) || response.Generation != (public.GenerationIDV1{}) || len(response.Neighbors) != 0 {
+		t.Fatalf("stale topology response = %#v, %v", response, err)
 	}
 }
 

--- a/TreeDB/nativewire/vector_partition_public_backend_v1_test.go
+++ b/TreeDB/nativewire/vector_partition_public_backend_v1_test.go
@@ -4,7 +4,10 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"slices"
+	"sort"
 	"testing"
+	"time"
 
 	"github.com/snissn/gomap/TreeDB/internal/raftcluster"
 	"github.com/snissn/gomap/TreeDB/internal/raftplacement"
@@ -68,10 +71,6 @@ func TestVectorPartitionPublicBackendLifecycleOverCatalogMetaRaftV1(t *testing.T
 		t.Fatal(err)
 	}
 	defer harness.Close()
-	servingAuthority, err := NewLinearizableCatalogVectorPartitionLifecycleAuthorityV1(harness.LeaderAuthority(), harness.LeaderFence())
-	if err != nil {
-		t.Fatal(err)
-	}
 	meta, ok := harness.LeaderAuthority().Status()
 	if !ok {
 		t.Fatal("leader authority unavailable")
@@ -82,16 +81,24 @@ func TestVectorPartitionPublicBackendLifecycleOverCatalogMetaRaftV1(t *testing.T
 	if err != nil {
 		t.Fatal(err)
 	}
-	topology, base, reads := newVectorPartitionProductionTopologyTwoGroupWithLifecycleReadySetTestV1(t, servingAuthority, readySetDigest)
-	defer topology.Close()
-	backend, err := NewVectorPartitionPublicBackendV1(VectorPartitionPublicBackendOptionsV1{Topology: topology, RequestBase: base, Lifecycle: harness.LifecycleCoordinator(), Identity: identity, RequiredGroups: requiredGroups, Builder: publicBackendLifecycleBuilderV1{}, MutationEpoch: 1, RebuildRequest: func(context.Context) error { return nil }})
-	if err != nil {
-		t.Fatal(err)
+	openService := func() (*public.ServiceV1, *VectorPartitionProductionTopologyV1, VectorPartitionCoordinatorRequestV1, map[raftcluster.GroupID]*fakeVectorPartitionReadCoordinatorV1) {
+		t.Helper()
+		servingAuthority, err := NewLinearizableCatalogVectorPartitionLifecycleAuthorityV1(harness.LeaderAuthority(), harness.LeaderFence())
+		if err != nil {
+			t.Fatal(err)
+		}
+		topology, base, reads := newVectorPartitionProductionTopologyTwoGroupWithLifecycleReadySetTestV1(t, servingAuthority, readySetDigest)
+		backend, err := NewVectorPartitionPublicBackendV1(VectorPartitionPublicBackendOptionsV1{Topology: topology, RequestBase: base, Lifecycle: harness.LifecycleCoordinator(), Identity: identity, RequiredGroups: requiredGroups, Builder: publicBackendLifecycleBuilderV1{}, MutationEpoch: 1, RebuildRequest: func(context.Context) error { return nil }})
+		if err != nil {
+			t.Fatal(err)
+		}
+		service, err := public.NewServiceV1(backend)
+		if err != nil {
+			t.Fatal(err)
+		}
+		return service, topology, base, reads
 	}
-	service, err := public.NewServiceV1(backend)
-	if err != nil {
-		t.Fatal(err)
-	}
+	service, topology, base, reads := openService()
 	id := public.GenerationIDV1{Index: base.IndexName, Generation: 7}
 	if _, err := service.Register(ctx, public.GenerationRegistrationV1{GenerationIDV1: id, SourceGeneration: 11, SourceChecksum: 22, SourceSchemaHash: 33, SourceRowCount: 2}); err != nil {
 		t.Fatal(err)
@@ -118,6 +125,26 @@ func TestVectorPartitionPublicBackendLifecycleOverCatalogMetaRaftV1(t *testing.T
 	if _, err := harness.LeaderFence().LinearizableCatalogMetaAppliedIndexV1(ctx); err != nil {
 		t.Fatal(err)
 	}
+	if err := topology.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := harness.RestartV1(ctx); err != nil {
+		t.Fatal(err)
+	}
+	service, topology, base, reads = openService()
+	defer topology.Close()
+	if status, err := service.Status(ctx, id); err != nil || !status.Active {
+		t.Fatalf("status after restart = %#v, %v", status, err)
+	}
+	request = public.SearchRequestV1{Version: 1, Generation: id, Query: []float32{1, 0}, Metric: public.MetricCosineV1, TopK: base.TopK, Probes: base.PartitionProbes, EfSearch: base.EfSearch, Consistency: public.ConsistencyGenerationSnapshotV1, Limits: public.SearchLimitsV1{RequestBytes: base.RequestBytesLimit, CandidateBytes: base.CandidateBytesLimit, ResponseBytes: base.ResponseBytesLimit, MergeEntries: base.MergeEntriesLimit}}
+	if response, err := service.Search(ctx, request); err != nil || len(response.Neighbors) == 0 {
+		t.Fatalf("search after restart = %#v, %v", response, err)
+	}
+	for group, read := range reads {
+		if read.callCount() == 0 {
+			t.Fatalf("group %q did not produce post-restart read evidence", group)
+		}
+	}
 	if _, err := service.Invalidate(ctx, id, "mutation"); err != nil {
 		t.Fatal(err)
 	}
@@ -136,18 +163,150 @@ func TestVectorPartitionPublicBackendLifecycleOverCatalogMetaRaftV1(t *testing.T
 func TestVectorPartitionPublicBackendSearchesProductionTopologyV1(t *testing.T) {
 	topology, base, reads := newVectorPartitionProductionTopologyTwoGroupTestV1(t)
 	defer topology.Close()
+	direct, err := topology.Coordinator().Search(context.Background(), base)
+	if err != nil {
+		t.Fatal(err)
+	}
 	backend := &VectorPartitionPublicBackendV1{opts: VectorPartitionPublicBackendOptionsV1{
 		Topology: topology, RequestBase: base,
 		Identity: raftplacement.VectorPartitionLifecycleIdentityV1{Index: raftplacement.VectorPartitionLifecycleIndexIdentityV1{IndexName: base.IndexName}, Generation: 7},
 	}}
-	request := public.SearchRequestV1{Version: 1, Generation: public.GenerationIDV1{Index: base.IndexName, Generation: 7}, Query: []float32{1, 0}, Metric: public.MetricCosineV1, TopK: base.TopK, Probes: base.PartitionProbes, EfSearch: base.EfSearch, Consistency: public.ConsistencyGenerationSnapshotV1, Limits: public.SearchLimitsV1{RequestBytes: base.RequestBytesLimit, CandidateBytes: base.CandidateBytesLimit, ResponseBytes: base.ResponseBytesLimit, MergeEntries: base.MergeEntriesLimit}}
-	response, err := backend.SearchVectorPartitionV1(context.Background(), request)
+	service, err := public.NewServiceV1(backend)
+	if err != nil {
+		t.Fatal(err)
+	}
+	request := publicSearchRequestTestV1(base)
+	response, err := service.Search(context.Background(), request)
 	if err != nil || len(response.Neighbors) == 0 {
 		t.Fatalf("search = %#v, %v", response, err)
+	}
+	wantNeighbors := publicNeighborsFromCoordinatorTestV1(direct.Neighbors)
+	if !slices.Equal(response.Neighbors, wantNeighbors) {
+		t.Fatalf("public neighbors = %+v, direct = %+v", response.Neighbors, wantNeighbors)
+	}
+	if want := publicCountersFromCoordinatorTestV1(direct.Counters); response.Counters != want {
+		t.Fatalf("public counters = %+v, direct = %+v", response.Counters, want)
+	}
+	response.Neighbors[0].ID = "caller-mutated"
+	again, err := service.Search(context.Background(), request)
+	if err != nil || !slices.Equal(again.Neighbors, wantNeighbors) {
+		t.Fatalf("owned ordered response after caller mutation = %+v, %v", again.Neighbors, err)
 	}
 	for group, read := range reads {
 		if read.callCount() == 0 {
 			t.Fatalf("group %q did not produce read evidence", group)
 		}
+	}
+}
+
+func BenchmarkVectorPartitionPublicServiceOverheadV1(b *testing.B) {
+	parityTopology, parityBase, _ := newVectorPartitionProductionTopologyTwoGroupTestV1(b)
+	parityBackend := &VectorPartitionPublicBackendV1{opts: VectorPartitionPublicBackendOptionsV1{
+		Topology: parityTopology, RequestBase: parityBase,
+		Identity: raftplacement.VectorPartitionLifecycleIdentityV1{Index: raftplacement.VectorPartitionLifecycleIndexIdentityV1{IndexName: parityBase.IndexName}, Generation: 7},
+	}}
+	parityService, err := public.NewServiceV1(parityBackend)
+	if err != nil {
+		b.Fatal(err)
+	}
+	direct, err := parityTopology.Coordinator().Search(context.Background(), parityBase)
+	if err != nil {
+		b.Fatal(err)
+	}
+	viaPublic, err := parityService.Search(context.Background(), publicSearchRequestTestV1(parityBase))
+	if err != nil {
+		b.Fatal(err)
+	}
+	if !slices.Equal(viaPublic.Neighbors, publicNeighborsFromCoordinatorTestV1(direct.Neighbors)) || viaPublic.Counters != publicCountersFromCoordinatorTestV1(direct.Counters) {
+		b.Fatalf("public/direct parity failed: public=%+v direct=%+v", viaPublic, direct)
+	}
+	if err := parityTopology.Close(); err != nil {
+		b.Fatal(err)
+	}
+	b.Run("direct", func(b *testing.B) {
+		topology, base, _ := newVectorPartitionProductionTopologyTwoGroupTestV1(b)
+		defer topology.Close()
+		for i := 0; i < 16; i++ {
+			if _, err := topology.Coordinator().Search(context.Background(), base); err != nil {
+				b.Fatal(err)
+			}
+		}
+		runVectorPartitionPublicBenchmarkV1(b, func() (public.SearchCountersV1, error) {
+			response, err := topology.Coordinator().Search(context.Background(), base)
+			return publicCountersFromCoordinatorTestV1(response.Counters), err
+		})
+	})
+	b.Run("public", func(b *testing.B) {
+		topology, base, _ := newVectorPartitionProductionTopologyTwoGroupTestV1(b)
+		defer topology.Close()
+		backend := &VectorPartitionPublicBackendV1{opts: VectorPartitionPublicBackendOptionsV1{
+			Topology: topology, RequestBase: base,
+			Identity: raftplacement.VectorPartitionLifecycleIdentityV1{Index: raftplacement.VectorPartitionLifecycleIndexIdentityV1{IndexName: base.IndexName}, Generation: 7},
+		}}
+		service, err := public.NewServiceV1(backend)
+		if err != nil {
+			b.Fatal(err)
+		}
+		request := publicSearchRequestTestV1(base)
+		for i := 0; i < 16; i++ {
+			if _, err := service.Search(context.Background(), request); err != nil {
+				b.Fatal(err)
+			}
+		}
+		runVectorPartitionPublicBenchmarkV1(b, func() (public.SearchCountersV1, error) {
+			response, err := service.Search(context.Background(), request)
+			return response.Counters, err
+		})
+	})
+}
+
+func runVectorPartitionPublicBenchmarkV1(b *testing.B, search func() (public.SearchCountersV1, error)) {
+	latencies := make([]uint64, b.N)
+	var counters public.SearchCountersV1
+	b.ReportAllocs()
+	b.ResetTimer()
+	started := time.Now()
+	for i := 0; i < b.N; i++ {
+		callStarted := time.Now()
+		var err error
+		counters, err = search()
+		latencies[i] = uint64(time.Since(callStarted))
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+	elapsed := time.Since(started)
+	b.StopTimer()
+	sort.Slice(latencies, func(i, j int) bool { return latencies[i] < latencies[j] })
+	b.ReportMetric(float64(b.N)/elapsed.Seconds(), "qps")
+	b.ReportMetric(float64(vectorPartitionShardPercentileTestV1(latencies, 50)), "p50-ns")
+	b.ReportMetric(float64(vectorPartitionShardPercentileTestV1(latencies, 95)), "p95-ns")
+	b.ReportMetric(float64(vectorPartitionShardPercentileTestV1(latencies, 99)), "p99-ns")
+	b.ReportMetric(float64(counters.QueryBytes), "query-B/op")
+	b.ReportMetric(float64(counters.RequestBytes), "request-B/op")
+	b.ReportMetric(float64(counters.CandidateBytes), "candidate-B/op")
+	b.ReportMetric(float64(counters.ResponseBytes), "response-B/op")
+	b.ReportMetric(float64(counters.Candidates), "candidates/op")
+	b.ReportMetric(float64(counters.Edges), "edges/op")
+}
+
+func publicSearchRequestTestV1(base VectorPartitionCoordinatorRequestV1) public.SearchRequestV1 {
+	return public.SearchRequestV1{Version: 1, Generation: public.GenerationIDV1{Index: base.IndexName, Generation: 7}, Query: slices.Clone(base.Query), Metric: public.MetricCosineV1, TopK: base.TopK, Probes: base.PartitionProbes, EfSearch: base.EfSearch, Consistency: public.ConsistencyGenerationSnapshotV1, Limits: public.SearchLimitsV1{RequestBytes: base.RequestBytesLimit, CandidateBytes: base.CandidateBytesLimit, ResponseBytes: base.ResponseBytesLimit, MergeEntries: base.MergeEntriesLimit}}
+}
+
+func publicNeighborsFromCoordinatorTestV1(neighbors []VectorPartitionCoordinatorNeighborV1) []public.NeighborV1 {
+	out := make([]public.NeighborV1, len(neighbors))
+	for i, neighbor := range neighbors {
+		out[i] = public.NeighborV1{ID: neighbor.ID, Score: neighbor.Score}
+	}
+	return out
+}
+
+func publicCountersFromCoordinatorTestV1(counters VectorPartitionCoordinatorCountersV1) public.SearchCountersV1 {
+	return public.SearchCountersV1{
+		SelectedPartitions: counters.SelectedPartitions, SelectedGroups: counters.SelectedGroups,
+		Requests: counters.Requests, RPCs: counters.RPCs, Retries: counters.Retries, Redirects: counters.Redirects,
+		Candidates: counters.Candidates, Edges: counters.Edges,
+		QueryBytes: counters.QueryBytes, RequestBytes: counters.RequestBytes, CandidateBytes: counters.CandidateBytes, ResponseBytes: counters.ResponseBytes,
 	}
 }

--- a/TreeDB/nativewire/vector_partition_public_backend_v1_test.go
+++ b/TreeDB/nativewire/vector_partition_public_backend_v1_test.go
@@ -1,0 +1,52 @@
+package nativewire
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/snissn/gomap/TreeDB/internal/raftplacement"
+	public "github.com/snissn/gomap/TreeDB/vectorpartition"
+)
+
+func TestVectorPartitionPublicBackendMapsCoordinatorErrorsV1(t *testing.T) {
+	cases := []struct {
+		code VectorPartitionCoordinatorErrorCodeV1
+		want public.ErrorCodeV1
+	}{
+		{VectorPartitionCoordinatorErrorInvalidRequestV1, public.ErrorInvalidRequestV1},
+		{VectorPartitionCoordinatorErrorGenerationMismatchV1, public.ErrorGenerationMismatchV1},
+		{VectorPartitionCoordinatorErrorCanceledV1, public.ErrorCanceledV1},
+		{VectorPartitionCoordinatorErrorDeadlineV1, public.ErrorDeadlineExceededV1},
+		{VectorPartitionCoordinatorErrorUnavailableV1, public.ErrorUnavailableV1},
+	}
+	for _, tc := range cases {
+		err := publicBackendErrorV1(&VectorPartitionCoordinatorErrorV1{Code: tc.code})
+		var got *public.ErrorV1
+		if !errors.As(err, &got) || got.Code != tc.want {
+			t.Fatalf("code=%q got=%v", tc.code, err)
+		}
+	}
+	if got := publicBackendErrorV1(context.Canceled); !errors.Is(got, context.Canceled) {
+		t.Fatalf("canceled = %v", got)
+	}
+}
+
+func TestVectorPartitionPublicBackendSearchesProductionTopologyV1(t *testing.T) {
+	topology, base, reads := newVectorPartitionProductionTopologyTwoGroupTestV1(t)
+	defer topology.Close()
+	backend := &VectorPartitionPublicBackendV1{opts: VectorPartitionPublicBackendOptionsV1{
+		Topology: topology, RequestBase: base,
+		Identity: raftplacement.VectorPartitionLifecycleIdentityV1{Index: raftplacement.VectorPartitionLifecycleIndexIdentityV1{IndexName: base.IndexName}, Generation: 7},
+	}}
+	request := public.SearchRequestV1{Version: 1, Generation: public.GenerationIDV1{Index: base.IndexName, Generation: 7}, Query: []float32{1, 0}, Metric: public.MetricCosineV1, TopK: base.TopK, Probes: base.PartitionProbes, EfSearch: base.EfSearch, Consistency: public.ConsistencyGenerationSnapshotV1, Limits: public.SearchLimitsV1{RequestBytes: base.RequestBytesLimit, CandidateBytes: base.CandidateBytesLimit, ResponseBytes: base.ResponseBytesLimit, MergeEntries: base.MergeEntriesLimit}}
+	response, err := backend.SearchVectorPartitionV1(context.Background(), request)
+	if err != nil || len(response.Neighbors) == 0 {
+		t.Fatalf("search = %#v, %v", response, err)
+	}
+	for group, read := range reads {
+		if read.callCount() == 0 {
+			t.Fatalf("group %q did not produce read evidence", group)
+		}
+	}
+}

--- a/TreeDB/nativewire/vector_partition_public_backend_v1_test.go
+++ b/TreeDB/nativewire/vector_partition_public_backend_v1_test.go
@@ -20,6 +20,7 @@ func TestVectorPartitionPublicBackendMapsCoordinatorErrorsV1(t *testing.T) {
 		want public.ErrorCodeV1
 	}{
 		{VectorPartitionCoordinatorErrorInvalidRequestV1, public.ErrorInvalidRequestV1},
+		{VectorPartitionCoordinatorErrorMalformedResponseV1, public.ErrorFailedV1},
 		{VectorPartitionCoordinatorErrorGenerationMismatchV1, public.ErrorGenerationMismatchV1},
 		{VectorPartitionCoordinatorErrorCanceledV1, public.ErrorCanceledV1},
 		{VectorPartitionCoordinatorErrorDeadlineV1, public.ErrorDeadlineExceededV1},

--- a/TreeDB/nativewire/vector_partition_public_backend_v1_test.go
+++ b/TreeDB/nativewire/vector_partition_public_backend_v1_test.go
@@ -56,9 +56,10 @@ func hasPublicErrorCodeV1(err error, want public.ErrorCodeV1) bool {
 	return errors.As(err, &apiErr) && apiErr.Code == want
 }
 
-type publicBackendLifecycleBuilderV1 struct{}
+type publicBackendLifecycleBuilderV1 struct{ calls int }
 
-func (publicBackendLifecycleBuilderV1) BuildAndStageVectorPartitionGroupV1(_ context.Context, _ raftplacement.VectorPartitionLifecycleIdentityV1, group raftcluster.GroupID) (raftplacement.VectorPartitionLifecycleGroupReadyV1, error) {
+func (b *publicBackendLifecycleBuilderV1) BuildAndStageVectorPartitionGroupV1(_ context.Context, _ raftplacement.VectorPartitionLifecycleIdentityV1, group raftcluster.GroupID) (raftplacement.VectorPartitionLifecycleGroupReadyV1, error) {
+	b.calls++
 	return raftplacement.VectorPartitionLifecycleGroupReadyV1{GroupID: group, AppliedIndex: 9, AssetSetDigest: fmt.Sprintf("%064x", len(group))}, nil
 }
 
@@ -78,7 +79,7 @@ func TestVectorPartitionPublicBackendLifecycleOverCatalogMetaRaftV1(t *testing.T
 	identity := raftplacement.VectorPartitionLifecycleIdentityV1{Index: raftplacement.VectorPartitionLifecycleIndexIdentityV1{Collection: raftplacement.CollectionRefV1{Database: "db", Catalog: "default", Collection: "docs"}, CollectionIncarnation: 1, IndexName: "embedding", IndexDefinitionDigest: vectorPartitionShardSearchDigestTestV1, IndexEpoch: 1, CatalogEpoch: meta.Epoch, CatalogDigest: meta.Digest}, Source: raftplacement.VectorPartitionLifecycleSourceIdentityV1{Generation: 11, Checksum: 22, SchemaHash: 33, RowCount: 2}, Generation: 7}
 	requiredGroups := []raftcluster.GroupID{"group-a", "group-b"}
 	readyGroups := []raftplacement.VectorPartitionLifecycleGroupReadyV1{{GroupID: "group-a", AppliedIndex: 9, AssetSetDigest: fmt.Sprintf("%064x", len("group-a"))}, {GroupID: "group-b", AppliedIndex: 9, AssetSetDigest: fmt.Sprintf("%064x", len("group-b"))}}
-	openService := func(boundIdentity raftplacement.VectorPartitionLifecycleIdentityV1) (*public.ServiceV1, *VectorPartitionProductionTopologyV1, VectorPartitionCoordinatorRequestV1, map[raftcluster.GroupID]*fakeVectorPartitionReadCoordinatorV1) {
+	openService := func(boundIdentity raftplacement.VectorPartitionLifecycleIdentityV1) (*public.ServiceV1, *VectorPartitionProductionTopologyV1, VectorPartitionCoordinatorRequestV1, map[raftcluster.GroupID]*fakeVectorPartitionReadCoordinatorV1, *publicBackendLifecycleBuilderV1) {
 		t.Helper()
 		readySetDigest, err := raftplacement.VectorPartitionLifecycleReadySetDigestV1(boundIdentity, requiredGroups, readyGroups)
 		if err != nil {
@@ -89,7 +90,8 @@ func TestVectorPartitionPublicBackendLifecycleOverCatalogMetaRaftV1(t *testing.T
 			t.Fatal(err)
 		}
 		topology, base, reads := newVectorPartitionProductionTopologyTwoGroupWithLifecycleReadySetTestV1(t, servingAuthority, readySetDigest)
-		backend, err := NewVectorPartitionPublicBackendV1(VectorPartitionPublicBackendOptionsV1{Topology: topology, RequestBase: base, Lifecycle: harness.LifecycleCoordinator(), Identity: boundIdentity, RequiredGroups: requiredGroups, Builder: publicBackendLifecycleBuilderV1{}, MutationEpoch: 1, RebuildRequest: func(context.Context) error { return nil }})
+		builder := &publicBackendLifecycleBuilderV1{}
+		backend, err := NewVectorPartitionPublicBackendV1(VectorPartitionPublicBackendOptionsV1{Topology: topology, RequestBase: base, Lifecycle: harness.LifecycleCoordinator(), Identity: boundIdentity, RequiredGroups: requiredGroups, Builder: builder, MutationEpoch: 1, RebuildRequest: func(context.Context) error { return nil }})
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -97,9 +99,9 @@ func TestVectorPartitionPublicBackendLifecycleOverCatalogMetaRaftV1(t *testing.T
 		if err != nil {
 			t.Fatal(err)
 		}
-		return service, topology, base, reads
+		return service, topology, base, reads, builder
 	}
-	service, topology, base, reads := openService(identity)
+	service, topology, base, reads, _ := openService(identity)
 	id := public.GenerationIDV1{Index: base.IndexName, Generation: 7}
 	if _, err := service.Register(ctx, public.GenerationRegistrationV1{GenerationIDV1: id, SourceGeneration: 11, SourceChecksum: 22, SourceSchemaHash: 33, SourceRowCount: 2}); err != nil {
 		t.Fatal(err)
@@ -132,7 +134,7 @@ func TestVectorPartitionPublicBackendLifecycleOverCatalogMetaRaftV1(t *testing.T
 	if err := harness.RestartV1(ctx); err != nil {
 		t.Fatal(err)
 	}
-	service, topology, base, reads = openService(identity)
+	service, topology, base, reads, _ = openService(identity)
 	if status, err := service.Status(ctx, id); err != nil || !status.Active {
 		t.Fatalf("status after restart = %#v, %v", status, err)
 	}
@@ -151,7 +153,7 @@ func TestVectorPartitionPublicBackendLifecycleOverCatalogMetaRaftV1(t *testing.T
 	}
 	successor := identity
 	successor.Generation++
-	service, topology, _, _ = openService(successor)
+	service, topology, _, _, builder := openService(successor)
 	defer topology.Close()
 	id = public.GenerationIDV1{Index: base.IndexName, Generation: successor.Generation}
 	if _, err := service.Register(ctx, public.GenerationRegistrationV1{GenerationIDV1: id, SourceGeneration: 11, SourceChecksum: 22, SourceSchemaHash: 33, SourceRowCount: 2}); err != nil {
@@ -162,6 +164,10 @@ func TestVectorPartitionPublicBackendLifecycleOverCatalogMetaRaftV1(t *testing.T
 	}
 	if status, err := service.Activate(ctx, id); err != nil || !status.Active {
 		t.Fatalf("activate successor = %#v, %v", status, err)
+	}
+	buildCalls := builder.calls
+	if _, err := service.Register(ctx, public.GenerationRegistrationV1{GenerationIDV1: id, SourceGeneration: 11, SourceChecksum: 22, SourceSchemaHash: 33, SourceRowCount: 2}); err != nil || builder.calls != buildCalls {
+		t.Fatalf("register retry rebuilt ready groups: calls=%d want=%d err=%v", builder.calls, buildCalls, err)
 	}
 	if _, err := predecessorService.Invalidate(ctx, predecessorID, "stale mutation"); !hasPublicErrorCodeV1(err, public.ErrorGenerationMismatchV1) {
 		t.Fatalf("stale predecessor invalidation = %v", err)

--- a/TreeDB/vectorpartition/api.go
+++ b/TreeDB/vectorpartition/api.go
@@ -1,6 +1,8 @@
-// Package vectorpartition exposes the offline M2 builder and deterministic M4
-// representative coarsening core to TreeDB commands. The persisted router
-// lifecycle and search handle remain collection APIs.
+// Package vectorpartition exposes the offline M2 builder, deterministic M4
+// representative coarsening core, and the supported V1 partition search and
+// generation lifecycle contract. Node construction supplies one opaque
+// production backend; ordinary callers never construct transport, Raft, or
+// lifecycle internals.
 package vectorpartition
 
 import (

--- a/TreeDB/vectorpartition/api.go
+++ b/TreeDB/vectorpartition/api.go
@@ -3,6 +3,8 @@
 // generation lifecycle contract. Node construction supplies one opaque
 // production backend; ordinary callers never construct transport, Raft, or
 // lifecycle internals.
+//
+// TreeDB is pre-alpha. These APIs may change without compatibility guarantees.
 package vectorpartition
 
 import (

--- a/TreeDB/vectorpartition/service_v1.go
+++ b/TreeDB/vectorpartition/service_v1.go
@@ -67,7 +67,9 @@ type NeighborV1 struct {
 }
 
 type SearchCountersV1 struct {
-	Requests, RPCs, Retries, Redirects, Candidates, Edges uint64
+	SelectedPartitions, SelectedGroups                      uint64
+	Requests, RPCs, Retries, Redirects, Candidates, Edges   uint64
+	QueryBytes, RequestBytes, CandidateBytes, ResponseBytes uint64
 }
 
 type SearchTimingV1 struct{ Total time.Duration }

--- a/TreeDB/vectorpartition/service_v1.go
+++ b/TreeDB/vectorpartition/service_v1.go
@@ -162,28 +162,28 @@ func (s *ServiceV1) Register(ctx context.Context, registration GenerationRegistr
 		return GenerationStatusV1{}, invalidV1("complete source identity is required")
 	}
 	status, err := s.backend.RegisterVectorPartitionV1(ctx, registration)
-	return status, classifyErrorV1(ctx, err)
+	return statusResultV1(ctx, registration.GenerationIDV1, status, err)
 }
 func (s *ServiceV1) Status(ctx context.Context, id GenerationIDV1) (GenerationStatusV1, error) {
 	if err := validateGenerationV1(ctx, id); err != nil {
 		return GenerationStatusV1{}, err
 	}
 	status, err := s.backend.GenerationStatusV1(ctx, id)
-	return status, classifyErrorV1(ctx, err)
+	return statusResultV1(ctx, id, status, err)
 }
 func (s *ServiceV1) Prepare(ctx context.Context, id GenerationIDV1) (GenerationStatusV1, error) {
 	if err := validateGenerationV1(ctx, id); err != nil {
 		return GenerationStatusV1{}, err
 	}
 	status, err := s.backend.PrepareVectorPartitionV1(ctx, id)
-	return status, classifyErrorV1(ctx, err)
+	return statusResultV1(ctx, id, status, err)
 }
 func (s *ServiceV1) Activate(ctx context.Context, id GenerationIDV1) (GenerationStatusV1, error) {
 	if err := validateGenerationV1(ctx, id); err != nil {
 		return GenerationStatusV1{}, err
 	}
 	status, err := s.backend.ActivateVectorPartitionV1(ctx, id)
-	return status, classifyErrorV1(ctx, err)
+	return statusResultV1(ctx, id, status, err)
 }
 func (s *ServiceV1) Invalidate(ctx context.Context, id GenerationIDV1, reason string) (GenerationStatusV1, error) {
 	if err := validateGenerationV1(ctx, id); err != nil {
@@ -193,28 +193,50 @@ func (s *ServiceV1) Invalidate(ctx context.Context, id GenerationIDV1, reason st
 		return GenerationStatusV1{}, invalidV1("invalidation reason is required")
 	}
 	status, err := s.backend.InvalidateVectorPartitionV1(ctx, id, reason)
-	return status, classifyErrorV1(ctx, err)
+	return statusResultV1(ctx, id, status, err)
 }
 func (s *ServiceV1) Retire(ctx context.Context, id GenerationIDV1) (GenerationStatusV1, error) {
 	if err := validateGenerationV1(ctx, id); err != nil {
 		return GenerationStatusV1{}, err
 	}
 	status, err := s.backend.RetireVectorPartitionV1(ctx, id)
-	return status, classifyErrorV1(ctx, err)
+	return statusResultV1(ctx, id, status, err)
 }
 func (s *ServiceV1) RequestRebuild(ctx context.Context, id GenerationIDV1) (GenerationStatusV1, error) {
 	if err := validateGenerationV1(ctx, id); err != nil {
 		return GenerationStatusV1{}, err
 	}
 	status, err := s.backend.RequestVectorPartitionRebuildV1(ctx, id)
-	return status, classifyErrorV1(ctx, err)
+	return statusResultV1(ctx, id, status, err)
 }
 func (s *ServiceV1) CleanupEligibility(ctx context.Context, id GenerationIDV1) (CleanupEligibilityV1, error) {
 	if err := validateGenerationV1(ctx, id); err != nil {
 		return CleanupEligibilityV1{}, err
 	}
 	eligibility, err := s.backend.VectorPartitionCleanupEligibilityV1(ctx, id)
-	return eligibility, classifyErrorV1(ctx, err)
+	if err != nil {
+		return CleanupEligibilityV1{}, classifyErrorV1(ctx, err)
+	}
+	if err := validateStatusIdentityV1(id, eligibility.Status); err != nil {
+		return CleanupEligibilityV1{}, err
+	}
+	return eligibility, nil
+}
+
+func statusResultV1(ctx context.Context, id GenerationIDV1, status GenerationStatusV1, err error) (GenerationStatusV1, error) {
+	if err != nil {
+		return GenerationStatusV1{}, classifyErrorV1(ctx, err)
+	}
+	if err := validateStatusIdentityV1(id, status); err != nil {
+		return GenerationStatusV1{}, err
+	}
+	return status, nil
+}
+func validateStatusIdentityV1(id GenerationIDV1, status GenerationStatusV1) error {
+	if status.Generation != id {
+		return &ErrorV1{Code: ErrorFailedV1, Err: errors.New("backend returned status for another generation")}
+	}
+	return nil
 }
 
 func validateGenerationV1(ctx context.Context, id GenerationIDV1) error {
@@ -232,6 +254,9 @@ func validateSearchRequestV1(ctx context.Context, r SearchRequestV1) error {
 	}
 	if r.Version != 1 || len(r.Query) == 0 || r.TopK <= 0 || r.Probes <= 0 || r.EfSearch <= 0 || r.Metric != MetricCosineV1 || r.Consistency != ConsistencyGenerationSnapshotV1 || r.Limits.RequestBytes == 0 || r.Limits.CandidateBytes == 0 || r.Limits.ResponseBytes == 0 || r.Limits.MergeEntries == 0 {
 		return invalidV1("version, query, metric, consistency, limits, top_k, probes, and ef_search are required")
+	}
+	if uint64(len(r.Query)) > r.Limits.RequestBytes/4 {
+		return invalidV1("query exceeds request byte limit")
 	}
 	if !r.Deadline.IsZero() && !time.Now().Before(r.Deadline) {
 		return &ErrorV1{Code: ErrorDeadlineExceededV1, Err: context.DeadlineExceeded}

--- a/TreeDB/vectorpartition/service_v1.go
+++ b/TreeDB/vectorpartition/service_v1.go
@@ -36,13 +36,29 @@ type GenerationIDV1 struct {
 }
 
 type SearchRequestV1 struct {
+	Version     uint32
 	Generation  GenerationIDV1
 	Query       []float32
+	Metric      MetricV1
 	TopK        int
 	Probes      int
 	EfSearch    int
-	Consistency string
+	Consistency ConsistencyV1
+	Limits      SearchLimitsV1
 	Deadline    time.Time
+}
+
+type MetricV1 string
+
+const MetricCosineV1 MetricV1 = "cosine"
+
+type ConsistencyV1 string
+
+const ConsistencyGenerationSnapshotV1 ConsistencyV1 = "linearizable_generation_snapshot"
+
+type SearchLimitsV1 struct {
+	RequestBytes, CandidateBytes, ResponseBytes uint64
+	MergeEntries                                int
 }
 
 type NeighborV1 struct {
@@ -142,6 +158,9 @@ func (s *ServiceV1) Register(ctx context.Context, registration GenerationRegistr
 	if err := validateGenerationV1(ctx, registration.GenerationIDV1); err != nil {
 		return GenerationStatusV1{}, err
 	}
+	if registration.SourceGeneration == 0 || registration.SourceChecksum == 0 || registration.SourceSchemaHash == 0 || registration.SourceRowCount == 0 {
+		return GenerationStatusV1{}, invalidV1("complete source identity is required")
+	}
 	status, err := s.backend.RegisterVectorPartitionV1(ctx, registration)
 	return status, classifyErrorV1(ctx, err)
 }
@@ -211,8 +230,8 @@ func validateSearchRequestV1(ctx context.Context, r SearchRequestV1) error {
 	if err := validateGenerationV1(ctx, r.Generation); err != nil {
 		return err
 	}
-	if len(r.Query) == 0 || r.TopK <= 0 || r.Probes <= 0 || r.EfSearch <= 0 {
-		return invalidV1("query, top_k, probes, and ef_search are required")
+	if r.Version != 1 || len(r.Query) == 0 || r.TopK <= 0 || r.Probes <= 0 || r.EfSearch <= 0 || r.Metric != MetricCosineV1 || r.Consistency != ConsistencyGenerationSnapshotV1 || r.Limits.RequestBytes == 0 || r.Limits.CandidateBytes == 0 || r.Limits.ResponseBytes == 0 || r.Limits.MergeEntries == 0 {
+		return invalidV1("version, query, metric, consistency, limits, top_k, probes, and ef_search are required")
 	}
 	if !r.Deadline.IsZero() && !time.Now().Before(r.Deadline) {
 		return &ErrorV1{Code: ErrorDeadlineExceededV1, Err: context.DeadlineExceeded}

--- a/TreeDB/vectorpartition/service_v1.go
+++ b/TreeDB/vectorpartition/service_v1.go
@@ -27,7 +27,12 @@ type ErrorV1 struct {
 	Err  error
 }
 
-func (e *ErrorV1) Error() string { return "vectorpartition: " + string(e.Code) + ": " + e.Err.Error() }
+func (e *ErrorV1) Error() string {
+	if e.Err == nil {
+		return "vectorpartition: " + string(e.Code)
+	}
+	return "vectorpartition: " + string(e.Code) + ": " + e.Err.Error()
+}
 func (e *ErrorV1) Unwrap() error { return e.Err }
 
 type GenerationIDV1 struct {

--- a/TreeDB/vectorpartition/service_v1.go
+++ b/TreeDB/vectorpartition/service_v1.go
@@ -1,0 +1,244 @@
+package vectorpartition
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"slices"
+	"time"
+)
+
+// ErrorCodeV1 is the stable error classification returned by ServiceV1.
+// Backend details, including transport and Raft state, are deliberately not
+// part of this contract.
+type ErrorCodeV1 string
+
+const (
+	ErrorInvalidRequestV1     ErrorCodeV1 = "invalid_request"
+	ErrorGenerationMismatchV1 ErrorCodeV1 = "generation_mismatch"
+	ErrorUnavailableV1        ErrorCodeV1 = "unavailable"
+	ErrorCanceledV1           ErrorCodeV1 = "canceled"
+	ErrorDeadlineExceededV1   ErrorCodeV1 = "deadline_exceeded"
+	ErrorFailedV1             ErrorCodeV1 = "failed"
+)
+
+type ErrorV1 struct {
+	Code ErrorCodeV1
+	Err  error
+}
+
+func (e *ErrorV1) Error() string { return "vectorpartition: " + string(e.Code) + ": " + e.Err.Error() }
+func (e *ErrorV1) Unwrap() error { return e.Err }
+
+type GenerationIDV1 struct {
+	Index      string
+	Generation uint64
+}
+
+type SearchRequestV1 struct {
+	Generation  GenerationIDV1
+	Query       []float32
+	TopK        int
+	Probes      int
+	EfSearch    int
+	Consistency string
+	Deadline    time.Time
+}
+
+type NeighborV1 struct {
+	ID    string
+	Score float32
+}
+
+type SearchCountersV1 struct {
+	Requests, RPCs, Retries, Redirects, Candidates, Edges uint64
+}
+
+type SearchTimingV1 struct{ Total time.Duration }
+
+type SearchResponseV1 struct {
+	Generation GenerationIDV1
+	Neighbors  []NeighborV1
+	Counters   SearchCountersV1
+	Timing     SearchTimingV1
+}
+
+// GenerationRegistrationV1 identifies an immutable derived generation without
+// exposing catalog records, group IDs, or lifecycle encodings.
+type GenerationRegistrationV1 struct {
+	GenerationIDV1
+	SourceGeneration uint64
+	SourceChecksum   uint64
+	SourceSchemaHash uint64
+	SourceRowCount   uint64
+}
+
+type GenerationStateV1 string
+
+const (
+	GenerationAbsentV1    GenerationStateV1 = "absent"
+	GenerationBuildingV1  GenerationStateV1 = "building"
+	GenerationStagedV1    GenerationStateV1 = "staged"
+	GenerationPreparedV1  GenerationStateV1 = "prepared"
+	GenerationActiveV1    GenerationStateV1 = "active"
+	GenerationInvalidV1   GenerationStateV1 = "invalidated"
+	GenerationRetiredV1   GenerationStateV1 = "retired"
+	GenerationCleanableV1 GenerationStateV1 = "cleanable"
+)
+
+type GenerationStatusV1 struct {
+	Generation GenerationIDV1
+	State      GenerationStateV1
+	Active     bool
+	Ready      bool
+	Revision   uint64
+}
+
+type CleanupEligibilityV1 struct {
+	Eligible bool
+	Status   GenerationStatusV1
+}
+
+// BackendV1 is the one construction-time seam for a node's already assembled
+// production topology and lifecycle authority. Request methods carry only
+// stable public values; nativewire, Raft, listeners, and records stay behind it.
+type BackendV1 interface {
+	SearchVectorPartitionV1(context.Context, SearchRequestV1) (SearchResponseV1, error)
+	RegisterVectorPartitionV1(context.Context, GenerationRegistrationV1) (GenerationStatusV1, error)
+	GenerationStatusV1(context.Context, GenerationIDV1) (GenerationStatusV1, error)
+	PrepareVectorPartitionV1(context.Context, GenerationIDV1) (GenerationStatusV1, error)
+	ActivateVectorPartitionV1(context.Context, GenerationIDV1) (GenerationStatusV1, error)
+	InvalidateVectorPartitionV1(context.Context, GenerationIDV1, string) (GenerationStatusV1, error)
+	RetireVectorPartitionV1(context.Context, GenerationIDV1) (GenerationStatusV1, error)
+	RequestVectorPartitionRebuildV1(context.Context, GenerationIDV1) (GenerationStatusV1, error)
+	VectorPartitionCleanupEligibilityV1(context.Context, GenerationIDV1) (CleanupEligibilityV1, error)
+}
+
+type ServiceV1 struct{ backend BackendV1 }
+
+func NewServiceV1(backend BackendV1) (*ServiceV1, error) {
+	if backend == nil {
+		return nil, errors.New("vectorpartition: backend is required")
+	}
+	return &ServiceV1{backend: backend}, nil
+}
+
+func (s *ServiceV1) Search(ctx context.Context, request SearchRequestV1) (SearchResponseV1, error) {
+	if err := validateSearchRequestV1(ctx, request); err != nil {
+		return SearchResponseV1{}, err
+	}
+	response, err := s.backend.SearchVectorPartitionV1(ctx, cloneSearchRequestV1(request))
+	if err != nil {
+		return SearchResponseV1{}, classifyErrorV1(ctx, err)
+	}
+	if response.Generation != request.Generation || len(response.Neighbors) > request.TopK {
+		return SearchResponseV1{}, &ErrorV1{Code: ErrorFailedV1, Err: errors.New("backend returned invalid search response")}
+	}
+	response.Neighbors = slices.Clone(response.Neighbors)
+	return response, nil
+}
+
+func (s *ServiceV1) Register(ctx context.Context, registration GenerationRegistrationV1) (GenerationStatusV1, error) {
+	if err := validateGenerationV1(ctx, registration.GenerationIDV1); err != nil {
+		return GenerationStatusV1{}, err
+	}
+	status, err := s.backend.RegisterVectorPartitionV1(ctx, registration)
+	return status, classifyErrorV1(ctx, err)
+}
+func (s *ServiceV1) Status(ctx context.Context, id GenerationIDV1) (GenerationStatusV1, error) {
+	if err := validateGenerationV1(ctx, id); err != nil {
+		return GenerationStatusV1{}, err
+	}
+	status, err := s.backend.GenerationStatusV1(ctx, id)
+	return status, classifyErrorV1(ctx, err)
+}
+func (s *ServiceV1) Prepare(ctx context.Context, id GenerationIDV1) (GenerationStatusV1, error) {
+	if err := validateGenerationV1(ctx, id); err != nil {
+		return GenerationStatusV1{}, err
+	}
+	status, err := s.backend.PrepareVectorPartitionV1(ctx, id)
+	return status, classifyErrorV1(ctx, err)
+}
+func (s *ServiceV1) Activate(ctx context.Context, id GenerationIDV1) (GenerationStatusV1, error) {
+	if err := validateGenerationV1(ctx, id); err != nil {
+		return GenerationStatusV1{}, err
+	}
+	status, err := s.backend.ActivateVectorPartitionV1(ctx, id)
+	return status, classifyErrorV1(ctx, err)
+}
+func (s *ServiceV1) Invalidate(ctx context.Context, id GenerationIDV1, reason string) (GenerationStatusV1, error) {
+	if err := validateGenerationV1(ctx, id); err != nil {
+		return GenerationStatusV1{}, err
+	}
+	if reason == "" {
+		return GenerationStatusV1{}, invalidV1("invalidation reason is required")
+	}
+	status, err := s.backend.InvalidateVectorPartitionV1(ctx, id, reason)
+	return status, classifyErrorV1(ctx, err)
+}
+func (s *ServiceV1) Retire(ctx context.Context, id GenerationIDV1) (GenerationStatusV1, error) {
+	if err := validateGenerationV1(ctx, id); err != nil {
+		return GenerationStatusV1{}, err
+	}
+	status, err := s.backend.RetireVectorPartitionV1(ctx, id)
+	return status, classifyErrorV1(ctx, err)
+}
+func (s *ServiceV1) RequestRebuild(ctx context.Context, id GenerationIDV1) (GenerationStatusV1, error) {
+	if err := validateGenerationV1(ctx, id); err != nil {
+		return GenerationStatusV1{}, err
+	}
+	status, err := s.backend.RequestVectorPartitionRebuildV1(ctx, id)
+	return status, classifyErrorV1(ctx, err)
+}
+func (s *ServiceV1) CleanupEligibility(ctx context.Context, id GenerationIDV1) (CleanupEligibilityV1, error) {
+	if err := validateGenerationV1(ctx, id); err != nil {
+		return CleanupEligibilityV1{}, err
+	}
+	eligibility, err := s.backend.VectorPartitionCleanupEligibilityV1(ctx, id)
+	return eligibility, classifyErrorV1(ctx, err)
+}
+
+func validateGenerationV1(ctx context.Context, id GenerationIDV1) error {
+	if err := ctx.Err(); err != nil {
+		return classifyErrorV1(ctx, err)
+	}
+	if id.Index == "" || id.Generation == 0 {
+		return invalidV1("index and generation are required")
+	}
+	return nil
+}
+func validateSearchRequestV1(ctx context.Context, r SearchRequestV1) error {
+	if err := validateGenerationV1(ctx, r.Generation); err != nil {
+		return err
+	}
+	if len(r.Query) == 0 || r.TopK <= 0 || r.Probes <= 0 || r.EfSearch <= 0 {
+		return invalidV1("query, top_k, probes, and ef_search are required")
+	}
+	if !r.Deadline.IsZero() && !time.Now().Before(r.Deadline) {
+		return &ErrorV1{Code: ErrorDeadlineExceededV1, Err: context.DeadlineExceeded}
+	}
+	return nil
+}
+func cloneSearchRequestV1(r SearchRequestV1) SearchRequestV1 {
+	r.Query = slices.Clone(r.Query)
+	return r
+}
+func invalidV1(message string) error {
+	return &ErrorV1{Code: ErrorInvalidRequestV1, Err: errors.New(message)}
+}
+func classifyErrorV1(ctx context.Context, err error) error {
+	if err == nil {
+		return nil
+	}
+	if errors.Is(err, context.Canceled) || errors.Is(ctx.Err(), context.Canceled) {
+		return &ErrorV1{Code: ErrorCanceledV1, Err: err}
+	}
+	if errors.Is(err, context.DeadlineExceeded) || errors.Is(ctx.Err(), context.DeadlineExceeded) {
+		return &ErrorV1{Code: ErrorDeadlineExceededV1, Err: err}
+	}
+	var existing *ErrorV1
+	if errors.As(err, &existing) {
+		return err
+	}
+	return &ErrorV1{Code: ErrorUnavailableV1, Err: fmt.Errorf("%w", err)}
+}

--- a/TreeDB/vectorpartition/service_v1_test.go
+++ b/TreeDB/vectorpartition/service_v1_test.go
@@ -67,7 +67,7 @@ func TestServiceV1PublicContract(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if _, err := svc.Register(context.Background(), GenerationRegistrationV1{GenerationIDV1: id}); err != nil {
+	if _, err := svc.Register(context.Background(), GenerationRegistrationV1{GenerationIDV1: id, SourceGeneration: 1, SourceChecksum: 2, SourceSchemaHash: 3, SourceRowCount: 4}); err != nil {
 		t.Fatal(err)
 	}
 	if _, err := svc.Prepare(context.Background(), id); err != nil {
@@ -76,7 +76,7 @@ func TestServiceV1PublicContract(t *testing.T) {
 	if status, err := svc.Activate(context.Background(), id); err != nil || !status.Active {
 		t.Fatalf("activate = %#v, %v", status, err)
 	}
-	response, err := svc.Search(context.Background(), SearchRequestV1{Generation: id, Query: []float32{1}, TopK: 1, Probes: 1, EfSearch: 1})
+	response, err := svc.Search(context.Background(), validSearchRequestV1(id))
 	if err != nil || len(response.Neighbors) != 1 || response.Neighbors[0].ID != "a" {
 		t.Fatalf("search = %#v, %v", response, err)
 	}
@@ -105,7 +105,7 @@ func TestServiceV1FailsClosedWithoutPartialResults(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	response, err := svc.Search(context.Background(), SearchRequestV1{Generation: id, Query: []float32{1}, TopK: 1, Probes: 1, EfSearch: 1})
+	response, err := svc.Search(context.Background(), validSearchRequestV1(id))
 	if response.Generation != (GenerationIDV1{}) || len(response.Neighbors) != 0 {
 		t.Fatalf("partial response escaped: %#v", response)
 	}
@@ -124,11 +124,35 @@ func TestServiceV1ValidatesCancellationAndDeadlineBeforeBackend(t *testing.T) {
 	}})
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
-	if _, err := svc.Search(ctx, SearchRequestV1{Generation: id, Query: []float32{1}, TopK: 1, Probes: 1, EfSearch: 1}); !hasCodeV1(err, ErrorCanceledV1) {
+	if _, err := svc.Search(ctx, validSearchRequestV1(id)); !hasCodeV1(err, ErrorCanceledV1) {
 		t.Fatalf("cancel = %v", err)
 	}
-	if _, err := svc.Search(context.Background(), SearchRequestV1{Generation: id, Query: []float32{1}, TopK: 1, Probes: 1, EfSearch: 1, Deadline: time.Now().Add(-time.Second)}); !hasCodeV1(err, ErrorDeadlineExceededV1) {
+	request := validSearchRequestV1(id)
+	request.Deadline = time.Now().Add(-time.Second)
+	if _, err := svc.Search(context.Background(), request); !hasCodeV1(err, ErrorDeadlineExceededV1) {
 		t.Fatalf("deadline = %v", err)
+	}
+	if called {
+		t.Fatal("backend called after rejected request")
+	}
+}
+
+func TestServiceV1RejectsUnsupportedRequestContractBeforeBackend(t *testing.T) {
+	id := GenerationIDV1{Index: "embedding", Generation: 7}
+	called := false
+	svc, _ := NewServiceV1(&serviceBackendV1{states: map[GenerationIDV1]GenerationStatusV1{}, search: func(context.Context, SearchRequestV1) (SearchResponseV1, error) {
+		called = true
+		return SearchResponseV1{}, nil
+	}})
+	for _, mutate := range []func(*SearchRequestV1){func(r *SearchRequestV1) { r.Version = 2 }, func(r *SearchRequestV1) { r.Metric = "dot" }, func(r *SearchRequestV1) { r.Consistency = "eventual" }, func(r *SearchRequestV1) { r.Limits.ResponseBytes = 0 }} {
+		r := validSearchRequestV1(id)
+		mutate(&r)
+		if _, err := svc.Search(context.Background(), r); !hasCodeV1(err, ErrorInvalidRequestV1) {
+			t.Fatalf("error = %v", err)
+		}
+	}
+	if _, err := svc.Register(context.Background(), GenerationRegistrationV1{GenerationIDV1: id}); !hasCodeV1(err, ErrorInvalidRequestV1) {
+		t.Fatalf("registration = %v", err)
 	}
 	if called {
 		t.Fatal("backend called after rejected request")
@@ -138,4 +162,8 @@ func TestServiceV1ValidatesCancellationAndDeadlineBeforeBackend(t *testing.T) {
 func hasCodeV1(err error, code ErrorCodeV1) bool {
 	var apiErr *ErrorV1
 	return errors.As(err, &apiErr) && apiErr.Code == code
+}
+
+func validSearchRequestV1(id GenerationIDV1) SearchRequestV1 {
+	return SearchRequestV1{Version: 1, Generation: id, Query: []float32{1}, Metric: MetricCosineV1, TopK: 1, Probes: 1, EfSearch: 1, Consistency: ConsistencyGenerationSnapshotV1, Limits: SearchLimitsV1{RequestBytes: 1, CandidateBytes: 1, ResponseBytes: 1, MergeEntries: 1}}
 }

--- a/TreeDB/vectorpartition/service_v1_test.go
+++ b/TreeDB/vectorpartition/service_v1_test.go
@@ -3,6 +3,7 @@ package vectorpartition
 import (
 	"context"
 	"errors"
+	"fmt"
 	"testing"
 	"time"
 )
@@ -115,6 +116,40 @@ func TestServiceV1FailsClosedWithoutPartialResults(t *testing.T) {
 	}
 }
 
+func TestServiceV1OwnsRequestAndOrderedResponseV1(t *testing.T) {
+	id := GenerationIDV1{Index: "embedding", Generation: 7}
+	backendNeighbors := []NeighborV1{{ID: "alpha", Score: .9}, {ID: "beta", Score: .9}, {ID: "gamma", Score: .8}}
+	svc, err := NewServiceV1(&serviceBackendV1{states: map[GenerationIDV1]GenerationStatusV1{}, search: func(_ context.Context, request SearchRequestV1) (SearchResponseV1, error) {
+		request.Query[0] = 99
+		return SearchResponseV1{Generation: request.Generation, Neighbors: backendNeighbors}, nil
+	}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	request := validSearchRequestV1(id)
+	request.TopK = len(backendNeighbors)
+	response, err := svc.Search(context.Background(), request)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if request.Query[0] != 1 {
+		t.Fatalf("backend mutated caller query: %v", request.Query)
+	}
+	for i, want := range []string{"alpha", "beta", "gamma"} {
+		if response.Neighbors[i].ID != want {
+			t.Fatalf("response order = %+v", response.Neighbors)
+		}
+	}
+	backendNeighbors[0].ID = "backend-mutated"
+	if response.Neighbors[0].ID != "alpha" {
+		t.Fatalf("backend retained response ownership: %+v", response.Neighbors)
+	}
+	response.Neighbors[1].ID = "caller-mutated"
+	if backendNeighbors[1].ID != "beta" {
+		t.Fatalf("caller mutated backend response: %+v", backendNeighbors)
+	}
+}
+
 func TestServiceV1ValidatesCancellationAndDeadlineBeforeBackend(t *testing.T) {
 	id := GenerationIDV1{Index: "embedding", Generation: 7}
 	called := false
@@ -187,4 +222,19 @@ func hasCodeV1(err error, code ErrorCodeV1) bool {
 
 func validSearchRequestV1(id GenerationIDV1) SearchRequestV1 {
 	return SearchRequestV1{Version: 1, Generation: id, Query: []float32{1}, Metric: MetricCosineV1, TopK: 1, Probes: 1, EfSearch: 1, Consistency: ConsistencyGenerationSnapshotV1, Limits: SearchLimitsV1{RequestBytes: 4, CandidateBytes: 1, ResponseBytes: 1, MergeEntries: 1}}
+}
+
+func ExampleServiceV1_Search() {
+	id := GenerationIDV1{Index: "embedding", Generation: 7}
+	backend := &serviceBackendV1{states: map[GenerationIDV1]GenerationStatusV1{}, search: func(_ context.Context, request SearchRequestV1) (SearchResponseV1, error) {
+		return SearchResponseV1{Generation: request.Generation, Neighbors: []NeighborV1{{ID: "alpha", Score: 0.9}}}, nil
+	}}
+	service, _ := NewServiceV1(backend)
+	response, _ := service.Search(context.Background(), SearchRequestV1{
+		Version: 1, Generation: id, Query: []float32{1}, Metric: MetricCosineV1,
+		TopK: 1, Probes: 1, EfSearch: 64, Consistency: ConsistencyGenerationSnapshotV1,
+		Limits: SearchLimitsV1{RequestBytes: 4, CandidateBytes: 1 << 20, ResponseBytes: 1 << 20, MergeEntries: 16},
+	})
+	fmt.Println(response.Neighbors[0].ID)
+	// Output: alpha
 }

--- a/TreeDB/vectorpartition/service_v1_test.go
+++ b/TreeDB/vectorpartition/service_v1_test.go
@@ -220,6 +220,12 @@ func hasCodeV1(err error, code ErrorCodeV1) bool {
 	return errors.As(err, &apiErr) && apiErr.Code == code
 }
 
+func TestErrorV1WithoutCause(t *testing.T) {
+	if got := (&ErrorV1{Code: ErrorFailedV1}).Error(); got != "vectorpartition: failed" {
+		t.Fatalf("error = %q", got)
+	}
+}
+
 func validSearchRequestV1(id GenerationIDV1) SearchRequestV1 {
 	return SearchRequestV1{Version: 1, Generation: id, Query: []float32{1}, Metric: MetricCosineV1, TopK: 1, Probes: 1, EfSearch: 1, Consistency: ConsistencyGenerationSnapshotV1, Limits: SearchLimitsV1{RequestBytes: 4, CandidateBytes: 1, ResponseBytes: 1, MergeEntries: 1}}
 }

--- a/TreeDB/vectorpartition/service_v1_test.go
+++ b/TreeDB/vectorpartition/service_v1_test.go
@@ -1,0 +1,141 @@
+package vectorpartition
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+)
+
+type serviceBackendV1 struct {
+	search func(context.Context, SearchRequestV1) (SearchResponseV1, error)
+	states map[GenerationIDV1]GenerationStatusV1
+}
+
+func (b *serviceBackendV1) SearchVectorPartitionV1(ctx context.Context, r SearchRequestV1) (SearchResponseV1, error) {
+	return b.search(ctx, r)
+}
+func (b *serviceBackendV1) RegisterVectorPartitionV1(_ context.Context, r GenerationRegistrationV1) (GenerationStatusV1, error) {
+	s := GenerationStatusV1{Generation: r.GenerationIDV1, State: GenerationBuildingV1}
+	b.states[r.GenerationIDV1] = s
+	return s, nil
+}
+func (b *serviceBackendV1) GenerationStatusV1(_ context.Context, id GenerationIDV1) (GenerationStatusV1, error) {
+	return b.states[id], nil
+}
+func (b *serviceBackendV1) PrepareVectorPartitionV1(_ context.Context, id GenerationIDV1) (GenerationStatusV1, error) {
+	s := b.states[id]
+	s.State, s.Ready = GenerationPreparedV1, true
+	b.states[id] = s
+	return s, nil
+}
+func (b *serviceBackendV1) ActivateVectorPartitionV1(_ context.Context, id GenerationIDV1) (GenerationStatusV1, error) {
+	s := b.states[id]
+	s.State, s.Active = GenerationActiveV1, true
+	b.states[id] = s
+	return s, nil
+}
+func (b *serviceBackendV1) InvalidateVectorPartitionV1(_ context.Context, id GenerationIDV1, _ string) (GenerationStatusV1, error) {
+	s := b.states[id]
+	s.State, s.Active = GenerationInvalidV1, false
+	b.states[id] = s
+	return s, nil
+}
+func (b *serviceBackendV1) RetireVectorPartitionV1(_ context.Context, id GenerationIDV1) (GenerationStatusV1, error) {
+	s := b.states[id]
+	s.State = GenerationRetiredV1
+	b.states[id] = s
+	return s, nil
+}
+func (b *serviceBackendV1) RequestVectorPartitionRebuildV1(_ context.Context, id GenerationIDV1) (GenerationStatusV1, error) {
+	return b.states[id], nil
+}
+func (b *serviceBackendV1) VectorPartitionCleanupEligibilityV1(_ context.Context, id GenerationIDV1) (CleanupEligibilityV1, error) {
+	return CleanupEligibilityV1{Status: b.states[id]}, nil
+}
+
+func TestServiceV1PublicContract(t *testing.T) {
+	id := GenerationIDV1{Index: "embedding", Generation: 7}
+	backend := &serviceBackendV1{states: make(map[GenerationIDV1]GenerationStatusV1)}
+	backend.search = func(_ context.Context, r SearchRequestV1) (SearchResponseV1, error) {
+		if got, want := r.Query[0], float32(1); got != want {
+			t.Fatalf("query = %v, want %v", got, want)
+		}
+		return SearchResponseV1{Generation: r.Generation, Neighbors: []NeighborV1{{ID: "a", Score: .9}}}, nil
+	}
+	svc, err := NewServiceV1(backend)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := svc.Register(context.Background(), GenerationRegistrationV1{GenerationIDV1: id}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := svc.Prepare(context.Background(), id); err != nil {
+		t.Fatal(err)
+	}
+	if status, err := svc.Activate(context.Background(), id); err != nil || !status.Active {
+		t.Fatalf("activate = %#v, %v", status, err)
+	}
+	response, err := svc.Search(context.Background(), SearchRequestV1{Generation: id, Query: []float32{1}, TopK: 1, Probes: 1, EfSearch: 1})
+	if err != nil || len(response.Neighbors) != 1 || response.Neighbors[0].ID != "a" {
+		t.Fatalf("search = %#v, %v", response, err)
+	}
+	if _, err := svc.RequestRebuild(context.Background(), id); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := svc.Invalidate(context.Background(), id, "mutation"); err != nil {
+		t.Fatal(err)
+	}
+	if status, err := svc.Status(context.Background(), id); err != nil || status.State != GenerationInvalidV1 {
+		t.Fatalf("status = %#v, %v", status, err)
+	}
+	if _, err := svc.Retire(context.Background(), id); err != nil {
+		t.Fatal(err)
+	}
+	if eligibility, err := svc.CleanupEligibility(context.Background(), id); err != nil || eligibility.Status.State != GenerationRetiredV1 {
+		t.Fatalf("cleanup eligibility = %#v, %v", eligibility, err)
+	}
+}
+
+func TestServiceV1FailsClosedWithoutPartialResults(t *testing.T) {
+	id := GenerationIDV1{Index: "embedding", Generation: 7}
+	svc, err := NewServiceV1(&serviceBackendV1{states: map[GenerationIDV1]GenerationStatusV1{}, search: func(context.Context, SearchRequestV1) (SearchResponseV1, error) {
+		return SearchResponseV1{Generation: id, Neighbors: []NeighborV1{{ID: "partial"}}}, errors.New("remote owner unavailable")
+	}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	response, err := svc.Search(context.Background(), SearchRequestV1{Generation: id, Query: []float32{1}, TopK: 1, Probes: 1, EfSearch: 1})
+	if response.Generation != (GenerationIDV1{}) || len(response.Neighbors) != 0 {
+		t.Fatalf("partial response escaped: %#v", response)
+	}
+	var apiErr *ErrorV1
+	if !errors.As(err, &apiErr) || apiErr.Code != ErrorUnavailableV1 {
+		t.Fatalf("error = %v", err)
+	}
+}
+
+func TestServiceV1ValidatesCancellationAndDeadlineBeforeBackend(t *testing.T) {
+	id := GenerationIDV1{Index: "embedding", Generation: 7}
+	called := false
+	svc, _ := NewServiceV1(&serviceBackendV1{states: map[GenerationIDV1]GenerationStatusV1{}, search: func(context.Context, SearchRequestV1) (SearchResponseV1, error) {
+		called = true
+		return SearchResponseV1{}, nil
+	}})
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	if _, err := svc.Search(ctx, SearchRequestV1{Generation: id, Query: []float32{1}, TopK: 1, Probes: 1, EfSearch: 1}); !hasCodeV1(err, ErrorCanceledV1) {
+		t.Fatalf("cancel = %v", err)
+	}
+	if _, err := svc.Search(context.Background(), SearchRequestV1{Generation: id, Query: []float32{1}, TopK: 1, Probes: 1, EfSearch: 1, Deadline: time.Now().Add(-time.Second)}); !hasCodeV1(err, ErrorDeadlineExceededV1) {
+		t.Fatalf("deadline = %v", err)
+	}
+	if called {
+		t.Fatal("backend called after rejected request")
+	}
+}
+
+func hasCodeV1(err error, code ErrorCodeV1) bool {
+	var apiErr *ErrorV1
+	return errors.As(err, &apiErr) && apiErr.Code == code
+}

--- a/TreeDB/vectorpartition/service_v1_test.go
+++ b/TreeDB/vectorpartition/service_v1_test.go
@@ -151,11 +151,32 @@ func TestServiceV1RejectsUnsupportedRequestContractBeforeBackend(t *testing.T) {
 			t.Fatalf("error = %v", err)
 		}
 	}
+	r := validSearchRequestV1(id)
+	r.Query = []float32{1, 2}
+	r.Limits.RequestBytes = 4
+	if _, err := svc.Search(context.Background(), r); !hasCodeV1(err, ErrorInvalidRequestV1) {
+		t.Fatalf("query byte limit = %v", err)
+	}
 	if _, err := svc.Register(context.Background(), GenerationRegistrationV1{GenerationIDV1: id}); !hasCodeV1(err, ErrorInvalidRequestV1) {
 		t.Fatalf("registration = %v", err)
 	}
 	if called {
 		t.Fatal("backend called after rejected request")
+	}
+}
+
+func TestServiceV1RejectsBackendStatusForAnotherGeneration(t *testing.T) {
+	id := GenerationIDV1{Index: "embedding", Generation: 7}
+	backend := &serviceBackendV1{states: map[GenerationIDV1]GenerationStatusV1{id: {Generation: GenerationIDV1{Index: "embedding", Generation: 8}}}}
+	svc, err := NewServiceV1(backend)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if status, err := svc.Status(context.Background(), id); status != (GenerationStatusV1{}) || !hasCodeV1(err, ErrorFailedV1) {
+		t.Fatalf("status = %#v, %v", status, err)
+	}
+	if eligibility, err := svc.CleanupEligibility(context.Background(), id); eligibility != (CleanupEligibilityV1{}) || !hasCodeV1(err, ErrorFailedV1) {
+		t.Fatalf("cleanup = %#v, %v", eligibility, err)
 	}
 }
 
@@ -165,5 +186,5 @@ func hasCodeV1(err error, code ErrorCodeV1) bool {
 }
 
 func validSearchRequestV1(id GenerationIDV1) SearchRequestV1 {
-	return SearchRequestV1{Version: 1, Generation: id, Query: []float32{1}, Metric: MetricCosineV1, TopK: 1, Probes: 1, EfSearch: 1, Consistency: ConsistencyGenerationSnapshotV1, Limits: SearchLimitsV1{RequestBytes: 1, CandidateBytes: 1, ResponseBytes: 1, MergeEntries: 1}}
+	return SearchRequestV1{Version: 1, Generation: id, Query: []float32{1}, Metric: MetricCosineV1, TopK: 1, Probes: 1, EfSearch: 1, Consistency: ConsistencyGenerationSnapshotV1, Limits: SearchLimitsV1{RequestBytes: 4, CandidateBytes: 1, ResponseBytes: 1, MergeEntries: 1}}
 }


### PR DESCRIPTION
Closes #4016

Parent: #4012  
Dependency: #4014 is merged/closed on the exact base  
Blocks: #4017 and #4018

## Objective

Expose the smallest supported V1 TreeDB vector-partition search and generation-lifecycle API so ordinary callers do not construct coordinator, placement, transport, or catalog-Raft internals.

## Context

#4014 connected vector-partition search to the production topology. This PR builds the supported public boundary over that topology: bounded generation-bound search, lifecycle administration, stable public errors, response ownership, and observable work/byte counters.

Exact ancestry:

- Base: `origin/main@48c7575461bbe752255cf0c2fce5c0fad14cde54`
- Head: `2684f50d8a3b94ce5edb626288c5be18e55c0580`
- Merge base: `48c7575461bbe752255cf0c2fce5c0fad14cde54`

## Non-goals

- Reimplementing router, coordinator, HNSW, Raft, or transport internals.
- Automatic rebuild policy, mutation-admission completion, or multi-host qualification.
- Document materialization; V1 remains an IDs/scores boundary.
- On-disk format or compatibility work. TreeDB remains pre-alpha.

## Design

- Adds the public `TreeDB/vectorpartition` V1 request, response, status, lifecycle, error, and service contracts.
- Adapts the existing production TCP topology and live catalog lifecycle authority behind one opaque backend.
- Preserves generation identity, bounded inputs, cancellation/deadline handling, deterministic ordered results, response ownership, and all-or-error behavior.
- Exposes selected partition/group, request/RPC/retry/redirect, candidate/edge, and coherent query/request/candidate/response byte counters.
- Extends the existing catalog lifecycle integration harness with `RestartV1`, reopening the same durable Raft directories/transports/configuration and waiting for leader election plus replay through the pre-restart committed index.
- Documents the pre-alpha API status and includes an executable `ExampleServiceV1_Search`.

## Scope

- Includes: `TreeDB/vectorpartition`, the production nativewire public adapter/tests, document-service exposure, and the existing catalog lifecycle harness.
- Excludes: storage formats, router/search algorithms, lifecycle record encoding, placement policy, automated rebuilds, and distributed qualification.

## Correctness

Tests run:

- `go test ./TreeDB/vectorpartition -count=1`
- `go test ./TreeDB/internal/raftplacement -run '^TestCatalogMetaLifecycleHarness' -count=1`
- `go test ./TreeDB/nativewire -run '^TestVectorPartitionPublicBackend.*V1$' -count=1 -v`
- `go test ./TreeDB/nativewire -run '^TestVectorPartitionPublicBackendLifecycleOverCatalogMetaRaftV1$' -count=3`
- `go test -race -p=1 ./TreeDB/vectorpartition ./TreeDB/nativewire -run '^(TestServiceV1|TestVectorPartitionPublicBackend)' -count=1`
- `go test ./TreeDB/vectorpartition ./TreeDB/nativewire -run '^(TestServiceV1|TestVectorPartitionPublicBackend)' -count=1`
- `go test -p=1 ./TreeDB/vectorpartition ./TreeDB/documentservice ./TreeDB/internal/raftplacement ./TreeDB/nativewire -count=1`

Covered regressions include request/response ownership, stable ordering, coordinator/public result and counter parity, unsupported and stale requests, all-or-error failures, cancellation/deadlines, catalog-Raft lifecycle replay after restart, and successor cutover over an active predecessor, stale-backend invalidation refusal, and stale-topology search refusal, idempotent registration without rebuilding recorded-ready groups, and executable example compilation.

## Performance

Benchmark:

`go test ./TreeDB/nativewire -run '^$' -bench '^BenchmarkVectorPartitionPublicServiceOverheadV1$' -benchtime=1s -count=5 -benchmem`

The benchmark reuses the production TCP two-group topology with independently created and warmed direct/public instances. Exact result and counter parity is checked outside the timed loop.

| Path | Median ns/op | Median QPS | allocs/op | Median B/op |
| --- | ---: | ---: | ---: | ---: |
| Direct coordinator | 129,897 | 7,698 | 321 | 35,007 |
| Public service | 133,150 | 7,510 | 328 | 35,517 |

The public boundary adds approximately 2.5% median latency, 7 allocations, and 510 bytes per operation in this small two-group shape. Candidate/edge and all four byte-counter values are identical to the direct path. No performance blocker was observed.

## Rollout / Toggle Plan

- This is an additive pre-alpha API surface with no default behavior or storage-format change.
- Revert the PR to remove the public surface; the underlying production topology remains unchanged.

## Follow-ups

- #4017 owns mutation-admission and crash-recovery completion.
- #4018 owns operational rebuild workflow.
- The coordinator owns latest-head review, CI, dependency-graph updates, and merge.

## AI Review Loop

- No automated review was requested while preparing this PR, per coordinator direction.
- Latest-head AI review, CI, thread resolution, and merge remain coordinator-owned gates.

## Optimization PR Checklist (TreeDB)

- [x] Single clear objective with explicit include/exclude boundaries.
- [x] Deterministic regressions cover the supported public contract and restart behavior.
- [x] Focused, repeat, race, reopen, benchmark, and broader affected-package tests pass locally.
- [x] Relevant direct-vs-public benchmark reports latency, QPS, allocations, bytes, candidates, and edges.
- [x] Pre-alpha API stability is documented; no format or configuration change is introduced.
- [x] `git diff --check` passes.
- [ ] Latest-head CI and mature review gates remain for the coordinator.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a public vector-partition service supporting search, generation registration, status tracking, activation, invalidation, retirement, rebuilding, and cleanup eligibility.
  * Added production support for routing vector-partition requests through coordinated topologies.
  * Added clear validation and error reporting for unavailable services, invalid requests, cancellation, deadlines, and generation mismatches.
  * Added document-level registration and retrieval of the vector-partition service.

* **Documentation**
  * Updated vector-partition API documentation to describe supported search and generation lifecycle capabilities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->