### PR TITLE
ci: give root test shards completion headroom

### DIFF
--- a/.github/scripts/test_root_ci_headroom.py
+++ b/.github/scripts/test_root_ci_headroom.py
@@ -167,7 +167,7 @@ class RootCIHeadroomContractTests(unittest.TestCase):
         )
 
     def test_timeout_and_shard_enumeration_contract_are_preserved(self) -> None:
-        self.assertIn("    timeout-minutes: 15", self.source)
+        self.assertIn("    timeout-minutes: 25", self.source)
         self.assertIn(
             "go list ./... | grep -v "
             "'^github.com/snissn/gomap/TreeDB/db$'",

--- a/.github/workflows/root-tests.yml
+++ b/.github/workflows/root-tests.yml
@@ -38,7 +38,7 @@ jobs:
             run_vet: false
             test_shard_index: 1
             test_shard_count: 2
-    timeout-minutes: 15
+    timeout-minutes: 25
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
## Objective

Repair the deterministic CI-budget failure blocking #4081 without weakening test coverage or sharding.

## Change

- raise the existing Root vet/test matrix job budget from 15 to 25 minutes;
- update the executable headroom contract to require the new bound;
- leave package/test enumeration, two-way Ubuntu/macOS sharding, vet/docs placement, memory limits, and test commands unchanged.

## Evidence

The #4081 exact-head root `macos-latest-2` Test step completed successfully after 14m33s, leaving insufficient time for job completion under the 15-minute boundary. One authorized failed-job retry reached the same cancellation boundary without a test assertion failure. The issue ledger records 30 successful jobs, three cancellations, and one derived required-gate failure.

The 25-minute bound matches the existing TreeDB Ubuntu budget and gives setup, cleanup, and artifact publication bounded headroom while retaining fail-closed cancellation.

## Validation

- `python3 .github/scripts/test_root_ci_headroom.py`
- workflow exact-head CI

Unblocks #4081. Does not close #4019.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Increased the automated test workflow timeout from 15 to 25 minutes.
  * Updated the related validation to reflect the new time limit.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->