### PR TITLE
bench: freeze local vector system qualification contract

### DIFF
--- a/TreeDB/docs/spec/artifacts/vector-partition-local-system-qualification-4019-plan.json
+++ b/TreeDB/docs/spec/artifacts/vector-partition-local-system-qualification-4019-plan.json
@@ -124,6 +124,7 @@
     "required_provenance_fields": ["artifact_root", "commands_path", "commands_sha256", "environment_path", "environment_sha256", "started_at", "completed_at"],
     "required_noise_fields": ["valid", "load_1", "load_5", "load_15"],
     "tree_db_counters": ["selected_partitions", "selected_groups", "requests", "rpcs", "retries", "redirects", "candidates", "edges", "query_bytes", "request_bytes", "candidate_bytes", "response_bytes"],
+    "tree_db_positive_counters": ["selected_partitions", "selected_groups", "requests", "rpcs", "candidates", "edges", "query_bytes", "request_bytes", "candidate_bytes", "response_bytes"],
     "complete_status": "complete",
     "nonclaim": "external relative ranking is observational and same-host results are not multi-host evidence"
   },

--- a/TreeDB/docs/spec/artifacts/vector-partition-local-system-qualification-4019-plan.json
+++ b/TreeDB/docs/spec/artifacts/vector-partition-local-system-qualification-4019-plan.json
@@ -120,7 +120,7 @@
     "required_phases": ["load", "index_build", "checkpoint_or_flush", "reopen_or_reconnect", "readiness", "warmup", "search", "cleanup"],
     "required_resources": ["cpu_seconds", "peak_rss_bytes", "persistent_bytes", "temporary_bytes", "network_rx_bytes", "network_tx_bytes", "swap_bytes"],
     "required_search_metrics": ["queries", "completed_queries", "result_count", "errors", "timeouts", "recall_at_10", "qps", "p50_nanos", "p95_nanos", "p99_nanos"],
-    "required_host_fields": ["cpu_model", "logical_cpus", "memory_bytes", "kernel", "storage_filesystem", "storage_root", "docker_version", "go_version", "python_version"],
+    "required_host_fields": ["cpu_model", "logical_cpus", "memory_bytes", "kernel", "storage_filesystem", "storage_root", "storage_free_bytes", "docker_version", "go_version", "python_version"],
     "required_provenance_fields": ["artifact_root", "commands_path", "commands_sha256", "environment_path", "environment_sha256", "started_at", "completed_at"],
     "required_noise_fields": ["valid", "load_1", "load_5", "load_15"],
     "tree_db_counters": ["selected_partitions", "selected_groups", "requests", "rpcs", "retries", "redirects", "candidates", "edges", "query_bytes", "request_bytes", "candidate_bytes", "response_bytes"],

--- a/TreeDB/docs/spec/artifacts/vector-partition-local-system-qualification-4019-plan.json
+++ b/TreeDB/docs/spec/artifacts/vector-partition-local-system-qualification-4019-plan.json
@@ -1,0 +1,237 @@
+{
+  "schema_version": 1,
+  "result_kind": "vector_partition_local_system_qualification_plan_v1",
+  "status": "planned_no_measurement",
+  "issue": 4019,
+  "accepted_inputs": {
+    "qualification_head_sha": "eed54bc0b9ec3b705e9170be26ab069bdc9b9771",
+    "campaign_index_path": "TreeDB/docs/evidence/vector-partition-qualification-4027/eed54bc0/campaign.json",
+    "campaign_index_sha256": "c20f11bb38898fd0d5907330bec3df80db29df14e44962a8766502e757849aa2",
+    "validator_stdout_sha256": "b1c2a147fb74725565ef72a111f1bd72549637564956cdf7d69a60f0ef166410",
+    "operations_api": "github.com/snissn/gomap/TreeDB/vectorpartition.OperationsV1",
+    "operations_search": "OperationsV1.Search",
+    "operations_readiness": "OperationsV1.Status",
+    "corpora": [
+      {
+        "id": "embedding_mixture_100k",
+        "vectors": 100000,
+        "queries": 1000,
+        "dimensions": 128,
+        "seed": 4017,
+        "metric": "cosine",
+        "top_k": 10,
+        "fixture_checksum": "ecc2224f386932e580e4956f2cfa852140d3134625971c3511bc0d5feddf9b95",
+        "manifest_sha256": "2548153084bd8a1c4dad91cd26033c870ab6e8fc9a354326f910e5d876e8919f",
+        "truth_identity": "accdb76c693e2da99333b9327efc0e3d83ba630b25a8ba2b6820f5a6f6e38937",
+        "truth_artifact_sha256": "0e9bce9465c9e1fa70c7833364e88c332bc831cfc52c628c90085e1c3068763c",
+        "truth_sha256": "6e17b00a04ad86ad4b13507e6afc1ae38d323280b3a0aa8405bce88b222fa1bc"
+      },
+      {
+        "id": "embedding_mixture_250k",
+        "vectors": 250000,
+        "queries": 1000,
+        "dimensions": 128,
+        "seed": 4016,
+        "metric": "cosine",
+        "top_k": 10,
+        "fixture_checksum": "d0c7c82ba868853aae9a4280161003d72714ad1701d41ed3169c2fa94d470d69",
+        "manifest_sha256": "14194cca83e94d776baf78897e423ba505d51b342cc189845e6b271945502025",
+        "truth_identity": "f1fab20b88cd3dcdd6e95a284400983230b1432b36bd4d73e321e251159795ab",
+        "truth_artifact_sha256": "5a518c1cb8182edc685ab692dc17a6974655572f426a4b97c10482fd1643f04e",
+        "truth_sha256": "89b84125e518f33cc30bc1e4e9defcc0639378d7108fb180f56ec2dc91d6f254"
+      }
+    ]
+  },
+  "workload": {
+    "serial_system_rows": true,
+    "repetitions": 3,
+    "concurrency": [1, 8, 32, 64],
+    "important_concurrency": [1, 8, 32],
+    "saturation_concurrency": 64,
+    "warmup_queries_per_cell": 1000,
+    "cache_state": "fresh_persistent_state_per_repetition; reopen_or_reconnect_before_search; no_os_cache_drop; warm_each_cell_immediately_before_timing",
+    "durability_state": "durable_build_then_checkpoint_or_flush_before_reopen_or_reconnect",
+    "budget_order_by_repetition": ["forward", "reverse", "deterministic_rotation"],
+    "deterministic_rotation_offset": 1,
+    "matched_recall_floor": 0.9,
+    "tree_db": {
+      "variant": "graph-overlap-020-v1",
+      "partitions": 16,
+      "groups": 4,
+      "router_candidates": 256,
+      "ef_search": 128,
+      "search_budgets": [
+        {"probes": 1},
+        {"probes": 2},
+        {"probes": 4},
+        {"probes": 8},
+        {"probes": 16}
+      ],
+      "selected_budget": {"probes": 2},
+      "exhaustive_partition_budget": {"probes": 16}
+    },
+    "milvus": {
+      "index": "HNSW",
+      "metric": "COSINE",
+      "M": 16,
+      "efConstruction": 128,
+      "search_budgets": [
+        {"ef": 16},
+        {"ef": 32},
+        {"ef": 64},
+        {"ef": 128},
+        {"ef": 256},
+        {"ef": 512}
+      ]
+    },
+    "pgvector": {
+      "index": "hnsw",
+      "metric": "vector_cosine_ops",
+      "m": 16,
+      "ef_construction": 128,
+      "search_budgets": [
+        {"ef_search": 16},
+        {"ef_search": 32},
+        {"ef_search": 64},
+        {"ef_search": 128},
+        {"ef_search": 256},
+        {"ef_search": 512}
+      ]
+    }
+  },
+  "resource_envelope": {
+    "host_cpu_model": "11th Gen Intel(R) Core(TM) i5-11400F @ 2.60GHz",
+    "logical_cpus": 12,
+    "cpu_set": "0-11",
+    "memory_limit_bytes": 25769803776,
+    "swap_limit_bytes": 0,
+    "pids_limit": 4096,
+    "storage_root": "/mnt/fast4tb/<campaign-root>",
+    "storage_filesystem": "ext4",
+    "minimum_free_bytes": 107374182400,
+    "enforcement": "cgroup_v2_for_native_and_docker_limits_for_containers",
+    "noise_policy": "no_concurrent_benchmark_or_build; record host load and invalidate any tainted repetition",
+    "accounting": "sum every process and container in the complete system row, including sidecars"
+  },
+  "artifact_contract": {
+    "schema_version": 1,
+    "result_kind": "vector_partition_local_system_qualification_v1",
+    "allowed_status": ["valid", "failed", "unsupported", "incomplete"],
+    "required_phases": ["load", "index_build", "checkpoint_or_flush", "reopen_or_reconnect", "readiness", "warmup", "search", "cleanup"],
+    "required_resources": ["cpu_seconds", "peak_rss_bytes", "persistent_bytes", "temporary_bytes", "network_rx_bytes", "network_tx_bytes", "swap_bytes"],
+    "required_search_metrics": ["queries", "completed_queries", "result_count", "errors", "timeouts", "recall_at_10", "qps", "p50_nanos", "p95_nanos", "p99_nanos"],
+    "required_host_fields": ["cpu_model", "logical_cpus", "memory_bytes", "kernel", "storage_filesystem", "storage_root", "docker_version", "go_version", "python_version"],
+    "required_provenance_fields": ["artifact_root", "commands_path", "commands_sha256", "environment_path", "environment_sha256", "started_at", "completed_at"],
+    "required_noise_fields": ["valid", "load_1", "load_5", "load_15"],
+    "tree_db_counters": ["selected_partitions", "selected_groups", "requests", "rpcs", "retries", "redirects", "candidates", "edges", "query_bytes", "request_bytes", "candidate_bytes", "response_bytes"],
+    "complete_status": "complete",
+    "nonclaim": "external relative ranking is observational and same-host results are not multi-host evidence"
+  },
+  "rows": [
+    {
+      "id": "treedb_single_daemon",
+      "system": "treedb",
+      "boundary": {
+        "client": "bounded_tcp_benchmark_client",
+        "service": "vectorpartition.OperationsV1.Search",
+        "topology": "single_daemon_four_group",
+        "processes": 1,
+        "containers": 0,
+        "group_ownership": "all_four_groups_in_one_daemon"
+      },
+      "pinned_identity": {
+        "source_revision": "<source_head_sha>",
+        "vcs_modified": false,
+        "go_version": "go1.26.0"
+      },
+      "required_identity_fields": ["binary_sha256", "source_revision", "vcs_modified", "go_version", "topology_identity_sha256"],
+      "search_budget": "tree_db"
+    },
+    {
+      "id": "treedb_native_multi_daemon",
+      "system": "treedb",
+      "boundary": {
+        "client": "bounded_tcp_benchmark_client",
+        "service": "vectorpartition.OperationsV1.Search",
+        "topology": "native_four_daemon_four_group",
+        "processes": 4,
+        "containers": 0,
+        "group_ownership": "one_group_per_daemon; daemon_zero_also_owns_client_coordinator"
+      },
+      "pinned_identity": {
+        "source_revision": "<source_head_sha>",
+        "vcs_modified": false,
+        "go_version": "go1.26.0"
+      },
+      "required_identity_fields": ["binary_sha256", "source_revision", "vcs_modified", "go_version", "topology_identity_sha256"],
+      "search_budget": "tree_db"
+    },
+    {
+      "id": "treedb_container_multi_daemon",
+      "system": "treedb",
+      "boundary": {
+        "client": "bounded_tcp_benchmark_client_over_isolated_docker_bridge",
+        "service": "vectorpartition.OperationsV1.Search",
+        "topology": "container_four_daemon_four_group",
+        "processes": 4,
+        "containers": 4,
+        "group_ownership": "one_group_per_container; container_zero_also_owns_client_coordinator"
+      },
+      "pinned_identity": {
+        "source_revision": "<source_head_sha>",
+        "vcs_modified": false,
+        "go_version": "go1.26.0",
+        "network": "one_fresh_internal_docker_bridge",
+        "volume_policy": "one_fresh_data_volume_per_container"
+      },
+      "required_identity_fields": ["binary_sha256", "image_sha256", "source_revision", "vcs_modified", "go_version", "network", "volume_policy", "topology_identity_sha256"],
+      "search_budget": "tree_db"
+    },
+    {
+      "id": "milvus_standalone",
+      "system": "milvus",
+      "boundary": {
+        "client": "pymilvus.MilvusClient",
+        "service": "Milvus Standalone gRPC",
+        "topology": "official_standalone_compose",
+        "processes": 3,
+        "containers": 3,
+        "group_ownership": "milvus_standalone_plus_official_etcd_and_minio_sidecars"
+      },
+      "pinned_identity": {
+        "server_version": "2.6.20",
+        "client_package": "pymilvus==2.6.16",
+        "compose_url": "https://github.com/milvus-io/milvus/releases/download/v2.6.20/milvus-standalone-docker-compose.yml",
+        "compose_sha256": "9e0e8187e197ce23d3da3e63c19bc20189782f96bacb97287f8fcee80ba628c3",
+        "milvus_image": "milvusdb/milvus:v2.6.20@sha256:e514fced2aa26cf3b94e7de20986fe9e535159fde08f9934d245d0e1a909c18c",
+        "etcd_image": "quay.io/coreos/etcd:v3.5.25@sha256:dc2bdc588d2adc5272204a1fff7f1d89f31e8caacea78fdf509fd409d7162a9d",
+        "minio_image": "minio/minio:RELEASE.2024-12-18T13-15-44Z@sha256:34c8e2f52a5984492555427fee07254c80036bdb7079bb91679232abd7a4fa20",
+        "network": "one_fresh_internal_docker_bridge",
+        "volume_policy": "fresh_etcd_minio_milvus_volumes_per_repetition"
+      },
+      "required_identity_fields": ["server_version", "client_package", "compose_url", "compose_sha256", "milvus_image", "etcd_image", "minio_image", "network", "volume_policy", "topology_identity_sha256"],
+      "search_budget": "milvus"
+    },
+    {
+      "id": "postgres_pgvector",
+      "system": "pgvector",
+      "boundary": {
+        "client": "psycopg.Connection",
+        "service": "PostgreSQL wire protocol",
+        "topology": "single_postgres_container",
+        "processes": 1,
+        "containers": 1,
+        "group_ownership": "one_postgresql_server"
+      },
+      "pinned_identity": {
+        "postgres_version": "16.14",
+        "pgvector_version": "0.8.6",
+        "client_package": "psycopg[binary]==3.3.4",
+        "image": "pgvector/pgvector:pg16@sha256:84a355869251af1a3379cfc9fa7b4dbf962c03f642a4bb7b339a203925071c43",
+        "volume_policy": "one_fresh_postgresql_data_volume_per_repetition"
+      },
+      "required_identity_fields": ["postgres_version", "pgvector_version", "client_package", "image", "volume_policy", "topology_identity_sha256"],
+      "search_budget": "pgvector"
+    }
+  ]
+}

--- a/TreeDB/docs/spec/vector-partition-local-system-qualification.md
+++ b/TreeDB/docs/spec/vector-partition-local-system-qualification.md
@@ -1,0 +1,72 @@
+# Vector-partition local-system qualification
+
+Status: pre-alpha M0 contract for issue #4019. No measurements are claimed by
+this document or its frozen plan.
+
+## Authoritative inputs
+
+The contract consumes the accepted #4022/#4027 structured qualification at
+head `eed54bc0b9ec3b705e9170be26ab069bdc9b9771` and the public
+`vectorpartition.OperationsV1` production boundary from #4018. The accepted
+corpora are the deterministic 100k and 250k embedding-mixture fixtures, each
+with 1,000 held-out queries, 128 dimensions, cosine distance, and top-k 10.
+Their exact checksums and truth identities are frozen in
+`artifacts/vector-partition-local-system-qualification-4019-plan.json`.
+
+This does not add a 1M or high-entropy claim.
+
+## Required rows
+
+| Row | Headline client boundary | Topology |
+| --- | --- | --- |
+| TreeDB single daemon | bounded TCP client to `OperationsV1.Search` | one process owns four groups |
+| TreeDB native multi-daemon | bounded TCP client to `OperationsV1.Search` | four processes, ports, roots, identities, one group each |
+| TreeDB container multi-daemon | bounded TCP client over an isolated bridge | four pinned containers and volumes, one group each |
+| Milvus Standalone | PyMilvus to official Standalone gRPC | pinned Milvus, etcd, and MinIO containers |
+| PostgreSQL + pgvector | Psycopg over the PostgreSQL wire protocol | one pinned PostgreSQL+pgvector container |
+
+All rows run serially on the same host. In-process TreeDB calls are not a
+headline comparator row. Same-host TCP and bridge results are not multi-host
+evidence; #3983 owns that qualification.
+
+## Fairness and evidence
+
+- Use the exact frozen corpus, query, metric, top-k, and oracle identities.
+- Give every complete row the frozen 12-CPU, 24-GiB, zero-swap envelope and
+  account for every server and sidecar process.
+- Time load, index build, checkpoint/flush, reopen/reconnect, readiness,
+  warmup, search, and cleanup separately.
+- Start every repetition from fresh persistent state, durably flush before
+  reopen/reconnect, keep the OS cache untouched, and warm each cell immediately
+  before timing it.
+- Sweep the engine-native budgets in the plan. TreeDB retains the accepted
+  p1/p2/p4/p8/p16, EF128, c256 ladder and selects p2; Milvus and pgvector use
+  the first pinned HNSW budget whose three-run median reaches recall@10 0.90.
+- Measure concurrency 1, 8, 32, and the declared 64 saturation row. The three
+  repetitions use forward, reverse, and one-position rotated budget order.
+- Preserve unsupported, failed, incomplete, and host-noise-tainted rows. They
+  do not qualify and are not averaged into a claim.
+- Bind the exact source head, clean binary or image identity, topology,
+  commands, environment, host, artifact paths, resources, and TreeDB public
+  path counters in the machine-readable result.
+
+Milvus uses the official v2.6.20 Standalone compose deployment and PyMilvus
+2.6.16. PostgreSQL 16.14 and pgvector 0.8.6 use the repository's existing
+full-vector HNSW adapter. External relative ranking is observational; it is not
+a TreeDB release threshold.
+
+Validate the frozen plan or a produced result with only the Python standard
+library:
+
+```sh
+python3 benchmarks/vector_db_compare/system_qualification.py \
+  --plan TreeDB/docs/spec/artifacts/vector-partition-local-system-qualification-4019-plan.json
+
+python3 benchmarks/vector_db_compare/system_qualification.py \
+  --plan TreeDB/docs/spec/artifacts/vector-partition-local-system-qualification-4019-plan.json \
+  --result /path/to/result.json --require-complete
+```
+
+The validator fails closed on missing identities, boundary drift, incomplete
+budget/concurrency/repetition matrices, changed measurement order, malformed
+metrics, absent matched-recall buckets, and non-valid required rows.

--- a/TreeDB/docs/spec/vector-partition-local-system-qualification.md
+++ b/TreeDB/docs/spec/vector-partition-local-system-qualification.md
@@ -42,6 +42,7 @@ evidence; #3983 owns that qualification.
 - Sweep the engine-native budgets in the plan. TreeDB retains the accepted
   p1/p2/p4/p8/p16, EF128, c256 ladder and selects p2; Milvus and pgvector use
   the first pinned HNSW budget whose three-run median reaches recall@10 0.90.
+  TreeDB's selected p2 budget must meet the same 0.90 floor.
 - Measure concurrency 1, 8, 32, and the declared 64 saturation row. The three
   repetitions use forward, reverse, and one-position rotated budget order.
 - Preserve unsupported, failed, incomplete, and host-noise-tainted rows. They

--- a/benchmarks/vector_db_compare/system_qualification.py
+++ b/benchmarks/vector_db_compare/system_qualification.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import argparse
 import hashlib
 import json
+import math
 from pathlib import Path
 from statistics import median
 from typing import Any
@@ -41,7 +42,7 @@ def _ids(values: list[dict[str, Any]], name: str) -> list[str]:
 
 
 def _number(value: Any) -> bool:
-    return isinstance(value, (int, float)) and not isinstance(value, bool)
+    return (isinstance(value, int) and not isinstance(value, bool)) or (isinstance(value, float) and math.isfinite(value))
 
 
 def _is_sha256(value: Any) -> bool:
@@ -220,13 +221,19 @@ def validate_result(plan: dict[str, Any], plan_sha256: str, result: dict[str, An
 
     host = result.get("host")
     _require(isinstance(host, dict), "host identity is required")
-    _require(all(isinstance(host.get(key), str) and host[key] for key in plan["artifact_contract"]["required_host_fields"] if key not in ("logical_cpus", "memory_bytes")), "host identity is incomplete")
-    _require(isinstance(host.get("logical_cpus"), int) and host["logical_cpus"] > 0, "host logical_cpus is invalid")
-    _require(isinstance(host.get("memory_bytes"), int) and host["memory_bytes"] > 0, "host memory_bytes is invalid")
-    _require(host["logical_cpus"] == plan["resource_envelope"]["logical_cpus"] and host["storage_filesystem"] == plan["resource_envelope"]["storage_filesystem"], "host does not match the resource envelope")
+    numeric_host_fields = ("logical_cpus", "memory_bytes", "storage_free_bytes")
+    _require(all(isinstance(host.get(key), str) and host[key] for key in plan["artifact_contract"]["required_host_fields"] if key not in numeric_host_fields), "host identity is incomplete")
+    _require(all(isinstance(host.get(key), int) and not isinstance(host[key], bool) and host[key] > 0 for key in numeric_host_fields), "host numeric identity is invalid")
+    envelope = plan["resource_envelope"]
+    storage_root = Path(host["storage_root"])
+    storage_parent = Path(envelope["storage_root"].removesuffix("/<campaign-root>"))
+    _require(host["cpu_model"] == envelope["host_cpu_model"] and host["logical_cpus"] == envelope["logical_cpus"], "host CPU does not match the resource envelope")
+    _require(host["memory_bytes"] >= envelope["memory_limit_bytes"] and host["storage_free_bytes"] >= envelope["minimum_free_bytes"], "host capacity is below the resource envelope")
+    _require(host["storage_filesystem"] == envelope["storage_filesystem"] and storage_root.is_absolute() and storage_root.name != "<campaign-root>" and ".." not in storage_root.parts and storage_root.parent == storage_parent, "host storage does not match the resource envelope")
     provenance = result.get("provenance")
     _require(isinstance(provenance, dict) and all(isinstance(provenance.get(key), str) and provenance[key] for key in plan["artifact_contract"]["required_provenance_fields"]), "result provenance is incomplete")
     _require(_is_sha256(provenance["commands_sha256"]) and _is_sha256(provenance["environment_sha256"]), "result provenance digests are invalid")
+    _require(provenance["artifact_root"] == host["storage_root"], "artifact root differs from the pinned storage root")
 
     expected_corpora = [{key: corpus[key] for key in ("id", "fixture_checksum", "manifest_sha256", "truth_identity", "truth_artifact_sha256", "truth_sha256")} for corpus in plan["accepted_inputs"]["corpora"]]
     corpus_contracts = {corpus["id"]: corpus for corpus in plan["accepted_inputs"]["corpora"]}

--- a/benchmarks/vector_db_compare/system_qualification.py
+++ b/benchmarks/vector_db_compare/system_qualification.py
@@ -33,7 +33,8 @@ def _reject_json_constant(value: str) -> None:
 
 
 def _load(path: Path, limit: int = 16 << 20) -> dict[str, Any]:
-    raw = path.read_bytes()
+    with path.open("rb") as stream:
+        raw = stream.read(limit + 1)
     _require(len(raw) <= limit, f"{path} exceeds {limit} bytes")
     value = json.loads(raw, parse_constant=_reject_json_constant)
     _require(isinstance(value, dict), f"{path} must contain an object")
@@ -198,10 +199,11 @@ def matched_recall_buckets(plan: dict[str, Any], result: dict[str, Any]) -> list
                 selected = None
                 for budget in candidates:
                     key = _budget_key(budget)
-                    metrics = [
-                        next(cell["metrics"] for cell in repetition["searches"] if _budget_key(cell["budget"]) == key and cell["concurrency"] == concurrency)
-                        for repetition in corpus["repetitions"]
-                    ]
+                    metrics = []
+                    for repetition in corpus["repetitions"]:
+                        cell = next((value for value in repetition["searches"] if _budget_key(value.get("budget")) == key and value.get("concurrency") == concurrency), None)
+                        _require(isinstance(cell, dict) and isinstance(cell.get("metrics"), dict), f"row {row['id']} corpus {corpus['id']} lacks metrics for budget {key} at concurrency {concurrency}")
+                        metrics.append(cell["metrics"])
                     recall = median(value["recall_at_10"] for value in metrics)
                     if recall >= floor:
                         selected = {

--- a/benchmarks/vector_db_compare/system_qualification.py
+++ b/benchmarks/vector_db_compare/system_qualification.py
@@ -12,6 +12,9 @@ from statistics import median
 from typing import Any
 
 
+FROZEN_PLAN_SEMANTIC_SHA256 = "9afa03cf82f4cfadc00a6e96178b8a634cdb8a5abbdc1a4b745f1a17a7662689"
+
+
 class ContractError(ValueError):
     pass
 
@@ -25,10 +28,14 @@ def _sha256(path: Path) -> str:
     return hashlib.sha256(path.read_bytes()).hexdigest()
 
 
+def _reject_json_constant(value: str) -> None:
+    raise ContractError(f"non-finite JSON number {value}")
+
+
 def _load(path: Path, limit: int = 16 << 20) -> dict[str, Any]:
     raw = path.read_bytes()
     _require(len(raw) <= limit, f"{path} exceeds {limit} bytes")
-    value = json.loads(raw)
+    value = json.loads(raw, parse_constant=_reject_json_constant)
     _require(isinstance(value, dict), f"{path} must contain an object")
     return value
 
@@ -51,6 +58,10 @@ def _is_sha256(value: Any) -> bool:
 
 def _budget_key(value: Any) -> str:
     return json.dumps(value, sort_keys=True, separators=(",", ":"))
+
+
+def _semantic_sha256(value: Any) -> str:
+    return hashlib.sha256(json.dumps(value, sort_keys=True, separators=(",", ":")).encode()).hexdigest()
 
 
 def validate_plan(plan: dict[str, Any]) -> None:
@@ -127,9 +138,11 @@ def validate_plan(plan: dict[str, Any]) -> None:
     _require(envelope.get("swap_limit_bytes") == 0, "swap must be disabled for measured rows")
     artifact = plan.get("artifact_contract")
     _require(isinstance(artifact, dict) and artifact.get("schema_version") == 1 and artifact.get("result_kind") == "vector_partition_local_system_qualification_v1", "artifact contract is invalid")
-    for key in ("allowed_status", "required_phases", "required_resources", "required_search_metrics", "required_host_fields", "required_provenance_fields", "required_noise_fields", "tree_db_counters"):
+    for key in ("allowed_status", "required_phases", "required_resources", "required_search_metrics", "required_host_fields", "required_provenance_fields", "required_noise_fields", "tree_db_counters", "tree_db_positive_counters"):
         _require(isinstance(artifact.get(key), list) and artifact[key] and len(artifact[key]) == len(set(artifact[key])), f"artifact contract lacks {key}")
     _require(artifact["allowed_status"] == ["valid", "failed", "unsupported", "incomplete"] and artifact.get("complete_status") == "complete", "artifact status contract changed")
+    _require(set(artifact["tree_db_positive_counters"]) < set(artifact["tree_db_counters"]), "positive TreeDB counters must be a proper subset")
+    _require(_semantic_sha256(plan) == FROZEN_PLAN_SEMANTIC_SHA256, "frozen plan content changed")
 
 
 def _resolve(value: Any, source_head_sha: str) -> Any:
@@ -292,10 +305,11 @@ def validate_result(plan: dict[str, Any], plan_sha256: str, result: dict[str, An
                     if contract["system"] == "treedb":
                         counters = cell.get("counters")
                         _require(isinstance(counters, dict) and all(isinstance(counters.get(key), int) and not isinstance(counters[key], bool) and counters[key] >= 0 for key in plan["artifact_contract"]["tree_db_counters"]), f"row {row['id']} lacks TreeDB path counters")
+                        _require(all(counters[key] > 0 for key in plan["artifact_contract"]["tree_db_positive_counters"]), f"row {row['id']} lacks nonzero TreeDB path proof")
 
     tree_identities = [row["identity"] for row in rows if plan_rows[row["id"]]["system"] == "treedb"]
     _require(len({identity["binary_sha256"] for identity in tree_identities}) == 1, "TreeDB rows do not use one benchmark binary")
-    _require(len({identity["topology_identity_sha256"] for identity in tree_identities}) == len(tree_identities), "TreeDB topology identities are not distinct")
+    _require(len({row["identity"]["topology_identity_sha256"] for row in rows}) == len(rows), "system topology identities are not distinct")
 
     expected_status = plan["artifact_contract"]["complete_status"] if all_valid else "incomplete"
     _require(result.get("status") == expected_status, "top-level status does not match row status")

--- a/benchmarks/vector_db_compare/system_qualification.py
+++ b/benchmarks/vector_db_compare/system_qualification.py
@@ -292,6 +292,7 @@ def validate_result(plan: dict[str, Any], plan_sha256: str, result: dict[str, An
                 _require(all(isinstance(repetition.get("phases", {}).get(key), int) and not isinstance(repetition["phases"][key], bool) and repetition["phases"][key] >= 0 for key in plan["artifact_contract"]["required_phases"]), f"row {row['id']} lacks phase timing")
                 _require(all(_number(repetition.get("resources", {}).get(key)) and repetition["resources"][key] >= 0 for key in plan["artifact_contract"]["required_resources"]), f"row {row['id']} lacks total-system resources")
                 _require(all(isinstance(repetition["resources"][key], int) and not isinstance(repetition["resources"][key], bool) for key in plan["artifact_contract"]["required_resources"] if key != "cpu_seconds"), f"row {row['id']} has malformed byte resources")
+                _require(repetition["resources"]["swap_bytes"] <= envelope["swap_limit_bytes"], f"row {row['id']} exceeds the swap limit")
                 _require(all(repetition["resources"][key] > 0 for key in ("cpu_seconds", "peak_rss_bytes", "persistent_bytes")), f"row {row['id']} has empty total-system resource observations")
                 cells = repetition.get("searches")
                 _require(isinstance(cells, list), f"row {row['id']} searches are required")

--- a/benchmarks/vector_db_compare/system_qualification.py
+++ b/benchmarks/vector_db_compare/system_qualification.py
@@ -1,0 +1,315 @@
+#!/usr/bin/env python3
+"""Fail-closed contract checks for the #4019 local-system comparison."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+from pathlib import Path
+from statistics import median
+from typing import Any
+
+
+class ContractError(ValueError):
+    pass
+
+
+def _require(ok: bool, message: str) -> None:
+    if not ok:
+        raise ContractError(message)
+
+
+def _sha256(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def _load(path: Path, limit: int = 16 << 20) -> dict[str, Any]:
+    raw = path.read_bytes()
+    _require(len(raw) <= limit, f"{path} exceeds {limit} bytes")
+    value = json.loads(raw)
+    _require(isinstance(value, dict), f"{path} must contain an object")
+    return value
+
+
+def _ids(values: list[dict[str, Any]], name: str) -> list[str]:
+    _require(all(isinstance(value, dict) for value in values), f"{name} entries must be objects")
+    ids = [value.get("id") for value in values]
+    _require(all(isinstance(value, str) and value for value in ids), f"{name} ids are required")
+    _require(len(ids) == len(set(ids)), f"{name} ids must be unique")
+    return ids
+
+
+def _number(value: Any) -> bool:
+    return isinstance(value, (int, float)) and not isinstance(value, bool)
+
+
+def _is_sha256(value: Any) -> bool:
+    return isinstance(value, str) and len(value) == 64 and all(char in "0123456789abcdef" for char in value)
+
+
+def _budget_key(value: Any) -> str:
+    return json.dumps(value, sort_keys=True, separators=(",", ":"))
+
+
+def validate_plan(plan: dict[str, Any]) -> None:
+    _require(plan.get("schema_version") == 1, "plan schema_version must be 1")
+    _require(plan.get("result_kind") == "vector_partition_local_system_qualification_plan_v1", "unexpected plan kind")
+    _require(plan.get("status") == "planned_no_measurement", "plan must not claim measurements")
+    _require(plan.get("issue") == 4019, "plan must bind issue 4019")
+
+    inputs = plan.get("accepted_inputs")
+    _require(isinstance(inputs, dict), "accepted_inputs are required")
+    _require(inputs.get("qualification_head_sha") == "eed54bc0b9ec3b705e9170be26ab069bdc9b9771", "accepted qualification head changed")
+    _require(inputs.get("campaign_index_sha256") == "c20f11bb38898fd0d5907330bec3df80db29df14e44962a8766502e757849aa2", "accepted campaign changed")
+    _require(inputs.get("validator_stdout_sha256") == "b1c2a147fb74725565ef72a111f1bd72549637564956cdf7d69a60f0ef166410", "accepted validator output changed")
+    corpora = inputs.get("corpora")
+    _require(isinstance(corpora, list) and len(corpora) == 2, "exactly two accepted corpora are required")
+    _require(_ids(corpora, "corpus") == ["embedding_mixture_100k", "embedding_mixture_250k"], "unexpected corpus order or identity")
+    expected_shapes = [(100000, 1000, 128), (250000, 1000, 128)]
+    for corpus, shape in zip(corpora, expected_shapes):
+        for key in ("fixture_checksum", "manifest_sha256", "truth_identity", "truth_artifact_sha256", "truth_sha256"):
+            _require(_is_sha256(corpus.get(key)), f"corpus {corpus['id']} lacks {key}")
+        _require((corpus.get("vectors"), corpus.get("queries"), corpus.get("dimensions")) == shape, f"corpus {corpus['id']} changes shape")
+        _require(corpus.get("metric") == "cosine" and corpus.get("top_k") == 10, f"corpus {corpus['id']} changes metric/top-k")
+
+    workload = plan.get("workload")
+    _require(isinstance(workload, dict), "workload is required")
+    _require(workload.get("serial_system_rows") is True, "system rows must be serial")
+    _require(workload.get("repetitions") == 3, "three repetitions are required")
+    _require(workload.get("concurrency") == [1, 8, 32, 64], "concurrency contract changed")
+    _require(workload.get("important_concurrency") == [1, 8, 32], "important concurrency contract changed")
+    _require(workload.get("warmup_queries_per_cell") == 1000, "warmup contract changed")
+    _require(workload.get("cache_state") == "fresh_persistent_state_per_repetition; reopen_or_reconnect_before_search; no_os_cache_drop; warm_each_cell_immediately_before_timing", "cache-state contract changed")
+    _require(workload.get("durability_state") == "durable_build_then_checkpoint_or_flush_before_reopen_or_reconnect", "durability contract changed")
+    _require(workload.get("budget_order_by_repetition") == ["forward", "reverse", "deterministic_rotation"], "budget order contract changed")
+    _require(workload.get("deterministic_rotation_offset") == 1, "budget rotation contract changed")
+    _require(workload.get("matched_recall_floor") == 0.9, "matched recall floor changed")
+    for key in ("tree_db", "milvus", "pgvector"):
+        budgets = workload.get(key, {}).get("search_budgets")
+        _require(isinstance(budgets, list) and budgets, f"{key} search budgets are required")
+        encoded = [_budget_key(value) for value in budgets]
+        _require(len(encoded) == len(set(encoded)), f"{key} search budgets must be unique")
+    tree = workload["tree_db"]
+    _require((tree.get("variant"), tree.get("partitions"), tree.get("groups"), tree.get("router_candidates"), tree.get("ef_search")) == ("graph-overlap-020-v1", 16, 4, 256, 128), "TreeDB accepted configuration changed")
+    _require(tree["search_budgets"] == [{"probes": value} for value in (1, 2, 4, 8, 16)] and tree.get("selected_budget") == {"probes": 2}, "TreeDB probe contract changed")
+    milvus = workload["milvus"]
+    _require((milvus.get("index"), milvus.get("metric"), milvus.get("M"), milvus.get("efConstruction")) == ("HNSW", "COSINE", 16, 128), "Milvus index contract changed")
+    _require(milvus["search_budgets"] == [{"ef": value} for value in (16, 32, 64, 128, 256, 512)], "Milvus search budgets changed")
+    pgvector = workload["pgvector"]
+    _require((pgvector.get("index"), pgvector.get("metric"), pgvector.get("m"), pgvector.get("ef_construction")) == ("hnsw", "vector_cosine_ops", 16, 128), "pgvector index contract changed")
+    _require(pgvector["search_budgets"] == [{"ef_search": value} for value in (16, 32, 64, 128, 256, 512)], "pgvector search budgets changed")
+
+    rows = plan.get("rows")
+    _require(isinstance(rows, list), "rows are required")
+    expected = [
+        "treedb_single_daemon",
+        "treedb_native_multi_daemon",
+        "treedb_container_multi_daemon",
+        "milvus_standalone",
+        "postgres_pgvector",
+    ]
+    _require(_ids(rows, "row") == expected, "required system rows changed")
+    for row in rows:
+        boundary = row.get("boundary")
+        _require(isinstance(boundary, dict) and boundary.get("client") and boundary.get("service") and boundary.get("topology"), f"row {row['id']} lacks a client/service/topology boundary")
+        _require(isinstance(boundary.get("processes"), int) and boundary["processes"] > 0, f"row {row['id']} lacks process count")
+        _require(isinstance(row.get("pinned_identity"), dict) and row["pinned_identity"], f"row {row['id']} lacks pinned identity")
+        required = row.get("required_identity_fields")
+        _require(isinstance(required, list) and required and len(required) == len(set(required)), f"row {row['id']} identity fields are invalid")
+        _require(row.get("search_budget") in ("tree_db", "milvus", "pgvector"), f"row {row['id']} lacks a search budget")
+
+    envelope = plan.get("resource_envelope")
+    _require(isinstance(envelope, dict), "resource envelope is required")
+    for key in ("logical_cpus", "memory_limit_bytes", "pids_limit", "minimum_free_bytes"):
+        _require(isinstance(envelope.get(key), int) and envelope[key] > 0, f"resource envelope lacks {key}")
+    _require(envelope.get("swap_limit_bytes") == 0, "swap must be disabled for measured rows")
+    artifact = plan.get("artifact_contract")
+    _require(isinstance(artifact, dict) and artifact.get("schema_version") == 1 and artifact.get("result_kind") == "vector_partition_local_system_qualification_v1", "artifact contract is invalid")
+    for key in ("allowed_status", "required_phases", "required_resources", "required_search_metrics", "required_host_fields", "required_provenance_fields", "required_noise_fields", "tree_db_counters"):
+        _require(isinstance(artifact.get(key), list) and artifact[key] and len(artifact[key]) == len(set(artifact[key])), f"artifact contract lacks {key}")
+    _require(artifact["allowed_status"] == ["valid", "failed", "unsupported", "incomplete"] and artifact.get("complete_status") == "complete", "artifact status contract changed")
+
+
+def _resolve(value: Any, source_head_sha: str) -> Any:
+    if isinstance(value, str):
+        return value.replace("<source_head_sha>", source_head_sha)
+    if isinstance(value, dict):
+        return {key: _resolve(item, source_head_sha) for key, item in value.items()}
+    if isinstance(value, list):
+        return [_resolve(item, source_head_sha) for item in value]
+    return value
+
+
+def _valid_metrics(metrics: Any, required: list[str], queries: int, top_k: int) -> bool:
+    if not isinstance(metrics, dict) or any(key not in metrics for key in required):
+        return False
+    integer_fields = ("queries", "completed_queries", "result_count", "errors", "timeouts", "p50_nanos", "p95_nanos", "p99_nanos")
+    if any(not isinstance(metrics[key], int) or isinstance(metrics[key], bool) for key in integer_fields):
+        return False
+    if not _number(metrics["recall_at_10"]) or not _number(metrics["qps"]):
+        return False
+    if metrics["queries"] != queries or metrics["completed_queries"] != queries or metrics["result_count"] != queries * top_k:
+        return False
+    if metrics["errors"] != 0 or metrics["timeouts"] != 0 or not 0 <= metrics["recall_at_10"] <= 1 or metrics["qps"] <= 0:
+        return False
+    return 0 < metrics["p50_nanos"] <= metrics["p95_nanos"] <= metrics["p99_nanos"]
+
+
+def _ordered_budgets(plan: dict[str, Any], budget_name: str, repetition: int) -> list[dict[str, Any]]:
+    budgets = plan["workload"][budget_name]["search_budgets"]
+    if repetition == 1:
+        return budgets
+    if repetition == 2:
+        return list(reversed(budgets))
+    offset = plan["workload"]["deterministic_rotation_offset"]
+    return budgets[offset:] + budgets[:offset]
+
+
+def matched_recall_buckets(plan: dict[str, Any], result: dict[str, Any]) -> list[dict[str, Any]]:
+    """Return the first per-system budget whose three-run median reaches the floor."""
+    buckets: list[dict[str, Any]] = []
+    contracts = {row["id"]: row for row in plan["rows"]}
+    floor = plan["workload"]["matched_recall_floor"]
+    for row in result["rows"]:
+        if row["status"] != "valid":
+            continue
+        contract = contracts[row["id"]]
+        configured = plan["workload"][contract["search_budget"]]
+        candidates = configured["search_budgets"]
+        if "selected_budget" in configured:
+            candidates = [configured["selected_budget"]]
+        for corpus in row["corpora"]:
+            for concurrency in plan["workload"]["important_concurrency"]:
+                selected = None
+                for budget in candidates:
+                    key = _budget_key(budget)
+                    metrics = [
+                        next(cell["metrics"] for cell in repetition["searches"] if _budget_key(cell["budget"]) == key and cell["concurrency"] == concurrency)
+                        for repetition in corpus["repetitions"]
+                    ]
+                    recall = median(value["recall_at_10"] for value in metrics)
+                    if recall >= floor:
+                        selected = {
+                            "row": row["id"],
+                            "corpus": corpus["id"],
+                            "concurrency": concurrency,
+                            "budget": budget,
+                            "recall_at_10_median": recall,
+                            "qps_median": median(value["qps"] for value in metrics),
+                            "qps_min": min(value["qps"] for value in metrics),
+                            "qps_max": max(value["qps"] for value in metrics),
+                            "p95_nanos_median": median(value["p95_nanos"] for value in metrics),
+                            "p95_nanos_min": min(value["p95_nanos"] for value in metrics),
+                            "p95_nanos_max": max(value["p95_nanos"] for value in metrics),
+                        }
+                        break
+                _require(selected is not None, f"row {row['id']} corpus {corpus['id']} has no matched-recall budget at concurrency {concurrency}")
+                buckets.append(selected)
+    return buckets
+
+
+def validate_result(plan: dict[str, Any], plan_sha256: str, result: dict[str, Any], *, require_complete: bool = False) -> bool:
+    validate_plan(plan)
+    _require(result.get("schema_version") == plan["artifact_contract"]["schema_version"], "result schema_version mismatch")
+    _require(result.get("result_kind") == plan["artifact_contract"]["result_kind"], "unexpected result kind")
+    _require(result.get("plan_sha256") == plan_sha256, "result does not bind the exact plan")
+    _require(result.get("resource_envelope") == plan["resource_envelope"], "result changes the resource envelope")
+    source_head = result.get("source_head_sha")
+    _require(isinstance(source_head, str) and len(source_head) == 40 and all(c in "0123456789abcdef" for c in source_head), "source_head_sha must be lowercase git SHA-1")
+
+    host = result.get("host")
+    _require(isinstance(host, dict), "host identity is required")
+    _require(all(isinstance(host.get(key), str) and host[key] for key in plan["artifact_contract"]["required_host_fields"] if key not in ("logical_cpus", "memory_bytes")), "host identity is incomplete")
+    _require(isinstance(host.get("logical_cpus"), int) and host["logical_cpus"] > 0, "host logical_cpus is invalid")
+    _require(isinstance(host.get("memory_bytes"), int) and host["memory_bytes"] > 0, "host memory_bytes is invalid")
+    _require(host["logical_cpus"] == plan["resource_envelope"]["logical_cpus"] and host["storage_filesystem"] == plan["resource_envelope"]["storage_filesystem"], "host does not match the resource envelope")
+    provenance = result.get("provenance")
+    _require(isinstance(provenance, dict) and all(isinstance(provenance.get(key), str) and provenance[key] for key in plan["artifact_contract"]["required_provenance_fields"]), "result provenance is incomplete")
+    _require(_is_sha256(provenance["commands_sha256"]) and _is_sha256(provenance["environment_sha256"]), "result provenance digests are invalid")
+
+    expected_corpora = [{key: corpus[key] for key in ("id", "fixture_checksum", "manifest_sha256", "truth_identity", "truth_artifact_sha256", "truth_sha256")} for corpus in plan["accepted_inputs"]["corpora"]]
+    corpus_contracts = {corpus["id"]: corpus for corpus in plan["accepted_inputs"]["corpora"]}
+    _require(result.get("corpora") == expected_corpora, "result changes accepted corpus/query/truth identity")
+
+    plan_rows = {row["id"]: row for row in plan["rows"]}
+    rows = result.get("rows")
+    _require(isinstance(rows, list) and _ids(rows, "result row") == list(plan_rows), "result rows are missing, duplicated, or reordered")
+    allowed = set(plan["artifact_contract"]["allowed_status"])
+    all_valid = True
+    for row in rows:
+        contract = plan_rows[row["id"]]
+        status = row.get("status")
+        _require(status in allowed, f"row {row['id']} has invalid status")
+        _require(row.get("boundary") == contract["boundary"], f"row {row['id']} changes client/service/topology boundary")
+        identity = row.get("identity")
+        _require(isinstance(identity, dict), f"row {row['id']} identity is required")
+        for field in contract["required_identity_fields"]:
+            _require(field in identity and identity[field] not in (None, ""), f"row {row['id']} lacks identity field {field}")
+            if field.endswith("_sha256"):
+                _require(_is_sha256(identity[field]), f"row {row['id']} has invalid identity digest {field}")
+        for field, value in _resolve(contract["pinned_identity"], source_head).items():
+            _require(identity.get(field) == value, f"row {row['id']} changes pinned identity {field}")
+        if status != "valid":
+            _require(isinstance(row.get("reason"), str) and row["reason"], f"row {row['id']} non-valid status needs a reason")
+            all_valid = False
+            continue
+
+        corpus_runs = row.get("corpora")
+        _require(isinstance(corpus_runs, list) and [value.get("id") for value in corpus_runs] == [value["id"] for value in expected_corpora], f"row {row['id']} lacks both corpora")
+        budgets = plan["workload"][contract["search_budget"]]["search_budgets"]
+        expected_cells = {(_budget_key(budget), concurrency) for budget in budgets for concurrency in plan["workload"]["concurrency"]}
+        for corpus in corpus_runs:
+            repetitions = corpus.get("repetitions")
+            _require(isinstance(repetitions, list) and [value.get("repetition") for value in repetitions] == [1, 2, 3], f"row {row['id']} corpus {corpus['id']} lacks three repetitions")
+            for repetition in repetitions:
+                noise = repetition.get("noise")
+                _require(repetition.get("status") == "valid" and isinstance(noise, dict) and noise.get("valid") is True, f"row {row['id']} has invalid or tainted repetition")
+                _require(all(_number(noise.get(key)) and noise[key] >= 0 for key in plan["artifact_contract"]["required_noise_fields"] if key != "valid"), f"row {row['id']} lacks host-load observations")
+                _require(repetition.get("warmup_queries_per_cell") == plan["workload"]["warmup_queries_per_cell"], f"row {row['id']} changes warmup count")
+                ordered_budgets = _ordered_budgets(plan, contract["search_budget"], repetition["repetition"])
+                _require(repetition.get("budget_order") == ordered_budgets, f"row {row['id']} changes the search-budget order")
+                _require(all(isinstance(repetition.get("phases", {}).get(key), int) and not isinstance(repetition["phases"][key], bool) and repetition["phases"][key] >= 0 for key in plan["artifact_contract"]["required_phases"]), f"row {row['id']} lacks phase timing")
+                _require(all(_number(repetition.get("resources", {}).get(key)) and repetition["resources"][key] >= 0 for key in plan["artifact_contract"]["required_resources"]), f"row {row['id']} lacks total-system resources")
+                _require(all(isinstance(repetition["resources"][key], int) and not isinstance(repetition["resources"][key], bool) for key in plan["artifact_contract"]["required_resources"] if key != "cpu_seconds"), f"row {row['id']} has malformed byte resources")
+                _require(all(repetition["resources"][key] > 0 for key in ("cpu_seconds", "peak_rss_bytes", "persistent_bytes")), f"row {row['id']} has empty total-system resource observations")
+                cells = repetition.get("searches")
+                _require(isinstance(cells, list), f"row {row['id']} searches are required")
+                actual_cells = {(_budget_key(value.get("budget")), value.get("concurrency")) for value in cells}
+                _require(len(cells) == len(actual_cells) and actual_cells == expected_cells, f"row {row['id']} search matrix is incomplete")
+                expected_order = [(_budget_key(budget), concurrency) for budget in ordered_budgets for concurrency in plan["workload"]["concurrency"]]
+                _require([(_budget_key(value.get("budget")), value.get("concurrency")) for value in cells] == expected_order, f"row {row['id']} search matrix order changed")
+                for cell in cells:
+                    corpus_contract = corpus_contracts[corpus["id"]]
+                    _require(cell.get("status") == "valid" and _valid_metrics(cell.get("metrics"), plan["artifact_contract"]["required_search_metrics"], corpus_contract["queries"], corpus_contract["top_k"]), f"row {row['id']} has invalid search metrics")
+                    if contract["system"] == "treedb":
+                        counters = cell.get("counters")
+                        _require(isinstance(counters, dict) and all(isinstance(counters.get(key), int) and not isinstance(counters[key], bool) and counters[key] >= 0 for key in plan["artifact_contract"]["tree_db_counters"]), f"row {row['id']} lacks TreeDB path counters")
+
+    tree_identities = [row["identity"] for row in rows if plan_rows[row["id"]]["system"] == "treedb"]
+    _require(len({identity["binary_sha256"] for identity in tree_identities}) == 1, "TreeDB rows do not use one benchmark binary")
+    _require(len({identity["topology_identity_sha256"] for identity in tree_identities}) == len(tree_identities), "TreeDB topology identities are not distinct")
+
+    expected_status = plan["artifact_contract"]["complete_status"] if all_valid else "incomplete"
+    _require(result.get("status") == expected_status, "top-level status does not match row status")
+    if all_valid:
+        matched_recall_buckets(plan, result)
+    if require_complete:
+        _require(all_valid, "qualification requires every row to be valid")
+    return all_valid
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--plan", type=Path, required=True)
+    parser.add_argument("--result", type=Path)
+    parser.add_argument("--require-complete", action="store_true")
+    args = parser.parse_args()
+    plan = _load(args.plan)
+    validate_plan(plan)
+    if args.result:
+        validate_result(plan, _sha256(args.plan), _load(args.result), require_complete=args.require_complete)
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/vector_db_compare/test_system_qualification.py
+++ b/benchmarks/vector_db_compare/test_system_qualification.py
@@ -187,6 +187,12 @@ class SystemQualificationContractTest(unittest.TestCase):
         with self.assertRaisesRegex(ContractError, "search matrix"):
             validate_result(self.plan, self.plan_sha256, missing_cell)
 
+        reordered = self.result()
+        searches = reordered["rows"][0]["corpora"][0]["repetitions"][0]["searches"]
+        searches[0], searches[1] = searches[1], searches[0]
+        with self.assertRaisesRegex(ContractError, "search matrix order"):
+            validate_result(self.plan, self.plan_sha256, reordered)
+
         bad_metrics = copy.deepcopy(self.result())
         bad_metrics["rows"][0]["corpora"][0]["repetitions"][0]["searches"][0]["metrics"]["p95_nanos"] = 0
         with self.assertRaisesRegex(ContractError, "search metrics"):
@@ -231,8 +237,15 @@ class SystemQualificationContractTest(unittest.TestCase):
             artifact.write_text('{"qps": NaN}', encoding="utf-8")
             with self.assertRaisesRegex(ContractError, "non-finite JSON number"):
                 _load(artifact)
+            with self.assertRaisesRegex(ContractError, "exceeds 1 bytes"):
+                _load(artifact, limit=1)
 
     def test_matched_recall_bucketing_rejects_missing_floor(self) -> None:
+        missing = self.result()
+        missing["rows"][3]["corpora"][0]["repetitions"][0]["searches"].pop(0)
+        with self.assertRaisesRegex(ContractError, "lacks metrics"):
+            matched_recall_buckets(self.plan, missing)
+
         result = self.result()
         milvus = result["rows"][3]
         for corpus in milvus["corpora"]:

--- a/benchmarks/vector_db_compare/test_system_qualification.py
+++ b/benchmarks/vector_db_compare/test_system_qualification.py
@@ -1,0 +1,201 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import copy
+import hashlib
+import json
+import unittest
+from pathlib import Path
+
+from system_qualification import ContractError, matched_recall_buckets, validate_plan, validate_result
+
+
+ROOT = Path(__file__).parents[2]
+PLAN_PATH = ROOT / "TreeDB/docs/spec/artifacts/vector-partition-local-system-qualification-4019-plan.json"
+
+
+class SystemQualificationContractTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.plan = json.loads(PLAN_PATH.read_text(encoding="utf-8"))
+        cls.plan_sha256 = hashlib.sha256(PLAN_PATH.read_bytes()).hexdigest()
+
+    def result(self) -> dict:
+        source_head = "1" * 40
+        corpora = [
+            {key: corpus[key] for key in ("id", "fixture_checksum", "manifest_sha256", "truth_identity", "truth_artifact_sha256", "truth_sha256")}
+            for corpus in self.plan["accepted_inputs"]["corpora"]
+        ]
+        rows = []
+        for row_index, contract in enumerate(self.plan["rows"]):
+            identity = {
+                key: (value.replace("<source_head_sha>", source_head) if isinstance(value, str) else value)
+                for key, value in contract["pinned_identity"].items()
+            }
+            for key in contract["required_identity_fields"]:
+                identity.setdefault(key, "a" * 64)
+            identity["topology_identity_sha256"] = f"{row_index + 1:064x}"
+            budgets = self.plan["workload"][contract["search_budget"]]["search_budgets"]
+            corpus_runs = []
+            for corpus in corpora:
+                repetitions = []
+                for repetition in range(1, 4):
+                    searches = []
+                    ordered_budgets = budgets if repetition == 1 else list(reversed(budgets)) if repetition == 2 else budgets[1:] + budgets[:1]
+                    for budget in ordered_budgets:
+                        for concurrency in self.plan["workload"]["concurrency"]:
+                            cell = {
+                                "budget": budget,
+                                "concurrency": concurrency,
+                                "status": "valid",
+                                "metrics": {
+                                    "queries": 1000,
+                                    "completed_queries": 1000,
+                                    "result_count": 10000,
+                                    "errors": 0,
+                                    "timeouts": 0,
+                                    "recall_at_10": 0.95,
+                                    "qps": 1.0,
+                                    "p50_nanos": 1,
+                                    "p95_nanos": 2,
+                                    "p99_nanos": 3,
+                                },
+                            }
+                            if contract["system"] == "treedb":
+                                cell["counters"] = {key: 0 for key in self.plan["artifact_contract"]["tree_db_counters"]}
+                            searches.append(cell)
+                    repetitions.append(
+                        {
+                            "repetition": repetition,
+                            "status": "valid",
+                            "noise": {"valid": True, "load_1": 0.1, "load_5": 0.1, "load_15": 0.1},
+                            "warmup_queries_per_cell": 1000,
+                            "budget_order": ordered_budgets,
+                            "phases": {key: 1 for key in self.plan["artifact_contract"]["required_phases"]},
+                            "resources": {key: (0 if key == "swap_bytes" else 1) for key in self.plan["artifact_contract"]["required_resources"]},
+                            "searches": searches,
+                        }
+                    )
+                corpus_runs.append({"id": corpus["id"], "repetitions": repetitions})
+            rows.append({"id": contract["id"], "status": "valid", "boundary": copy.deepcopy(contract["boundary"]), "identity": identity, "corpora": corpus_runs})
+        return {
+            "schema_version": 1,
+            "result_kind": "vector_partition_local_system_qualification_v1",
+            "status": "complete",
+            "plan_sha256": self.plan_sha256,
+            "resource_envelope": copy.deepcopy(self.plan["resource_envelope"]),
+            "source_head_sha": source_head,
+            "host": {
+                "cpu_model": "test cpu",
+                "logical_cpus": 12,
+                "memory_bytes": 33512759296,
+                "kernel": "test kernel",
+                "storage_filesystem": "ext4",
+                "storage_root": "/mnt/fast4tb/test",
+                "docker_version": "test docker",
+                "go_version": "go1.26.0",
+                "python_version": "3.10.12",
+            },
+            "provenance": {
+                "artifact_root": "/mnt/fast4tb/test",
+                "commands_path": "commands.json",
+                "commands_sha256": "b" * 64,
+                "environment_path": "environment.json",
+                "environment_sha256": "c" * 64,
+                "started_at": "2026-08-05T00:00:00Z",
+                "completed_at": "2026-08-05T01:00:00Z",
+            },
+            "corpora": corpora,
+            "rows": rows,
+        }
+
+    def test_frozen_plan_and_complete_result_validate(self) -> None:
+        validate_plan(self.plan)
+        milvus = next(row for row in self.plan["rows"] if row["id"] == "milvus_standalone")
+        pgvector = next(row for row in self.plan["rows"] if row["id"] == "postgres_pgvector")
+        self.assertEqual(milvus["pinned_identity"]["server_version"], "2.6.20")
+        self.assertIn("@sha256:", pgvector["pinned_identity"]["image"])
+        self.assertEqual(self.plan["accepted_inputs"]["campaign_index_sha256"], "c20f11bb38898fd0d5907330bec3df80db29df14e44962a8766502e757849aa2")
+        self.assertEqual(self.plan["accepted_inputs"]["corpora"][0]["fixture_checksum"], "ecc2224f386932e580e4956f2cfa852140d3134625971c3511bc0d5feddf9b95")
+        self.assertEqual(self.plan["accepted_inputs"]["corpora"][1]["fixture_checksum"], "d0c7c82ba868853aae9a4280161003d72714ad1701d41ed3169c2fa94d470d69")
+        self.assertTrue(validate_result(self.plan, self.plan_sha256, self.result(), require_complete=True))
+        self.assertEqual(len(matched_recall_buckets(self.plan, self.result())), 5 * 2 * 3)
+
+    def test_missing_identity_or_changed_boundary_fails_closed(self) -> None:
+        missing = self.result()
+        del missing["rows"][0]["identity"]["binary_sha256"]
+        with self.assertRaisesRegex(ContractError, "binary_sha256"):
+            validate_result(self.plan, self.plan_sha256, missing)
+
+        changed = self.result()
+        changed["rows"][1]["boundary"]["client"] = "in_process_call"
+        with self.assertRaisesRegex(ContractError, "boundary"):
+            validate_result(self.plan, self.plan_sha256, changed)
+
+        mixed_binary = self.result()
+        mixed_binary["rows"][1]["identity"]["binary_sha256"] = "f" * 64
+        with self.assertRaisesRegex(ContractError, "one benchmark binary"):
+            validate_result(self.plan, self.plan_sha256, mixed_binary)
+
+    def test_incomplete_row_is_preserved_but_cannot_qualify(self) -> None:
+        result = self.result()
+        result["status"] = "incomplete"
+        result["rows"][3] = {
+            "id": "milvus_standalone",
+            "status": "unsupported",
+            "reason": "official deployment unavailable",
+            "boundary": self.plan["rows"][3]["boundary"],
+            "identity": result["rows"][3]["identity"],
+        }
+        self.assertFalse(validate_result(self.plan, self.plan_sha256, result))
+        with self.assertRaisesRegex(ContractError, "every row"):
+            validate_result(self.plan, self.plan_sha256, result, require_complete=True)
+
+    def test_search_matrix_and_metrics_fail_closed(self) -> None:
+        missing_cell = self.result()
+        missing_cell["rows"][4]["corpora"][0]["repetitions"][0]["searches"].pop()
+        with self.assertRaisesRegex(ContractError, "search matrix"):
+            validate_result(self.plan, self.plan_sha256, missing_cell)
+
+        bad_metrics = copy.deepcopy(self.result())
+        bad_metrics["rows"][0]["corpora"][0]["repetitions"][0]["searches"][0]["metrics"]["p95_nanos"] = 0
+        with self.assertRaisesRegex(ContractError, "search metrics"):
+            validate_result(self.plan, self.plan_sha256, bad_metrics)
+
+        malformed = self.result()
+        malformed["rows"][0]["corpora"][0]["repetitions"][0]["searches"][0]["metrics"]["qps"] = "fast"
+        with self.assertRaisesRegex(ContractError, "search metrics"):
+            validate_result(self.plan, self.plan_sha256, malformed)
+
+        shortened = self.result()
+        metrics = shortened["rows"][0]["corpora"][0]["repetitions"][0]["searches"][0]["metrics"]
+        metrics["queries"] = metrics["completed_queries"] = 999
+        metrics["result_count"] = 9990
+        with self.assertRaisesRegex(ContractError, "search metrics"):
+            validate_result(self.plan, self.plan_sha256, shortened)
+
+    def test_matched_recall_bucketing_rejects_missing_floor(self) -> None:
+        result = self.result()
+        milvus = result["rows"][3]
+        for corpus in milvus["corpora"]:
+            for repetition in corpus["repetitions"]:
+                for cell in repetition["searches"]:
+                    if cell["budget"] == {"ef": 16}:
+                        cell["metrics"]["recall_at_10"] = 0.5
+        selected = [bucket for bucket in matched_recall_buckets(self.plan, result) if bucket["row"] == "milvus_standalone"]
+        self.assertTrue(selected)
+        self.assertTrue(all(bucket["budget"] == {"ef": 32} for bucket in selected))
+
+        result = self.result()
+        milvus = result["rows"][3]
+        for corpus in milvus["corpora"]:
+            for repetition in corpus["repetitions"]:
+                for cell in repetition["searches"]:
+                    cell["metrics"]["recall_at_10"] = 0.5
+        with self.assertRaisesRegex(ContractError, "no matched-recall budget"):
+            validate_result(self.plan, self.plan_sha256, result)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/benchmarks/vector_db_compare/test_system_qualification.py
+++ b/benchmarks/vector_db_compare/test_system_qualification.py
@@ -87,12 +87,13 @@ class SystemQualificationContractTest(unittest.TestCase):
             "resource_envelope": copy.deepcopy(self.plan["resource_envelope"]),
             "source_head_sha": source_head,
             "host": {
-                "cpu_model": "test cpu",
+                "cpu_model": "11th Gen Intel(R) Core(TM) i5-11400F @ 2.60GHz",
                 "logical_cpus": 12,
                 "memory_bytes": 33512759296,
                 "kernel": "test kernel",
                 "storage_filesystem": "ext4",
                 "storage_root": "/mnt/fast4tb/test",
+                "storage_free_bytes": 107374182400,
                 "docker_version": "test docker",
                 "go_version": "go1.26.0",
                 "python_version": "3.10.12",
@@ -138,6 +139,21 @@ class SystemQualificationContractTest(unittest.TestCase):
         with self.assertRaisesRegex(ContractError, "one benchmark binary"):
             validate_result(self.plan, self.plan_sha256, mixed_binary)
 
+        wrong_host = self.result()
+        wrong_host["host"]["cpu_model"] = "different cpu"
+        with self.assertRaisesRegex(ContractError, "host CPU"):
+            validate_result(self.plan, self.plan_sha256, wrong_host)
+
+        wrong_storage = self.result()
+        wrong_storage["host"]["storage_root"] = wrong_storage["provenance"]["artifact_root"] = "/tmp/test"
+        with self.assertRaisesRegex(ContractError, "host storage"):
+            validate_result(self.plan, self.plan_sha256, wrong_storage)
+
+        placeholder = self.result()
+        placeholder["host"]["storage_root"] = placeholder["provenance"]["artifact_root"] = self.plan["resource_envelope"]["storage_root"]
+        with self.assertRaisesRegex(ContractError, "host storage"):
+            validate_result(self.plan, self.plan_sha256, placeholder)
+
     def test_incomplete_row_is_preserved_but_cannot_qualify(self) -> None:
         result = self.result()
         result["status"] = "incomplete"
@@ -167,6 +183,16 @@ class SystemQualificationContractTest(unittest.TestCase):
         malformed["rows"][0]["corpora"][0]["repetitions"][0]["searches"][0]["metrics"]["qps"] = "fast"
         with self.assertRaisesRegex(ContractError, "search metrics"):
             validate_result(self.plan, self.plan_sha256, malformed)
+
+        nonfinite = self.result()
+        nonfinite["rows"][0]["corpora"][0]["repetitions"][0]["searches"][0]["metrics"]["qps"] = float("nan")
+        with self.assertRaisesRegex(ContractError, "search metrics"):
+            validate_result(self.plan, self.plan_sha256, nonfinite)
+
+        infinite_resource = self.result()
+        infinite_resource["rows"][0]["corpora"][0]["repetitions"][0]["resources"]["cpu_seconds"] = float("inf")
+        with self.assertRaisesRegex(ContractError, "total-system resources"):
+            validate_result(self.plan, self.plan_sha256, infinite_resource)
 
         shortened = self.result()
         metrics = shortened["rows"][0]["corpora"][0]["repetitions"][0]["searches"][0]["metrics"]

--- a/benchmarks/vector_db_compare/test_system_qualification.py
+++ b/benchmarks/vector_db_compare/test_system_qualification.py
@@ -5,10 +5,11 @@ from __future__ import annotations
 import copy
 import hashlib
 import json
+import tempfile
 import unittest
 from pathlib import Path
 
-from system_qualification import ContractError, matched_recall_buckets, validate_plan, validate_result
+from system_qualification import ContractError, _load, matched_recall_buckets, validate_plan, validate_result
 
 
 ROOT = Path(__file__).parents[2]
@@ -64,6 +65,8 @@ class SystemQualificationContractTest(unittest.TestCase):
                             }
                             if contract["system"] == "treedb":
                                 cell["counters"] = {key: 0 for key in self.plan["artifact_contract"]["tree_db_counters"]}
+                                for key in self.plan["artifact_contract"]["tree_db_positive_counters"]:
+                                    cell["counters"][key] = 1
                             searches.append(cell)
                     repetitions.append(
                         {
@@ -123,6 +126,11 @@ class SystemQualificationContractTest(unittest.TestCase):
         self.assertTrue(validate_result(self.plan, self.plan_sha256, self.result(), require_complete=True))
         self.assertEqual(len(matched_recall_buckets(self.plan, self.result())), 5 * 2 * 3)
 
+        changed_plan = copy.deepcopy(self.plan)
+        changed_plan["resource_envelope"]["memory_limit_bytes"] -= 1
+        with self.assertRaisesRegex(ContractError, "frozen plan content"):
+            validate_plan(changed_plan)
+
     def test_missing_identity_or_changed_boundary_fails_closed(self) -> None:
         missing = self.result()
         del missing["rows"][0]["identity"]["binary_sha256"]
@@ -153,6 +161,11 @@ class SystemQualificationContractTest(unittest.TestCase):
         placeholder["host"]["storage_root"] = placeholder["provenance"]["artifact_root"] = self.plan["resource_envelope"]["storage_root"]
         with self.assertRaisesRegex(ContractError, "host storage"):
             validate_result(self.plan, self.plan_sha256, placeholder)
+
+        reused_topology = self.result()
+        reused_topology["rows"][4]["identity"]["topology_identity_sha256"] = reused_topology["rows"][0]["identity"]["topology_identity_sha256"]
+        with self.assertRaisesRegex(ContractError, "topology identities"):
+            validate_result(self.plan, self.plan_sha256, reused_topology)
 
     def test_incomplete_row_is_preserved_but_cannot_qualify(self) -> None:
         result = self.result()
@@ -194,12 +207,25 @@ class SystemQualificationContractTest(unittest.TestCase):
         with self.assertRaisesRegex(ContractError, "total-system resources"):
             validate_result(self.plan, self.plan_sha256, infinite_resource)
 
+        missing_path_proof = self.result()
+        missing_path_proof["rows"][0]["corpora"][0]["repetitions"][0]["searches"][0]["counters"] = {
+            key: 0 for key in self.plan["artifact_contract"]["tree_db_counters"]
+        }
+        with self.assertRaisesRegex(ContractError, "nonzero TreeDB path proof"):
+            validate_result(self.plan, self.plan_sha256, missing_path_proof)
+
         shortened = self.result()
         metrics = shortened["rows"][0]["corpora"][0]["repetitions"][0]["searches"][0]["metrics"]
         metrics["queries"] = metrics["completed_queries"] = 999
         metrics["result_count"] = 9990
         with self.assertRaisesRegex(ContractError, "search metrics"):
             validate_result(self.plan, self.plan_sha256, shortened)
+
+        with tempfile.TemporaryDirectory() as directory:
+            artifact = Path(directory) / "nonfinite.json"
+            artifact.write_text('{"qps": NaN}', encoding="utf-8")
+            with self.assertRaisesRegex(ContractError, "non-finite JSON number"):
+                _load(artifact)
 
     def test_matched_recall_bucketing_rejects_missing_floor(self) -> None:
         result = self.result()

--- a/benchmarks/vector_db_compare/test_system_qualification.py
+++ b/benchmarks/vector_db_compare/test_system_qualification.py
@@ -207,6 +207,11 @@ class SystemQualificationContractTest(unittest.TestCase):
         with self.assertRaisesRegex(ContractError, "total-system resources"):
             validate_result(self.plan, self.plan_sha256, infinite_resource)
 
+        swapped = self.result()
+        swapped["rows"][0]["corpora"][0]["repetitions"][0]["resources"]["swap_bytes"] = 1
+        with self.assertRaisesRegex(ContractError, "swap limit"):
+            validate_result(self.plan, self.plan_sha256, swapped)
+
         missing_path_proof = self.result()
         missing_path_proof["rows"][0]["corpora"][0]["repetitions"][0]["searches"][0]["counters"] = {
             key: 0 for key in self.plan["artifact_contract"]["tree_db_counters"]


### PR DESCRIPTION
## Objective

Freeze the M0 contract and fail-closed artifact schema for issue #4019 before adding any topology or comparator adapter.

## Context

#4018 and #4022 are complete. This slice consumes the accepted 100k/250k structured evidence and the public `vectorpartition.OperationsV1` boundary, so every required local-system row now has one reviewable identity, fairness, resource, repetition, and matched-recall contract.

Part of #4019.

## Non-goals

- No benchmark measurements or performance claims.
- No product hot-path changes.
- No TreeDB daemon, container, Milvus, or pgvector adapter implementation.
- No multi-host claim; #3983 owns that work.

## Design

- Adds one frozen JSON plan for five required rows: TreeDB single daemon, native four-daemon, container four-daemon, Milvus Standalone, and PostgreSQL+pgvector.
- Pins the accepted #4022/#4027 corpus/truth identities, TreeDB p2/EF128/c256 candidate, official comparator versions/images, shared resource envelope, lifecycle phases, cache/durability state, and three-run measurement order.
- Adds a stdlib-only validator that fails closed on identity/boundary drift, malformed metrics/resources, shortened query sets, incomplete search matrices, mixed TreeDB binaries, reused topology identities, tainted runs, and absent matched-recall buckets.
- Uses the fixed accepted TreeDB p2 row and the first external HNSW budget whose three-run median reaches recall@10 0.90.

## Scope

- Includes:
  - `TreeDB/docs/spec/artifacts/vector-partition-local-system-qualification-4019-plan.json`
  - `TreeDB/docs/spec/vector-partition-local-system-qualification.md`
  - `benchmarks/vector_db_compare/system_qualification.py`
  - `benchmarks/vector_db_compare/test_system_qualification.py`
- Excludes all production code and adapter/runtime implementation.

## Correctness

Tests run:

- `PYTHONDONTWRITEBYTECODE=1 python3 benchmarks/vector_db_compare/test_system_qualification.py`
- `PYTHONDONTWRITEBYTECODE=1 python3 -m unittest discover -s benchmarks/vector_db_compare -p 'test_*.py'`
- `PYTHONDONTWRITEBYTECODE=1 python3 scripts/bench_vector_db_compare_test.py`
- `GOWORK=off go test ./TreeDB/docs -count=1`
- `git diff --check`

Covered failures include missing identity, changed client boundary, unsupported required row, missing search cell, malformed/shortened metrics, changed TreeDB binary, and no qualifying matched-recall budget.

## Performance

Harness contract only; no hot path changed and no benchmark is claimed.

## Rollout / Toggle Plan

No runtime behavior. Results qualify only when explicitly validated with `--require-complete` against the exact plan SHA.

## Follow-ups

- #4019 M1: add the production TreeDB topology and external comparator adapters.
- #4019 M2-M4: lifecycle/topology-tax evidence, canonical repeated matrix, compact report, and #3983 handoff.

### AI Review Loop

- Codex latest-head review: pending mature-head request
- Copilot latest-head review: pending
- CodeRabbit latest-head review: pending
- Review comments/threads resolved or explicitly dismissed: pending
- Re-requested after final meaningful push: not yet needed

---

## Optimization PR Checklist (TreeDB)

### Scope
- [x] Single, clear objective for this PR
- [x] Explicit include and exclude lists
- [x] No unwanted feature reintroduction

### Safety / Correctness
- [x] Trust-boundary input validation is fail-closed and bounded to 16 MiB
- [x] No storage, mmap, durability implementation, or concurrency change

### Tests
- [x] Deterministic contract regression tests added
- [x] Focused and affected local tests passed

### Benchmarks / Measurements
- [x] Not applicable: contract-only PR, no performance claim

### Docs
- [x] Pre-alpha contract and nonclaims documented

### Rollout / Toggle Plan
- [x] No runtime behavior; exact-plan validation is opt-in


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a qualification plan for comparing vector database deployments across defined corpora, workloads, resource limits, and benchmark scenarios.
  - Added a local-system qualification specification covering fairness, measurement, provenance, evidence preservation, and dependency requirements.
  - Added validation tooling for qualification plans and results, including integrity, completeness, metrics, resource, and recall checks.

- **Tests**
  - Added comprehensive coverage for valid and invalid qualification plans and result data, including edge cases and incomplete measurements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->